### PR TITLE
Relaxed compiler errors for nasm

### DIFF
--- a/recipes/nasm/ALL/conanfile.py
+++ b/recipes/nasm/ALL/conanfile.py
@@ -47,6 +47,8 @@ class NASMConan(ConanFile):
             elif self.settings.arch_build == "x86_64":
                 self._autotools.flags.append("-m64")
             self._autotools.configure(configure_dir=self._source_subfolder)
+            # GCC9 - ‘pure’ attribute on function returning ‘void’
+            tools.replace_in_file("Makefile", "-Werror=attributes", "")
         return self._autotools
 
     def _build_configure(self):


### PR DESCRIPTION
Here is a chirurgical patch for nasm. GCC9 complains about an attribute, which should be a warning, but as nasm uses -Werror flags, it results in an error.

It's working for GCC9 and CLANG8 on Linux.

Specify library name and version:  **nasm/2.13.x**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

