### PR TITLE
[OpenSSL] Adds arguments to compile openssl for Neutrino

### DIFF
--- a/recipes/openssl/ALL/conanfile.py
+++ b/recipes/openssl/ALL/conanfile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import fnmatch
 from functools import total_ordering

--- a/recipes/openssl/ALL/conanfile.py
+++ b/recipes/openssl/ALL/conanfile.py
@@ -339,6 +339,8 @@ class OpenSSLConan(ConanFile):
                 args.append("-DOPENSSL_CAPIENG_DIALOG=1")
         else:
             args.append("-fPIC" if self.options.fPIC else "")
+        if self.settings.os == "Neutrino":
+            args.append("-lsocket no-asm")
 
         if "zlib" in self.deps_cpp_info.deps:
             zlib_info = self.deps_cpp_info["zlib"]


### PR DESCRIPTION
The BASE_unix template is not complete for Neutrino. Until Neutrino is properly added to OpenSSL this will allow conan users to compile OpenSSL for QNX Neutrino. -lsocket provides things like setsockopt() while no-asm is used as asm_arch is not defined (which normally sets no-asm).

Specify library name and version:  **openssl/1.1.1d**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

