### PR TITLE
Fix openssl 1.0.2x shared library permissions

### DIFF
--- a/recipes/openssl/ALL/conanfile.py
+++ b/recipes/openssl/ALL/conanfile.py
@@ -555,6 +555,12 @@ class OpenSSLConan(ConanFile):
                 with tools.chdir(os.path.join(self.package_folder, 'lib')):
                     os.rename('libssl.lib', 'libssld.lib')
                     os.rename('libcrypto.lib', 'libcryptod.lib')
+        # Old OpenSSL version family has issues with permissions.
+        # See https://github.com/conan-io/conan/issues/5831
+        if self._full_version < "1.1.0" and self.options.shared and self.settings.os in ("Android", "FreeBSD", "Linux"):
+            with tools.chdir(os.path.join(self.package_folder, "lib")):
+                os.chmod("libssl.so.1.0.0", 0o755)
+                os.chmod("libcrypto.so.1.0.0", 0o755)
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):


### PR DESCRIPTION
Invoking `conan install` second time fails if openssl/1.0.2x package is used.
Shared libraries are built with permissions restricting owner to write, a behaviour that produces mentioned install failure.

Update openssl recipe to fix shared library permissions on Unix-like systems.

Closes https://github.com/conan-io/conan/issues/5831

Specify library name and version:  **openssl/1.0.2t**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

