### PR TITLE
Add asio (header-only)

### DIFF
--- a/recipes/asio/all/conandata.yml
+++ b/recipes/asio/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "1.13.0":
+    sha256: 54a1208d20f2104dbd6b7a04a9262f5ab649f4b7a9faf7eac4c2294e9e104c06
+    url: https://github.com/chriskohlhoff/asio/archive/asio-1-13-0.tar.gz
+  "1.12.2":
+    sha256: 1de23266b956674e766cd0b6c929a11259f2284ea8e96b765cc8c67b1689e0fd
+    url: https://github.com/chriskohlhoff/asio/archive/asio-1-12-2.tar.gz

--- a/recipes/asio/all/conanfile.py
+++ b/recipes/asio/all/conanfile.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+
+
+class Asio(ConanFile):
+    name = "asio"
+    
+    url = "https://github.com/bincrafters/conan-asio"
+    homepage = "https://github.com/chriskohlhoff/asio"
+    description = "Asio is a cross-platform C++ library for network and low-level I/O"
+    topics = ("conan", "asio", "network", "io", "low-level")
+    license = "BSL-1.0"
+
+    options = {
+        "standalone": [True, False],
+        "with_boost_regex": [True, False],
+        "with_openssl": [True, False]
+    }
+    default_options = {
+        "standalone": True,
+        "with_boost_regex": False,
+        "with_openssl": False
+    }
+
+    settings = "os"
+
+    no_copy_source = True
+    _source_subfolder = "source_subfolder"
+
+    def configure(self):
+        if self.options.standalone and self.options.with_boost_regex:
+            raise ConanInvalidConfiguration("'standalone' and 'with_boost_regex' are mutually exclusive! Please disable one of them.")
+
+    def requirements(self):
+        if self.options.with_boost_regex:
+            self.requires.add("boost/1.69.0")
+
+        if self.options.with_openssl:
+            self.requires.add("OpenSSL/1.0.2t")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        archive_name = "asio-" + self.version.replace(".", "-")
+        extracted_name = "asio-" + archive_name
+        os.rename(extracted_name, self._source_subfolder)
+
+    def package(self):
+        root_dir = os.path.join(self._source_subfolder, self.name)
+        include_dir = os.path.join(root_dir, "include")
+        self.copy(pattern="LICENSE_1_0.txt", dst="licenses", src=root_dir)
+        self.copy(pattern="*.hpp", dst="include", src=include_dir)
+        self.copy(pattern="*.ipp", dst="include", src=include_dir)
+
+    def package_info(self):
+        if self.options.standalone:
+            self.cpp_info.defines.append('ASIO_STANDALONE')
+        if self.settings.os == 'Linux':
+            self.cpp_info.libs.append('pthread')
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/asio/all/conanfile.py
+++ b/recipes/asio/all/conanfile.py
@@ -9,8 +9,8 @@ from conans.errors import ConanInvalidConfiguration
 class Asio(ConanFile):
     name = "asio"
     
-    url = "https://github.com/bincrafters/conan-asio"
-    homepage = "https://github.com/chriskohlhoff/asio"
+    url = "https://github.com/chriskohlhoff/asio"
+    homepage = "http://think-async.com/Asio"
     description = "Asio is a cross-platform C++ library for network and low-level I/O"
     topics = ("conan", "asio", "network", "io", "low-level")
     license = "BSL-1.0"
@@ -40,7 +40,7 @@ class Asio(ConanFile):
             self.requires.add("boost/1.69.0")
 
         if self.options.with_openssl:
-            self.requires.add("OpenSSL/1.0.2t")
+            self.requires.add("openssl/1.0.2t")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/asio/all/conanfile.py
+++ b/recipes/asio/all/conanfile.py
@@ -3,7 +3,6 @@
 
 import os
 from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
 
 
 class Asio(ConanFile):
@@ -15,32 +14,10 @@ class Asio(ConanFile):
     topics = ("conan", "asio", "network", "io", "low-level")
     license = "BSL-1.0"
 
-    options = {
-        "standalone": [True, False],
-        "with_boost_regex": [True, False],
-        "with_openssl": [True, False]
-    }
-    default_options = {
-        "standalone": True,
-        "with_boost_regex": False,
-        "with_openssl": False
-    }
-
-    settings = "os"
+    settings = "os", "arch", "compiler", "build_type"
 
     no_copy_source = True
     _source_subfolder = "source_subfolder"
-
-    def configure(self):
-        if self.options.standalone and self.options.with_boost_regex:
-            raise ConanInvalidConfiguration("'standalone' and 'with_boost_regex' are mutually exclusive! Please disable one of them.")
-
-    def requirements(self):
-        if self.options.with_boost_regex:
-            self.requires.add("boost/1.69.0")
-
-        if self.options.with_openssl:
-            self.requires.add("openssl/1.0.2t")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -56,10 +33,7 @@ class Asio(ConanFile):
         self.copy(pattern="*.ipp", dst="include", src=include_dir)
 
     def package_info(self):
-        if self.options.standalone:
-            self.cpp_info.defines.append('ASIO_STANDALONE')
-        if self.settings.os == 'Linux':
-            self.cpp_info.libs.append('pthread')
+        self.cpp_info.defines.append('ASIO_STANDALONE')
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/asio/all/test_package/CMakeLists.txt
+++ b/recipes/asio/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(test_package CXX)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/asio/all/test_package/conanfile.py
+++ b/recipes/asio/all/test_package/conanfile.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+from conans import ConanFile, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)

--- a/recipes/asio/all/test_package/test_package.cpp
+++ b/recipes/asio/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include <asio.hpp>
+
+int main()
+{
+	auto && service = asio::io_service{};
+	(void)service;
+}

--- a/recipes/asio/config.yml
+++ b/recipes/asio/config.yml
@@ -1,0 +1,6 @@
+---
+versions:
+  "1.13.0":
+    folder: all
+  "1.12.2":
+    folder: all


### PR DESCRIPTION
Adds:
 * asio/1.13.0
 * asio/1.12.2

There are other compilation modes **not added in this PR** that you can check [here](http://think-async.com/Asio/asio-1.13.0/doc/asio/using.html): with Boost.Coroutine, with Boost.Regex, using OpenSSL,... that may turn the library into an actual compiled library.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

