### PR TITLE
Allow 7zip to be built with mingw + fix 64 bit Visual Studio

### DIFF
--- a/recipes/7zip/19.00/conanfile.py
+++ b/recipes/7zip/19.00/conanfile.py
@@ -13,7 +13,7 @@ class Package7Zip(ConanFile):
     author = "Conan Community"
     homepage = "https://www.7-zip.org"
     topics = ("conan", "7zip", "zip", "compression", "decompression")
-    settings = "os_build", "arch_build"
+    settings = "os_build", "arch_build", "compiler"
 
     def configure(self):
         if self.settings.os_build != "Windows":
@@ -34,7 +34,7 @@ class Package7Zip(ConanFile):
         self.run("lzma920\\7zr.exe x {}".format(filename))
 
     def build(self):
-        if self.settings.os_build == "Windows":
+        if self.settings.compiler == "Visual Studio":
             env_build = VisualStudioBuildEnvironment(self)
             with tools.environment_append(env_build.vars):
                 vcvars = tools.vcvars_command(self.settings)
@@ -55,6 +55,9 @@ class Package7Zip(ConanFile):
             self.copy("*.dll", src="CPP/7zip", dst="bin", keep_path=False)
 
         # TODO: Package the libraries: binaries and headers (add the rest of settings)
+
+    def package_id(self):
+        del self.info.settings.compiler
 
     def package_info(self):
         bin_path = os.path.join(self.package_folder, "bin")

--- a/recipes/7zip/19.00/conanfile.py
+++ b/recipes/7zip/19.00/conanfile.py
@@ -33,13 +33,18 @@ class Package7Zip(ConanFile):
         tools.get(**self.conan_data["externals"]["lzma"])
         self.run("lzma920\\7zr.exe x {}".format(filename))
 
+    _msvc_platforms = {
+        'x86_64': 'x64',
+        'x86': 'x86',
+    }
+
     def build(self):
         if self.settings.compiler == "Visual Studio":
             env_build = VisualStudioBuildEnvironment(self)
             with tools.environment_append(env_build.vars):
                 vcvars = tools.vcvars_command(self.settings)
                 with tools.chdir("CPP/7zip"):
-                    self.run("%s && nmake /f makefile" % vcvars)
+                    self.run("%s && nmake /f makefile PLATFORM=%s" % (vcvars, self._msvc_platforms[str(self.settings.arch_build)]))
         else:
             # TODO: Enable non-Windows methods in configure
             env_build = AutoToolsBuildEnvironment(self)


### PR DESCRIPTION
Specify library name and version:  **7zip/19.00**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This should allow 7zip to be built with mingw.
Needs additional check by other eyes because untested because of appveyor (and because of working on Linux)
Should fix #153