### PR TITLE
Add cccl/1.1

### DIFF
--- a/recipes/cccl/all/conandata.yml
+++ b/recipes/cccl/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.1":
+    url: https://github.com/swig/cccl/archive/cccl-1.1.tar.gz
+    sha256: 03ed67d04e8b1e165b8f8d42546ab62ff6c42b3623a2358a7c8255ced144ce28

--- a/recipes/cccl/all/conanfile.py
+++ b/recipes/cccl/all/conanfile.py
@@ -1,0 +1,81 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class CcclConan(ConanFile):
+    name = "cccl"
+    description = "Unix cc compiler to Microsoft's cl compiler wrapper"
+    topics = ("conan", "msvc", "Visual Studio", "wrapper", "gcc")
+    homepage = "https://github.com/swig/cccl/"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "GPL-3.0-or-later"
+    options = {
+        "muffle": [True, False],
+        "verbose": [True, False],
+    }
+    default_options = {
+        "muffle": True,
+        "verbose": False,
+    }
+    settings = "compiler",
+
+    _source_subfolder = "source_subfolder"
+
+    def configure(self):
+        if self.settings.compiler != "Visual Studio":
+            raise ConanInvalidConfiguration("This recipe support only Visual Studio")
+        del self.settings.compiler
+
+    def package_id(self):
+        del self.info.options.muffle
+        del self.info.options.verbose
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("cccl-cccl-{}".format(self.version), self._source_subfolder)
+
+        cccl_path = os.path.join(self.source_folder, self._source_subfolder, "cccl")
+        tools.replace_in_file(cccl_path,
+                              "    --help)",
+                              "    *.lib)\n"
+                              "        linkopt+=(\"$lib\")"
+                              "        ;;\n\n"
+                              "    --help)")
+        tools.replace_in_file(cccl_path,
+                              "clopt+=(\"$lib\")",
+                              "linkopt+=(\"$lib\")")
+        tools.replace_in_file(cccl_path,
+                              "    -L*)",
+                              "    -LIBPATH:*)\n"
+                              "        linkopt+=(\"$1\")\n"
+                              "        ;;\n\n"
+                              "    -L*)")
+
+    def package(self):
+        self.copy("cccl", src=os.path.join(self.source_folder, self._source_subfolder), dst="bin")
+        self.copy("COPYING", src=os.path.join(self.source_folder, self._source_subfolder), dst="licenses")
+
+    def package_info(self):
+        self.cpp_info.bindirs = ["bin", ]
+
+        bindir = os.path.join(self.package_folder, "bin")
+        self.output.info('Appending PATH environment variable: {}'.format(bindir))
+        self.env_info.PATH.append(bindir)
+
+        cccl_args = [
+            "sh",
+            os.path.join(self.package_folder, "bin", "cccl"),
+        ]
+        if self.options.muffle:
+            cccl_args.append("--cccl-muffle")
+        if self.options.verbose:
+            cccl_args.append("--cccl-verbose")
+        cccl = " ".join(cccl_args)
+
+        self.output.info("Setting CC to '{}'".format(cccl))
+        self.env_info.CC = cccl
+        self.output.info("Setting CXX to '{}'".format(cccl))
+        self.env_info.CXX = cccl
+        self.output.info("Setting LD to '{}'".format(cccl))
+        self.env_info.LD = cccl

--- a/recipes/cccl/all/test_package/conanfile.py
+++ b/recipes/cccl/all/test_package/conanfile.py
@@ -1,0 +1,24 @@
+from conans import ConanFile, tools
+import os
+
+
+class CcclTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build_requirements(self):
+        if self.settings.os == "Windows":
+            self.build_requires("msys2/20161025")
+
+    def build(self):
+        environment = {}
+        if self.settings.compiler == "Visual Studio":
+            environment.update(tools.vcvars_dict(self.settings))
+        with tools.environment_append(environment):
+            cxx = tools.get_env("CXX")
+            self.run("{cxx} {src} -o example".format(
+                cxx=cxx, src=os.path.join(self.source_folder, "example.cpp")), win_bash=self.settings.os is "Windows")
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.run(os.path.join(self.build_folder, "example"))

--- a/recipes/cccl/all/test_package/example.cpp
+++ b/recipes/cccl/all/test_package/example.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello world\n";
+    return 0;
+}

--- a/recipes/cccl/config.yml
+++ b/recipes/cccl/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **cccl/1.1**

- This is a build dependency of swig.
It is used to wrap the visual studio in a gcc like script.

- port of https://github.com/bincrafters/conan-cccl_installer
- renamed to `cccl` (ditched the `_installer` suffix)  (or should this be added?)

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

