### PR TITLE
Declare dependencies that are encapsulated inside shared libraries private

### DIFF
--- a/recipes/mysql-connector-c/all/conanfile.py
+++ b/recipes/mysql-connector-c/all/conanfile.py
@@ -20,10 +20,10 @@ class MysqlConnectorCConan(ConanFile):
 
     def requirements(self):
         if self.options.with_ssl:
-            self.requires.add("openssl/1.0.2t")
+            self.requires.add("openssl/1.0.2t", private=self.options.shared)
 
         if self.options.with_zlib:
-            self.requires.add("zlib/1.2.11")
+            self.requires.add("zlib/1.2.11", private=self.options.shared)
 
     def source(self):
         archive_name = self.name + "-" + self.version + "-src"


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

The conan-mysql-connector-c fully encapsulates third-party libraries. Conan allows to make dependencies private in this case. It has several positive effects:
- The consumer can use versions of OpenSSL and zlib libraries which are not compatible with dependencies for conan-mysql-connector-c.
- The consumer can include the OpenSSL and zlib libraries in their source library and they will not conflict with dependencies for conan-mysql-connector-c.
- It reduces the chance of a Windows command line overflow (https://support.microsoft.com/en-us/help/830473/command-prompt-cmd-exe-command-line-string-limitation).
- It increases the build speed of the consumer because the compiler will not look for header files in the dependencies for conan-mysql-connector.
- It is necessary to solve a similar problem for Qt (https://github.com/bincrafters/conan-qt/pull/34).
