### PR TITLE
[strawberryperl] allow .pc files

### DIFF
--- a/recipes/strawberryperl/ALL/conanfile.py
+++ b/recipes/strawberryperl/ALL/conanfile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration

--- a/recipes/strawberryperl/ALL/conanfile.py
+++ b/recipes/strawberryperl/ALL/conanfile.py
@@ -31,9 +31,6 @@ class StrawberryperlConan(ConanFile):
         self.copy(pattern="*", src=os.path.join("c", "lib"), dst="lib")
         self.copy(pattern="*", src=os.path.join("c", "include"), dst="include")
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "Win32API", "File"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "Win32API", "Registry"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "Win32", "GuiTest"))
 
     def package_info(self):
         bin_path = os.path.join(self.package_folder, "bin")


### PR DESCRIPTION
allow `*.pc` files for perl, otherwise I have an error while building `libpq`:
```
Can't locate Win32API/File/cFile.pc in @INC (@INC contains: C:\Users\SSE4\.conan\data\libpq\11.5\bincrafters\testing\build\66397d4e4f72ab2f3a4c316d3e5132059c9ebf7b\source_subfolder\src\tools\msvc C:/.conan/3eefa9/1/lib) at C:/.conan/3eefa9/1/lib/Win32API/File.pm line 177.
Compilation failed in require at C:\Users\SSE4\.conan\data\libpq\11.5\bincrafters\testing\build\66397d4e4f72ab2f3a4c316d3e5132059c9ebf7b\source_subfolder\src\tools\msvc/Mkvcbuild.pm line 645.
BEGIN failed--compilation aborted at C:\Users\SSE4\.conan\data\libpq\11.5\bincrafters\testing\build\66397d4e4f72ab2f3a4c316d3e5132059c9ebf7b\source_subfolder\src\tools\msvc/Mkvcbuild.pm line 645.
Compilation failed in require at build.pl line 13.
BEGIN failed--compilation aborted at build.pl line 13.
```

perl's `.pc` files seems to have nothing to do with `pkg-config`: https://github.com/chorny/Win32API-File/blob/master/cFile.pc

related to #188

Specify library name and version:  **strawberryperl/5.30.0.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

