### PR TITLE
Fix zlib name for CMake generator

### DIFF
--- a/recipes/zlib/1.2.11/conanfile.py
+++ b/recipes/zlib/1.2.11/conanfile.py
@@ -163,3 +163,5 @@ class ZlibConan(ConanFile):
             if self.options.shared:
                 self.cpp_info.defines.append('MINIZIP_DLL')
         self.cpp_info.libs.append('zlib' if self.settings.os == "Windows" else "z")
+        self.cpp_info.name = "ZLIB"
+

--- a/recipes/zlib/1.2.8/conanfile.py
+++ b/recipes/zlib/1.2.8/conanfile.py
@@ -107,5 +107,3 @@ class ZlibConan(ConanFile):
                 self.cpp_info.libs[0] += "d"
         else:
             self.cpp_info.libs = ['z']
-        self.cpp_info.name = "ZLIB"
-

--- a/recipes/zlib/1.2.8/conanfile.py
+++ b/recipes/zlib/1.2.8/conanfile.py
@@ -107,3 +107,5 @@ class ZlibConan(ConanFile):
                 self.cpp_info.libs[0] += "d"
         else:
             self.cpp_info.libs = ['z']
+        self.cpp_info.name = "ZLIB"
+


### PR DESCRIPTION
Specify library name and version:  **zlib/1.2.11**

The default find package file provided by CMake is [FindZLIB](https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/FindZLIB.cmake). As you can see, the name is upper-cased, but the Conan package name is lower-case.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

