### PR TITLE
Use TIFF for cpp_info.name for CMake generator

### DIFF
--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, CMake, tools
 import os
 import shutil

--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -85,3 +85,4 @@ class LibtiffConan(ConanFile):
             self.cpp_info.libs = [lib+'.dll' for lib in self.cpp_info.libs]
         if self.settings.os == "Linux":
             self.cpp_info.libs.append("m")
+        self.cpp_info.name = "TIFF"

--- a/recipes/libtiff/all/test_package/conanfile.py
+++ b/recipes/libtiff/all/test_package/conanfile.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, CMake
 import os
 


### PR DESCRIPTION
Specify library name and version:  **libtiff/4.0.9**

Changing CMake generated module from libtiff to TIFF as it is known in [standard CMake module](  https://github.com/Kitware/CMake/tree/master/Modules)

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

