### PR TITLE
[7zip/19.00] Use msys2/20161025 for providing make for mingw builds

### DIFF
--- a/recipes/7zip/19.00/conandata.yml
+++ b/recipes/7zip/19.00/conandata.yml
@@ -1,15 +1,4 @@
 sources:
   "19.00":
     url: https://www.7-zip.org/a/7z1900-src.7z
-    filename: 7zip.7z
-
-checksum:
-  "19.00":
-    file_path: 7zip.7z
-    signature: 9ba70a5e8485cf9061b30a2a84fe741de5aeb8dd271aab8889da0e9b3bf1868e
-
-externals:
-  lzma:
-    url: https://www.7-zip.org/a/lzma920.tar.bz2
-    destination: lzma920
-    sha256: 8ac221acdca8b6f6dd110120763af42b3707363752fc04e63c7bbff76774a445
+    sha256: 9ba70a5e8485cf9061b30a2a84fe741de5aeb8dd271aab8889da0e9b3bf1868e

--- a/recipes/7zip/19.00/conanfile.py
+++ b/recipes/7zip/19.00/conanfile.py
@@ -19,26 +19,26 @@ class Package7Zip(ConanFile):
         if tools.os_info.is_windows and os.environ.get("CONAN_BASH_PATH", None) is None:
             if self.settings.compiler != "Visual Studio":
                 self.build_requires("msys2/20161025")
+        self.build_requires("7zip_bootstrap/9.20")
 
     def configure(self):
-        if self.settings.os_build != "Windows":
-            raise ConanInvalidConfiguration("Only Windows supported")
         if self.settings.arch_build not in ("x86", "x86_64"):
             raise ConanInvalidConfiguration("Unsupported architecture")
 
     def source(self):
-        tools.download(**self.conan_data["sources"][self.version])
-        tools.check_sha256(**self.conan_data["checksum"][self.version])
-        self._uncompress_7z(self.conan_data["sources"][self.version]["filename"])
+        filename = "7zip.7z"
+        tools.download(url=self.conan_data["sources"][self.version]["url"], filename=filename)
+        tools.check_sha256(filename, self.conan_data["sources"][self.version]["sha256"])
+        self._uncompress_7z(filename)
 
     def _uncompress_7z(self, filename):
         """ We need 7z itself to uncompress the file, we have two options:
             * download an executable and run it
-            * booststrap using a previous version (7zip/9.22) where sources are in .tar.bz2. Right
-              now it would we a loop in the Conan graph
+            * bootstrap using a previous version (7zip/9.20) where sources are in .tar.bz2.
+            Right now it would we a loop in the Conan graph
         """
-        tools.get(**self.conan_data["externals"]["lzma"])
-        self.run("lzma920\\7zr.exe x {}".format(filename))
+        self.run("7zDec x {}".format(filename))
+        os.unlink(filename)
 
     _msvc_platforms = {
         'x86_64': 'x64',

--- a/recipes/7zip/19.00/conanfile.py
+++ b/recipes/7zip/19.00/conanfile.py
@@ -15,6 +15,11 @@ class Package7Zip(ConanFile):
     topics = ("conan", "7zip", "zip", "compression", "decompression")
     settings = "os_build", "arch_build", "compiler"
 
+    def build_requirements(self):
+        if tools.os_info.is_windows and os.environ.get("CONAN_BASH_PATH", None) is None:
+            if self.settings.compiler != "Visual Studio":
+                self.build_requires("msys2/20161025")
+
     def configure(self):
         if self.settings.os_build != "Windows":
             raise ConanInvalidConfiguration("Only Windows supported")

--- a/recipes/7zip/19.00/test_package/conanfile.py
+++ b/recipes/7zip/19.00/test_package/conanfile.py
@@ -4,4 +4,4 @@ from conans import ConanFile
 class TestPackage(ConanFile):
     
     def test(self):
-        self.run("7z.exe")
+        self.run("7z")


### PR DESCRIPTION
Specify library name and version:  **7zip/19.00**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Continuation of #154 
When building 7zip using mingw on Windows, we need `make`.
This is provided by `msys2/20161025`.