### PR TITLE
[libpq] Add support for dynamic builds with Visual Studio

### DIFF
--- a/recipes/libpq/all/CMakeLists.txt
+++ b/recipes/libpq/all/CMakeLists.txt
@@ -39,8 +39,29 @@ file(REMOVE
     source_subfolder/src/include/pg_config_os.h
 )
 
+file(READ source_subfolder/configure CONFIGURE_FILE)
+string(REGEX MATCH "PACKAGE_VERSION='([0-9]+)" _ "${CONFIGURE_FILE}")
+set(PG_MAJORVERSION ${CMAKE_MATCH_1})
+
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define PG_MAJORVERSION \"${PG_MAJORVERSION}\"\n")
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#ifndef IGNORE_CONFIGURED_SETTINGS\n")
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define USE_LDAP 1\n")
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define RELSEG_SIZE 131072\n")
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define USE_FLOAT4_BYVAL 1\n")
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define FLOAT4PASSBYVAL true\n")
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define FLOAT8PASSBYVAL false\n")
+
+set(VAL_CONFIGURE_ZLIB_VALUE "--without-zlib")
+if (USE_ZLIB)
+    set(VAL_CONFIGURE_ZLIB_VALUE "--with-zlib")
+endif()
+set(VAL_CONFIGURE_VALUE "#define VAL_CONFIGURE \"--enable-thread-safety --with-ldap ${VAL_CONFIGURE_ZLIB_VALUE}\"")
+
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "${VAL_CONFIGURE_VALUE}\n")
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define BLCKSZ 8192\n")
 file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define BLCKSZ 8192\n")
 file(APPEND source_subfolder/src/include/pg_config.h.win32 "#define XLOG_BLCKSZ 8192\n")
+file(APPEND source_subfolder/src/include/pg_config.h.win32 "#endif /* IGNORE_CONFIGURED_SETTINGS */\n")
 
 
 configure_file(source_subfolder/src/include/pg_config.h.win32 include/pg_config.h)
@@ -61,18 +82,15 @@ set(pg_port_src
     source_subfolder/src/port/getaddrinfo.c
     source_subfolder/src/port/getopt.c
     source_subfolder/src/port/getopt_long.c
-    source_subfolder/src/port/getpeereid.c
     source_subfolder/src/port/getrusage.c
     source_subfolder/src/port/gettimeofday.c
     source_subfolder/src/port/inet_aton.c
     source_subfolder/src/port/inet_net_ntop.c
-    source_subfolder/src/port/isinf.c
     source_subfolder/src/port/kill.c
     source_subfolder/src/port/mkdtemp.c
     source_subfolder/src/port/noblock.c
     source_subfolder/src/port/open.c
     source_subfolder/src/port/path.c
-    source_subfolder/src/port/pg_crc32c_armv8_choose.c
     source_subfolder/src/port/pg_crc32c_sb8.c
     source_subfolder/src/port/pg_crc32c_sse42.c
     source_subfolder/src/port/pg_crc32c_sse42_choose.c
@@ -86,7 +104,6 @@ set(pg_port_src
     source_subfolder/src/port/qsort_arg.c
     source_subfolder/src/port/quotes.c
     source_subfolder/src/port/random.c
-    source_subfolder/src/port/rint.c
     source_subfolder/src/port/snprintf.c
     source_subfolder/src/port/sprompt.c
     source_subfolder/src/port/srandom.c
@@ -95,7 +112,6 @@ set(pg_port_src
     source_subfolder/src/port/system.c
     source_subfolder/src/port/tar.c
     source_subfolder/src/port/thread.c
-    source_subfolder/src/port/unsetenv.c
     source_subfolder/src/port/win32env.c
     source_subfolder/src/port/win32security.c
     source_subfolder/src/port/win32setlocale.c
@@ -110,32 +126,18 @@ include_directories(source_subfolder/src/include/port/win32 source_subfolder/src
 
 set(pg_backend_src
     source_subfolder/src/common/base64.c
-    source_subfolder/src/common/config_info.c
-    source_subfolder/src/common/controldata_utils.c
-    source_subfolder/src/common/fe_memutils.c
-    source_subfolder/src/common/file_perm.c
-    source_subfolder/src/common/file_utils.c
     source_subfolder/src/common/ip.c
-    source_subfolder/src/common/keywords.c
     source_subfolder/src/common/md5.c
-    source_subfolder/src/common/pg_lzcompress.c
-    source_subfolder/src/common/pgfnames.c
-    source_subfolder/src/common/psprintf.c
-    source_subfolder/src/common/restricted_token.c
-    source_subfolder/src/common/rmtree.c
     source_subfolder/src/common/saslprep.c
     source_subfolder/src/common/scram-common.c
-    source_subfolder/src/common/sha2.c
     source_subfolder/src/common/unicode_norm.c
-    source_subfolder/src/common/username.c
-    source_subfolder/src/common/wait_error.c
     source_subfolder/src/backend/utils/mb/wchar.c
     source_subfolder/src/backend/utils/mb/encnames.c
 )
 
 set(pg_libpq_src
-    source_subfolder/src/interfaces/libpq/fe-auth.c
     source_subfolder/src/interfaces/libpq/fe-auth-scram.c
+    source_subfolder/src/interfaces/libpq/fe-auth.c
     source_subfolder/src/interfaces/libpq/fe-connect.c
     source_subfolder/src/interfaces/libpq/fe-exec.c
     source_subfolder/src/interfaces/libpq/fe-lobj.c
@@ -144,10 +146,9 @@ set(pg_libpq_src
     source_subfolder/src/interfaces/libpq/fe-protocol2.c
     source_subfolder/src/interfaces/libpq/fe-protocol3.c
     source_subfolder/src/interfaces/libpq/fe-secure.c
-    source_subfolder/src/interfaces/libpq/fe-secure-common.c
+    source_subfolder/src/interfaces/libpq/libpq-dist.rc
     source_subfolder/src/interfaces/libpq/libpq-events.c
     source_subfolder/src/interfaces/libpq/pqexpbuffer.c
-    source_subfolder/src/interfaces/libpq/libpq-dist.rc
     source_subfolder/src/interfaces/libpq/pthread-win32.c
     source_subfolder/src/interfaces/libpq/win32.c
 )
@@ -168,9 +169,14 @@ set(pg_libpq_catalog_interface
 if (USE_OPENSSL)
     list(APPEND pg_libpq_src
         source_subfolder/src/interfaces/libpq/fe-secure-openssl.c
+        source_subfolder/src/interfaces/libpq/fe-secure-common.c
         )
     list(APPEND pg_backend_src
         source_subfolder/src/common/sha2_openssl.c
+        )
+else()
+    list(APPEND pg_backend_src
+        source_subfolder/src/common/sha2.c
         )
 endif()
 
@@ -180,13 +186,22 @@ if (USE_ZLIB)
         )
 endif()
 
-add_library(libpq ${pg_port_src} ${pg_backend_src} ${pg_libpq_src})
+set(DLL_DEF_FILE source_subfolder/src/interfaces/libpq/libpqdll.def)
 
-target_compile_definitions(libpq PRIVATE -DFRONTEND -DENABLE_THREAD_SAFETY ${OPENSSL_DEFINE} -D_CRT_SECURE_NO_WARNINGS)
-target_link_libraries(libpq PUBLIC ${CONAN_LIBS} ws2_32 secur32 advapi32 shell32 crypt32)
+set(BUILDING_DLL_DEFINE)
+if (BUILD_SHARED_LIBS)
+    set(BUILDING_DLL_DEFINE, -DBUILDING_DLL)
+endif()
 
+add_library(libpq ${pg_port_src} ${pg_backend_src} ${pg_libpq_src} ${DLL_DEF_FILE})
+target_compile_definitions(libpq PRIVATE -DFRONTEND -DENABLE_THREAD_SAFETY ${OPENSSL_DEFINE} -D_CRT_SECURE_NO_WARNINGS ${BUILDING_DLL_DEFINE})
+target_link_libraries(libpq PUBLIC ${CONAN_LIBS} ws2_32 wldap32 secur32 advapi32 shell32 crypt32)
 target_include_directories(libpq PRIVATE source_subfolder/src/include source_subfolder/src/port source_subfolder/src/backend ${CMAKE_BINARY_DIR}/include)
-set_target_properties(libpq PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+if (NOT BUILD_SHARED_LIBS)
+    # we don't need this in shared build, as have .def file)
+    set_target_properties(libpq PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 
 install(TARGETS libpq
     ARCHIVE DESTINATION lib

--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-
-from conans import ConanFile, AutoToolsBuildEnvironment, CMake, tools
+from conans import ConanFile, AutoToolsBuildEnvironment, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
@@ -13,7 +11,6 @@ class LibpqConan(ConanFile):
     homepage = "https://www.postgresql.org/docs/current/static/libpq.html"
     author = "Bincrafters <bincrafters@gmail.com>"
     license = "PostgreSQL"
-    exports_sources = ["CMakeLists.txt"]
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -25,6 +22,9 @@ class LibpqConan(ConanFile):
     generators = "cmake"
     _autotools = None
 
+    def build_requirements(self):
+        if self.settings.compiler == "Visual Studio":
+            self.build_requires("strawberryperl/5.30.0.1")
     @property
     def _source_subfolder(self):
         return "source_subfolder"
@@ -43,8 +43,6 @@ class LibpqConan(ConanFile):
     def configure(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-        if self.settings.os == 'Windows' and self.options.shared:
-            raise ConanInvalidConfiguration("libpq can not be built as shared library on Windows")
 
     def requirements(self):
         if self.options.with_zlib:
@@ -79,9 +77,18 @@ class LibpqConan(ConanFile):
         return cmake
 
     def build(self):
-        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
-            cmake = self._configure_cmake()
-            cmake.build()
+        if self.settings.compiler == "Visual Studio":
+            # https://www.postgresql.org/docs/8.3/install-win32-libpq.html
+            # https://github.com/postgres/postgres/blob/master/src/tools/msvc/README
+            if not self.options.shared:
+                tools.replace_in_file(os.path.join(self._source_subfolder, "src", "tools", "msvc", "MKvcbuild.pm"),
+                                      "$libpq = $solution->AddProject('libpq', 'dll', 'interfaces',",
+                                      "$libpq = $solution->AddProject('libpq', 'lib', 'interfaces',")
+            with tools.vcvars(self.settings):
+                config = "DEBUG" if self.settings.build_type == "Debug" else "RELEASE"
+                with tools.environment_append({"CONFIG": config}):
+                    with tools.chdir(os.path.join(self._source_subfolder, "src", "tools", "msvc")):
+                        self.run("perl build.pl libpq")
         else:
             autotools = self._configure_autotools()
             with tools.chdir(os.path.join(self._source_subfolder, "src", "backend")):
@@ -97,9 +104,18 @@ class LibpqConan(ConanFile):
 
     def package(self):
         self.copy(pattern="COPYRIGHT", dst="licenses", src=self._source_subfolder)
-        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
-            cmake = self._configure_cmake()
-            cmake.install()
+        if self.settings.compiler == "Visual Studio":
+            self.copy("*postgres_ext.h", src=self._source_subfolder, dst="include", keep_path=False)
+            self.copy("*pg_config.h", src=self._source_subfolder, dst="include", keep_path=False)
+            self.copy("*pg_config_ext.h", src=self._source_subfolder, dst="include", keep_path=False)
+            self.copy("*libpq-fe.h", src=self._source_subfolder, dst="include", keep_path=False)
+            self.copy("*libpq-events.h", src=self._source_subfolder, dst="include", keep_path=False)
+            self.copy("*.h", src=os.path.join(self._source_subfolder, "src", "include", "libpq"), dst=os.path.join("include", "libpq"), keep_path=False)
+            self.copy("*genbki.h", src=self._source_subfolder, dst=os.path.join("include", "catalog"), keep_path=False)
+            self.copy("*pg_type.h", src=self._source_subfolder, dst=os.path.join("include", "catalog"), keep_path=False)
+            self.copy("*.lib", src=self._source_subfolder, dst="lib", keep_path=False)
+            if self.options.shared:
+                self.copy("*.dll", src=self._source_subfolder, dst="bin", keep_path=False)
         else:
             autotools = self._configure_autotools()
             with tools.chdir(os.path.join(self._source_subfolder, "src", "common")):
@@ -122,4 +138,4 @@ class LibpqConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")
         elif self.settings.os == "Windows":
-            self.cpp_info.libs.extend(["ws2_32", "secur32", "advapi32", "shell32", "crypt32"])
+            self.cpp_info.libs.extend(["ws2_32", "secur32", "advapi32", "shell32", "crypt32", "wldap32"])

--- a/recipes/libpq/all/test_package/conanfile.py
+++ b/recipes/libpq/all/test_package/conanfile.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4
-
-from conans import ConanFile, CMake, tools, RunEnvironment
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -16,11 +12,5 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        with tools.environment_append(RunEnvironment(self).vars):
-            bin_path = os.path.join("bin", "test_package")
-            if self.settings.os == "Windows":
-                self.run(bin_path)
-            elif self.settings.os == "Macos":
-                self.run("DYLD_LIBRARY_PATH=%s %s" % (os.environ.get('DYLD_LIBRARY_PATH', ''), bin_path))
-            else:
-                self.run("LD_LIBRARY_PATH=%s %s" % (os.environ.get('LD_LIBRARY_PATH', ''), bin_path))
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)


### PR DESCRIPTION
* Fix source file lists to avoid link errors and to behave be as close as possible to the original MSVC projects.
* Generate more complete pg_config.h.
* Use .def file to make exported symbols work as expected.
* Add missing wldap32 library link in package_info().
* Enable dynamc build in conanfile.py

Specify library name and version:  **libpq/11.5**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Original related bug report: https://github.com/bincrafters/conan-libpq/pull/25
Original PR: https://github.com/conan-io/conan-center-index/pull/143