### PR TITLE
Libpq: Bump OpenSSL to global version 1.0.2t

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -50,7 +50,7 @@ class LibpqConan(ConanFile):
         if self.options.with_zlib:
             self.requires.add("zlib/1.2.11")
         if self.options.with_openssl:
-            self.requires.add("openssl/1.0.2s")
+            self.requires.add("openssl/1.0.2t")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **libpq**
