### PR TITLE
Add openjpeg 2.3.1

### DIFF
--- a/recipes/openjpeg/all/CMakeLists.txt
+++ b/recipes/openjpeg/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include("conanbuildinfo.cmake")
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/openjpeg/all/conandata.yml
+++ b/recipes/openjpeg/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.3.1":
+    url: "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz"
+    sha256: "63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9"

--- a/recipes/openjpeg/all/conanfile.py
+++ b/recipes/openjpeg/all/conanfile.py
@@ -1,0 +1,100 @@
+from conans import ConanFile, CMake, tools
+import os
+import glob
+import shutil
+
+
+class OpenjpegConan(ConanFile):
+    name = "openjpeg"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "OpenJPEG is an open-source JPEG 2000 codec written in C language."
+    topics = ("conan", "jpeg2000", "jp2", "openjpeg", "image", "multimedia", "format", "graphics")
+    options = {"shared": [True, False], "build_codec": [True, False], "fPIC": [True, False]}
+    default_options = {'shared': False, 'build_codec': True, 'fPIC': True}
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+    homepage = "https://github.com/uclouvain/openjpeg"
+    license = "BSD 2-Clause"
+
+    _source_subfolder = "source_subfolder"
+
+    requires = (
+        "zlib/1.2.11",
+        "lcms/2.9",
+        "libpng/1.6.37",
+        "libtiff/4.0.9"
+    )
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.remove("fPIC")
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def build(self):
+        # ensure that bundled cmake files are not used
+        os.unlink(os.path.join(self._source_subfolder, 'cmake', 'FindLCMS.cmake'))
+        os.unlink(os.path.join(self._source_subfolder, 'cmake', 'FindLCMS2.cmake'))
+
+        # fix installing libs when only shared or static library built
+        tools.replace_in_file(os.path.join(self._source_subfolder, 'src', 'lib', 'openjp2', 'CMakeLists.txt'),
+                              'add_library(${OPENJPEG_LIBRARY_NAME} ${OPENJPEG_SRCS})',
+                              'add_library(${OPENJPEG_LIBRARY_NAME} ${OPENJPEG_SRCS})\n'
+                              'set(INSTALL_LIBS ${OPENJPEG_LIBRARY_NAME})')
+
+        # cmake tries to find LCMS2 library with LCMS2 API that is packaged as lcms library
+        # it should not be changed in conan-lcms because both lcms and lcms2 names are widespread
+        tools.replace_in_file(os.path.join(self._source_subfolder, 'thirdparty', 'CMakeLists.txt'),
+                              'find_package(LCMS2)',
+                              'find_package(lcms)')
+        tools.replace_in_file(os.path.join(self._source_subfolder, 'thirdparty', 'CMakeLists.txt'),
+                              'if(LCMS2_FOUND)',
+                              'if(lcms_FOUND)')
+        tools.replace_in_file(os.path.join(self._source_subfolder, 'thirdparty', 'CMakeLists.txt'),
+                              'set(LCMS_LIBNAME ${LCMS2_LIBRARIES} PARENT_SCOPE)',
+                              'set(LCMS_LIBNAME ${lcms_LIBRARIES} PARENT_SCOPE)')
+        tools.replace_in_file(os.path.join(self._source_subfolder, 'thirdparty', 'CMakeLists.txt'),
+                              'set(LCMS_INCLUDE_DIRNAME ${LCMS2_INCLUDE_DIRS} PARENT_SCOPE)',
+                              'set(LCMS_INCLUDE_DIRNAME ${lcms_INCLUDE_DIRS} PARENT_SCOPE)')
+
+        # avoid always linking PNG
+        tools.save(os.path.join(self._source_subfolder, 'thirdparty', 'CMakeLists.txt'),
+                   'set(OPJ_HAVE_PNG_H 0 PARENT_SCOPE)\n' \
+                   'set(OPJ_HAVE_LIBPNG 0 PARENT_SCOPE)\n' \
+                   'set(PNG_LIBNAME "" PARENT_SCOPE)\n',
+                   append=True)
+
+
+        cmake = CMake(self)
+        cmake.definitions['BUILD_SHARED_LIBS'] = self.options.shared
+        cmake.definitions['BUILD_STATIC_LIBS'] = not self.options.shared
+        cmake.definitions['BUILD_PKGCONFIG_FILES'] = False
+        cmake.configure(source_folder=self._source_subfolder)
+        cmake.build()
+        cmake.install()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        # remove pkgconfig
+        tools.rmdir(os.path.join(self.package_folder, 'lib', 'pkgconfig'))
+        # remove cmake
+        for f in glob.glob(os.path.join(self.package_folder, 'lib',
+                                        'openjpeg-%s.%s' % tuple(self.version.split('.')[0:2]),
+                                        "*.cmake")):
+            os.remove(f)
+
+    def package_info(self):
+        self.cpp_info.includedirs.append(os.path.join('include', 'openjpeg-%s.%s' % tuple(self.version.split('.')[0:2])))
+        self.cpp_info.libs = tools.collect_libs(self)
+        if not self.options.shared:
+            self.cpp_info.defines.append('OPJ_STATIC')
+        if self.settings.os == "Linux":
+            self.cpp_info.libs.append("pthread")
+        self.cpp_info.name = 'OpenJPEG'

--- a/recipes/openjpeg/all/conanfile.py
+++ b/recipes/openjpeg/all/conanfile.py
@@ -80,6 +80,7 @@ class OpenjpegConan(ConanFile):
         cmake.definitions['BUILD_SHARED_LIBS'] = self.options.shared
         cmake.definitions['BUILD_STATIC_LIBS'] = not self.options.shared
         cmake.definitions['BUILD_PKGCONFIG_FILES'] = False
+        cmake.definitions['CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP'] = True
         cmake.configure()
         cmake.build()
         cmake.install()

--- a/recipes/openjpeg/all/conanfile.py
+++ b/recipes/openjpeg/all/conanfile.py
@@ -70,6 +70,10 @@ class OpenjpegConan(ConanFile):
                    'set(PNG_LIBNAME "" PARENT_SCOPE)\n',
                    append=True)
 
+        # fix missing TIFF_INCLUDE_DIR by cmake generator
+        tools.replace_in_file(os.path.join(self._source_subfolder, 'thirdparty', 'CMakeLists.txt'),
+                              'set(TIFF_INCLUDE_DIRNAME ${TIFF_INCLUDE_DIR} PARENT_SCOPE)',
+                              'set(TIFF_INCLUDE_DIRNAME ${TIFF_INCLUDE_DIRS} PARENT_SCOPE)')
 
         cmake = CMake(self)
         cmake.definitions['BUILD_SHARED_LIBS'] = self.options.shared

--- a/recipes/openjpeg/all/conanfile.py
+++ b/recipes/openjpeg/all/conanfile.py
@@ -1,7 +1,6 @@
 from conans import ConanFile, CMake, tools
 import os
 import glob
-import shutil
 
 
 class OpenjpegConan(ConanFile):

--- a/recipes/openjpeg/all/conanfile.py
+++ b/recipes/openjpeg/all/conanfile.py
@@ -14,6 +14,7 @@ class OpenjpegConan(ConanFile):
     generators = "cmake", "cmake_find_package"
     homepage = "https://github.com/uclouvain/openjpeg"
     license = "BSD 2-Clause"
+    exports_sources = ["CMakeLists.txt"]
 
     _source_subfolder = "source_subfolder"
 
@@ -79,7 +80,7 @@ class OpenjpegConan(ConanFile):
         cmake.definitions['BUILD_SHARED_LIBS'] = self.options.shared
         cmake.definitions['BUILD_STATIC_LIBS'] = not self.options.shared
         cmake.definitions['BUILD_PKGCONFIG_FILES'] = False
-        cmake.configure(source_folder=self._source_subfolder)
+        cmake.configure()
         cmake.build()
         cmake.install()
 

--- a/recipes/openjpeg/all/test_package/CMakeLists.txt
+++ b/recipes/openjpeg/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(test_package)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/openjpeg/all/test_package/conanfile.py
+++ b/recipes/openjpeg/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/openjpeg/all/test_package/test_package.cpp
+++ b/recipes/openjpeg/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+#include <cstdlib>
+#include <iostream>
+#include "openjpeg-2.3/openjpeg.h"
+
+
+int main() {
+    std::cout << "opj_has_thread_support: " << opj_has_thread_support() << std::endl;
+    std::cout << "opj_get_num_cpus: " << opj_get_num_cpus() << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/openjpeg/config.yml
+++ b/recipes/openjpeg/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.3.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **openjpeg/2.3.1**

It relies on zlib and libtiff packages that have renamed cmake files according to `cpp_info.name`. Those dependencies are recently published.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

