### PR TITLE
Add libcurl/7.66.0 and libcur/7.64.1

### DIFF
--- a/recipes/libcurl/all/CMakeLists.txt
+++ b/recipes/libcurl/all/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "7.66.0":
+    sha256: d0393da38ac74ffac67313072d7fe75b1fa1010eb5987f63f349b024a36b7ffb
+    url: https://curl.haxx.se/download/curl-7.66.0.tar.gz
+  "7.64.1":
+    sha256: 432d3f466644b9416bc5b649d344116a753aeaa520c8beaf024a90cba9d3d35d
+    url: https://curl.haxx.se/download/curl-7.64.1.tar.gz

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -88,7 +88,7 @@ class LibcurlConan(ConanFile):
         if self.options.with_openssl:
             # enforce shared linking due to openssl dependency
             if self.settings.os != "Macos" or not self.options.darwin_ssl:
-                self.options["OpenSSL"].shared = self.options.shared
+                self.options["openssl"].shared = self.options.shared
         if self.options.with_libssh2:
             if self.settings.compiler != "Visual Studio":
                 self.options["libssh2"].shared = self.options.shared
@@ -161,7 +161,7 @@ class LibcurlConan(ConanFile):
             params.append("--with-winssl")
             params.append("--without-ssl")
         elif self.options.with_openssl:
-            openssl_path = self.deps_cpp_info["OpenSSL"].rootpath.replace('\\', '/')
+            openssl_path = self.deps_cpp_info["openssl"].rootpath.replace('\\', '/')
             params.append("--with-ssl=%s" % openssl_path)
         else:
             params.append("--without-ssl")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from conans.errors import ConanInvalidConfiguration
 import os
 import re
 import shutil
 from conans import ConanFile, AutoToolsBuildEnvironment, RunEnvironment, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 
 
 class LibcurlConan(ConanFile):
@@ -16,9 +16,8 @@ class LibcurlConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://curl.haxx.se"
     license = "MIT"
-    exports = ["LICENSE.md"]
     exports_sources = ["lib_Makefile_add.am", "CMakeLists.txt"]
-    generators = "cmake"
+    generators = "cmake", "pkg_config"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False],
@@ -112,12 +111,12 @@ class LibcurlConan(ConanFile):
             elif self.settings.os == "Windows" and self.options.with_winssl:
                 pass
             else:
-                self.requires.add("openssl/1.1.1c")
+                self.requires.add("openssl/1.0.2t")
         if self.options.with_libssh2:
             if self.settings.compiler != "Visual Studio":
-                self.requires.add("libssh2/1.8.0@bincrafters/stable")
+                self.requires.add("libssh2/1.8.2")
         if self.options.with_nghttp2:
-            self.requires.add("nghttp2/1.38.0@bincrafters/stable")
+            self.requires.add("libnghttp2/1.39.2")
 
         self.requires.add("zlib/1.2.11")
 
@@ -172,7 +171,7 @@ class LibcurlConan(ConanFile):
             params.append("--without-libssh2")
 
         if self.options.with_nghttp2:
-            params.append("--with-nghttp2=%s" % self.deps_cpp_info["nghttp2"].rootpath.replace('\\', '/'))
+            params.append("--with-nghttp2=%s" % self.deps_cpp_info["libnghttp2"].rootpath.replace('\\', '/'))
         else:
             params.append("--without-nghttp2")
 

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans.errors import ConanInvalidConfiguration
+import os
+import re
+import shutil
+from conans import ConanFile, AutoToolsBuildEnvironment, RunEnvironment, CMake, tools
+
+
+class LibcurlConan(ConanFile):
+    name = "libcurl"
+
+    description = "command line tool and library for transferring data with URLs"
+    topics = ("conan", "libcurl", "data-transfer")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://curl.haxx.se"
+    license = "MIT"
+    exports = ["LICENSE.md"]
+    exports_sources = ["lib_Makefile_add.am", "CMakeLists.txt"]
+    generators = "cmake"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"shared": [True, False],
+               "fPIC": [True, False],
+               "with_openssl": [True, False],
+               "with_winssl": [True, False],
+               "disable_threads": [True, False],
+               "with_ldap": [True, False],
+               "custom_cacert": [True, False],
+               "darwin_ssl": [True, False],
+               "with_libssh2": [True, False],
+               "with_libidn": [True, False],
+               "with_librtmp": [True, False],
+               "with_libmetalink": [True, False],
+               "with_libpsl": [True, False],
+               "with_largemaxwritesize": [True, False],
+               "with_nghttp2": [True, False],
+               "with_brotli": [True, False]}
+    default_options = {'shared': False,
+                       'fPIC': True,
+                       'with_openssl': True,
+                       'with_winssl': False,
+                       'disable_threads': False,
+                       'with_ldap': False,
+                       'custom_cacert': False,
+                       'darwin_ssl': True,
+                       'with_libssh2': False,
+                       'with_libidn': False,
+                       'with_librtmp': False,
+                       'with_libmetalink': False,
+                       'with_libpsl': False,
+                       'with_largemaxwritesize': False,
+                       'with_nghttp2': False,
+                       'with_brotli': False
+                       }
+
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
+    _autotools = False
+
+    @property
+    def is_mingw(self):
+        return self.settings.os == "Windows" and self.settings.compiler != "Visual Studio"
+
+    def imports(self):
+        # Copy shared libraries for dependencies to fix DYLD_LIBRARY_PATH problems
+        #
+        # Configure script creates conftest that cannot execute without shared openssl binaries.
+        # Ways to solve the problem:
+        # 1. set *LD_LIBRARY_PATH (works with Linux with RunEnvironment
+        #     but does not work on OS X 10.11 with SIP)
+        # 2. copying dylib's to the build directory (fortunately works on OS X)
+
+        if self.settings.os == "Macos":
+            self.copy("*.dylib*", dst=self._source_subfolder, keep_path=False)
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+
+        # be careful with those flags:
+        # - with_openssl AND darwin_ssl uses darwin_ssl (to maintain recipe compatibilty)
+        # - with_openssl AND NOT darwin_ssl uses openssl
+        # - with_openssl AND with_winssl raises to error
+        # - with_openssl AND NOT with_winssl uses openssl
+        # Moreover darwin_ssl is set by default and with_winssl is not
+
+        if self.options.with_openssl:
+            # enforce shared linking due to openssl dependency
+            if self.settings.os != "Macos" or not self.options.darwin_ssl:
+                self.options["OpenSSL"].shared = self.options.shared
+        if self.options.with_libssh2:
+            if self.settings.compiler != "Visual Studio":
+                self.options["libssh2"].shared = self.options.shared
+
+    def config_options(self):
+        if self.settings.os != "Macos":
+            self.options.remove("darwin_ssl")
+        if self.settings.os != "Windows":
+            self.options.remove("with_winssl")
+
+        if self.settings.os == "Windows" and self.options.with_winssl and self.options.with_openssl:
+            raise ConanInvalidConfiguration('Specify only with_winssl or with_openssl')
+
+        if self.settings.os == "Windows":
+            self.options.remove("fPIC")
+
+    def requirements(self):
+        if self.options.with_openssl:
+            if self.settings.os == "Macos" and self.options.darwin_ssl:
+                pass
+            elif self.settings.os == "Windows" and self.options.with_winssl:
+                pass
+            else:
+                self.requires.add("openssl/1.1.1c")
+        if self.options.with_libssh2:
+            if self.settings.compiler != "Visual Studio":
+                self.requires.add("libssh2/1.8.0@bincrafters/stable")
+        if self.options.with_nghttp2:
+            self.requires.add("nghttp2/1.38.0@bincrafters/stable")
+
+        self.requires.add("zlib/1.2.11")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("curl-%s" % self.version, self._source_subfolder)
+        tools.download("https://curl.haxx.se/ca/cacert.pem", "cacert.pem", verify=True)
+
+    def build(self):
+        self.patch_misc_files()
+        if self.settings.compiler != "Visual Studio":
+            self.build_with_autotools()
+        else:
+            self.build_with_cmake()
+
+    def patch_misc_files(self):
+        if self.options.with_largemaxwritesize:
+            tools.replace_in_file(os.path.join(self._source_subfolder, 'include', 'curl', 'curl.h'),
+                                  "define CURL_MAX_WRITE_SIZE 16384",
+                                  "define CURL_MAX_WRITE_SIZE 10485760")
+
+        # https://github.com/curl/curl/issues/2835
+        if self.settings.compiler == 'apple-clang' and self.settings.compiler.version == '9.1':
+            if self.options.darwin_ssl:
+                tools.replace_in_file(os.path.join(self._source_subfolder, 'lib', 'vtls', 'sectransp.c'),
+                                      '#define CURL_BUILD_MAC_10_13 MAC_OS_X_VERSION_MAX_ALLOWED >= 101300',
+                                      '#define CURL_BUILD_MAC_10_13 0')
+
+    def get_configure_command_args(self):
+        params = []
+        params.append("--without-libidn2" if not self.options.with_libidn else "--with-libidn2")
+        params.append("--without-librtmp" if not self.options.with_librtmp else "--with-librtmp")
+        params.append("--without-libmetalink" if not self.options.with_libmetalink else "--with-libmetalink")
+        params.append("--without-libpsl" if not self.options.with_libpsl else "--with-libpsl")
+        params.append("--without-brotli" if not self.options.with_brotli else "--with-brotli")
+
+        if self.settings.os == "Macos" and self.options.darwin_ssl:
+            params.append("--with-darwinssl")
+            params.append("--without-ssl")
+        elif self.settings.os == "Windows" and self.options.with_winssl:
+            params.append("--with-winssl")
+            params.append("--without-ssl")
+        elif self.options.with_openssl:
+            openssl_path = self.deps_cpp_info["OpenSSL"].rootpath.replace('\\', '/')
+            params.append("--with-ssl=%s" % openssl_path)
+        else:
+            params.append("--without-ssl")
+
+        if self.options.with_libssh2:
+            params.append("--with-libssh2=%s" % self.deps_cpp_info["libssh2"].lib_paths[0].replace('\\', '/'))
+        else:
+            params.append("--without-libssh2")
+
+        if self.options.with_nghttp2:
+            params.append("--with-nghttp2=%s" % self.deps_cpp_info["nghttp2"].rootpath.replace('\\', '/'))
+        else:
+            params.append("--without-nghttp2")
+
+        params.append("--with-zlib=%s" % self.deps_cpp_info["zlib"].lib_paths[0].replace('\\', '/'))
+
+        if not self.options.shared:
+            params.append("--disable-shared")
+            params.append("--enable-static")
+        else:
+            params.append("--enable-shared")
+            params.append("--disable-static")
+
+        if self.options.disable_threads:
+            params.append("--disable-thread")
+
+        if not self.options.with_ldap:
+            params.append("--disable-ldap")
+
+        if self.options.custom_cacert:
+            params.append('--with-ca-bundle=cacert.pem')
+
+        # Cross building flags
+        if tools.cross_building(self.settings):
+            if self.settings.os == "Linux" and "arm" in self.settings.arch:
+                params.append('--host=%s' % self.get_linux_arm_host())
+
+        return params
+
+    def get_linux_arm_host(self):
+        arch = None
+        if self.settings.os == 'Linux':
+            arch = 'arm-linux-gnu'
+            # aarch64 could be added by user
+            if 'aarch64' in self.settings.arch:
+                arch = 'aarch64-linux-gnu'
+            elif 'arm' in self.settings.arch and 'hf' in self.settings.arch:
+                arch = 'arm-linux-gnueabihf'
+            elif 'arm' in self.settings.arch and self.arm_version(str(self.settings.arch)) > 4:
+                arch = 'arm-linux-gnueabi'
+        return arch
+
+    def arm_version(self, arch):
+        version = None
+        match = re.match(r"arm\w*(\d)", arch)
+        if match:
+            version = int(match.group(1))
+        return version
+
+    def patch_mingw_files(self):
+        if not self.is_mingw:
+            return
+        # patch autotools files
+        # for mingw builds - do not compile curl tool, just library
+        # linking errors are much harder to fix than to exclude curl tool
+        tools.replace_in_file("Makefile.am",
+                              'SUBDIRS = lib src',
+                              'SUBDIRS = lib')
+
+        tools.replace_in_file("Makefile.am",
+                              'include src/Makefile.inc',
+                              '')
+
+        # patch for zlib naming in mingw
+        # when cross-building, the name is correct
+        if not tools.cross_building(self.settings):
+            tools.replace_in_file("configure.ac",
+                                  '-lz ',
+                                  '-lzlib ')
+
+        if self.options.shared:
+            # patch for shared mingw build
+            tools.replace_in_file(os.path.join('lib', 'Makefile.am'),
+                                  'noinst_LTLIBRARIES = libcurlu.la',
+                                  '')
+            tools.replace_in_file(os.path.join('lib', 'Makefile.am'),
+                                  'noinst_LTLIBRARIES =',
+                                  '')
+            tools.replace_in_file(os.path.join('lib', 'Makefile.am'),
+                                  'lib_LTLIBRARIES = libcurl.la',
+                                  'noinst_LTLIBRARIES = libcurl.la')
+            # add directives to build dll
+            # used only for native mingw-make
+            if not tools.cross_building(self.settings):
+                added_content = tools.load(os.path.join(self.source_folder, 'lib_Makefile_add.am'))
+                tools.save(os.path.join('lib', 'Makefile.am'), added_content, append=True)
+
+    def build_with_autotools(self):
+        env_run = RunEnvironment(self)
+        # run configure with *LD_LIBRARY_PATH env vars
+        # it allows to pick up shared openssl
+        self.output.info("Run vars: " + repr(env_run.vars))
+        with tools.environment_append(env_run.vars):
+            with tools.chdir(self._source_subfolder):
+                use_win_bash = self.is_mingw and not tools.cross_building(self.settings)
+                autotools, autotools_vars = self._configure_autotools()
+
+                # autoreconf
+                self.run('./buildconf', win_bash=use_win_bash)
+
+                # fix generated autotools files
+                tools.replace_in_file("configure", "-install_name \\$rpath/", "-install_name ")
+                self.run("chmod +x configure")
+
+                configure_args = self.get_configure_command_args()
+                autotools.configure(vars=autotools_vars, args=configure_args)
+                autotools.make(vars=autotools_vars)
+
+    def _configure_autotools_vars(self):
+        autotools_vars = self._autotools.vars
+        # tweaks for mingw
+        if self.is_mingw:
+            autotools_vars['RCFLAGS'] = '-O COFF'
+            if self.settings.arch == "x86":
+                autotools_vars['RCFLAGS'] += ' --target=pe-i386'
+            else:
+                autotools_vars['RCFLAGS'] += ' --target=pe-x86-64'
+
+            del autotools_vars['LIBS']
+            self.output.info("Autotools env vars: " + repr(autotools_vars))
+        return autotools_vars
+
+    def _configure_autotools(self):
+        if not self._autotools:
+            use_win_bash = self.is_mingw and not tools.cross_building(self.settings)
+            self._autotools = AutoToolsBuildEnvironment(self, win_bash=use_win_bash)
+
+            if self.settings.os != "Windows":
+                self._autotools.fpic = self.options.fPIC
+
+            autotools_vars = self._configure_autotools_vars()
+
+            # tweaks for mingw
+            if self.is_mingw:
+                # patch autotools files
+                self.patch_mingw_files()
+
+                self._autotools.defines.append('_AMD64_')
+
+            configure_args = self.get_configure_command_args()
+            self._autotools.configure(vars=autotools_vars, args=configure_args)
+
+        return self._autotools, self._configure_autotools_vars()
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions['BUILD_TESTING'] = False
+        cmake.definitions['BUILD_CURL_EXE'] = False
+        cmake.definitions['CURL_DISABLE_LDAP'] = not self.options.with_ldap
+        cmake.definitions['BUILD_SHARED_LIBS'] = self.options.shared
+        cmake.definitions['CURL_STATICLIB'] = not self.options.shared
+        cmake.definitions['CMAKE_DEBUG_POSTFIX'] = ''
+        cmake.definitions['CMAKE_USE_LIBSSH2'] = self.options.with_libssh2
+
+        # all these options are exclusive. set just one of them
+        # mac builds do not use cmake so don't even bother about darwin_ssl
+        cmake.definitions['CMAKE_USE_WINSSL'] = 'with_winssl' in self.options and self.options.with_winssl
+        cmake.definitions['CMAKE_USE_OPENSSL'] = 'with_openssl' in self.options and self.options.with_openssl
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build_with_cmake(self):
+        # patch cmake files
+        with tools.chdir(self._source_subfolder):
+            tools.replace_in_file("CMakeLists.txt",
+                                  "include(CurlSymbolHiding)",
+                                  "")
+
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="COPYING*", dst="licenses", src=self._source_subfolder, ignore_case=True, keep_path=False)
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+
+        # Execute install
+        if self.settings.compiler != "Visual Studio":
+            env_run = RunEnvironment(self)
+
+            with tools.environment_append(env_run.vars):
+                with tools.chdir(self._source_subfolder):
+                    autotools, autotools_vars = self._configure_autotools()
+                    autotools.install(vars=autotools_vars)
+        else:
+            cmake = self._configure_cmake()
+            cmake.install()
+
+        # Copy the certs to be used by client
+        self.copy("cacert.pem", keep_path=False)
+
+        if self.settings.os == "Windows" and self.settings.compiler != "Visual Studio":
+            # Handle only mingw libs
+            self.copy(pattern="*.dll", dst="bin", keep_path=False)
+            self.copy(pattern="*dll.a", dst="lib", keep_path=False)
+            self.copy(pattern="*.def", dst="lib", keep_path=False)
+            self.copy(pattern="*.lib", dst="lib", keep_path=False)
+
+        # no need to distribute share folder (docs/man pages)
+        shutil.rmtree(os.path.join(self.package_folder, 'share'), ignore_errors=True)
+        # no need for pc files 
+        shutil.rmtree(os.path.join(self.package_folder, 'lib', 'pkgconfig'), ignore_errors=True)
+        # Remove libtool files (*.la)
+        if os.path.isfile(os.path.join(self.package_folder, 'lib', 'libcurl.la')):
+            os.remove(os.path.join(self.package_folder, 'lib', 'libcurl.la'))
+
+    def package_info(self):
+        if self.settings.compiler != "Visual Studio":
+            self.cpp_info.libs = ['curl']
+            if self.settings.os == "Linux":
+                self.cpp_info.libs.extend(["rt", "pthread"])
+                if self.options.with_libssh2:
+                    self.cpp_info.libs.extend(["ssh2"])
+                if self.options.with_libidn:
+                    self.cpp_info.libs.extend(["idn"])
+                if self.options.with_librtmp:
+                    self.cpp_info.libs.extend(["rtmp"])
+                if self.options.with_brotli:
+                    self.cpp_info.libs.extend(["brotlidec"])
+            if self.settings.os == "Macos":
+                if self.options.with_ldap:
+                    self.cpp_info.libs.extend(["ldap"])
+                if self.options.darwin_ssl:
+                    self.cpp_info.exelinkflags.append("-framework Cocoa")
+                    self.cpp_info.exelinkflags.append("-framework Security")
+                    self.cpp_info.sharedlinkflags = self.cpp_info.exelinkflags
+        else:
+            self.cpp_info.libs = ['libcurl_imp'] if self.options.shared else ['libcurl']
+
+        if self.settings.os == "Windows":
+            # used on Windows for VS build, native and cross mingw build
+            self.cpp_info.libs.append('ws2_32')
+            if self.options.with_ldap:
+                self.cpp_info.libs.append("wldap32")
+            if self.options.with_winssl:
+                self.cpp_info.libs.append("Crypt32")
+
+        if self.is_mingw:
+            # provide pthread for dependent packages
+            self.cpp_info.cflags.append("-pthread")
+            self.cpp_info.exelinkflags.append("-pthread")
+            self.cpp_info.sharedlinkflags.append("-pthread")
+
+        if not self.options.shared:
+            self.cpp_info.defines.append("CURL_STATICLIB=1")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import os
 import re
 import shutil

--- a/recipes/libcurl/all/lib_Makefile_add.am
+++ b/recipes/libcurl/all/lib_Makefile_add.am
@@ -1,0 +1,24 @@
+
+libcurl_dll_LIBRARY = libcurl.dll
+libcurl_dll_a_LIBRARY = libcurl.dll.a
+
+LIBCURL_OBJECTS := $(patsubst %.c,%.o,$(strip $(CSOURCES)))
+
+RESOURCE = libcurl.res
+
+RC = windres
+
+all-local: $(libcurl_dll_LIBRARY)
+
+
+$(libcurl_dll_LIBRARY): $(LIBCURL_OBJECTS) $(RESOURCE) $(libcurl_dll_DEPENDENCIES)
+	@$(call DEL, $@)
+	$(CC) $(LDFLAGS) -shared -o $@ \
+	  -Wl,--output-def,$(@:.dll=.def),--out-implib,$(libcurl_dll_a_LIBRARY) \
+	  $(LIBCURL_OBJECTS) $(RESOURCE) $(LIBCURL_LIBS)
+
+%.o: %.c $(PROOT)/include/curl/curlbuild.h
+	$(CC) $(INCLUDES) $(CFLAGS) -c $< -o $@
+
+%.res: %.rc
+	$(RC) $(RCFLAGS) -i $< -o $@

--- a/recipes/libcurl/all/test_package/CMakeLists.txt
+++ b/recipes/libcurl/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/libcurl/all/test_package/conanfile.py
+++ b/recipes/libcurl/all/test_package/conanfile.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile, CMake, tools
+import os
+import subprocess
+import re
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if "arm" in self.settings.arch:
+            self.test_arm()
+        elif tools.cross_building(self.settings) and self.settings.os == "Windows":
+            self.test_mingw_cross()
+        else:
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)
+
+    def test_mingw_cross(self):
+        bin_path = os.path.join("bin", "test_package.exe")
+        output = subprocess.check_output(["file", bin_path]).decode()
+        assert re.search(r"PE32.*executable.*Windows", output)
+
+    def test_arm(self):
+        file_ext = "so" if self.options["libcurl"].shared else "a"
+        lib_path = os.path.join(self.deps_cpp_info["libcurl"].libdirs[0], "libcurl.%s" % file_ext)
+        output = subprocess.check_output(["readelf", "-h", lib_path]).decode()
+
+        if "armv8" in self.settings.arch:
+            if self.settings.arch == "armv8_32":
+                assert re.search(r"Machine:\s+ARM", output)
+            else:
+                assert re.search(r"Machine:\s+AArch64", output)
+        else:
+            assert re.search(r"Machine:\s+ARM", output)

--- a/recipes/libcurl/all/test_package/test_package.cpp
+++ b/recipes/libcurl/all/test_package/test_package.cpp
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main(void)
+{
+  CURL *curl;
+  int retval = 0;
+  const char *const *proto;
+  curl_version_info_data* id = curl_version_info(CURLVERSION_NOW);
+  if (!id)
+    return 1;
+
+  printf("protocols: ");
+  for(proto = id->protocols; *proto; proto++) {
+    printf("%s ", *proto);
+  }
+  printf("\nversion: %s\nssl version: %s\nfeatures: %d\n", id->version, id->ssl_version, id->features);
+
+  curl = curl_easy_init();
+  if(curl) {
+    char errbuf[CURL_ERROR_SIZE];
+
+    /* provide a buffer to store errors in */
+    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
+
+    /* always cleanup */ 
+    curl_easy_cleanup(curl);
+    printf("Succeed\n");
+  } else {
+    printf("Failed to init curl\n");
+    retval = 3;
+  }
+
+  return retval;
+}

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,0 +1,5 @@
+versions:
+  "7.66.0":
+    folder: all
+  "7.64.1":
+    folder: all


### PR DESCRIPTION
Something looks like broken here: https://github.com/conan-io/conan-center-index/pull/235

Specify library name and version:  **libcurl/7.64.1** and **libcurl/7.66.0**
 
- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.



