### PR TITLE
Add lzma_sdk to bootstrap 7zip

### DIFF
--- a/recipes/lzma_sdk/9.20/conandata.yml
+++ b/recipes/lzma_sdk/9.20/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "9.20":
+    url: https://www.7-zip.org/a/lzma920.tar.bz2
+    sha256: 8ac221acdca8b6f6dd110120763af42b3707363752fc04e63c7bbff76774a445

--- a/recipes/lzma_sdk/9.20/conanfile.py
+++ b/recipes/lzma_sdk/9.20/conanfile.py
@@ -1,0 +1,133 @@
+import os
+from conans import ConanFile, tools, AutoToolsBuildEnvironment, VisualStudioBuildEnvironment
+
+
+""" This older lzma release is used to build 7zip (to extract its sources).
+    That's why this lzma_sdk/9.20 conan package includes a 7zDec executable.
+
+    Recent versions of 7zip are distributed as 7z archives.
+    So we need 7zip itself to uncompress its sources.
+    To break this cycle, we have 2 options:
+    * download an executable and run it
+    * bootstrap using a previous version (lzma_sdk/9.20) which sources are in .tar.bz2.
+    Right now it would be a loop in the Conan graph (if we'ld use the same recipe name)
+"""
+
+
+class PackageLzmaSdk(ConanFile):
+    name = "lzma_sdk"
+    version = "9.20"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "LZMA provides a high compression ratio and fast decompression, so it is very suitable for embedded applications."
+    license = ("LZMA-exception",)
+    homepage = "https://www.7-zip.org/sdk.html"
+    topics = ("conan", "lzma", "zip", "compression", "decompression")
+    settings = "os_build", "arch_build", "compiler"
+
+    def build_requirements(self):
+        if tools.os_info.is_windows and os.environ.get("CONAN_BASH_PATH", None) is None:
+            self.build_requires("msys2/20161025")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.unlink(os.path.join(self.source_folder, "7zr.exe"))
+        os.unlink(os.path.join(self.source_folder, "lzma.exe"))
+
+    @property
+    def _msvc_build_dirs(self):
+        return (
+            [os.path.join("C","Util","7z"), [["7zDec.exe"], []]],
+            [os.path.join("C","Util","Lzma"), [["LZMAc.exe"], []]],
+            [os.path.join("CPP","7zip","UI","Console"), [["7z.exe"], []]],
+            [os.path.join("CPP","7zip","Bundles","Alone7z"), [["7zr.exe"], []]],
+            [os.path.join("CPP","7zip","Bundles","LzmaCon"), [["lzma.exe"], []]],
+        )
+
+    @property
+    def _msvc_cpu(self):
+        return {
+            'x86_64': 'AMD64',
+            'x86': 'x86',
+        }[str(self.settings.arch_build)]
+
+    @property
+    def _autotools_build_dirs(self):
+        es = ".exe" if self.settings.os_build == "Windows" else ""
+        return (
+            [os.path.join("C","Util","7z"), [["7zDec{}".format(es)], []]],
+            [os.path.join("CPP","7zip","Bundles","LzmaCon"), [["lzma{}".format(es)],[]]]
+        )
+
+    def _build_msvc(self):
+        env_build = VisualStudioBuildEnvironment(self)
+        with tools.environment_append(env_build.vars):
+            vcvars = tools.vcvars_command(self.settings)
+            for make_dir, _ in self._msvc_build_dirs:
+                with tools.chdir(make_dir):
+                    self.run("%s && nmake /f makefile NEW_COMPILER=1 CPU=%s" % (vcvars, self._msvc_cpu))
+
+    def _build_autotools(self):
+        env_build = AutoToolsBuildEnvironment(self)
+        with tools.environment_append(env_build.vars):
+            for make_dir, _ in self._autotools_build_dirs:
+                with tools.chdir(make_dir):
+                    extra_args = ""
+                    if self.settings.os_build == "Windows":
+                        extra_args += " IS_MINGW=1"
+                    self.run("make -f makefile.gcc all%s" % extra_args)
+
+    def _patch_sources(self):
+        if self.settings.compiler == "Visual Studio":
+            tools.replace_in_file(os.path.join(self.build_folder, "CPP", "Build.mak"),
+                                  "-MT\r", "-" + str(self.settings.compiler.runtime))
+            tools.replace_in_file(os.path.join(self.build_folder, "CPP", "Build.mak"),
+                                  "-MD\r", "-" + str(self.settings.compiler.runtime))
+            tools.replace_in_file(os.path.join(self.build_folder, "CPP", "Build.mak"),
+                                  " -WX ", " ")
+
+        # Patches for other build systems
+        tools.replace_in_file(os.path.join(self.build_folder, "C", "Util", "7z", "makefile.gcc"),
+                              "CFLAGS = ",
+                              "CFLAGS = -fpermissive ")
+        tools.replace_in_file(os.path.join(self.build_folder, "C", "Util", "7z", "makefile.gcc"),
+                              ": 7zAlloc.c",
+                              ": ../../7zAlloc.c")
+        tools.replace_in_file(os.path.join(self.build_folder, "C", "Util", "Lzma", "makefile.gcc"),
+                              "CFLAGS = ",
+                              "CFLAGS = -fpermissive ")
+        tools.replace_in_file(os.path.join(self.build_folder, "CPP", "Common", "MyString.h"),
+                              "#ifdef _WIN32\r\n",
+                              "#ifdef _WIN32\r\n#ifndef UNDER_CE\r\n#include <windows.h>\r\n#endif\r\n")
+
+    def build(self):
+        self._patch_sources()
+        if self.settings.compiler == "Visual Studio":
+            self._build_msvc()
+        else:
+            self._build_autotools()
+
+    def package(self):
+        self.copy("lzma.txt", src=self.source_folder, dst="licenses")
+        self.copy("7zC.txt", src=self.source_folder, dst="licenses")
+        if self.settings.compiler == "Visual Studio":
+            for make_dir, [exes, libs] in self._msvc_build_dirs:
+                for exe in exes:
+                    self.copy(exe, src=os.path.join(make_dir, self._msvc_cpu), dst="bin", keep_path=False)
+                for lib in libs:
+                    self.copy(lib, src=os.path.join(make_dir, self._msvc_cpu), dst="lib", keep_path=False)
+        else:
+            for make_dir, [exes, libs] in self._autotools_build_dirs:
+                for exe in exes:
+                    self.copy(exe, src=os.path.join(make_dir), dst="bin", keep_path=False)
+                for lib in libs:
+                    self.copy(lib, src=os.path.join(make_dir), dst="lib", keep_path=False)
+
+    def package_id(self):
+        self.info.include_build_settings()
+        del self.info.settings.compiler
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info('Appending PATH environment variable: %s' % bin_path)
+        self.env_info.path.append(bin_path)

--- a/recipes/lzma_sdk/9.20/test_package/conanfile.py
+++ b/recipes/lzma_sdk/9.20/test_package/conanfile.py
@@ -1,0 +1,8 @@
+from conans import ConanFile
+
+
+class TestPackage(ConanFile):
+
+    def test(self):
+        self.run("7zDec")
+        self.run("lzma")


### PR DESCRIPTION
Specify library name and version:  **lzma_sdk/9.20**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Later versions of 7zip are only distributed as 7z archives.
Because older versions of 7zip were distributed as regular archives, an older version of 7zip is used to unpack these files.
Because conan does not support a package requiring a package of the same name,
I have introduced ~*7zip_bootstrap*~ *lzma_sdk* as a build requirement for 7zip.

Using ~*7zip_bootstrap*~ *lzma_sdk* as a build requirement for 7zip will also allow 7zip to be built on Linux,
because right now 7zip only builds on Windows.
This is because 7zip uses prebuilt Windows executables of the older 7zip releases.



Tested on Linux and Windows.
This allows building 7zip on Windows and Linux.


