### PR TITLE
Fix fPIC support for lz4

### DIFF
--- a/recipes/lz4/all/CMakeLists.txt
+++ b/recipes/lz4/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder/contrib/cmake_unofficial)

--- a/recipes/lz4/all/conandata.yml
+++ b/recipes/lz4/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "1.9.2":
     sha256: 658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc
     url: https://github.com/lz4/lz4/archive/v1.9.2.tar.gz
+patches:
+  "1.9.2":
+    - patch_file: "patches/0001-cmake-add-shared-DEFINE_SYMBOL.patch"
+      base_path: "source_subfolder"

--- a/recipes/lz4/all/conanfile.py
+++ b/recipes/lz4/all/conanfile.py
@@ -23,7 +23,7 @@ class LZ4Conan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx
-        del self.settings.compiler.stdcpp
+        del self.settings.compiler.cppstd
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/lz4/all/patches/0001-cmake-add-shared-DEFINE_SYMBOL.patch
+++ b/recipes/lz4/all/patches/0001-cmake-add-shared-DEFINE_SYMBOL.patch
@@ -1,0 +1,16 @@
+--- contrib/cmake_unofficial/CMakeLists.txt
++++ contrib/cmake_unofficial/CMakeLists.txt
+@@ -103,9 +103,13 @@
+ if(BUILD_SHARED_LIBS)
+   add_library(lz4_shared SHARED ${LZ4_SOURCES})
+   set_target_properties(lz4_shared PROPERTIES
+     OUTPUT_NAME lz4
+     SOVERSION "${LZ4_VERSION_MAJOR}"
+     VERSION "${LZ4_VERSION_STRING}")
+   list(APPEND LZ4_LIBRARIES_BUILT lz4_shared)
++   if(MSVC)
++     set_target_properties(lz4_shared PROPERTIES
++       DEFINE_SYMBOL LZ4_DLL_EXPORT=1)
++   endif()
+ endif()
+ if(BUILD_STATIC_LIBS)

--- a/recipes/lz4/all/test_package/CMakeLists.txt
+++ b/recipes/lz4/all/test_package/CMakeLists.txt
@@ -1,9 +1,20 @@
 project(test_package CXX)
 cmake_minimum_required(VERSION 2.8.12)
 
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
 target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CONAN_INCLUDE_DIRS})
 set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+
+option(TEST_SHARED_LIB "Use package in a shared library")
+if(TEST_AS_SHARED_LIB)
+    add_library(${CMAKE_PROJECT_NAME}2 SHARED lib.cpp)
+    target_link_libraries(${CMAKE_PROJECT_NAME}2 ${CONAN_LIBS})
+    target_include_directories(${CMAKE_PROJECT_NAME}2 PRIVATE ${CONAN_INCLUDE_DIRS})
+    set_property(TARGET ${CMAKE_PROJECT_NAME}2 PROPERTY CXX_STANDARD 11)
+endif()

--- a/recipes/lz4/all/test_package/conanfile.py
+++ b/recipes/lz4/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools, RunEnvironment
+from conans import ConanFile, CMake
 import os
 
 
@@ -8,6 +8,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["TEST_SHARED_LIB"] = dict(self.options["lz4"].items()).get("fPIC", True)
         cmake.configure()
         cmake.build()
 

--- a/recipes/lz4/all/test_package/lib.cpp
+++ b/recipes/lz4/all/test_package/lib.cpp
@@ -1,0 +1,13 @@
+#include "lz4.h"
+
+#ifdef _MSC_VER
+#define API __declspec(dllexport)
+#else
+#define API __attribute__ ((visibility("default")))
+#endif
+
+API
+int lz4_version()
+{
+    return LZ4_versionNumber();
+}


### PR DESCRIPTION
Specify library name and version:  **lz4/1.9.2**

- The Makefile based build system of lz4 does not pass `-fPIC` shen building a static library with `fPIC` enabled.
It also does not compile 32-bit libraries on 64-bit platforms. (it does not pass `-m32`)
~This pr adds a `FPIC` option to the makefile.~

- ~Also rename the static library in a static lz4 build on Windows to `lz4.lib` so a cmake `find_library(LZ4_LIB lz4)` will work on all platforms~

This pr adds a cmake based build system so it will automatically use the correct flags.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

