### PR TITLE
fix find_package(LibXML2 REQUIRED) on static Visual Studio builds of libxml2

### DIFF
--- a/recipes/libxml2/all/test_package/CMakeLists.txt
+++ b/recipes/libxml2/all/test_package/CMakeLists.txt
@@ -6,3 +6,5 @@ CONAN_BASIC_SETUP()
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+
+find_package(LibXML2 REQUIRED)


### PR DESCRIPTION
Specify library name and version:  **libxml2/2.9.9**

A static libxml2 build on Windows using Visual Studio generates a `libxml2_a.lib` file.
This library is not detected by cmake's `find_package(LibXML2)`.
So rename it to `libxml2.lib`.


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

