### PR TITLE
[libxml2] Use LibXml2 as cmake name

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -204,3 +204,4 @@ class Libxml2Conan(ConanFile):
             self.cpp_info.libs.append('m')
         if self.settings.os == "Windows":
             self.cpp_info.libs.append('ws2_32')
+        self.cpp_info.name = 'LibXml2'


### PR DESCRIPTION
Specify library name and version:  **libxml2/2.9.9**

As known in standard cmake module

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

