### PR TITLE
[xerces-c] Use XercesC as cmake name

### DIFF
--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -80,3 +80,4 @@ class XercesCConan(ConanFile):
             self.cpp_info.frameworks = ['CoreFoundation', 'CoreServices']
         elif self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")
+        self.cpp_info.name = 'XercesC'


### PR DESCRIPTION
Specify library name and version:  **xerces-c/2.9.9**

As known in standard cmake module

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

