### PR TITLE
add mbedtls support to libssh2

### DIFF
--- a/recipes/libssh2/all/CMakeLists.txt
+++ b/recipes/libssh2/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/libssh2/all/test_package/conanfile.py
+++ b/recipes/libssh2/all/test_package/conanfile.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, CMake, tools
 import os
 


### PR DESCRIPTION
Specify library name and version:  **libssh2/1.8.0** and **libssh2/1.8.2**

This adds support for mbedtls

Depends on #279

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

