### PR TITLE
Update Protobuf module name to CamelCase

### DIFF
--- a/recipes/protobuf/3.9.x/conanfile.py
+++ b/recipes/protobuf/3.9.x/conanfile.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 import os
-
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 from conans.tools import Version
@@ -87,3 +85,4 @@ class ProtobufConan(ConanFile):
         if self.settings.os == "Windows":
             if self.options.shared:
                 self.cpp_info.defines = ["PROTOBUF_USE_DLLS"]
+        self.cpp_info.name = "Protobuf"


### PR DESCRIPTION
Specify library name and version:  **protobuf/3.9.1**

Required by PR #65 

Protoc requires Protobuf library, but the correct CMake module name is Protobuf, not protobuf.

https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/FindProtobuf.cmake


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

