### PR TITLE
Fix Bzip2 1.0.6: non-ASCII character

### DIFF
--- a/recipes/bzip2/1.0.6/conanfile.py
+++ b/recipes/bzip2/1.0.6/conanfile.py
@@ -9,7 +9,7 @@ class Bzip2Conan(ConanFile):
     homepage = "http://www.bzip.org"
     author = "Conan Community"
     license = "bzip2-1.0.6"
-    description = "bzip2 is a free and open-source file compression program that uses the Burrows–Wheeler algorithm."
+    description = "bzip2 is a free and open-source file compression program that uses the Burrows Wheeler algorithm."
     topics = ("conan", "bzip2", "data-compressor", "file-compression")
     settings = "os", "compiler", "arch", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False], "build_executable": [True, False]}

--- a/recipes/bzip2/1.0.6/conanfile.py
+++ b/recipes/bzip2/1.0.6/conanfile.py
@@ -6,8 +6,7 @@ class Bzip2Conan(ConanFile):
     name = "bzip2"
     version = "1.0.6"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "http://www.bzip.org"
-    author = "Conan Community"
+    homepage = "http://www.bzip.org"    
     license = "bzip2-1.0.6"
     description = "bzip2 is a free and open-source file compression program that uses the Burrows Wheeler algorithm."
     topics = ("conan", "bzip2", "data-compressor", "file-compression")


### PR DESCRIPTION
Specify library name and version:  **bzip2/1.0.6**

Remove en-dash which is incompatible with Python 2

![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRcTAivfscQclZNmVgLF3YQZCtoHtZhrfOTdBLSCcuPbGz_vlOb&s)

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

