### PR TITLE
Remove author for lcms recipe

### DIFF
--- a/recipes/lcms/all/conanfile.py
+++ b/recipes/lcms/all/conanfile.py
@@ -10,7 +10,6 @@ class LcmsConan(ConanFile):
     description = "A free, open source, CMM engine."
     license = "MIT"
     homepage = "https://github.com/mm2/Little-CMS"
-    author = "Bicrafters <bincrafters@gmail.com>"
     topics = ("conan", "lcms", "cmm", "icc", "cmm-engine")
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}


### PR DESCRIPTION
Specify library name and version:  **lcms/2.9**

Merge job for PR #289 failed due to a hook check error. This PR fixes it by removing the author.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

