### PR TITLE
[boost] fix bootstrap toolset selection for 1.71+

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -772,8 +772,11 @@ class BoostConan(ConanFile):
                                                     str(self.settings.compiler))
 
         # fallback for the case when no unversioned gcc/clang is available
-        if with_toolset in ["gcc", "clang"] and not tools.which(with_toolset):
-            with_toolset = "cc"
+        if with_toolset in ["gcc", "clang"]:
+            # check for C++ compiler, as b2 uses only C++ one, which may not be installed alongside C compiler
+            compiler = "g++" if with_toolset == "gcc" else "clang++"
+            if not tools.which(compiler):
+                with_toolset = "cxx" if Version(str(self.version)) >= "1.71" else "cc"
         return with_toolset
 
     def _bootstrap(self):


### PR DESCRIPTION
closes: #193 

- check for C++ compiler instead of C compiler (it's possible to install only C compiler on the system, while b2 needs C++ one)
- use toolset name `cxx` instead of `cc` since boost 1.71

Specify library name and version:  **boost/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

