### PR TITLE
Use shared gflags when building shared

### DIFF
--- a/recipes/glog/all/conanfile.py
+++ b/recipes/glog/all/conanfile.py
@@ -22,6 +22,10 @@ class GlogConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.with_gflags:
+            self.options["gflags"].shared = self.options.shared
+
     def requirements(self):
         if self.options.with_gflags:
             self.requires("gflags/2.2.2")


### PR DESCRIPTION
Prevents duplicate symbol errors when a consumer uses gflags as well

Specify library name and version:  glog/*

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

