### PR TITLE
[boost] fix build when python path has spaces

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -684,7 +684,7 @@ class BoostConan(ConanFile):
 
         if not self.options.without_python:
             # https://www.boost.org/doc/libs/1_70_0/libs/python/doc/html/building/configuring_boost_build.html
-            contents += "\nusing python : {version} : {executable} : {includes} :  {libraries} ;"\
+            contents += '\nusing python : {version} : "{executable}" : "{includes}" : "{libraries}" ;'\
                 .format(version=self._python_version,
                         executable=self._python_executable,
                         includes=self._python_includes,


### PR DESCRIPTION
closes: #340 

Specify library name and version:  **boost/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

