### PR TITLE
Fix benchmark for cross-building

### DIFF
--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -51,7 +51,12 @@ class BenchmarkConan(ConanFile):
 
         # See https://github.com/google/benchmark/pull/638 for Windows 32 build explanation
         if self.settings.os != "Windows":
-            cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "ON" if "64" not in str(self.settings.arch) else "OFF"
+            if tools.cross_building(self.settings):
+                cmake.definitions["HAVE_STD_REGEX"] = False
+                cmake.definitions["HAVE_POSIX_REGEX"] = False
+                cmake.definitions["HAVE_STEADY_CLOCK"] = False
+            else:
+                cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "ON" if "64" not in str(self.settings.arch) else "OFF"
             cmake.definitions["BENCHMARK_USE_LIBCXX"] = "ON" if (str(self.settings.compiler.libcxx) == "libc++") else "OFF"
         else:
             cmake.definitions["BENCHMARK_USE_LIBCXX"] = "OFF"


### PR DESCRIPTION
Specify library name and version:  **benchmark/1.5.0**

Arm Linux build log: 
[benchmark-arm-linux.log](https://github.com/conan-io/conan-center-index/files/3875008/benchmark-arm-linux.log)

fixes #370

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

