### PR TITLE
[xz_utils] Improve the "Relax Windows SDK restriction"

### DIFF
--- a/recipes/xz_utils/all/conanfile.py
+++ b/recipes/xz_utils/all/conanfile.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import os
 from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
 from conans.tools import Version

--- a/recipes/xz_utils/all/conanfile.py
+++ b/recipes/xz_utils/all/conanfile.py
@@ -35,6 +35,7 @@ class XZUtils(ConanFile):
         return 'Debug' if self.settings.build_type == 'Debug' else 'Release'
 
     def configure(self):
+        del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
         if self.settings.compiler == 'Visual Studio':
             del self.options.fPIC

--- a/recipes/xz_utils/all/conanfile.py
+++ b/recipes/xz_utils/all/conanfile.py
@@ -43,11 +43,11 @@ class XZUtils(ConanFile):
         # Relax Windows SDK restriction
         tools.replace_in_file(os.path.join(self._source_subfolder, 'windows', 'vs2017', 'liblzma.vcxproj'),
                               "<WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>",
-                              "")
+                              "<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>")
 
         tools.replace_in_file(os.path.join(self._source_subfolder, 'windows', 'vs2017', 'liblzma_dll.vcxproj'),
                               "<WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>",
-                              "")
+                              "<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -56,6 +56,19 @@ class XZUtils(ConanFile):
 
     def _build_msvc(self):
         # windows\INSTALL-MSVC.txt
+
+        if self.settings.compiler.version == 15:
+            # emulate VS2019+ meaning of WindowsTargetPlatformVersion == '10.0'
+            # undocumented method, but officially recommended workaround by microsoft at at
+            # https://developercommunity.visualstudio.com/content/problem/140294/windowstargetplatformversion-makes-it-impossible-t.html
+            tools.replace_in_file(os.path.join(self._source_subfolder, 'windows', 'vs2017', 'liblzma.vcxproj'),
+                                  "<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>",
+                                  "<WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>")
+
+            tools.replace_in_file(os.path.join(self._source_subfolder, 'windows', 'vs2017', 'liblzma_dll.vcxproj'),
+                                  "<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>",
+                                  "<WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>")
+
         msvc_version = 'vs2017' if Version(self.settings.compiler.version) >= "15" else 'vs2013'
         with tools.chdir(os.path.join(self._source_subfolder, 'windows', msvc_version)):
             target = 'liblzma_dll' if self.options.shared else 'liblzma'

--- a/recipes/xz_utils/all/test_package/conanfile.py
+++ b/recipes/xz_utils/all/test_package/conanfile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from conans import ConanFile, CMake, tools, RunEnvironment
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -16,6 +16,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         # Test the library
-        with tools.environment_append(RunEnvironment(self).vars):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Currently --build xz_utils does not work for a default VS2017 installation
because completely removing WindowsTargetPlatformVersion causes VS2017
to default to a Windows 8.1 SDK, which is not installed by default.

In VS2019 using "10.0" means "default to latest 10.0.*";

In VS2017, getting the same behavior requires an uglier workaround,
recommended by Olga Arkhipova [MSFT] in the issue discussion at
https://developercommunity.visualstudio.com/content/problem/140294/windowstargetplatformversion-makes-it-impossible-t.html

Specify library name and version:  xz_utils/5.2.4

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

