### PR TITLE
Restoring the use of "user-config.jam" from build folder in case ~/user-config.jam exists

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -508,6 +508,7 @@ class BoostConan(ConanFile):
 
         flags.append("--layout=%s" % self.options.layout)
         flags.append("-sBOOST_BUILD_PATH=%s" % self._boost_build_dir)
+        flags.append("--user-config=%s" % os.path.join(self._boost_build_dir, 'user-config.jam'))
         flags.append("-sNO_ZLIB=%s" % ("0" if self.options.zlib else "1"))
         flags.append("-sNO_BZIP2=%s" % ("0" if self.options.bzip2 else "1"))
         flags.append("-sNO_LZMA=%s" % ("0" if self.options.lzma else "1"))


### PR DESCRIPTION
According to https://boostorg.github.io/build/manual/develop/index.html#bbv2.overview.configuration
the order of research for the user-config.jam object has always the home folder first.
It may happen that the user compiling the conan package has already a user-config.jam under
his home folder, and this will discard the specifically created user-config.jam.

Passinfg the "--user-config=" option to b2 restores the desired behaviour (see
https://boostorg.github.io/build/manual/develop/index.html#bbv2.reference.init.options.config).

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

