### PR TITLE
Making b2 building less sensitive to cross-compilation variables

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -802,7 +802,18 @@ class BoostConan(ConanFile):
                         option = "" if tools.os_info.is_windows else "-with-toolset="
                         cmd = "%s %s%s" % (bootstrap, option, self._get_boostrap_toolset())
                     self.output.info(cmd)
-                    with tools.environment_append({"CC": None, "CXX": None, "CFLAGS": None, "CXXFLAGS": None}):
+
+                    removed_environment_variables = [
+                        "CC",
+                        "CXX",
+                        "CFLAGS",
+                        "CXXFLAGS",
+                        "SDKROOT",
+                        "IPHONEOS_DEPLOYMENT_TARGET"
+                    ]
+                    removed_environment_variables = dict((env_var, None) for env_var in removed_environment_variables)
+
+                    with tools.environment_append(removed_environment_variables):
                         self.run(cmd)
 
         except Exception as exc:


### PR DESCRIPTION
This PR removes more variables from the environment used for building
b2. Our profile populates for instance SDKROOT and IPHONEOS_DEPLOYMENT_TARGET
on iOS targets, as those are required by some of the autotools we are using in
our project. Not removing any of those is creating a compilation issue
for b2.

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

