### PR TITLE
Fix in case the path pointed by CXX does not exist

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -644,7 +644,7 @@ class BoostConan(ConanFile):
 
     @property
     def _cxx(self):
-        if "CXX" in os.environ:
+        if "CXX" in os.environ and os.path.exists(os.environ["CXX"]):
             return os.environ["CXX"]
         if tools.is_apple_os(self.settings.os) and self.settings.compiler == "apple-clang":
             return tools.XCRun(self.settings).cxx


### PR DESCRIPTION
The conan profile may specify CC and CXX with additional arguments. This
is sometimes needed for build tools like autotools to have the configuration
checking with the right parameters.

The change checks if the value of CXX variable points to a correct location
and discards it if this is not the case.

This PR is rather WIP and subject to discussion: the problem has been exposed above
but the resolution is not very clear to me. Another option would be to remove all options
from CXX, such as `-arch xxx` from `CXX=/some/path/to/compiler -arch xxx`. 

Let me know what you think, thanks!

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

