### PR TITLE
libpng: use PNG as name

### DIFF
--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -83,6 +83,9 @@ class LibpngConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, 'lib', 'pkgconfig'))
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "PNG"
+        self.cpp_info.names["cmake_find_package_multi"] = "PNG"
+
         if self.settings.os == "Windows":
             if self.settings.compiler == "gcc":
                 self.cpp_info.libs = ["png"]


### PR DESCRIPTION
Specify library name and version:  **libpng/1.6.37**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

See https://cmake.org/cmake/help/git-master/module/FindPNG.html