### PR TITLE
sqlite: enable more options by default

### DIFF
--- a/recipes/sqlite3/all/conanfile.py
+++ b/recipes/sqlite3/all/conanfile.py
@@ -22,19 +22,21 @@ class ConanSqlite3(ConanFile):
                "enable_fts5": [True, False],
                "enable_json1": [True, False],
                "enable_rtree": [True, False],
-               "omit_load_extension": [True, False]
+               "omit_load_extension": [True, False],
+               "enable_unlock_notify": [True, False]
                }
     default_options = {"shared": False,
                        "fPIC": True,
                        "threadsafe": 1,
-                       "enable_column_metadata": False,
+                       "enable_column_metadata": True,
                        "enable_explain_comments": False,
                        "enable_fts3": False,
                        "enable_fts4": False,
                        "enable_fts5": False,
                        "enable_json1": False,
-                       "enable_rtree": False,
-                       "omit_load_extension": False
+                       "enable_rtree": True,
+                       "omit_load_extension": False,
+                       "enable_unlock_notify": True
                        }
     _source_subfolder = "source_subfolder"
 
@@ -64,6 +66,7 @@ class ConanSqlite3(ConanFile):
         cmake.definitions["ENABLE_JSON1"] = self.options.enable_json1
         cmake.definitions["ENABLE_RTREE"] = self.options.enable_rtree
         cmake.definitions["OMIT_LOAD_EXTENSION"] = self.options.omit_load_extension
+        cmake.definitions["SQLITE_ENABLE_UNLOCK_NOTIFY"] = self.options.enable_unlock_notify        
         cmake.definitions["HAVE_FDATASYNC"] = True
         cmake.definitions["HAVE_GMTIME_R"] = True
         cmake.definitions["HAVE_LOCALTIME_R"] = True


### PR DESCRIPTION
enable column_metadata, rtree and unlock_notify options by default
fixes #413

Specify library name and version:  **sqlite3/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

