### PR TITLE
pcre: fix pkg_config file name

### DIFF
--- a/recipes/pcre/all/CMakeLists.txt
+++ b/recipes/pcre/all/CMakeLists.txt
@@ -1,3 +1,4 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
 project(cmake_wrapper)
 
 message(STATUS "Conan CMake Wrapper")

--- a/recipes/pcre/all/conanfile.py
+++ b/recipes/pcre/all/conanfile.py
@@ -6,7 +6,6 @@ class PCREConan(ConanFile):
     name = "pcre"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.pcre.org"
-    author = "Bincrafters <bincrafters@gmail.com>"
     description = "Perl Compatible Regular Expressions"
     license = "BSD-3-Clause"
     exports_sources = ["CMakeLists.txt"]

--- a/recipes/pcre/all/conanfile.py
+++ b/recipes/pcre/all/conanfile.py
@@ -91,3 +91,4 @@ class PCREConan(ConanFile):
             self.cpp_info.libs = ['pcreposix', 'pcre']
         if not self.options.shared:
             self.cpp_info.defines.append("PCRE_STATIC=1")
+        self.cpp_info.names['pkg_config'] = 'libpcre'

--- a/recipes/pcre/all/test_package/conanfile.py
+++ b/recipes/pcre/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools, RunEnvironment
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -12,13 +12,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            with tools.environment_append(RunEnvironment(self).vars):
-                bin_path = os.path.join("bin", "test_package")
-                arguments = "%sw+ Bincrafters" % ("\\" if self.settings.os == "Windows" else "\\\\")
-                if self.settings.os == "Windows":
-                    self.run("%s %s" % (bin_path, arguments))
-                elif self.settings.os == "Macos":
-                    self.run("DYLD_LIBRARY_PATH=%s %s %s" % (os.environ.get('DYLD_LIBRARY_PATH', ''), bin_path, arguments))
-                else:
-                    self.run("LD_LIBRARY_PATH=%s %s %s" % (os.environ.get('LD_LIBRARY_PATH', ''), bin_path, arguments))
+        if not tools.cross_building(self.settings, skip_x64_x86=True):
+            bin_path = os.path.join("bin", "test_package")
+            arguments = "%sw+ Bincrafters" % ("\\" if self.settings.os == "Windows" else "\\\\")
+            self.run("%s %s" % (bin_path, arguments))

--- a/recipes/pcre/all/test_package/conanfile.py
+++ b/recipes/pcre/all/test_package/conanfile.py
@@ -15,4 +15,4 @@ class TestPackageConan(ConanFile):
         if not tools.cross_building(self.settings, skip_x64_x86=True):
             bin_path = os.path.join("bin", "test_package")
             arguments = "%sw+ Bincrafters" % ("\\" if self.settings.os == "Windows" else "\\\\")
-            self.run("%s %s" % (bin_path, arguments))
+            self.run("%s %s" % (bin_path, arguments), run_environment=True)


### PR DESCRIPTION
Fix pcre pkg_config file name. As specified here https://www.pcre.org/original/readme.txt the expected file name is `libpcre.pc`.
Also, fix hooks by

1. adding missing `CMAKE_MINIMUM_REQUIRED` in CMakeLists.txt
2. removing `author` attribute
3. Removing unnecessary `RunEnvironment`


- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

