### PR TITLE
[libcurl] CMake module name is CURL

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -371,6 +371,10 @@ class LibcurlConan(ConanFile):
             os.remove(os.path.join(self.package_folder, 'lib', 'libcurl.la'))
 
     def package_info(self):
+        self.cpp_info.names['cmake'] = 'CURL'
+        self.cpp_info.names['cmake_find_package'] = 'CURL'
+        self.cpp_info.names['cmake_find_package_multi'] = 'CURL'
+
         if self.settings.compiler != "Visual Studio":
             self.cpp_info.libs = ['curl']
             if self.settings.os == "Linux":

--- a/recipes/libcurl/all/test_package/CMakeLists.txt
+++ b/recipes/libcurl/all/test_package/CMakeLists.txt
@@ -4,5 +4,7 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(CURL)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} CURL::CURL)

--- a/recipes/libcurl/all/test_package/conanfile.py
+++ b/recipes/libcurl/all/test_package/conanfile.py
@@ -6,7 +6,7 @@ import re
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **libcurl/all**

CMake module name is CURL: https://cmake.org/cmake/help/v3.16/module/FindCURL.html

 * Needs `cpp_info.names` from Conan 1.21.0: https://docs.conan.io/en/latest/changelog.html#dec-2019

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

