### PR TITLE
Add timsort 1.2.0 and 2.0.0

### DIFF
--- a/recipes/timsort/all/conandata.yml
+++ b/recipes/timsort/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "1.2.0":
+    sha256: 3a189cb8717efbf0442da1d62109b7e881c158ab8167f8997e79cdb3a2cd7c9a
+    url: https://github.com/timsort/cpp-TimSort/archive/v1.2.0.tar.gz
+  "2.0.0":
+    sha256: 6cb23b0efb83e1d4f6eab58cddd35b36ca49cd927a46294575b9c0d304a2e833
+    url: https://github.com/timsort/cpp-TimSort/archive/v2.0.0.tar.gz

--- a/recipes/timsort/all/conanfile.py
+++ b/recipes/timsort/all/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conans import CMake, ConanFile, tools
+
+
+class TimsortConan(ConanFile):
+    name = "timsort"
+    description = "A C++ implementation of timsort"
+    topics = "conan", "timsort", "sorting", "algorithms"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/timsort/cpp-TimSort"
+    license = "MIT"
+    no_copy_source = True
+
+    _source_subfolder = "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "cpp-TimSort-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        self.copy("*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/timsort/all/test_package/CMakeLists.txt
+++ b/recipes/timsort/all/test_package/CMakeLists.txt
@@ -7,3 +7,4 @@ conan_basic_setup(TARGETS)
 
 add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
 target_link_libraries(${CMAKE_PROJECT_NAME} CONAN_PKG::timsort)
+set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/timsort/all/test_package/CMakeLists.txt
+++ b/recipes/timsort/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 2.8.11)
+
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
+target_link_libraries(${CMAKE_PROJECT_NAME} CONAN_PKG::timsort)

--- a/recipes/timsort/all/test_package/conanfile.py
+++ b/recipes/timsort/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os.path
+
+from conans import ConanFile, CMake
+
+
+class TimsortTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)

--- a/recipes/timsort/all/test_package/test_package.cpp
+++ b/recipes/timsort/all/test_package/test_package.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2011 Fuji, Goro (gfx) <gfuji@cpan.org>.
+ * Copyright (c) 2019 Morwenn.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include <cstddef>
+#include <iostream>
+#include <gfx/timsort.hpp>
+
+int main()
+{
+    const std::size_t size = 5;
+    
+    int arr[size] = { 5, 8, 3, 2, 9 };
+    gfx::timsort(arr, arr + size);
+
+    // should print 2 3 5 8 9
+    for (std::size_t idx = 0 ; idx < size ; ++idx) {
+        std::cout << arr[idx] << ' ';
+    }
+}

--- a/recipes/timsort/config.yml
+++ b/recipes/timsort/config.yml
@@ -1,0 +1,5 @@
+versions:
+  1.2.0:
+    folder: all
+  2.0.0:
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **timsort/1.2.0** &  **timsort/2.0.0**

I'm currently maintaining this packing and I've been trying to keep the "gfx" parts of the name and code out of the Conan interface so far because I they might have to change someday if there are clashes with the name "gfx" which exists in bigger libraries.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

