### PR TITLE
Correct CMake options for Expat ≥ 2.2.8

### DIFF
--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conans.tools import Version
 import os
 
 
@@ -33,11 +34,19 @@ class ExpatConan(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self, parallel=True)
-        cmake.definitions["BUILD_doc"] = "Off"
-        cmake.definitions["BUILD_examples"] =  "Off"
-        cmake.definitions["BUILD_shared"] = self.options.shared
-        cmake.definitions["BUILD_tests"] = "Off"
-        cmake.definitions["BUILD_tools"] = "Off"
+        if Version(self.version) < "2.2.8":
+            cmake.definitions["BUILD_doc"] = "Off"
+            cmake.definitions["BUILD_examples"] =  "Off"
+            cmake.definitions["BUILD_shared"] = self.options.shared
+            cmake.definitions["BUILD_tests"] = "Off"
+            cmake.definitions["BUILD_tools"] = "Off"
+        else:
+            # These options were renamed in 2.2.8 to be more consistent
+            cmake.definitions["EXPAT_BUILD_DOCS"] = "Off"
+            cmake.definitions["EXPAT_BUILD_EXAMPLES"] =  "Off"
+            cmake.definitions["EXPAT_SHARED_LIBS"] = self.options.shared
+            cmake.definitions["EXPAT_BUILD_TESTS"] = "Off"
+            cmake.definitions["EXPAT_BUILD_TOOLS"] = "Off"
 
         cmake.configure(build_folder=self._build_subfolder)
         return cmake 


### PR DESCRIPTION
The upstream project renamed some CMake options between 2.2.7 and 2.2.8: https://github.com/libexpat/libexpat/pull/329

I can't run the git hooks on this computer, but will try and remember to check later.

---

Specify library name and version:  **expat/2.2.9**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

