### PR TITLE
nghttp2: 1.40.0 + bump depepdencies + fix configure

### DIFF
--- a/recipes/libnghttp2/all/CMakeLists.txt
+++ b/recipes/libnghttp2/all/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+include(conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_subdirectory("source_subfolder")
+add_subdirectory(source_subfolder)

--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -18,3 +18,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/fix-findLibevent.cmake"
       base_path: "source_subfolder"
+    - patch_file: "patches/nghttp_static_include_directories.patch"
+      base_path: "source_subfolder"

--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.39.2":
     sha256: 92a23e4522328c8565028ee0c7270e74add7990614fd1148f2a79d873bc2a1d0
     url: https://github.com/nghttp2/nghttp2/releases/download/v1.39.2/nghttp2-1.39.2.tar.bz2
+  "1.40.0":
+    sha256: 82758e13727945f2408d0612762e4655180b039f058d5ff40d055fa1497bd94f
+    url: https://github.com/nghttp2/nghttp2/releases/download/v1.40.0/nghttp2-1.40.0.tar.bz2

--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -5,3 +5,16 @@ sources:
   "1.40.0":
     sha256: 82758e13727945f2408d0612762e4655180b039f058d5ff40d055fa1497bd94f
     url: https://github.com/nghttp2/nghttp2/releases/download/v1.40.0/nghttp2-1.40.0.tar.bz2
+patches:
+  "1.39.2":
+    - patch_file: "patches/fix-addNghttp2IncludesPathCMake.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-findJemalloc.cmake"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-findLibevent.cmake"
+      base_path: "source_subfolder"
+  "1.40.0":
+    - patch_file: "patches/fix-findJemalloc.cmake"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-findLibevent.cmake"
+      base_path: "source_subfolder"

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -23,7 +23,7 @@ class Nghttp2Conan(ConanFile):
                        "fPIC": True,
                        "with_app": True,
                        "with_hpack": True,
-                       "with_jemalloc": True,
+                       "with_jemalloc": False,
                        "with_asio": False}
 
     _source_subfolder = "source_subfolder"

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -1,5 +1,5 @@
 import os
-from conans import ConanFile, CMake, AutoToolsBuildEnvironment, tools
+from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
 
@@ -10,24 +10,26 @@ class Nghttp2Conan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://nghttp2.org"
     license = "MIT"
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake", "pkg_config"
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False],
                "fPIC": [True, False],
                "with_app": [True, False],
                "with_hpack": [True, False],
+               "with_jemalloc": [True, False],
                "with_asio": [True, False]}
     default_options = {"shared": False,
                        "fPIC": True,
                        "with_app": True,
                        "with_hpack": True,
+                       "with_jemalloc": True,
                        "with_asio": False}
 
     _source_subfolder = "source_subfolder"
 
     def config_options(self):
-        if self.settings.os == 'Windows':
+        if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
@@ -46,9 +48,12 @@ class Nghttp2Conan(ConanFile):
             self.requires.add("openssl/1.1.1d")
             self.requires.add("c-ares/1.15.0")
             self.requires.add("libev/4.27")
+            self.requires.add("libevent/2.1.11")
             self.requires.add("libxml2/2.9.9")
         if self.options.with_hpack:
             self.requires.add("jansson/2.12")
+        if self.options.with_jemalloc:
+            self.requires.add("jemalloc/5.2.1")
         if self.options.with_asio:
             self.requires.add("boost/1.71.0")
 
@@ -59,7 +64,6 @@ class Nghttp2Conan(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self)
-
         cmake.definitions["ENABLE_SHARED_LIB"] = "ON" if self.options.shared else "OFF"
         cmake.definitions["ENABLE_STATIC_LIB"] = "OFF" if self.options.shared else "ON"
         cmake.definitions["ENABLE_HPACK_TOOLS"] = "ON" if self.options.with_hpack else "OFF"
@@ -69,83 +73,48 @@ class Nghttp2Conan(ConanFile):
         cmake.definitions["ENABLE_FAILMALLOC"] = "OFF"
         # disable unneeded auto-picked dependencies
         cmake.definitions["WITH_LIBXML2"] = "OFF"
-        cmake.definitions["WITH_JEMALLOC"] = "OFF"
+        cmake.definitions["WITH_JEMALLOC"] = "ON" if self.options.with_jemalloc else "OFF"
         cmake.definitions["WITH_SPDYLAY"] = "OFF"
 
         cmake.definitions["ENABLE_ASIO_LIB"] = "ON" if self.options.with_asio else "OFF"
 
         if self.options.with_app:
-            cmake.definitions['OPENSSL_ROOT_DIR'] = self.deps_cpp_info['openssl'].rootpath
+            cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath
         if self.options.with_asio:
-            cmake.definitions['BOOST_ROOT'] = self.deps_cpp_info['boost'].rootpath
-        cmake.definitions['ZLIB_ROOT'] = self.deps_cpp_info['zlib'].rootpath
+            cmake.definitions["BOOST_ROOT"] = self.deps_cpp_info["boost"].rootpath
+        cmake.definitions["ZLIB_ROOT"] = self.deps_cpp_info["zlib"].rootpath
 
         cmake.configure()
         return cmake
 
-    def _build_with_autotools(self):
-        prefix = os.path.abspath(self.package_folder)
-        with tools.chdir(self._source_subfolder):
-            env_build = AutoToolsBuildEnvironment(self)
-            if self.settings.os == 'Windows':
-                prefix = tools.unix_path(prefix)
-            args = []
-            if self.options.shared:
-                args.extend(['--disable-static', '--enable-shared'])
-            else:
-                args.extend(['--disable-shared', '--enable-static'])
-            if self.options.with_hpack:
-                args.append('--enable-hpack-tools')
-            else:
-                args.append('--disable-hpack-tools')
-
-            if self.options.with_app:
-                args.append('--enable-app')
-            else:
-                args.append('--disable-app')
-
-            args.append('--disable-examples')
-            args.append('--disable-python-bindings')
-            # disable unneeded auto-picked dependencies
-            args.append('--without-jemalloc')
-            args.append('--without-systemd')
-            args.append('--without-libxml2')
-
-            if self.options.with_asio:
-                args.append('--enable-asio-lib')
-                args.append('--with-boost=' + self.deps_cpp_info['boost'].rootpath)
-            else:
-                args.append('--without-boost')
-
-            env_build.configure(args=args)
-            env_build.make()
-            env_build.make(args=['install'])
+    def _patch_sources(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+        target_libnghttp2 = "nghttp2" if self.options.shared else "nghttp2_static"
+        tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
+                              "\n"
+                              "link_libraries(\n"
+                              "  nghttp2\n",
+                              "\n"
+                              "link_libraries(\n"
+                              "  {} ${{CONAN_LIBS}}\n".format(target_libnghttp2))
 
     def build(self):
-        if self.settings.compiler == "Visual Studio":
-            cmake = self._configure_cmake()
-            cmake.build()
-        else:
-            self._build_with_autotools()
+        self._patch_sources()
+        cmake = self._configure_cmake()
+        cmake.build()
 
     def package(self):
         self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        if self.settings.compiler == "Visual Studio":
-            cmake = self._configure_cmake()
-            cmake.install()
-            cmake.patch_config_paths()
+        cmake = self._configure_cmake()
+        cmake.install()
+        cmake.patch_config_paths()
 
-        # remove unneeded directories
         tools.rmdir(os.path.join(self.package_folder, 'share'))
         tools.rmdir(os.path.join(self.package_folder, 'lib', 'pkgconfig'))
 
-        for la_name in ('libnghttp2.la', 'libnghttp2_asio.la'):
-            la_file = os.path.join(self.package_folder, "lib", la_name)
-            if os.path.isfile(la_file):
-                os.unlink(la_file)
-
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
-        if self.settings.compiler == 'Visual Studio':
+        if self.settings.compiler == "Visual Studio":
             if not self.options.shared:
-                self.cpp_info.defines.append('NGHTTP2_STATICLIB')
+                self.cpp_info.defines.append("NGHTTP2_STATICLIB")

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -26,29 +26,31 @@ class Nghttp2Conan(ConanFile):
 
     _source_subfolder = "source_subfolder"
 
+    def config_options(self):
+        if self.settings.os == 'Windows':
+            del self.options.fPIC
+
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        if self.options.with_asio and self.settings.compiler == "Visual Studio":
+            raise ConanInvalidConfiguration("Build with asio and MSVC is not supported yet, see upstream bug #589")
         if self.settings.compiler == "gcc":
             v = tools.Version(str(self.settings.compiler.version))
             if v < "6.0":
                 raise ConanInvalidConfiguration("gcc >= 6.0 required")
 
-    def config_options(self):
-        if self.settings.os == 'Windows':
-            del self.options.fPIC
-        if self.options.with_asio and self.settings.compiler == "Visual Studio":
-            raise ConanInvalidConfiguration("Build with asio and MSVC is not supported yet, see upstream bug #589")
-
     def requirements(self):
         self.requires.add("zlib/1.2.11")
         if self.options.with_app:
-            self.requires.add("openssl/1.0.2t")
+            self.requires.add("openssl/1.1.1d")
             self.requires.add("c-ares/1.15.0")
-            self.requires.add("libev/4.25")
+            self.requires.add("libev/4.27")
             self.requires.add("libxml2/2.9.9")
         if self.options.with_hpack:
             self.requires.add("jansson/2.12")
         if self.options.with_asio:
-            self.requires.add("boost/1.70.0")
+            self.requires.add("boost/1.71.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -90,6 +90,12 @@ class Nghttp2Conan(ConanFile):
     def _patch_sources(self):
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
+        # tools.replace_in_file(os.path.join(self._source_subfolder, "lib", "CMakeLists.txt"),
+        #                       "set_target_properties(nghttp2_static ",
+        #                       "target_include_directories(nghttp2_static INTERFACE\n"
+        #                       "${CMAKE_CURRENT_BINARY_DIR}/includes\n"
+        #                       "${CMAKE_CURRENT_SOURCE_DIR}/includes)\n"
+        #                       "set_target_properties(nghttp2_static ")
         target_libnghttp2 = "nghttp2" if self.options.shared else "nghttp2_static"
         tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
                               "\n"

--- a/recipes/libnghttp2/all/patches/fix-addNghttp2IncludesPathCMake.patch
+++ b/recipes/libnghttp2/all/patches/fix-addNghttp2IncludesPathCMake.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2019-12-12 20:23:38.855819744 +0100
++++ CMakeLists.txt	2019-12-12 20:22:54.194563670 +0100
+@@ -449,6 +449,8 @@
+
+ install(FILES README.rst DESTINATION "${CMAKE_INSTALL_DOCDIR}")
+
++include_directories(lib/includes)
++
+ add_subdirectory(lib)
+ #add_subdirectory(lib/includes)
+ add_subdirectory(third-party)

--- a/recipes/libnghttp2/all/patches/fix-findJemalloc.cmake
+++ b/recipes/libnghttp2/all/patches/fix-findJemalloc.cmake
@@ -1,0 +1,14 @@
+--- cmake/FindJemalloc.cmake
++++ cmake/FindJemalloc.cmake
+@@ -10,10 +10,10 @@
+ find_path(JEMALLOC_INCLUDE_DIR
+   NAMES jemalloc/jemalloc.h
+   HINTS ${PC_JEMALLOC_INCLUDE_DIRS}
+ )
+ find_library(JEMALLOC_LIBRARY
+-  NAMES jemalloc
++  NAMES jemalloc jemalloc_s jemalloc_pic
+   HINTS ${PC_JEMALLOC_LIBRARY_DIRS}
+ )
+
+ if(JEMALLOC_INCLUDE_DIR)

--- a/recipes/libnghttp2/all/patches/fix-findLibevent.cmake
+++ b/recipes/libnghttp2/all/patches/fix-findLibevent.cmake
@@ -1,0 +1,11 @@
+--- cmake/FindLibevent.cmake
++++ cmake/FindLibevent.cmake
+@@ -35,7 +35,7 @@
+ )
+
+ if(LIBEVENT_INCLUDE_DIR)
+-  set(_version_regex "^#define[ \t]+_EVENT_VERSION[ \t]+\"([^\"]+)\".*")
++  set(_version_regex "^#define[ \t]+EVENT__VERSION[ \t]+\"([^\"]+)\".*")
+   if(EXISTS "${LIBEVENT_INCLUDE_DIR}/event2/event-config.h")
+     # Libevent 2.0
+     file(STRINGS "${LIBEVENT_INCLUDE_DIR}/event2/event-config.h"

--- a/recipes/libnghttp2/all/patches/nghttp_static_include_directories.patch
+++ b/recipes/libnghttp2/all/patches/nghttp_static_include_directories.patch
@@ -1,0 +1,13 @@
+--- lib/CMakeLists.txt
++++ lib/CMakeLists.txt
+@@ -59,7 +59,10 @@
+ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
+   # Static library (for unittests because of symbol visibility)
+   add_library(nghttp2_static STATIC ${NGHTTP2_SOURCES})
++  target_include_directories(nghttp2_static INTERFACE
++    ${CMAKE_CURRENT_BINARY_DIR}/includes
++    ${CMAKE_CURRENT_SOURCE_DIR}/includes)
+   set_target_properties(nghttp2_static PROPERTIES
+     COMPILE_FLAGS "${WARNCFLAGS}"
+     VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
+     ARCHIVE_OUTPUT_NAME nghttp2_static

--- a/recipes/libnghttp2/config.yml
+++ b/recipes/libnghttp2/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.39.2":
     folder: all
+  "1.40.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **nghttp2/1.40.0**

- Depends on #475 : jemalloc is enabled by default
- Switched to cmake unconditionally

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

