### PR TITLE
Remove codecs for openjpeg

### DIFF
--- a/recipes/openjpeg/all/conanfile.py
+++ b/recipes/openjpeg/all/conanfile.py
@@ -18,16 +18,9 @@ class OpenjpegConan(ConanFile):
 
     _source_subfolder = "source_subfolder"
 
-    requires = (
-        "zlib/1.2.11",
-        "lcms/2.9",
-        "libpng/1.6.37",
-        "libtiff/4.0.9"
-    )
-
     def config_options(self):
         if self.settings.os == "Windows":
-            self.options.remove("fPIC")
+            del self.options.fPIC
 
     def configure(self):
         del self.settings.compiler.libcxx
@@ -44,6 +37,7 @@ class OpenjpegConan(ConanFile):
         cmake.definitions['BUILD_STATIC_LIBS'] = not self.options.shared
         cmake.definitions['BUILD_PKGCONFIG_FILES'] = False
         cmake.definitions['CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP'] = True
+        cmake.definitions['BUILD_CODEC'] = False
 
         cmake.configure()
         return cmake
@@ -107,5 +101,5 @@ class OpenjpegConan(ConanFile):
         if not self.options.shared:
             self.cpp_info.defines.append('OPJ_STATIC')
         if self.settings.os == "Linux":
-            self.cpp_info.libs.append("pthread")
+            self.cpp_info.system_libs = ["pthread", "m"]
         self.cpp_info.name = 'OpenJPEG'


### PR DESCRIPTION
Specify library name and version:  **openjpeg/2.3.1**

- Drop codec (executable) support, so we don't need external dependencies.

fixes #476

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

