### PR TITLE
meson: fix msvc (libpath)

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -8,3 +8,7 @@ sources:
   "0.52.1":
     url: "https://github.com/mesonbuild/meson/archive/0.52.1.tar.gz"
     sha256: "ad8dbad61d4c22cb7d768cb1f8a212b4abf0f3fbc17c298d816140ecd9f5d1df"
+patches:
+  "0.52.1":
+    - patch_file: "patches/0001-fix-msvc-libpath.patch"
+      base_path: "source_subfolder"

--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -9,6 +9,10 @@ sources:
     url: "https://github.com/mesonbuild/meson/archive/0.52.1.tar.gz"
     sha256: "ad8dbad61d4c22cb7d768cb1f8a212b4abf0f3fbc17c298d816140ecd9f5d1df"
 patches:
+  "0.51.2": []
+  "0.52.0":
+    - patch_file: "patches/0001-fix-msvc-libpath.patch"
+      base_path: "source_subfolder"
   "0.52.1":
     - patch_file: "patches/0001-fix-msvc-libpath.patch"
       base_path: "source_subfolder"

--- a/recipes/meson/all/conanfile.py
+++ b/recipes/meson/all/conanfile.py
@@ -8,6 +8,7 @@ class MesonInstallerConan(ConanFile):
     topics = ("conan", "meson", "mesonbuild", "build-system")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/mesonbuild/meson"
+    exports_sources = "patches/**"
     license = "Apache-2.0"
     no_copy_source = True
     requires = "ninja/1.9.0"
@@ -25,6 +26,9 @@ exec "$meson_dir/meson.py" "$@"
         extracted_dir = "meson-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+            
         # create wrapper scripts
         with open(os.path.join(self._source_subfolder, "meson.cmd"), "w") as f:
             f.write(self._meson_cmd)

--- a/recipes/meson/all/patches/0001-fix-msvc-libpath.patch
+++ b/recipes/meson/all/patches/0001-fix-msvc-libpath.patch
@@ -1,0 +1,35 @@
+From 6eee9e48bbf43e2be511fbdf1b2bcfee32f614ef Mon Sep 17 00:00:00 2001
+From: Aleksey Gurtovoy <agurtovoy@acm.org>
+Date: Fri, 25 Oct 2019 14:42:36 -0500
+Subject: [PATCH] MSVC: support -LIBPATH
+
+Fixes #6101 (with a test), following up #5881
+---
+ mesonbuild/compilers/mixins/visualstudio.py | 6 ++++--
+ run_unittests.py                            | 3 ++-
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/mesonbuild/compilers/mixins/visualstudio.py b/mesonbuild/compilers/mixins/visualstudio.py
+index 9fddbb41b3..ebf51ff4dd 100644
+--- a/mesonbuild/compilers/mixins/visualstudio.py
++++ b/mesonbuild/compilers/mixins/visualstudio.py
+@@ -217,7 +217,9 @@ def unix_args_to_native(cls, args: typing.List[str]) -> typing.List[str]:
+             # -pthread is only valid for GCC
+             if i in ('-mms-bitfields', '-pthread'):
+                 continue
+-            if i.startswith('-L'):
++            if i.startswith('-LIBPATH:'):
++                i = '/LIBPATH:' + i[9:]
++            elif i.startswith('-L'):
+                 i = '/LIBPATH:' + i[2:]
+             # Translate GNU-style -lfoo library name to the import library
+             elif i.startswith('-l'):
+@@ -250,7 +252,7 @@ def unix_args_to_native(cls, args: typing.List[str]) -> typing.List[str]:
+     def native_args_to_unix(cls, args: typing.List[str]) -> typing.List[str]:
+         result = []
+         for arg in args:
+-            if arg.startswith('/LIBPATH:'):
++            if arg.startswith(('/LIBPATH:', '-LIBPATH:')):
+                 result.append('-L' + arg[9:])
+             elif arg.endswith(('.a', '.lib')) and not os.path.isabs(arg):
+                 result.append('-l' + arg)


### PR DESCRIPTION
meson 0.52.1 does not handle properly msvc's environment variable -LIBPATH
see https://github.com/mesonbuild/meson/issues/6101
this change is a backport of the fix https://github.com/mesonbuild/meson/pull/6106

Specify library name and version:  **meson/0.52.1**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

