### PR TITLE
Fix pkg-config errors of bzip2 and zlib

### DIFF
--- a/recipes/bzip2/1.0.6/conanfile.py
+++ b/recipes/bzip2/1.0.6/conanfile.py
@@ -6,7 +6,7 @@ class Bzip2Conan(ConanFile):
     name = "bzip2"
     version = "1.0.6"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "http://www.bzip.org"    
+    homepage = "http://www.bzip.org"
     license = "bzip2-1.0.6"
     description = "bzip2 is a free and open-source file compression program that uses the Burrows Wheeler algorithm."
     topics = ("conan", "bzip2", "data-compressor", "file-compression")
@@ -55,4 +55,5 @@ class Bzip2Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.name = "BZip2"
+        self.cpp_info.names["pkg_config"] = "bzip2"
         self.cpp_info.libs = ['bz2']

--- a/recipes/bzip2/1.0.8/conanfile.py
+++ b/recipes/bzip2/1.0.8/conanfile.py
@@ -6,7 +6,7 @@ class Bzip2Conan(ConanFile):
     name = "bzip2"
     version = "1.0.8"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "http://www.bzip.org"    
+    homepage = "http://www.bzip.org"
     license = "bzip2-1.0.8"
     description = "bzip2 is a free and open-source file compression program that uses the Burrows Wheeler algorithm."
     topics = ("conan", "bzip2", "data-compressor", "file-compression")
@@ -54,4 +54,5 @@ class Bzip2Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.name = "BZip2"
+        self.cpp_info.names["pkg_config"] = "bzip2"
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/zlib/1.2.11/conanfile.py
+++ b/recipes/zlib/1.2.11/conanfile.py
@@ -80,7 +80,7 @@ class ZlibConan(ConanFile):
 
     def _build_zlib(self):
         with tools.chdir(self._source_subfolder):
-            # https://github.com/madler/zlib/issues/268 
+            # https://github.com/madler/zlib/issues/268
             tools.replace_in_file('gzguts.h',
                                   '#if defined(_WIN32) || defined(__CYGWIN__)',
                                   '#if defined(_WIN32) || defined(__MINGW32__)')
@@ -164,4 +164,5 @@ class ZlibConan(ConanFile):
                 self.cpp_info.defines.append('MINIZIP_DLL')
         self.cpp_info.libs.append('zlib' if self.settings.os == "Windows" else "z")
         self.cpp_info.name = "ZLIB"
+        self.cpp_info.names["pkg_config"] = "zlib"
 

--- a/recipes/zlib/1.2.8/conanfile.py
+++ b/recipes/zlib/1.2.8/conanfile.py
@@ -20,7 +20,7 @@ class ZlibConan(ConanFile):
     generators = "cmake"
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
-    
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -28,7 +28,7 @@ class ZlibConan(ConanFile):
     def configure(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-    
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
@@ -37,7 +37,7 @@ class ZlibConan(ConanFile):
             configure_file = os.path.join(self._source_subfolder, "configure")
             st = os.stat(configure_file)
             os.chmod(configure_file, st.st_mode | stat.S_IEXEC)
-                
+
     def build(self):
         if self.settings.os != "Windows":
             with tools.chdir(self._source_subfolder):
@@ -101,6 +101,7 @@ class ZlibConan(ConanFile):
                 self.copy(pattern="*.a", dst="lib", src=self._source_subfolder, keep_path=False)
 
     def package_info(self):
+        self.cpp_info.names["pkg_config"] = "zlib"
         if self.settings.os == "Windows":
             self.cpp_info.libs = ['zlib']
             if self.settings.build_type == "Debug" and self.settings.compiler == "Visual Studio":


### PR DESCRIPTION
Specify library name and version:  **bzip2/1.0.6, bzip/1.0.8, zlib/1.2.8, zlib/1.2.11**

In Conan 1.21.0, if the `cpp_info.names["pkg_config"]` is not explicitly set, the generated .pc files will be in lower-case. However, the `Requires` section generated by the `pkg_config` generator still contains `cpp_infos.name` which is in upper-case. So we need to explicitly set filename for pkg_config generator, and the convention for names in pkg_config should be lower-case. `Bzip2` and `ZLIB` names are for `cmake_*` generators.

Also, some spaces after a line are removed.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

