### PR TITLE
[boost] Rely on boost's install target to generate the package

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -31,6 +31,8 @@ patches:
       base_path: "boost_1_70_0"
     - patch_file: "patches/solaris_pthread_data.patch"
       base_path: "boost_1_70_0"
+    - patch_file: "patches/out_of_source_bootstrap_bat.patch"
+      base_path: "boost_1_70_0"
   1.71.0:
     - patch_file: "patches/bcp_namespace_issues_1_71.patch"
       base_path: "boost_1_71_0"
@@ -41,4 +43,6 @@ patches:
     - patch_file: "patches/python_base_prefix.patch"
       base_path: "boost_1_71_0"
     - patch_file: "patches/solaris_pthread_data.patch"
+      base_path: "boost_1_71_0"
+    - patch_file: "patches/out_of_source_bootstrap_bat.patch"
       base_path: "boost_1_71_0"

--- a/recipes/boost/all/patches/out_of_source_bootstrap_bat.patch
+++ b/recipes/boost/all/patches/out_of_source_bootstrap_bat.patch
@@ -1,0 +1,23 @@
+--- bootstrap.bat	2019-12-17 10:36:22.554737800 +0100
++++ bootstrap.patched.bat	2019-12-17 10:12:52.452738800 +0100
+@@ -10,15 +10,16 @@
+ 
+ ECHO Building Boost.Build engine
+ if exist ".\tools\build\src\engine\b2.exe" del tools\build\src\engine\b2.exe
+-pushd tools\build\src\engine
++set working_dir=%cd%
++pushd %~dp0\tools\build\src\engine
+ 
+-call .\build.bat %* > ..\..\..\..\bootstrap.log
++call .\build.bat %* > %working_dir%\bootstrap.log
+ @ECHO OFF
+ 
+ popd
+ 
+-if exist ".\tools\build\src\engine\b2.exe" (
+-   copy .\tools\build\src\engine\b2.exe . > nul
++if exist "%~dp0\tools\build\src\engine\b2.exe" (
++   copy %~dp0\tools\build\src\engine\b2.exe . > nul
+    goto :bjam_built)
+ 
+ goto :bjam_failure


### PR DESCRIPTION
Specify library name and version:  **boost/***

In this PR instead of building boost copying the libraries from the build folder, we ask boost build system to run the install target, this creates a folder ready for distribution. The package method copies the result into a directory layout that matches conan conventions.

This should result in lower maintenance cost, boost managing their internal structure and the conan recipe copying form the temporary "installation".

In addition it allows consumers to use the cmake configuration files produced by newer versions of boost (indeed this was the motivation for this change).

Note: the branch is based on https://github.com/conan-io/conan-center-index/pull/509 and its two commits appear in the list of commits but only the last commit is relevant for this PR.