### PR TITLE
[package] libjpeg/*: fix mingw compilation

### DIFF
--- a/recipes/libjpeg/all/conanfile.py
+++ b/recipes/libjpeg/all/conanfile.py
@@ -2,6 +2,7 @@ import os
 import shutil
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
 from conans.errors import ConanInvalidConfiguration
+from conans.tools import os_info
 
 
 class LibjpegConan(ConanFile):
@@ -30,7 +31,7 @@ class LibjpegConan(ConanFile):
 
     def build_requirements(self):
         if tools.os_info.is_windows and self.settings.compiler != "Visual Studio":
-            if "CONAN_BASH_PATH" not in os.environ:
+            if "CONAN_BASH_PATH" not in os.environ and os_info.detect_windows_subsystem() != 'msys2':
                 self.build_requires("msys2/20190524")
 
     def source(self):

--- a/recipes/libjpeg/all/conanfile.py
+++ b/recipes/libjpeg/all/conanfile.py
@@ -28,6 +28,11 @@ class LibjpegConan(ConanFile):
         if self.settings.compiler == 'Visual Studio' and self.options.shared:
             raise ConanInvalidConfiguration("shared builds aren't supported for MSVC")
 
+    def build_requirements(self):
+        if tools.os_info.is_windows and self.settings.compiler != "Visual Studio":
+            if "CONAN_BASH_PATH" not in os.environ:
+                self.build_requires("msys2/20190524")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("jpeg-" + self.version, self.source_subfolder)


### PR DESCRIPTION
msys2 build requirement was missing

Specify library name and version:  **libjpeg/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

