### PR TITLE
[libev/4.27] fix building on Windows + cache autotools properly

### DIFF
--- a/recipes/libev/all/test_package/test_package.cpp
+++ b/recipes/libev/all/test_package/test_package.cpp
@@ -6,5 +6,3 @@ int main()
     printf("libev ver=%d.%d\n", ev_version_major(), ev_version_minor());
 	return 0;
 }
-
-// vim: et ts=4 sw=4


### PR DESCRIPTION
Specify library name and version:  **libev/4.27**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

