### PR TITLE
Add OpenSSL 1.0.2u

### DIFF
--- a/recipes/openssl/ALL/conandata.yml
+++ b/recipes/openssl/ALL/conandata.yml
@@ -62,6 +62,9 @@ sources:
   1.0.2t:
     sha256: 14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc
     url: https://www.openssl.org/source/openssl-1.0.2t.tar.gz
+  1.0.2u:
+    sha256: ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
+    url: https://www.openssl.org/source/openssl-1.0.2u.tar.gz
   1.1.0:
     sha256: f5c69ff9ac1472c80b868efc1c1c0d8dcfc746d29ebe563de2365dd56dbd8c82
     url: https://www.openssl.org/source/openssl-1.1.0.tar.gz

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -3,6 +3,8 @@ versions:
     folder: ALL
   1.0.2t:
     folder: ALL
+  1.0.2u:
+    folder: ALL
   1.1.0k:
     folder: ALL
   1.1.0l:


### PR DESCRIPTION
Specify library name and version:  **openssl/1.0.2u**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

_____________________________________________

# Notice

OpenSSL 1.0.2 will be end of life on 2019-12-31.
OpenSSL 1.1.0 is end of life since 2019-09-11

Whenever we can we should migrate packages to use OpenSSL 1.1.1