### PR TITLE
leptonica: fix pkg-config file name

### DIFF
--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -114,3 +114,4 @@ class LeptonicaConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.system_libs = ["m"]
         self.cpp_info.name = 'Leptonica'
+        self.cpp_info.names['pkg_config'] = 'lept'


### PR DESCRIPTION
Specify library name and version:  **leptonica/***

the file is left.pc according to https://github.com/DanBloomberg/leptonica/blob/master/lept.pc.in and https://packages.ubuntu.com/eoan/amd64/libleptonica-dev/filelist

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

