### PR TITLE
Fix make build with clang9

### DIFF
--- a/recipes/make/all/conandata.yml
+++ b/recipes/make/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "4.2.1":
     url: "http://ftpmirror.gnu.org/gnu/make/make-4.2.1.tar.bz2"
     sha256: "d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589"
+patches:
+  "4.2.1":
+    - patch_file: "patches/0001-clang.patch"
+      base_path: "source_subfolder"

--- a/recipes/make/all/conanfile.py
+++ b/recipes/make/all/conanfile.py
@@ -18,14 +18,14 @@ class MakeConan(ConanFile):
         extracted_dir = "make-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
-        for patch in self.conan_data["patches"][self.version]:
-            tools.patch(**patch)
-
     def configure(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
     def build(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+
         with tools.chdir(self._source_subfolder):
             # README.W32
             if self.settings.os_build == "Windows":

--- a/recipes/make/all/conanfile.py
+++ b/recipes/make/all/conanfile.py
@@ -10,12 +10,16 @@ class MakeConan(ConanFile):
     homepage = "https://www.gnu.org/software/make/"
     license = "GPL-3.0-or-later"
     settings = "os_build", "arch_build", "compiler"
+    exports_sources = ["patches/*"]
     _source_subfolder = "source_subfolder"
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = "make-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
+
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
 
     def configure(self):
         del self.settings.compiler.libcxx

--- a/recipes/make/all/patches/0001-clang.patch
+++ b/recipes/make/all/patches/0001-clang.patch
@@ -1,0 +1,13 @@
+diff --git a/glob/glob.c b/glob/glob.c
+index f3911bc..8adbde3 100644
+--- a/glob/glob.c
++++ b/glob/glob.c
+@@ -208,7 +208,7 @@ my_realloc (p, n)
+ #endif /* __GNU_LIBRARY__ || __DJGPP__ */
+ 
+ 
+-#if !defined __alloca && !defined __GNU_LIBRARY__
++#if !defined __alloca && defined __GNU_LIBRARY__
+ 
+ # ifdef	__GNUC__
+ #  undef alloca

--- a/recipes/make/all/patches/0001-clang.patch
+++ b/recipes/make/all/patches/0001-clang.patch
@@ -1,5 +1,5 @@
 diff --git a/glob/glob.c b/glob/glob.c
-index f3911bc..8adbde3 100644
+index f3911bc..8ec8511 100644
 --- a/glob/glob.c
 +++ b/glob/glob.c
 @@ -208,7 +208,7 @@ my_realloc (p, n)
@@ -7,7 +7,7 @@ index f3911bc..8adbde3 100644
  
  
 -#if !defined __alloca && !defined __GNU_LIBRARY__
-+#if !defined __alloca && defined __GNU_LIBRARY__
++#if (!defined __alloca && defined __GNU_LIBRARY__ && __linux__) || (!defined __alloca && !defined __GNU_LIBRARY__)
  
  # ifdef	__GNUC__
  #  undef alloca


### PR DESCRIPTION
Specify library name and version:  **make/4.2.1**

We are not alone: https://github.com/osresearch/heads/issues/352
That patch came from https://github.com/osresearch/heads/blob/make-4.2.1/patches/make-4.2.1.patch

fixes #484 

We have 2 alternatives:
- Accept that patch and fix a project bug
- Drop clang 9 for make (which can affect other packages when used as build_requires)


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

