### PR TITLE
Add tl-expected/1.0 and tl-expected/20190710

### DIFF
--- a/recipes/tl-expected/all/conandata.yml
+++ b/recipes/tl-expected/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
-  "1.0.1":
+  "1.0.0":
+    url: https://github.com/TartanLlama/expected/archive/v1.0.0.zip
+    sha256: c1733556cbd3b532a02b68e2fbc2091b5bc2cccc279e4f6c6bd83877aabd4b02
+  "20190710":
     url: https://github.com/TartanLlama/expected/archive/6fe2af5191214cce620899f7f06585c047b9f1fc.zip
     sha256: 25b009593fcb27aafd3e836e0e726da351b4be7a20703b9bb709a5efd61c26d0

--- a/recipes/tl-expected/all/conandata.yml
+++ b/recipes/tl-expected/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.1":
+    url: https://github.com/TartanLlama/expected/archive/6fe2af5191214cce620899f7f06585c047b9f1fc.zip
+    sha256: 25b009593fcb27aafd3e836e0e726da351b4be7a20703b9bb709a5efd61c26d0

--- a/recipes/tl-expected/all/conanfile.py
+++ b/recipes/tl-expected/all/conanfile.py
@@ -1,0 +1,36 @@
+from conans import ConanFile, CMake, tools
+from fnmatch import fnmatch
+import os
+
+
+class TlExpectedConan(ConanFile):
+    name = "tl-expected"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://tl.tartanllama.xyz"
+    description = "C++11/14/17 std::expected with functional-style extensions"
+    topics = ("cpp11", "cpp14", "cpp17", "expected")
+    license = "CC0-1.0"
+    _source_subfolder = "tl-expected"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename(self._archive_dir, self._source_subfolder)
+
+    @property
+    def _archive_dir(self):
+        # the archive expands to a directory named expected-[COMMIT SHA1];
+        # we'd like to put this under a stable name
+        expected_dirs = [
+            de for de in os.scandir(self.source_folder)
+            if de.is_dir() and fnmatch(de.name, "expected-*")
+        ]
+        return expected_dirs[0].name
+
+    def package(self):
+        self.copy("*",
+                  src=os.path.join(self._source_subfolder, "include"),
+                  dst="include")
+        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/tl-expected/all/conanfile.py
+++ b/recipes/tl-expected/all/conanfile.py
@@ -10,6 +10,7 @@ class TlExpectedConan(ConanFile):
     description = "C++11/14/17 std::expected with functional-style extensions"
     topics = ("cpp11", "cpp14", "cpp17", "expected")
     license = "CC0-1.0"
+    no_copy_source = True
     _source_subfolder = "tl-expected"
 
     def source(self):

--- a/recipes/tl-expected/all/test_package/CMakeLists.txt
+++ b/recipes/tl-expected/all/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})
+
+# CTest is a testing tool that can be used to test your project.
+# enable_testing()
+# add_test(NAME example
+#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+#          COMMAND example)

--- a/recipes/tl-expected/all/test_package/CMakeLists.txt
+++ b/recipes/tl-expected/all/test_package/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(PackageTest CXX)
+set(CMAKE_CXX_STANDARD 11)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/tl-expected/all/test_package/CMakeLists.txt
+++ b/recipes/tl-expected/all/test_package/CMakeLists.txt
@@ -7,9 +7,3 @@ conan_basic_setup()
 
 add_executable(example example.cpp)
 target_link_libraries(example ${CONAN_LIBS})
-
-# CTest is a testing tool that can be used to test your project.
-# enable_testing()
-# add_test(NAME example
-#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-#          COMMAND example)

--- a/recipes/tl-expected/all/test_package/conanfile.py
+++ b/recipes/tl-expected/all/test_package/conanfile.py
@@ -14,5 +14,4 @@ class ExpectedTestConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self.settings):
-            os.chdir("bin")
-            self.run(".%sexample" % os.sep)
+            self.run(os.path.join("bin", "example"), run_environment=True)

--- a/recipes/tl-expected/all/test_package/conanfile.py
+++ b/recipes/tl-expected/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class ExpectedTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
+        # in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            os.chdir("bin")
+            self.run(".%sexample" % os.sep)

--- a/recipes/tl-expected/all/test_package/example.cpp
+++ b/recipes/tl-expected/all/test_package/example.cpp
@@ -1,0 +1,16 @@
+#include <tl/expected.hpp>
+
+tl::expected<int, const char*> maybe_do_something(int i) {
+  if (i < 5) {
+    return 0;
+  } else {
+    return tl::make_unexpected("Uh oh");
+  }
+}
+
+int main(int argc, char** argv) {
+  (void)argc;
+  (void)argv;
+
+  return maybe_do_something(0).value_or(-1);
+}

--- a/recipes/tl-expected/config.yml
+++ b/recipes/tl-expected/config.yml
@@ -1,0 +1,4 @@
+---
+versions:
+  "1.0.1":
+    folder: all

--- a/recipes/tl-expected/config.yml
+++ b/recipes/tl-expected/config.yml
@@ -1,4 +1,6 @@
 ---
 versions:
-  "1.0.1":
+  "1.0.0":
+    folder: all
+  "20190710":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **tl-expected/1.0.1**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.  _Running yapf 0.29.0 on conanfile.py yields no changes._
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.  _Conan 1.21.0._
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated. `conan create . tl-expected/1.0.1@` on Ubuntu 19.10/clang 9 passes all conan-center hook checks.

This recipe is a port of https://github.com/yipdw/conan-tl-expected with the following modifications:

- This recipe downloads from a ZIP on github, not the git repository.
- This recipe does not offer an option to build tl-expected's tests.
- This recipe does not use tl-expected's CMake installation machinery because it installs too much for the CCI checks.  Instead, the Conan recipe in this PR copies the include file and license into the package.


