### PR TITLE
expat: fix pkg-config file name

### DIFF
--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -56,6 +56,7 @@ class ExpatConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.name = "EXPAT"
+        self.cpp_info.names['pkg_config'] = 'expat'
         self.cpp_info.libs = tools.collect_libs(self)
         if not self.options.shared:
             self.cpp_info.defines = ["XML_STATIC"]


### PR DESCRIPTION
Specify library name and version:  **expat/***

expat.pc is lowercase : https://github.com/libexpat/libexpat/blob/master/expat/expat.pc.in and https://packages.ubuntu.com/eoan/amd64/libexpat1-dev/filelist

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

