### PR TITLE
c-ares: fix pkg-config file name

### DIFF
--- a/recipes/c-ares/all/conanfile.py
+++ b/recipes/c-ares/all/conanfile.py
@@ -55,3 +55,4 @@ class CAresConan(ConanFile):
             self.cpp_info.defines.append("CARES_STATICLIB")
         if self.settings.os == "Windows":
             self.cpp_info.libs.append("ws2_32")
+        self.cpp_info.names['pkg_config'] = 'libcares'


### PR DESCRIPTION
Specify library name and version:  **c-ares/***

pkg-config file name is `libcares.pc` according to https://github.com/c-ares/c-ares/blob/master/libcares.pc.in and https://packages.ubuntu.com/eoan/amd64/libc-ares-dev/filelist

[This workaround](https://github.com/conan-io/conan-center-index/blob/master/recipes/libnghttp2/all/conanfile.py#L86) will have to be deleted after this PR is merged

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

