### PR TITLE
Set threadsafe=0 for sqlite3

### DIFF
--- a/recipes/sqlite3/all/conanfile.py
+++ b/recipes/sqlite3/all/conanfile.py
@@ -28,7 +28,7 @@ class ConanSqlite3(ConanFile):
                }
     default_options = {"shared": False,
                        "fPIC": True,
-                       "threadsafe": 1,
+                       "threadsafe": 0,
                        "enable_column_metadata": True,
                        "enable_explain_comments": False,
                        "enable_fts3": False,
@@ -68,7 +68,7 @@ class ConanSqlite3(ConanFile):
         cmake.definitions["ENABLE_JSON1"] = self.options.enable_json1
         cmake.definitions["ENABLE_RTREE"] = self.options.enable_rtree
         cmake.definitions["OMIT_LOAD_EXTENSION"] = self.options.omit_load_extension
-        cmake.definitions["SQLITE_ENABLE_UNLOCK_NOTIFY"] = self.options.enable_unlock_notify        
+        cmake.definitions["SQLITE_ENABLE_UNLOCK_NOTIFY"] = self.options.enable_unlock_notify
         cmake.definitions["HAVE_FDATASYNC"] = True
         cmake.definitions["HAVE_GMTIME_R"] = True
         cmake.definitions["HAVE_LOCALTIME_R"] = True


### PR DESCRIPTION
Specify library name and version:  **sqlite/ANY**

Related PR: https://github.com/conan-io/conan-center-index/pull/377
Related discuss: https://github.com/conan-io/conan-center-index/pull/377#pullrequestreview-331310487

VCPKG does not set threadsafe, which means is 0 by default: https://github.com/microsoft/vcpkg/blob/master/ports/sqlite3/CMakeLists.txt

/cc @arnesor 

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

