### PR TITLE
Add mpir/3.0.0

### DIFF
--- a/recipes/mpir/all/conandata.yml
+++ b/recipes/mpir/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.0.0":
+    url: "http://mpir.org/mpir-3.0.0.zip"
+    sha256: "6277d3cc36ff39c98e4d4cc17b46b5a6ff42a22d30a4130b2d49255f98dd8c1f"

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -33,6 +33,12 @@ class MpirConan(ConanFile):
         self._dll_or_lib = "dll" if self.options.shared else "lib"
         # maybe configure architecture
 
+    @property
+    def _vcxproj_path(self):
+        compiler_version = self.settings.compiler.version if int(str(self.settings.compiler.version))<16 else "15"
+        return os.path.join(self._source_subfolder,"build.vc{}".format(compiler_version),
+                                                   "{}_mpir_gc".format(self._dll_or_lib),
+                                                   "{}_mpir_gc.vcxproj".format(self._dll_or_lib))
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
@@ -50,13 +56,8 @@ class MpirConan(ConanFile):
                     tools.replace_in_file(props_path, "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>",
                                                       "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>")
 
-            vcxproj_path = os.path.join(self._source_subfolder,
-                                        "build.vc{}".format(self.settings.compiler.version),
-                                        "{}_mpir_gc".format(self._dll_or_lib),
-                                        "{}_mpir_gc.vcxproj".format(self._dll_or_lib))
-            self.output.info(vcxproj_path)
             msbuild = MSBuild(self)
-            msbuild.build(vcxproj_path, platforms=self._platforms, upgrade_project=False)
+            msbuild.build(self._vcxproj_path, platforms=self._platforms, upgrade_project=False)
 
     def package(self):
         self.copy("COPYING*", dst="licenses", src=self._source_subfolder)        

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -13,7 +13,9 @@ class MpirConan(ConanFile):
     settings = "os", "compiler", "arch", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
+    _dll_or_lib = "lib"
     _source_subfolder = "source_subfolder"
+    _platforms={'x86': 'Win32', 'x86_64': 'x64'}
 
     def build_requirements(self):
         self.build_requires("yasm/1.3.0")
@@ -25,6 +27,7 @@ class MpirConan(ConanFile):
     def configure(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+        self._dll_or_lib = "dll" if self.options.shared else "lib"
         # maybe configure architecture
 
     def source(self):
@@ -34,20 +37,29 @@ class MpirConan(ConanFile):
 
     def build(self):
         if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
-            dll_or_lib = "dll" if self.options.shared else "lib"
+            if "MD" in self.settings.compiler.runtime and not self.options.shared:
+                props_path = os.path.join(self._source_subfolder, "build.vc", 
+                "mpir_{}_{}.props".format(str(self.settings.build_type).lower(), self._dll_or_lib))
+                if self.settings.build_type == "Debug":
+                    tools.replace_in_file(props_path, "<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>",
+                                                      "<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>")
+                else:
+                    tools.replace_in_file(props_path, "<RuntimeLibrary>MultiThreaded</RuntimeLibrary>",
+                                                      "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>")
+
             vcxproj_path = os.path.join(self._source_subfolder,
                                         "build.vc{}".format(self.settings.compiler.version),
-                                        "{}_mpir_gc".format(dll_or_lib),
-                                        "{}_mpir_gc.vcxproj".format(dll_or_lib))
+                                        "{}_mpir_gc".format(self._dll_or_lib),
+                                        "{}_mpir_gc.vcxproj".format(self._dll_or_lib))
             self.output.info(vcxproj_path)
             msbuild = MSBuild(self)
-            msbuild.build(vcxproj_path)
-            #TODO handle runtime
+            msbuild.build(vcxproj_path, platforms=self._platforms, upgrade_project=False)
 
     def package(self):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)        
-        lib_folder = os.path.join(self._source_subfolder,
-                                  "lib", "x64", str(self.settings.build_type))
+        lib_folder = os.path.join(self._source_subfolder, self._dll_or_lib, 
+                                  self._platforms.get(str(self.settings.arch)), 
+                                  str(self.settings.build_type))
         self.copy("*.h", dst="include", src=lib_folder, keep_path=True)
         self.copy(pattern="*.dll*", dst="bin", src=lib_folder, keep_path=False)
         self.copy(pattern="*.lib", dst="lib", src=lib_folder, keep_path=False)        

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -34,10 +34,11 @@ class MpirConan(ConanFile):
 
     @property
     def _vcxproj_path(self):
-        compiler_version = self.settings.compiler.version if int(str(self.settings.compiler.version))<16 else "15"
+        compiler_version = self.settings.compiler.version if tools.Version(self.settings.compiler.version) < "16" else "15"
         return os.path.join(self._source_subfolder,"build.vc{}".format(compiler_version),
                                                    "{}_mpir_gc".format(self._dll_or_lib),
                                                    "{}_mpir_gc.vcxproj".format(self._dll_or_lib))
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -1,7 +1,7 @@
 from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
 from conans.errors import ConanInvalidConfiguration
 import os
-
+import glob
 
 class MpirConan(ConanFile):
     name = "mpir"
@@ -89,11 +89,9 @@ class MpirConan(ConanFile):
                 autotools = self._configure_autotools()
                 autotools.install()
             tools.rmdir(os.path.join(self.package_folder, 'share'))
-            las = [os.path.join(self.package_folder, 'lib', '{}.la'.format(la)) for la in [
-                'libgmp', 'libgmpxx', 'libmpir', 'libmpirxx']]
-            for la in las:
-                if os.path.isfile(la):
-                    os.unlink(la)
+            with tools.chdir(os.path.join(self.package_folder, "lib")):
+                for filename in glob.glob("*.la"):
+                    os.unlink(filename)
 
     def package_info(self):
         self.cpp_info.libs = ['mpir']

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -42,7 +42,7 @@ class MpirConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def _build_visual_studio(self):
-        if "MD" in self.settings.compiler.runtime and not self.options.shared:
+        if "MD" in self.settings.compiler.runtime:
                 props_path = os.path.join(self._source_subfolder, "build.vc", 
                 "mpir_{}_{}.props".format(str(self.settings.build_type).lower(), self._dll_or_lib))
                 if self.settings.build_type == "Debug":

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -27,8 +27,6 @@ class MpirConan(ConanFile):
 
     def configure(self):
         self._dll_or_lib = "dll" if self.options.shared else "lib"
-        #del self.settings.compiler.libcxx
-        #del self.settings.compiler.cppstd
 
     @property
     def _vcxproj_path(self):

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -42,7 +42,7 @@ class MpirConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def _build_visual_studio(self):
-        if "MD" in self.settings.compiler.runtime:
+        if "MD" in self.settings.compiler.runtime and not self.options.shared: # RuntimeLibrary only defined in lib props files
                 props_path = os.path.join(self._source_subfolder, "build.vc", 
                 "mpir_{}_{}.props".format(str(self.settings.build_type).lower(), self._dll_or_lib))
                 if self.settings.build_type == "Debug":

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools, MSBuild
+from conans.errors import ConanInvalidConfiguration
 import os
 
 
@@ -25,6 +26,8 @@ class MpirConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.settings.os != "Windows":
+          raise ConanInvalidConfiguration("This recipe is only compatible with Windows for the moment")
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
         self._dll_or_lib = "dll" if self.options.shared else "lib"

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -14,7 +14,6 @@ class MpirConan(ConanFile):
     settings = "os", "compiler", "arch", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
-    _dll_or_lib = "lib"
     _source_subfolder = "source_subfolder"
     _platforms = {'x86': 'Win32', 'x86_64': 'x64'}
     _autotools = None

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -31,7 +31,6 @@ class MpirConan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
         self._dll_or_lib = "dll" if self.options.shared else "lib"
-        # maybe configure architecture
 
     @property
     def _vcxproj_path(self):

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -1,0 +1,56 @@
+from conans import ConanFile, tools, MSBuild
+import os
+
+
+class MpirConan(ConanFile):
+    name = "mpir"
+    description = "MPIR is a highly optimised library for bignum arithmetic" \
+                  "forked from the GMP bignum library."
+    topics = ("conan", "mpir", "multiprecision", "math", "mathematics")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://mpir.org/"
+    license = "LGPL v3+"
+    settings = "os", "compiler", "arch", "build_type"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+    _source_subfolder = "source_subfolder"
+
+    def build_requirements(self):
+        self.build_requires("yasm/1.3.0")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+        # maybe configure architecture
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def build(self):
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            dll_or_lib = "dll" if self.options.shared else "lib"
+            vcxproj_path = os.path.join(self._source_subfolder,
+                                        "build.vc{}".format(self.settings.compiler.version),
+                                        "{}_mpir_gc".format(dll_or_lib),
+                                        "{}_mpir_gc.vcxproj".format(dll_or_lib))
+            self.output.info(vcxproj_path)
+            msbuild = MSBuild(self)
+            msbuild.build(vcxproj_path)
+            #TODO handle runtime
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)        
+        lib_folder = os.path.join(self._source_subfolder,
+                                  "lib", "x64", str(self.settings.build_type))
+        self.copy("*.h", dst="include", src=lib_folder, keep_path=True)
+        self.copy(pattern="*.dll*", dst="bin", src=lib_folder, keep_path=False)
+        self.copy(pattern="*.lib", dst="lib", src=lib_folder, keep_path=False)        
+
+    def package_info(self):
+        self.cpp_info.libs = ['mpir']

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -10,7 +10,7 @@ class MpirConan(ConanFile):
     topics = ("conan", "mpir", "multiprecision", "math", "mathematics")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://mpir.org/"
-    license = "LGPL v3+"
+    license = "LGPL-3.0-or-later"
     settings = "os", "compiler", "arch", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -56,7 +56,7 @@ class MpirConan(ConanFile):
             msbuild.build(vcxproj_path, platforms=self._platforms, upgrade_project=False)
 
     def package(self):
-        self.copy("COPYING", dst="licenses", src=self._source_subfolder)        
+        self.copy("COPYING*", dst="licenses", src=self._source_subfolder)        
         lib_folder = os.path.join(self._source_subfolder, self._dll_or_lib, 
                                   self._platforms.get(str(self.settings.arch)), 
                                   str(self.settings.build_type))

--- a/recipes/mpir/all/test_package/CMakeLists.txt
+++ b/recipes/mpir/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/mpir/all/test_package/conanfile.py
+++ b/recipes/mpir/all/test_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            if tools.os_info.is_windows:
+                bin_path += ".exe"
+            self.run(bin_path, run_environment=True)

--- a/recipes/mpir/all/test_package/test_package.cpp
+++ b/recipes/mpir/all/test_package/test_package.cpp
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <mpir.h>
+
+void foo(mpz_t result, const mpz_t param, unsigned long n)
+{
+    unsigned long i;
+    mpz_mul_ui(result, param, n);
+    for (i = 1; i < n; i++)
+        mpz_add_ui(result, result, i * 7);
+}
+
+int main(void)
+{
+    mpz_t r, n;
+    mpz_init(r);
+    mpz_init_set_str(n, "123456", 0);
+    foo(r, n, 20L);
+    gmp_printf("%Zd\n", r);
+    return 0;
+}

--- a/recipes/mpir/config.yml
+++ b/recipes/mpir/config.yml
@@ -1,0 +1,3 @@
+versions:
+    "3.0.0":
+      folder: all


### PR DESCRIPTION
Specify library name and version:  **mpir/3.0.0**

Some options missing. The idea is to substitute **gmp** for this one when **cgal** is available in c3i.

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

