### PR TITLE
Add hdf5/1.10.6

### DIFF
--- a/recipes/hdf5/all/conandata.yml
+++ b/recipes/hdf5/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "1.10.5":
     sha256: 22a4a48f94b013e9fd482c0bb0251de02ff9963787a107c5dde26a3f903b3b90
     url: https://github.com/live-clones/hdf5/archive/hdf5-1_10_5.tar.gz
+  "1.10.6":
+    sha256: e524b374b1c6f14f1aa87595c0761608c861fe7838549dab84639ae564ff48e8
+    url: https://github.com/live-clones/hdf5/archive/hdf5-1_10_6.tar.gz

--- a/recipes/hdf5/config.yml
+++ b/recipes/hdf5/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   1.10.5:
     folder: all
+  1.10.6:
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **hdf5/1.10.6**

The new version was released in December and includes changes to the CMake that I had to take into account in the recipe. Most notably it allows not to build the static libraries which allows to avoid having to remove them in `shared` mode, which is pretty welcome to avoid useless world.

Instead of making a whole new recipe I decided to switch on the version (`tools.Version` is quite handy there). Is this fine as long as the delta between different versions isn't too large or is it frowned upon?

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

