### PR TITLE
[package] libsodium/1.0.18: Fixes fPIC option being accessed while being deleted on Windows

### DIFF
--- a/recipes/libsodium/1.0.18/conanfile.py
+++ b/recipes/libsodium/1.0.18/conanfile.py
@@ -188,6 +188,6 @@ class LibsodiumConan(ConanFile):
             self._autotools_bool_arg("soname-versions", self.options.use_soname),
             self._autotools_bool_arg("pie", self.options.PIE)
         ]
-        if self.options.fPIC:
+        if hasattr(self, 'options.fPIC') and self.options.fPIC:
             args.append("--with-pic")
         return args

--- a/recipes/libsodium/1.0.18/conanfile.py
+++ b/recipes/libsodium/1.0.18/conanfile.py
@@ -188,6 +188,6 @@ class LibsodiumConan(ConanFile):
             self._autotools_bool_arg("soname-versions", self.options.use_soname),
             self._autotools_bool_arg("pie", self.options.PIE)
         ]
-        if hasattr(self, 'options.fPIC') and self.options.fPIC:
+        if self.options.get_safe("fPIC"):
             args.append("--with-pic")
         return args


### PR DESCRIPTION
Specify library name and version:  libsodium/1.0.18

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Adds check to prevent python error when compiling on Windows due to self.options.fPIC not being used. Only tested with mingw.
