### PR TITLE
Changes Catch2 cpp info name to better match with the original package

### DIFF
--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -51,3 +51,4 @@ class ConanRecipe(ConanFile):
 
     def package_info(self):
         self.cpp_info.builddirs = [os.path.join("lib", "cmake", "Catch2")]
+        self.cpp_info.name = "Catch2"

--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -51,4 +51,5 @@ class ConanRecipe(ConanFile):
 
     def package_info(self):
         self.cpp_info.builddirs = [os.path.join("lib", "cmake", "Catch2")]
-        self.cpp_info.name = "Catch2"
+        self.cpp_info.names["cmake_find_package"] = "Catch2"
+        self.cpp_info.names["cmake_find_package_multi"] = "Catch2"


### PR DESCRIPTION
Specify library name and version:  Catch2/2.x.x

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Some libraries that interact with catch (such as FSeam) rely on the original Catch2::Catch2 target. In addition this allows you to change between conan or system libs without changing your cmake files.