### PR TITLE
Remove name for json-c

### DIFF
--- a/recipes/json-c/all/conanfile.py
+++ b/recipes/json-c/all/conanfile.py
@@ -63,4 +63,5 @@ class JSONCConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
-        self.cpp_info.name = "JSONC"
+        self.cpp_info.names["cmake_find_package"] = "JSONC"
+        self.cpp_info.names["cmake_find_package_multi"] = "JSONC"


### PR DESCRIPTION
Specify library name and version:  **json-c/all**

Related issue: https://github.com/conan-io/conan/issues/6269#issuecomment-570182130

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

