### PR TITLE
Remove name for libxml2

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -204,4 +204,5 @@ class Libxml2Conan(ConanFile):
             self.cpp_info.libs.append('m')
         if self.settings.os == "Windows":
             self.cpp_info.libs.append('ws2_32')
-        self.cpp_info.name = 'LibXml2'
+        self.cpp_info.names["cmake_find_package"] = "LibXml2"
+        self.cpp_info.names["cmake_find_package_multi"] = "LibXml2"


### PR DESCRIPTION
Specify library name and version:  **libxml2/all**

Related issue: https://github.com/conan-io/conan/issues/6269#issuecomment-570182130

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

