### PR TITLE
Remove name for openexr

### DIFF
--- a/recipes/openexr/2.4.0/conanfile.py
+++ b/recipes/openexr/2.4.0/conanfile.py
@@ -68,7 +68,8 @@ class OpenEXRConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.name = "OpenEXR"
+        self.cpp_info.names["cmake_find_package"] = "OpenEXR"
+        self.cpp_info.names["cmake_find_package_multi"] = "OpenEXR"
         parsed_version = self.version.split(".")
         lib_suffix = "-{}_{}".format(parsed_version[0], parsed_version[1])
         if self.settings.build_type == "Debug":


### PR DESCRIPTION
Specify library name and version:  **openexr/all**

Related issue: https://github.com/conan-io/conan/issues/6269#issuecomment-570182130

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

