### PR TITLE
Remove name for libarchive

### DIFF
--- a/recipes/libarchive/all/conanfile.py
+++ b/recipes/libarchive/all/conanfile.py
@@ -182,6 +182,7 @@ class LibarchiveConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
-        self.cpp_info.name = "LibArchive"
+        self.cpp_info.names["cmake_find_package"] = "LibArchive"
+        self.cpp_info.names["cmake_find_package_multi"] = "LibArchive"
         if self.settings.compiler == "Visual Studio" and not self.options.shared:
             self.cpp_info.defines = ["LIBARCHIVE_STATIC"]


### PR DESCRIPTION
Specify library name and version:  **libarchive/all**

Related issue: https://github.com/conan-io/conan/issues/6269#issuecomment-570182130

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

