### PR TITLE
Remove name for bzip2

### DIFF
--- a/recipes/bzip2/1.0.8/conanfile.py
+++ b/recipes/bzip2/1.0.8/conanfile.py
@@ -53,6 +53,6 @@ class Bzip2Conan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.name = "BZip2"
-        self.cpp_info.names["pkg_config"] = "bzip2"
+        self.cpp_info.names["cmake_find_package"] = "BZip2"
+        self.cpp_info.names["cmake_find_package_multi"] = "BZip2"
         self.cpp_info.libs = tools.collect_libs(self)


### PR DESCRIPTION
Specify library name and version:  **bzip2/all**

Related issue: https://github.com/conan-io/conan/issues/6269#issuecomment-570182130

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

