### PR TITLE
add meson 0.53.0

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "0.52.1":
     url: "https://github.com/mesonbuild/meson/archive/0.52.1.tar.gz"
     sha256: "ad8dbad61d4c22cb7d768cb1f8a212b4abf0f3fbc17c298d816140ecd9f5d1df"
+  "0.53.0":
+    url: "https://github.com/mesonbuild/meson/archive/0.53.0.tar.gz"
+    sha256: "cc15f416d0b538fb079c15a59ee2cd106895ca115fa5d654731a695c85c992fc"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "0.52.1":
     folder: all
+  "0.53.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **meson/0.53.0**

this version is the first one which can work with conan AND msvc, because it has a fix for https://github.com/mesonbuild/meson/issues/6101

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

