### PR TITLE
libx264: fix mingw build

### DIFF
--- a/recipes/libx264/all/conanfile.py
+++ b/recipes/libx264/all/conanfile.py
@@ -90,12 +90,12 @@ class LibX264Conan(ConanFile):
         return self._autotools
 
     def build(self):
-        with tools.vcvars(self.settings):
+        with tools.vcvars(self.settings) if self._is_msvc else tools.no_op():
             autotools = self._configure_autotools()
             autotools.make()
 
     def package(self):
-        with tools.vcvars(self.settings):
+        with tools.vcvars(self.settings) if self._is_msvc else tools.no_op():
             autotools = self._configure_autotools()
             autotools.install()
         self.copy(pattern="COPYING", src=self._source_subfolder, dst='licenses')


### PR DESCRIPTION
don't use tools.vcvars on mingw

fixes #627

Specify library name and version:  **lib/1.0**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

