### PR TITLE
libcurl/1.9.0: allow option 'with_libssh2' with Visual Studio

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -95,8 +95,7 @@ class LibcurlConan(ConanFile):
             if self.settings.os != "Macos" or not self.options.darwin_ssl:
                 self.options["openssl"].shared = self.options.shared
         if self.options.with_libssh2:
-            if self.settings.compiler != "Visual Studio":
-                self.options["libssh2"].shared = self.options.shared
+            self.options["libssh2"].shared = self.options.shared
 
     def system_requirements(self):
         # TODO: Declare tools needed to compile. The idea is Conan checking that they are
@@ -113,8 +112,7 @@ class LibcurlConan(ConanFile):
             else:
                 self.requires.add("openssl/1.1.1d")
         if self.options.with_libssh2:
-            if self.settings.compiler != "Visual Studio":
-                self.requires.add("libssh2/1.9.0")
+            self.requires.add("libssh2/1.9.0")
         if self.options.with_nghttp2:
             self.requires.add("libnghttp2/1.40.0")
 


### PR DESCRIPTION
It is possible to compile libcurl with Cmake and Visual Studio using the libssh2 option.

Library name and version:  **libcurl/1.9.0**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
