### PR TITLE
doctest: include doctest.cmake in the package

### DIFF
--- a/recipes/doctest/2.x.x/conanfile.py
+++ b/recipes/doctest/2.x.x/conanfile.py
@@ -26,7 +26,7 @@ class DoctestConan(ConanFile):
 
         cmake_script_dirs = {
             "src": os.path.join(self._source_subfolder, "scripts/cmake"),
-            "dst": "lib/cmake/doctest"
+            "dst": "lib/cmake"
         }
 
         self.copy(pattern="doctest.cmake", **cmake_script_dirs)
@@ -38,7 +38,8 @@ class DoctestConan(ConanFile):
             # can't use destructors in thread_local with mingw
             self.cpp_info.defines.append("DOCTEST_THREAD_LOCAL=")
 
-        self.cpp_info.builddirs.append("lib/cmake/doctest")
+        self.cpp_info.builddirs.append("lib/cmake")
+        self.cpp_info.build_modules.append("lib/cmake/doctest.cmake")
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/doctest/2.x.x/conanfile.py
+++ b/recipes/doctest/2.x.x/conanfile.py
@@ -24,11 +24,21 @@ class DoctestConan(ConanFile):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
         self.copy(pattern="*doctest.h", dst="include", src=self._source_subfolder)
 
+        cmake_script_dirs = {
+            "src": os.path.join(self._source_subfolder, "scripts/cmake"),
+            "dst": "lib/cmake/doctest"
+        }
+
+        self.copy(pattern="doctest.cmake", **cmake_script_dirs)
+        self.copy(pattern="doctestAddTests.cmake", **cmake_script_dirs)
+
     def package_info(self):
         if self._is_mingw:
             # See https://sourceforge.net/p/mingw-w64/bugs/727/
             # can't use destructors in thread_local with mingw
             self.cpp_info.defines.append("DOCTEST_THREAD_LOCAL=")
+
+        self.cpp_info.builddirs.append("lib/cmake/doctest")
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/doctest/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/doctest/2.x.x/test_package/CMakeLists.txt
@@ -9,3 +9,9 @@ file(GLOB SOURCE_FILES *.cpp)
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+
+enable_testing()
+
+include(doctest)
+doctest_discover_tests(${PROJECT_NAME})
+

--- a/recipes/doctest/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/doctest/2.x.x/test_package/CMakeLists.txt
@@ -12,6 +12,4 @@ target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 
 enable_testing()
 
-include(doctest)
 doctest_discover_tests(${PROJECT_NAME})
-

--- a/recipes/doctest/2.x.x/test_package/conanfile.py
+++ b/recipes/doctest/2.x.x/test_package/conanfile.py
@@ -6,14 +6,16 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 
-    def build(self):
+    def _configure_cmake(self):
         cmake = CMake(self)
         cmake.configure()
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
         cmake.build()
 
     def test(self):
         if not tools.cross_building(self.settings) or tools.os_info.is_windows:
-            bin_path = os.path.join("bin", "test_package")
-            if tools.os_info.is_windows:
-                bin_path += ".exe"
-            self.run(bin_path, run_environment=True)
+            cmake = self._configure_cmake()
+            cmake.test()


### PR DESCRIPTION
Specify library name and version:  **doctest/2.3.5**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This change adds `doctest.cmake` script to the package. The script defines a `doctest_discrover_tests` function, which sets up CTest tests for test cases in an executable.