### PR TITLE
Add include/leptonica to cpp_info for leptonica

### DIFF
--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -116,3 +116,4 @@ class LeptonicaConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "Leptonica"
         self.cpp_info.names["cmake_find_package_multi"] = "Leptonica"
         self.cpp_info.names['pkg_config'] = 'lept'
+        self.cpp_info.includedirs.append(os.path.join("include", "leptonica"))


### PR DESCRIPTION
It is required to export both include dirs as seen in Leptonica's cmake/pc files.

Specify library name and version:  **leptonica/1.78.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

