### PR TITLE
Add mozilla-build/3.3 recipe

### DIFF
--- a/recipes/mozilla-build/all/conandata.yml
+++ b/recipes/mozilla-build/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.3":
+    sha256: ac86e5794c6a99c25dee0b60720c7cfd9833ec64785c74838723179830749c9c
+    url: https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-3.3.exe

--- a/recipes/mozilla-build/all/conanfile.py
+++ b/recipes/mozilla-build/all/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class MozillaBuildConan(ConanFile):
     name = "mozilla-build"
-    homepage = "https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites"
+    homepage = "https://wiki.mozilla.org/MozillaBuild"
     description = "Mozilla build requirements on Windows"
     topics = ("conan", "mozilla", "build")
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/mozilla-build/all/conanfile.py
+++ b/recipes/mozilla-build/all/conanfile.py
@@ -23,7 +23,7 @@ class MozillaBuildConan(ConanFile):
         tools.download("https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt", "LICENSE")
 
     def package(self):
-        tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), "Mozilla Public License (MPL) version 2.0")
+        self.copy("LICENSE", dst="licenses")
         self.copy("nsinstall.exe", src="bin", dst="bin")
 
     def package_info(self):

--- a/recipes/mozilla-build/all/conanfile.py
+++ b/recipes/mozilla-build/all/conanfile.py
@@ -20,6 +20,7 @@ class MozillaBuildConan(ConanFile):
         tools.check_sha256("mozilla-build.exe", self.conan_data["sources"][self.version]["sha256"])
         self.run("7z x mozilla-build.exe")
         os.unlink("mozilla-build.exe")
+        tools.download("https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt", "LICENSE")
 
     def package(self):
         tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), "Mozilla Public License (MPL) version 2.0")

--- a/recipes/mozilla-build/all/conanfile.py
+++ b/recipes/mozilla-build/all/conanfile.py
@@ -1,0 +1,31 @@
+from conans import ConanFile, tools
+import os
+
+
+class MozillaBuildConan(ConanFile):
+    name = "mozilla-build"
+    homepage = "https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Windows_Prerequisites"
+    description = "Mozilla build requirements on Windows"
+    topics = ("conan", "mozilla", "build")
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = {"os_build": "Windows", "arch_build": ["x86", "x86_64"]}
+    license = "MPL-2.0"
+
+    def build_requirements(self):
+        self.build_requires("7zip/19.00")
+
+    def build(self):
+        url = self.conan_data["sources"][self.version]["url"]
+        tools.download(url, "mozilla-build.exe")
+        tools.check_sha256("mozilla-build.exe", self.conan_data["sources"][self.version]["sha256"])
+        self.run("7z x mozilla-build.exe")
+        os.unlink("mozilla-build.exe")
+
+    def package(self):
+        tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), "Mozilla Public License (MPL) version 2.0")
+        self.copy("nsinstall.exe", src="bin", dst="bin")
+
+    def package_info(self):
+        binpath = os.path.join(self.package_folder, "bin")
+        self.output.info("Adding to PATH: {}".format(binpath))
+        self.env_info.PATH.append(binpath)

--- a/recipes/mozilla-build/all/test_package/conanfile.py
+++ b/recipes/mozilla-build/all/test_package/conanfile.py
@@ -1,0 +1,15 @@
+from conans import ConanFile, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+
+    def test(self):
+        tools.save("file.txt", "some text")
+        assert not os.path.isdir("destionation")
+        self.run("nsinstall -D destination")
+        assert os.path.isdir("destination")
+        assert not os.path.isfile(os.path.join("destination", "file.txt"))
+        self.run("nsinstall -t -m 644 file.txt destination")
+        assert os.path.isfile(os.path.join("destination", "file.txt"))
+

--- a/recipes/mozilla-build/config.yml
+++ b/recipes/mozilla-build/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.3":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **mozilla-build/3.3**

For building nspr, we need the executable `nsinstall`.
The source for it is inside the nspr source tarball but it is not possible to build it using Visual Studio or mingw_installer@conan/stable.
Because it is crucial for building nspr on Windows, use the one inside the mozilla build archive.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

