### PR TITLE
Add IXWebSocket (7.6.3)

### DIFF
--- a/recipes/ixwebsocket/all/CMakeLists.txt
+++ b/recipes/ixwebsocket/all/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.1.2)
+project(conan-IXWebSocket)
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+add_subdirectory(sources)

--- a/recipes/ixwebsocket/all/conandata.yml
+++ b/recipes/ixwebsocket/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "7.6.3":
+    url: "https://github.com/machinezone/IXWebSocket/archive/v7.6.3.zip"
+    sha256: "068C20425C7E70C840AE710095237DF6515B1C1A0EA4416FF873AAD2DA49C3D3"

--- a/recipes/ixwebsocket/all/conandata.yml
+++ b/recipes/ixwebsocket/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "7.6.3":
-    url: "https://github.com/machinezone/IXWebSocket/archive/v7.6.3.zip"
-    sha256: "068C20425C7E70C840AE710095237DF6515B1C1A0EA4416FF873AAD2DA49C3D3"
+  "7.9.2":
+    url: "https://github.com/machinezone/IXWebSocket/archive/v7.9.2.zip"
+    sha256: "B5224C1DEC64E25933F2DC547C278265A1B335C4516F1B11FAC81F0AC99B747E"

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -142,6 +142,6 @@ class IXWebSocketConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")
 
-        if self.settings.os == "Macos" and not self.options.use_openssl and not self.options.use_mbed_tls:
+        if self.settings.use_tls and self.settings.os == "Macos" and not self.options.use_openssl and not self.options.use_mbed_tls:
             # Required
-             self.cpp_info.frameworks = [ 'Security' ]
+             self.cpp_info.frameworks = [ 'Security', 'CoreFoundation' ]

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -1,11 +1,12 @@
 from conans import ConanFile, CMake, tools
+from conans.tools import Version
 from conans.errors import ConanInvalidConfiguration
 import os
 
 
 class IXWebSocketConan(ConanFile):
     name = "ixwebsocket"
-    description = "WebSocket client/server"
+    description = "IXWebSocket is a C++ library for WebSocket client and server development"
     topics = ("conan", "IXWebSocket", "socket", "websocket")
 
     url = "https://github.com/conan-io/conan-center-index"
@@ -26,21 +27,18 @@ class IXWebSocketConan(ConanFile):
         "use_tls": [True, False],
         "use_openssl": [False, True],
         "use_vendored_third_party": [True, False],
-        "use_ws": [False, True],
         "fPIC": [True, False]
     }
     default_options = {k: v[0] for k, v in options.items()}
 
-    def intVersion(self):
-        return int(self.version.replace(".", ""))
-
-    def canUseOpenSSL(self):
+    def _can_use_openssl(self):
         if self.settings.os == "Windows":
-            # Future: support for OpenSSL was introduced in 7.9.3. Earlier versions force MbedTLS
-            return False if self.intVersion() < 793 else True
+            # Future: support for OpenSSL on Windows was introduced in 7.9.3. Earlier versions force MbedTLS
+            return Version(self.version) >= "7.9.3"
         # The others do, by default, support OpenSSL and MbedTLS. Non-standard operating systems might
         # be a challenge.
-        return True 
+        # Older versions doesn't support OpenSSL on Mac, but those are unlikely to be built now.
+        return True
 
     def configure(self):
         if self.options.use_mbed_tls and not self.options.use_tls or self.options.get_safe("use_openssl") and not self.options.use_tls:
@@ -48,11 +46,12 @@ class IXWebSocketConan(ConanFile):
         elif self.options.use_mbed_tls and self.options.get_safe("use_openssl"):
             raise ConanInvalidConfiguration("Cannot use both OpenSSL and MbedTLS")
 
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
             self.default_options["use_mbed_tls"] = True
-            if not self.canUseOpenSSL():
+            if not self._can_use_openssl():
                 del self.options.use_openssl
         elif self.settings.os == "Linux":
             # On Linux, if TLS is enabled and mbed is disabled, the only option is OpenSSL.
@@ -60,88 +59,55 @@ class IXWebSocketConan(ConanFile):
 
     def requirements(self):
 
-        if(self.canUseOpenSSL() and not self.options.use_mbed_tls and self.options.use_tls 
-                                and ("use_openssl" not in self.options or self.options.use_openssl)):    
+        if(self._can_use_openssl() and not self.options.use_mbed_tls and self.options.use_tls
+           and ("use_openssl" not in self.options or self.options.use_openssl)):
             self.requires.add("openssl/1.1.1c")
 
         self.requires.add("zlib/1.2.11")
 
-        if not self.options.use_vendored_third_party and (self.settings.os == "Windows" and self.options.use_tls 
-                                                          and not self.canUseOpenSSL() or self.options.use_mbed_tls):
+        if not self.options.use_vendored_third_party and (self.settings.os == "Windows" and self.options.use_tls
+                                                          and not self._can_use_openssl() or self.options.use_mbed_tls):
             self.requires.add("mbedtls/2.6.1")
-
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("IXWebSocket-" + self.version, "sources")
 
-    def addLibrary(self, keyBase, includeName, cmake):
+    def _add_library(self, keyBase, includeName, cmake):
         cmake.definitions[keyBase +
                           "_LIBRARY"] = self.deps_cpp_info[includeName].rootpath
-        includePath = keyBase + "_INCLUDE_DIR"
-        cmake.definitions[includePath] = os.path.join(
-            self.deps_cpp_info[includeName].rootpath, self.deps_cpp_info[includeName].includedirs[0])
 
-    def configure_cmake(self):
+    def _configure_cmake(self):
         cmake = CMake(self)
 
         # User-selectable options
         cmake.definitions["USE_TLS"] = self.options.use_tls
         cmake.definitions["USE_MBED_TLS"] = self.options.use_mbed_tls
-        cmake.definitions["USE_WS"] = self.options.use_ws
         cmake.definitions["USE_VENDORED_THIRD_PARTY"] = self.options.use_vendored_third_party
 
-        # Library linking
-        if (self.options.use_tls and not self.options.use_mbed_tls and not self.settings.os == "Windows" and not self.settings.os == "Macos"):
-            os.environ['OPENSSL_ROOT_DIR'] = self.deps_cpp_info["openssl"].rootpath
-        self.addLibrary("ZLIB", "zlib", cmake)
-        if not self.options.use_vendored_third_party and (self.options.use_mbed_tls or self.options.use_tls and self.settings.os == "Windows"):
-            self.addLibrary("MBEDTLS", "mbedtls", cmake)
-            self.addLibrary("MBEDCRYPTO", "mbedtls", cmake)
-            self.addLibrary("MBEDX509", "mbedtls", cmake)
         cmake.configure()
         return cmake
 
     def build(self):
-        cmake = self.configure_cmake()
+        cmake = self._configure_cmake()
         cmake.build()
         cmake.install()
 
     def package(self):
         # Include package license
-        self.copy("LICENSE.txt", dst="licenses", src="sources")
-
-        # Include binaries and headers
-        self.copy("*.h", dst="include", src="include")
-        self.copy("*.lib", dst="lib", keep_path=False)
-        self.copy("*.dll", dst="bin", keep_path=False)
-        self.copy("*.so", dst="lib", keep_path=False)
-        self.copy("*.dylib", dst="lib", keep_path=False)
-        self.copy("*.a", dst="lib", keep_path=False)
+        self.copy(pattern="LICENSE*", dst="licenses", src="sources")
+        cmake = self._configure_cmake()
+        cmake.install()
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
-        if self.options.use_tls and self.settings.os == "Windows":
+        if self.options.use_tls and not self.options.use_mbed_tls and not self.options.get_safe("use_openssl") and self.settings.os == "Windows":
             # Include linking with the websocket
             self.cpp_info.system_libs.append("Ws2_32")
-        if self.options.use_tls and (self.options.use_mbed_tls and self.options.use_vendored_third_party or self.settings.os == "Windows"):
-            # This doesn't really affect MSVC builds, but it might if the compiler changes in the future.
-            if "mbedtls" not in self.cpp_info.libs:
-                self.cpp_info.libs.extend(["mbedtls", "mbedx509", "mbedcrypto"])
-            else:
-                pIdx = self.cpp_info.libs.index("mbedtls")
-                cIdx = self.cpp_info.libs.index("mbedcrypto")
-                xIdx = self.cpp_info.libs.index("mbedx509")
-                # Linking order matters on some compilers. Aside MSVC, Clang and GCC, and potentially others, require the linking
-                # order of -lmbedtls -l mbedx509 -lmbedcrypto, as outlined in the README for mbedTLS.
-                # See also: https://stackoverflow.com/a/17741992/6296561
-                if (cIdx > pIdx or xIdx > pIdx or cIdx > xIdx):
-                    self.cpp_info.libs = [
-                        x for x in self.cpp_info.libs if "mbed" not in x] + ["mbedtls", "mbedx509", "mbedcrypto"]
 
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")
 
         if self.options.use_tls and self.settings.os == "Macos" and not self.options.use_openssl and not self.options.use_mbed_tls:
             # Required
-             self.cpp_info.frameworks = [ 'Security', 'CoreFoundation' ]
+            self.cpp_info.frameworks = ['Security', 'CoreFoundation']

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -142,6 +142,6 @@ class IXWebSocketConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")
 
-        if self.settings.use_tls and self.settings.os == "Macos" and not self.options.use_openssl and not self.options.use_mbed_tls:
+        if self.options.use_tls and self.settings.os == "Macos" and not self.options.use_openssl and not self.options.use_mbed_tls:
             # Required
              self.cpp_info.frameworks = [ 'Security', 'CoreFoundation' ]

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -75,7 +75,7 @@ class IXWebSocketConan(ConanFile):
 
         # Library linking
         if (self.options.use_tls and not self.options.use_mbed_tls and not self.settings.os == "Windows" and not self.settings.os == "Macos"):
-            os.environ['OPENSSL_ROOT_DIR'] = self.deps_cpp_info["OpenSSL"].rootpath
+            os.environ['OPENSSL_ROOT_DIR'] = self.deps_cpp_info["openssl"].rootpath
         self.addLibrary("ZLIB", "zlib", cmake)
         if not self.options.use_vendored_third_party and (self.options.use_mbed_tls or self.options.use_tls and self.settings.os == "Windows"):
             self.addLibrary("MBEDTLS", "mbedtls", cmake, True)

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -73,10 +73,6 @@ class IXWebSocketConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("IXWebSocket-" + self.version, "sources")
 
-    def _add_library(self, keyBase, includeName, cmake):
-        cmake.definitions[keyBase +
-                          "_LIBRARY"] = self.deps_cpp_info[includeName].rootpath
-
     def _configure_cmake(self):
         cmake = CMake(self)
 

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -41,7 +41,7 @@ class IXWebSocketConan(ConanFile):
             # Specifically, Windows is forced to use MbedTLS, while Mac can use
             # MBEDTLS or an Apple-specific SSL provider. UNIX can use OpenSSL or MbedTLS
             # So even though both these operating systems support it, it isn't used.
-            self.requires.add("OpenSSL/1.1.1c")
+            self.requires.add("openssl/1.1.1c")
 
         self.requires.add("zlib/1.2.11")
 

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -58,7 +58,7 @@ class IXWebSocketConan(ConanFile):
     def requirements(self):
 
         if(self._can_use_openssl() and not self.options.use_mbed_tls and self.options.use_tls
-           and ("use_openssl" not in self.options or self.options.use_openssl)):
+           and (self.options.get_safe("use_openssl") or self.settings.os == "Linux")):
             self.requires.add("openssl/1.1.1c")
 
         self.requires.add("zlib/1.2.11")

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -68,9 +68,6 @@ class IXWebSocketConan(ConanFile):
                                                           and not self.canUseOpenSSL() or self.options.use_mbed_tls):
             self.requires.add("mbedtls/2.6.1")
 
-        if self.settings.os == "Macos" and not self.options.use_openssl and not self.options.use_mbed_tls:
-            # Required
-             self.cpp_info.frameworks = [ 'Security' ]
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -126,11 +123,11 @@ class IXWebSocketConan(ConanFile):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.options.use_tls and self.settings.os == "Windows":
             # Include linking with the websocket
-            self.cpp_info.libs += ["Ws2_32"]
+            self.cpp_info.system_libs.append("Ws2_32")
         if self.options.use_tls and (self.options.use_mbed_tls and self.options.use_vendored_third_party or self.settings.os == "Windows"):
             # This doesn't really affect MSVC builds, but it might if the compiler changes in the future.
             if "mbedtls" not in self.cpp_info.libs:
-                self.cpp_info.libs += ["mbedtls", "mbedx509", "mbedcrypto"]
+                self.cpp_info.libs.extend(["mbedtls", "mbedx509", "mbedcrypto"])
             else:
                 pIdx = self.cpp_info.libs.index("mbedtls")
                 cIdx = self.cpp_info.libs.index("mbedcrypto")
@@ -143,4 +140,8 @@ class IXWebSocketConan(ConanFile):
                         x for x in self.cpp_info.libs if "mbed" not in x] + ["mbedtls", "mbedx509", "mbedcrypto"]
 
         if self.settings.os == "Linux":
-            self.cpp_info.libs.append("pthread")
+            self.cpp_info.system_libs.append("pthread")
+
+        if self.settings.os == "Macos" and not self.options.use_openssl and not self.options.use_mbed_tls:
+            # Required
+             self.cpp_info.frameworks = [ 'Security' ]

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -1,0 +1,125 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class IXWebSocketConan(ConanFile):
+    name = "ixwebsocket"
+    description = "WebSocket client/server"
+    topics = ("conan", "IXWebSocket", "socket", "websocket")
+
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/machinezone/IXWebSocket"
+
+    # License for the library
+    license = "BSD-3-Clause"
+
+    exports_sources = ["CMakeLists.txt"]
+
+    settings = "os", "compiler", "build_type", "arch"
+
+    short_paths = True
+    generators = "cmake"
+
+    options = {
+        "use_mbed_tls": [False, True],
+        "use_tls": [True, False],
+        "use_vendored_third_party": [True, False],
+        "use_ws": [False, True],
+        "fPIC": [True, False]
+    }
+    default_options = {k: v[0] for k, v in options.items()}
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+            self.default_options["use_mbed_tls"] = True
+
+    def requirements(self):
+
+        if(self.settings.os != "Windows" and self.settings.os != "Macos" and not self.options.use_mbed_tls and self.options.use_tls):
+            # On Windows and Mac, the current CMake config prefers different SSL providers.
+            # Specifically, Windows is forced to use MbedTLS, while Mac can use
+            # MBEDTLS or an Apple-specific SSL provider. UNIX can use OpenSSL or MbedTLS
+            # So even though both these operating systems support it, it isn't used.
+            self.requires.add("OpenSSL/1.1.1c")
+
+        self.requires.add("zlib/1.2.11")
+
+        if (self.options.use_mbed_tls and not self.options.use_tls):
+            print("WARN: Attempting to use mbed tls without enabling TLS.")
+
+        if not self.options.use_vendored_third_party and (self.settings.os == "Windows" and self.options.use_tls or self.options.use_mbed_tls):
+            self.requires.add("mbedtls/2.6.1")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("IXWebSocket-" + self.version, "sources")
+
+    def addLibrary(self, keyBase, includeName, cmake, plural=False):
+        cmake.definitions[keyBase +
+                          "_LIBRARY"] = self.deps_cpp_info[includeName].rootpath
+        includePath = keyBase + "_INCLUDE_DIR"
+        if plural == True:
+            includePath += "S"
+        cmake.definitions[includePath] = os.path.join(
+            self.deps_cpp_info[includeName].rootpath, self.deps_cpp_info[includeName].includedirs[0])
+
+    def configure_cmake(self):
+        cmake = CMake(self)
+
+        # User-selectable options
+        cmake.definitions["USE_TLS"] = self.options.use_tls
+        cmake.definitions["USE_MBED_TLS"] = self.options.use_mbed_tls
+        cmake.definitions["USE_WS"] = self.options.use_ws
+        cmake.definitions["USE_VENDORED_THIRD_PARTY"] = self.options.use_vendored_third_party
+
+        # Library linking
+        if (self.options.use_tls and not self.options.use_mbed_tls and not self.settings.os == "Windows" and not self.settings.os == "Macos"):
+            os.environ['OPENSSL_ROOT_DIR'] = self.deps_cpp_info["OpenSSL"].rootpath
+        self.addLibrary("ZLIB", "zlib", cmake)
+        if not self.options.use_vendored_third_party and (self.options.use_mbed_tls or self.options.use_tls and self.settings.os == "Windows"):
+            self.addLibrary("MBEDTLS", "mbedtls", cmake, True)
+            self.addLibrary("MBEDCRYPTO", "mbedtls", cmake, True)
+            self.addLibrary("MBEDX509", "mbedtls", cmake, True)
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        cmake = self.configure_cmake()
+        cmake.build()
+        cmake.install()
+
+    def package(self):
+        # Include package license
+        self.copy("license*", dst="licenses", src="sources")
+
+        # Include binaries and headers
+        self.copy("*.h", dst="include", src="include")
+        self.copy("*.lib", dst="lib", keep_path=False)
+        self.copy("*.dll", dst="bin", keep_path=False)
+        self.copy("*.so", dst="lib", keep_path=False)
+        self.copy("*.dylib", dst="lib", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        if self.options.use_tls and self.settings.os == "Windows":
+            # Include linking with the websocket
+            self.cpp_info.libs += ["Ws2_32"]
+        if self.options.use_tls and (self.options.use_mbed_tls and self.options.use_vendored_third_party or self.settings.os == "Windows"):
+            # This doesn't really affect MSVC builds, but it might if the compiler changes in the future.
+            if "mbedtls" not in self.cpp_info.libs:
+                self.cpp_info.libs += ["mbedtls", "mbedx509", "mbedcrypto"]
+            else:
+                pIdx = self.cpp_info.libs.index("mbedtls")
+                cIdx = self.cpp_info.libs.index("mbedcrypto")
+                xIdx = self.cpp_info.libs.index("mbedx509")
+                # Linking order matters on some compilers. Aside MSVC, Clang and GCC, and potentially others, require the linking
+                # order of -lmbedtls -l mbedx509 -lmbedcrypto, as outlined in the README for mbedTLS.
+                # See also: https://stackoverflow.com/a/17741992/6296561
+                if (cIdx > pIdx or xIdx > pIdx or cIdx > xIdx):
+                    self.cpp_info.libs = [
+                        x for x in self.cpp_info.libs if "mbed" not in x] + ["mbedtls", "mbedx509", "mbedcrypto"]
+
+        if self.settings.os == "Linux":
+            self.cpp_info.libs.append("pthread")

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -91,7 +91,7 @@ class IXWebSocketConan(ConanFile):
 
     def package(self):
         # Include package license
-        self.copy("license*", dst="licenses", src="sources")
+        self.copy("LICENSE.txt", dst="licenses", src="sources")
 
         # Include binaries and headers
         self.copy("*.h", dst="include", src="include")

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -26,7 +26,6 @@ class IXWebSocketConan(ConanFile):
         "use_mbed_tls": [False, True],
         "use_tls": [True, False],
         "use_openssl": [False, True],
-        "use_vendored_third_party": [True, False],
         "fPIC": [True, False]
     }
     default_options = {k: v[0] for k, v in options.items()}
@@ -46,7 +45,6 @@ class IXWebSocketConan(ConanFile):
         elif self.options.use_mbed_tls and self.options.get_safe("use_openssl"):
             raise ConanInvalidConfiguration("Cannot use both OpenSSL and MbedTLS")
 
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -65,9 +63,8 @@ class IXWebSocketConan(ConanFile):
 
         self.requires.add("zlib/1.2.11")
 
-        if not self.options.use_vendored_third_party and (self.settings.os == "Windows" and self.options.use_tls
-                                                          and not self._can_use_openssl() or self.options.use_mbed_tls):
-            self.requires.add("mbedtls/2.6.1")
+        if self.settings.os == "Windows" and self.options.use_tls and not self._can_use_openssl() or self.options.use_mbed_tls:
+            self.requires.add("mbedtls/2.16.3-apache")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -79,7 +76,6 @@ class IXWebSocketConan(ConanFile):
         # User-selectable options
         cmake.definitions["USE_TLS"] = self.options.use_tls
         cmake.definitions["USE_MBED_TLS"] = self.options.use_mbed_tls
-        cmake.definitions["USE_VENDORED_THIRD_PARTY"] = self.options.use_vendored_third_party
 
         cmake.configure()
         return cmake
@@ -87,7 +83,6 @@ class IXWebSocketConan(ConanFile):
     def build(self):
         cmake = self._configure_cmake()
         cmake.build()
-        cmake.install()
 
     def package(self):
         # Include package license

--- a/recipes/ixwebsocket/all/test_package/CMakeLists.txt
+++ b/recipes/ixwebsocket/all/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(PackageTest CXX)
+
+set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set (CMAKE_CXX_EXTENSIONS OFF)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(tests SimpleTests.cpp)
+
+target_link_libraries(tests ${CONAN_LIBS})
+

--- a/recipes/ixwebsocket/all/test_package/SimpleTests.cpp
+++ b/recipes/ixwebsocket/all/test_package/SimpleTests.cpp
@@ -1,80 +1,19 @@
 #include <iostream>
-#include <ixwebsocket/IXWebSocket.h>
-#include <string>
-#include <vector>
-#include <chrono>
-#include <thread>
-#include <ixwebsocket/IXNetSystem.h>
-#include <ixwebsocket/IXSocketTLSOptions.h>
-
-class SocketWrapper {
-private:
-    ix::WebSocket webSocket;
-    std::vector<std::string> receivedMessages;
-public:
-    SocketWrapper() {
-        webSocket.setUrl(std::string("ws://echo.websocket.org"));
-        webSocket.setOnMessageCallback(
-            [this](const ix::WebSocketMessagePtr& message) {
-                std::cout << "Something received" << std::endl;
-                if (message->type == ix::WebSocketMessageType::Open) {
-                    std::cout << "Connected\n";
-                    //webSocket.send(std::string("Congrats, your local version of IXWebSocket works!"));
-                } else if (message->type == ix::WebSocketMessageType::Close) {
-                    std::cout << "Closing socket...\n";
-                } else if (message->type == ix::WebSocketMessageType::Message) {
-                    std::cout << "Message received from server: " << message->str << std::endl;
-                    receivedMessages.push_back(message->str);
-                } else if (message->type == ix::WebSocketMessageType::Error) {
-                    std::cout << "ERROR:" << message->errorInfo.reason;
-                } 
-            });
-
-        webSocket.start();
-
-    }
-
-    bool hasReceived() { return receivedMessages.size() > 0; }
-    void close() { this->webSocket.close(); }
-    bool ready() { 
-        return this->webSocket.getReadyState() == ix::ReadyState::Open; 
-    }
-    void send(std::string message) { this->webSocket.send(message); }
-};
+#include <ixwebsocket/IXUrlParser.h>
 
 int main() {
-    try {
-        std::cout << "Starting socket..." << std::endl;
-        ix::initNetSystem(); // required for Windows
-        SocketWrapper socketWrapper;
-        int counter = 0;
-        while(true) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(2000));
-            if (!socketWrapper.ready())
-                continue;
-            counter++;
-            if (socketWrapper.hasReceived()) {
-                break;
-            } else if (counter >= 5) {
-                socketWrapper.close();
-                ix::uninitNetSystem();
-                std::cout << "No response for 10 seconds; assuming failure" << std::endl;
-                throw std::string("No response for 10 seconds: assuming failure");
-            }
+    std::string url = "https://github.com";
+    std::string protocol, host, path, query;
+    int port; 
 
-            if (socketWrapper.ready()) {
-                std::cout << "Sent message." << std::endl;
-                socketWrapper.send("Congrats, your local version of IXWebSocket works!");
-            }
-        }
-        std::cout << "Message received! Closing socket." << std::endl;
-        socketWrapper.close();
-        std::cout << "Socket disconnected." << std::endl;
+    bool res = ix::UrlParser::parse(url, protocol, host, path, query, port);
 
-        ix::uninitNetSystem(); // required for Windows.
+    std::cout 
+        << "URL parse result: \n"
+        << "Protocol: " << protocol
+        << "\nHost: " << host 
+        << "\nPath: " << path
+        << "\nQuery: " << query
+        << "\nPort: " << port << std::endl;
 
-    } catch (const char* ex) {
-        std::cout << ex;
-        throw;
-    }
 }

--- a/recipes/ixwebsocket/all/test_package/SimpleTests.cpp
+++ b/recipes/ixwebsocket/all/test_package/SimpleTests.cpp
@@ -1,0 +1,80 @@
+#include <iostream>
+#include <ixwebsocket/IXWebSocket.h>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <thread>
+#include <ixwebsocket/IXNetSystem.h>
+#include <ixwebsocket/IXSocketTLSOptions.h>
+
+class SocketWrapper {
+private:
+    ix::WebSocket webSocket;
+    std::vector<std::string> receivedMessages;
+public:
+    SocketWrapper() {
+        webSocket.setUrl(std::string("ws://echo.websocket.org"));
+        webSocket.setOnMessageCallback(
+            [this](const ix::WebSocketMessagePtr& message) {
+                std::cout << "Something received" << std::endl;
+                if (message->type == ix::WebSocketMessageType::Open) {
+                    std::cout << "Connected\n";
+                    //webSocket.send(std::string("Congrats, your local version of IXWebSocket works!"));
+                } else if (message->type == ix::WebSocketMessageType::Close) {
+                    std::cout << "Closing socket...\n";
+                } else if (message->type == ix::WebSocketMessageType::Message) {
+                    std::cout << "Message received from server: " << message->str << std::endl;
+                    receivedMessages.push_back(message->str);
+                } else if (message->type == ix::WebSocketMessageType::Error) {
+                    std::cout << "ERROR:" << message->errorInfo.reason;
+                } 
+            });
+
+        webSocket.start();
+
+    }
+
+    bool hasReceived() { return receivedMessages.size() > 0; }
+    void close() { this->webSocket.close(); }
+    bool ready() { 
+        return this->webSocket.getReadyState() == ix::ReadyState::Open; 
+    }
+    void send(std::string message) { this->webSocket.send(message); }
+};
+
+int main() {
+    try {
+        std::cout << "Starting socket..." << std::endl;
+        ix::initNetSystem(); // required for Windows
+        SocketWrapper socketWrapper;
+        int counter = 0;
+        while(true) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+            if (!socketWrapper.ready())
+                continue;
+            counter++;
+            if (socketWrapper.hasReceived()) {
+                break;
+            } else if (counter >= 5) {
+                socketWrapper.close();
+                ix::uninitNetSystem();
+                std::cout << "No response for 10 seconds; assuming failure" << std::endl;
+                throw std::string("No response for 10 seconds: assuming failure");
+            }
+
+            if (socketWrapper.ready()) {
+                std::cout << "Sent message." << std::endl;
+                socketWrapper.send("Congrats, your local version of IXWebSocket works!");
+            }
+        }
+        std::cout << "Message received! Closing socket." << std::endl;
+        socketWrapper.close();
+        std::cout << "Socket disconnected." << std::endl;
+
+        ix::uninitNetSystem(); // required for Windows.
+
+    } catch (const char* ex) {
+        std::cout << ex;
+        throw;
+    }
+}

--- a/recipes/ixwebsocket/all/test_package/conanfile.py
+++ b/recipes/ixwebsocket/all/test_package/conanfile.py
@@ -1,0 +1,20 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class IXWebSocketTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
+        # in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            os.chdir("bin")
+            self.run(".%stests" % os.sep)

--- a/recipes/ixwebsocket/all/test_package/conanfile.py
+++ b/recipes/ixwebsocket/all/test_package/conanfile.py
@@ -16,5 +16,5 @@ class IXWebSocketTestConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self.settings):
-            os.chdir("bin")
-            self.run(".%stests" % os.sep)
+            self.run(os.path.join("bin", "tests"), run_environment=True)
+

--- a/recipes/ixwebsocket/config.yml
+++ b/recipes/ixwebsocket/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "7.6.3":
+    folder: all

--- a/recipes/ixwebsocket/config.yml
+++ b/recipes/ixwebsocket/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "7.6.3":
+  "7.9.2":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **ixwebsocket/7.6.3**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Note about the version: It's currently the latest _release_, but not the latest _tag_ (going by GH definitions). This is mainly to get the inclusion process started, and because I need to make sure I can compile any other versions on at least Linux and Windows before I'll bother adding them. Dealing with one version for now also lets me focus on the recipe to make sure I properly converted it to the new format. 
