### PR TITLE
Add proxy package for libxrandr

### DIFF
--- a/recipes/libxrandr/all/conanfile.py
+++ b/recipes/libxrandr/all/conanfile.py
@@ -14,7 +14,7 @@ class LibXrandrConan(ConanFile):
     license = "X11"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.x.org/wiki/"
-    description = "libXrandr provides an X Window System client interface to the RandR extension to the X protocol.",
+    description = "libXrandr provides an X Window System client interface to the RandR extension to the X protocol."
     settings = "os", "compiler", "build_type", "arch"
     _required_system_package = "libxrandr-dev"
     _system_package_tool = None

--- a/recipes/libxrandr/all/conanfile.py
+++ b/recipes/libxrandr/all/conanfile.py
@@ -1,0 +1,62 @@
+import os
+import subprocess
+import shlex
+
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+
+def remove_prefix(s, prefix):
+    return s[len(prefix):] if s.startswith(prefix) else s
+
+
+class LibXrandrConan(ConanFile):
+    name = "libxrandr"
+    license = "X11"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.x.org/wiki/"
+    description = "libXrandr provides an X Window System client interface to the RandR extension to the X protocol.",
+    settings = "os", "compiler", "build_type", "arch"
+    _required_system_package = "libxrandr-dev"
+    _system_package_tool = None
+
+    def _system_packages(self):
+        if not self._system_package_tool:
+            self._system_package_tool = tools.SystemPackageTool()
+        return self._system_package_tool
+
+    def system_requirements(self):
+        installer = self._system_packages()
+        if not installer.installed(self._required_system_package):
+            raise ConanInvalidConfiguration(
+                "{0} system library missing. Install {0} in your system with something like: "\
+                "sudo apt-get install {0}"
+                .format(self._required_system_package))
+
+    def configure(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration(
+                "This library is only compatible with Linux")
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def package(self):
+        tools.download("https://gitlab.freedesktop.org/xorg/lib/libxrandr/raw/master/COPYING", filename="COPYING")
+        self.copy("COPYING", dst="licenses")
+
+
+    def package_info(self):
+        if self._system_packages().installed("pkg-config"):
+            pkg = tools.PkgConfig("xrandr")
+            self.cpp_info.includedirs = [remove_prefix(x,'-I') for x in pkg.cflags_only_I]
+            self.cpp_info.libdirs = [remove_prefix(x,'-L') for x in pkg.libs_only_L]
+            self.cpp_info.libs = [remove_prefix(x,'-l') for x in pkg.libs_only_l]
+            self.cpp_info.defines = [remove_prefix(x,'-D') for x in pkg.cflags_only_other if x.startswith('-D')]
+            self.cpp_info.cflags = [x for x in pkg.cflags_only_other if not x.startswith('-D')]
+            self.cpp_info.cppflags = [x for x in pkg.cflags_only_other if not x.startswith('-D')]
+            self.cpp_info.sharedlinkflags = pkg.libs_only_other
+            self.cpp_info.exelinkflags = pkg.libs_only_other
+        else:
+            self.cpp_info.libs.append("Xrandr")
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/libxrandr/all/conanfile.py
+++ b/recipes/libxrandr/all/conanfile.py
@@ -43,7 +43,6 @@ class LibXrandrConan(ConanFile):
         tools.download("https://gitlab.freedesktop.org/xorg/lib/libxrandr/raw/master/COPYING", filename="COPYING")
         self.copy("COPYING", dst="licenses")
 
-
     def package_info(self):
         if self._system_packages().installed("pkg-config"):
             pkg = tools.PkgConfig("xrandr")

--- a/recipes/libxrandr/all/conanfile.py
+++ b/recipes/libxrandr/all/conanfile.py
@@ -17,15 +17,9 @@ class LibXrandrConan(ConanFile):
     description = "libXrandr provides an X Window System client interface to the RandR extension to the X protocol."
     settings = "os", "compiler", "build_type", "arch"
     _required_system_package = "libxrandr-dev"
-    _system_package_tool = None
-
-    def _system_packages(self):
-        if not self._system_package_tool:
-            self._system_package_tool = tools.SystemPackageTool()
-        return self._system_package_tool
 
     def system_requirements(self):
-        installer = self._system_packages()
+        installer = tools.SystemPackageTool()
         if not installer.installed(self._required_system_package):
             raise ConanInvalidConfiguration(
                 "{0} system library missing. Install {0} in your system with something like: "\
@@ -44,7 +38,7 @@ class LibXrandrConan(ConanFile):
         self.copy("COPYING", dst="licenses")
 
     def package_info(self):
-        if self._system_packages().installed("pkg-config"):
+        if tools.which("pkg-config"):
             pkg = tools.PkgConfig("xrandr")
             self.cpp_info.includedirs = [remove_prefix(x,'-I') for x in pkg.cflags_only_I]
             self.cpp_info.libdirs = [remove_prefix(x,'-L') for x in pkg.libs_only_L]

--- a/recipes/libxrandr/all/test_package/CMakeLists.txt
+++ b/recipes/libxrandr/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 2.8.11)
+
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${CMAKE_PROJECT_NAME} example.cpp)
+target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/libxrandr/all/test_package/conanfile.py
+++ b/recipes/libxrandr/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os.path
+
+from conans import ConanFile, CMake
+
+
+class LibXrandrTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)

--- a/recipes/libxrandr/all/test_package/example.cpp
+++ b/recipes/libxrandr/all/test_package/example.cpp
@@ -1,0 +1,5 @@
+
+int main()
+{
+  return 0;
+}

--- a/recipes/libxrandr/all/test_package/example.cpp
+++ b/recipes/libxrandr/all/test_package/example.cpp
@@ -1,5 +1,9 @@
+#include <X11/extensions/Xrandr.h>
 
 int main()
 {
+  XRRScreenSize screen_size;
+  screen_size.width = 100;
+  screen_size.height = 100;
   return 0;
 }

--- a/recipes/libxrandr/config.yml
+++ b/recipes/libxrandr/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "system":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libxrandr/system**

This is a proxy package for libxrandr. This means that this package will verify if xrandr is installed in the user's system and populate the cpp_info with the required information.
When, in the near future, a package for this library is created, this can be transparently substituted in the consumer without requiring any changes.

Related to: #641 #678 

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

