### PR TITLE
fix(date): install also time zone headers date/2.4.1

### DIFF
--- a/recipes/date/all/CMakeLists.txt
+++ b/recipes/date/all/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
+
+message(STATUS "Conan CMake Wrapper")
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -44,7 +44,7 @@ class DateConan(ConanFile):
         else:
             cmake.definitions["USE_TZ_DB_IN_DOT"] = self.options.use_tz_db_in_dot
             cmake.definitions["USE_SYSTEM_TZ_DB"] = self.options.use_system_tz_db
-        cmake.configure(source_folder=self._source_subfolder)
+        cmake.configure()
         return cmake
 
     def requirements(self):

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -11,10 +11,10 @@ class DateConan(ConanFile):
               "calendar", "time", "iana-database")
     license = "MIT"
     exports_sources = ["patches/*"]
+    settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False],
                "fPIC": [True, False],
-               "use_system_tz_db": [True, False]
-               }
+               "use_system_tz_db": [True, False]}
     default_options = {"shared": False,
                        "fPIC": True,
                        "use_system_tz_db": False}
@@ -40,7 +40,7 @@ class DateConan(ConanFile):
     def requirements(self):
         if self.options.use_system_tz_db == False:
             self.requires("libcurl/7.67.0")
-        
+
     def build(self):
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -7,10 +7,17 @@ class DateConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/HowardHinnant/date"
     description = "A date and time library based on the C++11/14/17 <chrono> header"
-    topics = ("date", "datetime", "timezone", "calendar", "time", "iana-database")
+    topics = ("date", "datetime", "timezone",
+              "calendar", "time", "iana-database")
     license = "MIT"
     exports_sources = ["patches/*"]
-    no_copy_source = True
+    options = {"shared": [True, False],
+               "fPIC": [True, False],
+               "use_system_tz_db": [True, False]
+               }
+    default_options = {"shared": False,
+                       "fPIC": True,
+                       "use_system_tz_db": False}
 
     @property
     def _source_subfolder(self):
@@ -26,19 +33,26 @@ class DateConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["ENABLE_DATE_TESTING"] = False
-        cmake.definitions["USE_SYSTEM_TZ_DB"] = True
+        cmake.definitions["USE_SYSTEM_TZ_DB"] = self.options.use_system_tz_db
         cmake.configure(source_folder=self._source_subfolder)
         return cmake
 
+    def requirements(self):
+        if self.options.use_system_tz_db == False:
+            self.requires("libcurl/7.67.0")
+        
     def build(self):
         cmake = self._configure_cmake()
         cmake.build()
-        
+
     def package(self):
-        self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="LICENSE.txt", dst="licenses",
+                  src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib"))
 
-    def package_id(self):
-        self.info.header_only()
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        if tools.os_info.is_linux:
+            self.cpp_info.libs.append("pthread")

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -1,5 +1,5 @@
 import os
-from conans import ConanFile, tools
+from conans import ConanFile, CMake, tools
 
 
 class DateConan(ConanFile):

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -27,6 +27,10 @@ class DateConan(ConanFile):
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
 
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["ENABLE_DATE_TESTING"] = False

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -49,7 +49,7 @@ class DateConan(ConanFile):
 
     def requirements(self):
         if self.settings.os == "Windows" or not self.options.use_system_tz_db:
-            self.requires("libcurl/7.56.1")
+            self.requires("libcurl/7.67.0")
 
     def build(self):
         cmake = self._configure_cmake()

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -30,6 +30,10 @@ class DateConan(ConanFile):
         cmake.configure(source_folder=self._source_subfolder)
         return cmake
 
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+        
     def package(self):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -12,6 +12,7 @@ class DateConan(ConanFile):
     license = "MIT"
     exports_sources = ["patches/*"]
     settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package"
     options = {"shared": [True, False],
                "fPIC": [True, False],
                "use_system_tz_db": [True, False]}

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -23,7 +23,18 @@ class DateConan(ConanFile):
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
 
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["ENABLE_DATE_TESTING"] = False
+        cmake.definitions["USE_SYSTEM_TZ_DB"] = True
+        cmake.configure(source_folder=self._source_subfolder)
+        return cmake
+
     def package(self):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="date.h", dst=os.path.join("include", "date"),
-                  src=os.path.join(self._source_subfolder, "include", "date"))
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib"))
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -48,6 +48,7 @@ class DateConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "CMake"))
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -19,10 +19,8 @@ class DateConan(ConanFile):
     default_options = {"shared": False,
                        "fPIC": True,
                        "use_system_tz_db": False}
-
-    @property
-    def _source_subfolder(self):
-        return os.path.join(self.source_folder, "source_subfolder")
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -35,7 +33,7 @@ class DateConan(ConanFile):
         cmake = CMake(self)
         cmake.definitions["ENABLE_DATE_TESTING"] = False
         cmake.definitions["USE_SYSTEM_TZ_DB"] = self.options.use_system_tz_db
-        cmake.configure(source_folder=self._source_subfolder)
+        cmake.configure(build_folder=self._build_subfolder)
         return cmake
 
     def requirements(self):
@@ -51,7 +49,7 @@ class DateConan(ConanFile):
                   src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib"))
+        tools.rmdir(os.path.join(self.package_folder, "lib","cmake"))
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -10,7 +10,7 @@ class DateConan(ConanFile):
     topics = ("date", "datetime", "timezone",
               "calendar", "time", "iana-database")
     license = "MIT"
-    exports_sources = ["patches/*"]
+    exports_sources = ["patches/*", "CMakeLists.txt"]
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package"
     options = {"shared": [True, False],

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -65,7 +65,7 @@ class DateConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
-        if self.settings.os == "Linux"
+        if self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")
         if self.settings.os == "Windows":
             use_system_tz_db = 0

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -14,11 +14,9 @@ class DateConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package"
     options = {"shared": [True, False],
-               "fPIC": [True, False],
-               "use_system_tz_db": [True, False]}
+               "fPIC": [True, False]}
     default_options = {"shared": False,
-                       "fPIC": True,
-                       "use_system_tz_db": False}
+                       "fPIC": True}
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
 
@@ -32,13 +30,9 @@ class DateConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["ENABLE_DATE_TESTING"] = False
-        cmake.definitions["USE_SYSTEM_TZ_DB"] = self.options.use_system_tz_db
-        cmake.configure(build_folder=self._build_subfolder)
+        cmake.definitions["USE_SYSTEM_TZ_DB"] = True
+        cmake.configure(source_folder=self._source_subfolder)
         return cmake
-
-    def requirements(self):
-        if self.options.use_system_tz_db == False:
-            self.requires("libcurl/7.67.0")
 
     def build(self):
         cmake = self._configure_cmake()
@@ -49,7 +43,7 @@ class DateConan(ConanFile):
                   src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib","cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/date/all/conanfile.py
+++ b/recipes/date/all/conanfile.py
@@ -65,7 +65,7 @@ class DateConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
-        if tools.os_info.is_linux:
+        if self.settings.os == "Linux"
             self.cpp_info.libs.append("pthread")
         if self.settings.os == "Windows":
             use_system_tz_db = 0

--- a/recipes/date/all/test_package/test_package.cpp
+++ b/recipes/date/all/test_package/test_package.cpp
@@ -16,5 +16,12 @@ int main() {
     auto date3 = 22_d/March/2015;
     std::cout << date3 << '\n';
 
+    try {
+        auto tz = date::current_zone()->name();
+        std::cout << "timezone: " << tz << std::endl;
+    } catch (const std::exception & e) {
+         std::cout << "exception caught " << e.what() << std::endl;
+    }
+
     return EXIT_SUCCESS;
 }

--- a/recipes/date/all/test_package/test_package.cpp
+++ b/recipes/date/all/test_package/test_package.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 
 #include "date/date.h"
+#include "date/tz.h"
 
 int main() {
     using namespace std::chrono;
@@ -14,5 +15,8 @@ int main() {
     std::cout << date2 << '\n';
     auto date3 = 22_d/March/2015;
     std::cout << date3 << '\n';
+
+    std::cout << "current zone: " << date::current_zone()->name() << '\n';
+
     return EXIT_SUCCESS;
 }

--- a/recipes/date/all/test_package/test_package.cpp
+++ b/recipes/date/all/test_package/test_package.cpp
@@ -16,7 +16,5 @@ int main() {
     auto date3 = 22_d/March/2015;
     std::cout << date3 << '\n';
 
-    std::cout << "current zone: " << date::current_zone()->name() << '\n';
-
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

currently on `date/date.h` is installed, though the library has more useful headers, which are installed by default using upstream cmake script e.g. `date/tz.h`

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

