### PR TITLE
Add version libcurl/7.68.0

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.68.0":
+    sha256: 1dd7604e418b0b9a9077f62f763f6684c1b092a7bc17e3f354b8ad5c964d7358
+    url: https://curl.haxx.se/download/curl-7.68.0.tar.gz
   "7.67.0":
     sha256: 52af3361cf806330b88b4fe6f483b6844209d47ae196ac46da4de59bb361ab02
     url: https://curl.haxx.se/download/curl-7.67.0.tar.gz

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.68.0":
+    folder: all
   "7.67.0":
     folder: all
   "7.66.0":


### PR DESCRIPTION
Specify library name and version:  **libcurl/7.68.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Resolves #635

libcurl 7.68.0 does not introduce significant changes and should build as usual.