### PR TITLE
boost: fix patching step for old versions w/o patches

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -140,8 +140,9 @@ class BoostConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        for patch in self.conan_data["patches"][self.version]:
-            tools.patch(**patch)
+        if self.conan_data["patches"][self.version]:
+            for patch in self.conan_data["patches"][self.version]:
+                tools.patch(**patch)
 
     ##################### BUILDING METHODS ###########################
 

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -140,7 +140,7 @@ class BoostConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        if self.conan_data["patches"][self.version]:
+        if self.version in self.conan_data["patches"]:
             for patch in self.conan_data["patches"][self.version]:
                 tools.patch(**patch)
 


### PR DESCRIPTION
Signed-off-by: mbodmer <marc.bodmer@email.ch>

Boost versions prior to 1.70 did not have an patches to apply. Conan fails due to missing keys in conandata.yml.

Specify library name and version:  **boost/1.69.0 and older**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

