### PR TITLE
fix freetype cmake flags for dependencies

### DIFF
--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -61,12 +61,12 @@ class FreetypeConan(ConanFile):
             cmake.definitions["FT_WITH_ZLIB"] = False
             cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_ZLIB"] = True
         if self.options.with_png:
-            cmake.definitions["FT_WITH_PNG"] = self.options.with_png
+            cmake.definitions["FT_WITH_PNG"] = True
         else:
             cmake.definitions["FT_WITH_PNG"] = False
             cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_PNG"] = True
         if self.options.with_bzip2:
-            cmake.definitions["FT_WITH_BZIP2"] = self.options.with_bzip2
+            cmake.definitions["FT_WITH_BZIP2"] = True
         else:
             cmake.definitions["FT_WITH_BZIP2"] = False
             cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_BZip2"] = True

--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -55,10 +55,22 @@ class FreetypeConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["PROJECT_VERSION"] = self._libtool_version
-        cmake.definitions["WITH_ZLIB"] = self.options.with_zlib
-        cmake.definitions["WITH_PNG"] = self.options.with_png
-        cmake.definitions["WITH_BZip2"] = self.options.with_bzip2
-        cmake.definitions["WITH_HARFBUZZ"] = False
+        if self.options.with_zlib:
+            cmake.definitions["FT_WITH_ZLIB"] = True
+        else:
+            cmake.definitions["FT_WITH_ZLIB"] = False
+            cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_ZLIB"] = True
+        if self.options.with_png:
+            cmake.definitions["FT_WITH_PNG"] = self.options.with_png
+        else:
+            cmake.definitions["FT_WITH_PNG"] = False
+            cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_PNG"] = True
+        if self.options.with_bzip2:
+            cmake.definitions["FT_WITH_BZIP2"] = self.options.with_bzip2
+        else:
+            cmake.definitions["FT_WITH_BZIP2"] = False
+            cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_BZip2"] = True
+        cmake.definitions["FT_WITH_HARFBUZZ"] = False
         cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz"] = True
         cmake.configure(build_dir=self._build_subfolder)
         return cmake


### PR DESCRIPTION
Specify library name and version:  freetype/all

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

this fixes cmake flags in the freetype recipe to enable/disable dependencies. also it forbids finding packages via pkgconfig if the dependency was not enabled