### PR TITLE
Autoconf fixes

### DIFF
--- a/recipes/autoconf/all/conandata.yml
+++ b/recipes/autoconf/all/conandata.yml
@@ -8,3 +8,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0002-no-perl-path-in-shebang.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0003-uppercase-autom4te_perllibdir.patch"
+      base_path: "source_subfolder"

--- a/recipes/autoconf/all/conandata.yml
+++ b/recipes/autoconf/all/conandata.yml
@@ -1,4 +1,8 @@
 sources:
   "2.69":
     sha256: "954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969"
-    url: https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+    url: "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz"
+patches:
+  "2.69":
+    - patch_file: "patches/0001-autom4te-relocatable.patch"
+      base_path: "source_subfolder"

--- a/recipes/autoconf/all/conandata.yml
+++ b/recipes/autoconf/all/conandata.yml
@@ -6,3 +6,5 @@ patches:
   "2.69":
     - patch_file: "patches/0001-autom4te-relocatable.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0002-no-perl-path-in-shebang.patch"
+      base_path: "source_subfolder"

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -107,5 +107,5 @@ class AutoconfConan(ConanFile):
         self.env_info.AUTOM4TE = autom4te
 
         autom4te_perllibdir = self._autoconf_datarootdir
-        self.output.info("Setting autom4te_perllibdir to {}".format(autom4te_perllibdir))
-        self.env_info.autom4te_perllibdir = autom4te_perllibdir
+        self.output.info("Setting AUTOM4TE_PERLLIBDIR to {}".format(autom4te_perllibdir))
+        self.env_info.AUTOM4TE_PERLLIBDIR = autom4te_perllibdir

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -9,6 +9,7 @@ class AutoconfConan(ConanFile):
     description = "Autoconf is an extensible package of M4 macros that produce shell scripts to automatically configure software source code packages"
     topics = ("conan", "autoconf", "configure", "build")
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
+    exports_sources = "patches/**"
     settings = "os_build", "arch_build"
     _autotools = None
 
@@ -24,11 +25,19 @@ class AutoconfConan(ConanFile):
         if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:
             self.build_requires("msys2/20190524")
 
+    @property
+    def _datarootdir(self):
+        return os.path.join(self.package_folder, "bin", "share")
+
+    @property
+    def _autoconf_datarootdir(self):
+        return os.path.join(self._datarootdir, "autoconf")
+
     def _configure_autotools(self):
         if self._autotools:
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        datarootdir = os.path.join(self.package_folder, "bin", "share")
+        datarootdir = self._datarootdir
         prefix = self.package_folder
         if self.settings.os_build == "Windows":
             datarootdir = tools.unix_path(datarootdir)
@@ -40,7 +49,12 @@ class AutoconfConan(ConanFile):
         self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder)
         return self._autotools
 
+    def _patch_files(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+
     def build(self):
+        self._patch_files()
         autotools = self._configure_autotools()
         autotools.make()
 
@@ -63,6 +77,10 @@ class AutoconfConan(ConanFile):
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH env var with : {}".format(bin_path))
         self.env_info.PATH.append(bin_path)
+
+        ac_macrodir = self._autoconf_datarootdir
+        self.output.info("Setting AC_MACRODIR to {}".format(ac_macrodir))
+        self.env_info.AC_MACRODIR = ac_macrodir
 
         autoconf = os.path.join(self.package_folder, "bin", "autoconf")
         if self.settings.os_build == "Windows":
@@ -87,3 +105,7 @@ class AutoconfConan(ConanFile):
             autom4te = tools.unix_path(autom4te) + ".exe"
         self.output.info("Setting AUTOM4TE to {}".format(autom4te))
         self.env_info.AUTOM4TE = autom4te
+
+        autom4te_perllibdir = self._autoconf_datarootdir
+        self.output.info("Setting autom4te_perllibdir to {}".format(autom4te_perllibdir))
+        self.env_info.autom4te_perllibdir = autom4te_perllibdir

--- a/recipes/autoconf/all/patches/0001-autom4te-relocatable.patch
+++ b/recipes/autoconf/all/patches/0001-autom4te-relocatable.patch
@@ -1,0 +1,48 @@
+--- bin/autom4te.in
++++ bin/autom4te.in
+@@ -268,6 +268,7 @@
+ 	if /^\s*(\#.*)?$/;
+ 
+       my @words = shellwords ($_);
++      @words = map(s#AUTOCONF_M4DIR#$pkgdatadir#r, @words);
+       my $type = shift @words;
+       if ($type eq 'begin-language:')
+ 	{
+--- lib/autom4te.in
++++ lib/autom4te.in
+@@ -106,7 +106,7 @@
+ # This intermediate language is used by aclocal to build aclocal.m4.
+ 
+ begin-language: "Autoconf-without-aclocal-m4"
+-args: --prepend-include '@pkgdatadir@'
++args: --prepend-include 'AUTOCONF_M4DIR'
+ args: --cache=autom4te.cache
+ args: autoconf/autoconf.m4f
+ args: acsite.m4?
+@@ -133,7 +133,7 @@
+ ## -------- ##
+ 
+ begin-language: "Autotest"
+-args: --prepend-include '@pkgdatadir@'
++args: --prepend-include 'AUTOCONF_M4DIR'
+ args: autotest/autotest.m4f
+ args: package.m4?
+ args: local.at?
+@@ -147,7 +147,7 @@
+ ## ---- ##
+ 
+ begin-language: "M4sh"
+-args: --prepend-include '@pkgdatadir@'
++args: --prepend-include 'AUTOCONF_M4DIR'
+ args: m4sugar/m4sh.m4f
+ args: --mode 777
+ args: --language M4sugar
+@@ -159,7 +159,7 @@
+ ## ------- ##
+ 
+ begin-language: "M4sugar"
+-args: --prepend-include '@pkgdatadir@'
++args: --prepend-include 'AUTOCONF_M4DIR'
+ args: m4sugar/m4sugar.m4f
+ args: --warnings syntax
+ end-language: "M4sugar"

--- a/recipes/autoconf/all/patches/0002-no-perl-path-in-shebang.patch
+++ b/recipes/autoconf/all/patches/0002-no-perl-path-in-shebang.patch
@@ -1,0 +1,48 @@
+--- bin/autoheader.in
++++ bin/autoheader.in
+@@ -1,4 +1,4 @@
+-#! @PERL@
++#! /usr/bin/perl
+ # -*- Perl -*-
+ # @configure_input@
+ 
+--- bin/autom4te.in
++++ bin/autom4te.in
+@@ -1,4 +1,4 @@
+-#! @PERL@ -w
++#! /usr/bin/perl -w
+ # -*- perl -*-
+ # @configure_input@
+ 
+--- bin/autoreconf.in
++++ bin/autoreconf.in
+@@ -1,4 +1,4 @@
+-#! @PERL@ -w
++#! /usr/bin/perl -w
+ # -*- perl -*-
+ # @configure_input@
+ 
+--- bin/autoscan.in
++++ bin/autoscan.in
+@@ -1,4 +1,4 @@
+-#! @PERL@ -w
++#! /usr/bin/perl -w
+ # -*- perl -*-
+ # @configure_input@
+ 
+--- bin/autoupdate.in
++++ bin/autoupdate.in
+@@ -1,4 +1,4 @@
+-#! @PERL@ -w
++#! /usr/bin/perl -w
+ # -*- perl -*-
+ # @configure_input@
+ 
+--- bin/ifnames.in
++++ bin/ifnames.in
+@@ -1,4 +1,4 @@
+-#! @PERL@ -w
++#! /usr/bin/perl -w
+ # -*- perl -*-
+ # @configure_input@
+ 

--- a/recipes/autoconf/all/patches/0003-uppercase-autom4te_perllibdir.patch
+++ b/recipes/autoconf/all/patches/0003-uppercase-autom4te_perllibdir.patch
@@ -1,0 +1,156 @@
+--- bin/autoheader.in
++++ bin/autoheader.in
+@@ -28,7 +28,7 @@
+ 
+ BEGIN
+ {
+-  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
++  my $pkgdatadir = $ENV{'AUTOM4TE_PERLLIBDIR'} || '@pkgdatadir@';
+   unshift @INC, "$pkgdatadir";
+ 
+   # Override SHELL.  On DJGPP SHELL may not be set to a shell
+--- bin/autom4te.in
++++ bin/autom4te.in
+@@ -24,7 +24,7 @@
+ 
+ BEGIN
+ {
+-  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
++  my $pkgdatadir = $ENV{'AUTOM4TE_PERLLIBDIR'} || '@pkgdatadir@';
+   unshift @INC, $pkgdatadir;
+ 
+   # Override SHELL.  On DJGPP SHELL may not be set to a shell
+--- bin/autoreconf.in
++++ bin/autoreconf.in
+@@ -26,7 +26,7 @@
+ 
+ BEGIN
+ {
+-  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
++  my $pkgdatadir = $ENV{'AUTOM4TE_PERLLIBDIR'} || '@pkgdatadir@';
+   unshift @INC, $pkgdatadir;
+ 
+   # Override SHELL.  On DJGPP SHELL may not be set to a shell
+--- bin/autoscan.in
++++ bin/autoscan.in
+@@ -25,7 +25,7 @@
+ 
+ BEGIN
+ {
+-  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
++  my $pkgdatadir = $ENV{'AUTOM4TE_PERLLIBDIR'} || '@pkgdatadir@';
+   unshift @INC, $pkgdatadir;
+ 
+   # Override SHELL.  On DJGPP SHELL may not be set to a shell
+--- bin/autoupdate.in
++++ bin/autoupdate.in
+@@ -26,7 +26,7 @@
+ 
+ BEGIN
+ {
+-  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
++  my $pkgdatadir = $ENV{'AUTOM4TE_PERLLIBDIR'} || '@pkgdatadir@';
+   unshift @INC, $pkgdatadir;
+ 
+   # Override SHELL.  On DJGPP SHELL may not be set to a shell
+--- bin/ifnames.in
++++ bin/ifnames.in
+@@ -31,7 +31,7 @@
+ 
+ BEGIN
+ {
+-  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
++  my $pkgdatadir = $ENV{'AUTOM4TE_PERLLIBDIR'} || '@pkgdatadir@';
+   unshift @INC, $pkgdatadir;
+ 
+   # Override SHELL.  On DJGPP SHELL may not be set to a shell
+--- bin/Makefile.in
++++ bin/Makefile.in
+@@ -213,7 +213,7 @@
+ # others) to `false'.  Autoconf provides autom4te, so that doesn't
+ # apply to us.
+ MY_AUTOM4TE = \
+-	autom4te_perllibdir='$(top_srcdir)'/lib					\
++	AUTOM4TE_PERLLIBDIR='$(top_srcdir)'/lib					\
+ 	AUTOM4TE_CFG='$(AUTOM4TE_CFG)'         $(top_builddir)/bin/autom4te	\
+ 		-B '$(top_builddir)'/lib -B '$(top_srcdir)'/lib        # keep ` '
+ 
+--- lib/autoconf/Makefile.in
++++ lib/autoconf/Makefile.in
+@@ -229,7 +229,7 @@
+ # others) to `false'.  Autoconf provides autom4te, so that doesn't
+ # apply to us.
+ MY_AUTOM4TE = \
+-	autom4te_perllibdir='$(top_srcdir)'/lib					\
++	AUTOM4TE_PERLLIBDIR='$(top_srcdir)'/lib					\
+ 	AUTOM4TE_CFG='$(AUTOM4TE_CFG)'         $(top_builddir)/bin/autom4te	\
+ 		-B '$(top_builddir)'/lib -B '$(top_srcdir)'/lib        # keep ` '
+ 
+--- lib/autoscan/Makefile.in
++++ lib/autoscan/Makefile.in
+@@ -215,7 +215,7 @@
+ # others) to `false'.  Autoconf provides autom4te, so that doesn't
+ # apply to us.
+ MY_AUTOM4TE = \
+-	autom4te_perllibdir='$(top_srcdir)'/lib					\
++	AUTOM4TE_PERLLIBDIR='$(top_srcdir)'/lib					\
+ 	AUTOM4TE_CFG='$(AUTOM4TE_CFG)'         $(top_builddir)/bin/autom4te	\
+ 		-B '$(top_builddir)'/lib -B '$(top_srcdir)'/lib        # keep ` '
+ 
+--- lib/autotest/Makefile.in
++++ lib/autotest/Makefile.in
+@@ -222,7 +222,7 @@
+ # others) to `false'.  Autoconf provides autom4te, so that doesn't
+ # apply to us.
+ MY_AUTOM4TE = \
+-	autom4te_perllibdir='$(top_srcdir)'/lib					\
++	AUTOM4TE_PERLLIBDIR='$(top_srcdir)'/lib					\
+ 	AUTOM4TE_CFG='$(AUTOM4TE_CFG)'         $(top_builddir)/bin/autom4te	\
+ 		-B '$(top_builddir)'/lib -B '$(top_srcdir)'/lib        # keep ` '
+ 
+--- lib/freeze.mk
++++ lib/freeze.mk
+@@ -31,7 +31,7 @@
+ # others) to `false'.  Autoconf provides autom4te, so that doesn't
+ # apply to us.
+ MY_AUTOM4TE =									\
+-	autom4te_perllibdir='$(top_srcdir)'/lib					\
++	AUTOM4TE_PERLLIBDIR='$(top_srcdir)'/lib					\
+ 	AUTOM4TE_CFG='$(AUTOM4TE_CFG)'         $(top_builddir)/bin/autom4te	\
+ 		-B '$(top_builddir)'/lib -B '$(top_srcdir)'/lib        # keep ` '
+ 
+--- lib/m4sugar/Makefile.in
++++ lib/m4sugar/Makefile.in
+@@ -227,7 +227,7 @@
+ # others) to `false'.  Autoconf provides autom4te, so that doesn't
+ # apply to us.
+ MY_AUTOM4TE = \
+-	autom4te_perllibdir='$(top_srcdir)'/lib					\
++	AUTOM4TE_PERLLIBDIR='$(top_srcdir)'/lib					\
+ 	AUTOM4TE_CFG='$(AUTOM4TE_CFG)'         $(top_builddir)/bin/autom4te	\
+ 		-B '$(top_builddir)'/lib -B '$(top_srcdir)'/lib        # keep ` '
+ 
+--- tests/Makefile.in	2020-01-29 19:10:51.544709041 +0100
++++ tests/Makefile.in	2020-01-29 19:10:37.143656386 +0100
+@@ -200,7 +200,7 @@
+ # others) to `false'.  Autoconf provides autom4te, so that doesn't
+ # apply to us.
+ MY_AUTOM4TE = \
+-	autom4te_perllibdir='$(top_srcdir)'/lib					\
++	AUTOM4TE_PERLLIBDIR='$(top_srcdir)'/lib					\
+ 	AUTOM4TE_CFG='$(AUTOM4TE_CFG)'         $(top_builddir)/bin/autom4te	\
+ 		-B '$(top_builddir)'/lib -B '$(top_srcdir)'/lib        # keep ` '
+ 
+--- tests/wrapper.as	2020-01-29 19:10:54.928721413 +0100
++++ tests/wrapper.as	2020-01-29 19:10:37.143656386 +0100
+@@ -23,8 +23,8 @@
+ AUTOHEADER=autoheader
+ AUTOM4TE=autom4te
+ AUTOM4TE_CFG='@abs_top_builddir@/lib/autom4te.cfg'
+-autom4te_perllibdir='@abs_top_srcdir@/lib'
+-export AUTOCONF AUTOHEADER AUTOM4TE AUTOM4TE_CFG autom4te_perllibdir
++AUTOM4TE_PERLLIBDIR='@abs_top_srcdir@/lib'
++export AUTOCONF AUTOHEADER AUTOM4TE AUTOM4TE_CFG AUTOM4TE_PERLLIBDIR
+ 
+ case '@wrap_program@' in
+   ifnames)


### PR DESCRIPTION
Specify library name and version:  **autoconf/2.69**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

These are some fixes so automake #658 works.
These patches remove or override most of the paths of the build server, embedded in the sources.
It will also uppercase the environment variable `autom4te_perllibdir`, because on Windows, Python is unable to set environment variables in lower case
