### PR TITLE
libxml2: set pkg_config file name

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -248,3 +248,4 @@ class Libxml2Conan(ConanFile):
             self.cpp_info.libs.append('ws2_32')
         self.cpp_info.names["cmake_find_package"] = "LibXml2"
         self.cpp_info.names["cmake_find_package_multi"] = "LibXml2"
+        self.cpp_info.names["pkg_config"] = "libxml-2.0"


### PR DESCRIPTION
Specify library name and version:  **libxml2/***

according to https://packages.ubuntu.com/eoan/amd64/libxml2-dev/filelist and https://github.com/GNOME/libxml2/blob/v2.9.9/libxml-2.0.pc.in

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

