### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+tab_width = 4
+trim_trailing_whitespace = true
+
+[*.yml]
+tab_width = 2
+
+[{Makefile, Makefile.am, Makefile.in}]
+indent_style = tab
+
+[*.{diff, patch}]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,15 @@
 root = true
 
 [*]
+charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
 tab_width = 4
 trim_trailing_whitespace = true
+
+[*.py]
+max_line_length = 101
 
 [*.yml]
 tab_width = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ tab_width = 4
 trim_trailing_whitespace = true
 
 [*.py]
-max_line_length = 101
+max_line_length = 200
 
 [*.yml]
 tab_width = 2


### PR DESCRIPTION
In short, an `.editorconfig` file allows multiple developers using various editors and configurations,
to define a coding style.
See https://editorconfig.org/
A major advantage of editorconfig is that it's ide/platform independent.

I've been using editorconfig through PyCharm for the past 2 years and have rarely had a formatting error in a commit since then.