### PR TITLE
add missing system_libs in self.cpp_info

### DIFF
--- a/recipes/openh264/all/conanfile.py
+++ b/recipes/openh264/all/conanfile.py
@@ -116,3 +116,10 @@ class OpenH264Conan(ConanFile):
             self.cpp_info.system_libs.extend(['m', 'pthread'])
         if self.settings.os == "Android":
             self.cpp_info.system_libs.append("m")
+        libcxx = self.settings.get_safe("compiler.libcxx")
+        if libcxx in ["libstdc++", "libstdc++11"]:
+            self.cpp_info.system_libs.append("stdc++")
+        elif libcxx == "libc++":
+            self.cpp_info.system_libs.append("c++")
+        elif libcxx in ["c++_static", "c++_shared"]:
+            self.cpp_info.system_libs.extend([libcxx, "c++abi"])


### PR DESCRIPTION
Specify library name and version:  **openh264/1/7.0**

Without these system_libs, it is impossible to consume openh264 from C projects (eg ffmpeg)

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

