### PR TITLE
sqlcipher: allow consumers to include <sqlite3.h>

### DIFF
--- a/recipes/sqlcipher/all/conanfile.py
+++ b/recipes/sqlcipher/all/conanfile.py
@@ -174,3 +174,5 @@ class SqlcipherConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.extend(["pthread", "dl"])
         self.cpp_info.defines = ["SQLITE_HAS_CODEC", 'SQLCIPHER_CRYPTO_OPENSSL', 'SQLITE_TEMP_STORE=2']
+        # Allow using #include <sqlite3.h> even with sqlcipher (for libs like sqlpp11-connector-sqlite3)
+        self.cpp_info.includedirs.append(os.path.join("include", "sqlcipher"))


### PR DESCRIPTION
Specify library name and version:  **sqlcipher/4.3.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

~Follow-up~ Fix of #714, which does not allow `sqlcipher` to be used as a drop-in replacement of `sqlite3.h` (i.e. users are forced to include `sqlcipher/sqlite3.h`)