### PR TITLE
autoconf: small change

### DIFF
--- a/recipes/autoconf/all/test_package/conanfile.py
+++ b/recipes/autoconf/all/test_package/conanfile.py
@@ -19,8 +19,7 @@ class TestPackageConan(ConanFile):
                 with tools.environment_append({"CC": "cl -nologo", "CXX": "cl -nologo",}):
                     yield
         else:
-            with tools.no_op():
-                yield
+            yield
 
     def build(self):
         for src in self.exports_sources:
@@ -33,5 +32,5 @@ class TestPackageConan(ConanFile):
             autotools.make()
 
     def test(self):
-        bin_path = os.path.join(".", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self.settings):
+            self.run(os.path.join(".", "test_package"), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **autoconf/2.69**

Not absolutely necessary for the automake pr #658, but nice to have.
Even though autoconf is script-only and does not really need `arch_build` and `os_build`,
it is nice to have these added to test their behavior on the CI.

This pr adds a call to `include_build_settings` inside the `package_id` function.
This should allow us to view the CI logs.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

