### PR TITLE
[libcurl] Remove cpp_info.names for cmake generator

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -371,7 +371,6 @@ class LibcurlConan(ConanFile):
             os.remove(os.path.join(self.package_folder, 'lib', 'libcurl.la'))
 
     def package_info(self):
-        self.cpp_info.names['cmake'] = 'CURL'
         self.cpp_info.names['cmake_find_package'] = 'CURL'
         self.cpp_info.names['cmake_find_package_multi'] = 'CURL'
 


### PR DESCRIPTION
Specify library name and version:  **libcurl/all**

closes #787 
Related to https://github.com/conan-io/hooks/pull/142

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

