### PR TITLE
[backward-cpp] Remove cpp_info.names for cmake generator

### DIFF
--- a/recipes/backward-cpp/all/conanfile.py
+++ b/recipes/backward-cpp/all/conanfile.py
@@ -111,7 +111,6 @@ class BackwardCppConan(ConanFile):
         os.remove(os.path.join(self.package_folder, "lib", "backward", "BackwardConfig.cmake"))
 
     def package_info(self):
-        self.cpp_info.names["cmake"] = "Backward"
         self.cpp_info.names["cmake_find_package"] = "Backward"
         self.cpp_info.names["cmake_find_package_multi"] = "Backward"
 


### PR DESCRIPTION
Specify library name and version:  **backward-cpp/all**

closes #787
Related to conan-io/hooks#142

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

