### PR TITLE
sqlpp11-connector-sqlite3: add sqlcipher support

### DIFF
--- a/recipes/sqlpp11-connector-sqlite3/all/conanfile.py
+++ b/recipes/sqlpp11-connector-sqlite3/all/conanfile.py
@@ -11,16 +11,22 @@ class sqlpp11Conan(ConanFile):
     license = "BSD-2-Clause"
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "with_sqlcipher": [True, False]}
+    default_options = {"shared": False, "fPIC": True, "with_sqlcipher": False}
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
-    requires = "sqlpp11/0.58", "sqlite3/3.30.1"
     short_paths = True
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+    def requirements(self):
+        self.requires("sqlpp11/0.58")
+        if self.options.with_sqlcipher:
+            self.requires("sqlcipher/4.3.0")
+        else:
+            self.requires("sqlite3/3.30.1")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -30,8 +36,8 @@ class sqlpp11Conan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["ENABLE_TESTS"] = False
-        cmake.definitions['HinnantDate_ROOT_DIR'] = self.deps_cpp_info['date'].include_paths[0]
-        cmake.definitions['SQLPP11_INCLUDE_DIR'] = self.deps_cpp_info['sqlpp11'].include_paths[0]
+        cmake.definitions["SQLCIPHER"] = self.options.with_sqlcipher
+        cmake.definitions["SQLPP11_INCLUDE_DIR"] = self.deps_cpp_info["sqlpp11"].include_paths[0]
         cmake.configure(build_folder=self._build_subfolder)
         return cmake
 

--- a/recipes/sqlpp11-connector-sqlite3/all/test_package/conanfile.py
+++ b/recipes/sqlpp11-connector-sqlite3/all/test_package/conanfile.py
@@ -22,7 +22,7 @@ class TestPackageConan(ConanFile):
             cursor.execute("select * from tab_sample")
         except sqlite3.DatabaseError:
             assert self.options["sqlpp11-connector-sqlite3"].with_sqlcipher
-            print("database is encrypted with sqlcipher")
+            self.output.info("database is encrypted with sqlcipher")
             return
         assert not self.options["sqlpp11-connector-sqlite3"].with_sqlcipher
         print("database is not encrypted")

--- a/recipes/sqlpp11-connector-sqlite3/all/test_package/conanfile.py
+++ b/recipes/sqlpp11-connector-sqlite3/all/test_package/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake
 import os
+import sqlite3
 
 
 class TestPackageConan(ConanFile):
@@ -14,3 +15,14 @@ class TestPackageConan(ConanFile):
     def test(self):
         bin_path = os.path.join("bin", "test_package")
         self.run(bin_path, run_environment=True)
+        # test that the database is encrypted when sqlcipher is used
+        con = sqlite3.connect("test.db")
+        cursor = con.cursor()
+        try:
+            cursor.execute("select * from tab_sample")
+        except sqlite3.DatabaseError:
+            assert self.options["sqlpp11-connector-sqlite3"].with_sqlcipher
+            print("database is encrypted with sqlcipher")
+            return
+        assert not self.options["sqlpp11-connector-sqlite3"].with_sqlcipher
+        print("database is not encrypted")

--- a/recipes/sqlpp11-connector-sqlite3/all/test_package/conanfile.py
+++ b/recipes/sqlpp11-connector-sqlite3/all/test_package/conanfile.py
@@ -25,4 +25,4 @@ class TestPackageConan(ConanFile):
             self.output.info("database is encrypted with sqlcipher")
             return
         assert not self.options["sqlpp11-connector-sqlite3"].with_sqlcipher
-        print("database is not encrypted")
+        self.output.info("database is not encrypted")

--- a/recipes/sqlpp11-connector-sqlite3/all/test_package/test_package.cpp
+++ b/recipes/sqlpp11-connector-sqlite3/all/test_package/test_package.cpp
@@ -2,8 +2,8 @@
  * Copyright (c) 2013 - 2016, Roland Bock
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  *
  *  * Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
@@ -11,22 +11,23 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "TabSample.h"
 #include <sqlpp11/custom_query.h>
 #include <sqlpp11/sqlite3/sqlite3.h>
 #include <sqlpp11/sqlpp11.h>
+#include "TabSample.h"
 
 #ifdef SQLPP_USE_SQLCIPHER
 #include <sqlcipher/sqlite3.h>
@@ -42,12 +43,12 @@ SQLPP_ALIAS_PROVIDER(pragma)
 SQLPP_ALIAS_PROVIDER(sub)
 
 namespace sql = sqlpp::sqlite3;
-int main()
-{
+int main() {
   sql::connection_config config;
-  config.path_to_database = ":memory:";
+  config.path_to_database = "test.db";
   config.flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
   config.debug = true;
+  config.password = "password";
 
   sql::connection db(config);
   db.execute(R"(CREATE TABLE tab_sample (
@@ -65,30 +66,33 @@ int main()
   db(remove_from(tab).unconditionally());
 
   // explicit all_of(tab)
-  for (const auto& row : db(select(all_of(tab)).from(tab).unconditionally()))
-  {
-    std::cerr << "row.alpha: " << row.alpha << ", row.beta: " << row.beta << ", row.gamma: " << row.gamma << std::endl;
+  for (const auto& row : db(select(all_of(tab)).from(tab).unconditionally())) {
+    std::cerr << "row.alpha: " << row.alpha << ", row.beta: " << row.beta
+              << ", row.gamma: " << row.gamma << std::endl;
   };
   std::cerr << __FILE__ << ": " << __LINE__ << std::endl;
   // selecting a table implicitly expands to all_of(tab)
-  for (const auto& row : db(select(all_of(tab)).from(tab).unconditionally()))
-  {
-    std::cerr << "row.alpha: " << row.alpha << ", row.beta: " << row.beta << ", row.gamma: " << row.gamma << std::endl;
+  for (const auto& row : db(select(all_of(tab)).from(tab).unconditionally())) {
+    std::cerr << "row.alpha: " << row.alpha << ", row.beta: " << row.beta
+              << ", row.gamma: " << row.gamma << std::endl;
   };
   // selecting two multicolumns
   for (const auto& row :
-       db(select(multi_column(tab.alpha, tab.beta, tab.gamma).as(left), multi_column(all_of(tab)).as(tab))
+       db(select(multi_column(tab.alpha, tab.beta, tab.gamma).as(left),
+                 multi_column(all_of(tab)).as(tab))
               .from(tab)
-              .unconditionally()))
-  {
-    std::cerr << "row.left.alpha: " << row.left.alpha << ", row.left.beta: " << row.left.beta
+              .unconditionally())) {
+    std::cerr << "row.left.alpha: " << row.left.alpha
+              << ", row.left.beta: " << row.left.beta
               << ", row.left.gamma: " << row.left.gamma << std::endl;
-    std::cerr << "row.tabSample.alpha: " << row.tabSample.alpha << ", row.tabSample.beta: " << row.tabSample.beta
+    std::cerr << "row.tabSample.alpha: " << row.tabSample.alpha
+              << ", row.tabSample.beta: " << row.tabSample.beta
               << ", row.tabSample.gamma: " << row.tabSample.gamma << std::endl;
   };
 
   // insert
-  std::cerr << "no of required columns: " << TabSample::_required_insert_columns::size::value << std::endl;
+  std::cerr << "no of required columns: "
+            << TabSample::_required_insert_columns::size::value << std::endl;
   db(insert_into(tab).default_values());
   std::cout << "Last Insert ID: " << db.last_insert_id() << "\n";
   db(insert_into(tab).set(tab.gamma = true));
@@ -99,48 +103,55 @@ int main()
 
   // update
   db(update(tab).set(tab.gamma = false).where(tab.alpha.in(1)));
-  db(update(tab).set(tab.gamma = false).where(tab.alpha.in(sqlpp::value_list(std::vector<int>{1, 2, 3, 4}))));
+  db(update(tab)
+         .set(tab.gamma = false)
+         .where(tab.alpha.in(sqlpp::value_list(std::vector<int>{1, 2, 3, 4}))));
 
   // remove
   db(remove_from(tab).where(tab.alpha == tab.alpha + 3));
 
   auto result = db(select(all_of(tab)).from(tab).unconditionally());
-  std::cerr << "Accessing a field directly from the result (using the current row): " << result.begin()->alpha
+  std::cerr
+      << "Accessing a field directly from the result (using the current row): "
+      << result.begin()->alpha << std::endl;
+  std::cerr << "Can do that again, no problem: " << result.begin()->alpha
             << std::endl;
-  std::cerr << "Can do that again, no problem: " << result.begin()->alpha << std::endl;
 
   auto tx = start_transaction(db);
   TabFoo foo;
-  for (const auto& row : db(select(all_of(tab), select(max(foo.omega)).from(foo).where(foo.omega > tab.alpha))
-                                .from(tab)
-                                .unconditionally()))
-  {
+  for (const auto& row :
+       db(select(all_of(tab),
+                 select(max(foo.omega)).from(foo).where(foo.omega > tab.alpha))
+              .from(tab)
+              .unconditionally())) {
     int x = row.alpha;
     int a = row.max;
     std::cout << x << ", " << a << std::endl;
   }
   tx.commit();
 
-  for (const auto& row : db(select(tab.alpha).from(tab.join(foo).on(tab.alpha == foo.omega)).unconditionally()))
-  {
+  for (const auto& row : db(select(tab.alpha)
+                                .from(tab.join(foo).on(tab.alpha == foo.omega))
+                                .unconditionally())) {
     std::cerr << row.alpha << std::endl;
   }
 
   for (const auto& row :
-       db(select(tab.alpha).from(tab.left_outer_join(foo).on(tab.alpha == foo.omega)).unconditionally()))
-  {
+       db(select(tab.alpha)
+              .from(tab.left_outer_join(foo).on(tab.alpha == foo.omega))
+              .unconditionally())) {
     std::cerr << row.alpha << std::endl;
   }
 
   auto ps = db.prepare(select(all_of(tab))
                            .from(tab)
-                           .where(tab.alpha != parameter(tab.alpha) and tab.beta != parameter(tab.beta) and
+                           .where(tab.alpha != parameter(tab.alpha) and
+                                  tab.beta != parameter(tab.beta) and
                                   tab.gamma != parameter(tab.gamma)));
   ps.params.alpha = 7;
   ps.params.beta = "wurzelbrunft";
   ps.params.gamma = true;
-  for (const auto& row : db(ps))
-  {
+  for (const auto& row : db(ps)) {
     std::cerr << "bound result: alpha: " << row.alpha << std::endl;
     std::cerr << "bound result: beta: " << row.beta << std::endl;
     std::cerr << "bound result: gamma: " << row.gamma << std::endl;
@@ -149,8 +160,7 @@ int main()
   std::cerr << "--------" << std::endl;
   ps.params.alpha = sqlpp::eval<sqlpp::integer>(db, "last_insert_rowid()");
   ps.params.gamma = "false";
-  for (const auto& row : db(ps))
-  {
+  for (const auto& row : db(ps)) {
     std::cerr << "bound result: alpha: " << row.alpha << std::endl;
     std::cerr << "bound result: beta: " << row.beta << std::endl;
     std::cerr << "bound result: gamma: " << row.gamma << std::endl;
@@ -158,18 +168,20 @@ int main()
 
   std::cerr << "--------" << std::endl;
   ps.params.beta = "kaesekuchen";
-  for (const auto& row : db(ps))
-  {
+  for (const auto& row : db(ps)) {
     std::cerr << "bound result: alpha: " << row.alpha << std::endl;
     std::cerr << "bound result: beta: " << row.beta << std::endl;
     std::cerr << "bound result: gamma: " << row.gamma << std::endl;
   }
 
-  auto pi = db.prepare(insert_into(tab).set(tab.beta = parameter(tab.beta), tab.gamma = true));
+  auto pi = db.prepare(
+      insert_into(tab).set(tab.beta = parameter(tab.beta), tab.gamma = true));
   pi.params.beta = "prepared cake";
   std::cerr << "Inserted: " << db(pi) << std::endl;
 
-  auto pu = db.prepare(update(tab).set(tab.gamma = parameter(tab.gamma)).where(tab.beta == "prepared cake"));
+  auto pu = db.prepare(update(tab)
+                           .set(tab.gamma = parameter(tab.gamma))
+                           .where(tab.beta == "prepared cake"));
   pu.params.gamma = false;
   std::cerr << "Updated: " << db(pu) << std::endl;
 
@@ -181,40 +193,50 @@ int main()
   {
     auto s = select(all_of(tab))
                  .from(tab)
-                 .where((tab.beta.like(parameter(tab.beta)) and tab.alpha == parameter(tab.alpha)) or
+                 .where((tab.beta.like(parameter(tab.beta)) and
+                         tab.alpha == parameter(tab.alpha)) or
                         tab.gamma != parameter(tab.gamma));
     using P = decltype(db.prepare(s));
     P p;  // You must not use this one yet!
     p = db.prepare(s);
   }
 
-  auto i = db(sqlpp::sqlite3::insert_or_replace_into(tab).set(tab.beta = "test", tab.gamma = true));
+  auto i = db(sqlpp::sqlite3::insert_or_replace_into(tab).set(
+      tab.beta = "test", tab.gamma = true));
   std::cerr << i << std::endl;
 
-  i = db(sqlpp::sqlite3::insert_or_ignore_into(tab).set(tab.beta = "test", tab.gamma = true));
+  i = db(sqlpp::sqlite3::insert_or_ignore_into(tab).set(tab.beta = "test",
+                                                        tab.gamma = true));
   std::cerr << i << std::endl;
 
-  assert(db(select(count(tab.alpha)).from(tab).unconditionally()).begin()->count);
   assert(
-      db(select(all_of(tab)).from(tab).where(tab.alpha.not_in(select(tab.alpha).from(tab).unconditionally()))).empty());
+      db(select(count(tab.alpha)).from(tab).unconditionally()).begin()->count);
+  assert(db(select(all_of(tab))
+                .from(tab)
+                .where(tab.alpha.not_in(
+                    select(tab.alpha).from(tab).unconditionally())))
+             .empty());
 
   auto x = custom_query(sqlpp::verbatim("PRAGMA user_version = "), 1);
   db(x);
   int pragmaValue =
-      db(custom_query(sqlpp::verbatim("PRAGMA user_version")).with_result_type_of(select(sqlpp::value(1).as(pragma))))
+      db(custom_query(sqlpp::verbatim("PRAGMA user_version"))
+             .with_result_type_of(select(sqlpp::value(1).as(pragma))))
           .front()
           .pragma;
   std::cerr << pragmaValue << std::endl;
 
   // Testing sub select tables and unconditional joins
   const auto subQuery = select(tab.alpha).from(tab).unconditionally().as(sub);
-  for (const auto& row : db(select(subQuery.alpha).from(subQuery).unconditionally()))
-  {
+  for (const auto& row :
+       db(select(subQuery.alpha).from(subQuery).unconditionally())) {
     std::cerr << row.alpha;
   }
 
-  for (const auto& row : db(select(subQuery.alpha).from(tab.inner_join(subQuery).unconditionally()).unconditionally()))
-  {
+  for (const auto& row :
+       db(select(subQuery.alpha)
+              .from(tab.inner_join(subQuery).unconditionally())
+              .unconditionally())) {
     std::cerr << row.alpha;
   }
 

--- a/recipes/sqlpp11-connector-sqlite3/config.yml
+++ b/recipes/sqlpp11-connector-sqlite3/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.29":
-    folder: "all"
+  0.29:
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **sqlpp11-connector-sqlite3/0.29**

Add `with_sqlcipher` option.

I don't know if the CI is able to check if it works with both `sqlcipher` options (i.e. `crypto_library=libressl` and `crypto_library=openssl`), or if it will only use the default option -> openssl.

EDIT: Doesn't seem like it, is there a way to configure the CI to include additional options @danimtb ?

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

