### PR TITLE
automake: add AUTOMAKE_LIBDIR environment variable

### DIFF
--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -41,7 +41,7 @@ class AutomakeConan(ConanFile):
         return os.path.join(self.package_folder, "bin", "share")
 
     @property
-    def _automake_perllibdir(self):
+    def _automake_libdir(self):
         return os.path.join(self._datarootdir, "automake-{}".format(self._version_major_minor))
 
     def _configure_autotools(self):
@@ -104,7 +104,13 @@ class AutomakeConan(ConanFile):
         self.output.info("Setting AUTOMAKE_DATADIR to {}".format(automake_datadir))
         self.env_info.AUTOMAKE_DATADIR = automake_datadir
 
-        automake_perllibdir = self._automake_perllibdir
+        automake_libdir = self._automake_libdir
+        if self.settings.os_build == "Windows":
+            automake_libdir = tools.unix_path(automake_libdir)
+        self.output.info("Setting AUTOMAKE_LIBDIR to {}".format(automake_libdir))
+        self.env_info.AUTOMAKE_LIBDIR = automake_libdir
+
+        automake_perllibdir = self._automake_libdir
         if self.settings.os_build == "Windows":
             automake_perllibdir = tools.unix_path(automake_perllibdir)
         self.output.info("Setting AUTOMAKE_PERLLIBDIR to {}".format(automake_perllibdir))


### PR DESCRIPTION
Specify library name and version:  **automake/1.16.1**

Required for libtool #659

Also, I'd like some feedback on #776


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

