### PR TITLE
automake: use user_info to pass paths of compile and ar-lib

### DIFF
--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -121,3 +121,6 @@ class AutomakeConan(ConanFile):
             automake = tools.unix_path(automake)
         self.output.info("Setting AUTOMAKE to {}".format(automake))
         self.env_info.AUTOMAKE = automake
+
+        self.user_info.compile = os.path.join(self._automake_libdir, "compile")
+        self.user_info.ar_lib = os.path.join(self._automake_libdir, "ar-lib")

--- a/recipes/automake/all/test_package/conanfile.py
+++ b/recipes/automake/all/test_package/conanfile.py
@@ -6,7 +6,7 @@ import shutil
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    exports_sources = "configure.ac", "Makefile.am", "test_package.cpp"
+    exports_sources = "configure.ac", "Makefile.am", "test_package_1.c", "test_package.cpp"
 
     def build_requirements(self):
         if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ \
@@ -22,17 +22,51 @@ class TestPackageConan(ConanFile):
         else:
             yield
 
-    def build(self):
-        for src in self.exports_sources:
-            shutil.copy(os.path.join(self.source_folder, src), self.build_folder)
-        self.run("{} --verbose --install --force".format(os.environ["AUTORECONF"]), win_bash=tools.os_info.is_windows)
+    _default_cc = {
+        "gcc": "gcc",
+        "clang": "clang",
+        "Visual Studio": "cl -nologo",
+        "apple-clang": "clang",
+    }
+
+    @property
+    def _system_cc(self):
+        system_cc = os.environ.get("CC", None)
+        if not system_cc:
+            system_cc = self._default_cc.get(str(self.settings.compiler))
+        return system_cc
+
+    def _build_scripts(self):
+        """Test compile script of automake"""
+        compile_script = self.deps_user_info["automake"].compile
+        ar_script = self.deps_user_info["automake"].ar_lib
+        assert os.path.isfile(ar_script)
+        assert os.path.isfile(compile_script)
+
+        if self._system_cc:
+            with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
+                self.run("{} {} test_package_1.c -o script_test".format(tools.unix_path(compile_script), self._system_cc), win_bash=tools.os_info.is_windows)
+
+    def _build_autotools(self):
+        """Test autoreconf + configure + make"""
+        self.run("{} --verbose --install".format(os.environ["AUTORECONF"]), win_bash=tools.os_info.is_windows)
         self.run("{} --help".format(os.path.join(self.build_folder, "configure").replace("\\", "/")), win_bash=tools.os_info.is_windows)
         autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         with self._build_context():
             autotools.configure()
             autotools.make()
 
+    def build(self):
+        for src in self.exports_sources:
+            shutil.copy(os.path.join(self.source_folder, src), self.build_folder)
+
+        self._build_scripts()
+        self._build_autotools()
+
     def test(self):
-        bin_path = os.path.join(".", "test_package")
+        if self._system_cc:
+            if not tools.cross_building(self.settings):
+                self.run(os.path.join(".", "script_test"), run_environment=True)
+
         if not tools.cross_building(self.settings):
-            self.run(bin_path, run_environment=True)
+            self.run(os.path.join(".", "test_package"), run_environment=True)

--- a/recipes/automake/all/test_package/test_package.cpp
+++ b/recipes/automake/all/test_package/test_package.cpp
@@ -1,8 +1,9 @@
 #include "config.h"
 
+#include <cstdlib>
 #include <iostream>
 
 int main(int argc, char** argv) {
-    std::cout << "hello world from " PACKAGE_NAME "!\n";
-    return 0;
+    std::cout << "test_package.cpp: " << "hello world from " PACKAGE_NAME "!\n";
+    return EXIT_SUCCESS;
 }

--- a/recipes/automake/all/test_package/test_package_1.c
+++ b/recipes/automake/all/test_package/test_package_1.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    puts("test_package.c says 'Hello World'!\n");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Specify library name and version:  **automake/1.16.1**

@ericLemanissier 
I have some libraries that might benefit from the `compile` script, from the `automake` project.
#615 wanted to add these but was closed after automake was merged.
This pr makes the paths to these scripts avaiable through `self.deps_user_info["automake"].compile` and `self.deps_user_info["automake"].ar_lib`

What do you think about this method?
Should automake already apply `tools.unix_path` to the variables or should users do this?

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

