### PR TITLE
Add zstd 1.3.5

### DIFF
--- a/recipes/zstd/all/conandata.yml
+++ b/recipes/zstd/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.5":
+    sha256: d6e1559e4cdb7c4226767d4ddc990bff5f9aab77085ff0d0490c828b025e2eea
+    url: https://github.com/facebook/zstd/archive/v1.3.5.tar.gz
   "1.3.8":
     sha256: 90d902a1282cc4e197a8023b6d6e8d331c1fd1dfe60f7f8e4ee9da40da886dc3
     url: https://github.com/facebook/zstd/archive/v1.3.8.tar.gz

--- a/recipes/zstd/config.yml
+++ b/recipes/zstd/config.yml
@@ -1,5 +1,7 @@
 ---
 versions:
+  "1.3.5":
+    folder: all
   "1.3.8":
     folder: all
   "1.4.3":


### PR DESCRIPTION
Specify library name and version:  **zstd/1.3.5**

Why such old version? Folly (Bincrafters) requires it.

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

