### PR TITLE
[mozilla-build/all] Raise InvalidConfig instead of constraining the settings

### DIFF
--- a/recipes/mozilla-build/all/conanfile.py
+++ b/recipes/mozilla-build/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 
 
@@ -8,8 +9,12 @@ class MozillaBuildConan(ConanFile):
     description = "Mozilla build requirements on Windows"
     topics = ("conan", "mozilla", "build")
     url = "https://github.com/conan-io/conan-center-index"
-    settings = {"os_build": "Windows", "arch_build": ["x86", "x86_64"]}
+    settings = "os_build", "arch_build"
     license = "MPL-2.0"
+
+    def configure(self):
+        if self.settings.os_build != "Windows":
+            raise ConanInvalidConfiguration("Only Windows supported")
 
     def build_requirements(self):
         self.build_requires("7zip/19.00")


### PR DESCRIPTION
Specify library name and version:  **mozilla-build/all**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

