### PR TITLE
Libcurl: update to msys2/20190524 + fix mingw build on Windows

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -93,7 +93,7 @@ class LibcurlConan(ConanFile):
         if self.options.with_openssl:
             if self.settings.os != "Macos" or not self.options.darwin_ssl:
                 # warn about shared linking due to openssl dependency
-                self.output.info("It is not adviced to build a shared libcurl library with static openssl")
+                self.output.warn("Building libcurl library as shared with openssl as static is not recommended")
         if self.options.with_libssh2:
             if self.settings.compiler != "Visual Studio":
                 self.options["libssh2"].shared = self.options.shared

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -143,6 +143,9 @@ class LibcurlConan(ConanFile):
             self._build_with_cmake()
 
     def _patch_misc_files(self):
+        tools.replace_in_file(os.path.join(self._source_subfolder, 'configure.ac'),
+                              "OPENSSL_PCDIR=\"$OPT_SSL/lib/pkgconfig\"",
+                              "OPENSSL_PCDIR=\"${ac_pwd}\"")
         if self.options.with_largemaxwritesize:
             tools.replace_in_file(os.path.join(self._source_subfolder, 'include', 'curl', 'curl.h'),
                                   "define CURL_MAX_WRITE_SIZE 16384",

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -305,7 +305,7 @@ class LibcurlConan(ConanFile):
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
 
         configure_args = self._get_configure_command_args()
-        if self._is_mingw:
+        if self._is_mingw and self.settings.arch == "x86_64":
             self._autotools.defines.append('_AMD64_')
         self._autotools.configure(vars=autotools_vars, args=configure_args, configure_dir=self._source_subfolder)
         return self._autotools, autotools_vars


### PR DESCRIPTION
Specify library name and version:  **libcurl/\***

- Add `msys2/20190524` on Windows when not using *Visual Studio*
- Run the configure only once:
  - Before, the order was: ./configure ->autoreconf -> ./configure
  - If the first configure fails, the autoreconf and second configure never happens.
- On mingw, the configure script was unable to find openssl ==> patch `configure.ac`

(only tested libcurl/7.68.0 on Windows: msvc + mingw)

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

