### PR TITLE
fix libxml2 include directory

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -239,7 +239,7 @@ class Libxml2Conan(ConanFile):
             self.cpp_info.libs = ['libxml2' if self.options.shared else 'libxml2_a']
         else:
             self.cpp_info.libs = ['xml2']
-        self.cpp_info.includedirs = [os.path.join("include", "libxml2")]
+        self.cpp_info.includedirs.append(os.path.join("include", "libxml2"))
         if not self.options.shared:
             self.cpp_info.defines = ["LIBXML_STATIC"]
         if self.settings.os == "Linux" or self.settings.os == "Macos":


### PR DESCRIPTION
some project use the libxml2 prefix (eg gettext) : https://github.com/autotools-mirror/gettext/blob/d42096f0280f104e9b391f79943c9a2ef9985218/gnulib-local/m4/libxml.m4#L87

Specify library name and version:  **libxml2/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

