### PR TITLE
xz_utils/5.2.4: Correct behavior of determining if win bash should be used

### DIFF
--- a/recipes/xz_utils/all/conanfile.py
+++ b/recipes/xz_utils/all/conanfile.py
@@ -20,12 +20,11 @@ class XZUtils(ConanFile):
         return "source_subfolder"
 
     @property
-    def _is_mingw_windows(self):
-        # Linux MinGW doesn't require MSYS2 bash obviously
-        return self.settings.compiler == "gcc" and self.settings.os == "Windows" and os.name == "nt"
+    def _use_winbash(self):
+        return tools.os_info.is_windows
 
     def build_requirements(self):
-        if self._is_mingw_windows and "CONAN_BASH_PATH" not in os.environ and \
+        if self._use_winbash and "CONAN_BASH_PATH" not in os.environ and \
                 tools.os_info.detect_windows_subsystem() != "msys2":
             self.build_requires("msys2/20190524")
 
@@ -84,7 +83,7 @@ class XZUtils(ConanFile):
     def _build_configure(self):
         with tools.chdir(self._source_subfolder):
             args = []
-            env_build = AutoToolsBuildEnvironment(self, win_bash=self._is_mingw_windows)
+            env_build = AutoToolsBuildEnvironment(self, win_bash=self._use_winbash)
             args = ["--disable-doc"]
             if self.settings.os != "Windows" and self.options.fPIC:
                 args.append("--with-pic")


### PR DESCRIPTION
Correct behavior of determining if win bash should be used.
This patch fixed building failure while cross building for android, previous behavior will not choose to use win bash on this situation, and this is the cause of building failure.

Specify library name and version:  **xz_utils/5.2.4**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

