### PR TITLE
libressl: only install header files in include/

### DIFF
--- a/recipes/libressl/all/conanfile.py
+++ b/recipes/libressl/all/conanfile.py
@@ -45,7 +45,7 @@ class LibreSSLConan(ConanFile):
     def package(self):
         libressl_include_dir = os.path.join(self._source_subfolder, "include")
         self.copy("tls.h", dst="include", src=libressl_include_dir)
-        self.copy("openssl/*", dst="include", src=libressl_include_dir)
+        self.copy("openssl/*.h", dst="include", src=libressl_include_dir)
 
         self.copy("*COPYING", dst="licenses", keep_path=False)
         if self.options.shared:


### PR DESCRIPTION
Specify library name and version:  **libressl/3.0.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

