### PR TITLE
add leptonica/1.79.0

### DIFF
--- a/recipes/leptonica/all/conandata.yml
+++ b/recipes/leptonica/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.78.0":
     url: "https://github.com/DanBloomberg/leptonica/archive/1.78.0.tar.gz"
     sha256: "f8ac4d93cc76b524c2c81d27850bfc342e68b91368aa7a1f7d69e34ce13adbb4"
+  "1.79.0":
+    url: "https://github.com/DanBloomberg/leptonica/archive/1.79.0.tar.gz"
+    sha256: "bf9716f91a4844c2682a07ef21eaf68b6f1077af1f63f27c438394fd66218e17"

--- a/recipes/leptonica/all/conandata.yml
+++ b/recipes/leptonica/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.78.0":
+    url: "https://github.com/DanBloomberg/leptonica/archive/1.78.0.tar.gz"
+    sha256: "f8ac4d93cc76b524c2c81d27850bfc342e68b91368aa7a1f7d69e34ce13adbb4"
   "1.79.0":
     url: "https://github.com/DanBloomberg/leptonica/archive/1.79.0.tar.gz"
     sha256: "bf9716f91a4844c2682a07ef21eaf68b6f1077af1f63f27c438394fd66218e17"

--- a/recipes/leptonica/all/conandata.yml
+++ b/recipes/leptonica/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "1.78.0":
-    url: "https://github.com/DanBloomberg/leptonica/archive/1.78.0.tar.gz"
-    sha256: "f8ac4d93cc76b524c2c81d27850bfc342e68b91368aa7a1f7d69e34ce13adbb4"
   "1.79.0":
     url: "https://github.com/DanBloomberg/leptonica/archive/1.79.0.tar.gz"
     sha256: "bf9716f91a4844c2682a07ef21eaf68b6f1077af1f63f27c438394fd66218e17"

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -70,8 +70,8 @@ class LeptonicaConan(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self)
-        # was required in 1.78.0
-        # cmake.definitions['STATIC'] = not self.options.shared
+        if self.version == '1.78.0':
+            cmake.definitions['STATIC'] = not self.options.shared
         cmake.definitions['BUILD_PROG'] = False
         # avoid finding system libs
         cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_GIF'] = not self.options.with_gif
@@ -94,11 +94,11 @@ class LeptonicaConan(ConanFile):
 
         # upstream uses obsolete FOO_LIBRARY that is not generated
         # by cmake_find_package generator (upstream PR 456)
-        # was fixed in 1.79.0
-        #for dep in ('GIF', 'TIFF', 'PNG', 'JPEG', 'ZLIB'):
-        #   tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
-        #                         dep + "_LIBRARY",
-        #                         dep + "_LIBRARIES")
+        if self.version == '1.78.0':
+            for dep in ('GIF', 'TIFF', 'PNG', 'JPEG', 'ZLIB'):
+                tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
+                                      dep + "_LIBRARY",
+                                      dep + "_LIBRARIES")
 
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -70,8 +70,8 @@ class LeptonicaConan(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self)
-        if self.version == '1.78.0':
-            cmake.definitions['STATIC'] = not self.options.shared
+        # was required in 1.78.0
+        # cmake.definitions['STATIC'] = not self.options.shared
         cmake.definitions['BUILD_PROG'] = False
         # avoid finding system libs
         cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_GIF'] = not self.options.with_gif
@@ -94,11 +94,11 @@ class LeptonicaConan(ConanFile):
 
         # upstream uses obsolete FOO_LIBRARY that is not generated
         # by cmake_find_package generator (upstream PR 456)
-        if self.version == '1.78.0':
-            for dep in ('GIF', 'TIFF', 'PNG', 'JPEG', 'ZLIB'):
-                tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
-                                      dep + "_LIBRARY",
-                                      dep + "_LIBRARIES")
+        # was fixed in 1.79.0
+        #for dep in ('GIF', 'TIFF', 'PNG', 'JPEG', 'ZLIB'):
+        #   tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
+        #                         dep + "_LIBRARY",
+        #                         dep + "_LIBRARIES")
 
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -43,7 +43,7 @@ class LeptonicaConan(ConanFile):
         if self.options.with_png:
             self.requires.add("libpng/1.6.37")
         if self.options.with_tiff:
-            self.requires.add("libtiff/4.0.9")
+            self.requires.add("libtiff/4.1.0")
         if self.options.with_openjpeg:
             self.requires.add("openjpeg/2.3.1")
         if self.options.with_webp:

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -40,7 +40,7 @@ class LeptonicaConan(ConanFile):
         if self.options.with_gif:
             self.requires.add("giflib/5.1.4")
         if self.options.with_jpeg:
-            self.requires.add("libjpeg/9c")
+            self.requires.add("libjpeg/9d")
         if self.options.with_png:
             self.requires.add("libpng/1.6.37")
         if self.options.with_tiff:

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -70,7 +70,8 @@ class LeptonicaConan(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self)
-        cmake.definitions['STATIC'] = not self.options.shared
+        if self.version == '1.78.0':
+            cmake.definitions['STATIC'] = not self.options.shared
         cmake.definitions['BUILD_PROG'] = False
         # avoid finding system libs
         cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_GIF'] = not self.options.with_gif
@@ -79,6 +80,8 @@ class LeptonicaConan(ConanFile):
         cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_JPEG'] = not self.options.with_jpeg
         cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_webp'] = not self.options.with_webp
         cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_openjp2'] = not self.options.with_openjpeg
+
+        cmake.definitions['SW_BUILD'] = False
 
         cmake.configure(source_folder=self._source_subfolder)
         return cmake
@@ -91,10 +94,11 @@ class LeptonicaConan(ConanFile):
 
         # upstream uses obsolete FOO_LIBRARY that is not generated
         # by cmake_find_package generator (upstream PR 456)
-        for dep in ('GIF', 'TIFF', 'PNG', 'JPEG', 'ZLIB'):
-            tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
-                                  dep + "_LIBRARY",
-                                  dep + "_LIBRARIES")
+        if self.version == '1.78.0':
+            for dep in ('GIF', 'TIFF', 'PNG', 'JPEG', 'ZLIB'):
+                tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
+                                      dep + "_LIBRARY",
+                                      dep + "_LIBRARIES")
 
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -120,3 +120,5 @@ class LeptonicaConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "Leptonica"
         self.cpp_info.names["cmake_find_package_multi"] = "Leptonica"
         self.cpp_info.names['pkg_config'] = 'lept'
+        self.cpp_info.includedirs.append(os.path.join("include", "leptonica"))
+

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -32,6 +32,7 @@ class LeptonicaConan(ConanFile):
                        'with_webp': True,
                        'fPIC': True}
 
+    _cmake = None
     _source_subfolder = "source_subfolder"
 
     def requirements(self):
@@ -69,7 +70,9 @@ class LeptonicaConan(ConanFile):
                     os.path.join(self._source_subfolder, "CMakeLists.txt"))
 
     def _configure_cmake(self):
-        cmake = CMake(self)
+        if self._cmake:
+            return self._cmake
+        cmake = self._cmake = CMake(self)
         if self.version == '1.78.0':
             cmake.definitions['STATIC'] = not self.options.shared
         cmake.definitions['BUILD_PROG'] = False

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -97,7 +97,7 @@ class LeptonicaConan(ConanFile):
 
         # upstream uses obsolete FOO_LIBRARY that is not generated
         # by cmake_find_package generator (upstream PR 456)
-        if self.version == '1.78.0':
+        if tools.Version(self.version) <= '1.78.0':
             for dep in ('GIF', 'TIFF', 'PNG', 'JPEG', 'ZLIB'):
                 tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
                                       dep + "_LIBRARY",
@@ -124,4 +124,3 @@ class LeptonicaConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "Leptonica"
         self.cpp_info.names['pkg_config'] = 'lept'
         self.cpp_info.includedirs.append(os.path.join("include", "leptonica"))
-

--- a/recipes/leptonica/config.yml
+++ b/recipes/leptonica/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.78.0":
     folder: all
+  "1.79.0":
+    folder: all

--- a/recipes/leptonica/config.yml
+++ b/recipes/leptonica/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.78.0":
+    folder: all
   "1.79.0":
     folder: all

--- a/recipes/leptonica/config.yml
+++ b/recipes/leptonica/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "1.78.0":
-    folder: all
   "1.79.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **leptonica/1.79.0**

This recipe includes the latest 1.79.0 version but drops 1.78.0 with related workarounds (see PR #648). Also, `libtiff` version is bumped that possibly fixes a problem with locating requirement.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

