### PR TITLE
zeromq: allow encryption=None

### DIFF
--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -59,16 +59,18 @@ class ZeroMQConan(ConanFile):
 
     def _patch_sources(self):
         os.unlink(os.path.join(self._source_subfolder, "builds", "cmake", "Modules", "FindSodium.cmake"))
-        os.rename("Findlibsodium.cmake", "FindSodium.cmake")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                                   "SODIUM_FOUND",
-                                   "libsodium_FOUND")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                                   "SODIUM_INCLUDE_DIRS",
-                                   "libsodium_INCLUDE_DIRS")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                                   "SODIUM_LIBRARIES",
-                                   "libsodium_LIBRARIES")
+
+        if self.options.encryption == "libsodium":
+            os.rename("Findlibsodium.cmake", "FindSodium.cmake")
+            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                                       "SODIUM_FOUND",
+                                       "libsodium_FOUND")
+            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                                       "SODIUM_INCLUDE_DIRS",
+                                       "libsodium_INCLUDE_DIRS")
+            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                                       "SODIUM_LIBRARIES",
+                                       "libsodium_LIBRARIES")
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
Specify library name and version:  **zeromq/4.3.2**

When using `encryption=None`, the recipe fails with

```
zeromq/4.3.2: ERROR: Package '038baac88f4c7bfa972ce5adac1616bed8fe2ef4' build failed
zeromq/4.3.2: WARN: Build folder /home/patrick/.conan/data/zeromq/4.3.2/_/_/build/038baac88f4c7bfa972ce5adac1616bed8fe2ef4
ERROR: zeromq/4.3.2: Error in build() method, line 74
	self._patch_sources()
while calling '_patch_sources', line 62
	os.rename("Findlibsodium.cmake", "FindSodium.cmake")
	FileNotFoundError: [Errno 2] No such file or directory: 'Findlibsodium.cmake' -> 'FindSodium.cmake'
```

This checks if libsodium is needed, before applying patches.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

