### PR TITLE
[openssl] restore replace patterns

### DIFF
--- a/recipes/openssl/ALL/conanfile.py
+++ b/recipes/openssl/ALL/conanfile.py
@@ -357,18 +357,18 @@ class OpenSSLConan(ConanFile):
         with tools.environment_append(env_build.vars):
             if not "CROSS_COMPILE" in os.environ:
                 cc = os.environ.get("CC", "cc")
-                tools.replace_in_file(makefile_org, "CC= cc", "CC= %s %s" % (adjust_path(cc), os.environ["CFLAGS"]))
+                tools.replace_in_file(makefile_org, "CC= cc\n", "CC= %s %s\n" % (adjust_path(cc), os.environ["CFLAGS"]))
                 if "AR" in os.environ:
-                    tools.replace_in_file(makefile_org, "AR=ar", "AR=%s" % adjust_path(os.environ["AR"]))
+                    tools.replace_in_file(makefile_org, "AR=ar $(ARFLAGS) r\n", "AR=%s $(ARFLAGS) r\n" % adjust_path(os.environ["AR"]))
                 if "RANLIB" in os.environ:
-                    tools.replace_in_file(makefile_org, "RANLIB= ranlib", "RANLIB= %s" % adjust_path(os.environ["RANLIB"]))
+                    tools.replace_in_file(makefile_org, "RANLIB= ranlib\n", "RANLIB= %s\n" % adjust_path(os.environ["RANLIB"]))
                 rc = os.environ.get("WINDRES", os.environ.get("RC"))
                 if rc:
-                    tools.replace_in_file(makefile_org, "RC= windres", "RC= %s" % adjust_path(rc))
+                    tools.replace_in_file(makefile_org, "RC= windres\n", "RC= %s\n" % adjust_path(rc))
                 if "NM" in os.environ:
-                    tools.replace_in_file(makefile_org, "NM= nm", "NM= %s" % adjust_path(os.environ["NM"]))
+                    tools.replace_in_file(makefile_org, "NM= nm\n", "NM= %s\n" % adjust_path(os.environ["NM"]))
                 if "AS" in os.environ:
-                    tools.replace_in_file(makefile_org, "AS=$(CC) -c", "AS=%s" % adjust_path(os.environ["AS"]))
+                    tools.replace_in_file(makefile_org, "AS=$(CC) -c\n", "AS=%s\n" % adjust_path(os.environ["AS"]))
 
     def _get_env_build(self):
         if not self._env_build:

--- a/recipes/openssl/ALL/test_package/conanfile.py
+++ b/recipes/openssl/ALL/test_package/conanfile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from conans import CMake, tools, ConanFile
 import os
 


### PR DESCRIPTION
the commit https://github.com/conan-io/conan-center-index/commit/99320f9cfb9fcd9723f7a8357fe2f85e6547deb2 accidentally reverted the fix https://github.com/conan-io/conan-center-index/pull/129/commits/b80a9687e2103bfad0630ea519f9f6be45b14206. as a consequence, cross-compiling was broken for **1.0.x** versions.

closes: #940 

Specify library name and version:  **openssl/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

