### PR TITLE
HDF5: tweaks to optimize recipe

### DIFF
--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -11,7 +11,7 @@ class LibHdf5Conan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://portal.hdfgroup.org/display/support"
     license = "MIT"
-    exports = ["CMakeLists.txt"]
+    exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
 
     settings = "os", "arch", "compiler", "build_type"

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -30,6 +30,7 @@ class LibHdf5Conan(ConanFile):
 
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
+    _cmake = None
 
     def config_options(self):
         if self.settings.compiler == "Visual Studio":
@@ -57,23 +58,25 @@ class LibHdf5Conan(ConanFile):
             )
 
     def _configure_cmake(self):
-        cmake = CMake(self)
+        if self._cmake is not None:
+            return self._cmake
+        self._cmake = CMake(self)
 
         # Needed to avoid constructing the static libraries
         if tools.Version(self.version) >= "1.10.6":
-            cmake.definitions["ONLY_SHARED_LIBS"] = self.options.shared
+            self._cmake.definitions["ONLY_SHARED_LIBS"] = self.options.shared
 
         # Build only necessary modules
-        cmake.definitions["BUILD_TESTING"] = "OFF"
-        cmake.definitions["HDF5_BUILD_CPP_LIB"] = "ON"
-        cmake.definitions["HDF5_BUILD_EXAMPLES"] = "OFF"
-        cmake.definitions["HDF5_BUILD_TOOLS"] = "OFF"
+        self._cmake.definitions["BUILD_TESTING"] = "OFF"
+        self._cmake.definitions["HDF5_BUILD_CPP_LIB"] = "ON"
+        self._cmake.definitions["HDF5_BUILD_EXAMPLES"] = "OFF"
+        self._cmake.definitions["HDF5_BUILD_TOOLS"] = "OFF"
         # Modules depending on options
-        cmake.definitions["HDF5_BUILD_HL_LIB"] = self.options.hl
-        cmake.definitions["HDF5_ENABLE_Z_LIB_SUPPORT"] = self.options.with_zlib
+        self._cmake.definitions["HDF5_BUILD_HL_LIB"] = self.options.hl
+        self._cmake.definitions["HDF5_ENABLE_Z_LIB_SUPPORT"] = self.options.with_zlib
 
-        cmake.configure(build_folder=self._build_subfolder)
-        return cmake
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
 
     def build(self):
         cmake = self._configure_cmake()


### PR DESCRIPTION
Specify library name and version:  **hdf5/all**

I almost forgot I had a few improvements for the HDF5 recipe, so here is a pull request before I forget again. I implemented two small improvements:
* The result of `_configure_cmake` is now cached to avoid running it twice when building and packaging the library.
* The `CMakeLists.txt` was moved from `exports` to `exports_sources` since it is only needed when rebuilding the library.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

