### PR TITLE
SPIRV-Headers

### DIFF
--- a/recipes/spirv-headers/all/conandata.yml
+++ b/recipes/spirv-headers/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.5.1.corrected":
+    sha256: 2b6a0ce1c02b9fe7b9ef727369168fe579e5256f1ea013993acdb8d8f06b7e89
+    url: https://github.com/KhronosGroup/SPIRV-Headers/archive/1.5.1.corrected.tar.gz

--- a/recipes/spirv-headers/all/conandata.yml
+++ b/recipes/spirv-headers/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.5.1.corrected":
+  "1.5.1":
     sha256: 2b6a0ce1c02b9fe7b9ef727369168fe579e5256f1ea013993acdb8d8f06b7e89
     url: https://github.com/KhronosGroup/SPIRV-Headers/archive/1.5.1.corrected.tar.gz

--- a/recipes/spirv-headers/all/conanfile.py
+++ b/recipes/spirv-headers/all/conanfile.py
@@ -10,7 +10,7 @@ class SpirvheadersConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "compiler", "arch", "build_type"
 
-    license = "BSD"
+    license = "MIT-KhronosGroup"
 
 
     @property

--- a/recipes/spirv-headers/all/conanfile.py
+++ b/recipes/spirv-headers/all/conanfile.py
@@ -5,13 +5,11 @@ import os
 class SpirvheadersConan(ConanFile):
     name = "spirv-headers"
     homepage = "https://github.com/KhronosGroup/SPIRV-Headers"
-    description = "SPIRV-Headers"
+    description = "Header files for the SPIRV instruction set."
     topics = ("conan", "spirv", "spirv-v", "vulkan", "opengl", "opencl", "khronos")
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "compiler", "arch", "build_type"
-
     license = "MIT-KhronosGroup"
-
     _cmake = None
 
     @property
@@ -21,6 +19,8 @@ class SpirvheadersConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = "SPIRV-Headers-" + self.version
+        if self.version == "1.5.1":
+            extracted_dir = extracted_dir + ".corrected"
         os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_cmake(self):
@@ -38,7 +38,6 @@ class SpirvheadersConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE*", dst="licenses", src=self._source_subfolder)
-
         cmake = self._configure_cmake()
         cmake.install()
 

--- a/recipes/spirv-headers/all/conanfile.py
+++ b/recipes/spirv-headers/all/conanfile.py
@@ -1,0 +1,47 @@
+from conans import ConanFile, tools, CMake
+import os
+
+
+class SpirvheadersConan(ConanFile):
+    name = "spirv-headers"
+    homepage = "https://github.com/KhronosGroup/SPIRV-Headers"
+    description = "SPIRV-Headers"
+    topics = ("conan", "sprv","vulkan")
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "compiler", "arch", "build_type"
+
+    license = "BSD"
+
+    def requirements(self):
+        pass
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "SPIRV-Headers-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["SPIRV_HEADERS_SKIP_EXAMPLES"] = True
+        cmake.configure(source_folder=self._source_subfolder)
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE*", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        # Error KB-H016, complaining that Cmake config files are found
+        tools.rmdir(os.path.join(self.package_folder, "lib"))
+
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/spirv-headers/all/conanfile.py
+++ b/recipes/spirv-headers/all/conanfile.py
@@ -6,7 +6,7 @@ class SpirvheadersConan(ConanFile):
     name = "spirv-headers"
     homepage = "https://github.com/KhronosGroup/SPIRV-Headers"
     description = "SPIRV-Headers"
-    topics = ("conan", "sprv", "vulkan")
+    topics = ("conan", "spirv", "spirv-v", "vulkan", "opengl", "opencl", "khronos")
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "compiler", "arch", "build_type"
 

--- a/recipes/spirv-headers/all/conanfile.py
+++ b/recipes/spirv-headers/all/conanfile.py
@@ -12,8 +12,6 @@ class SpirvheadersConan(ConanFile):
 
     license = "BSD"
 
-    def requirements(self):
-        pass
 
     @property
     def _source_subfolder(self):

--- a/recipes/spirv-headers/all/conanfile.py
+++ b/recipes/spirv-headers/all/conanfile.py
@@ -6,7 +6,7 @@ class SpirvheadersConan(ConanFile):
     name = "spirv-headers"
     homepage = "https://github.com/KhronosGroup/SPIRV-Headers"
     description = "SPIRV-Headers"
-    topics = ("conan", "sprv","vulkan")
+    topics = ("conan", "sprv", "vulkan")
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "compiler", "arch", "build_type"
 
@@ -36,12 +36,12 @@ class SpirvheadersConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE*", dst="licenses", src=self._source_subfolder)
+
         cmake = self._configure_cmake()
         cmake.install()
 
         # Error KB-H016, complaining that Cmake config files are found
         tools.rmdir(os.path.join(self.package_folder, "lib"))
-
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/spirv-headers/all/conanfile.py
+++ b/recipes/spirv-headers/all/conanfile.py
@@ -12,6 +12,7 @@ class SpirvheadersConan(ConanFile):
 
     license = "MIT-KhronosGroup"
 
+    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -23,10 +24,13 @@ class SpirvheadersConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["SPIRV_HEADERS_SKIP_EXAMPLES"] = True
-        cmake.configure(source_folder=self._source_subfolder)
-        return cmake
+        if self._cmake:
+            return self._cmake
+
+        self._cmake = CMake(self)
+        self._cmake.definitions["SPIRV_HEADERS_SKIP_EXAMPLES"] = True
+        self._cmake.configure(source_folder=self._source_subfolder)
+        return self._cmake
 
     def build(self):
         cmake = self._configure_cmake()

--- a/recipes/spirv-headers/all/test_package/CMakeLists.txt
+++ b/recipes/spirv-headers/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(test_package)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/spirv-headers/all/test_package/CMakeLists.txt
+++ b/recipes/spirv-headers/all/test_package/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(test_package)
 
-set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/spirv-headers/all/test_package/conanfile.py
+++ b/recipes/spirv-headers/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/spirv-headers/all/test_package/test_package.cpp
+++ b/recipes/spirv-headers/all/test_package/test_package.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2016 The Khronos Group Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+//
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+#include <spirv/1.0/GLSL.std.450.h>
+#include <spirv/1.0/OpenCL.std.h>
+#include <spirv/1.0/spirv.hpp>
+
+namespace {
+
+const GLSLstd450 kSin = GLSLstd450Sin;
+const OpenCLLIB::Entrypoints kNative_cos = OpenCLLIB::Native_cos;
+const spv::Op kNop = spv::OpNop;
+
+}
+
+int main(int argc, char ** argv)
+{
+
+    return 0;
+}

--- a/recipes/spirv-headers/config.yml
+++ b/recipes/spirv-headers/config.yml
@@ -1,0 +1,4 @@
+---
+versions:
+  "1.5.1.corrected":
+    folder: all

--- a/recipes/spirv-headers/config.yml
+++ b/recipes/spirv-headers/config.yml
@@ -1,4 +1,4 @@
 ---
 versions:
-  "1.5.1.corrected":
+  "1.5.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **spirv-headers/1.5.1.corrected**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.


A header-only library for SPIRV. I have tried this out on Linux mint 19 with gcc7 and on Windows 10 using Visual Studios 2019 Community.

This is the base dependency for a lot of the SPIRV/Vulkan tools which will be added soon
