### PR TITLE
Add pkgconf/1.7.3 recipe

### DIFF
--- a/recipes/pkgconf/all/conandata.yml
+++ b/recipes/pkgconf/all/conandata.yml
@@ -1,8 +1,8 @@
 sources:
-  "1.6.3":
-    url: "https://git.sr.ht/~kaniini/pkgconf/archive/pkgconf-1.6.3.tar.gz"
-    sha256: "b95f331e652cab469c2956c4988aeeb688b6baf9acd1a5b89b782d082ea573cf"
+  "1.7.3":
+    url: "https://git.sr.ht/~kaniini/pkgconf/archive/pkgconf-1.7.3.tar.gz"
+    sha256: "88e93bbd1d4dc81fc08bfc7a39b3eca241aee3131091c9ba0684531ee4d9d2b3"
 patches:
-  "1.6.3":
+  "1.7.3":
     - patch_file: "patches/0001-meson-use-declare-dependencies.patch"
       base_path: "source_subfolder"

--- a/recipes/pkgconf/all/conandata.yml
+++ b/recipes/pkgconf/all/conandata.yml
@@ -6,3 +6,5 @@ patches:
   "1.7.3":
     - patch_file: "patches/0001-meson-use-declare-dependencies.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0002-c89-compatible.patch"
+      base_path: "source_subfolder"

--- a/recipes/pkgconf/all/conandata.yml
+++ b/recipes/pkgconf/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "1.6.3":
+    url: "https://git.sr.ht/~kaniini/pkgconf/archive/pkgconf-1.6.3.tar.gz"
+    sha256: "b95f331e652cab469c2956c4988aeeb688b6baf9acd1a5b89b782d082ea573cf"
+patches:
+  "1.6.3":
+    - patch_file: "patches/0001-meson-use-declare-dependencies.patch"
+      base_path: "source_subfolder"

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -104,7 +104,7 @@ class PkgConfConan(ConanFile):
         self.output.info("Appending PATH env var: {}".format(bindir))
         self.env_info.PATH.append(bindir)
 
-        pkg_config = os.path.join(bindir, "pkgconf")
+        pkg_config = os.path.join(bindir, "pkgconf").replace("\\", "/")
         self.output.info("Setting PKG_CONFIG env var: {}".format(pkg_config))
         self.env_info.PKG_CONFIG = pkg_config
 

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -104,10 +104,10 @@ class PkgConfConan(ConanFile):
         self.output.info("Appending PATH env var: {}".format(bindir))
         self.env_info.PATH.append(bindir)
 
-        pkg_config = tools.unix_path(os.path.join(bindir, "pkgconf"))
+        pkg_config = os.path.join(bindir, "pkgconf")
         self.output.info("Setting PKG_CONFIG env var: {}".format(pkg_config))
         self.env_info.PKG_CONFIG = pkg_config
 
-        automake_extra_includes = os.path.join(self.package_folder , "bin", "aclocal").replace("\\", "/")
+        automake_extra_includes = tools.unix_path(os.path.join(self.package_folder , "bin", "aclocal").replace("\\", "/"))
         self.output.info("Appending AUTOMAKE_CONAN_INCLUDES env var: {}".format(automake_extra_includes))
         self.env_info.AUTOMAKE_CONAN_INCLUDES.append(automake_extra_includes)

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -45,8 +45,7 @@ class PkgConfConan(ConanFile):
         os.rename("pkgconf-pkgconf-{}".format(self.version), self._source_subfolder)
 
     def build_requirements(self):
-        if not tools.which("meson"):
-            self.build_requires("meson/0.53.2")
+        self.build_requires("meson/0.53.2")
 
     @property
     def _sharedstatedir(self):

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -58,7 +58,8 @@ class PkgConfConan(ConanFile):
         self._meson = Meson(self)
         self._meson.options["tests"] = False
         self._meson.options["sharedstatedir"] = self._sharedstatedir
-        self._meson.configure(source_folder=self._source_subfolder, build_folder=self._build_subfolder)
+        with tools.environment_append({"CFLAGS": tools.get_env("CFLAGS", "") + " -std=c99",}):
+            self._meson.configure(source_folder=self._source_subfolder, build_folder=self._build_subfolder)
         return self._meson
 
     def _patch_sources(self):

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -107,5 +107,5 @@ class PkgConfConan(ConanFile):
         self.env_info.PKG_CONFIG = pkg_config
 
         automake_extra_includes = os.path.join(self.package_folder , "bin", "aclocal").replace("\\", "/")
-        self.output.info("Appending AUTOMAKE_EXTRA_INCLUDES env var: {}".format(automake_extra_includes))
-        self.env_info.AUTOMAKE_EXTRA_INCLUDES.append(automake_extra_includes)
+        self.output.info("Appending AUTOMAKE_CONAN_INCLUDES env var: {}".format(automake_extra_includes))
+        self.env_info.AUTOMAKE_CONAN_INCLUDES.append(automake_extra_includes)

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -104,7 +104,7 @@ class PkgConfConan(ConanFile):
         self.output.info("Appending PATH env var: {}".format(bindir))
         self.env_info.PATH.append(bindir)
 
-        pkg_config = os.path.join(bindir, "pkgconf").replace("\\", "/")
+        pkg_config = tools.unix_path(os.path.join(bindir, "pkgconf"))
         self.output.info("Setting PKG_CONFIG env var: {}".format(pkg_config))
         self.env_info.PKG_CONFIG = pkg_config
 

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, Meson, tools
+import glob
 import os
 
 
@@ -81,9 +82,12 @@ class PkgConfConan(ConanFile):
         meson.install()
 
         if self.settings.compiler == "Visual Studio":
+            for pdb in glob.glob(os.path.join(self.package_folder, "bin", "*.pdb")):
+                os.unlink(pdb)
             if not self.options.shared:
                 os.rename(os.path.join(self.package_folder, "lib", "libpkgconf.a"),
                           os.path.join(self.package_folder, "lib", "pkgconf.lib"),)
+
 
         tools.rmdir(os.path.join(self.package_folder, "share", "man"))
         os.rename(os.path.join(self.package_folder, "share", "aclocal"),

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -55,7 +55,6 @@ class PkgConfConan(ConanFile):
         if self._meson:
             return self._meson
         self._meson = Meson(self)
-        self._meson.build_type = "Release"
         self._meson.options["tests"] = False
         self._meson.options["sharedstatedir"] = self._sharedstatedir
         self._meson.configure(source_folder=self._source_subfolder, build_folder=self._build_subfolder)

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -58,8 +58,7 @@ class PkgConfConan(ConanFile):
         self._meson = Meson(self)
         self._meson.options["tests"] = False
         self._meson.options["sharedstatedir"] = self._sharedstatedir
-        with tools.environment_append({"CFLAGS": tools.get_env("CFLAGS", "") + " -std=c99",}):
-            self._meson.configure(source_folder=self._source_subfolder, build_folder=self._build_subfolder)
+        self._meson.configure(source_folder=self._source_subfolder, build_folder=self._build_subfolder)
         return self._meson
 
     def _patch_sources(self):

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -7,7 +7,7 @@ class PkgConfConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://pkgconf.org/"
     topics = ("conan", "pkgconf")
-    settings = "os_build", "arch_build", "compiler"
+    settings = "os", "arch", "compiler", "build_type"
     license = "ISC"
     description = "package compiler and linker metadata toolkit"
     exports_sources = "patches/**"
@@ -74,10 +74,6 @@ class PkgConfConan(ConanFile):
         os.rename(os.path.join(self.package_folder, "share", "aclocal"),
                   os.path.join(self.package_folder, "bin", "aclocal"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
-
-    def package_id(self):
-        del self.info.settings.compiler
-        self.info.include_build_settings()
 
     def package_info(self):
         bindir = os.path.join(self.package_folder, "bin")

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -37,14 +37,12 @@ class PkgConfConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("pkgconf-pkgconf-{}".format(self.version), self._source_subfolder)
-
-    def configure(self):
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
 
     def build_requirements(self):
         if not tools.which("meson"):
@@ -89,6 +87,7 @@ class PkgConfConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
+        self.cpp_info.libs = ["pkgconf"]
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH env var: {}".format(bindir))
         self.env_info.PATH.append(bindir)

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -11,6 +11,14 @@ class PkgConfConan(ConanFile):
     license = "ISC"
     description = "package compiler and linker metadata toolkit"
     exports_sources = "patches/**"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
 
     _meson = None
 
@@ -21,6 +29,14 @@ class PkgConfConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -43,7 +59,6 @@ class PkgConfConan(ConanFile):
             return self._meson
         self._meson = Meson(self)
         self._meson.build_type = "Release"
-        self._meson.options["default_library"] = "static"
         self._meson.options["tests"] = False
         self._meson.options["sharedstatedir"] = self._sharedstatedir
         self._meson.configure(source_folder=self._source_subfolder, build_folder=self._build_subfolder)

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -1,0 +1,93 @@
+from conans import ConanFile, Meson, tools
+import os
+
+
+class PkgConfConan(ConanFile):
+    name = "pkgconf"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://pkgconf.org/"
+    topics = ("conan", "pkgconf")
+    settings = "os_build", "arch_build", "compiler"
+    license = "ISC"
+    description = "package compiler and linker metadata toolkit"
+    exports_sources = "patches/**"
+
+    _meson = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("pkgconf-pkgconf-{}".format(self.version), self._source_subfolder)
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def build_requirements(self):
+        if not tools.which("meson"):
+            self.build_requires("meson/0.53.2")
+
+    @property
+    def _sharedstatedir(self):
+        return os.path.join(self.package_folder, "bin", "share")
+
+    def _configure_meson(self):
+        if self._meson:
+            return self._meson
+        self._meson = Meson(self)
+        self._meson.build_type = "Release"
+        self._meson.options["default_library"] = "static"
+        self._meson.options["tests"] = False
+        self._meson.options["sharedstatedir"] = self._sharedstatedir
+        self._meson.configure(source_folder=self._source_subfolder, build_folder=self._build_subfolder)
+        return self._meson
+
+    def _patch_sources(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+        tools.replace_in_file(os.path.join(self._source_subfolder, "meson.build"),
+                              "shared_library(", "library(")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "meson.build"),
+                              "'-DLIBPKGCONF_EXPORT'",
+                              "['-DLIBPKGCONF_EXPORT', '-DPKGCONFIG_IS_STATIC']")
+
+    def build(self):
+        self._patch_sources()
+        meson = self._configure_meson()
+        meson.build()
+
+    def package(self):
+        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
+        meson = self._meson
+        meson.install()
+
+        tools.rmdir(os.path.join(self.package_folder, "include"))
+        tools.rmdir(os.path.join(self.package_folder, "lib"))
+        tools.rmdir(os.path.join(self.package_folder, "share", "man"))
+        os.rename(os.path.join(self.package_folder, "share", "aclocal"),
+                  os.path.join(self.package_folder, "bin", "aclocal"))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_id(self):
+        del self.info.settings.compiler
+        self.info.include_build_settings()
+
+    def package_info(self):
+        bindir = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH env var: {}".format(bindir))
+        self.env_info.PATH.append(bindir)
+
+        pkg_config = os.path.join(bindir, "pkgconf").replace("\\", "/")
+        self.output.info("Setting PKG_CONFIG env var: {}".format(pkg_config))
+        self.env_info.PKG_CONFIG = pkg_config
+
+        automake_extra_includes = os.path.join(self.package_folder , "bin", "aclocal").replace("\\", "/")
+        self.output.info("Appending AUTOMAKE_EXTRA_INCLUDES env var: {}".format(automake_extra_includes))
+        self.env_info.AUTOMAKE_EXTRA_INCLUDES.append(automake_extra_includes)

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -83,8 +83,6 @@ class PkgConfConan(ConanFile):
         meson = self._meson
         meson.install()
 
-        tools.rmdir(os.path.join(self.package_folder, "include"))
-        tools.rmdir(os.path.join(self.package_folder, "lib"))
         tools.rmdir(os.path.join(self.package_folder, "share", "man"))
         os.rename(os.path.join(self.package_folder, "share", "aclocal"),
                   os.path.join(self.package_folder, "bin", "aclocal"))

--- a/recipes/pkgconf/all/patches/0001-meson-use-declare-dependencies.patch
+++ b/recipes/pkgconf/all/patches/0001-meson-use-declare-dependencies.patch
@@ -1,0 +1,20 @@
+--- meson.build
++++ meson.build
+@@ -84,12 +84,16 @@
+   soversion : '3',
+ )
+
++libpkgconf_dep = declare_dependency(
++    link_with: libpkgconf,
++    compile_args: '-DLIBPKGCONF_EXPORT',
++)
+
+ pkgconf_exe = executable('pkgconf',
+   'cli/main.c',
+   'cli/getopt_long.c',
+   'cli/renderer-msvc.c',
+-  link_with : libpkgconf,
++  dependencies: libpkgconf_dep,
+   install : true)
+
+ if get_option('tests')

--- a/recipes/pkgconf/all/patches/0002-c89-compatible.patch
+++ b/recipes/pkgconf/all/patches/0002-c89-compatible.patch
@@ -1,0 +1,58 @@
+--- libpkgconf/fragment.c
++++ libpkgconf/fragment.c
+@@ -35,6 +35,7 @@
+ static inline bool
+ pkgconf_fragment_is_unmergeable(const char *string)
+ {
++	size_t i;
+ 	static const struct pkgconf_fragment_check check_fragments[] = {
+ 		{"-framework", 10},
+ 		{"-isystem", 8},
+@@ -57,7 +58,7 @@
+ 	if (*string != '-')
+ 		return true;
+ 
+-	for (size_t i = 0; i < PKGCONF_ARRAY_SIZE(check_fragments); i++)
++	for (i = 0; i < PKGCONF_ARRAY_SIZE(check_fragments); i++)
+ 		if (!strncmp(string, check_fragments[i].token, check_fragments[i].len))
+ 			return true;
+ 
+--- libpkgconf/path.c
++++ libpkgconf/path.c
+@@ -281,6 +281,7 @@
+ static char *
+ normpath(const char *path)
+ {
++	int ii;
+ 	if (!path)
+ 		return NULL;
+ 
+@@ -289,7 +290,7 @@ normpath(const char *path)
+ 		return NULL;
+ 	char *ptr = copy;
+ 
+-	for (int ii = 0; copy[ii]; ii++)
++	for (ii = 0; copy[ii]; ii++)
+ 	{
+ 		*ptr++ = path[ii];
+ 		if ('/' == path[ii])
+--- libpkgconf/personality.c
++++ libpkgconf/personality.c
+@@ -57,14 +57,15 @@
+ #elif __HAIKU__
+ 	char **paths;
+ 	size_t count;
++	size_t i;
+ 	if (find_paths(B_FIND_PATH_DEVELOP_LIB_DIRECTORY, "pkgconfig", &paths, &count) == B_OK) {
+-		for (size_t i = 0; i < count; i++)
++		for (i = 0; i < count; i++)
+ 			pkgconf_path_add(paths[i], dirlist, true);
+ 		free(paths);
+ 		paths = NULL;
+ 	}
+ 	if (find_paths(B_FIND_PATH_DATA_DIRECTORY, "pkgconfig", &paths, &count) == B_OK) {
+-		for (size_t i = 0; i < count; i++)
++		for (i = 0; i < count; i++)
+ 			pkgconf_path_add(paths[i], dirlist, true);
+ 		free(paths);
+ 		paths = NULL;

--- a/recipes/pkgconf/all/test_package/CMakeLists.txt
+++ b/recipes/pkgconf/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(test_package LANGUAGES C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/pkgconf/all/test_package/conanfile.py
+++ b/recipes/pkgconf/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conans import AutoToolsBuildEnvironment, CMake, ConanFile, tools
+from conans import AutoToolsBuildEnvironment, CMake, ConanFile, tools, RunEnvironment
 from conans.errors import ConanException
 import os
 import shutil
@@ -20,7 +20,8 @@ class TestPackageConan(ConanFile):
                     os.path.join(self.build_folder, "configure.ac"))
         self.run("autoreconf -fiv", run_environment=True, win_bash=tools.os_info.is_windows)
         autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        autotools.configure()
+        with tools.environment_append(RunEnvironment(self).vars):
+            autotools.configure()
 
         cmake = CMake(self)
         cmake.configure()

--- a/recipes/pkgconf/all/test_package/conanfile.py
+++ b/recipes/pkgconf/all/test_package/conanfile.py
@@ -1,13 +1,27 @@
-from conans import CMake, ConanFile, tools
+from conans import AutoToolsBuildEnvironment, CMake, ConanFile, tools
 from conans.errors import ConanException
 import os
+import shutil
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
 
+    def build_requirements(self):
+        self.build_requires("automake/1.16.2")
+        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH") \
+                and tools.os_info.detect_windows_subsystem() != "msys2":
+            self.build_requires("msys2/20190524")
+
     def build(self):
+        # Test pkg.m4 integration into automake
+        shutil.copy(os.path.join(self.source_folder, "configure.ac"),
+                    os.path.join(self.build_folder, "configure.ac"))
+        self.run("autoreconf -fiv", run_environment=True, win_bash=tools.os_info.is_windows)
+        autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        autotools.configure()
+
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/pkgconf/all/test_package/conanfile.py
+++ b/recipes/pkgconf/all/test_package/conanfile.py
@@ -30,11 +30,14 @@ class TestPackageConan(ConanFile):
         if not tools.cross_building(self.settings):
             self.run(os.path.join("bin", "test_package"), run_environment=True)
 
-            if not os.environ["PKG_CONFIG"].startswith(self.deps_cpp_info["pkgconf"].rootpath):
+            pkg_config = tools.get_env("PKG_CONFIG")
+            self.output.info("Read environment variable PKG_CONFIG='{}'".format(pkg_config))
+            if not pkg_config or not pkg_config.startswith(self.deps_cpp_info["pkgconf"].rootpath.replace("\\", "/")):
                 raise ConanException("PKG_CONFIG variable incorrect")
 
             pkgconf_path = tools.which("pkgconf").replace("\\", "/")
-            if not pkgconf_path.startswith(self.deps_cpp_info["pkgconf"].rootpath):
+            self.output.info("Found pkgconf at '{}'".format(pkgconf_path))
+            if not pkgconf_path or not pkgconf_path.startswith(self.deps_cpp_info["pkgconf"].rootpath.replace("\\", "/")):
                 raise ConanException("pkgconf executable not found")
 
             with tools.environment_append({"PKG_CONFIG_PATH": self.source_folder}):

--- a/recipes/pkgconf/all/test_package/conanfile.py
+++ b/recipes/pkgconf/all/test_package/conanfile.py
@@ -1,13 +1,21 @@
-from conans import ConanFile, tools
+from conans import CMake, ConanFile, tools
 from conans.errors import ConanException
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
         if not tools.cross_building(self.settings):
+            self.run(os.path.join("bin", "test_package"), run_environment=True)
+
             if not os.environ["PKG_CONFIG"].startswith(self.deps_cpp_info["pkgconf"].rootpath):
                 raise ConanException("PKG_CONFIG variable incorrect")
 

--- a/recipes/pkgconf/all/test_package/conanfile.py
+++ b/recipes/pkgconf/all/test_package/conanfile.py
@@ -16,5 +16,5 @@ class TestPackageConan(ConanFile):
                 raise ConanException("pkgconf executable not found")
 
             with tools.environment_append({"PKG_CONFIG_PATH": self.source_folder}):
-                self.run("{} libexample1 --libs".format(os.environ["PKG_CONFIG"]))
-                self.run("{} libexample1 --cflags".format(os.environ["PKG_CONFIG"]))
+                self.run("{} libexample1 --libs".format(os.environ["PKG_CONFIG"]), run_environment=True)
+                self.run("{} libexample1 --cflags".format(os.environ["PKG_CONFIG"]), run_environment=True)

--- a/recipes/pkgconf/all/test_package/conanfile.py
+++ b/recipes/pkgconf/all/test_package/conanfile.py
@@ -1,16 +1,20 @@
 from conans import ConanFile, tools
-
+from conans.errors import ConanException
 import os
 
 
 class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
 
     def test(self):
-        pkgconf_path = tools.which("pkgconf").replace("\\", "/")
-        assert pkgconf_path.startswith(self.deps_cpp_info["pkgconf"].rootpath)
+        if not tools.cross_building(self.settings):
+            if not os.environ["PKG_CONFIG"].startswith(self.deps_cpp_info["pkgconf"].rootpath):
+                raise ConanException("PKG_CONFIG variable incorrect")
 
-        assert os.environ["PKG_CONFIG"].startswith(self.deps_cpp_info["pkgconf"].rootpath)
+            pkgconf_path = tools.which("pkgconf").replace("\\", "/")
+            if not pkgconf_path.startswith(self.deps_cpp_info["pkgconf"].rootpath):
+                raise ConanException("pkgconf executable not found")
 
-        with tools.environment_append({"PKG_CONFIG_PATH": self.source_folder}):
-            self.run("{} libexample1 --libs".format(os.environ["PKG_CONFIG"]))
-            self.run("{} libexample1 --cflags".format(os.environ["PKG_CONFIG"]))
+            with tools.environment_append({"PKG_CONFIG_PATH": self.source_folder}):
+                self.run("{} libexample1 --libs".format(os.environ["PKG_CONFIG"]))
+                self.run("{} libexample1 --cflags".format(os.environ["PKG_CONFIG"]))

--- a/recipes/pkgconf/all/test_package/conanfile.py
+++ b/recipes/pkgconf/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, tools
+
+import os
+
+
+class TestPackageConan(ConanFile):
+
+    def test(self):
+        pkgconf_path = tools.which("pkgconf").replace("\\", "/")
+        assert pkgconf_path.startswith(self.deps_cpp_info["pkgconf"].rootpath)
+
+        assert os.environ["PKG_CONFIG"].startswith(self.deps_cpp_info["pkgconf"].rootpath)
+
+        with tools.environment_append({"PKG_CONFIG_PATH": self.source_folder}):
+            self.run("{} libexample1 --libs".format(os.environ["PKG_CONFIG"]))
+            self.run("{} libexample1 --cflags".format(os.environ["PKG_CONFIG"]))

--- a/recipes/pkgconf/all/test_package/configure.ac
+++ b/recipes/pkgconf/all/test_package/configure.ac
@@ -1,0 +1,9 @@
+AC_INIT([test_package_pkgconf],[1.0])
+AC_PREREQ([2.69])
+
+PKG_PREREQ([0.29])
+PKG_PROG_PKG_CONFIG
+[echo pkg-config executable found at $PKG_CONFIG!]
+PKG_CHECK_EXISTS([sdl2],
+    [echo "found SDL2 :D"],
+    [echo "SDL2 not found :("])

--- a/recipes/pkgconf/all/test_package/libexample1.pc
+++ b/recipes/pkgconf/all/test_package/libexample1.pc
@@ -1,0 +1,6 @@
+Name: libexample1
+Description: This is a description of libexample1.
+Requires:
+Version: 0.42
+Libs: -L/usr/lib -lexample1
+Cflags:  -I/usr/include/libexample1 -I/usr/include -DEXAMPLE1_STATIC

--- a/recipes/pkgconf/all/test_package/test_package.c
+++ b/recipes/pkgconf/all/test_package/test_package.c
@@ -16,7 +16,7 @@ int main() {
 
     pkgconf_client_init(&client, error_callback, NULL, pkgconf_cross_personality_default());
 
-    pkgconf_error(&client, __FILE__, __LINE__, __FUNCTION__, "test error");
+    pkgconf_error(&client, "%s:%d %s: %s", __FILE__, __LINE__, __FUNCTION__, "test error");
 
     pkgconf_client_deinit(&client);
 

--- a/recipes/pkgconf/all/test_package/test_package.c
+++ b/recipes/pkgconf/all/test_package/test_package.c
@@ -7,7 +7,7 @@
 bool error_callback(const char *msg, const pkgconf_client_t *client, const void *data) {
     printf("error callback: %s\n", msg);
     fflush(stdout);
-    return 1;
+    return 1; // 1/true means message handled
 }
 
 int main() {

--- a/recipes/pkgconf/all/test_package/test_package.c
+++ b/recipes/pkgconf/all/test_package/test_package.c
@@ -1,0 +1,24 @@
+#include "libpkgconf.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool error_callback(const char *msg, const pkgconf_client_t *client, const void *data) {
+    printf("error callback: %s\n", msg);
+    fflush(stdout);
+    return 1;
+}
+
+int main() {
+    pkgconf_client_t client;
+    memset(&client, 0, sizeof(client));
+
+    pkgconf_client_init(&client, error_callback, NULL, pkgconf_cross_personality_default());
+
+    pkgconf_error(&client, __FILE__, __LINE__, __FUNCTION__, "test error");
+
+    pkgconf_client_deinit(&client);
+
+    return 0;
+}

--- a/recipes/pkgconf/config.yml
+++ b/recipes/pkgconf/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.6.3":
+    folder: all

--- a/recipes/pkgconf/config.yml
+++ b/recipes/pkgconf/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.6.3":
-    folder: all
+  "1.7.3":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **pkgconf/1.7.3**

- pkgconf is used on fedora as the default `pkg-config`
- I've used the meson build script because I could not get the autotools working for MSVC.
- There is a potential cyclic dependency with meson: https://todo.sr.ht/~kaniini/pkgconf/1
  But as long as the meson script for pkgconf is not using pkgconfig itself, it should be ok.

CC'ing @ericLemanissier because he opened #618 for which this is an alternative.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

---
Update 2020-06-27:
- update to 1.7.3
- test autotools integration.
-  [x] Test has hard dependency on  #2038

Update 2020-07-04

- [ ] Needs meson KB-H019 exception at https://github.com/conan-io/hooks/pull/208