### PR TITLE
cjson: add include/cjson to inlude directories

### DIFF
--- a/recipes/cjson/all/conanfile.py
+++ b/recipes/cjson/all/conanfile.py
@@ -89,6 +89,7 @@ class CjsonConan(ConanFile):
                 shutil.move(dll_file, bin_dir)
 
     def package_info(self):
+        self.cpp_info.includedirs.append(os.path.join("include", "cjson"))
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("m")


### PR DESCRIPTION
Some libraries such as k4a use #include <cJSON.h> directly.

Specify library name and version:  **cjson/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

