### PR TITLE
czmq: fix linkage and uuid library for mingw and msvc

### DIFF
--- a/recipes/czmq/all/CMakeLists.txt
+++ b/recipes/czmq/all/CMakeLists.txt
@@ -8,6 +8,10 @@ if(MSVC)
     add_definitions("-D_NOEXCEPT=noexcept")
 endif()
 
+if(NOT BUILD_SHARED_LIBS)
+    add_definitions("-DCZMQ_STATIC")
+endif()
+
 add_subdirectory(source_subfolder)
 
 foreach(TARGET zmakecert zsp test_randof czmq_selftest)

--- a/recipes/czmq/all/conanfile.py
+++ b/recipes/czmq/all/conanfile.py
@@ -91,5 +91,7 @@ class CzmqConan(ConanFile):
             self.cpp_info.libs = ["czmq"]
             if self.settings.os == "Linux":
                 self.cpp_info.system_libs.extend(["pthread", "m"])
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.append("rpcrt4")
         if not self.options.shared:
             self.cpp_info.defines.append("CZMQ_STATIC")


### PR DESCRIPTION
Specify library name and version:  **czmq/xx**

Found problem with czmq while creating zyre on mingw and msvc

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

