### PR TITLE
Fix CMake test_package cross building detection

### DIFF
--- a/recipes/cmake/all/test_package/conanfile.py
+++ b/recipes/cmake/all/test_package/conanfile.py
@@ -4,7 +4,8 @@ from conans import ConanFile, tools
 
 
 class TestPackageConan(ConanFile):
-
+    settings = "os", "os_build"
+    
     def test(self):
         if not tools.cross_building(self.settings):
             output = StringIO()


### PR DESCRIPTION
If test class doesn't have `os` and `os_build` as settings they're
discarded and the cross_building check does not work.

Specify library name and version:  cmake/all

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

