### PR TITLE
zeromq: Fix always building with ENABLE_CURVE.

### DIFF
--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -53,7 +53,7 @@ class ZeroMQConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-        self._cmake.definitions["ENABLE_CURVE"] = self.options.encryption is not None
+        self._cmake.definitions["ENABLE_CURVE"] = bool(self.options.encryption)
         self._cmake.definitions["WITH_LIBSODIUM"] = self.options.encryption == "libsodium"
         self._cmake.definitions["ZMQ_BUILD_TESTS"] = False
         self._cmake.definitions["WITH_PERF_TOOL"] = False


### PR DESCRIPTION
Even if set to "None" it's enabled because the option is converted to a
PackageOption. This should fix it according to the list in
https://github.com/conan-io/conan/issues/3620

Specify library name and version:  **zeromq/4.3.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

