### PR TITLE
libjpeg-turbo: do not override msvc runtime

### DIFF
--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -83,14 +83,23 @@ class LibjpegTurboConan(ConanFile):
         self._cmake.definitions["WITH_TURBOJPEG"] = self.options.turbojpeg
         self._cmake.definitions["WITH_JAVA"] = self.options.java
         self._cmake.definitions["WITH_12BIT"] = self.options.enable12bit
+        if self.settings.compiler == "Visual Studio":
+            self._cmake.definitions["WITH_CRT_DLL"] = True # avoid replacing /MD by /MT in compiler flags
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
-    def build(self):
+    def _patch_sources(self):
         # use standard GNUInstallDirs.cmake - custom one is broken
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "include(cmakescripts/GNUInstallDirs.cmake)",
                               "include(GNUInstallDirs)")
+        # do not override /MT by /MD if shared
+        tools.replace_in_file(os.path.join(self._source_subfolder, "sharedlib", "CMakeLists.txt"),
+                              """string(REGEX REPLACE "/MT" "/MD" ${var} "${${var}}")""",
+                              "")
+
+    def build(self):
+        self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **libjpeg-turbo/{2.0.2,2.0.4}**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

closes https://github.com/conan-io/conan-center-index/issues/1078