### PR TITLE
[bug] [boost] Do not modify the compiler version

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -765,8 +765,6 @@ class BoostConan(ConanFile):
     def _toolset_version_and_exe(self):
         compiler_version = str(self.settings.compiler.version)
         major = compiler_version.split(".")[0]
-        if "." not in compiler_version:
-            compiler_version += ".0"
         compiler = str(self.settings.compiler)
         if self._is_msvc:
             if Version(compiler_version) >= "16":


### PR DESCRIPTION
Specify library name and version:  **boost/all**

Do not add `.0` to the compiler version, it fails if the installed one is different

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

