### PR TITLE
szip: set cpp_info.name for cmake_find_package[_multi]

### DIFF
--- a/recipes/szip/all/conanfile.py
+++ b/recipes/szip/all/conanfile.py
@@ -72,4 +72,7 @@ class SzipConan(ConanFile):
         cmake.install()
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "SZIP"
+        self.cpp_info.names["cmake_find_package_multi"] = "SZIP"
+
         self.cpp_info.libs = tools.collect_libs(self)


### PR DESCRIPTION
`find_package(SZIP)` is the usual CMake way to locate szip, which seems required to implement #1072

Specify library name and version:  **szip/2.1.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

