### PR TITLE
libaec: fix libs order in cpp_info

### DIFF
--- a/recipes/libaec/all/conanfile.py
+++ b/recipes/libaec/all/conanfile.py
@@ -61,4 +61,7 @@ class LibaecConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, 'share'))
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        if self.settings.os == "Windows" and self.options.shared:
+            self.cpp_info.libs = ["szip", "aec"]
+        else:
+            self.cpp_info.libs = ["sz", "aec"]


### PR DESCRIPTION
Specify library name and version:  **libaec/1.0.4**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

libaec has 2 libs: sz and aec. sz depends on aec. I've encountered undefined reference while trying to use libaec in hdf5 as szip dependency.