### PR TITLE
zlib/1.2.8: use dict for default options

### DIFF
--- a/recipes/zlib/1.2.8/CMakeLists.txt
+++ b/recipes/zlib/1.2.8/CMakeLists.txt
@@ -1,8 +1,8 @@
-PROJECT(conanzlib)
 cmake_minimum_required(VERSION 2.8)
+project(conanzlib)
 
 include(conanbuildinfo.cmake)
-CONAN_BASIC_SETUP()
+conan_basic_setup()
 
 include_directories(${CMAKE_SOURCE_DIR}/source_subfolder)
 add_subdirectory(source_subfolder)

--- a/recipes/zlib/1.2.8/conanfile.py
+++ b/recipes/zlib/1.2.8/conanfile.py
@@ -15,7 +15,7 @@ class ZlibConan(ConanFile):
                   "(Also Free, Not to Mention Unencumbered by Patents)")
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = "shared=False", "fPIC=True"
+    default_options = {"shared": False, "fPIC": True}
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
     _source_subfolder = "source_subfolder"

--- a/recipes/zlib/1.2.8/test_package/CMakeLists.txt
+++ b/recipes/zlib/1.2.8/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
-PROJECT(test_package)
 cmake_minimum_required(VERSION 2.8)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-CONAN_BASIC_SETUP()
+conan_basic_setup()
 
-ADD_EXECUTABLE(${CMAKE_PROJECT_NAME} test_package.c)
-TARGET_LINK_LIBRARIES(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})
+add_executable(${CMAKE_PROJECT_NAME} test_package.c)
+target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})


### PR DESCRIPTION
This allows zlib to be built with the new `CONAN_V2_MODE`introduced in Conan 1.23.

Specify library name and version:  **zlib/1.2.8**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

