### PR TITLE
zlib/1.2.11: use dict for default options

### DIFF
--- a/recipes/zlib/1.2.11/conanfile.py
+++ b/recipes/zlib/1.2.11/conanfile.py
@@ -14,7 +14,7 @@ class ZlibConan(ConanFile):
                    "(Also Free, Not to Mention Unencumbered by Patents)")
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False], "minizip": [True, False]}
-    default_options = "shared=False", "fPIC=True", "minizip=False"
+    default_options = {"shared": False, "fPIC": True, "minizip": False}
     exports_sources = ["CMakeLists.txt", "CMakeLists_minizip.txt", "minizip.patch"]
     generators = "cmake"
     _source_subfolder = "source_subfolder"


### PR DESCRIPTION
This allows zlib to be built with the new `CONAN_V2_MODE` introduced in Conan 1.23.

Specify library name and version:  **zlib/1.2.11**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

