### PR TITLE
[boost] never use system b2, it might be outdated or incompatible

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -121,7 +121,7 @@ class BoostConan(ConanFile):
             del self.options.fPIC
 
     def build_requirements(self):
-        self.build_requires("b2/4.1.0")
+        self.build_requires("b2/4.2.0")
 
     def requirements(self):
         if self._zip_bzip2_requires_needed:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -121,8 +121,7 @@ class BoostConan(ConanFile):
             del self.options.fPIC
 
     def build_requirements(self):
-        if not tools.which("b2"):
-            self.build_requires("b2/4.1.0")
+        self.build_requires("b2/4.1.0")
 
     def requirements(self):
         if self._zip_bzip2_requires_needed:
@@ -338,7 +337,8 @@ class BoostConan(ConanFile):
 
     @property
     def _b2_exe(self):
-        return tools.which("b2")
+        b2_exe = "b2.exe" if tools.os_info.is_windows else "b2"
+        return os.path.join(self.deps_cpp_info["b2"].rootpath, "bin", b2_exe)
 
     @property
     def _bcp_exe(self):
@@ -414,11 +414,9 @@ class BoostConan(ConanFile):
 
         with tools.vcvars(self.settings) if self._is_msvc else tools.no_op():
             with tools.chdir(sources):
-                # to locate user config jam (BOOST_BUILD_PATH)
-                with tools.environment_append({"BOOST_BUILD_PATH": self._boost_build_dir}):
-                    # To show the libraries *1
-                    # self.run("%s --show-libraries" % b2_exe)
-                    self.run(full_command)
+                # To show the libraries *1
+                # self.run("%s --show-libraries" % b2_exe)
+                self.run(full_command)
 
         arch = self.settings.get_safe('arch')
         if arch.startswith("asm.js"):
@@ -535,7 +533,6 @@ class BoostConan(ConanFile):
             flags.append("abi=%s" % self._b2_abi)
 
         flags.append("--layout=%s" % self.options.layout)
-        flags.append("-sBOOST_BUILD_PATH=%s" % self._boost_build_dir)
         flags.append("--user-config=%s" % os.path.join(self._boost_build_dir, 'user-config.jam'))
         flags.append("-sNO_ZLIB=%s" % ("0" if self.options.zlib else "1"))
         flags.append("-sNO_BZIP2=%s" % ("0" if self.options.bzip2 else "1"))


### PR DESCRIPTION
- ensure b2 from conan is always used
- don't set **BOOST_BUILD_PATH** (it's already set by b2 itself: https://github.com/conan-io/conan-center-index/blob/master/recipes/b2/all/conanfile.py#L47)

closes: #1122 

Specify library name and version:  **boost/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

