### PR TITLE
remove explicit version specifier from yasm conanfile

### DIFF
--- a/recipes/yasm/all/conanfile.py
+++ b/recipes/yasm/all/conanfile.py
@@ -4,7 +4,6 @@ import os
 
 class YASMInstallerConan(ConanFile):
     name = "yasm"
-    version = "1.3.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/yasm/yasm"
     description = 'Yasm is a complete rewrite of the NASM assembler under the "new" BSD License'


### PR DESCRIPTION
Specify library name and version:  **yasm/1.3.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

