### PR TITLE
[fix] entt/all: Add all base settings for build helpers to work

### DIFF
--- a/recipes/entt/3.x.x/conanfile.py
+++ b/recipes/entt/3.x.x/conanfile.py
@@ -12,7 +12,7 @@ class EnttConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     license = "MIT"
     no_copy_source = True
-    settings = "compiler"
+    settings = "os", "compiler", "build_type", "arch"
 
     _cmake = None
 
@@ -72,7 +72,8 @@ class EnttConan(ConanFile):
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="LICENSE", dst="licenses",
+                  src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "cmake"))


### PR DESCRIPTION
Specify library name and version:  **entt/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

