### PR TITLE
Do not install docs for zeromq

### DIFF
--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -59,7 +59,10 @@ class ZeroMQConan(ConanFile):
         self._cmake.definitions["WITH_PERF_TOOL"] = False
         self._cmake.definitions["BUILD_SHARED"] = self.options.shared
         self._cmake.definitions["BUILD_STATIC"] = not self.options.shared
+        self._cmake.definitions["BUILD_TESTS"] = False
         self._cmake.definitions["ENABLE_CPACK"] = False
+        self._cmake.definitions["WITH_DOCS"] = False
+        self._cmake.definitions["WITH_DOC"] = False
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **zeromq/4.3.2**

Both WITH_DOCS and WITH_DOC are related to docs, but they are evaluated in different places, which means, both should be disabled.

fixes #1074

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

