### PR TITLE
[openal] Fix linker errors in win64 when using dsound backend

### DIFF
--- a/recipes/openal/all/conanfile.py
+++ b/recipes/openal/all/conanfile.py
@@ -60,7 +60,7 @@ class OpenALConan(ConanFile):
 
     def package_info(self):
         if self.settings.os == "Windows":
-            self.cpp_info.libs = ["OpenAL32", 'winmm']
+            self.cpp_info.libs = ["OpenAL32", 'winmm', 'OLE32', 'Shell32']
         else:
             self.cpp_info.libs = ["openal"]
         if self.settings.os == 'Linux':


### PR DESCRIPTION
Specify library name and version:  **openal/1.19.1**

When moving this library from https://github.com/bincrafters/conan-openal, some linker flags were omitted due to some reason.
Please refer to the original issue https://github.com/bincrafters/community/issues/953

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

