### PR TITLE
migrating websocketpp/0.8.1@bincrafters/stable to CCI

### DIFF
--- a/recipes/websocketpp/all/CMakeLists.txt
+++ b/recipes/websocketpp/all/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 2.8.11)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/websocketpp/all/CMakeLists.txt
+++ b/recipes/websocketpp/all/CMakeLists.txt
@@ -1,0 +1,6 @@
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/websocketpp/all/conandata.yml
+++ b/recipes/websocketpp/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "0.8.1":
+    url: "https://github.com/zaphoyd/websocketpp/archive/0.8.1.tar.gz"
+    sha256: "178899de48c02853b55b1ea8681599641cedcdfce59e56beaff3dd0874bf0286"
+patches:
+  "0.8.1":
+    - base_path: "source_subfolder"
+      patch_file: "patches/websocket_boost_support_1_7_x.patch"

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -20,7 +20,7 @@ class WebsocketPPConan(ConanFile):
         return "source_subfolder"
 
     def requirements(self):
-        self.requires.add('openssl/1.1.1d')
+        self.requires.add('openssl/1.1.1e')
         self.requires.add('zlib/1.2.11')
         if self.options.asio == 'standalone':
             self.requires.add('asio/1.14.0')

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -14,6 +14,7 @@ class WebsocketPPConan(ConanFile):
     generators = ["cmake"]
     options = {'asio': ['boost', 'standalone']}
     default_options = {'asio': 'boost'}
+    version = "0.8.1"
 
     @property
     def _source_subfolder(self):
@@ -37,13 +38,11 @@ class WebsocketPPConan(ConanFile):
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
 
-    def build(self):
+    def package(self):
         self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.install()
-
-    def package(self):
         self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
         # We have to copy the headers manually, since the current install() step in the 0.8.1 release doesn't do so.
         self.copy(pattern="*.hpp", dst="include/websocketpp", src=self._source_subfolder + '/websocketpp')

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -1,0 +1,57 @@
+import os
+from conans import ConanFile, tools, CMake
+
+
+class WebsocketPPConan(ConanFile):
+    name = "websocketpp"
+    description = "Header only C++ library that implements RFC6455 The WebSocket Protocol"
+    topics = ("conan", "websocketpp", "websocket", "network", "web", "rfc6455")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/zaphoyd/websocketpp"
+    license = "	BSD-3-Clause"
+    settings = "os", "arch", "compiler", "build_type"
+    exports_sources = ["CMakeLists.txt", 'patches/*']
+    generators = ["cmake"]
+    options = {'asio': ['boost', 'standalone']}
+    default_options = {'asio': 'boost'}
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def requirements(self):
+        self.requires.add('openssl/1.1.1d')
+        self.requires.add('zlib/1.2.11')
+        if self.options.asio == 'standalone':
+            self.requires.add('asio/1.14.0')
+        else:
+            self.requires.add('boost/1.72.0')
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+        self._patch_sources()
+
+    def _patch_sources(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.install()
+
+    def package(self):
+        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
+        # We have to copy the headers manually, since the current install() step in the 0.8.1 release doesn't do so.
+        self.copy(pattern="*.hpp", dst="include/websocketpp", src=self._source_subfolder + '/websocketpp')
+
+    def package_info(self):
+        self.cpp_info.builddirs.append(os.path.join(self.package_folder, 'cmake'))
+        if self.options.asio == 'standalone':
+            self.cpp_info.defines.extend(['ASIO_STANDALONE', '_WEBSOCKETPP_CPP11_STL_'])
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -14,7 +14,6 @@ class WebsocketPPConan(ConanFile):
     generators = ["cmake"]
     options = {'asio': ['boost', 'standalone']}
     default_options = {'asio': 'boost'}
-    version = "0.8.1"
 
     @property
     def _source_subfolder(self):
@@ -48,7 +47,12 @@ class WebsocketPPConan(ConanFile):
         self.copy(pattern="*.hpp", dst="include/websocketpp", src=self._source_subfolder + '/websocketpp')
 
     def package_info(self):
-        self.cpp_info.builddirs.append(os.path.join(self.package_folder, 'cmake'))
+        # https://github.com/zaphoyd/websocketpp/blob/0.8.1/CMakeLists.txt#L42-L47
+        if self.settings.os == "Windows":
+            self.cpp_info.builddirs.append(os.path.join(self.package_folder, 'cmake'))
+        else:
+            self.cpp_info.builddirs.append(os.path.join(self.package_folder, 'lib', 'cmake', 'websocketpp'))
+    
         if self.options.asio == 'standalone':
             self.cpp_info.defines.extend(['ASIO_STANDALONE', '_WEBSOCKETPP_CPP11_STL_'])
 

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -8,7 +8,7 @@ class WebsocketPPConan(ConanFile):
     topics = ("conan", "websocketpp", "websocket", "network", "web", "rfc6455")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/zaphoyd/websocketpp"
-    license = "	BSD-3-Clause"
+    license = "BSD-3-Clause"
     settings = "os", "arch", "compiler", "build_type"
     exports_sources = ["CMakeLists.txt", 'patches/*']
     generators = ["cmake"]
@@ -40,7 +40,7 @@ class WebsocketPPConan(ConanFile):
     def package(self):
         self._patch_sources()
         self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        # We have to copy the headers manually, since the current install() step in the 0.8.1 release doesn't do so.
+        # We have to copy the headers manually, since the current cmake.install() step in the 0.8.1 release doesn't do so.
         self.copy(pattern="*.hpp", dst="include/websocketpp", src=self._source_subfolder + '/websocketpp')
 
     def package_info(self):    

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -39,20 +39,11 @@ class WebsocketPPConan(ConanFile):
 
     def package(self):
         self._patch_sources()
-        cmake = CMake(self)
-        cmake.configure()
-        cmake.install()
         self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
         # We have to copy the headers manually, since the current install() step in the 0.8.1 release doesn't do so.
         self.copy(pattern="*.hpp", dst="include/websocketpp", src=self._source_subfolder + '/websocketpp')
 
-    def package_info(self):
-        # https://github.com/zaphoyd/websocketpp/blob/0.8.1/CMakeLists.txt#L42-L47
-        if self.settings.os == "Windows":
-            self.cpp_info.builddirs.append(os.path.join(self.package_folder, 'cmake'))
-        else:
-            self.cpp_info.builddirs.append(os.path.join(self.package_folder, 'lib', 'cmake', 'websocketpp'))
-    
+    def package_info(self):    
         if self.options.asio == 'standalone':
             self.cpp_info.defines.extend(['ASIO_STANDALONE', '_WEBSOCKETPP_CPP11_STL_'])
 

--- a/recipes/websocketpp/all/patches/websocket_boost_support_1_7_x.patch
+++ b/recipes/websocketpp/all/patches/websocket_boost_support_1_7_x.patch
@@ -1,0 +1,157 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2d13117..b803c21 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -123,7 +123,11 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
+ 
+     # g++
+     if (CMAKE_COMPILER_IS_GNUCXX)
+-        set (WEBSOCKETPP_PLATFORM_LIBS pthread rt)
++        if (NOT APPLE)
++            set (WEBSOCKETPP_PLATFORM_LIBS pthread rt)
++        else()
++            set (WEBSOCKETPP_PLATFORM_LIBS pthread)
++        endif()
+         set (WEBSOCKETPP_PLATFORM_TLS_LIBS ssl crypto)
+         set (WEBSOCKETPP_BOOST_LIBS system thread)
+         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+@@ -202,7 +206,7 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
+ 	endif ()
+ 
+     if (NOT Boost_USE_STATIC_LIBS)
+-        add_definitions (/DBOOST_TEST_DYN_LINK)
++        add_definitions (-DBOOST_TEST_DYN_LINK)
+     endif ()
+ 
+     set (Boost_FIND_REQUIRED TRUE)
+diff --git a/changelog.md b/changelog.md
+index 6771d6e..743d014 100644
+--- a/changelog.md
++++ b/changelog.md
+@@ -1,4 +1,9 @@
+ HEAD
++- CMake: Update cmake installer to better handle dependencies when using
++  g++ on MacOS. Thank you Luca Palano for reporting and a patch. #831
++- CMake: Update cmake installer to use a variable for the include directory
++  improving the ability of the install to be customized. THank you Schrijvers
++  Luc and Gianfranco Costamanga for reporting and a patch. #842
+ 
+ 0.8.1 - 2018-07-16
+ Note: This release does not change library behavior. It only corrects issues
+diff --git a/cmake/CMakeHelpers.cmake b/cmake/CMakeHelpers.cmake
+index 1478f4b..f603632 100644
+--- a/cmake/CMakeHelpers.cmake
++++ b/cmake/CMakeHelpers.cmake
+@@ -80,7 +80,7 @@ macro (final_target)
+     endif ()
+ 
+     install (DIRECTORY ${CMAKE_SOURCE_DIR}/${TARGET_NAME}
+-             DESTINATION include/
++             DESTINATION ${INSTALL_INCLUDE_DIR}/
+              FILES_MATCHING PATTERN "*.hpp*")
+ endmacro ()
+ 
+diff --git a/docs/faq.dox b/docs/faq.dox
+index 24059f7..9f417ec 100644
+--- a/docs/faq.dox
++++ b/docs/faq.dox
+@@ -55,7 +55,7 @@ If you handle errors from methods like send, ping, close, etc correctly then you
+ 
+ Normally, for security purposes, operating systems prevent programs from listening on sockets created by other programs. When your program crashes and restarts, the new instance is a different program from the perspective of the operating system. As such it can’t listen on the socket address/port that the previous program was using until after a timeout occurs to make sure the old program was done with it.
+ 
+-The the first step for handling this is to make sure that you provide a method (signal handler, admin websocket message, etc) to perform a clean server shutdown. There is a question elsewhere in this FAQ that describes the steps necessary for this.
++The first step for handling this is to make sure that you provide a method (signal handler, admin websocket message, etc) to perform a clean server shutdown. There is a question elsewhere in this FAQ that describes the steps necessary for this.
+ 
+ The clean close strategy won't help in the case of crashes or other abnormal closures. An option to consider for these cases is the use of the SO_REUSEADDR socket option. This instructs the OS to not request an exclusive lock on the socket. This means that after your program crashes the replacement you start can immediately listen on that address/port combo again.
+ 
+diff --git a/websocketpp/transport/asio/connection.hpp b/websocketpp/transport/asio/connection.hpp
+index 60f88a7..57dda74 100644
+--- a/websocketpp/transport/asio/connection.hpp
++++ b/websocketpp/transport/asio/connection.hpp
+@@ -311,9 +311,10 @@ public:
+      * needed.
+      */
+     timer_ptr set_timer(long duration, timer_handler callback) {
+-        timer_ptr new_timer = lib::make_shared<lib::asio::steady_timer>(
+-            lib::ref(*m_io_service),
+-            lib::asio::milliseconds(duration)
++        timer_ptr new_timer(
++            new lib::asio::steady_timer(
++                *m_io_service,
++                lib::asio::milliseconds(duration))
+         );
+ 
+         if (config::enable_multithreading) {
+@@ -461,8 +462,7 @@ protected:
+         m_io_service = io_service;
+ 
+         if (config::enable_multithreading) {
+-            m_strand = lib::make_shared<lib::asio::io_service::strand>(
+-                lib::ref(*io_service));
++            m_strand.reset(new lib::asio::io_service::strand(*io_service));
+         }
+ 
+         lib::error_code ec = socket_con_type::init_asio(io_service, m_strand,
+diff --git a/websocketpp/transport/asio/endpoint.hpp b/websocketpp/transport/asio/endpoint.hpp
+index ddab2c7..94509ad 100644
+--- a/websocketpp/transport/asio/endpoint.hpp
++++ b/websocketpp/transport/asio/endpoint.hpp
+@@ -195,8 +195,7 @@ public:
+ 
+         m_io_service = ptr;
+         m_external_io_service = true;
+-        m_acceptor = lib::make_shared<lib::asio::ip::tcp::acceptor>(
+-            lib::ref(*m_io_service));
++        m_acceptor.reset(new lib::asio::ip::tcp::acceptor(*m_io_service));
+ 
+         m_state = READY;
+         ec = lib::error_code();
+@@ -688,9 +687,7 @@ public:
+      * @since 0.3.0
+      */
+     void start_perpetual() {
+-        m_work = lib::make_shared<lib::asio::io_service::work>(
+-            lib::ref(*m_io_service)
+-        );
++        m_work.reset(new lib::asio::io_service::work(*m_io_service));
+     }
+ 
+     /// Clears the endpoint's perpetual flag, allowing it to exit when empty
+@@ -854,8 +851,7 @@ protected:
+ 
+         // Create a resolver
+         if (!m_resolver) {
+-            m_resolver = lib::make_shared<lib::asio::ip::tcp::resolver>(
+-                lib::ref(*m_io_service));
++            m_resolver.reset(new lib::asio::ip::tcp::resolver(*m_io_service));
+         }
+ 
+         tcon->set_uri(u);
+diff --git a/websocketpp/transport/asio/security/none.hpp b/websocketpp/transport/asio/security/none.hpp
+index 5c8293d..6c7d352 100644
+--- a/websocketpp/transport/asio/security/none.hpp
++++ b/websocketpp/transport/asio/security/none.hpp
+@@ -168,8 +168,7 @@ protected:
+             return socket::make_error_code(socket::error::invalid_state);
+         }
+ 
+-        m_socket = lib::make_shared<lib::asio::ip::tcp::socket>(
+-            lib::ref(*service));
++        m_socket.reset(new lib::asio::ip::tcp::socket(*service));
+ 
+         if (m_socket_init_handler) {
+             m_socket_init_handler(m_hdl, *m_socket);
+diff --git a/websocketpp/transport/asio/security/tls.hpp b/websocketpp/transport/asio/security/tls.hpp
+index c76fd9a..04ac379 100644
+--- a/websocketpp/transport/asio/security/tls.hpp
++++ b/websocketpp/transport/asio/security/tls.hpp
+@@ -193,8 +193,7 @@ protected:
+         if (!m_context) {
+             return socket::make_error_code(socket::error::invalid_tls_context);
+         }
+-        m_socket = lib::make_shared<socket_type>(
+-            _WEBSOCKETPP_REF(*service),lib::ref(*m_context));
++        m_socket.reset(new socket_type(*service, *m_context));
+ 
+         if (m_socket_init_handler) {
+             m_socket_init_handler(m_hdl, get_socket());

--- a/recipes/websocketpp/all/test_package/CMakeLists.txt
+++ b/recipes/websocketpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(test_package)
+cmake_minimum_required(VERSION 2.8.11)
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+file(GLOB SOURCE_FILES *.cpp)
+
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/websocketpp/all/test_package/CMakeLists.txt
+++ b/recipes/websocketpp/all/test_package/CMakeLists.txt
@@ -1,12 +1,11 @@
-project(test_package)
 cmake_minimum_required(VERSION 2.8.11)
+project(test_package)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-file(GLOB SOURCE_FILES *.cpp)
-
-add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/websocketpp/all/test_package/conanfile.py
+++ b/recipes/websocketpp/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
-from conans import ConanFile, CMake, RunEnvironment, tools
 import os
+from conans import ConanFile, CMake, tools
 
 
 class TestPackageConan(ConanFile):

--- a/recipes/websocketpp/all/test_package/conanfile.py
+++ b/recipes/websocketpp/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, RunEnvironment, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        with tools.environment_append(RunEnvironment(self).vars):
+            self.run(os.path.join("bin", "test_package"))

--- a/recipes/websocketpp/all/test_package/conanfile.py
+++ b/recipes/websocketpp/all/test_package/conanfile.py
@@ -12,5 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        with tools.environment_append(RunEnvironment(self).vars):
-            self.run(os.path.join("bin", "test_package"))
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/websocketpp/all/test_package/test_package.cpp
+++ b/recipes/websocketpp/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include <websocketpp/server.hpp>
+#include <websocketpp/config/asio_no_tls.hpp>
+
+int main()
+{
+	websocketpp::server<websocketpp::config::asio> server;
+}

--- a/recipes/websocketpp/config.yml
+++ b/recipes/websocketpp/config.yml
@@ -1,0 +1,4 @@
+---
+versions:
+  "0.8.1":
+    folder: all


### PR DESCRIPTION
Based on: https://github.com/bincrafters/conan-websocketpp/tree/fea456bee75c7e8459e358207e2477c8243ef735

fixes #1156

Specify library name and version:  **websocketpp/0.8.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Few difference from bincrafters recipe:
- update deps version
- moved patches to `conandata.yml`
- removed build step
