### PR TITLE
Update libcurl to depend on openssl-1.1.1e instead of 1.1.1d

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -111,7 +111,7 @@ class LibcurlConan(ConanFile):
             elif self.settings.os == "Windows" and self.options.with_winssl:
                 pass
             else:
-                self.requires.add("openssl/1.1.1d")
+                self.requires.add("openssl/1.1.1e")
         if self.options.with_libssh2:
             if self.settings.compiler != "Visual Studio":
                 self.requires.add("libssh2/1.9.0")


### PR DESCRIPTION
Specify library name and version:  **libcutl/7.69.1**

- [x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Fixes #1177