### PR TITLE
Add libpqxx/7.0.4

### DIFF
--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "7.0.3":
     url: "https://github.com/jtv/libpqxx/archive/7.0.3.tar.gz"
     sha256: "7e28ad68cf6563246d97ccdeba5996dd71316c589f39b253f2cb2fbac0c2f7ef"
+  "7.0.4":
+    url: "https://github.com/jtv/libpqxx/archive/7.0.4.tar.gz"
+    sha256: "b56b441eb49755b39f0ba194b81047f7596540ee23c1caa8aa1b963f1bded9f5"
 patches:
   "7.0.1":
     - patch_file: "patches/0001-cmake-fix-module.patch"
@@ -16,5 +19,8 @@ patches:
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
   "7.0.3":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+      base_path: "source_subfolder"
+  "7.0.4":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"

--- a/recipes/libpqxx/config.yml
+++ b/recipes/libpqxx/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "7.0.3":
     folder: all
+  "7.0.4":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libpqxx/7.0.4**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This version is a bug fix only release.
The CMake build related changes were not in this version.

However, there is a mistake that `PQXX_VERSION` macro remains at 7.0.3. When test_package is executed, "libpqxx version: 7.0.3" is printed, but the version is 7.0.4.
