### PR TITLE
fix(abseil): Automatic collection of abseil libs

### DIFF
--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -3,6 +3,7 @@ import glob
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration, ConanException
 
+
 class ConanRecipe(ConanFile):
     name = "abseil"
 
@@ -89,8 +90,61 @@ conan_basic_setup()""")
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
-
+        self.cpp_info.libs = [
+            "absl_flags_parse",
+            "absl_flags_usage",
+            "absl_flags_usage_internal",
+            "absl_flags",
+            "absl_flags_internal",
+            "absl_flags_registry",
+            "absl_flags_config",
+            "absl_flags_program_name",
+            "absl_flags_marshalling",
+            "absl_raw_hash_set",
+            "absl_random_seed_sequences",
+            "absl_hashtablez_sampler",
+            "absl_synchronization",
+            "absl_time",
+            "absl_civil_time",
+            "absl_time_zone",
+            "absl_failure_signal_handler",
+            "absl_random_internal_distribution_test_util",
+            "absl_examine_stack",
+            "absl_symbolize",
+            "absl_str_format_internal",
+            "absl_graphcycles_internal",
+            "absl_stacktrace",
+            "absl_malloc_internal",
+            "absl_demangle_internal",
+            "absl_debugging_internal",
+            "absl_periodic_sampler",
+            "absl_exponential_biased",
+            "absl_random_internal_pool_urbg",
+            "absl_random_distributions",
+            "absl_random_internal_seed_material",
+            "absl_random_seed_gen_exception",
+            "absl_hash",
+            "absl_strings",
+            "absl_strings_internal",
+            "absl_bad_variant_access",
+            "absl_throw_delegate",
+            "absl_city",
+            "absl_base",
+            "absl_dynamic_annotations",
+            "absl_bad_any_cast_impl",
+            "absl_scoped_set_env",
+            "absl_bad_optional_access",
+            "absl_raw_logging_internal",
+            "absl_log_severity",
+            "absl_spinlock_wait",
+            "absl_random_internal_randen",
+            "absl_random_internal_randen_hwaes",
+            "absl_random_internal_randen_slow",
+            "absl_random_internal_randen_hwaes_impl",
+            "absl_leak_check",
+            "absl_leak_check_disable",
+            "absl_int128"
+        ]
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")
         self.cpp_info.names["cmake_find_package"] = "absl"

--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -3,7 +3,6 @@ import glob
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration, ConanException
 
-
 class ConanRecipe(ConanFile):
     name = "abseil"
 
@@ -90,61 +89,8 @@ conan_basic_setup()""")
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.libs = [
-            "absl_flags_parse",
-            "absl_flags_usage",
-            "absl_flags_usage_internal",
-            "absl_flags",
-            "absl_flags_internal",
-            "absl_flags_registry",
-            "absl_flags_config",
-            "absl_flags_program_name",
-            "absl_flags_marshalling",
-            "absl_raw_hash_set",
-            "absl_random_seed_sequences",
-            "absl_hashtablez_sampler",
-            "absl_synchronization",
-            "absl_time",
-            "absl_civil_time",
-            "absl_time_zone",
-            "absl_failure_signal_handler",
-            "absl_random_internal_distribution_test_util",
-            "absl_examine_stack",
-            "absl_symbolize",
-            "absl_str_format_internal",
-            "absl_graphcycles_internal",
-            "absl_stacktrace",
-            "absl_malloc_internal",
-            "absl_demangle_internal",
-            "absl_debugging_internal",
-            "absl_periodic_sampler",
-            "absl_exponential_biased",
-            "absl_random_internal_pool_urbg",
-            "absl_random_distributions",
-            "absl_random_internal_seed_material",
-            "absl_random_seed_gen_exception",
-            "absl_hash",
-            "absl_strings",
-            "absl_strings_internal",
-            "absl_bad_variant_access",
-            "absl_throw_delegate",
-            "absl_city",
-            "absl_base",
-            "absl_dynamic_annotations",
-            "absl_bad_any_cast_impl",
-            "absl_scoped_set_env",
-            "absl_bad_optional_access",
-            "absl_raw_logging_internal",
-            "absl_log_severity",
-            "absl_spinlock_wait",
-            "absl_random_internal_randen",
-            "absl_random_internal_randen_hwaes",
-            "absl_random_internal_randen_slow",
-            "absl_random_internal_randen_hwaes_impl",
-            "absl_leak_check",
-            "absl_leak_check_disable",
-            "absl_int128"
-        ]
+        self.cpp_info.libs = tools.collect_libs(self)
+
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")
         self.cpp_info.names["cmake_find_package"] = "absl"

--- a/recipes/abseil/all/test_package/CMakeLists.txt
+++ b/recipes/abseil/all/test_package/CMakeLists.txt
@@ -10,4 +10,4 @@ find_package(absl REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} main.cpp)
 # Note: Conan 1.21 doesn't support granular target generation yet.
-target_link_libraries(${PROJECT_NAME} absl::absl)
+target_link_libraries(${PROJECT_NAME} absl::absl absl::optional absl::strings)


### PR DESCRIPTION
Why hardcode the list when you can just have Conan retrieve the list for
you. There's probably a reason that I'm not familiar with.

Specify library name and version:  **abseil/20200205**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated. => I haven't because it's a small incremental fix and I've tested this in my version of the recipe in our own recipes

Note: the list that was hardcoded was missing one library that we need to build grpc.