### PR TITLE
Add header-only option for CGAL

### DIFF
--- a/recipes/cgal/all/CMakeLists.txt
+++ b/recipes/cgal/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1.4)
+project(conan_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")


### PR DESCRIPTION
Specify library name and version:  **cgal/5.0.2**

- Add header-only option for CGAL
- I didn't add fPIC because CGAL only works on Windows due mpir/3.0.0
- Qt option will raise an exception, since it's present in CCI and we can't remove.

fixes #1019

/cc @SpaceIm 

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

