### PR TITLE
libgit2 only uses iconv on Apple platform (matching cmake behavior)

### DIFF
--- a/recipes/libgit2/all/conanfile.py
+++ b/recipes/libgit2/all/conanfile.py
@@ -103,7 +103,7 @@ class LibGit2Conan(ConanFile):
         if tools.is_apple_os(self.settings.os):
             cmake.definitions["USE_ICONV"] = self.options.with_iconv
         else:
-            cmake.definitions["USE_ICONV"] = True
+            cmake.definitions["USE_ICONV"] = False
 
         cmake.definitions["USE_HTTPS"] = self._cmake_https[str(self.options.with_https)]
         cmake.definitions["SHA1_BACKEND"] = self._cmake_sha1[str(self.options.with_sha1)]


### PR DESCRIPTION
Specify library name and version:  libgit2/0.28.3

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

