### PR TITLE
Remove SPDLOG_HEADER_ONLY define

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -100,7 +100,7 @@ class SpdlogConan(ConanFile):
 
     def package_info(self):
         if self.options.header_only:
-            self.cpp_info.defines = ["SPDLOG_HEADER_ONLY", "SPDLOG_FMT_EXTERNAL"]
+            self.cpp_info.defines = ["SPDLOG_FMT_EXTERNAL"]
         else:
             self.cpp_info.libs = tools.collect_libs(self)
             self.cpp_info.defines = ["SPDLOG_COMPILED_LIB", "SPDLOG_FMT_EXTERNAL"]


### PR DESCRIPTION
Defining this macro will cause a warning, since it is being defined in the code also if SPDLOG_COMPILED_LIB is not defined at include/spdlog/common.h:34

Specify library name and version:  **spdlog/1.5.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

