### PR TITLE
enet: Use configure() instead of deprecated config()

### DIFF
--- a/recipes/enet/all/conanfile.py
+++ b/recipes/enet/all/conanfile.py
@@ -41,5 +41,4 @@ class EnetConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.compiler == "Visual Studio":
-            self.cpp_info.libs.append("ws2_32")
-            self.cpp_info.libs.append("winmm")
+            self.cpp_info.system_libs.extend(["ws2_32", "winmm"])

--- a/recipes/enet/all/conanfile.py
+++ b/recipes/enet/all/conanfile.py
@@ -16,7 +16,7 @@ class EnetConan(ConanFile):
 
     _source_subfolder = "source_subfolder"
 
-    def config(self):
+    def configure(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 


### PR DESCRIPTION
Specify library name and version:  **enet/1.3.14**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

