### PR TITLE
[gmp] Set library list order

### DIFF
--- a/recipes/gmp/all/conanfile.py
+++ b/recipes/gmp/all/conanfile.py
@@ -80,8 +80,8 @@ class GmpConan(ConanFile):
         del self.info.options.run_checks  # run_checks doesn't affect package's ID
 
     def package_info(self):
-        self.cpp_info.libs = ["gmp"]
         if self.options.enable_cxx:
-            self.cpp_info.libs.append("gmpxx")
+            self.cpp_info.libs = ["gmpxx"]
+        self.cpp_info.libs.append("gmp")
         self.cpp_info.names["cmake_find_package"] = "GMP"
         self.cpp_info.names["cmake_find_package_multi"] = "GMP"

--- a/recipes/gmp/all/conanfile.py
+++ b/recipes/gmp/all/conanfile.py
@@ -80,6 +80,8 @@ class GmpConan(ConanFile):
         del self.info.options.run_checks  # run_checks doesn't affect package's ID
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = ["gmp"]
+        if self.options.enable_cxx:
+            self.cpp_info.libs.append("gmpxx")
         self.cpp_info.names["cmake_find_package"] = "GMP"
         self.cpp_info.names["cmake_find_package_multi"] = "GMP"

--- a/recipes/gmp/all/test_package/CMakeLists.txt
+++ b/recipes/gmp/all/test_package/CMakeLists.txt
@@ -6,3 +6,9 @@ conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+
+if (ENABLE_CXX)
+    add_executable(${PROJECT_NAME}_cpp test_package.cpp)
+    target_link_libraries(${PROJECT_NAME}_cpp ${CONAN_LIBS})
+    set_property(TARGET ${PROJECT_NAME}_cpp PROPERTY LINKER_LANGUAGE CXX)
+endif()

--- a/recipes/gmp/all/test_package/conanfile.py
+++ b/recipes/gmp/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -8,9 +8,14 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["ENABLE_CXX"] = self.options["gmp"].enable_cxx
         cmake.configure()
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)
+            if self.options["gmp"].enable_cxx:
+                bin_path = os.path.join("bin", "test_package_cpp")
+                self.run(bin_path, run_environment=True)

--- a/recipes/gmp/all/test_package/test_package.cpp
+++ b/recipes/gmp/all/test_package/test_package.cpp
@@ -1,0 +1,12 @@
+#include <cstdlib>
+#include <gmp.h>
+
+
+int main (void) {
+
+  mpz_t a,b,c;
+  mpz_inits(a,b,c,NULL);
+
+  mpz_set_str(a, "1234", 10);
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Specify library name and version:  **gmp/6.1.2**

- Use specific lib order to avoid liker errors
- Add extra test when cxx is enabled

fixes https://github.com/conan-io/conan-center-index/issues/997

/cc @SpaceIm 

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

