### PR TITLE
Fix OpenSSL link for libcurl

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -245,9 +245,10 @@ class LibcurlConan(ConanFile):
                                   '-lzlib ')
 
         # patch for openssl extras in mingw
-        tools.replace_in_file("configure",
-                              '-lcrypto ',
-                              '-lcrypto -lcrypt32 ')
+        if self.options.with_openssl:
+            tools.replace_in_file("configure",
+                                  '-lcrypto ',
+                                  '-lcrypto -lcrypt32 ')
 
         if self.options.shared:
             # patch for shared mingw build

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -244,6 +244,11 @@ class LibcurlConan(ConanFile):
                                   '-lz ',
                                   '-lzlib ')
 
+        # patch for openssl extras in mingw
+        tools.replace_in_file("configure",
+                              '-lcrypto ',
+                              '-lcrypto -lcrypt32 ')
+
         if self.options.shared:
             # patch for shared mingw build
             tools.replace_in_file(os.path.join('lib', 'Makefile.am'),


### PR DESCRIPTION
Specify library name and version:  **libcurl/7.69.1**

- Fix missing system lib for mingw build

fixes https://github.com/conan-io/conan-center-index/issues/1246

/cc @KingKili

Log for mingw build: https://gist.github.com/uilianries/13120dcad4af3d9f8db9673b6921d675

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

