### PR TITLE
Do not override CXX for zlib

### DIFF
--- a/recipes/zlib/1.2.11/conanfile.py
+++ b/recipes/zlib/1.2.11/conanfile.py
@@ -65,7 +65,9 @@ class ZlibConan(ConanFile):
         else:
             make_target = "libz.a"
 
-        env = {"CC": "clang", "CXX": "clang++"} if "clang" in str(self.settings.compiler) else {}
+        env = {}
+        if "clang" in str(self.settings.compiler) and tools.get_env("CC") is None and tools.get_env("CXX") is None:
+            env = {"CC": "clang", "CXX": "clang++"}
         with tools.environment_append(env):
             env_build.configure("../", build=False, host=False, target=False)
             env_build.make(target=make_target)
@@ -80,7 +82,7 @@ class ZlibConan(ConanFile):
 
     def _build_zlib(self):
         with tools.chdir(self._source_subfolder):
-            # https://github.com/madler/zlib/issues/268 
+            # https://github.com/madler/zlib/issues/268
             tools.replace_in_file('gzguts.h',
                                   '#if defined(_WIN32) || defined(__CYGWIN__)',
                                   '#if defined(_WIN32) || defined(__MINGW32__)')


### PR DESCRIPTION
Specify library name and version:  **zlib/1.2.11**

- Do not force CXX and CC when is already defined.

fixes https://github.com/conan-io/conan-center-index/issues/1259

/cc @zod

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

