### PR TITLE
Do not install pdb for libx265

### DIFF
--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -71,14 +71,10 @@ class Libx265Conan(ConanFile):
 
     def _patch_sources(self):
         cmakelists = os.path.join(self._source_subfolder, "source", "CMakeLists.txt")
-        if self.settings.os == "Windows":
-            tools.replace_in_file(cmakelists,
-                                  "${PROJECT_BINARY_DIR}/Debug/x265.pdb",
-                                  "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/x265.pdb")
-            tools.replace_in_file(cmakelists,
-                                  "${PROJECT_BINARY_DIR}/x265.pdb",
-                                  "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/x265.pdb")
-        elif self.settings.os == "Android":
+        tools.replace_in_file(cmakelists,
+                                "if((WIN32 AND ENABLE_CLI) OR (WIN32 AND ENABLE_SHARED))",
+                                "if(FALSE)")
+        if self.settings.os == "Android":
             tools.replace_in_file(cmakelists,
                 "list(APPEND PLATFORM_LIBS pthread)", "")
             tools.replace_in_file(cmakelists,


### PR DESCRIPTION
Specify library name and version:  **libx265/3.2.1**

fixes https://github.com/conan-io/conan-center-index/issues/892

/cc @leyewen

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

