### PR TITLE
icu/64.2: Fix target names

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -212,6 +212,9 @@ class ICUBase(ConanFile):
             del self.options.fPIC
 
     def package_info(self):
+        self.cpp_info.names['cmake_find_package'] = 'ICU'
+        self.cpp_info.names['cmake_find_package_multi'] = 'ICU'
+
         def lib_name(lib):
             name = lib
             if self.settings.os == "Windows":

--- a/recipes/icu/all/test_package/CMakeLists.txt
+++ b/recipes/icu/all/test_package/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_VERBOSE_MAKEFILE TRUE)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(ICU)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} ICU::ICU)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/icu/all/test_package/conanfile.py
+++ b/recipes/icu/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class ICUTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **icu/64.2**

CMake module uses `ICU` (capital letters): https://cmake.org/cmake/help/v3.7/module/FindICU.html

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

