### PR TITLE
boost: fix compilation with filesystem_no_deprecated=True

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -67,3 +67,5 @@ patches:
       base_path: "boost_1_72_0"
     - patch_file: "patches/0001-revert-cease-dependence-on-range.patch"
       base_path: "boost_1_72_0"
+    - patch_file: "patches/boost_log_filesystem_no_deprecated_1_72.patch"
+      base_path: "boost_1_72_0"

--- a/recipes/boost/all/patches/boost_log_filesystem_no_deprecated_1_72.patch
+++ b/recipes/boost/all/patches/boost_log_filesystem_no_deprecated_1_72.patch
@@ -1,0 +1,13 @@
+diff --git a/libs/log/src/text_file_backend.cpp b/libs/log/src/text_file_backend.cpp
+index 50cef3b..d5fd02e 100644
+--- a/libs/log/src/text_file_backend.cpp
++++ b/libs/log/src/text_file_backend.cpp
+@@ -39,6 +39,8 @@
+ #include <boost/type_traits/is_same.hpp>
+ #include <boost/system/error_code.hpp>
+ #include <boost/system/system_error.hpp>
++#include <boost/filesystem/directory.hpp>
++#include <boost/filesystem/exception.hpp>
+ #include <boost/filesystem/path.hpp>
+ #include <boost/filesystem/fstream.hpp>
+ #include <boost/filesystem/operations.hpp>


### PR DESCRIPTION
Specify library name and version:  **boost/1.72.0**

Add missing includes.
Patch is created from https://github.com/boostorg/log/commit/ea0dd6171be10e068e0693f74a9afd0c520fa740
 
Fixes #1265 
- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

