### PR TITLE
using new conan 1.24.0 tools.cppstd_flag in boost recipe

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1,7 +1,6 @@
 from conans import ConanFile
 from conans import tools
-from conans.client.build.cppstd_flags import cppstd_flag
-from conans.tools import Version
+from conans.tools import Version, cppstd_flag
 from conans.errors import ConanException
 
 from conans.errors import ConanInvalidConfiguration
@@ -568,12 +567,7 @@ class BoostConan(ConanFile):
         flags.append("toolset=%s" % self._toolset)
 
         if self.settings.get_safe("compiler.cppstd"):
-            flags.append("cxxflags=%s" % cppstd_flag(
-                    self.settings.get_safe("compiler"),
-                    self.settings.get_safe("compiler.version"),
-                    self.settings.get_safe("compiler.cppstd")
-                )
-            )
+            flags.append("cxxflags=%s" % cppstd_flag(self.settings))
 
         # CXX FLAGS
         cxx_flags = []


### PR DESCRIPTION
fixes #1225

Specify library name and version:  **boost/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

<details><Summary> Profile</Summary>

```
> conan profile show default
Configuration for profile default:

[settings]
os=Windows
os_build=Windows
arch=x86_64
arch_build=x86_64
compiler=Visual Studio
compiler.version=16
build_type=Release
compiler.cppstd=17
[options]
[build_requires]
[env]
```
</details>

<details><Summary> Snippet from logs</Summary>

```
file C:\.conan\36cc59\1\boost\bin.v2\libs\random\build\msvc-14.2\rls\adrs-mdl-64\lnk-sttc\thrd-mlt\random_device.obj.rsp
"libs\random\src\random_device.cpp" -Fo"C:\.conan\36cc59\1\boost\bin.v2\libs\random\build\msvc-14.2\rls\adrs-mdl-64\lnk-sttc\thrd-mlt\random_device.obj"    -TP /O2 /Ob2 /W3 /GR /MD /Zc:forScope /Zc:wchar_t /favor:blend /wd4675 /EHs /std:c++17 -c
-DBOOST_ALL_NO_LIB=1
-DBOOST_SYSTEM_STATIC_LINK=1
-DNDEBUG
"-I."
common.mkdir C:\.conan\36cc59\1\boost\bin.v2\libs\serialization\build\msvc-14.2\rls\adrs-mdl-64\lnk-sttc
```
</details>