### PR TITLE
for fallback url for old versions

### DIFF
--- a/recipes/openssl/all/conanfile.py
+++ b/recipes/openssl/all/conanfile.py
@@ -133,7 +133,7 @@ class OpenSSLConan(ConanFile):
         except ConanException:
             url = self.conan_data["sources"][self.version]["url"]
             url = url.replace("https://www.openssl.org/source/",
-                              "https://www.openssl.org/source/old/%s" % self._full_version.base)
+                              "https://www.openssl.org/source/old/%s/" % self._full_version.base)
             tools.get(url, sha256=self.conan_data["sources"][self.version]["sha256"])
         extracted_folder = "openssl-" + self.version
         os.rename(extracted_folder, self._source_subfolder)


### PR DESCRIPTION
Specify library name and version:  **openssl/all**

fix bug in generating the download url for versions that are not the latest one

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

