### PR TITLE
Update conan-botan for Botan 2.14.0

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -5,6 +5,9 @@ sources:
   "2.13.0":
     url: "https://github.com/randombit/botan/archive/2.13.0.tar.gz"
     sha256: "29a57d8efd6ab297eab67cbf489a5a423b06e120e0520aff2583074e8aea151c"
+  "2.14.0":
+    url: "https://github.com/randombit/botan/archive/2.14.0.tar.gz"
+    sha256: "38e34b8ef7652e811382744425b82da1b1a7fb5f14cc281a7d3a18543eaf72f7"
 patches:
   "2.12.1":
      - patch_file: "dll-dir.patch"

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -141,7 +141,7 @@ class BotanConan(ConanFile):
                (compiler == "gcc" and compiler_version < "8") or \
                (compiler == "clang" and compiler_version < "7"):
                 raise ConanInvalidConfiguration(
-                    "amalgamation is not supported for this compiler version")
+                    "amalgamation is not supported for {} {}".format(compiler, compiler_version))
 
     @property
     def _is_mingw_windows(self):

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -44,7 +44,7 @@ class BotanConan(ConanFile):
         if Version(self.version) >= "2.14.0":
             self._validate_v2_14()
 
-        if self.options.single_amalgamation:
+        if self.options.get_safe("single_amalgamation"):
             self.options.amalgamation = True
 
         if self.options.with_boost:
@@ -68,6 +68,11 @@ class BotanConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+        # --single-amalgamation option is no longer available
+        # See also https://github.com/randombit/botan/pull/2246
+        if Version(self.version) >= "2.14.0":
+            del self.options.single_amalgamation
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -127,12 +132,6 @@ class BotanConan(ConanFile):
 
         compiler = self.settings.compiler
         compiler_version = Version(compiler.version.value)
-
-        # --single-amalgamation option is no longer available
-        # See also https://github.com/randombit/botan/pull/2246
-        if self.options.single_amalgamation:
-            raise ConanInvalidConfiguration(
-                "single_amalgamation is not supported")
 
         # Some older compilers cannot handle the amalgamated build anymore
         # See also https://github.com/randombit/botan/issues/2328
@@ -213,7 +212,7 @@ class BotanConan(ConanFile):
         if self.options.amalgamation:
             build_flags.append('--amalgamation')
 
-        if self.options.single_amalgamation:
+        if self.options.get_safe("single_amalgamation"):
             build_flags.append('--single-amalgamation-file')
 
         if self.options.system_cert_bundle:

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -138,7 +138,8 @@ class BotanConan(ConanFile):
         # See also https://github.com/randombit/botan/issues/2328
         if self.options.amalgamation:
             if (compiler == "apple-clang" and compiler_version < "10") or \
-               (compiler == "gcc" and compiler_version < "7"):
+               (compiler == "gcc" and compiler_version < "8") or \
+               (compiler == "clang" and compiler_version < "7"):
                 raise ConanInvalidConfiguration(
                     "amalgamation is not supported for this compiler version")
 

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "2.13.0":
     folder: all
+  "2.14.0":
+    folder: all


### PR DESCRIPTION
Print a warning if the option `--single-amalgamation` is used in 2.14 upwards.
Starting in 2.14 the build system no longer supports `--single-amalgamation`. Instead, it is implied with `--amalgamation`.

Specify library name and version:  **botan/2.14.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

