### PR TITLE
[libiconv] fix x86 MSVC build(s)

### DIFF
--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -8,7 +8,7 @@ class LibiconvConan(ConanFile):
     description = "Convert text to and from Unicode"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.gnu.org/software/libiconv/"
-    topics = "libiconv", "iconv", "text", "encoding", "locale", "unicode", "conversion"
+    topics = ("libiconv", "iconv", "text", "encoding", "locale", "unicode", "conversion")
     license = "LGPL-2.1"
     exports_sources = "patches/**"
     settings = "os", "compiler", "build_type", "arch"

--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -67,7 +67,7 @@ class LibiconvConan(ConanFile):
             })
             env_vars["win32_target"] = "_WIN32_WINNT_VISTA"
 
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self.settings) or self._is_msvc:
             rc = None
             if self.settings.arch == "x86":
                 rc = "windres --target=pe-i386"
@@ -87,17 +87,14 @@ class LibiconvConan(ConanFile):
     def _configure_autotools(self):
         if self._autotools:
             return self._autotools
-        prefix = os.path.abspath(self.package_folder)
         host = None
         build = None
-        if self._use_winbash or self._is_msvc:
-            prefix = prefix.replace("\\", "/")
+        if self._is_msvc:
             build = False
-            if not tools.cross_building(self.settings):
-                if self.settings.arch == "x86":
-                    host = "i686-w64-mingw32"
-                elif self.settings.arch == "x86_64":
-                    host = "x86_64-w64-mingw32"
+            if self.settings.arch == "x86":
+                host = "i686-w64-mingw32"
+            elif self.settings.arch == "x86_64":
+                host = "x86_64-w64-mingw32"
 
         #
         # If you pass --build when building for iPhoneSimulator, the configure script halts.
@@ -108,7 +105,7 @@ class LibiconvConan(ConanFile):
 
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
 
-        configure_args = ["--prefix=%s" % prefix]
+        configure_args = []
         if self.options.shared:
             configure_args.extend(["--disable-static", "--enable-shared"])
         else:

--- a/recipes/libiconv/all/test_package/CMakeLists.txt
+++ b/recipes/libiconv/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(test_package)
 cmake_minimum_required(VERSION 2.8.11)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()


### PR DESCRIPTION
closes: #332

Specify library name and version:  **libiconv/all**

few changes:
- remove **--prefix** as conan handles it
- for MinGW, conan sets host properly already to **i686-w64-mingw32**/**x86_64-w64-mingw32**, so it's needed only for MSVC ([reference](https://git.savannah.gnu.org/gitweb/?p=libiconv.git;a=blob;f=INSTALL.windows;h=0c75279e827d78853e47c17dfec4a3df26431090;hb=HEAD)), related [code](https://github.com/conan-io/conan/blob/4e689e71b96eb5307c9ddada7775e06d5dd4c124/conans/test/unittests/util/tools_test.py#L596)
- windres code is needed for MSVC (irregardless of cross-building)

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

