### PR TITLE
libtiff: fix libs order

### DIFF
--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -120,7 +120,7 @@ class LibtiffConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, 'lib', 'pkgconfig'))
 
     def package_info(self):
-        self.cpp_info.libs = ["tiff", "tiffxx"]
+        self.cpp_info.libs = ["tiffxx", "tiff"]
         if self.settings.os == "Windows" and self.settings.build_type == "Debug" and self.settings.compiler == 'Visual Studio':
             self.cpp_info.libs = [lib+'d' for lib in self.cpp_info.libs]
         if self.options.shared and self.settings.os == "Windows" and self.settings.compiler != 'Visual Studio':


### PR DESCRIPTION
Specify library name and version:  **libtiff/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

tiffxx depends on tiff: https://gitlab.com/libtiff/libtiff/-/blob/v4.1.0/libtiff/CMakeLists.txt#L147