### PR TITLE
fix spdlog iOS build error that thread_local is not support

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -73,6 +73,8 @@ class SpdlogConan(ConanFile):
         self._cmake.definitions["SPDLOG_WCHAR_FILENAMES"] = self.options.wchar_filenames
         self._cmake.definitions["SPDLOG_INSTALL"] = True
         self._cmake.definitions["SPDLOG_NO_EXCEPTIONS"] = self.options.no_exceptions
+        if self.settings.os == "iOS":
+            self._cmake.definitions["SPDLOG_NO_TLS"] = True
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -73,7 +73,7 @@ class SpdlogConan(ConanFile):
         self._cmake.definitions["SPDLOG_WCHAR_FILENAMES"] = self.options.wchar_filenames
         self._cmake.definitions["SPDLOG_INSTALL"] = True
         self._cmake.definitions["SPDLOG_NO_EXCEPTIONS"] = self.options.no_exceptions
-        if self.settings.os == "iOS":
+        if self.settings.os in ("iOS", "tvOS", "watchOS"):
             self._cmake.definitions["SPDLOG_NO_TLS"] = True
         self._cmake.configure()
         return self._cmake


### PR DESCRIPTION
Specify library name and version:  **spdlog/1.5.0**

spdlog use thread_local but iOS is not support this keyword. 
![image](https://user-images.githubusercontent.com/14332136/78849024-ee71f800-7a45-11ea-9354-09cc962f186b.png)

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

