### PR TITLE
flann: fix cpp_info.names for CMake

### DIFF
--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -112,9 +112,6 @@ class LibFlannConan(ConanFile):
                     os.remove(file_to_remove)
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "FLANN"
-        self.cpp_info.names["cmake_find_package_multi"] = "FLANN"
-
         if self.options.shared:
             self.cpp_info.libs = ["flann", "flann_cpp"]
         else:


### PR DESCRIPTION
I looked again at the files generated by the official FLANN repository and it appears that it doesn't use all-caps target or config names and the idiomatic way  to find it is `find_package(flann)` in lowercase.

Specify library name and version:  **flann/1.9.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

