### PR TITLE
[b2] Build b2 with 'cxx' toolset when CXX is defined in the environment

### DIFF
--- a/recipes/b2/all/conanfile.py
+++ b/recipes/b2/all/conanfile.py
@@ -25,6 +25,9 @@ class B2Conan(ConanFile):
         engine_dir = os.path.join(build_dir, "src", "engine")
         os.chdir(engine_dir)
         with tools.environment_append({"VSCMD_START_DIR": os.curdir}):
+            if tools.get_env("CXX") is not None:
+                # Tell the b2 build to use the environment variable CXX for the compiler to use
+                command += ' cxx'
             self.run(command)
         os.chdir(build_dir)
         command = os.path.join(

--- a/recipes/b2/all/conanfile.py
+++ b/recipes/b2/all/conanfile.py
@@ -25,7 +25,7 @@ class B2Conan(ConanFile):
         engine_dir = os.path.join(build_dir, "src", "engine")
         os.chdir(engine_dir)
         with tools.environment_append({"VSCMD_START_DIR": os.curdir}):
-            if tools.get_env("CXX") is not None:
+            if tools.get_env("CXXFLAGS") is not None:
                 # Tell the b2 build to use the environment variable CXX for the compiler to use
                 command += ' cxx'
             self.run(command)


### PR DESCRIPTION
When CXX was set in the environment, use it by specifying the 'cxx' toolset to build.sh
Without this change, the b2 build queries to find compilers, but ignores CXXFLAGS, which is strictly required for building on AIX with gcc.

See issue 1238: 
https://github.com/conan-io/conan-center-index/issues/1238

Specify library name and version:  **b2/4.2.0** (and probably earlier)

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

