### PR TITLE
Added "extras" option for bullet3 

### DIFF
--- a/recipes/bullet3/all/conanfile.py
+++ b/recipes/bullet3/all/conanfile.py
@@ -22,6 +22,7 @@ class Bullet3Conan(ConanFile):
         "bt2_thread_locks": [True, False],
         "soft_body_multi_body_dynamics_world": [True, False],
         "network_support": [True, False],
+        "extras": [True, False]
     }
     default_options = {
         "shared": False,
@@ -32,6 +33,7 @@ class Bullet3Conan(ConanFile):
         "bt2_thread_locks": False,
         "soft_body_multi_body_dynamics_world": False,
         "network_support": False,
+        "extras": False
     }
 
     _source_subfolder = "source_subfolder"
@@ -66,7 +68,7 @@ class Bullet3Conan(ConanFile):
         self._cmake.definitions["BUILD_CPU_DEMOS"] = False
         self._cmake.definitions["BUILD_OPENGL3_DEMOS"] = False
         self._cmake.definitions["BUILD_BULLET2_DEMOS"] = False
-        self._cmake.definitions["BUILD_EXTRAS"] = False
+        self._cmake.definitions["BUILD_EXTRAS"] = self.options.extras
         self._cmake.definitions["BUILD_UNIT_TESTS"] = False
         if self.settings.compiler == "Visual Studio":
             self._cmake.definitions["USE_MSVC_RUNTIME_LIBRARY_DLL"] = "MD" in self.settings.compiler.runtime
@@ -102,6 +104,16 @@ class Bullet3Conan(ConanFile):
             "Bullet3Common",
             "BulletInverseDynamics",
         ]
+        if self.options.extras:
+            libs += [   "BulletInverseDynamicsUtils",
+                        "BulletRobotics",
+                        "BulletFileLoader",
+                        "BulletXmlWorldImporter",
+                        "BulletWorldImporter",
+                        "ConvexDecomposition",
+                        "HACD",
+                        "GIMPACTUtils"
+                    ]
         if self.settings.os == "Windows" and self.settings.build_type in ("Debug", "MinSizeRel", "RelWithDebInfo"):
             libs = [lib + "_{}".format(self.settings.build_type) for lib in libs]
 
@@ -109,3 +121,5 @@ class Bullet3Conan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "Bullet"
         self.cpp_info.libs = libs
         self.cpp_info.includedirs = ["include", os.path.join("include", "bullet")]
+        if self.options.extras:
+            self.cpp_info.includedirs.append(os.path.join("include", "bullet_robotics"))

--- a/recipes/bullet3/all/test_package/CMakeLists.txt
+++ b/recipes/bullet3/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(test_package)
 cmake_minimum_required(VERSION 2.8.11)
+project(test_package)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
@@ -8,4 +8,3 @@ conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-


### PR DESCRIPTION
I added the "extras" option for bullet3. It builds extra useful libraries such as ConvexDecomposition and BulletRobotics

I am not sure why the original package forced the EXTRAS to not be built, but I have  set an option for it and have it set options.extras=False as the default so that the recipe's default state is the same as the original recipe. Perhaps it should be set as True since there is no reason why it shouldn't be included. Thoughts?

Specify library name and version:  **bullet3/2.89**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

