### PR TITLE
Do not install zlib for OpenSSL/1.1.1

### DIFF
--- a/recipes/libgta/all/conanfile.py
+++ b/recipes/libgta/all/conanfile.py
@@ -34,9 +34,7 @@ class LibgtaConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def source(self):
-        auth = (tools.get_env("AUTH_USERNAME"), tools.get_env("AUTH_PASSWORD"))
-        #tools.get(**self.conan_data["sources"][self.version], auth=auth)
-        tools.get("https://marlam.de/gta/releases/libgta-1.2.1.tar.xz", sha256="d445667e145f755f0bc34ac89b63a6bfdce1eea943f87ee7a3f23dc0dcede8b1", auth=auth)
+        tools.get(**self.conan_data["sources"][self.version])
         os.rename(self.name + "-" + self.version, self._source_subfolder)
 
     def build(self):

--- a/recipes/libgta/all/conanfile.py
+++ b/recipes/libgta/all/conanfile.py
@@ -34,7 +34,9 @@ class LibgtaConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
+        auth = (tools.get_env("AUTH_USERNAME"), tools.get_env("AUTH_PASSWORD"))
+        #tools.get(**self.conan_data["sources"][self.version], auth=auth)
+        tools.get("https://marlam.de/gta/releases/libgta-1.2.1.tar.xz", sha256="d445667e145f755f0bc34ac89b63a6bfdce1eea943f87ee7a3f23dc0dcede8b1", auth=auth)
         os.rename(self.name + "-" + self.version, self._source_subfolder)
 
     def build(self):

--- a/recipes/openssl/all/conanfile.py
+++ b/recipes/openssl/all/conanfile.py
@@ -155,7 +155,7 @@ class OpenSSLConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        if not self.options.get_safe("no_zlib"):
+        if self.options.get_safe("no_zlib") == False:
             self.requires("zlib/1.2.11")
 
     @property
@@ -425,7 +425,7 @@ class OpenSSLConan(ConanFile):
         if self.settings.os == "Neutrino":
             args.append("-lsocket no-asm")
 
-        if not self.options.get_safe("no_zlib"):
+        if self.options.get_safe("no_zlib") == False:
             zlib_info = self.deps_cpp_info["zlib"]
             include_path = zlib_info.include_paths[0]
             if self.settings.os == "Windows":

--- a/recipes/openssl/all/test_package/conanfile.py
+++ b/recipes/openssl/all/test_package/conanfile.py
@@ -1,4 +1,5 @@
 from conans import CMake, tools, ConanFile
+from conans.tools import Version
 import os
 
 
@@ -11,7 +12,11 @@ class DefaultNameConan(ConanFile):
 
         if self.settings.os == "Android":
             cmake.definitions["CONAN_LIBCXX"] = ""
-        cmake.definitions["OPENSSL_WITH_ZLIB"] = not self.options["openssl"].no_zlib
+        openssl_version = Version(self.deps_cpp_info["openssl"].version)
+        if openssl_version.major == "1" and openssl_version.minor == "1":
+            cmake.definitions["OPENSSL_WITH_ZLIB"] = False
+        else:
+            cmake.definitions["OPENSSL_WITH_ZLIB"] = not self.options["openssl"].no_zlib
         cmake.definitions["USE_FIND_PACKAGE"] = use_find_package
         cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath
         cmake.definitions["OPENSSL_USE_STATIC_LIBS"] = not self.options["openssl"].shared

--- a/recipes/openssl/all/test_package/conanfile.py
+++ b/recipes/openssl/all/test_package/conanfile.py
@@ -1,5 +1,4 @@
 from conans import CMake, tools, ConanFile
-from conans.tools import Version
 import os
 
 
@@ -12,11 +11,7 @@ class DefaultNameConan(ConanFile):
 
         if self.settings.os == "Android":
             cmake.definitions["CONAN_LIBCXX"] = ""
-        openssl_version = Version(self.deps_cpp_info["openssl"].version)
-        if openssl_version.major == "1" and openssl_version.minor == "1":
-            cmake.definitions["OPENSSL_WITH_ZLIB"] = False
-        else:
-            cmake.definitions["OPENSSL_WITH_ZLIB"] = not self.options["openssl"].no_zlib
+        cmake.definitions["OPENSSL_WITH_ZLIB"] = not self.options["openssl"].no_zlib
         cmake.definitions["USE_FIND_PACKAGE"] = use_find_package
         cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath
         cmake.definitions["OPENSSL_USE_STATIC_LIBS"] = not self.options["openssl"].shared


### PR DESCRIPTION
Remove zlib from OpenSSL 1.1.1. get_safe returns None when there is no option.

Specify library name and version:  **openssl/1.1.1**

```
ldd libssl.so
	linux-vdso.so.1 (0x00007ffd43b39000)
	libcrypto.so.1.1 => /lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007fa64b24b000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fa64b228000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fa64b037000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fa64b031000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fa64b5c0000)
ldd libcrypto.so
	linux-vdso.so.1 (0x00007ffea6493000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f1832f5e000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f1832f3b000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f1832d4a000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f1833256000)
```

fixes #1289

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

