### PR TITLE
Add recipe for dlib 19.19 

### DIFF
--- a/recipes/dlib/all/CMakeLists.txt
+++ b/recipes/dlib/all/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+# Include the dlib subdirectory to skip a check
+add_subdirectory(source_subfolder/dlib)

--- a/recipes/dlib/all/conandata.yml
+++ b/recipes/dlib/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "19.19":
+    sha256: 7af455bb422d3ae5ef369c51ee64e98fa68c39435b0fa23be2e5d593a3d45b87
+    url: https://github.com/davisking/dlib/archive/v19.19.tar.gz

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -1,0 +1,108 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class DlibConan(ConanFile):
+    name = "dlib"
+    description = "A toolkit for making real world machine learning and data analysis applications"
+    topics = "conan", "dlib"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://dlib.net"
+    license = "BSL-1.0"
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_gif": [True, False],
+        "with_jpeg": [True, False],
+        "with_png": [True, False],
+        "with_sse2": [True, False, "auto"],
+        "with_sse4": [True, False, "auto"],
+        "with_avx": [True, False, "auto"]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_gif": False,  # Doesn't work out-of-the-box with MSVC
+        "with_jpeg": True,
+        "with_png": True,
+        "with_sse2": "auto",
+        "with_sse4": "auto",
+        "with_avx": "auto"
+    }
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def requirements(self):
+        self.requires("zlib/1.2.11")
+
+        if self.options.with_gif:
+            self.requires("giflib/5.1.4")
+        if self.options.with_jpeg:
+            self.requires("libjpeg/9d")
+        if self.options.with_png:
+            self.requires("libpng/1.6.37")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+
+        # With in-project builds dlib is always built as a static library,
+        # we want to be able to build it as a shared library too
+        self._cmake.definitions["DLIB_IN_PROJECT_BUILD"] = "OFF"
+
+        # Configure external dependencies
+        self._cmake.definitions["DLIB_GIF_SUPPORT"] = self.options.with_gif
+        self._cmake.definitions["DLIB_JPEG_SUPPORT"] = self.options.with_jpeg
+        self._cmake.definitions["DLIB_PNG_SUPPORT"] = self.options.with_png
+
+        # Configure SIMD options
+        if self.options.with_sse2 != "auto":
+            self._cmake.definitions["USE_SSE2_INSTRUCTIONS"] = self.options.with_sse2
+        if self.options.with_sse4 != "auto":
+            self._cmake.definitions["USE_SSE4_INSTRUCTIONS"] = self.options.with_sse4
+        if self.options.with_avx != "auto":
+            self._cmake.definitions["USE_AVX_INSTRUCTIONS"] = self.options.with_avx
+
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        self.copy("LICENSE.txt", "licenses", os.path.join(self._source_subfolder, "dlib"), keep_path=False)
+
+        # Remove configuration files
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        # There is a single library whose name depends on settings
+        self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -49,6 +49,10 @@ class DlibConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self.settings.arch not in ["x86", "x86_64"]:
+            del self.options.with_sse2
+            del self.options.with_sse4
+            del self.options.with_avx
 
     def configure(self):
         if self.settings.compiler == "Visual Studio" and self.options.shared:

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -100,8 +100,13 @@ class DlibConan(ConanFile):
         self.copy("LICENSE.txt", "licenses", os.path.join(self._source_subfolder, "dlib"), keep_path=False)
 
         # Remove configuration files
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        for dir_to_remove in [
+            os.path.join("lib", "cmake"),
+            os.path.join("lib", "pkgconfig"),
+            os.path.join("include", "dlib", "cmake_utils"),
+            os.path.join("include", "dlib", "external", "pybind11", "tools")
+        ]:
+            tools.rmdir(os.path.join(self.package_folder, dir_to_remove))
 
     def package_info(self):
         # There is a single library whose name depends on settings

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -6,7 +6,7 @@ from conans import ConanFile, CMake, tools
 class DlibConan(ConanFile):
     name = "dlib"
     description = "A toolkit for making real world machine learning and data analysis applications"
-    topics = "conan", "dlib"
+    topics = ("machine-learning", "deep-learning", "computer-vision")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://dlib.net"
     license = "BSL-1.0"
@@ -111,3 +111,5 @@ class DlibConan(ConanFile):
     def package_info(self):
         # There is a single library whose name depends on settings
         self.cpp_info.libs = tools.collect_libs(self)
+        if self.settings.os == "Linux":
+            self.system_info.libs = ["pthread"]

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -87,13 +87,14 @@ class DlibConan(ConanFile):
         self._cmake.definitions["DLIB_JPEG_SUPPORT"] = self.options.with_jpeg
         self._cmake.definitions["DLIB_PNG_SUPPORT"] = self.options.with_png
 
-        # Configure SIMD options
-        if self.options.with_sse2 != "auto":
-            self._cmake.definitions["USE_SSE2_INSTRUCTIONS"] = self.options.with_sse2
-        if self.options.with_sse4 != "auto":
-            self._cmake.definitions["USE_SSE4_INSTRUCTIONS"] = self.options.with_sse4
-        if self.options.with_avx != "auto":
-            self._cmake.definitions["USE_AVX_INSTRUCTIONS"] = self.options.with_avx
+        # Configure SIMD options if possible
+        if self.settings.arch in ["x86", "x86_64"]:
+            if self.options.with_sse2 != "auto":
+                self._cmake.definitions["USE_SSE2_INSTRUCTIONS"] = self.options.with_sse2
+            if self.options.with_sse4 != "auto":
+                self._cmake.definitions["USE_SSE4_INSTRUCTIONS"] = self.options.with_sse4
+            if self.options.with_avx != "auto":
+                self._cmake.definitions["USE_AVX_INSTRUCTIONS"] = self.options.with_avx
 
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 
 
 class DlibConan(ConanFile):
@@ -48,6 +49,10 @@ class DlibConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+    def configure(self):
+        if self.settings.compiler == "Visual Studio" and self.options.shared:
+            raise ConanInvalidConfiguration("dlib can not be built as a shared library with Visual Studio")
 
     def requirements(self):
         self.requires("zlib/1.2.11")

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -112,4 +112,4 @@ class DlibConan(ConanFile):
         # There is a single library whose name depends on settings
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
-            self.system_info.libs = ["pthread"]
+            self.cpp_info.system_libs = ["pthread"]

--- a/recipes/dlib/all/test_package/CMakeLists.txt
+++ b/recipes/dlib/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 2.8.11)
+
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
+target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/dlib/all/test_package/CMakeLists.txt
+++ b/recipes/dlib/all/test_package/CMakeLists.txt
@@ -7,3 +7,4 @@ conan_basic_setup()
 
 add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
 target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/dlib/all/test_package/conanfile.py
+++ b/recipes/dlib/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os.path
+
+from conans import ConanFile, CMake
+
+
+class DlibTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)

--- a/recipes/dlib/all/test_package/test_package.cpp
+++ b/recipes/dlib/all/test_package/test_package.cpp
@@ -1,0 +1,35 @@
+#include <dlib/logger.h>
+#include <dlib/misc_api.h>
+
+// Create a logger object somewhere.  It is usually convenient to make it at the global scope
+// which is what I am doing here.  The following statement creates a logger that is named example.
+dlib::logger dlog("conan-test");
+
+int main()
+{
+    // Every logger has a logging level (given by dlog.level()).  Each log message is tagged with a
+    // level and only levels equal to or higher than dlog.level() will be printed.  By default all 
+    // loggers start with level() == LERROR.  In this case I'm going to set the lowest level LALL 
+    // which means that dlog will print all logging messages it gets.
+    dlog.set_level(dlib::LALL);
+
+    // print our first message.  It will go to cout because that is the default.
+    dlog << dlib::LINFO << "This is an informational message.";
+
+    // now print a debug message.
+    int variable = 8;
+    dlog << dlib::LDEBUG << "The integer variable is set to " << variable;
+
+    // the logger can be used pretty much like any ostream object.  But you have to give a logging
+    // level first.  But after that you can chain << operators like normal.
+    
+    if (variable > 4)
+        dlog << dlib::LWARN << "The variable is bigger than 4!  Its value is " << variable;
+
+    dlog << dlib::LINFO << "we are going to sleep for half a second.";
+    // sleep for half a second
+    dlib::sleep(500);
+    dlog << dlib::LINFO << "we just woke up";
+
+    dlog << dlib::LINFO << "program ending";
+}

--- a/recipes/dlib/config.yml
+++ b/recipes/dlib/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "19.19":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **dlib/19.19**

Here is a simple recipe for dlib, with still a few pain points:
- I don't handle the libjpeg/libjpeg-turbo option (but I believe that we need to discuss the libjpeg/libjpeg-rubo/mozjpeg issues in CCI recipes globally at some point)
- The giflib option is defaulted to `False` because it apparently doesn't build on MSVC outside of a Windows subsystem: I don't exclude it, but it's not guaranteed to build
- dlib embeds pybind11 and gives no option to replace it with a user-provided one as far as I know
- I've got `["auto", True, False]` lists for SIMD options which mirror the ones in the CMakeLists.txt, I'm not sure whether those are a good idea or what would be the preferred alternative there
- I do use `tools.collect_libs` because dlib seems to generate a single library file but its name depends on the settings (for example mine is called `dlib19.19.0_release_64bit_msvc1916.lib`)

The example in `test_package.cpp` is from the dlib repository itself - all of their examples are apparently public domain.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

