### PR TITLE
Added Spirv-tools recipe

### DIFF
--- a/recipes/spirv-tools/all/CMakeLists.txt
+++ b/recipes/spirv-tools/all/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+  include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+else()
+  include(conanbuildinfo.cmake)
+endif()
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/spirv-tools/all/conandata.yml
+++ b/recipes/spirv-tools/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "2019.2":
     sha256: 1fde9d2a0df920a401441cd77253fc7b3b9ab0578eabda8caaaceaa6c7638440
     url: https://github.com/KhronosGroup/SPIRV-Tools/archive/v2019.2.tar.gz
-  "2020.1":
-    sha256: 1eaa5e09c638d7113b60d825e6ce44406b35031be68db894a016b5faf45de568
-    url: https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.1.tar.gz

--- a/recipes/spirv-tools/all/conandata.yml
+++ b/recipes/spirv-tools/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "2019.2":
+  "v2019.2":
     sha256: 1fde9d2a0df920a401441cd77253fc7b3b9ab0578eabda8caaaceaa6c7638440
     url: https://github.com/KhronosGroup/SPIRV-Tools/archive/v2019.2.tar.gz

--- a/recipes/spirv-tools/all/conandata.yml
+++ b/recipes/spirv-tools/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "2019.2":
+    sha256: 1fde9d2a0df920a401441cd77253fc7b3b9ab0578eabda8caaaceaa6c7638440
+    url: https://github.com/KhronosGroup/SPIRV-Tools/archive/v2019.2.tar.gz
+  "2020.1":
+    sha256: 1eaa5e09c638d7113b60d825e6ce44406b35031be68db894a016b5faf45de568
+    url: https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.1.tar.gz

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -18,13 +18,11 @@ class SpirvtoolsConan(ConanFile):
 
     options = {
         "shared": [True, False],
-        "fPIC": [True, False],
-        "skip_executables": [True, False]
+        "fPIC": [True, False]
     }
     default_options = {
         "shared": True,
-        "fPIC": True,
-        "skip_executables": False
+        "fPIC": True
     }
 
     def requirements(self):
@@ -63,7 +61,6 @@ class SpirvtoolsConan(ConanFile):
         # need to turn this off
         cmake.definitions["SPIRV_WERROR"] = False
 
-        cmake.definitions["SPIRV_SKIP_EXECUTABLES"] = self.options.skip_executables
         cmake.definitions["SKIP_SPIRV_TOOLS_INSTALL"] = False
         cmake.definitions["SPIRV_LOG_DEBUG"] = False
         cmake.definitions["SPIRV_SKIP_TESTS"] = True
@@ -120,7 +117,6 @@ class SpirvtoolsConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("rt") # for SPIRV-Tools
 
-        if not self.options.skip_executables:
-            bin_path = os.path.join(self.package_folder, "bin")
-            self.output.info('Appending PATH environment variable: %s' % bin_path)
-            self.env_info.path.append(bin_path)
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info('Appending PATH environment variable: %s' % bin_path)
+        self.env_info.path.append(bin_path)

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -16,11 +16,13 @@ class SpirvtoolsConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "skip_executables": [True, False],
         "c_only": [True, False]
     }
     default_options = {
         "shared": True,
         "fPIC": True,
+        "skip_executables": False,
         "c_only": False
     }
 
@@ -46,6 +48,8 @@ class SpirvtoolsConan(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self)
+
+        cmake.definitions["SPIRV_SKIP_EXECUTABLES"] = self.options.skip_executables
 
         # Required by the project's CMakeLists.txt
         cmake.definitions["SPIRV-Headers_SOURCE_DIR"] = self.deps_cpp_info["spirv-headers"].rootpath
@@ -85,3 +89,8 @@ class SpirvtoolsConan(ConanFile):
             self.cpp_info.libs.append("SPIRV-Tools-link")
             self.cpp_info.libs.append("SPIRV-Tools-opt")
             self.cpp_info.libs.append("SPIRV-Tools")
+
+        if not self.options.skip_executables:
+            bin_path = os.path.join(self.package_folder, "bin")
+            self.output.info('Appending PATH environment variable: %s' % bin_path)
+            self.env_info.path.append(bin_path)

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -1,0 +1,86 @@
+from conans import ConanFile, tools, CMake
+import os
+
+
+class SpirvtoolsConan(ConanFile):
+    name = "spirv-tools"
+    homepage = "https://github.com/KhronosGroup/SPIRV-Tools/"
+    description = "SPIRV-Tools "
+    topics = ("conan", "spirv", "spirv-v", "vulkan", "opengl", "opencl", "hlsl", "khronos")
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "compiler", "arch", "build_type"
+    exports_sources = ["CMakeLists.txt"]
+    license = "Apache-2.0"
+    generators = "cmake"
+
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "c_only": [True, False]
+    }
+    default_options = {
+        "shared": True,
+        "fPIC": True,
+        "c_only": False
+    }
+
+    def requirements(self):
+        self.requires.add("spirv-headers/1.5.1")
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "SPIRV-Tools-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def configure(self):
+        if self.settings.os == 'Windows':
+            del self.options.fPIC
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+
+        # Required by the project's CMakeLists.txt
+        cmake.definitions["SPIRV-Headers_SOURCE_DIR"] = self.deps_cpp_info["spirv-headers"].rootpath
+
+        # There are some switch( ) statements that are causing errors
+        # need to turn this off
+        cmake.definitions["SPIRV_WERROR"] = False
+
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE*", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        # Error KB-H020, complaining that .pc files are found
+        tools.rmdir(os.path.join(self.package_folder, "lib/pkgconfig"))
+
+        # Error KB-H019, complaining that .pc files are found
+        tools.rmdir(os.path.join(self.package_folder, "lib/cmake"))
+
+    def package_info(self):
+        # The spirv-tools CMAKE builds a SPIRV-Tools-shared.so which is
+        # apparantly only exports the C-interface of the library.
+        # The test_package.c is used when testing the c_only option
+        # The C-interface is ALWAYS built as a shared-object as per the original
+        # CMakeLists.txt file
+        if self.options.c_only:
+            self.cpp_info.libs.append("SPIRV-Tools-shared")
+        else:
+            self.cpp_info.libs.append("SPIRV-Tools-reduce")
+            self.cpp_info.libs.append("SPIRV-Tools-opt")
+            self.cpp_info.libs.append("SPIRV-Tools")

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -116,7 +116,7 @@ class SpirvtoolsConan(ConanFile):
         self.cpp_info.libs.append("SPIRV-Tools")
 
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs.append("rt") # for SPIRV-Tools
+            self.cpp_info.system_libs.extend(["m", "rt"]) # m for SPIRV-Tools-opt, rt for SPIRV-Tools
 
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info('Appending PATH environment variable: %s' % bin_path)

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -26,7 +26,7 @@ class SpirvtoolsConan(ConanFile):
     }
 
     def requirements(self):
-        self.requires.add("spirv-headers/1.5.1")
+        self.requires("spirv-headers/1.5.1")
 
     @property
     def _source_subfolder(self):

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -38,7 +38,7 @@ class SpirvtoolsConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "SPIRV-Tools-" + self.version
+        extracted_dir = "SPIRV-Tools-" + self.version[1:]
         os.rename(extracted_dir, self._source_subfolder)
 
     def configure(self):

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -82,5 +82,6 @@ class SpirvtoolsConan(ConanFile):
             self.cpp_info.libs.append("SPIRV-Tools-shared")
         else:
             self.cpp_info.libs.append("SPIRV-Tools-reduce")
+            self.cpp_info.libs.append("SPIRV-Tools-link")
             self.cpp_info.libs.append("SPIRV-Tools-opt")
             self.cpp_info.libs.append("SPIRV-Tools")

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -87,11 +87,8 @@ class SpirvtoolsConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
 
-        # Error KB-H020, complaining that .pc files are found
-        tools.rmdir(os.path.join(self.package_folder, "lib/pkgconfig"))
-
-        # Error KB-H019, complaining that .pc files are found
-        tools.rmdir(os.path.join(self.package_folder, "lib/cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
         # SPIRV-Tools-shared is meant to be a shared-only c-only API for the library .
         # it is built by the original CMakeLists.txt file. It is the same
@@ -104,6 +101,10 @@ class SpirvtoolsConan(ConanFile):
             os.remove(lib_file)
 
     def package_info(self):
+        # TODO: set targets names when components available in conan
+        self.cpp_info.names["cmake_find_package"] = "SPIRV-Tools"
+        self.cpp_info.names["cmake_find_package_multi"] = "SPIRV-Tools"
+
         # The spirv-tools CMAKE builds a SPIRV-Tools-shared.so which is
         # apparantly only exports the C-interface of the library.
         # The test_package.c is used when testing the c_only option

--- a/recipes/spirv-tools/all/test_package/CMakeLists.txt
+++ b/recipes/spirv-tools/all/test_package/CMakeLists.txt
@@ -12,12 +12,10 @@ set(CMAKE_VERBOSE_MAKEFILE TRUE)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-if( ${BUILD_C_TEST_PACKAGE} )
+add_executable(${PROJECT_NAME}_c test_package.c)
+target_link_libraries(${PROJECT_NAME}_c ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME}_c PROPERTY LINKER_LANGUAGE CXX)
 
-    add_executable(${PROJECT_NAME} test_package.c)
-
-else()
-    add_executable(${PROJECT_NAME} test_package.cpp)
-endif()
-
+add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/spirv-tools/all/test_package/CMakeLists.txt
+++ b/recipes/spirv-tools/all/test_package/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(test_package)
+
+if( ${BUILD_C_TEST_PACKAGE} )
+    set(CMAKE_C_STANDARD 11)
+else()
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+if( ${BUILD_C_TEST_PACKAGE} )
+
+    add_executable(${PROJECT_NAME} test_package.c)
+
+else()
+    add_executable(${PROJECT_NAME} test_package.cpp)
+endif()
+
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/spirv-tools/all/test_package/CMakeLists.txt
+++ b/recipes/spirv-tools/all/test_package/CMakeLists.txt
@@ -1,12 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(test_package)
 
-if( ${BUILD_C_TEST_PACKAGE} )
-    set(CMAKE_C_STANDARD 11)
-else()
-    set(CMAKE_CXX_STANDARD 11)
-endif()
-
 set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/spirv-tools/all/test_package/conanfile.py
+++ b/recipes/spirv-tools/all/test_package/conanfile.py
@@ -1,0 +1,21 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        if self.options["spirv-tools"].c_only:
+            # so the list file knows to use the test_package.c instead
+            # of test_package.cpp
+            cmake.definitions["BUILD_C_TEST_PACKAGE"] = True
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/spirv-tools/all/test_package/conanfile.py
+++ b/recipes/spirv-tools/all/test_package/conanfile.py
@@ -8,14 +8,12 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        if self.options["spirv-tools"].c_only:
-            # so the list file knows to use the test_package.c instead
-            # of test_package.cpp
-            cmake.definitions["BUILD_C_TEST_PACKAGE"] = True
         cmake.configure()
         cmake.build()
 
     def test(self):
         if not tools.cross_building(self.settings):
             bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)
+            bin_path = os.path.join("bin", "test_package_c")
             self.run(bin_path, run_environment=True)

--- a/recipes/spirv-tools/all/test_package/test_package.c
+++ b/recipes/spirv-tools/all/test_package/test_package.c
@@ -1,0 +1,31 @@
+#include "spirv-tools/libspirv.h"
+
+int main(int argc, char ** argv)
+{
+const char input_text[] =
+    "OpCapability Shader\n"
+    "OpCapability Linkage\n"
+    "OpMemoryModel Logical GLSL450";
+  spv_text text;
+  spv_binary binary;
+  spv_context context;
+
+  context  = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+
+  binary = 0;
+  if( SPV_SUCCESS != spvTextToBinary(context, input_text, sizeof(input_text), &binary, 0) )
+  {
+      return 1;
+  }
+
+  text = 0;
+  if( SPV_SUCCESS != spvBinaryToText(context, binary->code, binary->wordCount, 0, &text, 0) )
+  {
+      return 1;
+  }
+
+  spvTextDestroy(text);
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+  return 0;
+}

--- a/recipes/spirv-tools/all/test_package/test_package.cpp
+++ b/recipes/spirv-tools/all/test_package/test_package.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This program demonstrates basic SPIR-V module processing using
+// SPIRV-Tools C++ API:
+// * Assembling
+// * Validating
+// * Optimizing
+// * Disassembling
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "spirv-tools/libspirv.hpp"
+#include "spirv-tools/optimizer.hpp"
+
+int main() {
+  const std::string source =
+      "         OpCapability Linkage "
+      "         OpCapability Shader "
+      "         OpMemoryModel Logical GLSL450 "
+      "         OpSource GLSL 450 "
+      "         OpDecorate %spec SpecId 1 "
+      "  %int = OpTypeInt 32 1 "
+      " %spec = OpSpecConstant %int 0 "
+      "%const = OpConstant %int 42";
+
+  spvtools::SpirvTools core(SPV_ENV_UNIVERSAL_1_3);
+  spvtools::Optimizer opt(SPV_ENV_UNIVERSAL_1_3);
+
+  auto print_msg_to_stderr = [](spv_message_level_t, const char*,
+                                const spv_position_t&, const char* m) {
+    std::cerr << "error: " << m << std::endl;
+  };
+  core.SetMessageConsumer(print_msg_to_stderr);
+  opt.SetMessageConsumer(print_msg_to_stderr);
+
+  std::vector<uint32_t> spirv;
+  if (!core.Assemble(source, &spirv)) return 1;
+  if (!core.Validate(spirv)) return 1;
+
+  opt.RegisterPass(spvtools::CreateSetSpecConstantDefaultValuePass({{1, "42"}}))
+      .RegisterPass(spvtools::CreateFreezeSpecConstantValuePass())
+      .RegisterPass(spvtools::CreateUnifyConstantPass())
+      .RegisterPass(spvtools::CreateStripDebugInfoPass());
+  if (!opt.Run(spirv.data(), spirv.size(), &spirv)) return 1;
+
+  std::string disassembly;
+  if (!core.Disassemble(spirv, &disassembly)) return 1;
+  std::cout << disassembly << "\n";
+
+  return 0;
+}

--- a/recipes/spirv-tools/config.yml
+++ b/recipes/spirv-tools/config.yml
@@ -1,0 +1,6 @@
+---
+versions:
+  "2019.2":
+    folder: all
+  "2020.1":
+    folder: all

--- a/recipes/spirv-tools/config.yml
+++ b/recipes/spirv-tools/config.yml
@@ -2,5 +2,3 @@
 versions:
   "2019.2":
     folder: all
-  "2020.1":
-    folder: all

--- a/recipes/spirv-tools/config.yml
+++ b/recipes/spirv-tools/config.yml
@@ -1,4 +1,4 @@
 ---
 versions:
-  "2019.2":
+  "v2019.2":
     folder: all


### PR DESCRIPTION
Specify library name and version: **spirv-tools/2019.2**

- This recipe depends on `spirv-headers`
- Tested this on linux mint 19
- This recipe contains two `test_package`  sources, test_package.c and test_package.cpp, the one that is built is depends on whether the `c_only` option is selected. The project's CMakeLists file produces multiple libraries, plus an additional `spirv-tools-shared.so` which is the same as the combination of all the other libraries produced, except it only exports the C-interface, therefore only this file is linked when c_only is set.  It is always built as a shared-library even when `shared` is set to true. The other C++ libs are built appropriately. 

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

