### PR TITLE
Do not use system bin for 7zip

### DIFF
--- a/recipes/7zip/19.00/conanfile.py
+++ b/recipes/7zip/19.00/conanfile.py
@@ -30,8 +30,7 @@ class Package7Zip(ConanFile):
         os.unlink(filename)
 
     def build_requirements(self):
-        if not tools.which("7zr"):
-            self.build_requires("lzma_sdk/9.20")
+        self.build_requires("lzma_sdk/9.20")
 
         if tools.os_info.is_windows and "make" not in os.environ.get("CONAN_MAKE_PROGRAM", ""):
             self.build_requires("make/4.2.1")


### PR DESCRIPTION
Specify library name and version:  **7zip/19.00**

System binaries are hard to track, usually we can't reproduce their behavior.

closes https://github.com/conan-io/conan/issues/6866

/cc @michaelmaguire

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

