### PR TITLE
Update OpenSSL version for sqlicipher

### DIFF
--- a/recipes/sqlcipher/all/conanfile.py
+++ b/recipes/sqlcipher/all/conanfile.py
@@ -30,9 +30,9 @@ class SqlcipherConan(ConanFile):
 
     def requirements(self):
         if self.options.crypto_library == "openssl":
-            self.requires("openssl/1.1.1d")
+            self.requires("openssl/1.1.1f")
         else:
-            self.requires("libressl/2.9.2")
+            self.requires("libressl/3.0.2")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **sqlcipher/4.3.0**

Update OpenSSL version to the latest version.

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

