### PR TITLE
fmt, spdlog: Keep the CMake config file around after packaging

### DIFF
--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -71,7 +71,6 @@ class FmtConan(ConanFile):
         else:
             cmake = self._configure_cmake()
             cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
 

--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -90,7 +90,6 @@ class SpdlogConan(ConanFile):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "spdlog", "cmake"))
 


### PR DESCRIPTION
Specify library name and version:  **fmt/all**, **spdlog/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I couldn't find any reason why the Conan recipes explicitly remove the CMake config files for these libraries, but they are needed to make `find_package(fmt)` and `find_package(spdlog)` work flawlessly in consumers of these libraries. If the files are removed, CMake won't find Conan's packaged library.

I've done a local test build of these and everything works fine in the default configuration.
