### PR TITLE
Add OpenSSL to CMake

### DIFF
--- a/recipes/cmake/all/conanfile.py
+++ b/recipes/cmake/all/conanfile.py
@@ -28,6 +28,10 @@ class CMakeConan(ConanFile):
     def _minor_version(self):
         return ".".join(str(self.version).split(".")[:2])
 
+    def build_requirements(self):
+        if self.settings.os_build in ["Linux", "FreeBSD"]:
+            self.build_requires("openssl/1.1.1f")
+
     def configure(self):
         if self._os == "Macos" and self._arch == "x86":
             raise ConanInvalidConfiguration("CMake does not support x86 for macOS")


### PR DESCRIPTION
Specify library name and version:  **cmake/any**

fixes #1401

cmake only requires openssl for linux and freebsd: https://gitlab.kitware.com/cmake/cmake/-/blob/master/CMakeLists.txt#L459

/cc @fulara

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

