### PR TITLE
Update jansson repo url

### DIFF
--- a/recipes/jansson/all/conandata.yml
+++ b/recipes/jansson/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2.12":
-    url: "http://www.digip.org/jansson/releases/jansson-2.12.tar.gz"
-    sha256: "5f8dec765048efac5d919aded51b26a32a05397ea207aa769ff6b53c7027d2c9"
+    url: "https://github.com/akheron/jansson/archive/v2.12.tar.gz"
+    sha256: "76260d30e9bbd0ef392798525e8cd7fe59a6450c54ca6135672e3cd6a1642941"


### PR DESCRIPTION
Specify library name and version:  **jansson/2.12**

- Update repository for Jansson. Now it uses Github
- The checksum is not the same, because the old tar contains more build files, but the source is same for both. I've checked using `diff` command.

/cc @timblechmann @Croydon 

fixes #1399

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

