### PR TITLE
disable build of example apps

### DIFF
--- a/recipes/miniz/all/conandata.yml
+++ b/recipes/miniz/all/conandata.yml
@@ -2,3 +2,8 @@ sources:
   "2.1.0":
     url: "https://github.com/richgel999/miniz/archive/2.1.0.tar.gz"
     sha256: "95f9b23c92219ad2670389a23a4ed5723b7329c82c3d933b7047673ecdfc1fea"
+
+patches:
+  "2.1.0":
+    - patch_file: "patches/2.1.0/001-remove-examples.patch"
+      base_path: "source_subfolder"

--- a/recipes/miniz/all/conanfile.py
+++ b/recipes/miniz/all/conanfile.py
@@ -10,7 +10,7 @@ class MinizConan(ConanFile):
     topics = ("conan", "miniz", "compression", "lossless")
     homepage = "https://github.com/richgel999/miniz"
     url = "https://github.com/conan-io/conan-center-index"
-    exports_sources = "CMakeLists.txt"
+    exports_sources = "CMakeLists.txt", "patches/*"
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
@@ -46,6 +46,8 @@ class MinizConan(ConanFile):
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build(target=self.name)
 

--- a/recipes/miniz/all/conanfile.py
+++ b/recipes/miniz/all/conanfile.py
@@ -46,7 +46,7 @@ class MinizConan(ConanFile):
         return self._cmake
 
     def build(self):
-        for patch in self.conan_data["patches"][self.version]:
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/miniz/all/conanfile.py
+++ b/recipes/miniz/all/conanfile.py
@@ -49,7 +49,7 @@ class MinizConan(ConanFile):
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
         cmake = self._configure_cmake()
-        cmake.build(target=self.name)
+        cmake.build()
 
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)

--- a/recipes/miniz/all/patches/2.1.0/001-remove-examples.patch
+++ b/recipes/miniz/all/patches/2.1.0/001-remove-examples.patch
@@ -1,0 +1,43 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f3e453a..65ca6de 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,31 +15,6 @@ set(miniz_SOURCE miniz.c miniz_zip.c miniz_tinfl.c miniz_tdef.c)
+ add_library(miniz ${miniz_SOURCE})
+ target_include_directories(miniz PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+ 
+-set(EXAMPLE1_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example1.c")
+-set(EXAMPLE2_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example2.c")
+-set(EXAMPLE3_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example3.c")
+-set(EXAMPLE4_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example4.c")
+-set(EXAMPLE5_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example5.c")
+-set(EXAMPLE6_SRC_LIST "${CMAKE_CURRENT_SOURCE_DIR}/examples/example6.c")
+-set(MINIZ_TESTER_SRC_LIST
+-    "${CMAKE_CURRENT_SOURCE_DIR}/tests/miniz_tester.cpp"
+-    "${CMAKE_CURRENT_SOURCE_DIR}/tests/timer.cpp")
+-
+-add_executable(example1 ${EXAMPLE1_SRC_LIST})
+-target_link_libraries(example1 miniz)
+-add_executable(example2 ${EXAMPLE2_SRC_LIST})
+-target_link_libraries(example2 miniz)
+-add_executable(example3 ${EXAMPLE3_SRC_LIST})
+-target_link_libraries(example3 miniz)
+-add_executable(example4 ${EXAMPLE4_SRC_LIST})
+-target_link_libraries(example4 miniz)
+-add_executable(example5 ${EXAMPLE5_SRC_LIST})
+-target_link_libraries(example5 miniz)
+-add_executable(example6 ${EXAMPLE6_SRC_LIST})
+-target_link_libraries(example6 miniz)
+-if(${UNIX})
+-    target_link_libraries(example6 m)
+-endif()
+ 
+ # add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
+ # target_link_libraries(miniz_tester miniz)
+@@ -49,4 +24,4 @@ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
+     LIBRARY DESTINATION lib
+     )
+ file(GLOB INSTALL_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+-install(FILES ${INSTALL_HEADERS} DESTINATION include/${PROJECT_NAME})
+\ No newline at end of file
++install(FILES ${INSTALL_HEADERS} DESTINATION include/${PROJECT_NAME})


### PR DESCRIPTION
Specify library name and version:  **miniz/2.1.0**

upstream has already a way to disable test/example binaries in the cmake file, as it should be, but 2.1.0 builds them every time.
This is unwanted build time/work and also fails on iOS since binaries would need to be signed.
Therefore I added a patch to disable the build of the non required test and example apps

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

