### PR TITLE
libjpeg-turbo bugfixes

### DIFF
--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -124,10 +124,4 @@ class LibjpegTurboConan(ConanFile):
         self.copy("license*", src=self._source_subfolder, dst="licenses", ignore_case=True, keep_path=False)
 
     def package_info(self):
-        if self.settings.compiler == "Visual Studio":
-            if self.options.shared:
-                self.cpp_info.libs = ["jpeg", "turbojpeg"]
-            else:
-                self.cpp_info.libs = ["jpeg-static", "turbojpeg-static"]
-        else:
-            self.cpp_info.libs = ["jpeg", "turbojpeg"]
+        self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -123,5 +123,13 @@ class LibjpegTurboConan(ConanFile):
 
         self.copy("license*", src=self._source_subfolder, dst="licenses", ignore_case=True, keep_path=False)
 
+    def _collect_libs(self):
+        libs = ["jpeg"]
+        if self.options.turbojpeg:
+            libs.append("turbojpeg")
+        if self.settings.compiler == "Visual Studio" and not self.options.shared:
+            libs = [lib + "-static" for lib in libs]
+        return libs
+
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = self._collect_libs()

--- a/recipes/libjpeg-turbo/all/test_package/conanfile.py
+++ b/recipes/libjpeg-turbo/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -12,6 +12,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        img_name = os.path.join(self.source_folder, "testimg.jpg")
-        bin_path = os.path.join("bin", "test_package")
-        self.run('%s %s' % (bin_path, img_name), run_environment=True)
+        if not tools.cross_building(self.settings):
+            img_name = os.path.join(self.source_folder, "testimg.jpg")
+            bin_path = os.path.join("bin", "test_package")
+            self.run('%s %s' % (bin_path, img_name), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **libjpeg-turbo/***

This PR addresses two bugs that I found while using this recipe:
1-  test_package crashed when crosscompiling.
2- cpp_tools.libs whas being manually populated without taking into account the effect of the option turbojpeg=False, generating linking issues. Instead of manually adding the case for turbojpeg=False in each condition I used tools.collect_libs().

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

