### PR TITLE
[openssl/all] Allow paths with spaces. This fixes a build failure on Windows where it is referencing files under my user directory which has a space in it.

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -403,8 +403,8 @@ class OpenSSLConan(ConanFile):
         openssldir = tools.unix_path(openssldir) if self._win_bash else openssldir
         args = ['"%s"' % (self._target if self._full_version >= "1.1.0" else self._ancestor_target),
                 "shared" if self.options.shared else "no-shared",
-                "--prefix=%s" % prefix,
-                "--openssldir=%s" % openssldir,
+                "--prefix=\"%s\"" % prefix,
+                "--openssldir=\"%s\"" % openssldir,
                 "no-unit-test"]
         if self._full_version >= "1.1.1":
             args.append("PERL=%s" % self._perl)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

