### PR TITLE
Adding the possibility to build boost without multi threading

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -47,6 +47,7 @@ class BoostConan(ConanFile):
         "python_version": "ANY",  # major.minor; computed automatically, if None
         "namespace": "ANY",  # custom boost namespace for bcp, e.g. myboost
         "namespace_alias": [True, False],  # enable namespace alias for bcp, boost=myboost
+        "multithreading": [True, False],  # enables multithreading support
         "zlib": [True, False],
         "bzip2": [True, False],
         "lzma": [True, False],
@@ -73,6 +74,7 @@ class BoostConan(ConanFile):
         'python_version': 'None',
         'namespace': 'boost',
         'namespace_alias': False,
+        'multithreading': True,
         'zlib': True,
         'bzip2': True,
         'lzma': False,
@@ -124,6 +126,15 @@ class BoostConan(ConanFile):
     def configure(self):
         if not self.options.i18n_backend and not self.options.without_locale:
             raise ConanInvalidConfiguration("Boost 'locale' library requires a i18n_backend, either 'icu' or 'iconv'")
+
+        if not self.options.multithreading:
+            # * For the reason 'thread' is deactivate look at https://stackoverflow.com/a/20991533
+            #   Look also on the comments of the answer for more details
+            # * Although the 'context' and 'atomic' library does not mention anything about threading,
+            #   when being build the compiler uses the -pthread flag, which makes it quite dangerous
+            for lib in ['locale', 'coroutine', 'wave', 'type_erasure', 'fiber', 'thread', 'context', 'atomic']:
+                if not self.options.get_safe('without_%s' % lib):
+                    raise ConanInvalidConfiguration("Boost '%s' library requires multi threading" % lib)
 
     def build_requirements(self):
         self.build_requires("b2/4.2.0")
@@ -570,7 +581,8 @@ class BoostConan(ConanFile):
         if self._is_msvc and self.settings.compiler.runtime:
             flags.append("runtime-link=%s" % ("static" if "MT" in str(self.settings.compiler.runtime) else "shared"))
 
-        flags.append("threading=multi")
+        # For details https://boostorg.github.io/build/manual/master/index.html
+        flags.append("threading=%s" % ("single" if not self.options.multithreading else "multi" ))
 
         flags.append("link=%s" % ("static" if not self.options.shared else "shared"))
         if self.settings.build_type == "Debug":
@@ -629,8 +641,10 @@ class BoostConan(ConanFile):
                                                                     self.settings.os.version))
 
         if self.settings.os == "iOS":
-            cxx_flags.append("-DBOOST_AC_USE_PTHREADS")
-            cxx_flags.append("-DBOOST_SP_USE_PTHREADS")
+            if self.options.multithreading:
+                cxx_flags.append("-DBOOST_AC_USE_PTHREADS")
+                cxx_flags.append("-DBOOST_SP_USE_PTHREADS")
+
             cxx_flags.append("-fvisibility=hidden")
             cxx_flags.append("-fvisibility-inlines-hidden")
             cxx_flags.append("-fembed-bitcode")
@@ -892,8 +906,10 @@ class BoostConan(ConanFile):
                 # https://github.com/conan-community/conan-boost/issues/127#issuecomment-404750974
                 self.cpp_info.system_libs.append("bcrypt")
             elif self.settings.os == "Linux":
-                # https://github.com/conan-community/conan-boost/issues/135
-                self.cpp_info.system_libs.extend(["pthread", "rt"])
+                # https://github.com/conan-community/community/issues/135
+                self.cpp_info.system_libs.append("rt")
+                if self.options.multithreading:
+                    self.cpp_info.system_libs.append("pthread")
 
         self.env_info.BOOST_ROOT = self.package_folder
         self.cpp_info.bindirs.append("lib")


### PR DESCRIPTION
Specify library name and version:  **boost/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.


This PR is adding the possibility to build boost without threading=multi (see https://github.com/conan-io/conan-center-index/pull/1412 for more details)

CC: @SSE4 

Open questions:

According to:
* https://stackoverflow.com/a/14738583 and
* https://stackoverflow.com/a/28821606

probably we are using the wrong flags for ios compilation. What do you think?

