### PR TITLE
Fix zlib renaming on Windows using clang

### DIFF
--- a/recipes/zlib/1.2.11/conanfile.py
+++ b/recipes/zlib/1.2.11/conanfile.py
@@ -130,6 +130,9 @@ class ZlibConan(ConanFile):
                 elif self.settings.compiler == "gcc":
                     current_lib = os.path.join(lib_path, "libzlibstatic.a")
                     os.rename(current_lib, os.path.join(lib_path, "libzlib.a"))
+                elif self.settings.compiler == "clang":
+                    current_lib = os.path.join(lib_path, "zlibstatic.lib")
+                    os.rename(current_lib, os.path.join(lib_path, "zlib.lib"))
 
     def package(self):
         # Extract the License/s from the header to a file


### PR DESCRIPTION
Specify library name and version:  **zlib/1.2.11**

A quick test indicates that the binary file name generated using clang is always `zlibstatic.lib`.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

