### PR TITLE
Fix Boost build on Windows using clang-cl

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -373,7 +373,7 @@ class BoostConan(ConanFile):
                 self.run(command)
 
     def _run_bcp(self):
-        with tools.vcvars(self.settings) if self._is_msvc else tools.no_op():
+        with tools.vcvars(self.settings) if self._is_msvc or (self.settings.os == "Windows" and self.settings.compiler == "clang") else tools.no_op():
             with tools.chdir(self.source_folder):
                 os.mkdir(self._bcp_dir)
                 namespace = "--namespace=%s" % self.options.namespace
@@ -710,8 +710,8 @@ class BoostConan(ConanFile):
         contents = ""
         if self._zip_bzip2_requires_needed:
             def create_library_config(deps_name, name):
-                includedir = self.deps_cpp_info[deps_name].include_paths[0].replace('\\', '/')
-                libdir = self.deps_cpp_info[deps_name].lib_paths[0].replace('\\', '/')
+                includedir = '"%s"' % self.deps_cpp_info[deps_name].include_paths[0].replace('\\', '/')
+                libdir = '"%s"' % self.deps_cpp_info[deps_name].lib_paths[0].replace('\\', '/')
                 lib = self.deps_cpp_info[deps_name].libs[0]
                 version = self.deps_cpp_info[deps_name].version
                 return "\nusing {name} : {version} : " \
@@ -743,7 +743,7 @@ class BoostConan(ConanFile):
 
         # Specify here the toolset with the binary if present if don't empty parameter :
         contents += '\nusing "%s" : %s : ' % (self._toolset, self._toolset_version)
-        contents += ' %s' % self._cxx.replace("\\", "/")
+        contents += ' "%s"' % self._cxx.replace("\\", "/")
 
         if tools.is_apple_os(self.settings.os):
             if self.settings.compiler == "apple-clang":
@@ -877,7 +877,7 @@ class BoostConan(ConanFile):
                 if not self.options.shared:
                     self.cpp_info.defines.append("BOOST_PYTHON_STATIC_LIB")
 
-            if self._is_msvc:
+            if self._is_msvc or (self.settings.os == "Windows" and self.settings.compiler == "clang"):
                 if not self.options.magic_autolink:
                     # DISABLES AUTO LINKING! NO SMART AND MAGIC DECISIONS THANKS!
                     self.cpp_info.defines.append("BOOST_ALL_NO_LIB")

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -105,6 +105,10 @@ class BoostConan(ConanFile):
         return self.settings.compiler == "Visual Studio"
 
     @property
+    def _is_clang_cl(self):
+        return self.settings.os == "Windows" and self.settings.compiler == "clang"
+
+    @property
     def _zip_bzip2_requires_needed(self):
         return not self.options.without_iostreams and not self.options.header_only
 
@@ -373,7 +377,7 @@ class BoostConan(ConanFile):
                 self.run(command)
 
     def _run_bcp(self):
-        with tools.vcvars(self.settings) if self._is_msvc or (self.settings.os == "Windows" and self.settings.compiler == "clang") else tools.no_op():
+        with tools.vcvars(self.settings) if self._is_msvc or self._is_clang_cl else tools.no_op():
             with tools.chdir(self.source_folder):
                 os.mkdir(self._bcp_dir)
                 namespace = "--namespace=%s" % self.options.namespace
@@ -877,7 +881,7 @@ class BoostConan(ConanFile):
                 if not self.options.shared:
                     self.cpp_info.defines.append("BOOST_PYTHON_STATIC_LIB")
 
-            if self._is_msvc or (self.settings.os == "Windows" and self.settings.compiler == "clang"):
+            if self._is_msvc or self._is_clang_cl:
                 if not self.options.magic_autolink:
                     # DISABLES AUTO LINKING! NO SMART AND MAGIC DECISIONS THANKS!
                     self.cpp_info.defines.append("BOOST_ALL_NO_LIB")

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -9,26 +9,27 @@ class DefaultNameConan(ConanFile):
     generators = "cmake"
 
     def build(self):
-        cmake = CMake(self)
-        if self.options["boost"].header_only:
-            cmake.definitions["HEADER_ONLY"] = "TRUE"
-        else:
-            cmake.definitions["Boost_USE_STATIC_LIBS"] = not self.options["boost"].shared
-        if not self.options["boost"].without_python:
-            cmake.definitions["WITH_PYTHON"] = "TRUE"
-        if not self.options["boost"].without_random:
-            cmake.definitions["WITH_RANDOM"] = "TRUE"
-        if not self.options["boost"].without_regex:
-            cmake.definitions["WITH_REGEX"] = "TRUE"
-        if not self.options["boost"].without_test:
-            cmake.definitions["WITH_TEST"] = "TRUE"
-        if not self.options["boost"].without_coroutine:
-            cmake.definitions["WITH_COROUTINE"] = "TRUE"
-        if not self.options["boost"].without_chrono:
-            cmake.definitions["WITH_CHRONO"] = "TRUE"
-        cmake.definitions["Boost_NO_BOOST_CMAKE"] = "TRUE"
-        cmake.configure()
-        cmake.build()
+        with tools.vcvars(self.settings) if (self.settings.os == "Windows" and self.settings.compiler == "clang") else tools.no_op():
+            cmake = CMake(self)
+            if self.options["boost"].header_only:
+                cmake.definitions["HEADER_ONLY"] = "TRUE"
+            else:
+                cmake.definitions["Boost_USE_STATIC_LIBS"] = not self.options["boost"].shared
+            if not self.options["boost"].without_python:
+                cmake.definitions["WITH_PYTHON"] = "TRUE"
+            if not self.options["boost"].without_random:
+                cmake.definitions["WITH_RANDOM"] = "TRUE"
+            if not self.options["boost"].without_regex:
+                cmake.definitions["WITH_REGEX"] = "TRUE"
+            if not self.options["boost"].without_test:
+                cmake.definitions["WITH_TEST"] = "TRUE"
+            if not self.options["boost"].without_coroutine:
+                cmake.definitions["WITH_COROUTINE"] = "TRUE"
+            if not self.options["boost"].without_chrono:
+                cmake.definitions["WITH_CHRONO"] = "TRUE"
+            cmake.definitions["Boost_NO_BOOST_CMAKE"] = "TRUE"
+            cmake.configure()
+            cmake.build()
 
     def test(self):
         if tools.cross_building(self.settings):


### PR DESCRIPTION
Specify library name and version:  **boost/1.72.0**

- Enable vcvars when using Clang on Windows because it needs to link against MSVC runtime libs.
- Put paths in quotes when generating JAM file. (The path of `clang-cl.exe` is often `C:\Program Files\LLVM\bin\clang-cl.exe` which will be misinterpret as two paths)
- This can only succeed after #1452 is merged.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

