### PR TITLE
autoconf now supports <5.14 perls

### DIFF
--- a/recipes/autoconf/all/patches/0001-autom4te-relocatable.patch
+++ b/recipes/autoconf/all/patches/0001-autom4te-relocatable.patch
@@ -4,7 +4,12 @@
  	if /^\s*(\#.*)?$/;
  
        my @words = shellwords ($_);
-+      @words = map(s#AUTOCONF_M4DIR#$pkgdatadir#r, @words);
++      my @words_clone = @words;
++      @words = ();
++      foreach ( @words_clone ) {
++          push(@words, do { (my $tmp = $_) =~ s#AUTOCONF_M4DIR#$pkgdatadir#; $tmp });
++      }
++
        my $type = shift @words;
        if ($type eq 'begin-language:')
  	{

--- a/recipes/autoconf/all/patches/0001-autom4te-relocatable.patch
+++ b/recipes/autoconf/all/patches/0001-autom4te-relocatable.patch
@@ -1,9 +1,10 @@
 --- bin/autom4te.in
 +++ bin/autom4te.in
-@@ -268,6 +268,12 @@
+@@ -268,6 +268,13 @@
  	if /^\s*(\#.*)?$/;
  
        my @words = shellwords ($_);
++      # not using: s#AUTOCONF_M4DIR#$pkgdatadir#r to support perl <5.14
 +      my @words_clone = @words;
 +      @words = ();
 +      foreach ( @words_clone ) {

--- a/recipes/autoconf/all/patches/0001-autom4te-relocatable.patch
+++ b/recipes/autoconf/all/patches/0001-autom4te-relocatable.patch
@@ -1,6 +1,6 @@
 --- bin/autom4te.in
 +++ bin/autom4te.in
-@@ -268,6 +268,7 @@
+@@ -268,6 +268,12 @@
  	if /^\s*(\#.*)?$/;
  
        my @words = shellwords ($_);


### PR DESCRIPTION
Specify library name and version:  **autoconf/2.69**

redhat 6 and some different OS'es may not have perl 5.14+ available.
non-destructive replace to my knowledge was only added in 5.14.
But I went off some random information of the internet on that.

Anyway, the code seems to work fine just copy this into your interpreter to verify:
```
my $pkgdatadir="some/path";
my @words = ("AUTOCONF_M4DIR", "XX AUTOCONF_M4DIR XX");
my @words_prev_v = @words;
my @words_clone = @words;
@words = ();
@words_prev_v = map(s#AUTOCONF_M4DIR#$pkgdatadir#r, @words_prev_v);
foreach ( @words_clone ) {
    push(@words, do { (my $tmp = $_) =~ s#AUTOCONF_M4DIR#$pkgdatadir#; $tmp });
}
print "new v: @words \n";
print "previous v: @words_prev_v \n";
```

If you know more concise way of doing this please let me know :)

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

/cc @madebr 

closes: https://github.com/conan-io/conan-center-index/issues/1426
