### PR TITLE
Bump Version: cpprestsdk 2.10.16

### DIFF
--- a/recipes/cpprestsdk/all/conandata.yml
+++ b/recipes/cpprestsdk/all/conandata.yml
@@ -2,9 +2,18 @@ sources:
   "2.10.15":
     sha256: 1c027a53457e87b0b3a475e5c8045b94400c475898c8bd51b0fbd218b99a7f7b
     url: https://github.com/Microsoft/cpprestsdk/archive/v2.10.15.tar.gz
+  "2.10.16":
+    sha256: 3d75e17c7d79131320438f2a15331f7ca6281c38c0e2daa27f051e290eeb8681
+    url: https://github.com/microsoft/cpprestsdk/archive/v2.10.16.tar.gz
+
 patches:
   "2.10.15":
     - patch_file: "patches/0001-find-cmake-targets.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-remove-wconversion.patch"
+      base_path: "source_subfolder"
+  "2.10.16":
+    - patch_file: "patches/0001-find-cmake-targets-2.10.16.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0002-remove-wconversion.patch"
       base_path: "source_subfolder"

--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -46,7 +46,7 @@ class CppRestSDKConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("openssl/1.1.1f")
+        self.requires("openssl/1.1.1g")
         if self.options.with_compression:
             self.requires("zlib/1.2.11")
         if self.options.with_websockets:

--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -50,7 +50,7 @@ class CppRestSDKConan(ConanFile):
         if self.options.with_compression:
             self.requires("zlib/1.2.11")
         if self.options.with_websockets:
-            self.requires("websocketpp/0.8.1")
+            self.requires("websocketpp/0.8.2")
         self.requires("boost/1.72.0")
 
     def source(self):

--- a/recipes/cpprestsdk/all/patches/0001-find-cmake-targets-2.10.16.patch
+++ b/recipes/cpprestsdk/all/patches/0001-find-cmake-targets-2.10.16.patch
@@ -1,0 +1,125 @@
+diff --git a/Release/cmake/cpprest_find_openssl.cmake b/Release/cmake/cpprest_find_openssl.cmake
+index 93336636..a4ce046a 100644
+--- a/Release/cmake/cpprest_find_openssl.cmake
++++ b/Release/cmake/cpprest_find_openssl.cmake
+@@ -1,80 +1,7 @@
+ function(cpprest_find_openssl)
+-  if(TARGET cpprestsdk_openssl_internal)
+-    return()
+-  endif()
+-
+-  if(IOS)
+-    set(IOS_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../Build_iOS")
+-
+-    set(OPENSSL_INCLUDE_DIR "${IOS_SOURCE_DIR}/openssl/include" CACHE INTERNAL "")
+-    set(OPENSSL_LIBRARIES
+-      "${IOS_SOURCE_DIR}/openssl/lib/libcrypto.a"
+-      "${IOS_SOURCE_DIR}/openssl/lib/libssl.a"
+-      CACHE INTERNAL ""
+-      )
+-    set(_SSL_LEAK_SUPPRESS_AVAILABLE ON CACHE INTERNAL "")
+-  elseif(ANDROID)
+-    if(ARM)
+-      set(OPENSSL_INCLUDE_DIR "${CMAKE_BINARY_DIR}/../openssl/armeabi-v7a/include" CACHE INTERNAL "")
+-      set(OPENSSL_LIBRARIES
+-        "${CMAKE_BINARY_DIR}/../openssl/armeabi-v7a/lib/libssl.a"
+-        "${CMAKE_BINARY_DIR}/../openssl/armeabi-v7a/lib/libcrypto.a"
+-        CACHE INTERNAL ""
+-        )
+-    else()
+-      set(OPENSSL_INCLUDE_DIR "${CMAKE_BINARY_DIR}/../openssl/x86/include" CACHE INTERNAL "")
+-      set(OPENSSL_LIBRARIES
+-        "${CMAKE_BINARY_DIR}/../openssl/x86/lib/libssl.a"
+-        "${CMAKE_BINARY_DIR}/../openssl/x86/lib/libcrypto.a"
+-        CACHE INTERNAL ""
+-        )
+-    endif()
+-    set(_SSL_LEAK_SUPPRESS_AVAILABLE ON CACHE INTERNAL "")
+-  else()
+-    if(APPLE)
+-      if(NOT DEFINED OPENSSL_ROOT_DIR)
+-        # Prefer a homebrew version of OpenSSL over the one in /usr/lib
+-        file(GLOB OPENSSL_ROOT_DIR /usr/local/Cellar/openssl*/*)
+-        # Prefer the latest (make the latest one first)
+-        list(REVERSE OPENSSL_ROOT_DIR)
+-        list(GET OPENSSL_ROOT_DIR 0 OPENSSL_ROOT_DIR)
+-      endif()
+-      # This should prevent linking against the system provided 0.9.8y
+-      message(STATUS "OPENSSL_ROOT_DIR = ${OPENSSL_ROOT_DIR}")
+-      set(_OPENSSL_VERSION "")
+-    endif()
+-    if(UNIX)
+-      find_package(PkgConfig)
+-      pkg_search_module(OPENSSL openssl)
+-    endif()
+-    if(OPENSSL_FOUND)
+-      target_link_libraries(cpprest PRIVATE ${OPENSSL_LDFLAGS})
+-    else()
+-      find_package(OpenSSL 1.0.0 REQUIRED)
+-    endif()
+-
+-    INCLUDE(CheckCXXSourceCompiles)
+-    set(CMAKE_REQUIRED_INCLUDES "${OPENSSL_INCLUDE_DIR}")
+-    set(CMAKE_REQUIRED_LIBRARIES "${OPENSSL_LIBRARIES}")
+-    CHECK_CXX_SOURCE_COMPILES("
+-      #include <openssl/ssl.h>
+-      int main()
+-      {
+-      ::SSL_COMP_free_compression_methods();
+-      }
+-    " _SSL_LEAK_SUPPRESS_AVAILABLE)
+-  endif()
+-
+-  add_library(cpprestsdk_openssl_internal INTERFACE)
+-  if(TARGET OpenSSL::SSL)
+-    target_link_libraries(cpprestsdk_openssl_internal INTERFACE OpenSSL::SSL)
+-  else()
+-    target_link_libraries(cpprestsdk_openssl_internal INTERFACE "$<BUILD_INTERFACE:${OPENSSL_LIBRARIES}>")
+-    target_include_directories(cpprestsdk_openssl_internal INTERFACE "$<BUILD_INTERFACE:${OPENSSL_INCLUDE_DIR}>")
+-  endif()
+-
+-  if (NOT _SSL_LEAK_SUPPRESS_AVAILABLE)
+-    # libressl doesn't ship with the cleanup method being used in ws_client_wspp
+-    target_compile_definitions(cpprestsdk_openssl_internal INTERFACE -DCPPREST_NO_SSL_LEAK_SUPPRESS)
++  if(NOT TARGET cpprestsdk_openssl_internal)
++    add_library(cpprestsdk_openssl_internal INTERFACE)
++    target_include_directories(cpprestsdk_openssl_internal INTERFACE "${CONAN_INCLUDE_DIRS_OPENSSL}")
++    target_link_libraries(cpprestsdk_openssl_internal INTERFACE "${CONAN_LIBS_OPENSSL}")
+   endif()
+ endfunction()
+diff --git a/Release/cmake/cpprest_find_websocketpp.cmake b/Release/cmake/cpprest_find_websocketpp.cmake
+index 94ea81a4..e35a8f7c 100644
+--- a/Release/cmake/cpprest_find_websocketpp.cmake
++++ b/Release/cmake/cpprest_find_websocketpp.cmake
+@@ -1,27 +1,7 @@
+ function(cpprest_find_websocketpp)
+-  if(TARGET cpprestsdk_websocketpp_internal)
+-    return()
++  if(NOT TARGET cpprestsdk_websocketpp_internal)
++    add_library(cpprestsdk_websocketpp_internal INTERFACE)
++    target_include_directories(cpprestsdk_websocketpp_internal INTERFACE "${CONAN_INCLUDE_DIRS_WEBSOCKETPP}")
++    target_link_libraries(cpprestsdk_websocketpp_internal INTERFACE "${CONAN_LIBS_WEBSOCKETPP}")
+   endif()
+-
+-  find_package(WEBSOCKETPP CONFIG QUIET)
+-  if(WEBSOCKETPP_FOUND)
+-    message("-- Found websocketpp version " ${WEBSOCKETPP_VERSION} " on system")
+-    set(WEBSOCKETPP_INCLUDE_DIR ${WEBSOCKETPP_INCLUDE_DIR} CACHE INTERNAL "")
+-  elseif(EXISTS ${PROJECT_SOURCE_DIR}/libs/websocketpp/CMakeLists.txt)
+-    message("-- websocketpp not found, using the embedded version")
+-    set(WEBSOCKETPP_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/libs/websocketpp CACHE INTERNAL "")
+-  else()
+-    message(FATAL_ERROR "-- websocketpp not found and embedded version not present; try `git submodule update --init` and run CMake again")
+-  endif()
+-
+-  cpprest_find_boost()
+-  cpprest_find_openssl()
+-
+-  add_library(cpprestsdk_websocketpp_internal INTERFACE)
+-  target_include_directories(cpprestsdk_websocketpp_internal INTERFACE "$<BUILD_INTERFACE:${WEBSOCKETPP_INCLUDE_DIR}>")
+-  target_link_libraries(cpprestsdk_websocketpp_internal
+-    INTERFACE
+-      cpprestsdk_boost_internal
+-      cpprestsdk_openssl_internal
+-  )
+ endfunction()

--- a/recipes/cpprestsdk/config.yml
+++ b/recipes/cpprestsdk/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.10.15":
     folder: "all"
+  "2.10.16":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **cpprestsdk/2.10.16**

Note that one of the patches (to adapt the dependency discovery in the build system) needed a slight adjustment due to upstream changes. I added a second version of the patch file (`0001-find-cmake-targets-2.10.16.patch`) next to the old version. Is that the preferred way of dealing with situations like that, or is there a better way?

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

