### PR TITLE
mysql-connector-c: add missing system_lib m

### DIFF
--- a/recipes/mysql-connector-c/all/conanfile.py
+++ b/recipes/mysql-connector-c/all/conanfile.py
@@ -101,3 +101,5 @@ class MysqlConnectorCConan(ConanFile):
         if not self.options.shared:
             if self._stdcpp_library:
                 self.cpp_info.system_libs.append(self._stdcpp_library)
+            if self.settings.os == "Linux":
+                self.cpp_info.system_libs.append('m')

--- a/recipes/mysql-connector-c/all/test_package/CMakeLists.txt
+++ b/recipes/mysql-connector-c/all/test_package/CMakeLists.txt
@@ -6,5 +6,5 @@ conan_basic_setup()
 
 find_package(Threads)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})

--- a/recipes/mysql-connector-c/all/test_package/test_package.c
+++ b/recipes/mysql-connector-c/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include <mysql.h>
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+  printf("MySQL client version: %s\n", mysql_get_client_info());
+  return 0;
+}

--- a/recipes/mysql-connector-c/all/test_package/test_package.cpp
+++ b/recipes/mysql-connector-c/all/test_package/test_package.cpp
@@ -1,8 +1,0 @@
-#include <mysql.h>
-#include <iostream>
-
-int main(int argc, char **argv)
-{
-  std::cout << "MySQL client version: " << mysql_get_client_info() << std::endl;
-  return 0;
-}


### PR DESCRIPTION
Specify library name and version:  **mysql-connector-c/6.0.11**

also, test mysql-connector-c with C

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

