### PR TITLE
poco: add JWT library

### DIFF
--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -163,6 +163,7 @@ class PocoConan(ConanFile):
                 ("enable_netssl", "PocoNetSSL"),
                 ("enable_netssl_win", "PocoNetSSLWin"),
                 ("enable_net", "PocoNet"),
+                ("enable_jwt", "PocoJWT"),
                 ("enable_crypto", "PocoCrypto"),
                 ("enable_data_sqlite", "PocoDataSQLite"),
                 ("enable_data_mysql", "PocoDataMySQL"),


### PR DESCRIPTION
The jwt library is missing. See also:  https://github.com/pocoproject/conan-poco/blob/release/1.10.1/conanfile.py

Specify library name and version:  **poco/1.10.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

