### PR TITLE
Set the environment variable BISON_PKGDATADIR in the bison enviornment.

### DIFF
--- a/recipes/bison/all/conanfile.py
+++ b/recipes/bison/all/conanfile.py
@@ -138,3 +138,6 @@ class BisonConan(ConanFile):
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info('Appending PATH environment variable: {}'.format(bindir))
         self.env_info.PATH.append(bindir)
+        pkgdir = os.path.join(bindir, 'share', 'bison')
+        self.output.info('Setting the BISON_PKGDATADIR environment variable: {}'.format(pkgdir))
+        self.env_info.BISON_PKGDATADIR = pkgdir


### PR DESCRIPTION
This corrects a problem on some platforms where bison's own m4 files are not found at runtime.
https://github.com/conan-io/conan-center-index/issues/1498

Specify library name and version:  **bison/3.5.3**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

