### PR TITLE
[icu] Add option to disable dyload

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -22,12 +22,14 @@ class ICUBase(ConanFile):
                "fPIC": [True, False],
                "data_packaging": ["files", "archive", "library", "static"],
                "with_unit_tests": [True, False],
-               "silent": [True, False]}
+               "silent": [True, False],
+               "with_dyload": [True, False]}
     default_options = {"shared": False,
                        "fPIC": True,
                        "data_packaging": "archive",
                        "with_unit_tests": False,
-                       "silent": True}
+                       "silent": True,
+                       "with_dyload": True}
 
     @property
     def _is_msvc(self):
@@ -156,6 +158,9 @@ class ICUBase(ConanFile):
                 "--disable-samples",
                 "--disable-layout",
                 "--disable-layoutex"]
+        
+        if not self.options.with_dyload:
+            args += ["--disable-dyload"]
 
         if self.cross_building:
             if self._env_build.build:
@@ -242,7 +247,7 @@ class ICUBase(ConanFile):
 
         if not self.options.shared:
             self.cpp_info.defines.append("U_STATIC_IMPLEMENTATION")
-        if self.settings.os == 'Linux':
+        if self.settings.os == 'Linux' and self.options.with_dyload:
             self.cpp_info.libs.append('dl')
 
         if self.settings.os == 'Windows':


### PR DESCRIPTION
Specify library name and version:  **icu/***

On my quest to compile `boost` with ICU I've found it is not working in Linux because the test during config for ICU fails to link due to `dl-xxx` symbols. It looks like it is an old friend here https://github.com/bincrafters/community/issues/647

Adding this option to ICU and using it to compile `boost+icu` I can finally find ICU libraries \o/


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

