### PR TITLE
flatbuffers: adds header only option

### DIFF
--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -13,8 +13,8 @@ class FlatbuffersConan(ConanFile):
     topics = ("conan", "flatbuffers", "serialization", "rpc", "json-parser")
     description = "Memory Efficient Serialization Library"
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "header_only": [True, False]}
+    default_options = {"shared": False, "fPIC": True, "header_only": False}
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
 
@@ -38,32 +38,43 @@ class FlatbuffersConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["FLATBUFFERS_BUILD_TESTS"] = False
-        cmake.definitions["FLATBUFFERS_BUILD_SHAREDLIB"] = self.options.shared
-        cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = not self.options.shared
+        cmake.definitions["FLATBUFFERS_BUILD_SHAREDLIB"] = self.options.shared and not self.options.header_only
+        cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = not self.options.shared and not self.options.header_only
         cmake.definitions["FLATBUFFERS_BUILD_FLATC"] = False
         cmake.definitions["FLATBUFFERS_BUILD_FLATHASH"] = False
         cmake.configure(build_folder=self._build_subfolder)
         return cmake
 
     def build(self):
-        cmake = self._configure_cmake()
-        cmake.build()
+        if not self.options.header_only:
+            cmake = self._configure_cmake()
+            cmake.build()
 
     def package(self):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
-        cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        if self.settings.os == "Windows" and self.options.shared:
-            if self.settings.compiler == "Visual Studio":
-                tools.mkdir(os.path.join(self.package_folder, "bin"))
-                shutil.move(os.path.join(self.package_folder, "lib", "%s.dll" % self.name),
-                            os.path.join(self.package_folder, "bin", "%s.dll" % self.name))
-            elif self.settings.compiler == "gcc":
-                shutil.move(os.path.join(self.package_folder, "lib", "lib%s.dll" % self.name),
-                            os.path.join(self.package_folder, "bin", "lib%s.dll" % self.name))
+        if self.options.header_only:
+            header_dir = os.path.join(self._source_subfolder, "include", "flatbuffers")
+            dst_dir = os.path.join("include", "flatbuffers")
+            self.copy("*.h", dst=dst_dir, src=header_dir)
+        else:
+            cmake = self._configure_cmake()
+            cmake.install()
+            tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+            if self.settings.os == "Windows" and self.options.shared:
+                if self.settings.compiler == "Visual Studio":
+                    tools.mkdir(os.path.join(self.package_folder, "bin"))
+                    shutil.move(os.path.join(self.package_folder, "lib", "%s.dll" % self.name),
+                                os.path.join(self.package_folder, "bin", "%s.dll" % self.name))
+                elif self.settings.compiler == "gcc":
+                    shutil.move(os.path.join(self.package_folder, "lib", "lib%s.dll" % self.name),
+                                os.path.join(self.package_folder, "bin", "lib%s.dll" % self.name))
+
+    def package_id(self):
+        if self.options.header_only:
+            self.info.header_only()
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
-        if self.settings.os == "Linux":
-            self.cpp_info.libs.append("m")
+        if not self.options.header_only:
+            self.cpp_info.libs = tools.collect_libs(self)
+            if self.settings.os == "Linux":
+                self.cpp_info.libs.append("m")

--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -38,8 +38,8 @@ class FlatbuffersConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["FLATBUFFERS_BUILD_TESTS"] = False
-        cmake.definitions["FLATBUFFERS_BUILD_SHAREDLIB"] = self.options.shared and not self.options.header_only
-        cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = not self.options.shared and not self.options.header_only
+        cmake.definitions["FLATBUFFERS_BUILD_SHAREDLIB"] = self.options.shared
+        cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = not self.options.shared
         cmake.definitions["FLATBUFFERS_BUILD_FLATC"] = False
         cmake.definitions["FLATBUFFERS_BUILD_FLATHASH"] = False
         cmake.configure(build_folder=self._build_subfolder)

--- a/recipes/flatbuffers/all/test_package/CMakeLists.txt
+++ b/recipes/flatbuffers/all/test_package/CMakeLists.txt
@@ -5,5 +5,10 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
+
+if (FLATBUFFERS_HEADER_ONLY)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE FLATBUFFERS_HEADER_ONLY=1)
+endif(FLATBUFFERS_HEADER_ONLY)
+
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/flatbuffers/all/test_package/conanfile.py
+++ b/recipes/flatbuffers/all/test_package/conanfile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -11,9 +11,11 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["FLATBUFFERS_HEADER_ONLY"] = self.options["flatbuffers"].header_only
         cmake.configure()
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/flatbuffers/all/test_package/test_package.cpp
+++ b/recipes/flatbuffers/all/test_package/test_package.cpp
@@ -17,20 +17,33 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "flatbuffers/util.h"
+#include "flatbuffers/flatbuffers.h"
 
+#ifndef FLATBUFFERS_HEADER_ONLY
+  #include "flatbuffers/util.h"
+#endif
 // Test to validate Conan package generated
 
 int main(int /*argc*/, const char * /*argv*/ []) {
 
-  const std::string filename("conanbuildinfo.cmake");
+  flatbuffers::FlatBufferBuilder builder;
+  const auto offset = builder.CreateString("test");
+  if (!offset.IsNull()) {
+    std::cout << "Offset is " << builder.CreateString("test").o << ".\n";
+  } else {
+    std::cout << "Offset is null.\n";
+    return EXIT_FAILURE;
+  }
 
+#ifndef FLATBUFFERS_HEADER_ONLY
+  const std::string filename("conanbuildinfo.cmake");
   if (flatbuffers::FileExists(filename.c_str())) {
     std::cout << "File " << filename << " exists.\n";
   } else {
     std::cout << "File " << filename << " does not exist.\n";
     return EXIT_FAILURE;
   }
+#endif
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Specify library name and version:  **flatbuffers/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Adds a header-only option to flatbuffers as its core functionality is header only. I did not make it default to not change the package default behaviour.