### PR TITLE
openssl: fix 1.0.2 fail to build with arm arch

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -357,6 +357,12 @@ class OpenSSLConan(ConanFile):
             return getattr(tools.XCRun(self.settings), apple_name)
         return None
 
+    def _patch_configure(self):
+        # since _patch_makefile_org will replace binutils variables
+        # use a more restricted regular expresion to prevent that Configure script trying to do it again
+        configure = os.path.join(self._source_subfolder, "Configure")
+        tools.replace_in_file(configure, r"s/^AR=\s*ar/AR= $ar/;", r"s/^AR=\s*ar\b/AR= $ar/;")
+
     def _patch_makefile_org(self):
         # https://wiki.openssl.org/index.php/Compilation_and_Installation#Modifying_Build_Settings
         # its often easier to modify Configure and Makefile.org rather than trying to add targets to the configure scripts
@@ -605,6 +611,7 @@ class OpenSSLConan(ConanFile):
                 if self._full_version >= "1.1.0":
                     self._create_targets()
                 else:
+                    self._patch_configure()
                     self._patch_makefile_org()
                 self._make()
 


### PR DESCRIPTION
If CROSS_COMPILE is empty but AR is starts with "ar" (ex. arm-linux-gnueabi-ar), the regular expression substitution will not work properly.
> AR= arm-linux-gnueabi-ar => AR= $(ar)m-linux-gnueabi-ar

Specify library name and version:  **openssl/1.0.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

closes: #940 