### PR TITLE
adding jwt-cpp/0.4.0

### DIFF
--- a/recipes/jwt-cpp/all/conandata.yml
+++ b/recipes/jwt-cpp/all/conandata.yml
@@ -2,7 +2,13 @@ sources:
     "0.3.1":
         url: "https://github.com/Thalhammer/jwt-cpp/archive/v0.3.1.zip"
         sha256: "c19677c2bbfc51c9a0b3825bc5787a7cdea14e5d4c578283e5d9e94025865420"
+    "0.4.0":
+        url: "https://github.com/Thalhammer/jwt-cpp/archive/v0.4.0.zip"
+        sha256: "8a267a283715cda7746182a63f5ee4d6398058991bb71c212e99038297346538"
 patches:
     "0.3.1":
         - patch_file: "patches/0002-fix-openssl-change-version.patch"
+          base_path: "source_subfolder"
+    "0.4.0":
+        - patch_file: "patches/0003-fix-picojson-header-location-for-conan.patch"
           base_path: "source_subfolder"

--- a/recipes/jwt-cpp/all/conanfile.py
+++ b/recipes/jwt-cpp/all/conanfile.py
@@ -8,7 +8,7 @@ class JwtCppConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/Thalhammer/jwt-cpp"
     description = "A C++ JSON Web Token library for encoding/decoding"
-    topics = ("jwt-cpp", "json", "jwt", "header-only", "jose")
+    topics = ("jwt-cpp", "json", "jwt", "jose", "header-only")
     exports_sources = ["patches/**"]
     no_copy_source = True
 
@@ -18,7 +18,7 @@ class JwtCppConan(ConanFile):
 
     def requirements(self):
         self.requires("picojson/1.3.0")
-        self.requires("openssl/1.1.1f")
+        self.requires("openssl/1.1.1g")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -28,9 +28,8 @@ class JwtCppConan(ConanFile):
             tools.patch(**patch)
 
     def package(self):
-        header_dir = os.path.join(self._source_subfolder, "include", "jwt-cpp")
-        self.copy("jwt.h", dst="include", src=header_dir, keep_path=False)
-        self.copy("base.h", dst="include", src=header_dir, keep_path=False)
+        header_dir = os.path.join(self._source_subfolder, "include", "")
+        self.copy(pattern="jwt-cpp/*.h", dst="include", src=header_dir, keep_path=True)
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
 
     def package_id(self):

--- a/recipes/jwt-cpp/all/patches/0003-fix-picojson-header-location-for-conan.patch
+++ b/recipes/jwt-cpp/all/patches/0003-fix-picojson-header-location-for-conan.patch
@@ -1,0 +1,6 @@
+diff --git a/include/jwt-cpp/jwt.h b/include/jwt-cpp/jwt.h
+--- a/include/jwt-cpp/jwt.h
++++ b/include/jwt-cpp/jwt.h
+@@ -3,1 +3,1 @@
+-#include "picojson/picojson.h"
++#include "picojson.h"

--- a/recipes/jwt-cpp/all/test_package/example.cpp
+++ b/recipes/jwt-cpp/all/test_package/example.cpp
@@ -1,4 +1,4 @@
-#include <jwt.h>
+#include <jwt-cpp/jwt.h>
 #include <iostream>
 
 int main() {

--- a/recipes/jwt-cpp/config.yml
+++ b/recipes/jwt-cpp/config.yml
@@ -1,3 +1,5 @@
 versions:
     "0.3.1":
         folder: all
+    "0.4.0":
+        folder: all


### PR DESCRIPTION
match behavoir to the current cmake install behavoir
https://github.com/Thalhammer/jwt-cpp/blob/34bb0644ea613cfcbc09c148db9de8aa6c5612b5/CMakeLists.txt#L51

Specify library name and version:  **jwt-cpp/0.4.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

