### PR TITLE
Fix #1525 - zlib/1.2.11 do not install internal-only header crypt.h

### DIFF
--- a/recipes/zlib/1.2.11/CMakeLists_minizip.txt
+++ b/recipes/zlib/1.2.11/CMakeLists_minizip.txt
@@ -5,7 +5,9 @@ include(../../../conanbuildinfo.cmake)
 conan_basic_setup()
 
 set(SOURCES ioapi.c mztools.c unzip.c zip.c)
-set(HEADERS crypt.h ioapi.h mztools.h unzip.h zip.h minizip_extern.h)
+set(PUBLIC_HEADERS ioapi.h mztools.h unzip.h zip.h minizip_extern.h)
+# crypt.h is internal-only and should be no-install
+set(HEADERS crypt.h ${PUBLIC_HEADERS})
 
 if(WIN32)
   set(SOURCES ${SOURCES} iowin32.c)
@@ -37,7 +39,7 @@ if(BUILD_SHARED_LIBS)
   endif()
 endif()
 
-set_target_properties(minizip PROPERTIES PUBLIC_HEADER "${HEADERS}")
+set_target_properties(minizip PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")
 set_target_properties(minizip PROPERTIES SOVERSION 1)
 set_target_properties(minizip PROPERTIES VERSION "1.1.0")
 

--- a/recipes/zlib/1.2.11/test_package/CMakeLists.txt
+++ b/recipes/zlib/1.2.11/test_package/CMakeLists.txt
@@ -4,8 +4,6 @@ project(test_package C)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-# find_package(ZLIB REQUIRED)
-
 add_executable(test_zlib test.c)
 target_link_libraries(test_zlib CONAN_PKG::zlib)
 set_target_properties(test_zlib PROPERTIES OUTPUT_NAME "test")

--- a/recipes/zlib/1.2.11/test_package/CMakeLists.txt
+++ b/recipes/zlib/1.2.11/test_package/CMakeLists.txt
@@ -2,15 +2,15 @@ cmake_minimum_required(VERSION 3.0)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-find_package(ZLIB REQUIRED)
+# find_package(ZLIB REQUIRED)
 
 add_executable(test_zlib test.c)
-target_link_libraries(test_zlib ZLIB::ZLIB)
+target_link_libraries(test_zlib CONAN_PKG::zlib)
 set_target_properties(test_zlib PROPERTIES OUTPUT_NAME "test")
 
 if(WITH_MINIZIP)
   add_executable(test_minizip test_minizip.c)
-  target_link_libraries(test_minizip ZLIB::ZLIB)
+  target_link_libraries(test_minizip CONAN_PKG::zlib)
 endif()

--- a/recipes/zlib/1.2.11/test_package/test_minizip.c
+++ b/recipes/zlib/1.2.11/test_package/test_minizip.c
@@ -9,7 +9,7 @@
 #endif
 
 /* TODO: create test for this headers */
-#include <crypt.h>
+// #include <crypt.h> // THIS IS INTERNAL ONLY, NOT INSTALLED
 #include <mztools.h>
 
 const char text[] = ""
@@ -238,7 +238,7 @@ void Display64BitsSize(ZPOS64_T n, int size_char) {
     int offset = 19;
     int pos_string = 19;
     number[20] = 0;
-    
+
     for (;;) {
         number[offset] = (char) ((n % 10) + '0');
       if (number[offset] != '0') {

--- a/recipes/zlib/1.2.11/test_package/test_minizip.c
+++ b/recipes/zlib/1.2.11/test_package/test_minizip.c
@@ -8,8 +8,7 @@
     #include <iowin32.h>
 #endif
 
-/* TODO: create test for this headers */
-// #include <crypt.h> // THIS IS INTERNAL ONLY, NOT INSTALLED
+/* TODO: create test for this header */
 #include <mztools.h>
 
 const char text[] = ""


### PR DESCRIPTION
Specify library name and version:  **zlib/1.2.11**

## Fix #1525: do not install crypt.h

Basically removed it from the call to 
`set_target_properties(minizip PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")`


---


## Unrelated to #1525: fix the test package when minizip

Locally the test_package with minizip was failing already, so I started by addressing that

```
$ conan create . zlib/1.2.11@ -o zlib:minizip=True

[...]
[100%] Linking C executable bin/test_minizip
CMakeFiles/test_minizip.dir/test_minizip.c.o: In function `print_zip_info':
test_minizip.c:(.text+0x50): undefined reference to `unzGetGlobalComment'
test_minizip.c:(.text+0x7c): undefined reference to `unzGoToFirstFile'
test_minizip.c:(.text+0xa2): undefined reference to `unzGetGlobalInfo64'
test_minizip.c:(.text+0x143): undefined reference to `unzGetCurrentFileInfo64'
test_minizip.c:(.text+0x39f): undefined reference to `unzGoToNextFile'
CMakeFiles/test_minizip.dir/test_minizip.c.o: In function `main':
test_minizip.c:(.text.startup+0x32): undefined reference to `zipOpen64'
test_minizip.c:(.text.startup+0x79): undefined reference to `zipOpenNewFileInZip64'
test_minizip.c:(.text.startup+0x99): undefined reference to `zipWriteInFileInZip'
test_minizip.c:(.text.startup+0xa9): undefined reference to `zipCloseFileInZip'
test_minizip.c:(.text.startup+0xc0): undefined reference to `zipClose'
test_minizip.c:(.text.startup+0xfa): undefined reference to `unzOpen64'
test_minizip.c:(.text.startup+0x11e): undefined reference to `unzGoToFirstFile'
test_minizip.c:(.text.startup+0x14e): undefined reference to `unzGetCurrentFileInfo64'
test_minizip.c:(.text.startup+0x172): undefined reference to `unzOpenCurrentFile'
test_minizip.c:(.text.startup+0x1a5): undefined reference to `unzReadCurrentFile'
test_minizip.c:(.text.startup+0x1d1): undefined reference to `unzClose'
collect2: error: ld returned 1 exit status
CMakeFiles/test_minizip.dir/build.make:101: recipe for target 'bin/test_minizip' failed
make[2]: *** [bin/test_minizip] Error 1
CMakeFiles/Makefile2:94: recipe for target 'CMakeFiles/test_minizip.dir/all' failed
make[1]: *** [CMakeFiles/test_minizip.dir/all] Error 2
Makefile:100: recipe for target 'all' failed
make: *** [all] Error 2
ERROR: zlib/1.2.11@jmarrec/testing (test package): Error in build() method, line 18
	cmake.build()
	ConanException: Error 2 while executing cmake --build '/home/julien/Software/Others/conan/conan-center-index/recipes/zlib/1.2.11/test_package/build/0d153e213847422e331841c60510b2d45af17ef5' '--' '-j12'

``` 

the test_minizip.c does an `#include <zip.h>` and couldn't find that one, so use the cmake TARGETS instead, so that the zlib/include directory is added to the call.


----

## Checklist

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

