### PR TITLE
integrate libiconv in cmake RelWithDebInfo builds

### DIFF
--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -85,6 +85,8 @@ class LibiconvConan(ConanFile):
                     yield
 
     def _configure_autotools(self):
+        if self.settings.build_type == "RelWithDebInfo":
+           self.settings.build_type = "Release"
         if self._autotools:
             return self._autotools
         host = None


### PR DESCRIPTION
fixes builds using libiconv integrated with other packages when in cmake RelWithDebInfo builds

Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

