### PR TITLE
[mpir] fix python 2 compatibility

### DIFF
--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -37,9 +37,7 @@ class MpirConan(ConanFile):
                                                    "{}_mpir_gc.vcxproj".format(self._dll_or_lib))
 
     def source(self):
-        args = self.conan_data["sources"][self.version]
-        args["keep_permissions"] = True
-        tools.get(**args)
+        tools.get(keep_permissions=True, **self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -37,7 +37,9 @@ class MpirConan(ConanFile):
                                                    "{}_mpir_gc.vcxproj".format(self._dll_or_lib))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], keep_permissions=True)
+        args = self.conan_data["sources"][self.version]
+        args["keep_permissions"] = True
+        tools.get(**args)
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 


### PR DESCRIPTION
running on python 2 I get the following error:
```
ERROR: Error loading conanfile at '/Users/sse4/.conan/data/mpir/3.0.0/_/_/export/conanfile.py': Unable to load conanfile in /Users/sse4/.conan/data/mpir/3.0.0/_/_/export/conanfile.py
  File "/Users/sse4/.conan/data/mpir/3.0.0/_/_/export/conanfile.py", line 40
    tools.get(**self.conan_data["sources"][self.version], keep_permissions=True)
                                                        ^
SyntaxError: invalid syntax
```
that's the only recipe using `keep_permissions=True`. I doubt it's needed at all.

Specify library name and version:  **mpir/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

