### PR TITLE
sqlite: fix default threadsafe option value

### DIFF
--- a/recipes/sqlite3/all/conanfile.py
+++ b/recipes/sqlite3/all/conanfile.py
@@ -29,7 +29,7 @@ class ConanSqlite3(ConanFile):
                }
     default_options = {"shared": False,
                        "fPIC": True,
-                       "threadsafe": 0,
+                       "threadsafe": 1,
                        "enable_column_metadata": True,
                        "enable_explain_comments": False,
                        "enable_fts3": False,


### PR DESCRIPTION
Specify library name and version:  **sqlite/***

1. SQLite documentation says `This option controls whether or not code is included in SQLite to enable it to operate safely in a multithreaded environment. The default is SQLITE_THREADSAFE=1`
2. vcpkg does not set these value, so it uses sqlite default value : 1
3. the author of sqlitecpp said that threadsafe=1 would work fine in post https://github.com/SRombauts/SQLiteCpp/issues/195#issuecomment-488113454 
4. using threadsafe=0 does not solve any problem in any program/library. The only gain is in performance, but if you use sqlite api from several threads, you get into UB land


fixes #1396 

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

