### PR TITLE
[jinja2cpp] Fix rapidjson target name

### DIFF
--- a/recipes/jinja2cpp/1.1.0/conandata.yml
+++ b/recipes/jinja2cpp/1.1.0/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "1.1.0":
     url: https://github.com/jinja2cpp/Jinja2Cpp/archive/1.1.0.tar.gz
     sha256: 3d321a144f3774702d3a6252e3a6370cdaff9c96d8761d850bb79cdb45b372c5
+patches:
+  "1.1.0":
+    - patch_file: "patches/01-fix-rapidjson.patch"
+      base_path: "source_subfolder"

--- a/recipes/jinja2cpp/1.1.0/conanfile.py
+++ b/recipes/jinja2cpp/1.1.0/conanfile.py
@@ -11,7 +11,7 @@ class Jinja2cppConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     description = "Jinja2 C++ (and for C++) almost full-conformance template engine implementation"
     topics = ("conan", "cpp14", "cpp17", "jinja2", "string templates", "templates engine")
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = "CMakeLists.txt", "patches/**"
     generators = "cmake", "cmake_find_package"
     settings = "os", "compiler", "build_type", "arch"
     options = {
@@ -55,7 +55,12 @@ class Jinja2cppConan(ConanFile):
         extracted_dir = "Jinja2Cpp-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
+    def _patch_sources(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+
     def build(self):
+        self._patch_sources()
         cmake = CMake(self)
         cmake.definitions["JINJA2CPP_BUILD_TESTS"] = False
         cmake.definitions["JINJA2CPP_STRICT_WARNINGS"] = False

--- a/recipes/jinja2cpp/1.1.0/patches/01-fix-rapidjson.patch
+++ b/recipes/jinja2cpp/1.1.0/patches/01-fix-rapidjson.patch
@@ -1,0 +1,14 @@
+diff --git a/thirdparty/thirdparty-conan-build.cmake b/thirdparty/thirdparty-conan-build.cmake
+index 5aecfbd..e1a15ce 100644
+--- a/thirdparty/thirdparty-conan-build.cmake
++++ b/thirdparty/thirdparty-conan-build.cmake
+@@ -8,7 +8,7 @@ find_package(string-view-lite)
+ find_package(Boost)
+ set(CONAN_BOOST_PACKAGE_NAME Boost::Boost)
+ find_package(fmt)
+-find_package(rapidjson)
++find_package(RapidJSON)
+ 
+-set(JINJA2_PRIVATE_LIBS_INT ${CONAN_BOOST_PACKAGE_NAME} fmt::fmt rapidjson::rapidjson)
++set(JINJA2_PRIVATE_LIBS_INT ${CONAN_BOOST_PACKAGE_NAME} fmt::fmt RapidJSON::RapidJSON)
+ set(JINJA2_PUBLIC_LIBS_INT expected-lite::expected-lite variant-lite::variant-lite optional-lite::optional-lite string-view-lite::string-view-lite)


### PR DESCRIPTION
Specify library name and version:  **jinja2cpp/1.1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

closes https://github.com/conan-io/conan-center-index/issues/1577
PR submitted upstream too: https://github.com/jinja2cpp/Jinja2Cpp/pull/197