### PR TITLE
Fix OpenSSL versions 1.1.1 & newer for tvOS

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -414,11 +414,11 @@ class OpenSSLConan(ConanFile):
         if self._full_version >= "1.1.0":
             args.append("--debug" if self.settings.build_type == "Debug" else "--release")
 
-        if str(self.settings.os) == "tvOS":
+        if self.settings.os == "tvOS":
             args.append(" -DNO_FORK") # fork is not available on tvOS
-        if str(self.settings.os) == "Android":
+        if self.settings.os == "Android":
             args.append(" -D__ANDROID_API__=%s" % str(self.settings.os.api_level))  # see NOTES.ANDROID
-        if str(self.settings.os) == "Emscripten":
+        if self.settings.os == "Emscripten":
             args.append("-D__STDC_NO_ATOMICS__=1")
         if self.settings.os == "Windows":
             if self.options.capieng_dialog:

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -96,6 +96,7 @@ class OpenSSLConan(ConanFile):
     default_options["openssldir"] = None
     _env_build = None
     _source_subfolder = "source_subfolder"
+    exports_sources = ['patches/*']
 
     def build_requirements(self):
         if tools.os_info.is_windows:
@@ -413,6 +414,8 @@ class OpenSSLConan(ConanFile):
         if self._full_version >= "1.1.0":
             args.append("--debug" if self.settings.build_type == "Debug" else "--release")
 
+        if str(self.settings.os) == "tvOS":
+            args.append(" -DNO_FORK") # fork is not available on tvOS
         if str(self.settings.os) == "Android":
             args.append(" -D__ANDROID_API__=%s" % str(self.settings.os.api_level))  # see NOTES.ANDROID
         if str(self.settings.os) == "Emscripten":
@@ -603,6 +606,9 @@ class OpenSSLConan(ConanFile):
                 env_vars["CROSS_TOP"] = os.path.dirname(os.path.dirname(xcrun.sdk_path))
             with tools.environment_append(env_vars):
                 if self._full_version >= "1.1.0":
+                    if self.settings.os == "tvOS":
+                        tools.patch(patch_file=os.path.join("patches", "1.1.1-tvos.patch"),
+                                    base_path=self._source_subfolder)
                     self._create_targets()
                 else:
                     self._patch_makefile_org()

--- a/recipes/openssl/1.x.x/patches/1.1.1-tvos.patch
+++ b/recipes/openssl/1.x.x/patches/1.1.1-tvos.patch
@@ -1,0 +1,48 @@
+--- apps/speed.c
++++ apps/speed.c
+@@ -99,6 +99,13 @@
+ #endif
+ #include <openssl/modes.h>
+ 
++/* fork() breaks AppleTVOS, WatchOS, AppleTVSimulator and WatchSimulator */
++/* Users should configure with -DNO_FORK */
++#if defined(NO_FORK)
++# undef HAVE_FORK
++# define HAVE_FORK 0
++#endif
++
+ #ifndef HAVE_FORK
+ # if defined(OPENSSL_SYS_VMS) || defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_VXWORKS)
+ #  define HAVE_FORK 0
+@@ -110,6 +117,7 @@
+ #if HAVE_FORK
+ # undef NO_FORK
+ #else
++# undef NO_FORK
+ # define NO_FORK
+ #endif
+ 
+--- apps/ocsp.c
++++ apps/ocsp.c
+@@ -36,6 +36,13 @@
+ # include <openssl/x509v3.h>
+ # include <openssl/rand.h>
+
++/* fork() breaks AppleTVOS, WatchOS, AppleTVSimulator and WatchSimulator */
++/* Users should configure with -DNO_FORK */
++#if defined(NO_FORK)
++# undef HAVE_FORK
++# define HAVE_FORK 0
++#endif
++
+ #ifndef HAVE_FORK
+ # if defined(OPENSSL_SYS_VMS) || defined(OPENSSL_SYS_WINDOWS)
+ #  define HAVE_FORK 0
+@@ -47,6 +54,7 @@
+ #if HAVE_FORK
+ # undef NO_FORK
+ #else
++# undef NO_FORK
+ # define NO_FORK
+ #endif
+


### PR DESCRIPTION
`fork()` is unavailable on tvOS. This adds and applies a patch file when
building for tvOS and sets an argument for the compiler.

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

