### PR TITLE
add vcvrack-sdk version 1.1.6 recipe

### DIFF
--- a/recipes/vcvrack-sdk/1.1.6/conandata.yml
+++ b/recipes/vcvrack-sdk/1.1.6/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.1.6":
+    url: https://vcvrack.com/downloads/Rack-SDK-1.1.6.zip
+    sha256: 361f3dfb6c319ff64eef937a6bb6cd55d45b36911612a83254c305f8830f201b

--- a/recipes/vcvrack-sdk/1.1.6/conanfile.py
+++ b/recipes/vcvrack-sdk/1.1.6/conanfile.py
@@ -1,0 +1,187 @@
+import os, stat, json, re, subprocess
+from conans import ConanFile, CMake, tools
+from conans.tools import os_info, SystemPackageTool
+from conans.errors import ConanInvalidConfiguration
+from conans.model import Generator
+
+
+class VCVRackSDKConan(ConanFile):
+    name = "vcvrack-sdk"
+    version = "1.1.6"
+    license = "GPL-3.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://vcvrack.com"
+    description = "VCV Rack SDK for Rack plugin development."
+
+    settings = "os", "compiler", "arch"
+
+    _SDK_DIR = "Rack-SDK"
+
+    def configure(self):
+        if self._isVisualStudioBuild:
+            self.output.error("Rack SDK on Windows is only compatible with MinGW GCC toolchain!")
+            raise ConanInvalidConfiguration("VCV Rack SDK is not compatible with Visual Studio!")
+
+        if self.settings.arch != "x86_64":
+            raise ConanInvalidConfiguration("VCV Rack SDK only supports x86_64 platform!")
+
+    def requirements(self):
+        if self.settings.os == "Windows":
+            self.requires.add("msys2/20190524")
+
+    def system_requirements(self):
+        packages = ["git", "zip", "make", "cmake", "jq"]
+        update_installer = True
+
+        if self.settings.os == "Windows":
+            self.output.warn("manipulate script internal environment - add MSYS_BIN to PATH for using pacman tool")
+            del os.environ["CONAN_SYSREQUIRES_SUDO"]
+            os.environ["PATH"] += os.pathsep + self.env["MSYS_BIN"]
+            packages = ["zip", "mingw-w64-x86_64-jq", "mingw-w64-x86_64-libwinpthread"]
+            update_installer = False
+
+        if self.settings.os == "Macos":
+            packages += ["autoconf", "automake", "libtool"]
+
+        if self.settings.os == "Linux":
+            mesaPackage = { "ubuntu": "libglu1-mesa-dev",
+                            "debian": "libglu1-mesa-dev",
+                            "fedora": "mesa-libGLU-devel",
+                            "centos": "mesa-libGLU-devel",
+                            "arch": "mesa"
+                          }
+            packages += [mesaPackage[os_info.linux_distro]]
+
+        installer = SystemPackageTool()
+        for package in packages:
+            installer.install(package, update=update_installer)
+
+    def build(self):
+        tools.get(**self.conan_data["sources"][self.version])
+
+    def package(self):
+        self.copy("*.*", dst="include", src="{}/include".format(self._SDK_DIR))
+        self.copy("*.*", dst="dep", src="{}/dep".format(self._SDK_DIR))
+        self.copy("*.mk", dst=".", src="{}".format(self._SDK_DIR))
+        os.chmod(os.path.join(self._SDK_DIR, "helper.py"), stat.S_IRWXU|stat.S_IRGRP|stat.S_IROTH)
+        self.copy("helper.py", dst="script", src="{}".format(self._SDK_DIR))
+        self.copy("*Rack*.a", dst=".", keep_path=False)
+
+    def package_info(self):
+        if self.settings.os == "Windows":
+            self.cpp_info.cxxflags.append("-DARCH_WIN")
+            self.cpp_info.libs.append("Rack")
+            self.env_info.path.append(os.path.join(self.deps_env_info["msys2"].MSYS_ROOT, "mingw64", "bin"))
+            self.cpp_info.libdirs.append(os.path.join(self.package_folder))
+            self.user_info.rack_sdk_dir = os.path.join(self.package_folder)
+
+        if self.settings.os == "Linux":
+            self.cpp_info.cxxflags.append("-DARCH_LIN")
+
+        if self.settings.os == "Macos":
+            self.cpp_info.cxxflags.append("-DARCH_MAC -undefined dynamic_lookup")
+        else:
+            self.cpp_info.cxxflags.append("-Wsuggest-override")
+
+        self.cpp_info.cxxflags.append("-D_USE_MATH_DEFINES -march=nocona -funsafe-math-optimizations -fPIC")
+        self.cpp_info.cxxflags.append("-Wall -Wextra -Wno-unused-parameter")
+
+        self.cpp_info.includedirs = ["include", "dep/include"]
+        self.env_info.path.append(os.path.join(self.package_folder, "script"))
+        self.env_info.RACK_DIR = os.path.join(self.package_folder)
+
+    def package_id(self):
+       self.info.header_only()
+
+    @property
+    def _isMinGWBuild(self):
+        return self.settings.os == "Windows" and self.settings.compiler == "gcc"
+
+    @property
+    def _isVisualStudioBuild(self):
+        return self.settings.os == "Windows" and self.settings.compiler == "Visual Studio"
+
+# custom generator to generate CMakeSettings.json that can be used with MS Visual Studio
+class VSCMakeSettings(Generator):
+
+    @property
+    def filename(self):
+        return "CMakeSettings.json"
+
+    @property
+    def content(self):
+        if self.settings.os != "Windows":
+            print("*** VSCMakeSettings generator is only supported on Windows - generate empty file!")
+            return "VSCMakeSettings generator is only supported on Windows!"
+        print("*** Generate '{}' for Visual Studio".format(self.filename))
+        print("*** Please copy the generated '{}' manually into your Plugin source folder to use it with Visual Studio!".format(self.filename))
+        content = { "configurations" : [ self._createConfiguration("Release"),
+                                         self._createConfiguration("Debug")
+                                       ]
+                  }
+        return json.dumps(content, indent=2)
+
+    def _createConfiguration(self, cmakeBuildtype):
+        configuration = { "name" : "Mingw64-{}".format(cmakeBuildtype),
+                          "generator": "Ninja",
+                          "configurationType": cmakeBuildtype,
+                          "buildRoot": "${projectDir}\\out\\build\\${name}",
+                          "installRoot": "${projectDir}\\out\\install\\${name}",
+                          "cmakeCommandArgs": "",
+                          "buildCommandArgs": "-v",
+                          "ctestCommandArgs": "",
+                          "inheritEnvironments": [ "mingw_64" ],
+                          "environments": [ self._createEnvironment ],
+                          "variables": self._createVariables,
+                          "intelliSenseMode": "linux-gcc-x64"
+         }
+        return configuration
+
+    @property
+    def _createEnvironment(self):
+        environment = { "MINGW64_ROOT": self._getMinGWRoot,
+                        "BIN_ROOT": os.path.join(self._getMinGWHome, "bin"),
+                        "FLAVOR": self._getFlavor,
+                        "TOOLSET_VERSION": self._getToolsetVersion,
+                        "GCC_HEADERS_ROOT": "${env.MINGW64_ROOT}\\${env.FLAVOR}\\${env.TOOLSET_VERSION}\\include",
+                        "PATH": "${env.BIN_ROOT};${env.PATH}",
+                        "INCLUDE": "${env.INCLUDE};${env.GCC_HEADERS_ROOT}\\c++;${env.GCC_HEADERS_ROOT}\\c++\\${env.FLAVOR};${env.GCC_HEADERS_ROOT}\\c++\\backward;${env.GCC_HEADERS_ROOT}\\include;${env.GCC_HEADERS_ROOT}\\..\\include-fixed;${env.BIN_ROOT}\\..\\${env.FLAVOR}\\include",
+                        "environment": "mingw_64"
+                      }
+        return environment
+
+    @property
+    def _getMinGWHome(self):
+        return self.conanfile.deps_env_info["mingw_installer"].MINGW_HOME
+
+    @property
+    def _getMinGWRoot(self):
+        return os.path.join(self._getMinGWHome, "lib", "gcc")
+
+    def _getGccInfo(self, option):
+        result = subprocess.run(os.path.join(self._getMinGWHome, "bin", "gcc.exe") + " -{}".format(option), capture_output=True)
+        return result.stdout.decode('utf-8').strip()
+
+    @property
+    def _getFlavor(self):
+        return self._getGccInfo("dumpmachine")
+
+    @property
+    def _getToolsetVersion(self):
+        return self._getGccInfo("dumpversion")
+
+    @property
+    def _createVariables(self):
+        variables = [ self._createCMakeVariable("CMAKE_C_COMPILER", "${env.BIN_ROOT}\\gcc.exe", "STRING"),
+                      self._createCMakeVariable("CMAKE_CXX_COMPILER", "${env.BIN_ROOT}\\g++.exe", "STRING"),
+                      self._createCMakeVariable("RACK_SDK", "{}".format(self.conanfile.deps_user_info["vcvrack-sdk"].rack_sdk_dir), "STRING")
+                    ]
+        return variables
+
+
+    def _createCMakeVariable(self, name, value, varType):
+        variable = { "name": name,
+                      "value": value,
+                      "type": varType
+                   }
+        return variable

--- a/recipes/vcvrack-sdk/1.1.6/conanfile.py
+++ b/recipes/vcvrack-sdk/1.1.6/conanfile.py
@@ -69,7 +69,7 @@ class VCVRackSDKConan(ConanFile):
 
     def package_info(self):
         if self.settings.os == "Windows":
-            self.cpp_info.cxxflags.append("-DARCH_WIN")
+            self.cpp_info.cxxflags.append("-DARCH_WIN -D_USE_MATH_DEFINES")
             self.cpp_info.libs.append("Rack")
             self.env_info.path.append(os.path.join(self.deps_env_info["msys2"].MSYS_ROOT, "mingw64", "bin"))
             self.cpp_info.libdirs.append(os.path.join(self.package_folder))
@@ -83,7 +83,7 @@ class VCVRackSDKConan(ConanFile):
         else:
             self.cpp_info.cxxflags.append("-Wsuggest-override")
 
-        self.cpp_info.cxxflags.append("-D_USE_MATH_DEFINES -march=nocona -funsafe-math-optimizations -fPIC")
+        self.cpp_info.cxxflags.append("-march=nocona -funsafe-math-optimizations -fPIC")
         self.cpp_info.cxxflags.append("-Wall -Wextra -Wno-unused-parameter")
 
         self.cpp_info.includedirs = ["include", "dep/include"]

--- a/recipes/vcvrack-sdk/1.1.6/test_package/CMakeLists.txt
+++ b/recipes/vcvrack-sdk/1.1.6/test_package/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required (VERSION 3.5)
+
+# https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+
+project (VCVRackSDKTest)
+
+set (LIB_NAME plugintest)
+set (CMAKE_CXX_STANDARD 11)
+
+include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_library(${LIB_NAME} MODULE plugintest.cpp)
+
+target_link_libraries(plugintest ${CONAN_LIBS})
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  set_target_properties(${LIB_NAME} PROPERTIES SUFFIX ".dylib")
+endif ()

--- a/recipes/vcvrack-sdk/1.1.6/test_package/Makefile
+++ b/recipes/vcvrack-sdk/1.1.6/test_package/Makefile
@@ -1,0 +1,4 @@
+SOURCES += $(wildcard *.cpp)
+
+# Include the Rack plugin Makefile framework
+include $(RACK_DIR)/plugin.mk

--- a/recipes/vcvrack-sdk/1.1.6/test_package/conanfile.py
+++ b/recipes/vcvrack-sdk/1.1.6/test_package/conanfile.py
@@ -1,0 +1,35 @@
+import os
+from conans import ConanFile, CMake, AutoToolsBuildEnvironment, tools
+from conans.tools import os_info, SystemPackageTool
+
+
+class VCVRackSDKTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "make"
+
+    def build(self):
+        self._buildWithCMake()
+        self._buildWithMake()
+
+    def test(self):
+        self.output.info("check for helper.py availability")
+        self.run("helper.py")
+        self.output.info("cleanup Make build artifacts")
+        plugin_suffix = "dylib"
+        if self.settings.os == "Windows":
+            plugin_suffix = "dll"
+        if self.settings.os == "Linux":
+            plugin_suffix = "so"
+        os.remove(os.path.join("..", "..", "plugin.{}".format(plugin_suffix)))
+
+    def _buildWithCMake(self):
+        self.output.info("building test plugin with CMake ...")
+        cmake = CMake(self)
+        cmake.configure(build_dir="cmake-build")
+        cmake.build(build_dir="cmake-build")
+
+    def _buildWithMake(self):
+        self.output.info("building test plugin with Make ...")
+        with tools.chdir("../.."):
+            autotools = AutoToolsBuildEnvironment(self)
+            autotools.make()

--- a/recipes/vcvrack-sdk/1.1.6/test_package/plugin.json
+++ b/recipes/vcvrack-sdk/1.1.6/test_package/plugin.json
@@ -1,0 +1,24 @@
+{
+  "slug": "test",
+  "name": "test",
+  "version": "1.0.0",
+  "license": "",
+  "brand": "",
+  "author": "",
+  "authorEmail": "",
+  "authorUrl": "",
+  "pluginUrl": "",
+  "manualUrl": "",
+  "sourceUrl": "",
+  "donateUrl": "",
+  "changelogUrl": "",
+  "modules": [
+    {
+      "slug": "test",
+      "name": "test",
+      "description": "",
+      "tags": ["test"],
+      "manualUrl": ""
+    }
+  ]
+}

--- a/recipes/vcvrack-sdk/1.1.6/test_package/plugintest.cpp
+++ b/recipes/vcvrack-sdk/1.1.6/test_package/plugintest.cpp
@@ -1,0 +1,75 @@
+#include <rack.hpp>
+
+//check for availability of deps/include from SDK
+#include <speex/speex_resampler.h>
+#include <nanovg_gl.h>
+
+
+namespace vcvracksdktest {
+
+class TestModule : public rack::Module
+{
+ public:
+
+  enum ParamIds {
+    NUM_PARAMS
+  };
+
+  enum InputIds {
+    NUM_INPUTS
+  };
+
+  enum OutputIds {
+    NUM_OUTPUTS
+  };
+
+  enum LightIds {
+    NUM_LIGHTS
+  };
+
+  TestModule() : Module()
+  {
+    config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
+  }
+
+  virtual ~TestModule() = default;
+
+  void process(const ProcessArgs& args) override { }
+};
+
+class TestWidget : public rack::ModuleWidget
+{
+ public:
+
+  TestWidget(TestModule* module) : ModuleWidget(), _module(module)
+  {
+    setModule(module);
+  }
+
+  virtual ~TestWidget() = default;
+
+  void step() override
+  {
+    ModuleWidget::step();
+  }
+
+  void draw(const DrawArgs& args) override
+  {
+    ModuleWidget::draw(args);
+  }
+
+ private:
+
+  TestModule* _module;
+};
+
+}
+
+rack::plugin::Plugin* pluginInstance;
+
+rack::Model* modelTestPlugin = rack::createModel<vcvracksdktest::TestModule, vcvracksdktest::TestWidget>("TestModule");
+
+void init(rack::plugin::Plugin* p) {
+   pluginInstance = p;
+   p->addModel(modelTestPlugin);
+}


### PR DESCRIPTION
This is a conan recipe for [VCV Rack](https://vcvrack.com) SDK.

The origin of this recipe is https://github.com/qno/conan-vcvrack-sdk

Specify library name and version:  **vcvrack-sdk/1.1.6**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

