### PR TITLE
Add new recipe - bitserializer-cpprestjson

### DIFF
--- a/recipes/bitserializer-cpprestjson/all/conandata.yml
+++ b/recipes/bitserializer-cpprestjson/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.9":
+    sha256: 6325dbc632229df24092b3f9779fd673b54f6a48ecfbf29488df349fbcf60475
+    url: https://bitbucket.com/Pavel_Kisliak/BitSerializer/get/0.9.tar.gz

--- a/recipes/bitserializer-cpprestjson/all/conanfile.py
+++ b/recipes/bitserializer-cpprestjson/all/conanfile.py
@@ -1,0 +1,55 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class BitserializerConan(ConanFile):
+    name = "bitserializer-cpprestjson"
+    description = "C++ 17 library for serialization, module for support JSON (implementation based on the CppRestSDK library)"
+    topics = ("serialization", "json")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://bitbucket.org/Pavel_Kisliak/bitserializer"
+    license = "MIT"
+    settings = ("compiler",)
+    no_copy_source = True
+    requires = ("bitserializer/0.9", "cpprestsdk/2.10.16")
+
+    @property
+    def _supported_compilers(self):
+        return {
+            "gcc": "8",
+            "clang": "7",
+            "Visual Studio": "15",
+            "apple-clang": "10",
+        }
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def configure(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            tools.check_min_cppstd(self, "17")
+        try:
+            minimum_required_compiler_version = self._supported_compilers[str(self.settings.compiler)]
+            if tools.Version(self.settings.compiler.version) < minimum_required_compiler_version:
+                raise ConanInvalidConfiguration("This package requires c++17 support. The current compiler does not support it.")
+        except KeyError:
+            self.output.warn("This recipe has no support for the current compiler. Please consider adding it.")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        # Find and rename folder in the extracted sources
+        # This workaround used in connection that zip-archive from BitBucket contains folder with some hash in name
+        for dirname in os.listdir(self.source_folder):
+            if "-bitserializer-" in dirname:
+                os.rename(dirname, self._source_subfolder)
+                break
+
+    def package(self):
+        include_folder = os.path.join(self._source_subfolder, "archives")
+        self.copy(pattern="license.txt", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern=os.path.join("bitserializer_cpprest_json", "*.h"), dst="include", src=include_folder)
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/bitserializer-cpprestjson/all/test_package/CMakeLists.txt
+++ b/recipes/bitserializer-cpprestjson/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/recipes/bitserializer-cpprestjson/all/test_package/conanfile.py
+++ b/recipes/bitserializer-cpprestjson/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/bitserializer-cpprestjson/all/test_package/test_package.cpp
+++ b/recipes/bitserializer-cpprestjson/all/test_package/test_package.cpp
@@ -1,0 +1,20 @@
+#include <iostream>
+#include <sstream>
+#include "bitserializer/bit_serializer.h"
+#include "bitserializer_cpprest_json/cpprest_json_archive.h"
+
+using namespace BitSerializer;
+using JsonArchive = BitSerializer::Json::CppRest::JsonArchive;
+
+int main() {
+	BitSerializer::SerializationOptions serializationOptions;
+	serializationOptions.streamOptions.writeBom = false;
+
+	std::string testObj = "BitSerializer JSON archive (based on CppRestJson)";
+
+	std::stringstream outputStream;
+	BitSerializer::SaveObject<JsonArchive>(testObj, outputStream, serializationOptions);
+	std::cout << outputStream.str() << std::endl;
+
+	return 0;
+}

--- a/recipes/bitserializer-cpprestjson/config.yml
+++ b/recipes/bitserializer-cpprestjson/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.9":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version: bitserializer-cpprestjson/0.9

Please merge after core library bitserializer/0.9 which is in separate PR #1599.

Description: C++ 17 library for serialization, module for support JSON (implementation based on the CppRestSDK library)
Home page: https://bitbucket.org/Pavel_Kisliak/bitserializer

- [ √ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ √ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ √ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ √ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
