### PR TITLE
[libx265] Remove register classifier (deprecated in C++17)

### DIFF
--- a/recipes/libx265/all/conandata.yml
+++ b/recipes/libx265/all/conandata.yml
@@ -1,4 +1,8 @@
 sources:
-  "3.2.1":
+  3.2.1:
     url: "https://bitbucket.org/multicoreware/x265/downloads/x265_3.2.1.tar.gz"
     sha256: "7cf8ed2927fcb2914cdca51c974594770da705cb43288beea62b69c53725b5d7"
+patches:
+  3.2.1:
+    - patch_file: "patches/0001-remove_register_classifier.patch"
+      base_path: "source_subfolder"

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -9,7 +9,7 @@ class Libx265Conan(ConanFile):
     topics = ("conan", "libx265", "codec", "video", "H.265")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = " https://bitbucket.org/multicoreware/x265"
-    exports_sources = "CMakeLists.txt"
+    exports_sources = ["CMakeLists.txt", "patches/*"]
     generators = "cmake"
     license = ("GPL-2.0-only", "commercial")  # https://bitbucket.org/multicoreware/x265/src/default/COPYING
     settings = "os", "arch", "compiler", "build_type"
@@ -49,6 +49,9 @@ class Libx265Conan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("x265_{}".format(self.version), self._source_subfolder)
+        if self.version in self.conan_data["patches"]:
+            for patch in self.conan_data["patches"][self.version]:
+                tools.patch(**patch)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -49,9 +49,6 @@ class Libx265Conan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("x265_{}".format(self.version), self._source_subfolder)
-        if self.version in self.conan_data["patches"]:
-            for patch in self.conan_data["patches"][self.version]:
-                tools.patch(**patch)
 
     def _configure_cmake(self):
         if self._cmake:
@@ -82,6 +79,8 @@ class Libx265Conan(ConanFile):
                 "list(APPEND PLATFORM_LIBS pthread)", "")
             tools.replace_in_file(cmakelists,
                 "list(APPEND PLATFORM_LIBS rt)", "")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
 
     def build(self):
         self._patch_sources()

--- a/recipes/libx265/all/patches/0001-remove_register_classifier.patch
+++ b/recipes/libx265/all/patches/0001-remove_register_classifier.patch
@@ -1,0 +1,13 @@
+diff --git a/source/common/md5.cpp b/source/common/md5.cpp
+index 285b44a..c4964e7 100644
+--- a/source/common/md5.cpp
++++ b/source/common/md5.cpp
+@@ -185,7 +185,7 @@ void MD5Final(MD5Context *ctx, uint8_t *digest)
+  */
+ void MD5Transform(uint32_t *buf, uint32_t *in)
+ {
+-    register uint32_t a, b, c, d;
++    uint32_t a, b, c, d;
+ 
+     a = buf[0];
+     b = buf[1];


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**
- [✓] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [✓] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [✓] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [✓] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This adds a patch to make it possible to compile with C++17 flag with newer versions of clang which would otherwise fail due to deprecation error. I've also submitted a patch to the upstream ([see here](https://bitbucket.org/multicoreware/x265/issues/544/register-storage-class-specifier)).