### PR TITLE
Decrease debug level for boost package

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -53,7 +53,7 @@ class BoostConan(ConanFile):
         "lzma": [True, False],
         "zstd": [True, False],
         "segmented_stacks": [True, False],
-        "debug_level": [i for i in range(1, 14)],
+        "debug_level": [i for i in range(0, 14)],
         "pch": [True, False],
         "extra_b2_flags": "ANY",  # custom b2 flags
         "i18n_backend": ["iconv", "icu", None],
@@ -80,7 +80,7 @@ class BoostConan(ConanFile):
         'lzma': False,
         'zstd': False,
         'segmented_stacks': False,
-        "debug_level": 2,
+        "debug_level": 0,
         'pch': True,
         'extra_b2_flags': 'None',
         "i18n_backend": 'iconv',
@@ -383,7 +383,9 @@ class BoostConan(ConanFile):
         folder = os.path.join(self.source_folder, self._folder_name, 'tools', 'bcp')
         with tools.vcvars(self.settings) if self._is_msvc else tools.no_op():
             with tools.chdir(folder):
-                command = "%s -j%s --abbreviate-paths -d2 toolset=%s" % (self._b2_exe, tools.cpu_count(), self._toolset)
+                command = "%s -j%s --abbreviate-paths toolset=%s" % (self._b2_exe, tools.cpu_count(), self._toolset)
+                if self.options.debug_level:
+                    command.append(" -d%d" % self.options.debug_level)
                 self.output.warn(command)
                 self.run(command)
 
@@ -662,8 +664,9 @@ class BoostConan(ConanFile):
         flags.extend(["install",
                       "--prefix=%s" % self.package_folder,
                       "-j%s" % tools.cpu_count(),
-                      "--abbreviate-paths",
-                      "-d%s" % str(self.options.debug_level)])
+                      "--abbreviate-paths"])
+        if self.options.debug_level:
+            flags.append("-d%d" % self.options.debug_level)
         return flags
 
     @property

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -385,7 +385,7 @@ class BoostConan(ConanFile):
             with tools.chdir(folder):
                 command = "%s -j%s --abbreviate-paths toolset=%s" % (self._b2_exe, tools.cpu_count(), self._toolset)
                 if self.options.debug_level:
-                    command.append(" -d%d" % self.options.debug_level)
+                    command += " -d%d" % self.options.debug_level
                 self.output.warn(command)
                 self.run(command)
 


### PR DESCRIPTION
Specify library name and version:  **Boost**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

There is this comment around line 434:
```
# -d2 is to print more debug info and avoid travis timing out without output
```
However the package is not built with Travis anymore, and if it is - I believe such option should go to `CONAN_OPTIONS` or like in `.travis.yml`. During our GHA runs, Boost builds (debug+release, static+shared) result in +-60 MB of logs per compiler, more than 400k lines long, which is... quite unreadable, esp. since it mostly consists of lines like
```
2020-05-12T08:37:55.2949892Z common.copy /home/conan/.conan/data/boost/1.69.0/_/_/package/28221a1f80ccfa6a971856cbd200b515160f78b1/include/boost/io_fwd.hpp
2020-05-12T08:37:55.2951451Z 
2020-05-12T08:37:55.2954182Z     cp "/home/conan/.conan/data/boost/1.69.0/_/_/source/boost_1_69_0/boost/io_fwd.hpp"  "/home/conan/.conan/data/boost/1.69.0/_/_/package/28221a1f80ccfa6a971856cbd200b515160f78b1/include/boost/io_fwd.hpp"
```

Without `-d2`, the logs become about 120k lines and 20 MB. I would also probably even got rid of those `common.copy` lines, since they take about 80% of the log, but this seems to be the default behavior.