### PR TITLE
Fix typo in units recipe

### DIFF
--- a/recipes/units/all/conanfile.py
+++ b/recipes/units/all/conanfile.py
@@ -29,7 +29,7 @@ class UnitsConan(ConanFile):
         }.get(str(self.settings.compiler))
         if not minimum_version:
             self.output.warn(
-                "Unknown compiler: assuminging compiler supports C++14")
+                "Unknown compiler: assuming compiler supports C++14")
         else:
             if Version(self.settings.compiler.version) < minimum_version:
                 raise ConanInvalidConfiguration(


### PR DESCRIPTION
Specify library name and version:  **units/x.x**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

