### PR TITLE
Remove UTF-8 chars when no encoding is specified

### DIFF
--- a/recipes/nasm/all/conanfile.py
+++ b/recipes/nasm/all/conanfile.py
@@ -45,7 +45,7 @@ class NASMConan(ConanFile):
             elif self.settings.arch_build == "x86_64":
                 self._autotools.flags.append("-m64")
             self._autotools.configure(configure_dir=self._source_subfolder)
-            # GCC9 - ‘pure’ attribute on function returning ‘void’
+            # GCC9 - 'pure' attribute on function returning 'void'
             tools.replace_in_file("Makefile", "-Werror=attributes", "")
         return self._autotools
 


### PR DESCRIPTION
According to PEP 263, Unicode literals should only appear in Python code if the encoding is declared on one of the first two lines of the source file. Without such a declaration, the Unicode literals on line 48 cause a syntax error for some Python 2 interpreters that prevents a successful build.

This is not the only solution to the problem; a good alternative would be this comment line at the top of the file:

    # coding=utf-8

Specify library name and version:  **nasm/2.14**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I apologize, but I have not been able to reproduce the problem locally. My Travis-CI builds on Linux, Mac, and Windows are all failing right now because the Python interpreter cannot handle this UTF-8 comment.

I can only assume that the unicode single-quotes in this comment were a cut-and-paste error. I don't think they add much value to the codebase. If you disagree, I am perfectly amenable to the alternate 'encoding definition' solution.

Thank you for all your work maintaining this project; we all appreciate and depend on it!

**Edit:** Changed some language to reflect the fact that this only affects Python 2 interpreters. Thanks @Croydon!

closes https://github.com/conan-io/conan-center-index/pull/1678