### PR TITLE
fix weird chars in nasm

### DIFF
--- a/recipes/nasm/all/conanfile.py
+++ b/recipes/nasm/all/conanfile.py
@@ -45,7 +45,7 @@ class NASMConan(ConanFile):
             elif self.settings.arch_build == "x86_64":
                 self._autotools.flags.append("-m64")
             self._autotools.configure(configure_dir=self._source_subfolder)
-            # GCC9 - ‘pure’ attribute on function returning ‘void’
+            # GCC9 - "pure" attribute on function returning "void"
             tools.replace_in_file("Makefile", "-Werror=attributes", "")
         return self._autotools
 


### PR DESCRIPTION
Nasm is failing in some conditions, due to weird chars: https://twitter.com/lefticus/status/1262770161410400256?s=20

> ERROR: Error loading conanfile at '/home/travis/.conan/data/nasm/2.14/_/_/export/conanfile.py': Unable to load conanfile in /home/travis/.conan/data/nasm/2.14/_/_/export/conanfile.py
  File "/home/travis/.conan/data/nasm/2.14/_/_/export/conanfile.py", line 48
SyntaxError: Non-ASCII character '\xe2' in file /home/travis/.conan/data/nasm/2.14/_/_/export/conanfile.py on line 48, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

From https://travis-ci.org/github/lefticus/cpp_weekly_game_project/jobs/688565969#L734-L736

