### PR TITLE
FIX: gentoo fails to compile b2 the recipe

### DIFF
--- a/recipes/b2/all/conanfile.py
+++ b/recipes/b2/all/conanfile.py
@@ -33,7 +33,7 @@ class B2Conan(ConanFile):
         command = os.path.join(
             engine_dir, "b2.exe" if use_windows_commands else "b2")
         full_command = \
-            "{0} --prefix=../output --abbreviate-paths install".format(
+            "{0} --ignore-site-config --prefix=../output --abbreviate-paths install".format(
                 command)
         self.run(full_command)
 


### PR DESCRIPTION
Gentoo has a site config with Gentoo specific content that only the
patched bjam of Gentoo can understand. bjam has special option to ignore
site configs.

Specify library name and version:  b2/4.2.0

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.