### PR TITLE
Add IXWebSocket 9.6.4

### DIFF
--- a/recipes/ixwebsocket/all/conandata.yml
+++ b/recipes/ixwebsocket/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "9.1.9":
     url: "https://github.com/machinezone/IXWebSocket/archive/v9.1.9.zip"
     sha256: "dd83b4855882b538ca9782b42e80be4ebf96f978974e2615def673fb9d58c33b"
+  "9.6.3":
+    url: "https://github.com/machinezone/IXWebSocket/archive/v9.6.3.zip"
+    sha256: "b8bfbf566456b9aa69dbeda74c3898b744034498c8265edf76ef52c59ee5b08b"

--- a/recipes/ixwebsocket/all/conandata.yml
+++ b/recipes/ixwebsocket/all/conandata.yml
@@ -5,6 +5,6 @@ sources:
   "9.1.9":
     url: "https://github.com/machinezone/IXWebSocket/archive/v9.1.9.zip"
     sha256: "dd83b4855882b538ca9782b42e80be4ebf96f978974e2615def673fb9d58c33b"
-  "9.6.3":
-    url: "https://github.com/machinezone/IXWebSocket/archive/v9.6.3.zip"
-    sha256: "b8bfbf566456b9aa69dbeda74c3898b744034498c8265edf76ef52c59ee5b08b"
+  "9.6.4":
+    url: "https://github.com/machinezone/IXWebSocket/archive/v9.6.4.zip"
+    sha256: "b249b3bd0323f5b9aa4808852266f17073afd9f1f3a89815205a39604230f0ea"

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -73,7 +73,8 @@ class IXWebSocketConan(ConanFile):
         # User-selectable options
         cmake.definitions["USE_TLS"] = self.options.tls != False
         cmake.definitions["USE_MBED_TLS"] = self.options.tls == "mbedtls"
-        cmake.definitions["USE_OPENSSL"] = self.options.tls == "openssl"
+        cmake.definitions["USE_OPEN_SSL"] = self.options.tls == "openssl"
+        # Apple configures itself
 
         cmake.configure()
         return cmake

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -49,7 +49,7 @@ class IXWebSocketConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires.add("zlib/1.2.11")
+        self.requires("zlib/1.2.11")
 
         if not self.options.tls:
             # if we're not using TLS of some or another type, then no libraries after this
@@ -59,9 +59,9 @@ class IXWebSocketConan(ConanFile):
         # Invalid configurations have been eliminated by this point, so it should be safe
         # to add the dependencies without any further checks
         if self.options.tls == "openssl":
-            self.requires.add("openssl/1.1.1e")
+            self.requires("openssl/1.1.1e")
         elif self.options.tls == "mbedtls":
-            self.requires.add("mbedtls/2.16.3-apache")
+            self.requires("mbedtls/2.16.3-apache")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/ixwebsocket/config.yml
+++ b/recipes/ixwebsocket/config.yml
@@ -3,5 +3,5 @@ versions:
     folder: all
   "9.1.9":
     folder: all
-  "9.6.3":
+  "9.6.4":
     folder: all

--- a/recipes/ixwebsocket/config.yml
+++ b/recipes/ixwebsocket/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "9.1.9":
     folder: all
+  "9.6.3":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **ixwebsocket/9.6.4**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Meta: also replaces `requires.add()` with `requires()`, as per KB-H044
Bugfix with OpenSSL: the CMake parameter is USE_OPEN_SSL, not USE_OPENSSL. My bad :')