### PR TITLE
Add doxygen/1.8.17

### DIFF
--- a/recipes/doxygen/all/conandata.yml
+++ b/recipes/doxygen/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "1.8.17":
+    - url: "http://downloads.sourceforge.net/project/doxygen/rel-1.8.17/doxygen-1.8.17.windows.bin.zip"
+      sha256: "5adf183f2591fc6590e57e11c929758bda6229486fce17aee248329da85e34fa"
+    - url: "http://downloads.sourceforge.net/project/doxygen/rel-1.8.17/doxygen-1.8.17.windows.x64.bin.zip"
+      sha256: "49051ae149715b765d94d51eb8c4c6043636464cb27ba5f75c14f71ab81d8740"
+    - url: "http://downloads.sourceforge.net/project/doxygen/rel-1.8.17/Doxygen-1.8.17.dmg"
+      sha256: "bf051b2c26ad5569efe9ca09396199340d03c6c96d61b730d50d5cd8f547425b"
+    - url: "http://downloads.sourceforge.net/project/doxygen/rel-1.8.17/doxygen-1.8.17.linux.bin.tar.gz"
+      sha256: "2ca403e7b9c37c6ca7d9a44c717ba5388500b99ee707d474d159ced11c53242c"

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -10,7 +10,7 @@ class DoxygenInstallerConan(ConanFile):
     topics = ("conan", "doxygen", "installer", "devtool", "documentation")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/doxygen/doxygen"
-    license = "GPL-2.0-only"
+    license = "GPL-2.0-or-later"
 
     settings = {"os", "arch"}
 

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -1,0 +1,83 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+import shutil
+
+
+class DoxygenInstallerConan(ConanFile):
+    name = "doxygen"
+    version = "1.8.17"
+    description = "A documentation system for C++, C, Java, IDL and PHP --- Note: Dot is disabled in this package"
+    topics = ("conan", "doxygen", "installer", "devtool", "documentation")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/doxygen/doxygen"
+    author = "Inexor <info@inexor.org>"
+    license = "GPL-2.0-only"
+
+    settings = {
+        "os_build": ["Windows", "Linux", "Macos"],
+        "arch_build": ["x86", "x86_64"]
+    }
+#   options = {"build_from_source": [False, True]} NOT SUPPORTED YET
+#   default_options = "build_from_source=False"
+
+    def config(self):
+        if self.settings.os_build in ["Linux", "Macos"] and self.settings.arch_build == "x86":
+            raise ConanInvalidConfiguration("x86 is not supported on Linux or Macos")
+
+    def unpack_dmg(self, dest_file):
+        mount_point = os.path.join(self.build_folder, "mnt")
+        tools.mkdir(mount_point)
+        self.run("hdiutil attach -mountpoint %s %s" % (mount_point, dest_file))
+        try:
+            for program in ["doxygen", "doxyindexer", "doxysearch.cgi"]:
+                shutil.copy(os.path.join(mount_point, "Doxygen.app", "Contents",
+                                         "Resources", program), self.build_folder)
+            shutil.copy(os.path.join(mount_point, "Doxygen.app", "Contents",
+                                    "Frameworks", "libclang.dylib"), self.build_folder)
+        finally:
+            self.run("diskutil eject %s" % (mount_point))
+            tools.rmdir(mount_point)
+
+    def build(self):
+        os_name = {
+            "Windows": "windows.bin" if self.settings.arch_build == "x86" else "windows.x64.bin",
+            "Macos": ".dmg",
+            "Linux": "linux"
+        }
+        dest_file = None
+        for data in self.conan_data["sources"][self.version]:
+            sha = data["sha256"]
+            url = data["url"]
+            filename = url[url.rfind("/") + 1:]
+            self.output.info("Downloading: {}".format(url))
+            tools.download(url, filename)
+            tools.check_sha256(filename, sha)
+            if os_name[str(self.settings.os_build)] in url:
+                dest_file = filename
+
+        if not dest_file:
+            raise ConanInvalidConfiguration("could not find source file fo the configuration")
+
+        if self.settings.os_build == "Macos":
+            self.unpack_dmg(dest_file)
+            # Redirect the path of libclang.dylib to be adjacent to the doxygen executable, instead of in Frameworks
+            self.run('install_name_tool -change "@executable_path/../Frameworks/libclang.dylib" "@executable_path/libclang.dylib" doxygen')
+        else:
+            tools.unzip(dest_file)
+
+    def package(self):
+        if self.settings.os_build == "Linux":
+            srcdir = "doxygen-{}/bin".format(self.version)
+            self.copy("*", dst="bin", src=srcdir)
+
+        self.copy("doxygen", dst="bin")
+        self.copy("doxyindexer", dst="bin")
+        self.copy("doxysearch.cgi", dst="bin")
+        self.copy("*.exe", dst="bin")
+        self.copy("*.dylib", dst="bin")
+        self.copy("*.dll", dst="bin")
+
+    def package_info(self):
+        bindir = os.path.join(self.package_folder, "bin")
+        self.env_info.PATH.append(bindir)

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -58,6 +58,8 @@ class DoxygenInstallerConan(ConanFile):
         if not dest_file:
             raise ConanInvalidConfiguration("could not find source file fo the configuration")
 
+        tools.unzip("doxygen-{}.linux.bin.tar.gz".format(self.version), pattern="*LICENSE")
+
         if self.settings.os_build == "Macos":
             self.unpack_dmg(dest_file)
             # Redirect the path of libclang.dylib to be adjacent to the doxygen executable, instead of in Frameworks
@@ -76,6 +78,7 @@ class DoxygenInstallerConan(ConanFile):
         self.copy("*.exe", dst="bin")
         self.copy("*.dylib", dst="bin")
         self.copy("*.dll", dst="bin")
+        self.copy("*LICENSE", dst="licenses", keep_path=False)
 
     def package_info(self):
         bindir = os.path.join(self.package_folder, "bin")

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -11,7 +11,6 @@ class DoxygenInstallerConan(ConanFile):
     topics = ("conan", "doxygen", "installer", "devtool", "documentation")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/doxygen/doxygen"
-    author = "Inexor <info@inexor.org>"
     license = "GPL-2.0-only"
 
     settings = {

--- a/recipes/doxygen/all/test_package/CMakeLists.txt
+++ b/recipes/doxygen/all/test_package/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
-cmake_policy(SET CMP0057 NEW) # if IN_LIST
+cmake_minimum_required(VERSION 3.3)
 
 include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
 

--- a/recipes/doxygen/all/test_package/CMakeLists.txt
+++ b/recipes/doxygen/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8.12)
+cmake_policy(SET CMP0057 NEW) # if IN_LIST
+
+include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
+
+project(test_package)
+
+find_package(Doxygen REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+
+doxygen_add_docs(docs test_package.cpp ALL COMMENT "generate HTML")

--- a/recipes/doxygen/all/test_package/conanfile.py
+++ b/recipes/doxygen/all/test_package/conanfile.py
@@ -1,0 +1,13 @@
+from conans import ConanFile, CMake, tools
+
+class TestPackageConan(ConanFile):
+    generators = "cmake_paths"
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.output.info("Version:")
+            self.run("doxygen --version", run_environment=True)

--- a/recipes/doxygen/all/test_package/test_package.cpp
+++ b/recipes/doxygen/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+/// \brief just a simple main fuction for the hello world
+int main()
+{
+    std::cout << "bincrafters" << std::endl;
+}

--- a/recipes/doxygen/config.yml
+++ b/recipes/doxygen/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.8.17":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **doxygen/1.8.17**

This is a port of the bincrafters repo https://github.com/bincrafters/conan-doxygen_installer (stable/1.8.17). I implemented the same tactic as in the nodejs recipe (which is already in the conan-center-index) to download the sources (immutable source).

I've tested it locally on windows 10 x64.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
