### PR TITLE
[dlib] No need to require 'zlib'

### DIFF
--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -59,8 +59,6 @@ class DlibConan(ConanFile):
             raise ConanInvalidConfiguration("dlib can not be built as a shared library with Visual Studio")
 
     def requirements(self):
-        self.requires("zlib/1.2.11")
-
         if self.options.with_gif:
             self.requires("giflib/5.1.4")
         if self.options.with_jpeg:


### PR DESCRIPTION
Specify library name and version:  **dlib/all**

ZLib is needed only if using `libpng`, and `zlib` is a requirement of `libpng`.

https://github.com/davisking/dlib/blob/master/dlib/CMakeLists.txt#L432
