### PR TITLE
Fix android compile error "cannot find -lpthread" when use asio

### DIFF
--- a/recipes/asio/all/conanfile.py
+++ b/recipes/asio/all/conanfile.py
@@ -29,7 +29,7 @@ class Asio(ConanFile):
 
     def package_info(self):
         self.cpp_info.defines.append('ASIO_STANDALONE')
-        if str(self.settings.os) in ["Linux", "Android"]:
+        if str(self.settings.os) in ["Linux"]:
             self.cpp_info.libs.append('pthread')
 
     def package_id(self):


### PR DESCRIPTION
Specify library name and version:  **asio/1.12.2**

compile error android library when I use asio
```
clang50++: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
/home/screenshare/Android/android-19-armeabi-v7a/lib/gcc/arm-linux-androideabi/4.9.x/../../../../arm-linux-androideabi/bin/ld: error: cannot find -lpthread
clang50++: error: linker command failed with exit code 1 (use -v to see invocation)
``` 

According to this [so](https://stackoverflow.com/questions/38666609/cant-find-lpthread-when-cross-compile-to-arm), there is no need to link pthread under android.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

