### PR TITLE
proj 7.x.x: add shell32 to system libs on Windows

### DIFF
--- a/recipes/proj/7.x.x/conanfile.py
+++ b/recipes/proj/7.x.x/conanfile.py
@@ -97,6 +97,8 @@ class ProjConan(ConanFile):
             self.cpp_info.system_libs.append("m")
             if self.options.threadsafe:
                 self.cpp_info.system_libs.append("pthread")
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.append("shell32")
         if not self.options.shared and self._stdcpp_library:
             self.cpp_info.system_libs.append(self._stdcpp_library)
         if self.options.shared and self.settings.compiler == "Visual Studio":


### PR DESCRIPTION
Specify library name and version:  **proj/7.x.x**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

https://github.com/OSGeo/PROJ/blob/6cb4a50283906c09b90afb3898e5242154045929/src/filemanager.cpp#L1203