### PR TITLE
Add qbs/1.18.0 recipe

### DIFF
--- a/recipes/qbs/all/conandata.yml
+++ b/recipes/qbs/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "1.18.0":
+    - url: "http://download.qt.io/official_releases/qbs/1.18.0/qbs-src-1.18.0.tar.gz"
+      sha256: 3d0211e021bea3e56c4d5a65c789d11543cc0b6e88f1bfe23c2f8ebf0f89f8d4
+
+patches:
+  "1.18.0":
+    - patch_file: "patches/Id906423bd0d8d85b7a4f3342df4b9d39f60c4e36.patch"

--- a/recipes/qbs/all/conanfile.py
+++ b/recipes/qbs/all/conanfile.py
@@ -1,0 +1,125 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+class QbsConan(ConanFile):
+    name = "qbs"
+    description = "The Qbs build system"
+    topics = ("conan", "qbs", "build", "automation")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://qbs.io"
+    license = "LGPL-2.1-only", "LGPL-3.0-only", "Nokia-Qt-exception-1.1"
+    settings = "arch", "build_type", "compiler", "os"
+    no_copy_source=True
+    exports = ["patches/*.patch"]
+    build_policy = "missing"
+
+    build_requires = "qt/5.15.2"
+
+    def build_requirements(self):
+        if tools.os_info.is_windows and self.settings.compiler == "Visual Studio":
+            self.build_requires("jom/1.1.3")
+
+    def configure(self):
+        if self.settings.os not in ["Windows", "Linux", "Macos"]:
+            raise ConanInvalidConfiguration("The OS ({}) is not supported by {}.".format(self.settings.os, self.name))
+        if self.settings.arch not in ["x86_64"]:
+            raise ConanInvalidConfiguration("The arch ({}) is not supported by {}.".format(self.settings.arch, self.name))
+
+        self.options["qt"].gui = False
+        self.options["qt"].openssl = False
+        self.options["qt"].qtscript = True
+        self.options["qt"].shared = False
+        self.options["qt"].widgets = False
+        self.options["qt"].with_odbc = False
+        self.options["qt"].with_pq = False
+        self.options["qt"].with_sqlite3 = False
+        self.options["qt"].with_zstd = False
+        for dep, options in self._data["options"].items():
+            for key, value in options.items():
+                setattr(self.options[dep], key, value)
+
+        minimal_cpp_standard = "11"
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, minimal_cpp_standard)
+
+        minimal_version = {
+            "gcc": "5.0",
+            "clang": "6.0",
+            "apple-clang": "11",
+            "Visual Studio": "16",
+        }
+
+        compiler = str(self.settings.compiler)
+        if compiler not in minimal_version:
+            self.output.warn(
+                "{} recipe lacks information about the {} compiler standard version support".format(self.name, compiler))
+            self.output.warn(
+                "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
+            return
+
+        version = tools.Version(self.settings.compiler.version)
+        if version < minimal_version[compiler]:
+            raise ConanInvalidConfiguration(
+                "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
+
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version][0])
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch, base_path="qbs-src-%s" % self.version)
+
+    def build(self):
+        qmake = os.path.join(self.deps_cpp_info["qt"].bin_paths[0], "qmake")
+        source_dirpath = os.path.join(self.source_folder, "qbs-src-%s" % self.version)
+        project_filepath = os.path.join(source_dirpath, "qbs.pro")
+        args = [
+            "-r", project_filepath,
+            "QT-=gui",
+            "CONFIG+=release",
+            "CONFIG-=debug",
+            "CONFIG-=debug_and_release",
+            "CONFIG+=nomake_tests",
+            "CONFIG+=qbs_no_dev_install",
+            "CONFIG+=qbs_no_man_install",
+            "QBS_INSTALL_PREFIX=/"
+        ]
+        ncores = tools.cpu_count()
+
+        with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
+            self.run("%s %s" % (qmake, " ".join(args)), run_environment=True)
+            self.run("%s -j%s" % (self._data["build_tool"], ncores), run_environment=True)
+
+    def package(self):
+        install_root = os.path.join(self.package_folder, "bin")
+        self.run("%s install INSTALL_ROOT=%s" % (self._data["build_tool"], install_root))
+        # This recipe builds Qbs statically, the libs are not needed.
+        tools.rmdir(os.path.join(install_root, "lib"))
+        tools.rmdir(os.path.join(install_root, "share", "qbs", "examples"))
+        self.copy(src="qbs-src-%s" % self.version, dst="licenses", pattern="LICENSE*")
+        self.copy(src="qbs-src-%s" % self.version, dst="licenses", pattern="LGPL*")
+
+    def package_id(self):
+        del self.info.settings.compiler
+
+    def package_info(self):
+        binpath = os.path.join(self.package_folder, 'bin/bin')
+        self.env_info.PATH.append(binpath)
+
+    @property
+    def _data(self):
+        data = {
+            'Linux': {
+                "build_tool": "make",
+                'options': {}
+            },
+            'Macos': {
+                "build_tool": "make",
+                'options': {}
+            },
+            'Windows': {
+                "build_tool": "jom" if self.settings.compiler == "Visual Studio" else "mingw32-make",
+                'options': {}
+            }
+        }
+        return data[str(self.settings.os)]

--- a/recipes/qbs/all/patches/Id906423bd0d8d85b7a4f3342df4b9d39f60c4e36.patch
+++ b/recipes/qbs/all/patches/Id906423bd0d8d85b7a4f3342df4b9d39f60c4e36.patch
@@ -1,0 +1,36 @@
+From 46136e470fc8852ba46f542ebcf92e240cbb78cb Mon Sep 17 00:00:00 2001
+From: Richard Weickelt <richard@weickelt.de>
+Date: Thu, 28 Jan 2021 22:17:19 +0100
+Subject: [PATCH] Fix static build with qmake
+
+Building Qbs statically did not work since Qbs 1.17 because the application
+target did not correctly track the plugins as a dependency. The condition in
+qbs.pro was simply wrong.
+
+Change-Id: Id906423bd0d8d85b7a4f3342df4b9d39f60c4e36
+---
+ qbs.pro | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/qbs.pro b/qbs.pro
+index 565a6a632..0ec8d07b9 100644
+--- a/qbs.pro
++++ b/qbs.pro
+@@ -35,12 +35,10 @@ msbuildlib.subdir = src/lib/msbuild
+ msbuildlib.depends = corelib
+ src_app.subdir = src/app
+ src_app.depends = corelib
++CONFIG(static, static|shared): src_app.depends += src_plugins
+ src_libexec.subdir = src/libexec
+ src_plugins.subdir = src/plugins
+-CONFIG(shared, static|shared) {
+-    src_plugins.depends = corelib
+-    src_app.depends += src_plugins
+-}
++CONFIG(shared, static|shared): src_plugins.depends = corelib
+ src_plugins.depends += msbuildlib
+ tests.depends = static_res
+ static_res.file = static-res.pro
+-- 
+2.25.1
+

--- a/recipes/qbs/all/test_package/conanfile.py
+++ b/recipes/qbs/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from six import StringIO
+from conans import ConanFile, tools
+
+class QbsTestConan(ConanFile):
+    settings = {
+        "arch": ["x86_64"],
+        "os": ["Linux", "Macos", "Windows"]
+    }
+
+    def build(self):
+        args = ["--file %s" % self.source_folder]
+        self.run("qbs build %s" % " ".join(args), run_environment=True)
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            # Run the build result
+            self.run("qbs run -p test", run_environment=True)
+
+            output = StringIO()
+            self.run("qbs show-version", run_environment=True)
+            self.run("qbs show-version", output=output, run_environment=True)
+            output_str = str(output.getvalue())
+            self.output.info("Installed version: {}".format(output_str))
+            require_version = str(self.deps_cpp_info["qbs"].version)
+            self.output.info("Expected version: {}".format(require_version))
+            assert(require_version in output_str)

--- a/recipes/qbs/all/test_package/test.cpp
+++ b/recipes/qbs/all/test_package/test.cpp
@@ -1,0 +1,7 @@
+#include <cstdlib>
+#include <iostream>
+
+int main() {
+    std::cout << "Hello Qbs :3\n";
+    return EXIT_SUCCESS;
+}

--- a/recipes/qbs/all/test_package/test.qbs
+++ b/recipes/qbs/all/test_package/test.qbs
@@ -1,0 +1,3 @@
+CppApplication {
+    files: "test.cpp"
+}

--- a/recipes/qbs/config.yml
+++ b/recipes/qbs/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.18.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **qbs/1.16.0**

- [x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Qbs is a cross-platform build automation system.

This recipe extracts the Qbs binaries from an official Qt Creator binary
package provided by The Qt Company. It omits building Qbs from source
because that would require a reliably working Conan package for Qt.

Fixes: #1218