### PR TITLE
[zstd] upgrade to 1.4.5


### DIFF
--- a/recipes/zstd/all/conandata.yml
+++ b/recipes/zstd/all/conandata.yml
@@ -1,13 +1,16 @@
-sources:
+"sources":
   "1.3.5":
-    sha256: d6e1559e4cdb7c4226767d4ddc990bff5f9aab77085ff0d0490c828b025e2eea
-    url: https://github.com/facebook/zstd/archive/v1.3.5.tar.gz
+    "sha256": "d6e1559e4cdb7c4226767d4ddc990bff5f9aab77085ff0d0490c828b025e2eea"
+    "url": "https://github.com/facebook/zstd/archive/v1.3.5.tar.gz"
   "1.3.8":
-    sha256: 90d902a1282cc4e197a8023b6d6e8d331c1fd1dfe60f7f8e4ee9da40da886dc3
-    url: https://github.com/facebook/zstd/archive/v1.3.8.tar.gz
+    "sha256": "90d902a1282cc4e197a8023b6d6e8d331c1fd1dfe60f7f8e4ee9da40da886dc3"
+    "url": "https://github.com/facebook/zstd/archive/v1.3.8.tar.gz"
   "1.4.3":
-    sha256: 5eda3502ecc285c3c92ee0cc8cd002234dee39d539b3f692997a0e80de1d33de
-    url: https://github.com/facebook/zstd/archive/v1.4.3.tar.gz
+    "sha256": "5eda3502ecc285c3c92ee0cc8cd002234dee39d539b3f692997a0e80de1d33de"
+    "url": "https://github.com/facebook/zstd/archive/v1.4.3.tar.gz"
   "1.4.4":
-    sha256: a364f5162c7d1a455cc915e8e3cf5f4bd8b75d09bc0f53965b0c9ca1383c52c8
-    url: https://github.com/facebook/zstd/archive/v1.4.4.tar.gz
+    "sha256": "a364f5162c7d1a455cc915e8e3cf5f4bd8b75d09bc0f53965b0c9ca1383c52c8"
+    "url": "https://github.com/facebook/zstd/archive/v1.4.4.tar.gz"
+  "1.4.5":
+    "sha256": "734d1f565c42f691f8420c8d06783ad818060fc390dee43ae0a89f86d0a4f8c2"
+    "url": "https://github.com/facebook/zstd/archive/v1.4.5.tar.gz"

--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -49,6 +49,7 @@ class ZstdConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/zstd/config.yml
+++ b/recipes/zstd/config.yml
@@ -1,10 +1,11 @@
----
-versions:
+"versions":
   "1.3.5":
-    folder: all
+    "folder": "all"
   "1.3.8":
-    folder: all
+    "folder": "all"
   "1.4.3":
-    folder: all
+    "folder": "all"
   "1.4.4":
-    folder: all
+    "folder": "all"
+  "1.4.5":
+    "folder": "all"


### PR DESCRIPTION
[zstd] upgrade to 1.4.5
NOTE: this is automated commit created by conan-bump32!
command line: conan-bump32.py -p zstd -v 1.4.5