### PR TITLE
[giflib] upgrade to 5.2.1


### DIFF
--- a/recipes/giflib/all/conandata.yml
+++ b/recipes/giflib/all/conandata.yml
@@ -1,4 +1,7 @@
-sources:
+"sources":
   "5.1.4":
-    url: "https://downloads.sourceforge.net/project/giflib/giflib-5.1.4.tar.gz"
-    sha256: "34a7377ba834397db019e8eb122e551a49c98f49df75ec3fcc92b9a794a4f6d1"
+    "sha256": "34a7377ba834397db019e8eb122e551a49c98f49df75ec3fcc92b9a794a4f6d1"
+    "url": "https://downloads.sourceforge.net/project/giflib/giflib-5.1.4.tar.gz"
+  "5.2.1":
+    "sha256": "31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd"
+    "url": "https://downloads.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz"

--- a/recipes/giflib/config.yml
+++ b/recipes/giflib/config.yml
@@ -1,3 +1,5 @@
-versions:
+"versions":
   "5.1.4":
-    folder: all
+    "folder": "all"
+  "5.2.1":
+    "folder": "all"


### PR DESCRIPTION
[giflib] upgrade to 5.2.1
NOTE: this is automated commit created by conan-bump32!
command line: conan-bump32.py -p giflib -v 5.2.1