### PR TITLE
[c-ares] upgrade to 1.16.0


### DIFF
--- a/recipes/c-ares/all/conandata.yml
+++ b/recipes/c-ares/all/conandata.yml
@@ -1,7 +1,10 @@
-sources:
-  "1.15.0":
-    sha256: 7deb7872cbd876c29036d5f37e30c4cbc3cc068d59d8b749ef85bb0736649f04
-    url: https://github.com/c-ares/c-ares/archive/cares-1_15_0.tar.gz
+"sources":
   "1.14.0":
-    sha256: 62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8
-    url: https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
+    "sha256": "62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8"
+    "url": "https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz"
+  "1.15.0":
+    "sha256": "7deb7872cbd876c29036d5f37e30c4cbc3cc068d59d8b749ef85bb0736649f04"
+    "url": "https://github.com/c-ares/c-ares/archive/cares-1_15_0.tar.gz"
+  "1.16.0":
+    "sha256": "b045ef78cda05edd4c677ab351f209315aab8fb041051031bdbe185aaf74baf3"
+    "url": "https://github.com/c-ares/c-ares/archive/cares-1_16_0.tar.gz"

--- a/recipes/c-ares/config.yml
+++ b/recipes/c-ares/config.yml
@@ -1,5 +1,7 @@
-versions:
-  "1.15.0":
-    folder: all
+"versions":
   "1.14.0":
-    folder: all
+    "folder": "all"
+  "1.15.0":
+    "folder": "all"
+  "1.16.0":
+    "folder": "all"


### PR DESCRIPTION
[c-ares] upgrade to 1.16.0
NOTE: this is automated commit created by conan-bump32!
command line: conan-bump32.py -p c-ares -v 1.16.0 -f https://github.com/c-ares/c-ares/archive/cares-{major}_{minor}_{patch}.tar.gz