### PR TITLE
cmake: add compiler + remove compiler.version to reduce number of builds

### DIFF
--- a/recipes/cmake/3.x.x/CMakeLists.txt
+++ b/recipes/cmake/3.x.x/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
-if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-  include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-else()
-  include(conanbuildinfo.cmake)
-endif()
+include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_subdirectory("source_subfolder")

--- a/recipes/cmake/3.x.x/CMakeLists.txt
+++ b/recipes/cmake/3.x.x/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
+cmake_policy(SET CMP0091 NEW)
+
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 

--- a/recipes/cmake/3.x.x/CMakeLists.txt
+++ b/recipes/cmake/3.x.x/CMakeLists.txt
@@ -1,9 +1,0 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(cmake_wrapper)
-
-cmake_policy(SET CMP0091 NEW)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory("source_subfolder")

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -35,11 +35,6 @@ class CMakeConan(ConanFile):
     def configure(self):
         if self.settings.os == "Macos" and self.settings.arch == "x86":
             raise ConanInvalidConfiguration("CMake does not support x86 for macOS")
-        if self.settings.build_type != "Release":
-            raise ConanInvalidConfiguration("only Release build_type is supported")
-        if self.settings.compiler == "Visual Studio":
-            if self.settings.compiler.runtime != "MT":
-                raise ConanInvalidConfiguration("Only MT MSVC runtime is supported")
 
     def requirements(self):
         if self._with_openssl:
@@ -81,9 +76,6 @@ class CMakeConan(ConanFile):
 
     def package_id(self):
         self.info.options.with_openssl = self._with_openssl
-
-        del self.info.settings.compiler
-        del self.info.settings.build_type
 
     def package_info(self):
         minor = self._minor_version()

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -35,6 +35,11 @@ class CMakeConan(ConanFile):
     def configure(self):
         if self.settings.os == "Macos" and self.settings.arch == "x86":
             raise ConanInvalidConfiguration("CMake does not support x86 for macOS")
+        if self.settings.build_type != "Release":
+            raise ConanInvalidConfiguration("only Release build_type is supported")
+        if self.settings.compiler == "Visual Studio":
+            if self.settings.compiler.runtime != "MT":
+                raise ConanInvalidConfiguration("Only MT MSVC runtime is supported")
 
     def requirements(self):
         if self._with_openssl:

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -13,7 +13,7 @@ class CMakeConan(ConanFile):
     license = "BSD-3-Clause"
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
-    settings = "os", "arch", "build_type"
+    settings = "os", "arch", "compiler", "build_type"
 
     _source_subfolder = "source_subfolder"
     _cmake = None
@@ -53,6 +53,10 @@ class CMakeConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "doc"))
+
+    def package_id(self):
+        # CMake is a executable-only package, so the compiler version does not matter
+        del self.info.settings.compiler.version
 
     def package_info(self):
         minor = self._minor_version()

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -83,8 +83,8 @@ class CMakeConan(ConanFile):
     def package_id(self):
         self.info.options.with_openssl = self._with_openssl
 
-        # CMake is a executable-only package, so the compiler version does not matter
-        del self.info.settings.compiler.version
+        del self.info.settings.compiler
+        del self.info.settings.build_type
 
     def package_info(self):
         minor = self._minor_version()

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -14,6 +14,8 @@ class CMakeConan(ConanFile):
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
 
+    requires = "openssl/1.1.1g"
+
     _source_subfolder = "source_subfolder"
     _cmake = None
 
@@ -34,7 +36,7 @@ class CMakeConan(ConanFile):
             self._cmake = CMake(self)
             self._cmake.definitions["CMAKE_BOOTSTRAP"] = False
             if self.settings.os == "Linux":
-                self._cmake.definitions["OPENSSL_USE_STATIC_LIBS"] = True
+                self._cmake.definitions["OPENSSL_USE_STATIC_LIBS"] = not self.options["openssl"].shared
                 self._cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-lz"
             self._cmake.configure()
         return self._cmake

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -10,7 +10,6 @@ class CMakeConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/Kitware/CMake"
     license = "BSD-3-Clause"
-    exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
 
@@ -55,10 +54,14 @@ class CMakeConan(ConanFile):
                 if self._with_openssl:
                     self._cmake.definitions["OPENSSL_USE_STATIC_LIBS"] = not self.options["openssl"].shared
                 self._cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-lz"
-            self._cmake.configure()
+            self._cmake.configure(source_folder=self._source_subfolder)
         return self._cmake
 
     def build(self):
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              "project(CMake)",
+                              "project(CMake)\ninclude(\"{}/conanbuildinfo.cmake\")\nconan_basic_setup()".format(
+                                  self.build_folder.replace("\\", "/")))
         if self.settings.os == "Linux":
             tools.replace_in_file(os.path.join(self._source_subfolder, "Utilities", "cmcurl", "CMakeLists.txt"),
                                   "list(APPEND CURL_LIBS ${OPENSSL_LIBRARIES})",

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -1,6 +1,5 @@
 import os
 from conans import tools, ConanFile, CMake
-from conans.tools import Version
 from conans.errors import ConanInvalidConfiguration, ConanException
 
 

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -58,7 +58,6 @@ class CMakeConan(ConanFile):
                 self._cmake.definitions["CMAKE_USE_OPENSSL"] = self._with_openssl
                 if self._with_openssl:
                     self._cmake.definitions["OPENSSL_USE_STATIC_LIBS"] = not self.options["openssl"].shared
-                self._cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-lz"
             self._cmake.configure(source_folder=self._source_subfolder)
         return self._cmake
 

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -36,7 +36,7 @@ class CMakeConan(ConanFile):
             if self.settings.os == "Linux":
                 self._cmake.definitions["OPENSSL_USE_STATIC_LIBS"] = True
                 self._cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-lz"
-            self._cmake.configure(source_dir=self._source_subfolder)
+            self._cmake.configure()
         return self._cmake
 
     def build(self):


### PR DESCRIPTION
Specify library name and version:  **cmake/all**

For #1705 : by adding compiler to the package_id, the ci will/should build a package for `Visual Studio` where `compiler.runtime` is not a debug runtime


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

