### PR TITLE
Run pybind11 test package with correct python version

### DIFF
--- a/recipes/pybind11/all/test_package/CMakeLists.txt
+++ b/recipes/pybind11/all/test_package/CMakeLists.txt
@@ -15,3 +15,8 @@ conan_basic_setup()
 pybind11_add_module(test_package MODULE
     test_package.cpp
 )
+
+enable_testing()
+
+add_test(run_example
+  ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py ${CMAKE_CURRENT_BINARY_DIR}/lib)

--- a/recipes/pybind11/all/test_package/conanfile.py
+++ b/recipes/pybind11/all/test_package/conanfile.py
@@ -13,6 +13,4 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        self.run("{} {} {}".format(sys.executable,
-                                   os.path.join(self.source_folder, "test.py"),
-                                   os.path.join(self.build_folder, "lib")), run_environment=True)
+        CMake(self).test()


### PR DESCRIPTION
The python version used to run Conan is not necessarily the python
version used to compile the pybind11-based python module. If you for
example have a /usr/bin/python of version 2.7, Conan will still run
using a python 3.x interpreter. The test package will discover the
python 2.7 version and use this for compilation. The created test
module will not successfully load in python 3.x.

Fixed by moving the test execution into cmake to reuse the discovered
python version instead.

Specify library name and version:  **pybind11/2.4.3**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

