### PR TITLE
xerces-c: fix cpp_info.libs for MinGW + cache cmake + pthread in system_libs

### DIFF
--- a/recipes/xerces-c/all/conandata.yml
+++ b/recipes/xerces-c/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "3.2.2":
-    url: "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.2.2.tar.bz2"
-    sha256: "1f2a4d1dbd0086ce0f52b718ac0fa4af3dc1ce7a7ff73a581a05fbe78a82bce0"
+    url: "https://github.com/apache/xerces-c/archive/v3.2.2.tar.gz"
+    sha256: "7fe5af7d7ad9d4a06503c15fb5bb0aa5f2ba7959700d16c21b8bd183ca542e7f"

--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -20,7 +20,7 @@ class XercesCConan(ConanFile):
     _build_subfolder = "build_subfolder"
 
     def config_options(self):
-        if self.settings.os == 'Windows':
+        if self.settings.os == "Windows":
             del self.options.fPIC
 
     def source(self):
@@ -43,13 +43,13 @@ class XercesCConan(ConanFile):
                                               "Macos": "posix",
                                               "Linux": "posix"}.get(str(self.settings.os))
         # avoid picking up system dependency
-        cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_CURL'] = True
-        cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_ICU'] = True
+        cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_CURL"] = True
+        cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_ICU"] = True
         cmake.configure(build_folder=self._build_subfolder)
         return cmake
 
     def configure(self):
-        if self.settings.os not in ('Windows', 'Macos', 'Linux'):
+        if self.settings.os not in ("Windows", "Macos", "Linux"):
             raise ConanInvalidConfiguration("OS is not supported")
 
     def build(self):
@@ -61,15 +61,15 @@ class XercesCConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         # remove unneeded directories
-        tools.rmdir(os.path.join(self.package_folder, 'share'))
-        tools.rmdir(os.path.join(self.package_folder, 'lib', 'pkgconfig'))
-        tools.rmdir(os.path.join(self.package_folder, 'lib', 'cmake'))
-        tools.rmdir(os.path.join(self.package_folder, 'cmake'))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "cmake"))
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Macos":
-            self.cpp_info.frameworks = ['CoreFoundation', 'CoreServices']
+            self.cpp_info.frameworks = ["CoreFoundation", "CoreServices"]
         elif self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")
         self.cpp_info.names["cmake_find_package"] = "XercesC"

--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -67,15 +67,7 @@ class XercesCConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, 'cmake'))
 
     def package_info(self):
-        version_tokens = self.version.split(".")
-        if self.settings.os == "Windows":
-            lib = "xerces-c_%s" % version_tokens[0]
-            if self.settings.build_type == "Debug":
-                lib += "d"
-            self.cpp_info.libs = [lib]
-        else:
-            self.cpp_info.libs = ["xerces-c" if self.options.shared else
-                                  ("xerces-c-%s.%s" % (version_tokens[0], version_tokens[1]))]
+        self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Macos":
             self.cpp_info.frameworks = ['CoreFoundation', 'CoreServices']
         elif self.settings.os == "Linux":

--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -80,6 +80,6 @@ class XercesCConan(ConanFile):
         if self.settings.os == "Macos":
             self.cpp_info.frameworks = ["CoreFoundation", "CoreServices"]
         elif self.settings.os == "Linux":
-            self.cpp_info.libs.append("pthread")
+            self.cpp_info.system_libs.append("pthread")
         self.cpp_info.names["cmake_find_package"] = "XercesC"
         self.cpp_info.names["cmake_find_package_multi"] = "XercesC"

--- a/recipes/xerces-c/all/test_package/CMakeLists.txt
+++ b/recipes/xerces-c/all/test_package/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(test_package)
 
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 

--- a/recipes/xerces-c/all/test_package/conanfile.py
+++ b/recipes/xerces-c/all/test_package/conanfile.py
@@ -1,4 +1,3 @@
-
 from conans import ConanFile, CMake, tools
 import os
 


### PR DESCRIPTION
Specify library name and version:  **xerces-c/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

cpp_info.libs was wrong for MinGW (seen while trying to compile gdal with all dependencies enabled on MinGW)