### PR TITLE
[jsoncpp] upgrade to 1.9.3


### DIFF
--- a/recipes/jsoncpp/all/conandata.yml
+++ b/recipes/jsoncpp/all/conandata.yml
@@ -1,10 +1,13 @@
-sources:
-  "1.9.1":
-    url: https://github.com/open-source-parsers/jsoncpp/archive/1.9.1.tar.gz
-    sha256: c7b40f5605dd972108f503f031b20186f5e5bca2b65cd4b8bd6c3e4ba8126697
-  "1.9.2":
-    url: https://github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz
-    sha256: 77a402fb577b2e0e5d0bdc1cf9c65278915cdb25171e3452c68b6da8a561f8f0
+"sources":
   "1.8.3":
-    url: https://github.com/open-source-parsers/jsoncpp/archive/1.8.3.tar.gz
-    sha256: 3671ba6051e0f30849942cc66d1798fdf0362d089343a83f704c09ee7156604f
+    "sha256": "3671ba6051e0f30849942cc66d1798fdf0362d089343a83f704c09ee7156604f"
+    "url": "https://github.com/open-source-parsers/jsoncpp/archive/1.8.3.tar.gz"
+  "1.9.1":
+    "sha256": "c7b40f5605dd972108f503f031b20186f5e5bca2b65cd4b8bd6c3e4ba8126697"
+    "url": "https://github.com/open-source-parsers/jsoncpp/archive/1.9.1.tar.gz"
+  "1.9.2":
+    "sha256": "77a402fb577b2e0e5d0bdc1cf9c65278915cdb25171e3452c68b6da8a561f8f0"
+    "url": "https://github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz"
+  "1.9.3":
+    "sha256": "8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d"
+    "url": "https://github.com/open-source-parsers/jsoncpp/archive/v1.9.3.tar.gz"

--- a/recipes/jsoncpp/config.yml
+++ b/recipes/jsoncpp/config.yml
@@ -1,7 +1,9 @@
-versions:
+"versions":
   "1.8.3":
-    folder: all
+    "folder": "all"
   "1.9.1":
-    folder: all
+    "folder": "all"
   "1.9.2":
-    folder: all
+    "folder": "all"
+  "1.9.3":
+    "folder": "all"


### PR DESCRIPTION
[jsoncpp] upgrade to 1.9.3
NOTE: this is automated commit created by conan-bump32!
command line: C:\bincrafters\conan-bump32\conan-bump32.py -p jsoncpp -v 1.9.3 -f https://github.com/open-source-parsers/jsoncpp/archive/v{version}.tar.gz