### PR TITLE
libiconv: fix cpp_info.libs

### DIFF
--- a/recipes/libiconv/all/conandata.yml
+++ b/recipes/libiconv/all/conandata.yml
@@ -6,7 +6,6 @@ sources:
     url: "https://ftp.gnu.org/gnu/libiconv/libiconv-1.16.tar.gz"
     sha256: "e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04"
 patches:
-  "1.15": []
   "1.16":
     - patch_file: "patches/0001-libcharset-fix-linkage.patch"
       base_path: "source_subfolder"

--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -115,8 +115,8 @@ class LibiconvConan(ConanFile):
         return self._autotools
 
     def _patch_sources(self):
-        for patchdata in self.conan_data["patches"][self.version]:
-            tools.patch(**patchdata)
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
 
     def build(self):
         self._patch_sources()
@@ -137,10 +137,9 @@ class LibiconvConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "Iconv"
         self.cpp_info.names["cmake_find_package_multi"] = "Iconv"
-        lib = "iconv"
-        if self.settings.os == "Windows" and self.options.shared:
-            lib += ".dll" + ".lib" if self.settings.compiler == "Visual Studio" else ".a"
-        self.cpp_info.libs = [lib]
+        self.cpp_info.libs = ["iconv", "charset"]
+        if self._is_msvc and self.options.shared:
+            self.cpp_info.libs = [lib + ".dll.lib" for lib in self.cpp_info.libs]
 
         binpath = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment var: {}".format(binpath))


### PR DESCRIPTION
Specify library name and version:  **libiconv/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Fix `cpp_info.libs`:
- Name of import lib (shared) for MinGW was wrong.
- `charset` lib was not listed. There are 2 libs, but without dependencies between each other, therefore we can rely on `tools.collect_libs(self)`