### PR TITLE
giflib: fix extern linkage for msvc

### DIFF
--- a/recipes/giflib/all/gif_lib.h
+++ b/recipes/giflib/all/gif_lib.h
@@ -14,14 +14,12 @@ extern "C" {
 #ifdef _MSC_VER
   #ifdef USE_GIF_LIB
     #define GIF_EXPORT
-    #define GIF_EXTERN extern
   #else /* USE_GIF_LIB */
     #ifdef USE_GIF_DLL
       #define GIF_EXPORT __declspec(dllimport)
     #else /* USE_GIF_DLL */
       #define GIF_EXPORT __declspec(dllexport)
     #endif /* USE_GIF_DLL */
-    #define GIF_EXTERN
   #endif /* USE_GIF_LIB */
 #endif /* _MSC_VER */
 
@@ -317,21 +315,21 @@ GIF_EXPORT int EGifGCBToSavedExtension(const GraphicsControlBlock *GCB,
 
 #define GIF_FONT_WIDTH  8
 #define GIF_FONT_HEIGHT 8
-GIF_EXPORT GIF_EXTERN const unsigned char GifAsciiTable8x8[][GIF_FONT_WIDTH];
+GIF_EXPORT extern const unsigned char GifAsciiTable8x8[][GIF_FONT_WIDTH];
 
-GIF_EXPORT GIF_EXTERN void GifDrawText8x8(SavedImage *Image,
+GIF_EXPORT void GifDrawText8x8(SavedImage *Image,
                      const int x, const int y,
                      const char *legend, const int color);
 
-GIF_EXPORT GIF_EXTERN void GifDrawBox(SavedImage *Image,
+GIF_EXPORT void GifDrawBox(SavedImage *Image,
                     const int x, const int y,
                     const int w, const int d, const int color);
 
-GIF_EXPORT GIF_EXTERN void GifDrawRectangle(SavedImage *Image,
+GIF_EXPORT void GifDrawRectangle(SavedImage *Image,
                    const int x, const int y,
                    const int w, const int d, const int color);
 
-GIF_EXPORT GIF_EXTERN void GifDrawBoxedText8x8(SavedImage *Image,
+GIF_EXPORT void GifDrawBoxedText8x8(SavedImage *Image,
                           const int x, const int y,
                           const char *legend,
                           const int border, const int bg, const int fg);


### PR DESCRIPTION
Specify library name and version:  **giflib/5.1.4**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

const `GifAsciiTable8x8` must have external linkage whatever static or shared. `extern` in front of  functions declarations is useless.