### PR TITLE
jasper: fix exported symbols

### DIFF
--- a/recipes/jasper/all/conandata.yml
+++ b/recipes/jasper/all/conandata.yml
@@ -5,3 +5,10 @@ sources:
   "2.0.16":
     url: "https://github.com/mdadams/jasper/archive/version-2.0.16.zip"
     sha256: "912495d1074de635fe36884085214cf389403e51f1075d50c6008602e8d9480a"
+patches:
+  "2.0.14":
+    - patch_file: "patches/fix-exported-symbols.patch"
+      base_path: "source_subfolder"
+  "2.0.16":
+    - patch_file: "patches/fix-exported-symbols.patch"
+      base_path: "source_subfolder"

--- a/recipes/jasper/all/conanfile.py
+++ b/recipes/jasper/all/conanfile.py
@@ -10,8 +10,8 @@ class JasperConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     topics = ("conan", "jasper", "tool-kit", "coding")
     description = "JasPer Image Processing/Coding Tool Kit"
-    exports_sources = "CMakeLists.txt"
-    generators = "cmake"
+    exports_sources = ["CMakeLists.txt", "patches/**"]
+    generators = "cmake", "cmake_find_package"
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False],
                "fPIC": [True, False],
@@ -28,12 +28,6 @@ class JasperConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
-    def requirements(self):
-        if self.options.jpegturbo:
-            self.requires("libjpeg-turbo/2.0.4")
-        else:
-            self.requires("libjpeg/9d")
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -41,6 +35,12 @@ class JasperConan(ConanFile):
     def configure(self):
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
+
+    def requirements(self):
+        if self.options.jpegturbo:
+            self.requires("libjpeg-turbo/2.0.4")
+        else:
+            self.requires("libjpeg/9d")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -60,6 +60,8 @@ class JasperConan(ConanFile):
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/jasper/all/patches/fix-exported-symbols.patch
+++ b/recipes/jasper/all/patches/fix-exported-symbols.patch
@@ -1,0 +1,163 @@
+--- a/src/libjasper/include/jasper/jas_cm.h
++++ b/src/libjasper/include/jasper/jas_cm.h
+@@ -237,13 +237,13 @@ int jas_cm_prof_setattr(jas_cm_prof_t *prof, jas_cm_attrname_t name, void *val);
+ void *jas_cm_prof_getattr(jas_cm_prof_t *prof, jas_cm_attrname_t name);
+ #endif
+ 
+-jas_cmxform_t *jas_cmxform_create(jas_cmprof_t *inprof, jas_cmprof_t *outprof,
++JAS_DLLEXPORT jas_cmxform_t *jas_cmxform_create(jas_cmprof_t *inprof, jas_cmprof_t *outprof,
+   jas_cmprof_t *proofprof, int op, int intent, int optimize);
+ 
+-void jas_cmxform_destroy(jas_cmxform_t *xform);
++JAS_DLLEXPORT void jas_cmxform_destroy(jas_cmxform_t *xform);
+ 
+ /* Apply a transform to data. */
+-int jas_cmxform_apply(jas_cmxform_t *xform, jas_cmpixmap_t *in,
++JAS_DLLEXPORT int jas_cmxform_apply(jas_cmxform_t *xform, jas_cmpixmap_t *in,
+   jas_cmpixmap_t *out);
+ 
+ int jas_cxform_optimize(jas_cmxform_t *xform, int optimize);
+--- a/src/libjasper/include/jasper/jas_debug.h
++++ b/src/libjasper/include/jasper/jas_debug.h
+@@ -107,10 +107,10 @@ JAS_DLLEXPORT int jas_setdbglevel(int dbglevel);
+ JAS_DLLEXPORT int jas_eprintf(const char *fmt, ...);
+ 
+ /* Dump memory to a stream. */
+-int jas_memdump(FILE *out, void *data, size_t len);
++JAS_DLLEXPORT int jas_memdump(FILE *out, void *data, size_t len);
+ 
+ /* Warn about use of deprecated functionality. */
+-void jas_deprecated(const char *s);
++JAS_DLLEXPORT void jas_deprecated(const char *s);
+ 
+ /* Convert to a string literal */
+ #define JAS_STRINGIFY(x) #x
+--- a/src/libjasper/include/jasper/jas_icc.h
++++ b/src/libjasper/include/jasper/jas_icc.h
+@@ -395,10 +395,10 @@ JAS_DLLEXPORT jas_iccattrval_t *jas_iccattrval_create(jas_iccuint32_t type);
+ 
+ JAS_DLLEXPORT void jas_iccattrtab_dump(jas_iccattrtab_t *attrtab, FILE *out);
+ 
+-extern jas_uchar jas_iccprofdata_srgb[];
+-extern int jas_iccprofdata_srgblen;
+-extern jas_uchar jas_iccprofdata_sgray[];
+-extern int jas_iccprofdata_sgraylen;
++JAS_DLLEXPORT extern jas_uchar jas_iccprofdata_srgb[];
++JAS_DLLEXPORT extern int jas_iccprofdata_srgblen;
++JAS_DLLEXPORT extern jas_uchar jas_iccprofdata_sgray[];
++JAS_DLLEXPORT extern int jas_iccprofdata_sgraylen;
+ JAS_DLLEXPORT jas_iccprof_t *jas_iccprof_createfrombuf(jas_uchar *buf, int len);
+ JAS_DLLEXPORT jas_iccprof_t *jas_iccprof_createfromclrspc(int clrspc);
+ 
+--- a/src/libjasper/include/jasper/jas_image.h
++++ b/src/libjasper/include/jasper/jas_image.h
+@@ -492,21 +492,21 @@ JAS_DLLEXPORT int jas_image_getfmt(jas_stream_t *in);
+ 
+ 
+ #define	jas_image_cmprof(image)	((image)->cmprof_)
+-int jas_image_ishomosamp(jas_image_t *image);
+-int jas_image_sampcmpt(jas_image_t *image, int cmptno, int newcmptno,
++JAS_DLLEXPORT int jas_image_ishomosamp(jas_image_t *image);
++JAS_DLLEXPORT int jas_image_sampcmpt(jas_image_t *image, int cmptno, int newcmptno,
+   jas_image_coord_t ho, jas_image_coord_t vo, jas_image_coord_t hs,
+   jas_image_coord_t vs, int sgnd, int prec);
+-int jas_image_writecmpt2(jas_image_t *image, int cmptno, jas_image_coord_t x,
++JAS_DLLEXPORT int jas_image_writecmpt2(jas_image_t *image, int cmptno, jas_image_coord_t x,
+   jas_image_coord_t y, jas_image_coord_t width, jas_image_coord_t height,
+   long *buf);
+-int jas_image_readcmpt2(jas_image_t *image, int cmptno, jas_image_coord_t x,
++JAS_DLLEXPORT int jas_image_readcmpt2(jas_image_t *image, int cmptno, jas_image_coord_t x,
+   jas_image_coord_t y, jas_image_coord_t width, jas_image_coord_t height,
+   long *buf);
+ 
+ #define	jas_image_setcmprof(image, cmprof) ((image)->cmprof_ = cmprof)
+ JAS_DLLEXPORT jas_image_t *jas_image_chclrspc(jas_image_t *image, jas_cmprof_t *outprof,
+   int intent);
+-void jas_image_dump(jas_image_t *image, FILE *out);
++JAS_DLLEXPORT void jas_image_dump(jas_image_t *image, FILE *out);
+ 
+ /******************************************************************************\
+ * Image format-dependent operations.
+@@ -514,58 +514,58 @@ void jas_image_dump(jas_image_t *image, FILE *out);
+ 
+ #if !defined(EXCLUDE_JPG_SUPPORT)
+ /* Format-dependent operations for JPG support. */
+-jas_image_t *jpg_decode(jas_stream_t *in, const char *optstr);
+-int jpg_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
+-int jpg_validate(jas_stream_t *in);
++JAS_DLLEXPORT jas_image_t *jpg_decode(jas_stream_t *in, const char *optstr);
++JAS_DLLEXPORT int jpg_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
++JAS_DLLEXPORT int jpg_validate(jas_stream_t *in);
+ #endif
+ 
+ #if !defined(EXCLUDE_MIF_SUPPORT)
+ /* Format-dependent operations for MIF support. */
+-jas_image_t *mif_decode(jas_stream_t *in, const char *optstr);
+-int mif_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
+-int mif_validate(jas_stream_t *in);
++JAS_DLLEXPORT jas_image_t *mif_decode(jas_stream_t *in, const char *optstr);
++JAS_DLLEXPORT int mif_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
++JAS_DLLEXPORT int mif_validate(jas_stream_t *in);
+ #endif
+ 
+ #if !defined(EXCLUDE_PNM_SUPPORT)
+ /* Format-dependent operations for PNM support. */
+-jas_image_t *pnm_decode(jas_stream_t *in, const char *optstr);
+-int pnm_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
+-int pnm_validate(jas_stream_t *in);
++JAS_DLLEXPORT jas_image_t *pnm_decode(jas_stream_t *in, const char *optstr);
++JAS_DLLEXPORT int pnm_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
++JAS_DLLEXPORT int pnm_validate(jas_stream_t *in);
+ #endif
+ 
+ #if !defined(EXCLUDE_RAS_SUPPORT)
+ /* Format-dependent operations for Sun Rasterfile support. */
+-jas_image_t *ras_decode(jas_stream_t *in, const char *optstr);
+-int ras_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
+-int ras_validate(jas_stream_t *in);
++JAS_DLLEXPORT jas_image_t *ras_decode(jas_stream_t *in, const char *optstr);
++JAS_DLLEXPORT int ras_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
++JAS_DLLEXPORT int ras_validate(jas_stream_t *in);
+ #endif
+ 
+ #if !defined(EXCLUDE_BMP_SUPPORT)
+ /* Format-dependent operations for BMP support. */
+-jas_image_t *bmp_decode(jas_stream_t *in, const char *optstr);
+-int bmp_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
+-int bmp_validate(jas_stream_t *in);
++JAS_DLLEXPORT jas_image_t *bmp_decode(jas_stream_t *in, const char *optstr);
++JAS_DLLEXPORT int bmp_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
++JAS_DLLEXPORT int bmp_validate(jas_stream_t *in);
+ #endif
+ 
+ #if !defined(EXCLUDE_JP2_SUPPORT)
+ /* Format-dependent operations for JP2 support. */
+-jas_image_t *jp2_decode(jas_stream_t *in, const char *optstr);
+-int jp2_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
+-int jp2_validate(jas_stream_t *in);
++JAS_DLLEXPORT jas_image_t *jp2_decode(jas_stream_t *in, const char *optstr);
++JAS_DLLEXPORT int jp2_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
++JAS_DLLEXPORT int jp2_validate(jas_stream_t *in);
+ #endif
+ 
+ #if !defined(EXCLUDE_JPC_SUPPORT)
+ /* Format-dependent operations for JPEG-2000 code stream support. */
+-jas_image_t *jpc_decode(jas_stream_t *in, const char *optstr);
+-int jpc_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
+-int jpc_validate(jas_stream_t *in);
++JAS_DLLEXPORT jas_image_t *jpc_decode(jas_stream_t *in, const char *optstr);
++JAS_DLLEXPORT int jpc_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
++JAS_DLLEXPORT int jpc_validate(jas_stream_t *in);
+ #endif
+ 
+ #if !defined(EXCLUDE_PGX_SUPPORT)
+ /* Format-dependent operations for PGX support. */
+-jas_image_t *pgx_decode(jas_stream_t *in, const char *optstr);
+-int pgx_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
+-int pgx_validate(jas_stream_t *in);
++JAS_DLLEXPORT jas_image_t *pgx_decode(jas_stream_t *in, const char *optstr);
++JAS_DLLEXPORT int pgx_encode(jas_image_t *image, jas_stream_t *out, const char *optstr);
++JAS_DLLEXPORT int pgx_validate(jas_stream_t *in);
+ #endif
+ 
+ #ifdef __cplusplus

--- a/recipes/jasper/all/test_package/CMakeLists.txt
+++ b/recipes/jasper/all/test_package/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(test_package)
 
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 


### PR DESCRIPTION
Specify library name and version:  **jasper/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I've submitted a PR in Jasper repo (but it doesn't seem to be actively maintained anymore): https://github.com/mdadams/jasper/pull/218
I think also that `jpegturbo=True` is broken in this recipe (not tested, but there is no reason `find_package(JEPG)` could find libjpegturbo).