### PR TITLE
libjpeg: rename libjpeg.dll.lib to libjpeg.lib when setting.compiler=…

### DIFF
--- a/recipes/libjpeg/all/conanfile.py
+++ b/recipes/libjpeg/all/conanfile.py
@@ -56,7 +56,7 @@ class LibjpegConan(ConanFile):
             else:
                 tools.replace_in_file("makefile.vc", "(cvars)", "(cvarsmt)")
                 tools.replace_in_file("makefile.vc", "(conlibs)", "(conlibsmt)")
-            target = "libjpeg.dll.lib" if self.options.shared else "libjpeg.lib"
+            target = "{}/libjpeg.lib".format( "shared" if self.options.shared else "static" )
             with tools.vcvars(self.settings):
                 self.run("nmake -f makefile.vc {} {}".format(" ".join(make_args), target))
 
@@ -105,8 +105,10 @@ class LibjpegConan(ConanFile):
         if self.settings.compiler == "Visual Studio":
             for filename in ["jpeglib.h", "jerror.h", "jconfig.h", "jmorecfg.h"]:
                 self.copy(pattern=filename, dst="include", src=self._source_subfolder, keep_path=False)
+            
             self.copy(pattern="*.lib", dst="lib", src=self._source_subfolder, keep_path=False)
-            self.copy(pattern="*.dll", dst="bin", src=self._source_subfolder, keep_path=False)
+            if self.options.shared:
+                self.copy(pattern="*.dll", dst="bin", src=self._source_subfolder, keep_path=False)
         else:
             autotools = self._configure_autotools()
             autotools.install()
@@ -124,10 +126,7 @@ class LibjpegConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "JPEG"
         self.cpp_info.names["cmake_find_package_multi"] = "JPEG"
         if self.settings.compiler == "Visual Studio":
-            lib = "libjpeg"
-            if self.options.shared:
-                lib += ".dll.lib"
-            self.cpp_info.libs = [lib]
+            self.cpp_info.libs = ["libjpeg"]
         else:
             self.cpp_info.libs = ["jpeg"]
         if not self.options.shared:

--- a/recipes/libjpeg/all/patches/0001-libjpeg-add-msvc-dll-support.patch
+++ b/recipes/libjpeg/all/patches/0001-libjpeg-add-msvc-dll-support.patch
@@ -32,14 +32,61 @@
 
 --- makefile.vc
 +++ makefile.vc
-@@ -111,6 +111,10 @@ libjpeg.lib: $(LIBOBJECTS)
- 	$(RM) libjpeg.lib
- 	lib -out:libjpeg.lib  $(LIBOBJECTS)
+@@ -30,6 +30,7 @@
+ # miscellaneous OS-dependent stuff
+ # file deletion command
+ RM= del
++MKDIR=mkdir
  
-+libjpeg.dll.lib libjpeg-9.dll: $(LIBOBJECTS)
-+	$(RM) libjpeg-9.dll libjpeg.dll.lib
-+	link -DLL -out:libjpeg-9.dll -implib:libjpeg.dll.lib $(LIBOBJECTS)
+ # End of configurable options.
+ 
+@@ -105,20 +106,30 @@
+ 	$(cc) $(CFLAGS) $*.c
+ 
+ 
+-all: libjpeg.lib cjpeg.exe djpeg.exe jpegtran.exe rdjpgcom.exe wrjpgcom.exe
++all: shared/libjpeg.lib static/libjpeg.lib cjpeg.exe djpeg.exe jpegtran.exe rdjpgcom.exe wrjpgcom.exe
+ 
+-libjpeg.lib: $(LIBOBJECTS)
+-	$(RM) libjpeg.lib
+-	lib -out:libjpeg.lib  $(LIBOBJECTS)
++shared:
++	$(MKDIR) shared
++	
++static:
++	$(MKDIR) static
++	
++static/libjpeg.lib: $(LIBOBJECTS) static
++	$(RM) static\libjpeg.lib
++	lib -out:static/libjpeg.lib  $(LIBOBJECTS)
 +
- cjpeg.exe: $(COBJECTS) libjpeg.lib
- 	$(link) $(LDFLAGS) -out:cjpeg.exe $(COBJECTS) libjpeg.lib $(LDLIBS)
++shared/libjpeg.lib shared/libjpeg-9.dll: $(LIBOBJECTS) shared
++	$(RM) shared\libjpeg.lib shared\libjpeg-9.dll
++	link -DLL -out:shared/libjpeg-9.dll -implib:shared/libjpeg.lib $(LIBOBJECTS)
  
+-cjpeg.exe: $(COBJECTS) libjpeg.lib
+-	$(link) $(LDFLAGS) -out:cjpeg.exe $(COBJECTS) libjpeg.lib $(LDLIBS)
++cjpeg.exe: $(COBJECTS) static/libjpeg.lib
++	$(link) $(LDFLAGS) -out:cjpeg.exe $(COBJECTS) static/libjpeg.lib $(LDLIBS)
+ 
+-djpeg.exe: $(DOBJECTS) libjpeg.lib
+-	$(link) $(LDFLAGS) -out:djpeg.exe $(DOBJECTS) libjpeg.lib $(LDLIBS)
++djpeg.exe: $(DOBJECTS) static/libjpeg.lib
++	$(link) $(LDFLAGS) -out:djpeg.exe $(DOBJECTS) static/libjpeg.lib $(LDLIBS)
+ 
+-jpegtran.exe: $(TROBJECTS) libjpeg.lib
+-	$(link) $(LDFLAGS) -out:jpegtran.exe $(TROBJECTS) libjpeg.lib $(LDLIBS)
++jpegtran.exe: $(TROBJECTS) static/libjpeg.lib
++	$(link) $(LDFLAGS) -out:jpegtran.exe $(TROBJECTS) static/libjpeg.lib $(LDLIBS)
+ 
+ rdjpgcom.exe: rdjpgcom.obj
+ 	$(link) $(LDFLAGS) -out:rdjpgcom.exe rdjpgcom.obj $(LDLIBS)
+@@ -128,7 +139,7 @@
+ 
+ 
+ clean:
+-	$(RM) *.obj *.exe libjpeg.lib
++	$(RM) *.obj *.exe static\libjpeg.lib shared\libjpeg.lib shared\libjpeg-9.dll
+ 	$(RM) testout*
+ 
+ setup-vc6:


### PR DESCRIPTION
Specify library name and version:  **libjpeg/9c**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

…msvc and option.shared=True

libjpeg.dll.lib name come from our patch, and this is not the regular name of  jpeg .lib file.
Cmake’s FindJPEG.cmake script will not found it, so just rename to libjpeg.lib to be
consistent with other jpeg implemention.