### PR TITLE
systemc: MSVC requires the /vmg option

### DIFF
--- a/recipes/systemc/2.3.3/conanfile.py
+++ b/recipes/systemc/2.3.3/conanfile.py
@@ -112,3 +112,5 @@ class SystemcConan(ConanFile):
 
         if self.settings.os == "Linux":
             self.cpp_info.system_libs = ["pthread"]
+        if self.settings.compiler == "Visual Studio":
+            self.cpp_info.cxxflags.append("/vmg")


### PR DESCRIPTION
Specify library name and version:  **systemc/2.3.3**

systemc on MSVC requires the `/vmg` flag.
See https://github.com/accellera-official/systemc/blob/master/INSTALL.md#creating-systemc-applications

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

