### PR TITLE
verilator: run systemc test on MSVC

### DIFF
--- a/recipes/verilator/all/test_package/conanfile.py
+++ b/recipes/verilator/all/test_package/conanfile.py
@@ -7,23 +7,18 @@ class TestVerilatorConan(ConanFile):
     generators = "cmake", "cmake_find_package"
 
     @property
-    def _build_systemc_example(self):
+    def _with_systemc_example(self):
         # systemc is not available on Macos
         return self.settings.os != "Macos"
 
-    @property
-    def _run_systemc_example(self):
-        # systemc does not run on MSVC: https://forums.accellera.org/topic/6621-systemc-233-using-msvc-causes-read-access-violation/
-        return self._build_systemc_example and self.settings.compiler != "Visual Studio"
-
     def requirements(self):
-        if self._build_systemc_example:
+        if self._with_systemc_example:
             self.requires("systemc/2.3.3")
 
     def build(self):
         if not tools.cross_building(self.settings, skip_x64_x86=True):
             cmake = CMake(self)
-            cmake.definitions["BUILD_SYSTEMC"] = self._build_systemc_example
+            cmake.definitions["BUILD_SYSTEMC"] = self._with_systemc_example
             cmake.configure()
             cmake.build()
 
@@ -32,5 +27,5 @@ class TestVerilatorConan(ConanFile):
             with tools.run_environment(self):
                 self.run("perl {} --version".format(os.path.join(self.deps_cpp_info["verilator"].rootpath, "bin", "verilator")), run_environment=True)
             self.run(os.path.join("bin", "blinky"), run_environment=True)
-            if self._run_systemc_example:
+            if self._with_systemc_example:
                 self.run(os.path.join("bin", "blinky_sc"), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **verilator/4.034**

- [x] Requires #1901 because that fixes the MSVC systemc example/test

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

