### PR TITLE
Add standalone_asio option to packio

### DIFF
--- a/recipes/packio/all/conanfile.py
+++ b/recipes/packio/all/conanfile.py
@@ -26,7 +26,7 @@ class PackioConan(ConanFile):
         return any(compiler == sc[0] and version >= sc[1] for sc in supported_compilers)
 
     def config_options(self):
-        if self.version < tools.Version("1.2.0"):
+        if tools.Version(self.version) < "1.2.0":
             del self.options.standalone_asio
 
     def requirements(self):

--- a/recipes/packio/all/conanfile.py
+++ b/recipes/packio/all/conanfile.py
@@ -32,7 +32,7 @@ class PackioConan(ConanFile):
     def requirements(self):
         self.requires("msgpack/3.2.1")
 
-        if self.options.standalone_asio:
+        if self.options.get_safe("standalone_asio"):
             self.requires("asio/1.16.1")
         else:
             self.requires("boost/1.73.0")

--- a/recipes/packio/all/conanfile.py
+++ b/recipes/packio/all/conanfile.py
@@ -26,7 +26,7 @@ class PackioConan(ConanFile):
         return any(compiler == sc[0] and version >= sc[1] for sc in supported_compilers)
 
     def config_options(self):
-        if self._as_number(self.version) < self._as_number("1.2.0"):
+        if self.version < tools.Version("1.2.0"):
             del self.options.standalone_asio
 
     def requirements(self):

--- a/recipes/packio/all/conanfile.py
+++ b/recipes/packio/all/conanfile.py
@@ -58,8 +58,3 @@ class PackioConan(ConanFile):
     def package_info(self):
         if self.options.get_safe("standalone_asio"):
             self.cpp_info.defines.append("PACKIO_STANDALONE_ASIO")
-
-    @staticmethod
-    def _as_number(version):
-        major, minor, patch = version.split('.')
-        return int(major) * 1e6 + int(minor) * 1e3 + int(patch)

--- a/recipes/packio/all/conanfile.py
+++ b/recipes/packio/all/conanfile.py
@@ -10,13 +10,11 @@ class PackioConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/qchateau/packio"
     description = "An asynchronous msgpack-RPC library built on top of Boost.Asio."
-    topics = ("rpc", "msgpack", "asio", "async", "cpp17")
+    topics = ("rpc", "msgpack", "asio", "async", "cpp17", "cpp20", "coroutines")
     settings = "compiler"
     no_copy_source = True
-    requires = [
-        "msgpack/3.2.1",
-        "boost/1.72.0",
-    ]
+    options = {"standalone_asio": [True, False]}
+    default_options = {"standalone_asio": False}
 
     @property
     def _source_subfolder(self):
@@ -26,6 +24,18 @@ class PackioConan(ConanFile):
         supported_compilers = [("apple-clang", 10), ("clang", 6), ("gcc", 7), ("Visual Studio", 16)]
         compiler, version = self.settings.compiler, Version(self.settings.compiler.version)
         return any(compiler == sc[0] and version >= sc[1] for sc in supported_compilers)
+
+    def config_options(self):
+        if self._as_number(self.version) < self._as_number("1.2.0"):
+            del self.options.standalone_asio
+
+    def requirements(self):
+        self.requires("msgpack/3.2.1")
+
+        if self.options.standalone_asio:
+            self.requires("asio/1.16.1")
+        else:
+            self.requires("boost/1.73.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -44,3 +54,12 @@ class PackioConan(ConanFile):
 
     def package_id(self):
         self.info.header_only()
+
+    def package_info(self):
+        if self.options.standalone_asio:
+            self.cpp_info.defines.append("PACKIO_STANDALONE_ASIO")
+
+    @staticmethod
+    def _as_number(version):
+        major, minor, patch = version.split('.')
+        return int(major) * 1e6 + int(minor) * 1e3 + int(patch)

--- a/recipes/packio/all/conanfile.py
+++ b/recipes/packio/all/conanfile.py
@@ -56,7 +56,7 @@ class PackioConan(ConanFile):
         self.info.header_only()
 
     def package_info(self):
-        if self.options.standalone_asio:
+        if self.options.get_safe("standalone_asio"):
             self.cpp_info.defines.append("PACKIO_STANDALONE_ASIO")
 
     @staticmethod

--- a/recipes/packio/all/test_package/1.2.x.cpp
+++ b/recipes/packio/all/test_package/1.2.x.cpp
@@ -1,13 +1,17 @@
 #include <packio/packio.h>
 
-namespace ip = boost::asio::ip;
+#if defined(PACKIO_STANDALONE_ASIO)
+namespace net = ::asio;
+#else // defined(PACKIO_STANDALONE_ASIO)
+namespace net = ::boost::asio;
+#endif // defined(PACKIO_STANDALONE_ASIO)
 
 int main(int, char **) {
-  boost::asio::io_context io;
+  net::io_context io;
 
-  ip::tcp::endpoint bind_ep{ip::make_address("127.0.0.1"), 0};
-  auto server = packio::make_server(ip::tcp::acceptor{io, bind_ep});
-  auto client = packio::make_client(ip::tcp::socket{io});
+  net::ip::tcp::endpoint bind_ep{net::ip::make_address("127.0.0.1"), 0};
+  auto server = packio::make_server(net::ip::tcp::acceptor{io, bind_ep});
+  auto client = packio::make_client(net::ip::tcp::socket{io});
 
   return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **packio**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

No new version, but adds an option to use asio instead of boost, compatible from 1.2.0 onwards
