### PR TITLE
xorg: install libx11-xcb-dev on apt systems

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -47,8 +47,7 @@ class ConanXOrg(ConanFile):
                 packages = ["Xorg-x11-devel"]
             else:
                 self.warn("Do not know how to install 'xorg' for {}.".format(tools.os_info.linux_distro))
-            for p in packages:
-                package_tool.install(update=True, packages=p)
+            package_tool.install(update=True, packages=" ".join(packages))
 
     def package_info(self):
         for name in ["x11", "dmx", "fontenc", "libfs", "ice", "sm", "xau", "xaw7", "xcomposite",

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -38,7 +38,7 @@ class ConanXOrg(ConanFile):
         if tools.os_info.is_linux and self.settings.os == "Linux":
             package_tool = tools.SystemPackageTool(conanfile=self, default_mode="verify")
             if tools.os_info.with_apt:
-                packages = ["xorg-dev"]
+                packages = ["xorg-dev", "libx11-xcb-dev"]
             elif tools.os_info.with_yum:
                 packages = ["xorg-x11-server-devel"]
             elif tools.os_info.with_pacman:
@@ -47,7 +47,8 @@ class ConanXOrg(ConanFile):
                 packages = ["Xorg-x11-devel"]
             else:
                 self.warn("Do not know how to install 'xorg' for {}.".format(tools.os_info.linux_distro))
-            package_tool.install(update=True, packages=packages)
+            for p in packages:
+                package_tool.install(update=True, packages=p)
 
     def package_info(self):
         for name in ["x11", "dmx", "fontenc", "libfs", "ice", "sm", "xau", "xaw7", "xcomposite",

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -50,8 +50,8 @@ class ConanXOrg(ConanFile):
             package_tool.install(update=True, packages=" ".join(packages))
 
     def package_info(self):
-        for name in ["x11", "dmx", "fontenc", "libfs", "ice", "sm", "xau", "xaw7", "xcomposite",
-                     "xcursor", "xdamage", "xdmcp", "xext", "xfixes", "xft", "xi",
+        for name in ["x11", "x11-xcb", "dmx", "fontenc", "libfs", "ice", "sm", "xau", "xaw7",
+                     "xcomposite","xcursor", "xdamage", "xdmcp", "xext", "xfixes", "xft", "xi",
                      "xinerama", "xkbfile", "xmu", "xmuu", "xpm", "xrandr", "xrender", "xres",
                      "xscrnsaver", "xt", "xtst", "xv", "xvmc", "xxf86dga", "xxf86vm", "xtrans"]:
             self._fill_cppinfo_from_pkgconfig(name)


### PR DESCRIPTION
this is required by several packages, eg pulseaudio or qt
https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/blob/1fe37e6d4bd5b2d183244538b250dae82ea27d47/configure.ac#L631
https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/configure.json?h=5.15.0#n692

Specify library name and version:  **xorg/system**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

