### PR TITLE
Allow standard CMake scripts to import gtest

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -63,8 +63,6 @@ class GTestConan(ConanFile):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         for pdb_file in glob.glob(os.path.join(self.package_folder, "lib", "*.pdb")):
             os.unlink(pdb_file)
 


### PR DESCRIPTION
Specify library name and version:  gtest/1.10.0

- [x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

By deleting Google Test's CMake scripts from the package, consuming projects must have Conan-specific logic. This saves a negligible amount of space in the binary package but puts unnecessary restrictions on end users. Leaving the package import scripts in allows consuming packages to import GTest and GMock however they please.