### PR TITLE
openal: add User32 to system libs + cache cmake + cmake name

### DIFF
--- a/recipes/openal/all/conanfile.py
+++ b/recipes/openal/all/conanfile.py
@@ -16,6 +16,8 @@ class OpenALConan(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
 
+    _cmake = None
+
     @property
     def _source_subfolder(self):
         return "source_subfolder"
@@ -44,14 +46,16 @@ class OpenALConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["LIBTYPE"] = "SHARED" if self.options.shared else "STATIC"
-        cmake.definitions["ALSOFT_UTILS"] = False
-        cmake.definitions["ALSOFT_EXAMPLES"] = False
-        cmake.definitions["ALSOFT_TESTS"] = False
-        cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_SoundIO"] = True
-        cmake.configure(build_folder=self._build_subfolder)
-        return cmake
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["LIBTYPE"] = "SHARED" if self.options.shared else "STATIC"
+        self._cmake.definitions["ALSOFT_UTILS"] = False
+        self._cmake.definitions["ALSOFT_EXAMPLES"] = False
+        self._cmake.definitions["ALSOFT_TESTS"] = False
+        self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_SoundIO"] = True
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
 
     def build(self):
         for patch in self.conan_data["patches"][self.version]:

--- a/recipes/openal/all/conanfile.py
+++ b/recipes/openal/all/conanfile.py
@@ -72,6 +72,8 @@ class OpenALConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "OpenAL"
+        self.cpp_info.names["cmake_find_package_multi"] = "OpenAL"
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.extend(["dl", "m"])

--- a/recipes/openal/all/conanfile.py
+++ b/recipes/openal/all/conanfile.py
@@ -14,13 +14,22 @@ class OpenALConan(ConanFile):
 
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {'shared': False, 'fPIC': True}
+    default_options = {"shared": False, "fPIC": True}
 
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
 
     def configure(self):
-        if self.settings.os == 'Windows':
+        if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
@@ -33,20 +42,20 @@ class OpenALConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = "openal-soft-openal-soft-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
-        for patch in self.conan_data["patches"][self.version]:
-            tools.patch(**patch)
 
     def _configure_cmake(self):
         cmake = CMake(self)
-        cmake.definitions['LIBTYPE'] = 'SHARED' if self.options.shared else 'STATIC'
-        cmake.definitions['ALSOFT_UTILS'] = False
-        cmake.definitions['ALSOFT_EXAMPLES'] = False
-        cmake.definitions['ALSOFT_TESTS'] = False
-        cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_SoundIO'] = True
+        cmake.definitions["LIBTYPE"] = "SHARED" if self.options.shared else "STATIC"
+        cmake.definitions["ALSOFT_UTILS"] = False
+        cmake.definitions["ALSOFT_EXAMPLES"] = False
+        cmake.definitions["ALSOFT_TESTS"] = False
+        cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_SoundIO"] = True
         cmake.configure(build_folder=self._build_subfolder)
         return cmake
 
     def build(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -60,12 +69,12 @@ class OpenALConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
-        if self.settings.os == 'Linux':
-            self.cpp_info.system_libs.extend(['dl', 'm'])
-        elif self.settings.os == 'Macos':
-            self.cpp_info.frameworks.extend(['AudioToolbox', 'CoreAudio', 'CoreFoundation'])
-        elif self.settings.os == 'Windows':
-            self.cpp_info.system_libs.extend(['winmm', 'ole32', 'shell32', "User32"])
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.extend(["dl", "m"])
+        elif self.settings.os == "Macos":
+            self.cpp_info.frameworks.extend(["AudioToolbox", "CoreAudio", "CoreFoundation"])
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["winmm", "ole32", "shell32", "User32"])
         self.cpp_info.includedirs = ["include", "include/AL"]
         if not self.options.shared:
-            self.cpp_info.defines.append('AL_LIBTYPE_STATIC')
+            self.cpp_info.defines.append("AL_LIBTYPE_STATIC")

--- a/recipes/openal/all/conanfile.py
+++ b/recipes/openal/all/conanfile.py
@@ -65,7 +65,7 @@ class OpenALConan(ConanFile):
         elif self.settings.os == 'Macos':
             self.cpp_info.frameworks.extend(['AudioToolbox', 'CoreAudio', 'CoreFoundation'])
         elif self.settings.os == 'Windows':
-            self.cpp_info.system_libs.extend(['winmm', 'ole32', 'shell32'])
+            self.cpp_info.system_libs.extend(['winmm', 'ole32', 'shell32', "User32"])
         self.cpp_info.includedirs = ["include", "include/AL"]
         if not self.options.shared:
             self.cpp_info.defines.append('AL_LIBTYPE_STATIC')

--- a/recipes/openal/all/test_package/conanfile.py
+++ b/recipes/openal/all/test_package/conanfile.py
@@ -1,4 +1,3 @@
-
 from conans import ConanFile, CMake, tools
 import os
 


### PR DESCRIPTION
Specify library name and version:  **openal/1.19.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I have undefined references to `User32` symbols on Windows while building `qt/5.15.0@bincrafters/stable` with openal.