### PR TITLE
xorg:fix system package installation

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -38,7 +38,7 @@ class ConanXOrg(ConanFile):
         if tools.os_info.is_linux and self.settings.os == "Linux":
             package_tool = tools.SystemPackageTool(conanfile=self, default_mode="verify")
             if tools.os_info.with_apt:
-                packages = ["xorg-dev", "libx11-xcb-dev", "libxcb-render0-dev"]
+                packages = ["xorg-dev", "libx11-xcb-dev", "libxcb-render0-dev", "libxcb-render-util0-dev"]
             elif tools.os_info.with_yum:
                 packages = ["xorg-x11-server-devel"]
             elif tools.os_info.with_pacman:

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -47,7 +47,8 @@ class ConanXOrg(ConanFile):
                 packages = ["Xorg-x11-devel"]
             else:
                 self.warn("Do not know how to install 'xorg' for {}.".format(tools.os_info.linux_distro))
-            package_tool.install(update=True, packages=" ".join(packages))
+            for p in packages:
+                package_tool.install(update=True, packages=p)
 
     def package_info(self):
         for name in ["x11", "x11-xcb", "dmx", "fontenc", "libfs", "ice", "sm", "xau", "xaw7",

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -38,7 +38,7 @@ class ConanXOrg(ConanFile):
         if tools.os_info.is_linux and self.settings.os == "Linux":
             package_tool = tools.SystemPackageTool(conanfile=self, default_mode="verify")
             if tools.os_info.with_apt:
-                packages = ["xorg-dev", "libx11-xcb-dev"]
+                packages = ["xorg-dev", "libx11-xcb-dev", "libxcb-render0-dev"]
             elif tools.os_info.with_yum:
                 packages = ["xorg-x11-server-devel"]
             elif tools.os_info.with_pacman:


### PR DESCRIPTION
Specify library name and version:  **xorg/system**

closes: #1997 

Supplying several packages separated with spaces breaks (at least) in the cross compilation scenario, because it is split by [this function](https://github.com/conan-io/conan/blob/51bf334b28361088bf84b688e612514e2d327177/conans/client/tools/system_pm.py#L141) which returns an array. In the end the only "safe" way to install several system packages is to do one call to [install](https://github.com/conan-io/conan/blob/51bf334b28361088bf84b688e612514e2d327177/conans/client/tools/system_pm.py#L94) for each package (which is what the [documentation ](https://docs.conan.io/en/latest/reference/conanfile/methods.html#systempackagetool)asks anyway)

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

