### PR TITLE
ninja: allow any MSVC runtime when consuming ninja

### DIFF
--- a/recipes/ninja/1.10.x/conanfile.py
+++ b/recipes/ninja/1.10.x/conanfile.py
@@ -15,11 +15,6 @@ class NinjaConan(ConanFile):
     _source_subfolder = "source_subfolder"
     _cmake = None
 
-    def configure(self):
-        if self.settings.compiler == "Visual Studio":
-            if self.settings.compiler.runtime != "MT":
-                raise ConanInvalidConfiguration("Only MT MSVC runtime is supported")
-
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake
@@ -34,6 +29,9 @@ class NinjaConan(ConanFile):
         os.rename("ninja-%s" % self.version, self._source_subfolder)
 
     def build(self):
+        if self.settings.compiler == "Visual Studio":
+            if self.settings.compiler.runtime != "MT":
+                raise ConanInvalidConfiguration("Only MT MSVC runtime is supported")
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
 


### PR DESCRIPTION
Specify library name and version:  **ninja/1.10.0**

closes: #1831


CC @robert-shade 

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

