### PR TITLE
[boost] fix includedirs for the versioned layout

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -846,8 +846,21 @@ class BoostConan(ConanFile):
                 self.output.info(cmd)
                 self.run(cmd)
 
+    @property
+    def _is_versioned_layout(self):
+        layout = self.options.get_safe("layout")
+        return layout == "versioned" or (layout == "b2-default" and os.name == 'nt')
+
     def package_info(self):
         gen_libs = [] if self.options.header_only else tools.collect_libs(self)
+
+        if self._is_versioned_layout:
+            version_tokens = str(self.version).split(".")
+            if len(version_tokens) >= 2:
+                major = version_tokens[0]
+                minor = version_tokens[1]
+                boost_version_tag = "boost-%s_%s" % (major, minor)
+                self.cpp_info.includedirs = [os.path.join(self.package_folder, "include", boost_version_tag)]
 
         # List of lists, so if more than one matches the lib like serialization and wserialization
         # both will be added to the list


### PR DESCRIPTION
closes: #1979 

Specify library name and version:  **boost/all*

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

