### PR TITLE
[sqlite3] upgrade to 3.32.3


### DIFF
--- a/recipes/sqlite3/all/conandata.yml
+++ b/recipes/sqlite3/all/conandata.yml
@@ -1,13 +1,16 @@
-sources:
-  "3.31.1":
-    url: "https://www.sqlite.org/2020/sqlite-amalgamation-3310100.zip"
-    sha256: "f3c79bc9f4162d0b06fa9fe09ee6ccd23bb99ce310b792c5145f87fbcc30efca"
-  "3.31.0":
-    url: "https://www.sqlite.org/2020/sqlite-amalgamation-3310000.zip"
-    sha256: "75836c58be49e9aba539d36e80e72f432e9dedff46618ad2a3adfe5730400bed"
-  "3.30.1":
-    url: "https://www.sqlite.org/2019/sqlite-amalgamation-3300100.zip"
-    sha256: "adf051d4c10781ea5cfabbbc4a2577b6ceca68590d23b58b8260a8e24cc5f081"
+"sources":
   "3.29.0":
-    url: "https://www.sqlite.org/2019/sqlite-amalgamation-3290000.zip"
-    sha256: "48253d8f1616f213422e4374cff39050488d2497812d9bbb8609524127d45732"
+    "sha256": "48253d8f1616f213422e4374cff39050488d2497812d9bbb8609524127d45732"
+    "url": "https://www.sqlite.org/2019/sqlite-amalgamation-3290000.zip"
+  "3.30.1":
+    "sha256": "adf051d4c10781ea5cfabbbc4a2577b6ceca68590d23b58b8260a8e24cc5f081"
+    "url": "https://www.sqlite.org/2019/sqlite-amalgamation-3300100.zip"
+  "3.31.0":
+    "sha256": "75836c58be49e9aba539d36e80e72f432e9dedff46618ad2a3adfe5730400bed"
+    "url": "https://www.sqlite.org/2020/sqlite-amalgamation-3310000.zip"
+  "3.31.1":
+    "sha256": "f3c79bc9f4162d0b06fa9fe09ee6ccd23bb99ce310b792c5145f87fbcc30efca"
+    "url": "https://www.sqlite.org/2020/sqlite-amalgamation-3310100.zip"
+  "3.32.3":
+    "sha256": "e9cec01d4519e2d49b3810615237325263fe1feaceae390ee12b4a29bd73dbe2"
+    "url": "https://www.sqlite.org/2020/sqlite-amalgamation-3320300.zip"

--- a/recipes/sqlite3/config.yml
+++ b/recipes/sqlite3/config.yml
@@ -1,9 +1,11 @@
-versions:
-  "3.31.1":
-    folder: all
-  "3.31.0":
-    folder: all
-  "3.30.1":
-    folder: all
+"versions":
   "3.29.0":
-    folder: all
+    "folder": "all"
+  "3.30.1":
+    "folder": "all"
+  "3.31.0":
+    "folder": "all"
+  "3.31.1":
+    "folder": "all"
+  "3.32.3":
+    "folder": "all"


### PR DESCRIPTION
[sqlite3] upgrade to 3.32.3
NOTE: this is automated commit created by conan-bump32!
command line: C:\bincrafters\conan-bump32\conan-bump32.py -p sqlite3 -v 3.32.3 -f https://www.sqlite.org/2020/sqlite-amalgamation-{major}{minor}0{patch}00.zip -c 2014
closes: https://github.com/conan-io/conan-center-index/issues/2014
