### PR TITLE
[sqlite3] upgrade to 3.32.3


### DIFF
--- a/recipes/sqlite3/all/conandata.yml
+++ b/recipes/sqlite3/all/conandata.yml
@@ -17,4 +17,6 @@
   "3.32.2":
     "sha256": "7e1ebd182a61682f94b67df24c3e6563ace182126139315b659f25511e2d0b5d"
     "url": "https://www.sqlite.org/2020/sqlite-amalgamation-3320200.zip"
-
+  "3.32.3":
+    "sha256": "e9cec01d4519e2d49b3810615237325263fe1feaceae390ee12b4a29bd73dbe2"
+    "url": "https://www.sqlite.org/2020/sqlite-amalgamation-3320300.zip"

--- a/recipes/sqlite3/config.yml
+++ b/recipes/sqlite3/config.yml
@@ -11,3 +11,5 @@
     "folder": "all"
   "3.32.2":
     "folder": "all"
+  "3.32.3":
+    "folder": "all"


### PR DESCRIPTION
[sqlite3] upgrade to 3.32.3
NOTE: this is automated commit created by conan-bump32!
command line: C:\bincrafters\conan-bump32\conan-bump32.py -p sqlite3 -v 3.32.3 -f https://www.sqlite.org/2020/sqlite-amalgamation-{major}{minor}0{patch}00.zip -c 2014
closes: https://github.com/conan-io/conan-center-index/issues/2014
