### PR TITLE
[oatpp] upgrade to 1.1.0


### DIFF
--- a/recipes/oatpp/all/conandata.yml
+++ b/recipes/oatpp/all/conandata.yml
@@ -1,4 +1,7 @@
-sources:
+"sources":
   "1.0.0":
-    url: "https://github.com/oatpp/oatpp/archive/1.0.0.tar.gz"
-    sha256: "9ba7c75e3ada8ec894ec10beae712e775774a835fd3de89d8c34e17740202619"
+    "sha256": "9ba7c75e3ada8ec894ec10beae712e775774a835fd3de89d8c34e17740202619"
+    "url": "https://github.com/oatpp/oatpp/archive/1.0.0.tar.gz"
+  "1.1.0":
+    "sha256": "fcc59615e1282d51826093f95b6c0ded3240ea5c1f322bc253bc36da1f0d3c1c"
+    "url": "https://github.com/oatpp/oatpp/archive/1.1.0.tar.gz"

--- a/recipes/oatpp/config.yml
+++ b/recipes/oatpp/config.yml
@@ -1,3 +1,5 @@
-versions:
+"versions":
   "1.0.0":
-    folder: all
+    "folder": "all"
+  "1.1.0":
+    "folder": "all"


### PR DESCRIPTION
[oatpp] upgrade to 1.1.0
NOTE: this is automated commit created by conan-bump32!
command line: C:\bincrafters\conan-bump32\conan-bump32.py -p oatpp -v 1.1.0 -c 1983
closes: https://github.com/conan-io/conan-center-index/issues/1983
