### PR TITLE
Protobuf: Fix system_libs

### DIFF
--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -85,9 +85,9 @@ class ProtobufConan(ConanFile):
         self.cpp_info.libs.sort(reverse=True)
 
         if self.settings.os == "Linux":
-            self.cpp_info.libs.append("pthread")
+            self.cpp_info.system_libs.append("pthread")
             if self._is_clang_x86 or "arm" in str(self.settings.arch):
-                self.cpp_info.libs.append("atomic")
+                self.cpp_info.system_libs.append("atomic")
 
         if self.settings.os == "Windows":
             if self.options.shared:


### PR DESCRIPTION
Specify library name and version:  **protobuf/**

`pthread` and `atomic` should be in `system_libs` not in `libs`.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

