### PR TITLE
[nng] improve option handling, fix NNGCAT option

### DIFF
--- a/recipes/nng/all/conanfile.py
+++ b/recipes/nng/all/conanfile.py
@@ -18,8 +18,14 @@ class NngConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "nngcat": [True, False],
+        "http": [True, False],
     }
-    default_options = {"shared": False, "fPIC": True, "nngcat": False}
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "nngcat": False,
+        "http": True,
+    }
 
     _source_subfolder = "source_subfolder"
     _cmake = None
@@ -48,7 +54,9 @@ class NngConan(ConanFile):
 
         self._cmake = CMake(self)
         self._cmake.definitions["NNG_TESTS"] = False
-        self._cmake.definitions["NNG_NNGCAT"] = self.options.nngcat
+        self._cmake.definitions["NNG_ENABLE_TLS"] = False
+        self._cmake.definitions["NNG_ENABLE_NNGCAT"] = self.options.nngcat
+        self._cmake.definitions["NNG_ENABLE_HTTP"] = self.options.http
         self._cmake.configure()
 
         return self._cmake


### PR DESCRIPTION
Specify library name and version:  **nng/1.3.0**

I was asked to add the HTTP option and make the TLS option more explicit. But I also discovered a bug where I previously didn't handle the option to build the nngcat tool correctly. Hence,

 * fix NNGCAT option (didn't work at all before)
 * explicitly set ENABLE_TLS to False; this is the default in NNG, so the package behavior is unchanged
 * add ENABLE_HTTP option; defaults to True, as it does in NNG, so the package behavior is unchanged

----

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

