### PR TITLE
Add libsvm

### DIFF
--- a/recipes/libsvm/all/CMakeLists.txt
+++ b/recipes/libsvm/all/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(svm C CXX)
 
-include(../conanbuildinfo.cmake)
+include(${CMAKE_SOURCE_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_library(svm svm.cpp)

--- a/recipes/libsvm/all/CMakeLists.txt
+++ b/recipes/libsvm/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.4)
 project(svm C CXX)
 
 include(${CMAKE_SOURCE_DIR}/conanbuildinfo.cmake)

--- a/recipes/libsvm/all/CMakeLists.txt
+++ b/recipes/libsvm/all/CMakeLists.txt
@@ -6,7 +6,6 @@ conan_basic_setup()
 
 add_library(svm source_subfolder/svm.cpp)
 set_target_properties(svm PROPERTIES PUBLIC_HEADER source_subfolder/svm.h)
-target_include_directories(svm PRIVATE source_subfolder)
 
 add_executable(svm-predict source_subfolder/svm-predict.c)
 target_link_libraries(svm-predict svm)

--- a/recipes/libsvm/all/CMakeLists.txt
+++ b/recipes/libsvm/all/CMakeLists.txt
@@ -4,16 +4,17 @@ project(svm C CXX)
 include(${CMAKE_SOURCE_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_library(svm svm.cpp)
-set_target_properties(svm PROPERTIES PUBLIC_HEADER svm.h)
+add_library(svm source_subfolder/svm.cpp)
+set_target_properties(svm PROPERTIES PUBLIC_HEADER source_subfolder/svm.h)
+target_include_directories(svm PRIVATE source_subfolder)
 
-add_executable(svm-predict svm-predict.c)
+add_executable(svm-predict source_subfolder/svm-predict.c)
 target_link_libraries(svm-predict svm)
 
-add_executable(svm-train svm-train.c)
+add_executable(svm-train source_subfolder/svm-train.c)
 target_link_libraries(svm-train svm)
 
-add_executable(svm-scale svm-scale.c)
+add_executable(svm-scale source_subfolder/svm-scale.c)
 
 install(TARGETS svm svm-predict svm-train svm-scale
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/svm

--- a/recipes/libsvm/all/CMakeLists.txt
+++ b/recipes/libsvm/all/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 2.8)
+project(svm C CXX)
+
+include(../conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_library(svm svm.cpp)
+set_target_properties(svm PROPERTIES PUBLIC_HEADER svm.h)
+
+add_executable(svm-predict svm-predict.c)
+target_link_libraries(svm-predict svm)
+
+add_executable(svm-train svm-train.c)
+target_link_libraries(svm-train svm)
+
+add_executable(svm-scale svm-scale.c)
+
+install(TARGETS svm svm-predict svm-train svm-scale
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/svm
+        )

--- a/recipes/libsvm/all/conandata.yml
+++ b/recipes/libsvm/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "324":
+    url: "https://github.com/cjlin1/libsvm/archive/v324.tar.gz"
+    sha256: "3ba1ac74ee08c4dd57d3a9e4a861ffb57dab88c6a33fd53eac472fc84fbb2a8f"

--- a/recipes/libsvm/all/conanfile.py
+++ b/recipes/libsvm/all/conanfile.py
@@ -1,6 +1,5 @@
 from conans import ConanFile, tools, CMake
 import os
-import shutil
 
 class libsvmConan(ConanFile):
     name = "libsvm"
@@ -23,7 +22,7 @@ class libsvmConan(ConanFile):
     def _configure_cmake(self):
         if not self._cmake:
             self._cmake = CMake(self)
-            self._cmake.configure(source_folder=self._source_subfolder)
+            self._cmake.configure()
         return self._cmake
 
     def config_options(self):
@@ -36,8 +35,6 @@ class libsvmConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def build(self):
-        #Use custom CMakeLists.txt
-        shutil.copy(src=os.path.join(self.source_folder, "CMakeLists.txt"), dst=os.path.join(self.source_folder,self._source_subfolder))
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/libsvm/all/conanfile.py
+++ b/recipes/libsvm/all/conanfile.py
@@ -22,6 +22,8 @@ class libsvmConan(ConanFile):
     def _configure_cmake(self):
         if not self._cmake:
             self._cmake = CMake(self)
+            if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio" and self.options.shared:
+                self._cmake.definitions["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
             self._cmake.configure()
         return self._cmake
 

--- a/recipes/libsvm/all/conanfile.py
+++ b/recipes/libsvm/all/conanfile.py
@@ -1,0 +1,52 @@
+from conans import ConanFile, tools, CMake
+import os
+import shutil
+
+class libsvmConan(ConanFile):
+    name = "libsvm"
+    description = "Libsvm is a simple, easy-to-use, and efficient software for SVM classification and regression"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.csie.ntu.edu.tw/~cjlin/libsvm/"
+    license = "BSD-3-Clause"
+    topics = ("conan", "svm", "vector")
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def _configure_cmake(self):
+        if not self._cmake:
+            self._cmake = CMake(self)
+            self._cmake.configure(source_folder=self._source_subfolder)
+        return self._cmake
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def build(self):
+        #Use custom CMakeLists.txt
+        shutil.copy(src=os.path.join(self.source_folder, "CMakeLists.txt"), dst=os.path.join(self.source_folder,self._source_subfolder))
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("COPYRIGHT", src=self._source_subfolder, dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.names["cmake_find_package"] = "LibSVM"
+        self.cpp_info.names["cmake_find_package_multi"] = "LibSVM"

--- a/recipes/libsvm/all/test_package/CMakeLists.txt
+++ b/recipes/libsvm/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package ${CONAN_LIBS})

--- a/recipes/libsvm/all/test_package/conanfile.py
+++ b/recipes/libsvm/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class apriltagTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libsvm/all/test_package/test_package.cpp
+++ b/recipes/libsvm/all/test_package/test_package.cpp
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "svm/svm.h"
+
+struct svm_parameter param;
+
+int main(int argc, char **argv)
+{
+	param.svm_type = C_SVC;
+	param.kernel_type = PRECOMPUTED;
+
+	//Allocate some dummy data
+	param.weight = (double*)malloc(10 * sizeof(double));
+	svm_destroy_param(&param);
+
+	printf("libsvm version %d test_package OK \n", LIBSVM_VERSION);
+}

--- a/recipes/libsvm/config.yml
+++ b/recipes/libsvm/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "324":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libsvm/324**

libsvm uses a VERY simple `makefile` since it only has 4 source files and one header. Making the makefile conan-friendly will imply a patch probably as long as the makefile itself since it has some hardcoded flags and it only builds `shared`, so I decided to write a custom `CMakeLists.txt` instead. This also means that the recipe is much simpler since we do not need `nmake` and packaging the artifacts manually with `self.copy()`.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

