### PR TITLE
zlib: xcode12 compile fix

### DIFF
--- a/recipes/zlib/1.2.11/conandata.yml
+++ b/recipes/zlib/1.2.11/conandata.yml
@@ -9,3 +9,5 @@ patches:
   "1.2.11":
     - patch_file: "patches/0001-minizip.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0001-gzguts-xcode12-compile-fix.patch"
+      base_path: "source_subfolder"

--- a/recipes/zlib/1.2.11/patches/0001-gzguts-xcode12-compile-fix.patch
+++ b/recipes/zlib/1.2.11/patches/0001-gzguts-xcode12-compile-fix.patch
@@ -1,0 +1,27 @@
+From 4ff188d490445fe7bad629a94d5bf4b641d4ab8d Mon Sep 17 00:00:00 2001
+From: Tim Blechmann <tim@klingt.org>
+Date: Thu, 2 Jul 2020 12:04:38 +0800
+Subject: [PATCH] xcode12 compile fix
+
+---
+ gzguts.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/gzguts.h b/gzguts.h
+index 990a4d2..c78cb40 100644
+--- a/gzguts.h
++++ b/gzguts.h
+@@ -26,6 +26,10 @@
+ #  include <limits.h>
+ #endif
+ 
++#ifdef __APPLE__
++#include <unistd.h>
++#endif
++
+ #ifndef _POSIX_SOURCE
+ #  define _POSIX_SOURCE
+ #endif
+-- 
+2.27.0
+


### PR DESCRIPTION
Specify library name and version:  **zlib/1.2.11**

zlib does not compile with xcode12 due to a missing header

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

