### PR TITLE
Update glu recipe

### DIFF
--- a/recipes/glu/all/conanfile.py
+++ b/recipes/glu/all/conanfile.py
@@ -12,7 +12,7 @@ class SysConfigGLUConan(ConanFile):
     homepage = "https://cgit.freedesktop.org/mesa/glu/"
     license = "SGI-B-2.0"
     settings = "os"
-    requirements = "opengl/system"
+    requires = "opengl/system"
 
     def system_requirements(self):
         if tools.os_info.is_linux and self.settings.os == "Linux":

--- a/recipes/glu/all/conanfile.py
+++ b/recipes/glu/all/conanfile.py
@@ -2,6 +2,7 @@ from conans import ConanFile, tools
 from conans.errors import ConanException
 import os
 
+
 class SysConfigGLUConan(ConanFile):
     name = "glu"
     version = "system"
@@ -10,33 +11,8 @@ class SysConfigGLUConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://cgit.freedesktop.org/mesa/glu/"
     license = "SGI-B-2.0"
-    settings = ("os",)
-
-    def requirements(self):
-        self.requires("opengl/system")
-
-    def package_id(self):
-        self.info.header_only()
-
-    def _fill_cppinfo_from_pkgconfig(self, name):
-        pkg_config = tools.PkgConfig(name)
-        if not pkg_config.provides:
-            raise ConanException("GLU development files aren't available, give up")
-        libs = [lib[2:] for lib in pkg_config.libs_only_l]
-        lib_dirs = [lib[2:] for lib in pkg_config.libs_only_L]
-        ldflags = [flag for flag in pkg_config.libs_only_other]
-        include_dirs = [include[2:] for include in pkg_config.cflags_only_I]
-        cflags = [flag for flag in pkg_config.cflags_only_other if not flag.startswith("-D")]
-        defines = [flag[2:] for flag in pkg_config.cflags_only_other if flag.startswith("-D")]
-
-        self.cpp_info.system_libs.extend(libs)
-        self.cpp_info.libdirs.extend(lib_dirs)
-        self.cpp_info.sharedlinkflags.extend(ldflags)
-        self.cpp_info.exelinkflags.extend(ldflags)
-        self.cpp_info.defines.extend(defines)
-        self.cpp_info.includedirs.extend(include_dirs)
-        self.cpp_info.cflags.extend(cflags)
-        self.cpp_info.cxxflags.extend(cflags)
+    settings = "os"
+    requirements = "opengl/system"
 
     def system_requirements(self):
         if tools.os_info.is_linux and self.settings.os == "Linux":
@@ -55,6 +31,26 @@ class SysConfigGLUConan(ConanFile):
             for p in packages:
                 package_tool.install(update=True, packages=p)
 
+    def _fill_cppinfo_from_pkgconfig(self, name):
+        pkg_config = tools.PkgConfig(name)
+        if not pkg_config.provides:
+            raise ConanException("GLU development files aren't available, giving up")
+        libs = [lib[2:] for lib in pkg_config.libs_only_l]
+        lib_dirs = [lib[2:] for lib in pkg_config.libs_only_L]
+        ldflags = [flag for flag in pkg_config.libs_only_other]
+        include_dirs = [include[2:] for include in pkg_config.cflags_only_I]
+        cflags = [flag for flag in pkg_config.cflags_only_other if not flag.startswith("-D")]
+        defines = [flag[2:] for flag in pkg_config.cflags_only_other if flag.startswith("-D")]
+
+        self.cpp_info.system_libs.extend(libs)
+        self.cpp_info.libdirs.extend(lib_dirs)
+        self.cpp_info.sharedlinkflags.extend(ldflags)
+        self.cpp_info.exelinkflags.extend(ldflags)
+        self.cpp_info.defines.extend(defines)
+        self.cpp_info.includedirs.extend(include_dirs)
+        self.cpp_info.cflags.extend(cflags)
+        self.cpp_info.cxxflags.extend(cflags)
+
     def package_info(self):
         self.cpp_info.include_dirs = []
         self.cpp_info.libdirs = []
@@ -63,3 +59,6 @@ class SysConfigGLUConan(ConanFile):
             self.cpp_info.system_libs = ["Glu32"]
         elif self.settings.os == "Linux":
             self._fill_cppinfo_from_pkgconfig("glu")
+
+    def package_id(self):
+        self.info.header_only()


### PR DESCRIPTION
Specify library name and version:  **glu/system**

After merging https://github.com/conan-io/conan-center-index/pull/1976 it seems that the recipe was not uploaded to ConanCenter, which may be caused due to an error during github downtime yesterday. This PR updates the recipe in order to retrigger the pipeline

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

