### PR TITLE
Issue #2102 : automake configure depends on package m4

### DIFF
--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -22,7 +22,9 @@ class AutoconfConan(ConanFile):
         os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
 
     def requirements(self):
-        self.requires("m4/1.4.18")
+        if not tools.os_info.is_windows:
+            #the Conan m4 package currently doesn't work correctly with autoconf
+            self.requires("m4/1.4.18")
 
     def build_requirements(self):
         if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -21,6 +21,9 @@ class AutoconfConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
 
+    def requirements(self):
+        self.requires("m4/1.4.18")
+
     def build_requirements(self):
         if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:
             self.build_requires("msys2/20190524")

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -22,7 +22,7 @@ class AutoconfConan(ConanFile):
         os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
 
     def requirements(self):
-        if not tools.os_info.is_windows:
+        if self.settings.os_build != "Windows":
             #the Conan m4 package currently doesn't work correctly with autoconf
             self.requires("m4/1.4.18")
 

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -23,7 +23,7 @@ class AutoconfConan(ConanFile):
 
     def requirements(self):
         if self.settings.os_build != "Windows":
-            #the Conan m4 package currently doesn't work correctly with autoconf
+            #the Conan m4 package currently doesn't work correctly with autoconf on Windows
             self.requires("m4/1.4.18")
 
     def build_requirements(self):

--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -29,7 +29,6 @@ class AutomakeConan(ConanFile):
 
     def requirements(self):
         self.requires("autoconf/2.69")
-        self.requires("m4/1.4.18")
         # automake requires perl-Thread-Queue package
 
     def build_requirements(self):

--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -29,6 +29,7 @@ class AutomakeConan(ConanFile):
 
     def requirements(self):
         self.requires("autoconf/2.69")
+        self.requires("m4/1.4.18")
         # automake requires perl-Thread-Queue package
 
     def build_requirements(self):


### PR DESCRIPTION
Specify library name and version:  **automake/1.16.2**

Pull request to fix #2102 . When you try to create the automake package on a Linux system where m4 is not installed, the automake configure step will fail.

- [x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

