### PR TITLE
opengl: don't fail hard when distro is unknown

### DIFF
--- a/recipes/opengl/all/conanfile.py
+++ b/recipes/opengl/all/conanfile.py
@@ -56,8 +56,10 @@ class SysConfigOpenGLConan(ConanFile):
             elif tools.os_info.with_zypper:
                 packages = ["Mesa-libGL-devel"]
             else:
+                packages = []
                 self.output.warn("Don't know how to install OpenGL for your distro.")
-            package_tool.install(update=True, packages=packages)
+            for p in packages:
+                package_tool.install(update=True, packages=p)
 
     def package_info(self):
         self.cpp_info.includedirs = []


### PR DESCRIPTION
Specify library name and version:  **opengl/system**

without this change, all unknown distribution have a hard fail with
```
opengl/system: WARN: Don't know how to install OpenGL for your distro.
opengl/system: ERROR: while executing system_requirements(): local variable 'packages' referenced before assignment
ERROR: Error in system requirements
```

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

