### PR TITLE
[libxcrypt] Update build_requires: use same versions as libtool

### DIFF
--- a/recipes/libxcrypt/all/conanfile.py
+++ b/recipes/libxcrypt/all/conanfile.py
@@ -43,7 +43,7 @@ class LibxcryptConan(ConanFile):
         os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
 
     def build_requirements(self):
-        self.build_requires("automake/1.16.1")
+        self.build_requires("automake/1.16.2")
         self.build_requires("libtool/2.4.6")
 
     def _configure_autotools(self):


### PR DESCRIPTION
Specify library name and version:  **libxcrypt/all**

Conan reports a conflict even though they are different build_requires. This is something we'll try to improve in Conan 2.0 with an improved graph model.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

