### PR TITLE
[PR] wt/4.3.1: duplicate symbols during linking, "multiple definition of `Wt::WServer::~WServer()" (closes #2095)

### DIFF
--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -41,7 +41,7 @@ class WtConan(ConanFile):
         'with_postgres': True,
         'with_mysql': True,
         'with_mssql': False,
-        'with_test': True,
+        'with_test': False,
         'with_dbo': True,
         'with_opengl': False,
         'with_unwind': True,

--- a/recipes/wt/all/test_package/conanfile.py
+++ b/recipes/wt/all/test_package/conanfile.py
@@ -15,5 +15,6 @@ class TestPackageConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+            args = " --docroot . --http-listen http://127.0.0.1:8080"
+            self.run(bin_path + args, run_environment=True)
 

--- a/recipes/wt/all/test_package/test_package.cpp
+++ b/recipes/wt/all/test_package/test_package.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <Wt/WLength.h>
+#include <Wt/WServer.h>
 
 #ifdef WITH_DBO
 
@@ -9,12 +10,14 @@
 #endif
 
 
-int main()
+int main(int argc, char** argv)
 {
     Wt::WLength l("10px");
 #ifdef WITH_DBO
     Wt::Dbo::Session session;
 #endif
+
+    Wt::WServer server(argc, argv, WTHTTP_CONFIGURATION);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Specify library name and version:  **wt/4.3.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

