### PR TITLE
libuv: add libuv/1.38.1

### DIFF
--- a/recipes/libuv/all/conandata.yml
+++ b/recipes/libuv/all/conandata.yml
@@ -5,6 +5,9 @@ sources:
   "1.38.0":
     url: "https://github.com/libuv/libuv/archive/v1.38.0.zip"
     sha256: "6502ee75e1007325ba2e15e06d3d7b94ac911704793b2fe6f7bb933e1748db72"
+  "1.38.1":
+    url: "https://github.com/libuv/libuv/archive/v1.38.1.zip"
+    sha256: "0359369492742eb2a36312fffe26f80bcffe4cec981a4fd72d182b061ee14890"
 patches:
   "1.34.2":
     - base_path: "source_subfolder"
@@ -12,3 +15,6 @@ patches:
   "1.38.0":
     - base_path: "source_subfolder"
       patch_file: "patches/1.38.0/fix-cmake.patch"
+  "1.38.1":
+    - base_path: "source_subfolder"
+      patch_file: "patches/1.38.1/fix-cmake.patch"

--- a/recipes/libuv/all/patches/1.38.1/fix-cmake.patch
+++ b/recipes/libuv/all/patches/1.38.1/fix-cmake.patch
@@ -1,0 +1,78 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2518c747..05b5add1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -297,13 +297,17 @@ if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|Linux|NetBSD|OpenBSD")
+   list(APPEND uv_test_libraries util)
+ endif()
+ 
+-add_library(uv SHARED ${uv_sources})
+-target_compile_definitions(uv
+-  INTERFACE
+-    USING_UV_SHARED=1
+-  PRIVATE
+-    BUILDING_UV_SHARED=1
+-    ${uv_defines})
++add_library(uv ${uv_sources})
++get_target_property(target_type uv TYPE)
++if (target_type STREQUAL "SHARED_LIBRARY")
++  target_compile_definitions(uv
++    INTERFACE
++      USING_UV_SHARED=1
++    PRIVATE
++      BUILDING_UV_SHARED=1
++  )
++endif()
++target_compile_definitions(uv PRIVATE ${uv_defines})
+ target_compile_options(uv PRIVATE ${uv_cflags})
+ target_include_directories(uv
+   PUBLIC
+@@ -313,17 +317,6 @@ target_include_directories(uv
+     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+ target_link_libraries(uv ${uv_libraries})
+ 
+-add_library(uv_a STATIC ${uv_sources})
+-target_compile_definitions(uv_a PRIVATE ${uv_defines})
+-target_compile_options(uv_a PRIVATE ${uv_cflags})
+-target_include_directories(uv_a
+-  PUBLIC
+-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+-  PRIVATE
+-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+-target_link_libraries(uv_a ${uv_libraries})
+-
+ if(LIBUV_BUILD_TESTS)
+   # Small hack: use ${uv_test_sources} now to get the runner skeleton,
+   # before the actual tests are added.
+@@ -558,22 +551,20 @@ if(UNIX)
+   set(includedir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
+   set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+   set(prefix ${CMAKE_INSTALL_PREFIX})
+-  configure_file(libuv.pc.in libuv.pc @ONLY)
+ 
+   install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+-  install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
+-  install(FILES ${PROJECT_BINARY_DIR}/libuv.pc
+-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+-  install(TARGETS uv LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  install(TARGETS uv_a ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++  install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses)
++  install(TARGETS uv
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ endif()
+ 
+ if(WIN32)
+   install(DIRECTORY include/ DESTINATION include)
+-  install(FILES LICENSE DESTINATION .)
+-  install(TARGETS uv uv_a
+-          RUNTIME DESTINATION lib/$<CONFIG>
+-          ARCHIVE DESTINATION lib/$<CONFIG>)
++  install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses)
++  install(TARGETS uv
++    RUNTIME DESTINATION bin
++    ARCHIVE DESTINATION lib)
+ endif()
+ 
+ message(STATUS "summary of build options:

--- a/recipes/libuv/config.yml
+++ b/recipes/libuv/config.yml
@@ -3,3 +3,5 @@ versions:
         folder: all
     "1.38.0":
         folder: all
+    "1.38.1":
+        folder: all


### PR DESCRIPTION
Specify library name and version:  **libuv/1.38.1**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.  **Tested with Conan 1.27.0.**
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.  **Built on Kubuntu 20.04 using clang 10.**

---

This PR adds libuv 1.38.1 to the libuv recipe.  The CMake patch has been updated to accommodate changes in 1.38.1's build system.  (All changes are hunk offsets.)