### PR TITLE
glfw: fix pkgconfig name

### DIFF
--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -66,6 +66,7 @@ class GlfwConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
+        self.cpp_info.names["pkg_config"] = "glfw3"
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.extend(["m", "pthread", "dl", "rt"])

--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -42,6 +42,8 @@ class GlfwConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 


### PR DESCRIPTION
Specify library name and version:  **glfw/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

pkgconfig file name: https://github.com/glfw/glfw/blob/4ae93e054774c97a3e39ca6ba03000e84f5e2127/CMakeLists.txt#L295