### PR TITLE
giflib <= 5.1.4: fix cmake target + delete fPIC option if shared

### DIFF
--- a/recipes/giflib/all/conanfile.py
+++ b/recipes/giflib/all/conanfile.py
@@ -103,8 +103,6 @@ class GiflibConan(ConanFile):
     def build_configure(self):
         env_build = AutoToolsBuildEnvironment(self, win_bash=self.settings.os == "Windows" and
                                               platform.system() == "Windows")
-        if self.settings.os != "Windows":
-            env_build.fpic = self.options.get_safe("fPIC", True)
 
         prefix = os.path.abspath(self.package_folder)
         if self.settings.os == "Windows":

--- a/recipes/giflib/all/conanfile.py
+++ b/recipes/giflib/all/conanfile.py
@@ -26,6 +26,8 @@ class GiflibConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
@@ -102,7 +104,7 @@ class GiflibConan(ConanFile):
         env_build = AutoToolsBuildEnvironment(self, win_bash=self.settings.os == "Windows" and
                                               platform.system() == "Windows")
         if self.settings.os != "Windows":
-            env_build.fpic = self.options.fPIC
+            env_build.fpic = self.options.get_safe("fPIC", True)
 
         prefix = os.path.abspath(self.package_folder)
         if self.settings.os == "Windows":

--- a/recipes/giflib/all/conanfile.py
+++ b/recipes/giflib/all/conanfile.py
@@ -131,6 +131,8 @@ class GiflibConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "GIF"
+        self.cpp_info.names["cmake_find_package_multi"] = "GIF"
         self.cpp_info.libs = ["gif"]
         if self.settings.compiler == "Visual Studio":
             if self.options.shared:


### PR DESCRIPTION
Specify library name and version:  **giflib <= 5.1.4**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

https://cmake.org/cmake/help/v3.14/module/FindGIF.html