### PR TITLE
add opensslextra configure option

### DIFF
--- a/recipes/wolfssl/all/conanfile.py
+++ b/recipes/wolfssl/all/conanfile.py
@@ -15,11 +15,13 @@ class WolfSSLConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "opensslextra": [True, False],
+        "opensslall": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "opensslextra": False,
+        "opensslall": False,
     }
 
     _autotools = None
@@ -80,6 +82,8 @@ class WolfSSLConan(ConanFile):
         ]
         if self.options.opensslextra:
             conf_args.extend(["--enable-opensslextra"])
+            if self.options.opensslall:
+                conf_args.extend(["--enable-opensslall"])
         if self.options.shared:
             conf_args.extend(["--enable-shared", "--disable-static"])
         else:

--- a/recipes/wolfssl/all/conanfile.py
+++ b/recipes/wolfssl/all/conanfile.py
@@ -14,10 +14,12 @@ class WolfSSLConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "opensslextra": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "opensslextra": False,
     }
 
     _autotools = None
@@ -76,6 +78,8 @@ class WolfSSLConan(ConanFile):
             "--enable-harden",
             "--enable-debug" if self.settings.build_type == "Debug" else "--disable-debug",
         ]
+        if self.options.opensslextra:
+            conf_args.extend(["--enable-opensslextra"])
         if self.options.shared:
             conf_args.extend(["--enable-shared", "--disable-static"])
         else:


### PR DESCRIPTION
Add support for opensslextra configuration option for openssl compatibility layer
default value is false.
This is based on the work from theirix PR 2027

closes #2154 

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

