### PR TITLE
snappy: fix cmake target

### DIFF
--- a/recipes/snappy/all/conanfile.py
+++ b/recipes/snappy/all/conanfile.py
@@ -61,16 +61,8 @@ class SnappyConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "Snappy"
         self.cpp_info.names["cmake_find_package_multi"] = "Snappy"
-        self.cpp_info.libs = tools.collect_libs(self)
-        if not self.options.shared and self._stdcpp_library:
-            self.cpp_info.system_libs.append(self._stdcpp_library)
-
-    @property
-    def _stdcpp_library(self):
-        libcxx = self.settings.get_safe("compiler.libcxx")
-        if libcxx in ("libstdc++", "libstdc++11"):
-            return "stdc++"
-        elif libcxx in ("libc++",):
-            return "c++"
-        else:
-            return False
+        self.cpp_info.components["snappylib"].names["cmake_find_package"] = "snappy"
+        self.cpp_info.components["snappylib"].names["cmake_find_package_multi"] = "snappy"
+        self.cpp_info.components["snappylib"].libs = tools.collect_libs(self)
+        if not self.options.shared and tools.stdcpp_library(self):
+            self.cpp_info.components["snappylib"].system_libs.append(tools.stdcpp_library(self))

--- a/recipes/snappy/all/test_package/CMakeLists.txt
+++ b/recipes/snappy/all/test_package/CMakeLists.txt
@@ -1,12 +1,14 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(Snappy REQUIRED)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} Snappy::snappy)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
 
 add_executable(${PROJECT_NAME}_c test_package.c)
-target_link_libraries(${PROJECT_NAME}_c ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME}_c Snappy::snappy)

--- a/recipes/snappy/all/test_package/conanfile.py
+++ b/recipes/snappy/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **snappy/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Snappy imported target is `Snappy::snappy`.
patches in `c-blosc` recipe should also be fixed to use `Snappy::snappy` instead of `Snappy::Snappy` (this is why most of the time I prefer to rely on `CONAN_PKG::recipename` inside CCI recipes, it can't break).