### PR TITLE
[OpenBlas] Change default dynamic_arch option to true

### DIFF
--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -26,7 +26,7 @@ class OpenblasConan(ConanFile):
         "fPIC": True,
         "build_lapack": False,
         "use_thread": True,
-        "dynamic_arch": False
+        "dynamic_arch": True
     }
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"


### PR DESCRIPTION
Specify library name and version:  **OpenBlas/all**

OpenBlas is a complex library that compiles different code depending on CPU type within the same architecture. When a binary package is retrieved from Conan center, we are retrieving a package compiled for a specific CPU which may not match the destination CPU. 
I think a better option is to compile by default for multiples CPUs (using `dynamic_arch` option) and let the library decide at runtime which implementation to use. If you want to use a version compiled only for your CPU yo just have to set the option `dynamic_arch` to `False`.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

