### PR TITLE
physx: add components

### DIFF
--- a/recipes/physx/4.x.x/test_package/CMakeLists.txt
+++ b/recipes/physx/4.x.x/test_package/CMakeLists.txt
@@ -1,14 +1,17 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(PhysX REQUIRED PhysX PhysXExtensions)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PhysX::PhysX PhysX::PhysXExtensions)
 
 option(TEST_SHARED_LIBRARY "Build a test shared library")
 if(TEST_SHARED_LIBRARY)
+    find_package(PhysX REQUIRED PhysXFoundation)
     add_library(${PROJECT_NAME}_lib SHARED test_library.cpp)
-    target_link_libraries(${PROJECT_NAME}_lib ${CONAN_LIBS})
+    target_link_libraries(${PROJECT_NAME}_lib PhysX::PhysXFoundation PhysX::PhysXExtensions)
 endif()

--- a/recipes/physx/4.x.x/test_package/conanfile.py
+++ b/recipes/physx/4.x.x/test_package/conanfile.py
@@ -5,7 +5,7 @@ from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **physx/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Currenrly, PhysX doesn't export its targets, but it should be fixed by https://github.com/NVIDIAGameWorks/PhysX/pull/222

PhysX has a target `PhysX::PhysX` which doesn't depend on all components. With current behaviour of conan, there is no way to properly model this target, since it is reserved for "custom conan global target".
Therefore, consumers could only link `PhysX::PhysX` with conan generators, without link errors, while they may have link errors without conan (if they use components not dragged by `PhysX::PhysX`, like `PhysXExtensions`, `PhysXVehicle`, `PhysXCooking` and `PhysXCharacterKinematic`, and forget to also link them).