### PR TITLE
harfbuzz: add missing system lib

### DIFF
--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -68,6 +68,8 @@ class HarfbuzzConan(ConanFile):
         compiler = str(self.settings.compiler)
         if compiler in ("clang", "apple-clang"):
             flags.append("-Wno-deprecated-declarations")
+        if self.settings.compiler == "gcc" and self.settings.os == "Windows":
+            flags.append("-Wa,-mbig-obj")
         cmake.definitions["CMAKE_C_FLAGS"] = " ".join(flags)
         cmake.definitions["CMAKE_CXX_FLAGS"] = cmake.definitions["CMAKE_C_FLAGS"]
 
@@ -114,6 +116,6 @@ class HarfbuzzConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("m")
         if self.settings.os == "Windows" and not self.options.shared:
-            self.cpp_info.system_libs.extend(["dwrite", "rpcrt4", "usp10", "gdi32"])
+            self.cpp_info.system_libs.extend(["dwrite", "rpcrt4", "usp10", "gdi32", "user32"])
         if self.settings.os == "Macos":
             self.cpp_info.frameworks.extend(["CoreFoundation", "CoreGraphics", "CoreText"])


### PR DESCRIPTION
windows requires user32, for getDC() and ReleaseDC()

also fix mingw debug build

Specify library name and version:  **harfbuzz/2.6.8**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

