### PR TITLE
c-blosc: use Snappy::snappy target in patches

### DIFF
--- a/recipes/c-blosc/all/patches/cmake-dependencies-1.8.1-.patch
+++ b/recipes/c-blosc/all/patches/cmake-dependencies-1.8.1-.patch
@@ -47,7 +47,7 @@
  if(NOT DEACTIVATE_SNAPPY)
      if(SNAPPY_FOUND)
 -        set(LIBS ${LIBS} ${SNAPPY_LIBRARY})
-+        set(LIBS ${LIBS} "Snappy::Snappy")
++        set(LIBS ${LIBS} "Snappy::snappy")
      else(SNAPPY_FOUND)
          file(GLOB SNAPPY_FILES ${SNAPPY_LOCAL_DIR}/*.cc)
          set(SOURCES ${SOURCES} ${SNAPPY_FILES})

--- a/recipes/c-blosc/all/patches/cmake-dependencies-1.9.0+.patch
+++ b/recipes/c-blosc/all/patches/cmake-dependencies-1.9.0+.patch
@@ -47,7 +47,7 @@
  if(NOT DEACTIVATE_SNAPPY)
      if(SNAPPY_FOUND)
 -        set(LIBS ${LIBS} ${SNAPPY_LIBRARY})
-+        set(LIBS ${LIBS} "Snappy::Snappy")
++        set(LIBS ${LIBS} "Snappy::snappy")
      else(SNAPPY_FOUND)
          file(GLOB SNAPPY_FILES ${SNAPPY_LOCAL_DIR}/*.cc)
          set(SOURCES ${SOURCES} ${SNAPPY_FILES})


### PR DESCRIPTION
`c-blosc` optionally depends on `snappy`.
https://github.com/conan-io/conan-center-index/pull/2169 fixed Snappy target for conan generators (`Snappy::snappy` instead of `Snappy::Snappy`) and patches in `c-blosc` recipe rely on this target.

Specify library name and version:  **c-blosc/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

