### PR TITLE
autoconf: remove requires from the package id calculation

### DIFF
--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -22,9 +22,7 @@ class AutoconfConan(ConanFile):
         os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
 
     def requirements(self):
-        if self.settings.os_build != "Windows":
-            #the Conan m4 package currently doesn't work correctly with autoconf on Windows
-            self.requires("m4/1.4.18")
+        self.requires("m4/1.4.18")
 
     def build_requirements(self):
         if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -78,6 +78,10 @@ class AutoconfConan(ConanFile):
                     continue
                 os.rename(fullpath, fullpath + ".exe")
 
+    def package_id(self):
+        # The m4 requirement does not change the contents of this package
+        self.info.requires.clear()
+
     def package_info(self):
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH env var with : {}".format(bin_path))


### PR DESCRIPTION
Specify library name and version:  **autoconf/2.69**

- [x] Depends on #2198

- Fixes problem at https://github.com/conan-io/conan-center-index/pull/1986#issuecomment-657462799
- Fixes problem at https://github.com/conan-io/conan-center-index/pull/2103#issuecomment-653607752 (after #2198)

@ericLemanissier 

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

