### PR TITLE
add premake/5.0.0-alpha15

### DIFF
--- a/recipes/premake/5.x/conandata.yml
+++ b/recipes/premake/5.x/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "5.0.0-alpha14":
     url: "https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-src.zip"
     sha256: "7c9fa4488156625c819dd03f2b48bfd4712fbfabdc2b5768e8c7f52dd7d16608"
+  "5.0.0-alpha15":
+    url: "https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-src.zip"
+    sha256: "880f56e7cb9f4945d1cb879f059189462c1b7bf62ef43ac7d25842dfb177dd53"

--- a/recipes/premake/5.x/conanfile.py
+++ b/recipes/premake/5.x/conanfile.py
@@ -10,7 +10,7 @@ class PremakeConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://premake.github.io"
     license = "BSD-3-Clause"
-    settings = "os", "arch", "compiler"
+    settings = "os", "arch", "compiler", "build_type"
     _source_subfolder = "source_subfolder"
 
     def configure(self):
@@ -37,7 +37,7 @@ class PremakeConan(ConanFile):
         with tools.chdir(os.path.join(self._source_subfolder, "build", self._platform)):
             if self.settings.os == "Windows":
                 msbuild = MSBuild(self)
-                msbuild.build("Premake5.sln", platforms={"x86": "Win32", "x86_64": "x64"}, build_type="Release", arch="{}".format(self.settings.arch))
+                msbuild.build("Premake5.sln", platforms={"x86": "Win32", "x86_64": "x64"})
             elif self.settings.os == "Linux" or self.settings.os == "Macos":
                 env_build = AutoToolsBuildEnvironment(self)
                 env_build.make(args=["config=release"])

--- a/recipes/premake/5.x/conanfile.py
+++ b/recipes/premake/5.x/conanfile.py
@@ -5,17 +5,16 @@ import os
 
 class PremakeConan(ConanFile):
     name = "premake"
-    version = "5.0.0-alpha14"
     topics = ("conan", "premake", "build", "build-systems")
     description = "Describe your software project just once, using Premake's simple and easy to read syntax, and build it everywhere"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://premake.github.io/"
+    homepage = "https://premake.github.io"
     license = "BSD-3-Clause"
-    settings = "os_build", "arch_build", "compiler"
+    settings = "os", "arch", "compiler"
     _source_subfolder = "source_subfolder"
 
     def configure(self):
-        if self.settings.os_build == "Windows" and self.settings.compiler == "gcc":
+        if self.settings.os == "Windows" and self.settings.compiler == "gcc":
             raise ConanInvalidConfiguration("Building with MinGW isn't supported currently by the recipe")
 
     def source(self):
@@ -25,21 +24,21 @@ class PremakeConan(ConanFile):
 
     @property
     def _platform(self):
-        return {'Windows': 'vs2017',
-                'Linux': 'gmake.unix',
-                'Macos': 'gmake.macosx'}.get(str(self.settings.os_build))
+        return {"Windows": "vs2017",
+                "Linux": "gmake.unix",
+                "Macos": "gmake.macosx"}.get(str(self.settings.os))
 
     def build(self):
-        with tools.chdir(os.path.join(self._source_subfolder, 'build', self._platform)):
-            if self.settings.os_build == 'Windows':
+        with tools.chdir(os.path.join(self._source_subfolder, "build", self._platform)):
+            if self.settings.os == "Windows":
                 msbuild = MSBuild(self)
-                msbuild.build("Premake5.sln", platforms={'x86': 'Win32', 'x86_64': 'x64'}, build_type="Release", arch=self.settings.arch_build)
-            elif self.settings.os_build == 'Linux':
+                msbuild.build("Premake5.sln", platforms={"x86": "Win32", "x86_64": "x64"}, build_type="Release", arch=self.settings.arch)
+            elif self.settings.os == "Linux":
                 env_build = AutoToolsBuildEnvironment(self)
-                env_build.make(args=['config=release'])
-            elif self.settings.os_build == 'Macos':
+                env_build.make(args=["config=release"])
+            elif self.settings.os == "Macos":
                 env_build = AutoToolsBuildEnvironment(self)
-                env_build.make(args=['config=release'])
+                env_build.make(args=["config=release"])
 
     def package(self):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)

--- a/recipes/premake/5.x/conanfile.py
+++ b/recipes/premake/5.x/conanfile.py
@@ -37,7 +37,7 @@ class PremakeConan(ConanFile):
         with tools.chdir(os.path.join(self._source_subfolder, "build", self._platform)):
             if self.settings.os == "Windows":
                 msbuild = MSBuild(self)
-                msbuild.build("Premake5.sln", platforms={"x86": "Win32", "x86_64": "x64"}, build_type="Release", arch=self.settings.arch)
+                msbuild.build("Premake5.sln", platforms={"x86": "Win32", "x86_64": "x64"}, build_type="Release", arch="{}".format(self.settings.arch))
             elif self.settings.os == "Linux" or self.settings.os == "Macos":
                 env_build = AutoToolsBuildEnvironment(self)
                 env_build.make(args=["config=release"])

--- a/recipes/premake/5.x/conanfile.py
+++ b/recipes/premake/5.x/conanfile.py
@@ -24,19 +24,21 @@ class PremakeConan(ConanFile):
 
     @property
     def _platform(self):
-        return {"Windows": "vs2017",
-                "Linux": "gmake.unix",
-                "Macos": "gmake.macosx"}.get(str(self.settings.os))
+        if self.version == "5.0.0-alpha14":
+            return {"Windows": "vs2017",
+                    "Linux": "gmake.unix",
+                    "Macos": "gmake.macosx"}.get(str(self.settings.os))
+        else:
+            return {"Windows": "vs2017",
+                    "Linux": "gmake2.unix",
+                    "Macos": "gmake2.macosx"}.get(str(self.settings.os))
 
     def build(self):
         with tools.chdir(os.path.join(self._source_subfolder, "build", self._platform)):
             if self.settings.os == "Windows":
                 msbuild = MSBuild(self)
                 msbuild.build("Premake5.sln", platforms={"x86": "Win32", "x86_64": "x64"}, build_type="Release", arch=self.settings.arch)
-            elif self.settings.os == "Linux":
-                env_build = AutoToolsBuildEnvironment(self)
-                env_build.make(args=["config=release"])
-            elif self.settings.os == "Macos":
+            elif self.settings.os == "Linux" or self.settings.os == "Macos":
                 env_build = AutoToolsBuildEnvironment(self)
                 env_build.make(args=["config=release"])
 

--- a/recipes/premake/config.yml
+++ b/recipes/premake/config.yml
@@ -1,3 +1,5 @@
 versions:
   "5.0.0-alpha14":
     folder: "5.x"
+  "5.0.0-alpha15":
+    folder: "5.x"


### PR DESCRIPTION
Specify library name and version:  **premake/5.0.0-alpha15**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

____________

Let's see what CI is saying. On my local Windows machine I have the following error:

```
ERROR: premake/5.0.0-alpha15: Error in build() method, line 35
        msbuild.build("Premake5.sln", platforms={"x86": "Win32", "x86_64": "x64"}, build_type="Release", arch=self.settings.arch)
        TypeError: unhashable type: 'SettingsItem'
```

Which makes that curious is that I even had the error with the old version before I change this particular line. And it worked for me in the past (I contributed this recipe) 🤔 

