### PR TITLE
Patch boost to build with PCH instead of PTH to enable Clang

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -47,6 +47,11 @@ sources:
     ]
     sha256: "4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402"
 patches:
+  1.68.0:
+    - patch_file: "patches/python_base_prefix.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/boost_build_clang_fix_emit_pth.patch"
+      base_path: "source_subfolder"
   1.69.0:
     - patch_file: "patches/boost_build_asmflags.patch"
       base_path: "source_subfolder"

--- a/recipes/boost/all/patches/boost_build_clang_fix_emit_pth.patch
+++ b/recipes/boost/all/patches/boost_build_clang_fix_emit_pth.patch
@@ -1,0 +1,83 @@
+diff --git a/tools/build/src/tools/clang-linux.jam b/tools/build/src/tools/clang-linux.jam
+index 9b7ec8b..8f9fec1 100644
+--- a/tools/build/src/tools/clang-linux.jam
++++ b/tools/build/src/tools/clang-linux.jam
+@@ -85,47 +85,47 @@ toolset.flags clang-linux.link OPTIONS <threading>multi/<target-os>windows : -pt
+ # C and C++ compilation
+ 
+ rule compile.c++ ( targets * : sources * : properties * ) {
+-  local pth-file = [ on $(<) return $(PCH_FILE) ] ;
++  local pch-file = [ on $(<) return $(PCH_FILE) ] ;
+ 
+-  if $(pth-file) {
+-    DEPENDS $(<) : $(pth-file) ;
++  if $(pch-file) {
++    DEPENDS $(<) : $(pch-file) ;
+     clang-linux.compile.c++.with-pch $(targets) : $(sources) ;
+   }
+   else {
+-    clang-linux.compile.c++.without-pth $(targets) : $(sources) ;
++    clang-linux.compile.c++.without-pch $(targets) : $(sources) ;
+   }
+ }
+ 
+-actions compile.c++.without-pth {
++actions compile.c++.without-pch {
+   "$(CONFIG_COMMAND)" -c -x c++ $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -o "$(<)" "$(>)"
+ }
+ 
+ actions compile.c++.with-pch bind PCH_FILE
+ {
+-  "$(CONFIG_COMMAND)" -c -x c++ $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -include-pth -Xclang "$(PCH_FILE)" -o "$(<)" "$(>)"
++  "$(CONFIG_COMMAND)" -c -x c++ $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -include-pch -Xclang "$(PCH_FILE)" -o "$(<)" "$(>)"
+ }
+ 
+ rule compile.c ( targets * : sources * : properties * )
+ {
+-  local pth-file = [ on $(<) return $(PCH_FILE) ] ;
++  local pch-file = [ on $(<) return $(PCH_FILE) ] ;
+ 
+-  if $(pth-file) {
+-    DEPENDS $(<) : $(pth-file) ;
++  if $(pch-file) {
++    DEPENDS $(<) : $(pch-file) ;
+     clang-linux.compile.c.with-pch $(targets) : $(sources) ;
+   }
+   else {
+-    clang-linux.compile.c.without-pth $(targets) : $(sources) ;
++    clang-linux.compile.c.without-pch $(targets) : $(sources) ;
+   }
+ }
+ 
+-actions compile.c.without-pth
++actions compile.c.without-pch
+ {
+   "$(CONFIG_COMMAND)" -c -x c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
+ }
+ 
+ actions compile.c.with-pch bind PCH_FILE
+ {
+-  "$(CONFIG_COMMAND)" -c -x c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -include-pth -Xclang "$(PCH_FILE)" -c -o "$(<)" "$(>)"
++  "$(CONFIG_COMMAND)" -c -x c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -include-pch -Xclang "$(PCH_FILE)" -c -o "$(<)" "$(>)"
+ }
+ 
+ ###############################################################################
+@@ -137,7 +137,7 @@ rule compile.c++.pch ( targets * : sources * : properties * ) {
+ }
+
+ actions compile.c++.pch {
+-  $(RM) -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
++  $(RM) -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
+ }
+
+ rule compile.c.pch ( targets * : sources * : properties * ) {
+@@ -145,7 +145,7 @@ rule compile.c.pch ( targets * : sources * : properties * ) {
+
+ actions compile.c.pch
+ {
+-  $(RM) -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pth -o "$(<)" "$(>)"
++  $(RM) -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
+ }
+
+ ###############################################################################
+}} 

--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 enable_testing()
 

--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CONAN_SETTINGS_OS STREQUAL "Android")
     set(CONAN_LIBCXX "") # NDK fails when specified: https://github.com/android-ndk/ndk/issues/541
 endif()
 
-CONAN_BASIC_SETUP()
+conan_basic_setup()
 
 IF(NOT HEADER_ONLY)
     set(boost_components)


### PR DESCRIPTION
Boost build with Clang fails without the patch. 

Specify library name and version:  **boost/1.69.0** - **boost/1.73.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

