### PR TITLE
libiconv: fix parallel builds with msvc

### DIFF
--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -111,6 +111,9 @@ class LibiconvConan(ConanFile):
         else:
             configure_args.extend(["--enable-static", "--disable-shared"])
 
+        if self._is_msvc:
+            self._autotools.flags.append("-FS")
+
         self._autotools.configure(args=configure_args, host=host, build=build)
         return self._autotools
 


### PR DESCRIPTION
disabling parallel builds get me one step further to build libiconv with msvc, but it's still failing in a `sed` script

----

compilation fails with
```
libiconv/1.16: ./relocatable-stub.c: fatal error C1041: cannot open program database 'C:\users\tim\.conan\data\libiconv\1.16\_\_\build\75ed07303f056424be45ffb582032fe7ad980a95\source_subfolder\libcharset\lib\vc140.pdb'; if multiple CL.EXE write to the same .PDB file, please use /FS
```

we therefore disable parallel builds with msvc

fixes #2210

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

