### PR TITLE
zstd: cache cmake + delete fPIC option if shared + fix cmake imported target

### DIFF
--- a/recipes/zstd/all/CMakeLists.txt
+++ b/recipes/zstd/all/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 2.8.11)
 project(cmake_wrapper)
 
-message(STATUS "CMake Conan Wrapper")
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 

--- a/recipes/zstd/all/CMakeLists.txt
+++ b/recipes/zstd/all/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.11)
 project(cmake_wrapper)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_subdirectory(source_subfolder/build/cmake)

--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -9,8 +9,8 @@ class ZstdConan(ConanFile):
     description = "Zstandard - Fast real-time compression algorithm"
     topics = ("conan", "zstd", "compression", "algorithm", "decoder")
     license = "BSD-3-Clause"
-    exports_sources = ['CMakeLists.txt', "patches/**"]
-    generators = 'cmake'
+    exports_sources = ["CMakeLists.txt", "patches/**"]
+    generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}

--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -67,7 +67,9 @@ class ZstdConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        zstd_component = "libzstd_shared" if self.options.shared else "libzstd_static"
-        self.cpp_info.components[zstd_component].libs = tools.collect_libs(self)
+        zstd_cmake = "libzstd_shared" if self.options.shared else "libzstd_static"
+        self.cpp_info.components["zstdlib"].names["cmake_find_package"] = zstd_cmake
+        self.cpp_info.components["zstdlib"].names["cmake_find_package_multi"] = zstd_cmake
+        self.cpp_info.components["zstdlib"].libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
-            self.cpp_info.components[zstd_component].system_libs.append("pthread")
+            self.cpp_info.components["zstdlib"].system_libs.append("pthread")

--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -67,6 +67,7 @@ class ZstdConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        zstd_component = "libzstd_shared" if self.options.shared else "libzstd_static"
+        self.cpp_info.components[zstd_component].libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.components[zstd_component].system_libs.append("pthread")

--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -35,6 +35,8 @@ class ZstdConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 

--- a/recipes/zstd/all/test_package/CMakeLists.txt
+++ b/recipes/zstd/all/test_package/CMakeLists.txt
@@ -1,7 +1,5 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package C)
-
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/logo.png
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
@@ -9,5 +7,11 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/logo.png
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(zstd REQUIRED)
+
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+if(ZSTD_SHARED)
+  target_link_libraries(${PROJECT_NAME} zstd::libzstd_shared)
+else()
+  target_link_libraries(${PROJECT_NAME} zstd::libzstd_static)
+endif()

--- a/recipes/zstd/all/test_package/conanfile.py
+++ b/recipes/zstd/all/test_package/conanfile.py
@@ -4,10 +4,11 @@ from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["ZSTD_SHARED"] = self.options["zstd"].shared
         cmake.configure()
         cmake.build()
 

--- a/recipes/zstd/config.yml
+++ b/recipes/zstd/config.yml
@@ -1,4 +1,3 @@
----
 versions:
   "1.3.5":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **zstd/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

imported target is `zstd::libzstd_static` if static else `zstd::libzstd_shared` :(

https://github.com/facebook/zstd/blob/bd21e4b26460a707955e29572cd1110a550a6c5a/build/cmake/lib/CMakeLists.txt#L83
https://github.com/facebook/zstd/blob/bd21e4b26460a707955e29572cd1110a550a6c5a/build/cmake/lib/CMakeLists.txt#L93
https://github.com/facebook/zstd/blob/bd21e4b26460a707955e29572cd1110a550a6c5a/build/cmake/lib/CMakeLists.txt#L159
https://github.com/facebook/zstd/blob/bd21e4b26460a707955e29572cd1110a550a6c5a/build/cmake/CMakeLists.txt#L194