### PR TITLE
spirv-headers: wrap build with conan CMakeLists + fix cmake name

### DIFF
--- a/recipes/spirv-headers/all/CMakeLists.txt
+++ b/recipes/spirv-headers/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/spirv-headers/all/conanfile.py
+++ b/recipes/spirv-headers/all/conanfile.py
@@ -8,6 +8,8 @@ class SpirvheadersConan(ConanFile):
     description = "Header files for the SPIRV instruction set."
     topics = ("conan", "spirv", "spirv-v", "vulkan", "opengl", "opencl", "khronos")
     url = "https://github.com/conan-io/conan-center-index"
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake"
     settings = "os", "compiler", "arch", "build_type"
     license = "MIT-KhronosGroup"
     _cmake = None
@@ -15,6 +17,13 @@ class SpirvheadersConan(ConanFile):
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def package_id(self):
+        self.info.header_only()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -26,10 +35,9 @@ class SpirvheadersConan(ConanFile):
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake
-
         self._cmake = CMake(self)
         self._cmake.definitions["SPIRV_HEADERS_SKIP_EXAMPLES"] = True
-        self._cmake.configure(source_folder=self._source_subfolder)
+        self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
     def build(self):
@@ -40,9 +48,4 @@ class SpirvheadersConan(ConanFile):
         self.copy(pattern="LICENSE*", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-
-        # Error KB-H016, complaining that Cmake config files are found
         tools.rmdir(os.path.join(self.package_folder, "lib"))
-
-    def package_id(self):
-        self.info.header_only()

--- a/recipes/spirv-headers/all/conanfile.py
+++ b/recipes/spirv-headers/all/conanfile.py
@@ -49,3 +49,7 @@ class SpirvheadersConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib"))
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "SPIRV-Headers"
+        self.cpp_info.names["cmake_find_package_multi"] = "SPIRV-Headers"

--- a/recipes/spirv-headers/all/test_package/CMakeLists.txt
+++ b/recipes/spirv-headers/all/test_package/CMakeLists.txt
@@ -1,8 +1,10 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(SPIRV-Headers REQUIRED)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} SPIRV-Headers::SPIRV-Headers)

--- a/recipes/spirv-headers/all/test_package/conanfile.py
+++ b/recipes/spirv-headers/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **spirv-headers/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

see https://github.com/KhronosGroup/SPIRV-Headers/blob/master/CMakeLists.txt for cmake config file and imported target.