### PR TITLE
rabbitmq-c: fix pkgconfig name + delete fPIC if shared

### DIFF
--- a/recipes/rabbitmq-c/all/conanfile.py
+++ b/recipes/rabbitmq-c/all/conanfile.py
@@ -27,6 +27,8 @@ class RabbitmqcConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 

--- a/recipes/rabbitmq-c/all/conanfile.py
+++ b/recipes/rabbitmq-c/all/conanfile.py
@@ -71,6 +71,10 @@ class RabbitmqcConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
+        # TODO: add cmake import information
+        # - for config file: rabbitmq-c
+        # - imported target: rabbitmq::rabbitmq if shared else rabbitmq::rabbitmq-static)
+        self.cpp_info.names["pkg_config"] = "librabbitmq"
         if self.settings.os == "Windows":
             self.cpp_info.libs = [
                 "rabbitmq.4" if self.options.shared else "librabbitmq.4"


### PR DESCRIPTION
Specify library name and version:  **rabbitmq-c/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

pkgconfig name: https://github.com/alanxz/rabbitmq-c/blob/f182c13765e2a653da3bd9c3b49cac92e8dbd9fa/CMakeLists.txt#L371