### PR TITLE
ninja: add patch to support ninja as a cmake subproject

### DIFF
--- a/recipes/ninja/1.10.x/conandata.yml
+++ b/recipes/ninja/1.10.x/conandata.yml
@@ -11,6 +11,8 @@ patches:
      patch_file: patches/add_install_target_to_cmake_build.patch
    - base_path: source_subfolder
      patch_file: patches/build_testing_option.patch
+   - base_path: source_subfolder
+     patch_file: patches/add_subproject_support.patch
   "1.10.1":
    - base_path: source_subfolder
      patch_file: patches/build_testing_option_1.10.1.patch

--- a/recipes/ninja/1.10.x/patches/add_subproject_support.patch
+++ b/recipes/ninja/1.10.x/patches/add_subproject_support.patch
@@ -1,0 +1,15 @@
+--- a/CMakeLists.txt	2020-07-16 14:12:55.679748344 +0200
++++ b/CMakeLists.txt	2020-07-16 14:13:44.435902524 +0200
+@@ -32,9 +32,9 @@
+ 			COMMAND ${RE2C} -b -i --no-generation-date -o ${OUT} ${IN}
+ 		)
+ 	endfunction()
+-	re2c(${CMAKE_SOURCE_DIR}/src/depfile_parser.in.cc ${CMAKE_BINARY_DIR}/depfile_parser.cc)
+-	re2c(${CMAKE_SOURCE_DIR}/src/lexer.in.cc ${CMAKE_BINARY_DIR}/lexer.cc)
+-	add_library(libninja-re2c OBJECT ${CMAKE_BINARY_DIR}/depfile_parser.cc ${CMAKE_BINARY_DIR}/lexer.cc)
++	re2c(${PROJECT_SOURCE_DIR}/src/depfile_parser.in.cc ${PROJECT_BINARY_DIR}/depfile_parser.cc)
++	re2c(${PROJECT_SOURCE_DIR}/src/lexer.in.cc ${PROJECT_BINARY_DIR}/lexer.cc)
++	add_library(libninja-re2c OBJECT ${PROJECT_BINARY_DIR}/depfile_parser.cc ${PROJECT_BINARY_DIR}/lexer.cc)
+ else()
+ 	message(WARNING "re2c was not found; changes to src/*.in.cc will not affect your build.")
+ 	add_library(libninja-re2c OBJECT src/depfile_parser.cc src/lexer.cc)


### PR DESCRIPTION
Specify library name and version:  **ninja/1.10.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

ninja's cmake script use CMAKE_{SOURCE,BINARY}_DIR instead of
PROJECT_{SOURCE,BINARY}_DIR that break the build when ninja become a cmake
subproject
cf ninja's [PR1813](https://github.com/ninja-build/ninja/pull/1813)
