### PR TITLE
opencolorio: exported CMake wrapper, correct class name

### DIFF
--- a/recipes/opencolorio/all/CMakeLists.txt
+++ b/recipes/opencolorio/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -12,7 +12,6 @@ class OpenColorIOConan(ConanFile):
     default_options = {"shared": False, "fPIC": True}
     generators = "cmake", "cmake_find_package"
     exports_sources = ["CMakeLists.txt", "patches/*"]
-    short_paths = True
 
     _cmake = None
 

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -1,7 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os, shutil
 
-class OpenEXRConan(ConanFile):
+class OpenColorIOConan(ConanFile):
     name = "opencolorio"
     description = "A color management framework for visual effects and animation."
     license = "BSD-3-Clause"
@@ -11,7 +11,8 @@ class OpenEXRConan(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
     generators = "cmake", "cmake_find_package"
-    exports_sources = ["patches/*"]
+    exports_sources = ["CMakeLists.txt", "patches/*"]
+    short_paths = True
 
     _cmake = None
 
@@ -50,13 +51,12 @@ class OpenEXRConan(ConanFile):
         self._cmake.definitions["OCIO_BUILD_PYGLUE"] = False
         self._cmake.definitions["USE_EXTERNAL_YAML"] = True
         self._cmake.definitions["USE_EXTERNAL_LCMS"] = True
-        self._cmake.definitions["YAML_CPP_VERSION"] = self.deps_cpp_info["yaml-cpp"].version
 
         # FIXME: OpenColorIO uses old TinyXML which doesn't have Conan package.
         self._cmake.definitions["USE_EXTERNAL_TINYXML"] = False
         self._cmake.definitions["TINYXML_OBJECT_LIB_EMBEDDED"] = True
         
-        self._cmake.configure(source_folder=self._source_subfolder)
+        self._cmake.configure()
         return self._cmake
 
     def _patch_sources(self):

--- a/recipes/opencolorio/all/patches/1.1.1.patch
+++ b/recipes/opencolorio/all/patches/1.1.1.patch
@@ -1,21 +1,23 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e4f3119..1847ffd 100644
+index e4f3119..1f7f77c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -9,6 +9,12 @@ if(NOT DEFINED CMAKE_FIRST_RUN)
+@@ -4,11 +4,13 @@ set(OCIO_VERSION_MINOR 1)
+ set(OCIO_VERSION_PATCH 1)
+ 
+ cmake_minimum_required(VERSION 2.8)
+-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/share/cmake)
++list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/share/cmake)
+ if(NOT DEFINED CMAKE_FIRST_RUN)
      SET(CMAKE_FIRST_RUN 1 CACHE INTERNAL "")
  endif()
  
-+include("${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake")
-+conan_basic_setup()
-+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_BINARY_DIR}")
-+
 +set(CMAKE_CXX_STANDARD 11)
 +
  ###############################################################################
  ### GLOBAL ###
  
-@@ -142,7 +148,7 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
+@@ -142,11 +144,11 @@ endif(CMAKE_COMPILER_IS_GNUCXX)
  ###############################################################################
  ### Python ###
  
@@ -24,7 +26,25 @@ index e4f3119..1847ffd 100644
  
  # Find Python, used for (possibly) building pyglue, and now to
  # construct the external project path
-@@ -204,6 +210,7 @@ else(USE_EXTERNAL_TINYXML)
+-set(EXTDIST_ROOT ${CMAKE_BINARY_DIR}/ext/dist)
++set(EXTDIST_ROOT ${PROJECT_BINARY_DIR}/ext/dist)
+ set(EXTDIST_BINPATH ${EXTDIST_ROOT}/bin)
+ if(PYTHON_OK)
+     set(EXTDIST_PYTHONPATH ${EXTDIST_ROOT}/${PYTHON_VARIANT_PATH})
+@@ -189,9 +191,9 @@ else(USE_EXTERNAL_TINYXML)
+         set(TINYXML_CMAKE_ARGS ${TINYXML_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
+     endif()
+     set(TINYXML_CMAKE_ARGS ${TINYXML_CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+-    set(TINYXML_ZIPFILE     "${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.tar.gz")
+-    set(TINYXML_PATCHFILE   "${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.patch")
+-    set(TINYXML_SOURCE_DIR  "${CMAKE_BINARY_DIR}/ext")
++    set(TINYXML_ZIPFILE     "${PROJECT_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.tar.gz")
++    set(TINYXML_PATCHFILE   "${PROJECT_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.patch")
++    set(TINYXML_SOURCE_DIR  "${PROJECT_BINARY_DIR}/ext")
+     ## Create our TINYXML_LIB target
+     if(CMAKE_VERSION VERSION_GREATER "2.8.7")
+         option(TINYXML_OBJECT_LIB_EMBEDDED ${OCIO_BUILD_STATIC} "directly embedded tinyxml 3rdParty object lib into our resulting static lib, no link needed anymore")
+@@ -204,6 +206,7 @@ else(USE_EXTERNAL_TINYXML)
          set(tinyxml_sources ${TINYXML_SOURCE_DIR}/tinyxml/tinystr.cpp       ${TINYXML_SOURCE_DIR}/tinyxml/tinyxml.cpp 
                              ${TINYXML_SOURCE_DIR}/tinyxml/tinyxmlerror.cpp  ${TINYXML_SOURCE_DIR}/tinyxml/tinyxmlparser.cpp )
          set(tinyxml_headers ${TINYXML_SOURCE_DIR}/tinyxml/tinystr.h         ${TINYXML_SOURCE_DIR}/tinyxml/tinyxml.h )
@@ -32,7 +52,7 @@ index e4f3119..1847ffd 100644
          add_custom_command(                                 ## will be done at build time
              OUTPUT ${tinyxml_sources} ${tinyxml_headers}    ## expected output files
              COMMAND ${CMAKE_COMMAND} -E tar xzf ${TINYXML_ZIPFILE}
-@@ -248,124 +255,11 @@ endif(USE_EXTERNAL_TINYXML)
+@@ -248,124 +251,12 @@ endif(USE_EXTERNAL_TINYXML)
  ###############################################################################
  ### YAML ###
  
@@ -52,8 +72,7 @@ index e4f3119..1847ffd 100644
 -    if(YAML_CPP_VERSION VERSION_LESS ${YAML_VERSION_MIN})
 -        message(FATAL_ERROR "ERROR: yaml-cpp ${YAML_VERSION_MIN} or greater is required.")
 -    endif()
-+find_package(yaml-cpp)
- 
+-
 -    find_package_handle_standard_args(yaml-cpp
 -                                      REQUIRED_VARS YAML_CPP_LIBRARIES YAML_CPP_INCLUDE_DIRS )
 -    set(YAML_CPP_FOUND ${YAML-CPP_FOUND})
@@ -151,18 +170,72 @@ index e4f3119..1847ffd 100644
 -    endif()
 -    set_target_properties(YAML_CPP_LIB PROPERTIES FOLDER External)
 -endif(USE_EXTERNAL_YAML)
--
++find_package(yaml-cpp)
+ 
 -if(YAML_CPP_VERSION VERSION_LESS "0.5.0")
 -    set(YAML_CPP_COMPILE_FLAGS "-DOLDYAML")
 -endif()
 +set(YAML_CPP_INCLUDE_DIRS "${CONAN_INCLUDE_DIRS_YAML-CPP}")
 +set(YAML_CPP_LIBRARIES yaml-cpp::yaml-cpp)
++set(YAML_CPP_VERSION "${yaml-cpp_VERSION}")
 +list(APPEND EXTERNAL_LIBRARIES ${YAML_CPP_LIBRARIES})
  
  ###############################################################################
  ### Externals ###
+@@ -528,7 +419,7 @@ endif()
+ 
+ ###############################################################################
+ ### Configure env script ###
+-configure_file(${CMAKE_SOURCE_DIR}/share/ocio/setup_ocio.sh.in
++configure_file(${PROJECT_SOURCE_DIR}/share/ocio/setup_ocio.sh.in
+     ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/setup_ocio.sh @ONLY)
+ 
+ INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/setup_ocio.sh DESTINATION share/ocio/)
+@@ -597,7 +488,7 @@ if(TARGET OpenColorIO_STATIC)
+     endif()
+ endif()
+ install(EXPORT OpenColorIO DESTINATION cmake)
+-file(WRITE "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake"
++file(WRITE "${PROJECT_BINARY_DIR}/OpenColorIOConfig.cmake"
+     "
+     get_filename_component(OpenColorIO_DIR \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)
+     
+@@ -646,4 +537,4 @@ file(WRITE "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake"
+     message(STATUS OPENCOLORIO_FOUND=\${OPENCOLORIO_FOUND})
+     "
+ )
+-install(FILES "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake" DESTINATION .)
++install(FILES "${PROJECT_BINARY_DIR}/OpenColorIOConfig.cmake" DESTINATION .)
+diff --git a/share/cmake/OCIOMacros.cmake b/share/cmake/OCIOMacros.cmake
+index b9fb239..b1a206e 100644
+--- a/share/cmake/OCIOMacros.cmake
++++ b/share/cmake/OCIOMacros.cmake
+@@ -356,9 +356,9 @@ ENDMACRO()
+ 
+ MACRO(ExtractRstCPP INFILE OUTFILE)
+    add_custom_command(
+-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
++      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+       OUTPUT ${OUTFILE}
+-      COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceCPP.py ${INFILE} ${OUTFILE}
++      COMMAND ${PYTHON} ${PROJECT_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceCPP.py ${INFILE} ${OUTFILE}
+       DEPENDS ${INFILE}
+       COMMENT "Extracting reStructuredText from ${INFILE} (using old process)"
+    )
+@@ -366,9 +366,9 @@ ENDMACRO()
+ 
+ MACRO(ExtractRstSimple INFILE OUTFILE)
+    add_custom_command(
+-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
++      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+       OUTPUT ${OUTFILE}
+-      COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceSimple.py ${INFILE} ${OUTFILE}
++      COMMAND ${PYTHON} ${PROJECT_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceSimple.py ${INFILE} ${OUTFILE}
+       DEPENDS ${INFILE}
+       COMMENT "Extracting reStructuredText from ${INFILE}"
+    )
 diff --git a/src/apps/ociobakelut/CMakeLists.txt b/src/apps/ociobakelut/CMakeLists.txt
-index d31b4e3..a14ab48 100644
+index d31b4e3..efebda6 100644
 --- a/src/apps/ociobakelut/CMakeLists.txt
 +++ b/src/apps/ociobakelut/CMakeLists.txt
 @@ -1,6 +1,10 @@
@@ -178,11 +251,91 @@ index d31b4e3..a14ab48 100644
  if(LCMS_FOUND AND (LCMS_VERSION VERSION_EQUAL 2.1 OR LCMS_VERSION VERSION_GREATER 2.1))
      FIND_PACKAGE_MESSAGE(LCMS "Found lcms: ${LCMS_LIBRARIES}"
          "${LCMS_INCLUDE_DIR}")
+@@ -15,12 +19,12 @@ else()
+     if(CMAKE_TOOLCHAIN_FILE)
+         set(LCMS_CMAKE_ARGS ${LCMS_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
+     endif()
+-    set(LCMS_INSTALL_DIR ${CMAKE_BINARY_DIR}/ext/dist)
++    set(LCMS_INSTALL_DIR ${PROJECT_BINARY_DIR}/ext/dist)
+     ExternalProject_Add(LCMS
+-        PREFIX         ${CMAKE_BINARY_DIR}/lcms2-prefix
+-        URL            ${CMAKE_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.tar.gz
+-        PATCH_COMMAND  ${GIT_EXECUTABLE} apply ${CMAKE_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.patch
+-        BINARY_DIR     ${CMAKE_BINARY_DIR}/ext/build/lcms2
++        PREFIX         ${PROJECT_BINARY_DIR}/lcms2-prefix
++        URL            ${PROJECT_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.tar.gz
++        PATCH_COMMAND  ${GIT_EXECUTABLE} apply ${PROJECT_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.patch
++        BINARY_DIR     ${PROJECT_BINARY_DIR}/ext/build/lcms2
+         INSTALL_DIR    ${LCMS_INSTALL_DIR}
+         CMAKE_ARGS     ${LCMS_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${LCMS_INSTALL_DIR} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+     )
+@@ -29,12 +33,12 @@ else()
+     set(LCMS_LIBRARIES 		${PROJECT_BINARY_DIR}/ext/dist/lib/${CMAKE_STATIC_LIBRARY_PREFIX}lcms2${CMAKE_STATIC_LIBRARY_SUFFIX})
+ endif()
+ 
+-file(GLOB_RECURSE share_src_files "${CMAKE_SOURCE_DIR}/src/apps/share/*.cpp")
++file(GLOB_RECURSE share_src_files "${PROJECT_SOURCE_DIR}/src/apps/share/*.cpp")
+ 
+ include_directories(
+-    ${CMAKE_SOURCE_DIR}/export/
+-    ${CMAKE_BINARY_DIR}/export/
+-    ${CMAKE_SOURCE_DIR}/src/apps/share/
++    ${PROJECT_SOURCE_DIR}/export/
++    ${PROJECT_BINARY_DIR}/export/
++    ${PROJECT_SOURCE_DIR}/src/apps/share/
+     ${LCMS_INCLUDE_DIRS}
+     ${Boost_INCLUDE_DIR}
+ )
+diff --git a/src/apps/ociocheck/CMakeLists.txt b/src/apps/ociocheck/CMakeLists.txt
+index 4955f4d..14b5017 100644
+--- a/src/apps/ociocheck/CMakeLists.txt
++++ b/src/apps/ociocheck/CMakeLists.txt
+@@ -1,9 +1,9 @@
+-file(GLOB_RECURSE share_src_files "${CMAKE_SOURCE_DIR}/src/apps/share/*.cpp")
++file(GLOB_RECURSE share_src_files "${PROJECT_SOURCE_DIR}/src/apps/share/*.cpp")
+ 
+ include_directories(
+-    ${CMAKE_SOURCE_DIR}/export/
+-    ${CMAKE_BINARY_DIR}/export/
+-    ${CMAKE_SOURCE_DIR}/src/apps/share/
++    ${PROJECT_SOURCE_DIR}/export/
++    ${PROJECT_BINARY_DIR}/export/
++    ${PROJECT_SOURCE_DIR}/src/apps/share/
+     ${Boost_INCLUDE_DIR}
+     )
+ 
 diff --git a/src/core/CMakeLists.txt b/src/core/CMakeLists.txt
-index 1eb691b..2d4f1d6 100644
+index 1eb691b..a2f099a 100644
 --- a/src/core/CMakeLists.txt
 +++ b/src/core/CMakeLists.txt
-@@ -21,10 +21,10 @@ list(APPEND core_export_headers ${CMAKE_BINARY_DIR}/export/OpenColorABI.h)
+@@ -2,29 +2,29 @@
+ ### OCIO CORE ###
+ 
+ include_directories(
+-    ${CMAKE_SOURCE_DIR}/export/
+-    ${CMAKE_BINARY_DIR}/export/
+-    ${CMAKE_SOURCE_DIR}/ext/oiio/src/include
++    ${PROJECT_SOURCE_DIR}/export/
++    ${PROJECT_BINARY_DIR}/export/
++    ${PROJECT_SOURCE_DIR}/ext/oiio/src/include
+     ${EXTERNAL_INCLUDE_DIRS}
+ )
+ 
+-file(GLOB_RECURSE core_src_files "${CMAKE_SOURCE_DIR}/src/core/*.cpp")
+-file(GLOB_RECURSE core_export_headers "${CMAKE_SOURCE_DIR}/export/OpenColorIO/*.h")
++file(GLOB_RECURSE core_src_files "${PROJECT_SOURCE_DIR}/src/core/*.cpp")
++file(GLOB_RECURSE core_export_headers "${PROJECT_SOURCE_DIR}/export/OpenColorIO/*.h")
+ 
+ message(STATUS "Create OpenColorABI.h from OpenColorABI.h.in")
+-configure_file(${CMAKE_SOURCE_DIR}/export/OpenColorIO/OpenColorABI.h.in
+-    ${CMAKE_BINARY_DIR}/export/OpenColorABI.h @ONLY)
+-list(APPEND core_export_headers ${CMAKE_BINARY_DIR}/export/OpenColorABI.h)
++configure_file(${PROJECT_SOURCE_DIR}/export/OpenColorIO/OpenColorABI.h.in
++    ${PROJECT_BINARY_DIR}/export/OpenColorABI.h @ONLY)
++list(APPEND core_export_headers ${PROJECT_BINARY_DIR}/export/OpenColorABI.h)
+ 
+ # Process all warnings as errors
+ 
  if(WIN32)
      # On debug mode there are other kinds of warning...
      if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
@@ -195,16 +348,21 @@ index 1eb691b..2d4f1d6 100644
  endif()
  
  # SHARED
-diff --git a/src/pyglue/CMakeLists.txt b/src/pyglue/CMakeLists.txt
-index a90ca1c..a156dac 100644
---- a/src/pyglue/CMakeLists.txt
-+++ b/src/pyglue/CMakeLists.txt
-@@ -23,7 +23,7 @@ endif()
- # Process all warnings as errors
- # Unfortunately Windows still has a warning
- if(UNIX)
--    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-+    # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
- endif()
+@@ -75,7 +75,7 @@ endif()
+ # STATIC
  
- find_package(PythonLibs)
+ if(OCIO_BUILD_STATIC)
+-    list(REMOVE_ITEM core_src_files ${CMAKE_SOURCE_DIR}/src/core/UnitTest.cpp)
++    list(REMOVE_ITEM core_src_files ${PROJECT_SOURCE_DIR}/src/core/UnitTest.cpp)
+     add_library(OpenColorIO_STATIC STATIC ${EXTERNAL_OBJECTS} ${core_src_files})
+     add_dependencies(OpenColorIO_STATIC TINYXML_LIB YAML_CPP_LIB)
+     if(EXTERNAL_LIBRARIES)
+@@ -113,7 +113,7 @@ install(FILES ${core_export_headers}
+ 
+ # pkg-config
+ message(STATUS "Create OpenColorIO.pc from OpenColorIO.pc.in")
+-configure_file(${CMAKE_SOURCE_DIR}/export/pkgconfig/OpenColorIO.pc.in
++configure_file(${PROJECT_SOURCE_DIR}/export/pkgconfig/OpenColorIO.pc.in
+     ${CMAKE_CURRENT_BINARY_DIR}/OpenColorIO.pc @ONLY)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenColorIO.pc
+     DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib${LIB_SUFFIX}/pkgconfig/)


### PR DESCRIPTION
**opencolorio/1.1.1**

This PR adds a top level `CMakeLists.txt` wrapper, as suggested by @SpaceIm in the [previous PR](https://github.com/conan-io/conan-center-index/pull/2130#discussion_r455016464), so that it has similar layout to other recipes.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

