### PR TITLE
expat: fix cmake_find_package_multi + delete fPIC option if shared

### DIFF
--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -68,7 +68,7 @@ class ExpatConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "EXPAT"
-        self.cpp_info.names["cmake_find_package_multi"] = "EXPAT"
+        self.cpp_info.names["cmake_find_package_multi"] = "expat"
         self.cpp_info.libs = tools.collect_libs(self)
         if not self.options.shared:
             self.cpp_info.defines = ["XML_STATIC"]

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -25,6 +25,8 @@ class ExpatConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 

--- a/recipes/expat/all/test_package/CMakeLists.txt
+++ b/recipes/expat/all/test_package/CMakeLists.txt
@@ -4,5 +4,7 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(EXPAT REQUIRED)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} EXPAT::EXPAT)

--- a/recipes/expat/all/test_package/conanfile.py
+++ b/recipes/expat/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **expat/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

cmake_find_package is EXPAT: https://cmake.org/cmake/help/v3.12/module/FindEXPAT.html)
But surprinsingly config file is lower case and creates lower case imported targets: https://github.com/libexpat/libexpat/blob/5a7fe4d19a240727d6be7161092b1a2e34892fd8/expat/CMakeLists.txt#L580