### PR TITLE
m4: no canonical names for MSVC

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -39,7 +39,13 @@ class M4Conan(ConanFile):
             return self._autotools
         conf_args = []
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder)
+        build_canonical_name = None
+        host_canonical_name = None
+        if self.settings.compiler == "Visual Studio":
+            # The somewhat older configure script of m4 does not understand the canonical names of Visual Studio
+            build_canonical_name = False
+            host_canonical_name = False
+        self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder, build=build_canonical_name, host=host_canonical_name)
         return self._autotools
 
     @contextmanager


### PR DESCRIPTION
Specify library name and version:  **m4/1.4.18**

Fixes #2183
@jmarrec 

The configure script of m4 does not understand the canonical names of VIsual Studio,
so don't pass them.
A newer release of m4 will probably fix this.
A autoreconf would also probably fix this, but that would create a circular dependency.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

