### PR TITLE
Include OpenSSL < 1.0.2s

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -552,6 +552,10 @@ class OpenSSLConan(ConanFile):
             # /Library/Developer/CommandLineTools/usr/bin/ar: internal ranlib command failed
             if self.settings.os == "Macos" and self._full_version < "1.1.0":
                 parallel = False
+
+            # Building in parallel for versions less than 1.0.2d causes errors
+            if self._full_version < "1.0.2d":
+                parallel = False                
             command.append(("-j%s" % tools.cpu_count()) if parallel else "-j1")
         self.run(" ".join(command), win_bash=self._win_bash)
 


### PR DESCRIPTION
This commit modifies the OpenSSL config.yml to include all versions
defined in the OpenSSL 1.x.x conandata.yml file.

Also, enabling "make" parallelisation when building OpenSSL < 1.0.2d
causes errors. This commit modifies the OpenSSL 1.x.x recipe to
disable parallel builds for versions less than 1.0.2d.

Specify library name and version:  **openssl/1.0.2d**

fixes #2254

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

