### PR TITLE
Muparserx: Fix hooks. Default fPIC value

### DIFF
--- a/recipes/muparserx/all/CMakeLists.txt
+++ b/recipes/muparserx/all/CMakeLists.txt
@@ -5,3 +5,4 @@ include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_subdirectory("source_subfolder")
+

--- a/recipes/muparserx/all/conandata.yml
+++ b/recipes/muparserx/all/conandata.yml
@@ -2,3 +2,4 @@ sources:
   "4.0.8":
     url: https://github.com/beltoforion/muparserx/archive/v4.0.8.tar.gz
     sha256: 5913e0a4ca29a097baad1b78a4674963bc7a06e39ff63df3c73fbad6fadb34e1
+

--- a/recipes/muparserx/all/conanfile.py
+++ b/recipes/muparserx/all/conanfile.py
@@ -13,7 +13,7 @@ class MuparserxConan(ConanFile):
     options = {"shared": [True, False],
                "fPIC": [True, False]}
     default_options = {"shared": False,
-                       "fPIC": False}
+                       "fPIC": True}
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
     _cmake = None

--- a/recipes/muparserx/all/test_package/CMakeLists.txt
+++ b/recipes/muparserx/all/test_package/CMakeLists.txt
@@ -7,3 +7,4 @@ conan_basic_setup()
 add_executable(test_package test_package.cpp)
 target_link_libraries(test_package ${CONAN_LIBS})
 set_target_properties(test_package PROPERTIES CXX_STANDARD 11)
+

--- a/recipes/muparserx/config.yml
+++ b/recipes/muparserx/config.yml
@@ -2,3 +2,4 @@
 versions:
   "4.0.8":
     folder: all
+


### PR DESCRIPTION
Specify library name and version:  **Muparserx/4.0.8**

Fix hooks errors reported in #2232 .
Set fPIC default value to True, as it is a "more" default way of consuming it.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

