### PR TITLE
octomap: add 1.9.5 + components (partial) + del fPIC option if shared

### DIFF
--- a/recipes/octomap/all/conandata.yml
+++ b/recipes/octomap/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.9.3":
     url: "https://github.com/OctoMap/octomap/archive/v1.9.3.tar.gz"
     sha256: "8488de97ed2c8f4757bfbaf3225e82a9e36783dce1f573b3bde1cf968aa89696"
+  "1.9.5":
+    url: "https://github.com/OctoMap/octomap/archive/v1.9.5.tar.gz"
+    sha256: "adf87320c4c830c0fd85fe8d913d8aa174e2f72d0ea64c917599a50a561092b6"

--- a/recipes/octomap/all/conanfile.py
+++ b/recipes/octomap/all/conanfile.py
@@ -35,6 +35,10 @@ class OctomapConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename(self.name + "-" + self.version, self._source_subfolder)

--- a/recipes/octomap/all/conanfile.py
+++ b/recipes/octomap/all/conanfile.py
@@ -72,6 +72,17 @@ class OctomapConan(ConanFile):
         self.copy(pattern="*.dll", dst="bin", src=build_bin_dir, keep_path=False)
 
     def package_info(self):
-        self.cpp_info.libs = ["octomap", "octomath"]
+        # TODO: no namespace for CMake imported targets
+        # octomath
+        octomath_cmake = "octomath" if self.options.shared else "octomath-static"
+        self.cpp_info.components["octomath"].names["cmake_find_package"] = octomath_cmake
+        self.cpp_info.components["octomath"].names["cmake_find_package_multi"] = octomath_cmake
+        self.cpp_info.components["octomath"].libs = ["octomath"]
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs.append("m")
+            self.cpp_info.components["octomath"].system_libs.append("m")
+        # octomap
+        octomap_cmake = "octomap" if self.options.shared else "octomap-static"
+        self.cpp_info.components["octomaplib"].names["cmake_find_package"] = octomap_cmake
+        self.cpp_info.components["octomaplib"].names["cmake_find_package_multi"] = octomap_cmake
+        self.cpp_info.components["octomaplib"].libs = ["octomap"]
+        self.cpp_info.components["octomaplib"].requires = ["octomath"]

--- a/recipes/octomap/all/test_package/CMakeLists.txt
+++ b/recipes/octomap/all/test_package/CMakeLists.txt
@@ -1,8 +1,15 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(octomap REQUIRED)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+# TODO: no namespace
+if(OCTOMAP_SHARED)
+  target_link_libraries(${PROJECT_NAME} octomap::octomap octomap::octomath)
+else()
+  target_link_libraries(${PROJECT_NAME} octomap::octomap-static octomap::octomath-static)
+endif()

--- a/recipes/octomap/all/test_package/conanfile.py
+++ b/recipes/octomap/all/test_package/conanfile.py
@@ -4,10 +4,11 @@ from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["OCTOMAP_SHARED"] = self.options["octomap"].shared
         cmake.configure()
         cmake.build()
 

--- a/recipes/octomap/config.yml
+++ b/recipes/octomap/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.9.3":
     folder: all
+  "1.9.5":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **octomap/1.9.5**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

octomap imported targets are not namespaced, therefore current recipe cannot fully mimic official config file.