### PR TITLE
Adding an option to include the programs and the scripts of libxml2

### DIFF
--- a/recipes/libxml2/all/test_package/CMakeLists.txt
+++ b/recipes/libxml2/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Specify library name and version:  **libxml2/**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Hello Everyone,

This PR restores the possibility of installing also the utilities programs (e.g xmllint) 
They were removed with commit 16739f13e00cdc9527b108d549816df4a46032a1, but I think they are useful. 
In my case, I am using these utilities in a couple of UT, so it would be nice if they were included :) What do you think?

KR,
Vasileios

