### PR TITLE
Harfuzz: enable glib by default

### DIFF
--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -14,6 +14,7 @@ class HarfbuzzConan(ConanFile):
     short_paths = True
 
     settings = "os", "arch", "compiler", "build_type"
+    
     options = {
         "shared": [True, False],
         "fPIC": [True, False],

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -28,7 +28,7 @@ class HarfbuzzConan(ConanFile):
         "fPIC": True,
         "with_freetype": True,
         "with_icu": False,
-        "with_glib": False,
+        "with_glib": True,
         "with_gdi": True,
         "with_uniscribe": True
     }


### PR DESCRIPTION
it's ok now that it builds on windows (and required by several coming libraries, eg pango)

Specify library name and version:  **harfbuzz/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

