### PR TITLE
Fix jemalloc build on SLES11

### DIFF
--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -196,4 +196,4 @@ class JemallocConan(ConanFile):
         if not self.options.shared:
             self.cpp_info.defines = ["JEMALLOC_EXPORT="]
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs.extend(["dl", "pthread"])
+            self.cpp_info.system_libs.extend(["dl", "pthread", "rt"])

--- a/recipes/jemalloc/all/test_package/CMakeLists.txt
+++ b/recipes/jemalloc/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Solves failed dependency:

    src/nstime.c:128: undefined reference to `clock_gettime'

Specify library name and version:  **jemalloc/5.2.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

