### PR TITLE
glib: disable MT runtime too

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -40,8 +40,10 @@ class GLibConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-        if self.settings.os == "Windows" and not self.options.shared:
-            raise ConanInvalidConfiguration("glib can not be built as static on Windows.")
+        if (self.settings.os == "Windows" and not self.options.shared) or\
+           "MT" in self.settings.get_safe("compiler.runtime", default=""):
+            raise ConanInvalidConfiguration("glib can not be built as static library on Windows. "\
+                                           "see https://gitlab.gnome.org/GNOME/glib/-/issues/692")
 
     def config_options(self):
         if self.settings.os == "Windows":


### PR DESCRIPTION
Without this change, consumer packages which can be built as static library
try to build with static runtime and fail because of missing glib binary

Specify library name and version:  **glib/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

