### PR TITLE
add opensslextra and opensslall configure options for wolfssl

### DIFF
--- a/recipes/wolfssl/all/conanfile.py
+++ b/recipes/wolfssl/all/conanfile.py
@@ -81,11 +81,9 @@ class WolfSSLConan(ConanFile):
             "--disable-crypttests",
             "--enable-harden",
             "--enable-debug" if self.settings.build_type == "Debug" else "--disable-debug",
+            "--enable-opensslall" if self.options.opensslall else "--disable-opensslall",
+            "--enable-opensslextra" if self.options.opensslextra else "--disable-opensslextra",
         ]
-        if self.options.opensslextra:
-            conf_args.extend(["--enable-opensslextra"])
-            if self.options.opensslall:
-                conf_args.extend(["--enable-opensslall"])
         if self.options.shared:
             conf_args.extend(["--enable-shared", "--disable-static"])
         else:

--- a/recipes/wolfssl/all/conanfile.py
+++ b/recipes/wolfssl/all/conanfile.py
@@ -35,6 +35,8 @@ class WolfSSLConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.opensslall and not self.options.opensslextra:
+            raise ConanInvalidConfiguration("The option 'opensslall' requires 'opensslextra=True'")
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.cppstd
@@ -84,9 +86,6 @@ class WolfSSLConan(ConanFile):
             conf_args.extend(["--enable-opensslextra"])
             if self.options.opensslall:
                 conf_args.extend(["--enable-opensslall"])
-        else:
-            if self.options.opensslall:
-                conf_args.extend(["--enable-opensslextra --enable-opensslall"])
         if self.options.shared:
             conf_args.extend(["--enable-shared", "--disable-static"])
         else:

--- a/recipes/wolfssl/all/conanfile.py
+++ b/recipes/wolfssl/all/conanfile.py
@@ -14,10 +14,14 @@ class WolfSSLConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "opensslextra": [True, False],
+        "opensslall": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "opensslextra": False,
+        "opensslall": False,
     }
 
     _autotools = None
@@ -76,6 +80,13 @@ class WolfSSLConan(ConanFile):
             "--enable-harden",
             "--enable-debug" if self.settings.build_type == "Debug" else "--disable-debug",
         ]
+        if self.options.opensslextra:
+            conf_args.extend(["--enable-opensslextra"])
+            if self.options.opensslall:
+                conf_args.extend(["--enable-opensslall"])
+        else:
+            if self.options.opensslall:
+                conf_args.extend(["--enable-opensslextra --enable-opensslall"])
         if self.options.shared:
             conf_args.extend(["--enable-shared", "--disable-static"])
         else:


### PR DESCRIPTION
With opensslextra only partial functionality gets enabled.
In order to enable complete functionality,
using all OpenSSL APIs, opensslall flag is needed.
Default value for both options is false.

openssl options are not environment specific or generic from
perspective of wolfssl. One who needs openssl will use either
of opensslextra OR opensslextra + opensslall OR opensslall only.
Only having opensslall=True sliently enables "opensslextra as well.

Specify library name and version:  **wolfssl/4.4.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

