### PR TITLE
m4: support for windows x86

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -26,8 +26,10 @@ class M4Conan(ConanFile):
         return str(self.settings.compiler).endswith("clang")
 
     def build_requirements(self):
-        if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ and \
-                tools.os_info.detect_windows_subsystem() != "msys2":
+        if (tools.os_info.is_windows
+            and "CONAN_BASH_PATH" not in os.environ
+            and ((tools.os_info.detect_windows_subsystem() != "msys2")
+                 or not tools.which("make"))):
             self.build_requires("msys2/20190524")
 
     def source(self):

--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -26,10 +26,7 @@ class M4Conan(ConanFile):
         return str(self.settings.compiler).endswith("clang")
 
     def build_requirements(self):
-        if (tools.os_info.is_windows
-            and "CONAN_BASH_PATH" not in os.environ
-            and ((tools.os_info.detect_windows_subsystem() != "msys2")
-                 or not tools.which("make"))):
+        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/20190524")
 
     def source(self):


### PR DESCRIPTION
Fix #2183 

cf https://github.com/conan-io/conan-center-index/issues/2183#issuecomment-665094197

Adjust build_requires to check if make exists, otherwise require msys2

Specify library name and version:  **m4/1.4.18**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

