### PR TITLE
gnu-config: add gnu-config/cci.20200712 recipe

### DIFF
--- a/recipes/gnu-config/all/conandata.yml
+++ b/recipes/gnu-config/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "cci.20200712":
-    url: "http://git.savannah.gnu.org/cgit/config.git/snapshot/config-2593751ef276497e312d7c4ce7fd049614c7bf80.tar.gz"
-    sha256: "b90ec3ccb67cbace74f076d179dd367ef63d3d7be4136fefe4c6968a9d6d8d34"
+  "cci.20201022":
+    url: "http://git.savannah.gnu.org/cgit/config.git/snapshot/config-1c4398015583eb77bc043234f5734be055e64bea.tar.gz"
+    sha256: "339eb64757bf5af9e23ca15daa136acdd9d778753377190ce17fba7e1b222aff"

--- a/recipes/gnu-config/all/conandata.yml
+++ b/recipes/gnu-config/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "cci.20200712":
+  "20200712":
     url: "http://git.savannah.gnu.org/cgit/config.git/snapshot/config-2593751ef276497e312d7c4ce7fd049614c7bf80.tar.gz"
     sha256: "b90ec3ccb67cbace74f076d179dd367ef63d3d7be4136fefe4c6968a9d6d8d34"

--- a/recipes/gnu-config/all/conandata.yml
+++ b/recipes/gnu-config/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "20200712":
+  "cci.20200712":
     url: "http://git.savannah.gnu.org/cgit/config.git/snapshot/config-2593751ef276497e312d7c4ce7fd049614c7bf80.tar.gz"
     sha256: "b90ec3ccb67cbace74f076d179dd367ef63d3d7be4136fefe4c6968a9d6d8d34"

--- a/recipes/gnu-config/all/conandata.yml
+++ b/recipes/gnu-config/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20200712":
+    url: "http://git.savannah.gnu.org/cgit/config.git/snapshot/config-2593751ef276497e312d7c4ce7fd049614c7bf80.tar.gz"
+    sha256: "b90ec3ccb67cbace74f076d179dd367ef63d3d7be4136fefe4c6968a9d6d8d34"

--- a/recipes/gnu-config/all/conanfile.py
+++ b/recipes/gnu-config/all/conanfile.py
@@ -1,0 +1,53 @@
+from conans import ConanFile, tools
+from conans.errors import ConanException
+import glob
+import os
+
+
+class GnuConfigConan(ConanFile):
+    name = "gnu-config"
+    description = "The GNU config.guess and config.sub scripts"
+    homepage = "https://savannah.gnu.org/projects/config/"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("conan", "gnu", "config", "autotools", "canonical", "host", "build", "target", "triplet")
+    license = "GPL-3.0-or-later", "autoconf-special-exception"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename(glob.glob("config*")[0], self._source_subfolder)
+
+    def _extract_license(self):
+        txt_lines = tools.load(os.path.join(self.source_folder, self._source_subfolder, "config.guess")).splitlines()
+        start_index = None
+        end_index = None
+        for line_i, line in enumerate(txt_lines):
+            if start_index is None:
+                if "This file is free" in line:
+                    start_index = line_i
+            if end_index is None:
+                if "Please send patches" in line:
+                    end_index = line_i
+        if not all((start_index, end_index)):
+            raise ConanException("Failed to extract the license")
+        return "\n".join(txt_lines[start_index:end_index])
+
+    def package(self):
+        tools.save(os.path.join(self.package_folder, "licenses", "COPYING"), self._extract_license())
+        self.copy("config.guess", src=self._source_subfolder, dst="bin")
+        self.copy("config.sub", src=self._source_subfolder, dst="bin")
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)
+
+        self.user_info.CONFIG_GUESS = os.path.join(bin_path, "config.guess")
+        self.user_info.CONFIG_SUB = os.path.join(bin_path, "config.sub")

--- a/recipes/gnu-config/all/test_package/conanfile.py
+++ b/recipes/gnu-config/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, tools
+from conans.errors import ConanException
+
+
+class TestConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+
+    def build_requirements(self):
+        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/20190524")
+
+    def test(self):
+        triplet = tools.get_gnu_triplet(str(self.settings.os), str(self.settings.arch), str(self.settings.compiler))
+        self.run("config.guess", run_environment=True, win_bash=tools.os_info.is_windows)
+        try:
+            self.run("config.sub {}".format(triplet), run_environment=True, win_bash=tools.os_info.is_windows)
+        except ConanException:
+            self.output.info("Current configuration is not supported by GNU config.\nIgnoring...")

--- a/recipes/gnu-config/config.yml
+++ b/recipes/gnu-config/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20200712":
+  "cci.20201022":
     folder: "all"

--- a/recipes/gnu-config/config.yml
+++ b/recipes/gnu-config/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20200712":
+  "20200712":
     folder: "all"

--- a/recipes/gnu-config/config.yml
+++ b/recipes/gnu-config/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "20200712":
+  "cci.20200712":
     folder: "all"

--- a/recipes/gnu-config/config.yml
+++ b/recipes/gnu-config/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20200712":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **gnu-config/cci.20200712**

- The scripts in this package are required when using `AC_CANONICAL_*` in autoconf (without automake).
- These scripts are useful to update the canonical host/build/target triplet detection without having to run autotools' reconfiguration.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

