### PR TITLE
nspr: add version 4.27

### DIFF
--- a/recipes/nspr/all/conandata.yml
+++ b/recipes/nspr/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "4.24":
     sha256: 90a59a0df6a11528749647fe18401cc7e03881e3e63c309f8c520ce06dd413d0
     url: https://ftp.mozilla.org/pub/nspr/releases/v4.24/src/nspr-4.24.tar.gz
+  "4.27":
+    sha256: 6d495192b6ab00a3c28db053492cf794329f7c0351a5728db198111a1816e89b
+    url: https://ftp.mozilla.org/pub/nspr/releases/v4.27/src/nspr-4.27.tar.gz

--- a/recipes/nspr/all/test_package/CMakeLists.txt
+++ b/recipes/nspr/all/test_package/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.12)
 project(test_package)
 
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/nspr/config.yml
+++ b/recipes/nspr/config.yml
@@ -1,3 +1,5 @@
 versions:
   "4.24":
     folder: all
+  "4.27":
+    folder: all


### PR DESCRIPTION
nspr supports macos11

Specify library name and version:  **nspr/4.27**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

