### PR TITLE
nspr: compile support for apple silicon

### DIFF
--- a/recipes/nspr/all/conandata.yml
+++ b/recipes/nspr/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "4.24":
     sha256: 90a59a0df6a11528749647fe18401cc7e03881e3e63c309f8c520ce06dd413d0
     url: https://ftp.mozilla.org/pub/nspr/releases/v4.24/src/nspr-4.24.tar.gz
+  "4.27":
+    sha256: 6d495192b6ab00a3c28db053492cf794329f7c0351a5728db198111a1816e89b
+    url: https://ftp.mozilla.org/pub/nspr/releases/v4.27/src/nspr-4.27.tar.gz

--- a/recipes/nspr/all/conandata.yml
+++ b/recipes/nspr/all/conandata.yml
@@ -5,3 +5,11 @@ sources:
   "4.27":
     sha256: 6d495192b6ab00a3c28db053492cf794329f7c0351a5728db198111a1816e89b
     url: https://ftp.mozilla.org/pub/nspr/releases/v4.27/src/nspr-4.27.tar.gz
+
+patches:
+  "4.24":
+    - patch_file: "patches/0001-apple-silicon-support.patch"
+      base_path: "source_subfolder"
+  "4.27":
+    - patch_file: "patches/0001-apple-silicon-support.patch"
+      base_path: "source_subfolder"

--- a/recipes/nspr/all/conanfile.py
+++ b/recipes/nspr/all/conanfile.py
@@ -24,6 +24,7 @@ class NsprConan(ConanFile):
         "win32_target": "winnt",
     }
     generators = "cmake"
+    exports_sources = ["patches/**"]
 
     _autotools = None
 
@@ -95,6 +96,9 @@ class NsprConan(ConanFile):
         return self._autotools
 
     def build(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+
         with tools.chdir(self._source_subfolder):
             with self._build_context():
                 autotools = self._configure_autotools()

--- a/recipes/nspr/all/patches/0001-apple-silicon-support.patch
+++ b/recipes/nspr/all/patches/0001-apple-silicon-support.patch
@@ -1,0 +1,88 @@
+From 8fdc1bbcc29eb60968a30c22355ea3dacad52438 Mon Sep 17 00:00:00 2001
+From: Tim Blechmann <tim@klingt.org>
+Date: Wed, 29 Jul 2020 13:22:12 +0800
+Subject: [PATCH] apple silicon support
+
+---
+ configure    | 16 ++--------------
+ configure.in |  2 +-
+ 2 files changed, 3 insertions(+), 15 deletions(-)
+
+diff --git a/configure b/configure
+index 98b3f04..dffd23f 100755
+--- a/configure
++++ b/configure
+@@ -756,7 +756,6 @@ infodir
+ docdir
+ oldincludedir
+ includedir
+-runstatedir
+ localstatedir
+ sharedstatedir
+ sysconfdir
+@@ -868,7 +867,6 @@ datadir='${datarootdir}'
+ sysconfdir='${prefix}/etc'
+ sharedstatedir='${prefix}/com'
+ localstatedir='${prefix}/var'
+-runstatedir='${localstatedir}/run'
+ includedir='${prefix}/include'
+ oldincludedir='/usr/include'
+ docdir='${datarootdir}/doc/${PACKAGE}'
+@@ -1121,15 +1119,6 @@ do
+   | -silent | --silent | --silen | --sile | --sil)
+     silent=yes ;;
+ 
+-  -runstatedir | --runstatedir | --runstatedi | --runstated \
+-  | --runstate | --runstat | --runsta | --runst | --runs \
+-  | --run | --ru | --r)
+-    ac_prev=runstatedir ;;
+-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+-  | --run=* | --ru=* | --r=*)
+-    runstatedir=$ac_optarg ;;
+-
+   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
+     ac_prev=sbindir ;;
+   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
+@@ -1267,7 +1256,7 @@ fi
+ for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
+ 		datadir sysconfdir sharedstatedir localstatedir includedir \
+ 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
+-		libdir localedir mandir runstatedir
++		libdir localedir mandir
+ do
+   eval ac_val=\$$ac_var
+   # Remove trailing slashes.
+@@ -1420,7 +1409,6 @@ Fine tuning of the installation directories:
+   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
+   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
+   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
+   --libdir=DIR            object code libraries [EPREFIX/lib]
+   --includedir=DIR        C header files [PREFIX/include]
+   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
+@@ -6448,7 +6436,7 @@ fi
+     CFLAGS="$CFLAGS -Wall -fno-common"
+     case "${target_cpu}" in
+         arm*)
+-            CPU_ARCH=arm
++            CPU_ARCH=arm64
+             ;;
+         i*86*|x86_64)
+             if test -n "$USE_64"; then
+diff --git a/configure.in b/configure.in
+index ef46a40..c6cc447 100644
+--- a/configure.in
++++ b/configure.in
+@@ -1317,7 +1317,7 @@ case "$target" in
+     CFLAGS="$CFLAGS -Wall -fno-common"
+     case "${target_cpu}" in
+         arm*)
+-            CPU_ARCH=arm
++            CPU_ARCH=arm64
+             ;;
+         i*86*|x86_64)
+             if test -n "$USE_64"; then
+-- 
+2.27.0
+

--- a/recipes/nspr/all/test_package/CMakeLists.txt
+++ b/recipes/nspr/all/test_package/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.12)
 project(test_package)
 
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/nspr/config.yml
+++ b/recipes/nspr/config.yml
@@ -1,3 +1,5 @@
 versions:
   "4.24":
     folder: all
+  "4.27":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **nspr/4.27**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

---

i'm not sure how to deal with the test package correctly: on apple silicon the test package is still compiled as `x86_64` not as `arm64`, so linking fails