### PR TITLE
automake: aclocal needs unix paths on Windows when using CCI's m4

### DIFF
--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -58,6 +58,13 @@ class AutomakeConan(ConanFile):
     def _patch_files(self):
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
+        if self.settings.os == "Windows":
+            # tracing using m4 on Windows returns Windows paths => use cygpath to convert to unix paths
+            tools.replace_in_file(os.path.join(self._source_subfolder, "bin", "aclocal.in"),
+                                               "          $map_traced_defs{$arg1} = $file;",
+                                               "          $file = `cygpath -u $file`;\n"
+                                               "          $file =~ s/^\s+|\s+$//g;\n"
+                                               "          $map_traced_defs{$arg1} = $file;")
 
     def build(self):
         self._patch_files()

--- a/recipes/automake/all/test_package/conanfile.py
+++ b/recipes/automake/all/test_package/conanfile.py
@@ -51,7 +51,7 @@ class TestPackageConan(ConanFile):
     def _build_autotools(self):
         """Test autoreconf + configure + make"""
         with tools.environment_append({"AUTOMAKE_CONAN_INCLUDES": [tools.unix_path(self.source_folder)]}):
-            self.run("{} --verbose --install".format(os.environ["AUTORECONF"]), win_bash=tools.os_info.is_windows)
+            self.run("{} -fiv".format(os.environ["AUTORECONF"]), win_bash=tools.os_info.is_windows)
         self.run("{} --help".format(os.path.join(self.build_folder, "configure").replace("\\", "/")), win_bash=tools.os_info.is_windows)
         autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         with self._build_context():

--- a/recipes/automake/all/test_package/configure.ac
+++ b/recipes/automake/all/test_package/configure.ac
@@ -1,28 +1,18 @@
-# Must init the autoconf setup
-# The first parameter is project name
-# second is version number
-# third is bug report address
+AC_PREREQ([2.69])
 AC_INIT([test_package], [1.0])
+AC_CONFIG_AUX_DIR([build-aux])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 # Safety checks in case user overwritten --srcdir
 AC_CONFIG_SRCDIR([test_package.cpp])
 
-
-# Store the auxiliary build tools (e.g., install-sh, config.sub, config.guess)
-# in this dir (build-aux)
-AC_CONFIG_AUX_DIR([build-aux])
-
-# Init automake, and specify this program use relaxed structures.
-# i.e. this program doesn't follow the gnu coding standards, and doesn't have
-# ChangeLog, COPYING, AUTHORS, INSTALL, README etc. files.
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AC_CANONICAL_HOST
 
 # Test includes of extra including directories using conan
 AUTOMAKE_TEST_PACKAGE_PREREQ([1.0])
 AUTOMAKE_TEST_PACKAGE_HELLO([argument1], [argument2], [...], [last argument])
 
 AC_CONFIG_HEADER([config.h])
-
 
 # Check for CC and CXX compiler
 AC_PROG_CC


### PR DESCRIPTION
Specify library name and version:  **automake/all**

automake on Windows broke when using cci's m4.
- This should fix the build failure seen in https://github.com/conan-io/conan-center-index/pull/2294
- Some build failures in https://github.com/conan-io/conan-center-index/issues/2293 should be fixed as well


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

