### PR TITLE
winflexbison: set LEX and YACC environment variable

### DIFF
--- a/recipes/winflexbison/all/conanfile.py
+++ b/recipes/winflexbison/all/conanfile.py
@@ -16,7 +16,7 @@ class WinflexbisonConan(ConanFile):
     settings = "os", "build_type", "arch", "compiler"
 
     _source_subfolder = "source_subfolder"
-    
+
     _cmake = None
 
     def config_options(self):
@@ -52,7 +52,7 @@ class WinflexbisonConan(ConanFile):
         self.copy(pattern="*.exe", dst="bin", src=actual_build_path, keep_path=False)
         self.copy(pattern="data/*", dst="bin", src="{}/bison".format(self._source_subfolder), keep_path=True)
         self.copy(pattern="FlexLexer.h", dst="include", src=os.path.join(self._source_subfolder, "flex", "src"), keep_path=False)
-        
+
         # Copy licenses
         self._extract_license()
         self.copy(pattern="COPYING.GPL3", dst="licenses")
@@ -65,3 +65,11 @@ class WinflexbisonConan(ConanFile):
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bindir))
         self.env_info.PATH.append(bindir)
+
+        lex_path = os.path.join(self.package_folder, "bin", "win_flex").replace("\\", "/")
+        self.output.info("Setting LEX environment variable: {}".format(lex_path))
+        self.env_info.LEX = lex_path
+
+        yacc_path = os.path.join(self.package_folder, "bin", "win_bison -y").replace("\\", "/")
+        self.output.info("Setting YACC environment variable: {}".format(yacc_path))
+        self.env_info.YACC = yacc_path

--- a/recipes/winflexbison/all/test_package/CMakeLists.txt
+++ b/recipes/winflexbison/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(test_package)
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup(NO_OUTPUT_DIRS)
+conan_basic_setup()
 
 # Flex
 
@@ -29,8 +29,6 @@ endforeach()
 FLEX_TARGET(TestParser basic_nr.l "${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp" COMPILE_FLAGS "${FLEX_TARGET_COMPILE_FLAGS}")
 add_executable(flex_test_package ${FLEX_TestParser_OUTPUTS})
 set_property(TARGET flex_test_package PROPERTY CXX_STANDARD 11)
-enable_testing()
-add_test(TestLexer ${CMAKE_CURRENT_BINARY_DIR}/flex_test_package "${CMAKE_CURRENT_LIST_DIR}/basic_nr.txt")
 
 # Bison
 
@@ -54,5 +52,3 @@ bison_target(bison_parser_target mc_parser.yy "${CMAKE_CURRENT_BINARY_DIR}/mc_pa
 add_executable(bison_test_package "${CMAKE_CURRENT_BINARY_DIR}/mc_parser.cpp" dummy_lex.cpp)
 set_property(TARGET bison_test_package PROPERTY CXX_STANDARD 11)
 target_include_directories(bison_test_package PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
-enable_testing()
-add_test(TestBison ${CMAKE_CURRENT_BINARY_DIR}/bison_test_package)

--- a/recipes/winflexbison/all/test_package/conanfile.py
+++ b/recipes/winflexbison/all/test_package/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
+
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
@@ -15,5 +16,5 @@ class TestPackageConan(ConanFile):
         self.run("win_bison --version", run_environment=True)
 
         if not tools.cross_building(self.settings):
-            cmake = CMake(self)
-            cmake.test()
+            self.run(os.path.join("bin", "bison_test_package"), run_environment=True)
+            self.run("{} {}".format(os.path.join("bin", "flex_test_package"), os.path.join(self.source_folder, "basic_nr.txt")), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **winflexbison/all**

Required to fix building swig with `Visual Studio`.
Found this problem while debugging https://github.com/conan-io/conan-center-index/issues/2293

Without this change, system bison of msys2 would be used.
The `-y` flag is required becayse [automake assumes y.tab.c/y.tab.h are generated](https://www.gnu.org/software/automake/manual/html_node/Yacc-and-Lex.html)


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

