### PR TITLE
[libcurl] Added --with-wolfssl flag for building libcurl with wolfSSL

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -194,6 +194,9 @@ class LibcurlConan(ConanFile):
         elif self.options.with_openssl:
             openssl_path = self.deps_cpp_info["openssl"].rootpath.replace("\\", "/")
             params.append("--with-ssl=%s" % openssl_path)
+        elif self.options.with_wolfssl:
+            params.append("--with-wolfssl")
+            params.append("--without-ssl")
         else:
             params.append("--without-ssl")
 


### PR DESCRIPTION
Fixed libcurl building with wolfSSL by adding the necessary `--with-wolfssl` flag when bulding.
Reference: https://www.wolfssl.com/using-curl-wolfssl-tls-1-3/

Specify library name and version:  **libcurl/***

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

