### PR TITLE
brotli: add components + cache cmake

### DIFF
--- a/recipes/brotli/all/CMakeLists.txt
+++ b/recipes/brotli/all/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+include(conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_subdirectory(source_subfolder)
+add_subdirectory("source_subfolder")

--- a/recipes/brotli/all/conanfile.py
+++ b/recipes/brotli/all/conanfile.py
@@ -19,7 +19,16 @@ class BrotliConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-    _source_subfolder = "source_subfolder"
+
+    _cmake = None
+
+    @ property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @ property
+    def _build_subfolder(self):
+        return "build_subfolder"
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -37,11 +46,13 @@ class BrotliConan(ConanFile):
         os.rename(extracted_folder, self._source_subfolder)
 
     def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["BROTLI_BUNDLED_MODE"] = False
-        cmake.definitions["BROTLI_DISABLE_TESTS"] = True
-        cmake.configure()
-        return cmake
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["BROTLI_BUNDLED_MODE"] = False
+        self._cmake.definitions["BROTLI_DISABLE_TESTS"] = True
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
 
     def build(self):
         for patch in self.conan_data["patches"][self.version]:

--- a/recipes/brotli/all/conanfile.py
+++ b/recipes/brotli/all/conanfile.py
@@ -5,6 +5,7 @@ import os
 class BrotliConan(ConanFile):
     name = "brotli"
     description = "Brotli compression format"
+    topics = ("conan", "brotli", "compression")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/google/brotli"
     license = "MIT",

--- a/recipes/brotli/all/conanfile.py
+++ b/recipes/brotli/all/conanfile.py
@@ -73,6 +73,8 @@ class BrotliConan(ConanFile):
         self.cpp_info.components["brotlicommon"].names["pkg_config"] = "libbrotlicommon"
         self.cpp_info.components["brotlicommon"].includedirs.append(includedir)
         self.cpp_info.components["brotlicommon"].libs = [self._get_decorated_lib("brotlicommon")]
+        if self.settings.os == "Windows" and self.options.shared:
+            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_SHARED_COMPILATION")
         # brotlidec
         self.cpp_info.components["brotlidec"].names["pkg_config"] = "libbrotlidec"
         self.cpp_info.components["brotlidec"].includedirs.append(includedir)
@@ -85,11 +87,6 @@ class BrotliConan(ConanFile):
         self.cpp_info.components["brotlienc"].requires = ["brotlicommon"]
         if self.settings.os == "Linux":
             self.cpp_info.components["brotlienc"].system_libs = ["m"]
-
-        if self.settings.os == "Windows" and self.options.shared:
-            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_SHARED_COMPILATION")
-            self.cpp_info.components["brotlidec"].defines.append("BROTLI_SHARED_COMPILATION")
-            self.cpp_info.components["brotlienc"].defines.append("BROTLI_SHARED_COMPILATION")
 
     def _get_decorated_lib(self, name):
         libname = name

--- a/recipes/brotli/all/conanfile.py
+++ b/recipes/brotli/all/conanfile.py
@@ -23,11 +23,11 @@ class BrotliConan(ConanFile):
 
     _cmake = None
 
-    @ property
+    @property
     def _source_subfolder(self):
         return "source_subfolder"
 
-    @ property
+    @property
     def _build_subfolder(self):
         return "build_subfolder"
 
@@ -68,6 +68,8 @@ class BrotliConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "Brotli"
+        self.cpp_info.names["cmake_find_package_multi"] = "Brotli"
         includedir = os.path.join("include", "brotli")
         # brotlicommon
         self.cpp_info.components["brotlicommon"].names["pkg_config"] = "libbrotlicommon"

--- a/recipes/brotli/all/test_package/CMakeLists.txt
+++ b/recipes/brotli/all/test_package/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(test_package)
 
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 

--- a/recipes/brotli/config.yml
+++ b/recipes/brotli/config.yml
@@ -1,3 +1,3 @@
 versions:
-  1.0.7:
+  "1.0.7":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **brotli/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

closes https://github.com/conan-io/conan-center-index/issues/2318

- cache cmake
- remove non official cmake name
- add components (though, conan is not yet able to create one pkgconfig file per component through `pkg_config` generator)