### PR TITLE
naive-tsearch: add naive-tsearch/0.1.0 recipe

### DIFF
--- a/recipes/naive-tsearch/all/CMakeLists.txt
+++ b/recipes/naive-tsearch/all/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 2.8.14)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+
+add_subdirectory(source_subfolder)

--- a/recipes/naive-tsearch/all/CMakeLists.txt
+++ b/recipes/naive-tsearch/all/CMakeLists.txt
@@ -2,5 +2,6 @@ cmake_minimum_required(VERSION 2.8.14)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
+conan_basic_setup()
 
 add_subdirectory(source_subfolder)

--- a/recipes/naive-tsearch/all/conandata.yml
+++ b/recipes/naive-tsearch/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/kulp/naive-tsearch/releases/download/v0.1.0/naive-tsearch-0.1.0.tar.xz"
+    sha256: "0e45b7ffb5ff98dce56c4e01365905158843f4c75e6bf1061774153f3c63a2a4"

--- a/recipes/naive-tsearch/all/conanfile.py
+++ b/recipes/naive-tsearch/all/conanfile.py
@@ -66,6 +66,7 @@ class NaiveTsearchConan(ConanFile):
     def package_info(self):
         if self.options.header_only:
             self.cpp_info.components["header_only"].libs = []
+            self.cpp_info.components["header_only"].libdirs = []
             self.cpp_info.components["header_only"].includedirs.append(os.path.join("include", "naive-tsearch"))
             self.cpp_info.components["header_only"].defines = ["NAIVE_TSEARCH_HDRONLY"]
             self.cpp_info.components["header_only"].names["cmake_find_package"] = "naive-tsearch-hdronly"

--- a/recipes/naive-tsearch/all/conanfile.py
+++ b/recipes/naive-tsearch/all/conanfile.py
@@ -27,10 +27,6 @@ class NaiveTsearchConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -48,7 +44,7 @@ class NaiveTsearchConan(ConanFile):
             return self._cmake
         self._cmake = CMake(self)
         self._cmake.definitions["NAIVE_TSEARCH_INSTALL"] = True
-        self._cmake.configure(build_folder=self._build_subfolder)
+        self._cmake.configure()
         return self._cmake
 
     def build(self):

--- a/recipes/naive-tsearch/all/conanfile.py
+++ b/recipes/naive-tsearch/all/conanfile.py
@@ -1,0 +1,81 @@
+from conans import CMake, ConanFile, tools
+import os
+
+
+class NaiveTsearchConan(ConanFile):
+    name = "naive-tsearch"
+    description = "A simple tsearch() implementation for platforms without one"
+    topics = ("conan", "naive-tsearch", "tsearch", "search", "tree", "msvc")
+    license = "MIT"
+    homepage = "https://github.com/kulp/naive-tsearch"
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "arch", "compiler", "build_type"
+    exports_sources = ['CMakeLists.txt']
+    options = {
+        "fPIC": [True, False],
+        "header_only": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "header_only": True,
+    }
+    generators = "cmake"
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["NAIVE_TSEARCH_INSTALL"] = True
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_id(self):
+        del self.info.options.header_only
+
+    def package_info(self):
+        if self.options.header_only:
+            self.cpp_info.components["header_only"].libs = []
+            self.cpp_info.components["header_only"].includedirs.append(os.path.join("include", "naive-tsearch"))
+            self.cpp_info.components["header_only"].defines = ["NAIVE_TSEARCH_HDRONLY"]
+            self.cpp_info.components["header_only"].names["cmake_find_package"] = "naive-tsearch-hdronly"
+            self.cpp_info.components["header_only"].names["cmake_find_package_multi"] = "naive-tsearch-hdronly"
+        else:
+            self.cpp_info.components["naive_tsearch"].libs = ["naive-tsearch"]
+            self.cpp_info.components["naive_tsearch"].includedirs.append(os.path.join("include", "naive-tsearch"))
+            self.cpp_info.components["naive_tsearch"].names["cmake_find_package"] = "naive-tsearch"
+            self.cpp_info.components["naive_tsearch"].names["cmake_find_package_multi"] = "naive-tsearch"

--- a/recipes/naive-tsearch/all/conanfile.py
+++ b/recipes/naive-tsearch/all/conanfile.py
@@ -10,7 +10,7 @@ class NaiveTsearchConan(ConanFile):
     homepage = "https://github.com/kulp/naive-tsearch"
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "arch", "compiler", "build_type"
-    exports_sources = ['CMakeLists.txt']
+    exports_sources = ["CMakeLists.txt"]
     options = {
         "fPIC": [True, False],
         "header_only": [True, False],

--- a/recipes/naive-tsearch/all/test_package/CMakeLists.txt
+++ b/recipes/naive-tsearch/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(test_package C)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/naive-tsearch/all/test_package/conanfile.py
+++ b/recipes/naive-tsearch/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/naive-tsearch/all/test_package/test_package.c
+++ b/recipes/naive-tsearch/all/test_package/test_package.c
@@ -1,4 +1,4 @@
-#include <tsearch.h>
+#include <search.h>
 
 #include <stdio.h>
 
@@ -6,7 +6,7 @@ static void walk_tree(const void *what, VISIT kind, int level) {
 }
 
 int main() {
-    void *root;
+    void *root = NULL;
     twalk(root, walk_tree);
     return 0;
 }

--- a/recipes/naive-tsearch/all/test_package/test_package.c
+++ b/recipes/naive-tsearch/all/test_package/test_package.c
@@ -1,0 +1,12 @@
+#include <tsearch.h>
+
+#include <stdio.h>
+
+static void walk_tree(const void *what, VISIT kind, int level) {
+}
+
+int main() {
+    void *root;
+    twalk(root, walk_tree);
+    return 0;
+}

--- a/recipes/naive-tsearch/config.yml
+++ b/recipes/naive-tsearch/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **naive-tsearch/0.1.0**

This package is required for supporting extended colors for ncurses with Visual Studio

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Thanks @kulp  for the superbe co-operation :clap: !