### PR TITLE
flann: add components + use external lz4 + several fixes

### DIFF
--- a/recipes/flann/all/conandata.yml
+++ b/recipes/flann/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "1.9.1":
     sha256: b23b5f4e71139faa3bcb39e6bbcc76967fbaf308c4ee9d4f5bfbeceaa76cc5d3
     url: https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz
+patches:
+  "1.9.1":
+    - patch_file: "patches/external-lz4-and-export-symbols.patch"
+      base_path: "source_subfolder"

--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -47,7 +47,7 @@ class LibFlannConan(ConanFile):
     def requirements(self):
         self.requires("lz4/1.9.2")
         if self.options.with_hdf5:
-            self.requires("hdf5/1.10.6")
+            self.requires("hdf5/1.12.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -37,7 +37,11 @@ class LibFlannConan(ConanFile):
         return "build_subfolder"
 
     def config_options(self):
-        if self.settings.compiler == "Visual Studio":
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
             del self.options.fPIC
 
     def requirements(self):

--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -119,10 +119,25 @@ class LibFlannConan(ConanFile):
                 os.remove(lib_to_remove)
 
     def package_info(self):
-        if self.options.shared:
-            self.cpp_info.libs = ["flann", "flann_cpp"]
-        else:
-            self.cpp_info.libs = ["flann_s", "flann_cpp_s"]
-
+        self.cpp_info.names["cmake_find_package"] = "Flann"
+        self.cpp_info.names["cmake_find_package_multi"] = "flann"
+        # flann_cpp
+        flann_cpp_lib = "flann_cpp" if self.options.shared else "flann_cpp_s"
+        self.cpp_info.components["flann_cpp"].names["cmake_find_package"] = flann_cpp_lib
+        self.cpp_info.components["flann_cpp"].names["cmake_find_package_multi"] = flann_cpp_lib
+        self.cpp_info.components["flann_cpp"].libs = [flann_cpp_lib]
+        if not self.options.shared and tools.stdcpp_library(self):
+            self.cpp_info.components["flann_cpp"].system_libs.append(tools.stdcpp_library(self))
+        self.cpp_info.components["flann_cpp"].requires = ["lz4::lz4"]
+        if self.options.with_hdf5:
+            self.cpp_info.components["flann_cpp"].requires = ["hdf5::hdf5"]
+        # flann
+        flann_c_lib = "flann" if self.options.shared else "flann_s"
+        self.cpp_info.components["flann_c"].names["cmake_find_package"] = flann_c_lib
+        self.cpp_info.components["flann_c"].names["cmake_find_package_multi"] = flann_c_lib
+        self.cpp_info.components["flann_c"].libs = [flann_c_lib]
+        if self.settings.os == "Linux":
+            self.cpp_info.components["flann_c"].system_libs.append("m")
         if not self.options.shared:
-            self.cpp_info.defines.append("FLANN_STATIC")
+            self.cpp_info.components["flann_c"].defines.append("FLANN_STATIC")
+        self.cpp_info.components["flann_c"].requires = ["flann_cpp"]

--- a/recipes/flann/all/patches/external-lz4-and-export-symbols.patch
+++ b/recipes/flann/all/patches/external-lz4-and-export-symbols.patch
@@ -1,0 +1,69 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,6 +66,7 @@ if (NOT BUILD_C_BINDINGS)
+     set(BUILD_MATLAB_BINDINGS OFF)
+ endif()
+ 
++find_package(lz4 REQUIRED)
+ 
+ # find python
+ find_package(PythonInterp)
+--- a/src/cpp/CMakeLists.txt
++++ b/src/cpp/CMakeLists.txt
+@@ -4,11 +4,12 @@ add_definitions(-D_FLANN_VERSION=${FLANN_VERSION})
+ 
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/flann/config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/flann/config.h)
+ 
+-file(GLOB_RECURSE C_SOURCES flann.cpp lz4.c lz4hc.c)
+-file(GLOB_RECURSE CPP_SOURCES flann_cpp.cpp lz4.c lz4hc.c)
++file(GLOB_RECURSE C_SOURCES flann.cpp)
++file(GLOB_RECURSE CPP_SOURCES flann_cpp.cpp)
+ file(GLOB_RECURSE CU_SOURCES *.cu)
+ 
+ add_library(flann_cpp_s STATIC ${CPP_SOURCES})
++target_link_libraries(flann_cpp_s PUBLIC lz4::lz4)
+ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
+     set_target_properties(flann_cpp_s PROPERTIES COMPILE_FLAGS -fPIC)
+ endif()
+@@ -42,10 +43,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_COMPILER_IS_GNUCC)
+     endif()
+ else()
+     add_library(flann_cpp SHARED ${CPP_SOURCES})
++    target_link_libraries(flann_cpp PUBLIC lz4::lz4)
+     if (BUILD_CUDA_LIB)
+ 		cuda_add_library(flann_cuda SHARED ${CPP_SOURCES})
+         set_property(TARGET flann_cpp PROPERTY COMPILE_DEFINITIONS FLANN_USE_CUDA)
+     endif()
++    set_target_properties(flann_cpp PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ endif()
+ 
+ set_target_properties(flann_cpp PROPERTIES
+@@ -77,6 +80,7 @@ endif()
+ 
+ if (BUILD_C_BINDINGS)
+     add_library(flann_s STATIC ${C_SOURCES})
++    target_link_libraries(flann_s PUBLIC lz4::lz4)
+     if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
+         set_target_properties(flann_s PROPERTIES COMPILE_FLAGS -fPIC)
+     endif()
+@@ -88,6 +92,7 @@ if (BUILD_C_BINDINGS)
+         target_link_libraries(flann -Wl,-whole-archive flann_s -Wl,-no-whole-archive)
+     else()
+         add_library(flann SHARED ${C_SOURCES})
++        target_link_libraries(flann PUBLIC lz4::lz4)
+ 
+         if(MINGW AND OPENMP_FOUND)
+           target_link_libraries(flann gomp)
+--- a/src/cpp/flann/util/serialization.h
++++ b/src/cpp/flann/util/serialization.h
+@@ -6,8 +6,8 @@
+ #include <cstdlib>
+ #include <cstring>
+ #include <stdio.h>
+-#include "flann/ext/lz4.h"
+-#include "flann/ext/lz4hc.h"
++#include <lz4.h>
++#include <lz4hc.h>
+ 
+ 
+ namespace flann

--- a/recipes/flann/all/test_package/CMakeLists.txt
+++ b/recipes/flann/all/test_package/CMakeLists.txt
@@ -1,9 +1,14 @@
-cmake_minimum_required(VERSION 2.8.11)
-
-project(test_package LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
-target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})
+find_package(flann REQUIRED CONFIG)
+
+add_executable(${CMAKE_PROJECT_NAME} test_package.c)
+if(FLANN_SHARED)
+  target_link_libraries(${CMAKE_PROJECT_NAME} flann::flann)
+else()
+  target_link_libraries(${CMAKE_PROJECT_NAME} flann::flann_s)
+endif()

--- a/recipes/flann/all/test_package/conanfile.py
+++ b/recipes/flann/all/test_package/conanfile.py
@@ -1,17 +1,19 @@
 import os.path
 
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 
 
 class FlannTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["FLANN_SHARED"] = self.options["flann"].shared
         cmake.configure()
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/flann/all/test_package/test_package.c
+++ b/recipes/flann/all/test_package/test_package.c
@@ -1,8 +1,10 @@
-#include <iostream>
 #include <flann/flann.h>
+
+#include <stdio.h>
 
 int main()
 {
     // Simply make sure that it builds an runs
-    std::cout << flann_get_distance_type() << '\n';
+    printf("%i\n", flann_get_distance_type());
+    return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **flann/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Several fixes:
- add components: flann 1.9.1 doesn't export its targets, but master branch does. There is also a `FindFlann.cmake` file available in flann repo, but it doesn't define targets. I decided to define same targets than config file.
- properly remove either shared/static lib (its was broken except for Visual Studio) and ms runtime during packaging.
- use external `lz4` dependency instead of embeded one.
- only use `WINDOWS_EXPORT_ALL_SYMBOLS` for `flann_cpp` target, because `flann` target properly exports its symbols on Windows.
- fix fPIC deletion, though I think that flann can't be built without PIC (or it requires a big patch in CMakeLists files I think).
- bump `hdf5` dependency to 1.12.0 (I don't know if `with_hdf5` option really makes sense without `parallel` implemented in `hdf5` recipe and without `openmpi` in CCI).