### PR TITLE
m4: allow msvc debug build

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -46,6 +46,12 @@ class M4Conan(ConanFile):
             build_canonical_name = False
             host_canonical_name = False
             self._autotools.flags.append("-FS")
+            # Avoid a `Assertion Failed Dialog Box` during configure with build_type=Debug
+            # Visual Studio does not support the %n format flag:
+            # https://docs.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions
+            # Because the %n format is inherently insecure, it is disabled by default. If %n is encountered in a format string,
+            # the invalid parameter handler is invoked, as described in Parameter Validation. To enable %n support, see _set_printf_count_output.
+            conf_args.extend(["gl_cv_func_printf_directive_n=no", "gl_cv_func_snprintf_directive_n=no", "gl_cv_func_snprintf_directive_n=no"])
             if self.settings.build_type in ("Debug", "RelWithDebInfo"):
                 self._autotools.link_flags.append("-PDB")
         self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder, build=build_canonical_name, host=host_canonical_name)

--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -45,6 +45,7 @@ class M4Conan(ConanFile):
             # The somewhat older configure script of m4 does not understand the canonical names of Visual Studio
             build_canonical_name = False
             host_canonical_name = False
+            self._autotools.flags.append("-FS")
         self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder, build=build_canonical_name, host=host_canonical_name)
         return self._autotools
 

--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -11,7 +11,7 @@ class M4Conan(ConanFile):
     homepage = "https://www.gnu.org/software/m4/"
     license = "GPL-3.0-only"
     exports_sources = ["patches/*.patch"]
-    settings = "os", "arch", "compiler"
+    settings = "os", "arch", "compiler", "build_type"
 
     _autotools = None
     _source_subfolder = "source_subfolder"
@@ -46,6 +46,8 @@ class M4Conan(ConanFile):
             build_canonical_name = False
             host_canonical_name = False
             self._autotools.flags.append("-FS")
+            if self.settings.build_type in ("Debug", "RelWithDebInfo"):
+                self._autotools.link_flags.append("-PDB")
         self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder, build=build_canonical_name, host=host_canonical_name)
         return self._autotools
 


### PR DESCRIPTION
Specify library name and version:  **m4/1.4.18**

@jmarrec 

This allows building m4 using MSVC in Debug.
Debug assertions will show up during configuration, but `make` won't fail any longer due to parallelism. 

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

