### PR TITLE
Fix no_copy_source in cppcodec

### DIFF
--- a/recipes/cppcodec/all/conanfile.py
+++ b/recipes/cppcodec/all/conanfile.py
@@ -9,7 +9,7 @@ class CppcodecConan(ConanFile):
     homepage = "https://github.com/tplgy/cppcodec"
     description = "Header-only C++11 library to encode/decode base64, base64url, base32, base32hex and hex (a.k.a. base16) as specified in RFC 4648, plus Crockford's base32"
     topics = ("base64", "cpp11", "codec", "base32")
-    no_copy_sources = True
+    no_copy_source = True
 
     _source_subfolder = "source_subfolder"
 
@@ -22,5 +22,6 @@ class CppcodecConan(ConanFile):
         self.copy("*hpp", dst=os.path.join("include", "cppcodec"), src=os.path.join(self._source_subfolder, "cppcodec"))
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
 
-    def package_info(self):
+    def package_id(self):
         self.info.header_only()
+

--- a/recipes/cppcodec/all/test_package/example.cpp
+++ b/recipes/cppcodec/all/test_package/example.cpp
@@ -11,3 +11,4 @@ int main() {
   std::cout << base32::encode(decoded) << std::endl; // "C5Q7J833C5S6WRBC41R6RSB1EDTQ4S8"
   return 0;
 }
+


### PR DESCRIPTION
Specify library name and version:  **cppcodec/0.2**

The attribute `no_copy_sources` doesn't exist, the correct one is `no_copy_source`.

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

