### PR TITLE
glog: fix cmake name again + cache cmake + delete fPIC option if shared

### DIFF
--- a/recipes/glog/all/conandata.yml
+++ b/recipes/glog/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "0.4.0":
     sha256: f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c
     url: https://github.com/google/glog/archive/v0.4.0.tar.gz
+patches:
+  "0.4.0":
+    - patch_file: "patches/fix-cmake.patch"
+      base_path: "source_subfolder"

--- a/recipes/glog/all/conanfile.py
+++ b/recipes/glog/all/conanfile.py
@@ -63,5 +63,3 @@ class GlogConan(ConanFile):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")
-        self.cpp_info.names["cmake_find_package"] = "GLOG"
-        self.cpp_info.names["cmake_find_package_multi"] = "GLOG"

--- a/recipes/glog/all/conanfile.py
+++ b/recipes/glog/all/conanfile.py
@@ -9,7 +9,7 @@ class GlogConan(ConanFile):
     description = "Google logging library"
     topics = ("conan", "glog", "logging")
     license = "BSD 3-Clause"
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake", "cmake_find_package"
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False], "with_gflags": [True, False], "with_threads": [True, False]}
@@ -51,12 +51,8 @@ class GlogConan(ConanFile):
         return self._cmake
 
     def build(self):
-        if self.options.with_gflags:
-            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                                  "gflags 2.2.0", "gflags 2.2.1 REQUIRED")
-            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                                  "target_link_libraries (glog PUBLIC gflags)",
-                                  "target_link_libraries (glog PUBLIC ${CONAN_LIBS})")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/glog/all/conanfile.py
+++ b/recipes/glog/all/conanfile.py
@@ -25,6 +25,8 @@ class GlogConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         if self.options.with_gflags:
             self.options["gflags"].shared = self.options.shared
 

--- a/recipes/glog/all/conanfile.py
+++ b/recipes/glog/all/conanfile.py
@@ -7,6 +7,7 @@ class GlogConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/google/glog/"
     description = "Google logging library"
+    topics = ("conan", "glog", "logging")
     license = "BSD 3-Clause"
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake", "cmake_find_package"

--- a/recipes/glog/all/conanfile.py
+++ b/recipes/glog/all/conanfile.py
@@ -14,6 +14,8 @@ class GlogConan(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False], "with_gflags": [True, False], "with_threads": [True, False]}
     default_options = {"shared": False, "fPIC": True, "with_gflags": True, "with_threads": True}
 
+    _cmake = None
+
     @property
     def _source_subfolder(self):
         return "source_subfolder"
@@ -36,12 +38,14 @@ class GlogConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["WITH_GFLAGS"] = self.options.with_gflags
-        cmake.definitions["WITH_THREADS"] = self.options.with_threads
-        cmake.definitions["BUILD_TESTING"] = False
-        cmake.configure()
-        return cmake
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["WITH_GFLAGS"] = self.options.with_gflags
+        self._cmake.definitions["WITH_THREADS"] = self.options.with_threads
+        self._cmake.definitions["BUILD_TESTING"] = False
+        self._cmake.configure()
+        return self._cmake
 
     def build(self):
         if self.options.with_gflags:

--- a/recipes/glog/all/patches/fix-cmake.patch
+++ b/recipes/glog/all/patches/fix-cmake.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -489,7 +489,7 @@ if (WIN32 AND HAVE_SNPRINTF)
+ endif (WIN32 AND HAVE_SNPRINTF)
+ 
+ if (gflags_FOUND)
+-  target_link_libraries (glog PUBLIC gflags)
++  target_link_libraries (glog PUBLIC gflags::gflags)
+ 
+   if (NOT BUILD_SHARED_LIBS)
+     # Don't use __declspec(dllexport|dllimport) if this is a static build

--- a/recipes/glog/all/test_package/CMakeLists.txt
+++ b/recipes/glog/all/test_package/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
-
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(glog REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} glog::glog)

--- a/recipes/glog/all/test_package/conanfile.py
+++ b/recipes/glog/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/glog/config.yml
+++ b/recipes/glog/config.yml
@@ -1,4 +1,3 @@
----
 versions:
   "0.4.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **glog/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

revert to cmake names prior to https://github.com/conan-io/conan-center-index/pull/1181:
https://github.com/google/glog/blob/0a2e5931bd5ff22fd3bf8999eb8ce776f159cda6/CMakeLists.txt#L835