### PR TITLE
glew: fix cmake find generators

### DIFF
--- a/recipes/glew/all/test_package/CMakeLists.txt
+++ b/recipes/glew/all/test_package/CMakeLists.txt
@@ -1,8 +1,10 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(test_package)
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(GLEW REQUIRED)
+
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} GLEW::GLEW)

--- a/recipes/glew/all/test_package/conanfile.py
+++ b/recipes/glew/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **glew/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Official glew CMake import files:
- module: file is `FindGLEW.cmake` and target is `GLEW::GLEW` (https://cmake.org/cmake/help/v3.1/module/FindGLEW.html)
- config: file is `glew-config.cmake` and target is `GLEW::glew_s` if static else `GLEW::glew`, + some sort of alias target `GLEW::GLEW`. With this modification, `cmake_find_package_multi` generator properly creates `GLEW::GLEW` and either `GLEW::glew_s` or `GLEW::glew` imported targets :)

Requires conan 1.28.0