### PR TITLE
Added CMake 3.15.7

### DIFF
--- a/recipes/cmake/3.x.x/conandata.yml
+++ b/recipes/cmake/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.15.7":
+    sha256: 71999d8a14c9b51708847371250a61533439a7331eb7702ac105cfb3cb1be54b
+    url: https://cmake.org/files/v3.15/cmake-3.15.7.tar.gz
   "3.16.2":
     sha256: 8c09786ec60ca2be354c29829072c38113de9184f29928eb9da8446a5f2ce6a9
     url: https://cmake.org/files/v3.16/cmake-3.16.2.tar.gz

--- a/recipes/cmake/config.yml
+++ b/recipes/cmake/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.15.7":
+    folder: "3.x.x"
   "3.16.2":
     folder: "3.x.x"
   "3.16.3":


### PR DESCRIPTION
Specify library name and version:  **cmake/3.15.7**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Since CMake 3.16 there is a regression in the functionality of AUTOMOC: 
https://gitlab.kitware.com/cmake/cmake/-/issues/20598

Therefore it would be nice to have at least CMake 3.15.7 available in conan-center as non deprecated pkg.