### PR TITLE
dataframe: fix cmake name + cache cmake + del fPIC if shared

### DIFF
--- a/recipes/dataframe/all/conanfile.py
+++ b/recipes/dataframe/all/conanfile.py
@@ -108,8 +108,9 @@ class DataFrameConan(ConanFile):
             tools.rmdir(os.path.join(self.package_folder, dir_to_remove))
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "DataFrame"
+        self.cpp_info.names["cmake_find_package_multi"] = "DataFrame"
+        self.cpp_info.names["pkg_config"] = "DataFrame"
         self.cpp_info.libs = tools.collect_libs(self)
-
-        # in linux we need to link also with these libs
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.extend(["pthread", "dl", "rt"])

--- a/recipes/dataframe/all/conanfile.py
+++ b/recipes/dataframe/all/conanfile.py
@@ -44,6 +44,9 @@ class DataFrameConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
         compiler = str(self.settings.compiler)
         compiler_version = tools.Version(self.settings.compiler.version)
 

--- a/recipes/dataframe/all/conanfile.py
+++ b/recipes/dataframe/all/conanfile.py
@@ -30,14 +30,11 @@ class DataFrameConan(ConanFile):
     generators = "cmake"
     exports_sources = ["CMakeLists.txt", "patches/*"]
 
+    _cmake = None
+
     @property
     def _source_subfolder(self):
         return os.path.join(self.source_folder, "source_subfolder")
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_folder = "DataFrame-{}".format(self.version)
-        os.rename(extracted_folder, self._source_subfolder)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -85,10 +82,17 @@ class DataFrameConan(ConanFile):
                 )
             )
 
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_folder = "DataFrame-{}".format(self.version)
+        os.rename(extracted_folder, self._source_subfolder)
+
     def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.configure()
-        return cmake
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure()
+        return self._cmake
 
     def build(self):
         for patch in self.conan_data["patches"][self.version]:

--- a/recipes/dataframe/all/test_package/CMakeLists.txt
+++ b/recipes/dataframe/all/test_package/CMakeLists.txt
@@ -1,13 +1,15 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
+
+find_package(DataFrame REQUIRED CONFIG)
 
 if(MSVC)
   add_definitions(-DLIBRARY_EXPORTS)
 endif()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} DataFrame::DataFrame)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/recipes/dataframe/all/test_package/conanfile.py
+++ b/recipes/dataframe/all/test_package/conanfile.py
@@ -3,9 +3,9 @@ import os
 from conans import ConanFile, CMake, tools
 
 
-class DataFrameTestConan(ConanFile):
+class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -13,4 +13,6 @@ class DataFrameTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        self.run(os.path.join("bin", "test_package"), run_environment=True)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **dataframe/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I've also noticed that this lib is more or less broken with Visual Studio, not only if shared (https://github.com/hosseinmoein/DataFrame/issues/76). `test_package` has to add `LIBRARY_EXPORTS` definition to force using `dllexport` at consume time (!!!!) for static lib to avoid an error.
Anyway I won't fix this issue in this PR ;)