### PR TITLE
mpir: restore installation of gmp headers for Visual Studio

### DIFF
--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -48,7 +48,7 @@ class MpirConan(ConanFile):
         self.build_requires("yasm/1.3.0")
         if self.settings.os == "Windows" and self.settings.compiler != "Visual Studio" and \
            "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != "msys2":
-            self.build_requires("msys2/20190524")
+            self.build_requires("msys2/20200517")
 
     def source(self):
         tools.get(keep_permissions=True, **self.conan_data["sources"][self.version])

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
-from conans.errors import ConanInvalidConfiguration
 import os
 import glob
 


### PR DESCRIPTION
Specify library name and version:  **mpir/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Install `gmp` headers again for Visual Studio if `enable_gmpcompat=True`. Maybe it should be unconditional for Visual Studio, I'm not sure.