### PR TITLE
Remove YACC from bison

### DIFF
--- a/recipes/bison/all/conanfile.py
+++ b/recipes/bison/all/conanfile.py
@@ -150,6 +150,6 @@ class BisonConan(ConanFile):
         self.output.info('Setting the BISON_PKGDATADIR environment variable: {}'.format(pkgdir))
         self.env_info.BISON_PKGDATADIR = pkgdir
 
-        yacc_bin = os.path.join(self.package_folder, "bin", "yacc").replace("\\", "/")
-        self.output.info("Setting YACC environment variable: {}".format(yacc_bin))
-        self.env_info.YACC = yacc_bin
+        # yacc_bin = os.path.join(self.package_folder, "bin", "yacc").replace("\\", "/")
+        # self.output.info("Setting YACC environment variable: {}".format(yacc_bin))
+        # self.env_info.YACC = yacc_bin

--- a/recipes/bison/all/conanfile.py
+++ b/recipes/bison/all/conanfile.py
@@ -150,6 +150,5 @@ class BisonConan(ConanFile):
         self.output.info('Setting the BISON_PKGDATADIR environment variable: {}'.format(pkgdir))
         self.env_info.BISON_PKGDATADIR = pkgdir
 
-        # yacc_bin = os.path.join(self.package_folder, "bin", "yacc").replace("\\", "/")
-        # self.output.info("Setting YACC environment variable: {}".format(yacc_bin))
-        # self.env_info.YACC = yacc_bin
+        # yacc is a shell script, so requires a shell (such as bash)
+        self.user_info.YACC = os.path.join(self.package_folder, "bin", "yacc").replace("\\", "/")


### PR DESCRIPTION
Having YACC makes my recipe build fail. Removing it makes it work.


@madebr Helped me figure that out earlier.

Specify library name and version:  **bison**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

