### PR TITLE
Added easy_profiler 2.1.0

### DIFF
--- a/recipes/easy_profiler/all/CMakeLists.txt
+++ b/recipes/easy_profiler/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/easy_profiler/all/CMakeLists.txt
+++ b/recipes/easy_profiler/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/easy_profiler/all/conandata.yml
+++ b/recipes/easy_profiler/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.1.0":
+    url: "https://github.com/yse/easy_profiler/archive/v2.1.0.tar.gz"
+    sha256: "fabf95d59ede9da4873aebd52ef8a762fa8578dcdbcc6d7cdd811b5a7c3367ad"

--- a/recipes/easy_profiler/all/conanfile.py
+++ b/recipes/easy_profiler/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools, CMake
+from conans.errors import ConanInvalidConfiguration
 import os
 import glob
 

--- a/recipes/easy_profiler/all/conanfile.py
+++ b/recipes/easy_profiler/all/conanfile.py
@@ -68,6 +68,10 @@ class EasyProfilerConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         os.remove(os.path.join(self.package_folder, "LICENSE.MIT"))
         os.remove(os.path.join(self.package_folder, "LICENSE.APACHE"))
+        if self.settings.os == "Windows":
+            for dll_file in glob.glob(os.path.join(self.package_folder, "bin", "*.dll")):
+                if os.path.basename(dll_file).startswith(("concrt", "msvcp", "vcruntime")):
+                    os.remove(dll_file)
 
     def package_info(self):
         self.cpp_info.libs = ["easy_profiler"]

--- a/recipes/easy_profiler/all/conanfile.py
+++ b/recipes/easy_profiler/all/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, tools, CMake
-from conans.errors import ConanInvalidConfiguration
 import os
 import glob
 
@@ -19,7 +18,7 @@ class EasyProfilerConan(ConanFile):
         "fPIC": [True, False]
     }
     default_options = {
-        "shared": True,
+        "shared": False,
         "fPIC": True
     }
     short_paths = True
@@ -41,11 +40,6 @@ class EasyProfilerConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        # The windows build seems to be giving problems due to certain symbols
-        # not being exported properly for static libraries.
-        if not self.options.shared and self.settings.os == "Windows":
-            raise ConanInvalidConfiguration("Must be built as shared on \
-              Windows")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -86,3 +80,7 @@ class EasyProfilerConan(ConanFile):
         self.cpp_info.libs = ["easy_profiler"]
         if self.settings.os == "Linux":
             self.cpp_info.system_libs = ["m", "pthread"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["psapi", "ws2_32"]
+            if not self.options.shared:
+                self.cpp_info.defines.append("EASY_PROFILER_STATIC")

--- a/recipes/easy_profiler/all/conanfile.py
+++ b/recipes/easy_profiler/all/conanfile.py
@@ -1,12 +1,11 @@
 from conans import ConanFile, tools, CMake
 import os
-import glob
 
 
-class easy_profilerConan(ConanFile):
+class EasyProfilerConan(ConanFile):
     name = "easy_profiler"
     description = "Lightweight profiler library for c++"
-    license = "BSD"
+    license = "MIT"
     topics = ("conan", "easy_profiler")
     homepage = "https://github.com/yse/easy_profiler/"
     url = "https://github.com/conan-io/conan-center-index"
@@ -73,5 +72,3 @@ class easy_profilerConan(ConanFile):
         self.cpp_info.libs = ["easy_profiler"]
         if self.settings.os == "Linux":
             self.cpp_info.system_libs = ["m", "pthread"]
-        self.cpp_info.names["cmake_find_package"] = "easy_profiler"
-        self.cpp_info.names["cmake_find_package_multi"] = "easy_profiler"

--- a/recipes/easy_profiler/all/conanfile.py
+++ b/recipes/easy_profiler/all/conanfile.py
@@ -1,0 +1,73 @@
+from conans import ConanFile, tools, CMake
+import os
+import glob
+
+
+class easy_profilerConan(ConanFile):
+    name = "easy_profiler"
+    description = "Lightweight profiler library for c++"
+    license = "BSD"
+    topics = ("conan", "easy_profiler")
+    homepage = "https://github.com/yse/easy_profiler/"
+    url = "https://github.com/conan-io/conan-center-index"
+    exports_sources = ["CMakeLists.txt", "patches/*"]
+    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True
+    }
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        url = self.conan_data["sources"][self.version]["url"]
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        # Don't build the GUI because it is dependent on Qt
+        self._cmake.definitions["EASY_PROFILER_NO_GUI"] = True
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["easy_profiler"]
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs = ["m", "pthread"]
+        self.cpp_info.names["cmake_find_package"] = "easy_profiler"
+        self.cpp_info.names["cmake_find_package_multi"] = "easy_profiler"

--- a/recipes/easy_profiler/all/conanfile.py
+++ b/recipes/easy_profiler/all/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, tools, CMake
 import os
-
+import glob
 
 class EasyProfilerConan(ConanFile):
     name = "easy_profiler"

--- a/recipes/easy_profiler/all/conanfile.py
+++ b/recipes/easy_profiler/all/conanfile.py
@@ -2,6 +2,7 @@ from conans import ConanFile, tools, CMake
 import os
 import glob
 
+
 class EasyProfilerConan(ConanFile):
     name = "easy_profiler"
     description = "Lightweight profiler library for c++"
@@ -17,7 +18,7 @@ class EasyProfilerConan(ConanFile):
         "fPIC": [True, False]
     }
     default_options = {
-        "shared": False,
+        "shared": True,
         "fPIC": True
     }
     short_paths = True
@@ -39,6 +40,11 @@ class EasyProfilerConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        # The windows build seems to be giving problems due to certain symbols
+        # not being exported properly for static libraries.
+        if self.options.shared is False and self.settings.os == "Windows":
+            raise ConanInvalidConfiguration("Must be built as shared on \
+              Windows")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -69,8 +75,10 @@ class EasyProfilerConan(ConanFile):
         os.remove(os.path.join(self.package_folder, "LICENSE.MIT"))
         os.remove(os.path.join(self.package_folder, "LICENSE.APACHE"))
         if self.settings.os == "Windows":
-            for dll_file in glob.glob(os.path.join(self.package_folder, "bin", "*.dll")):
-                if os.path.basename(dll_file).startswith(("concrt", "msvcp", "vcruntime")):
+            for dll_file in \
+              glob.glob(os.path.join(self.package_folder, "bin", "*.dll")):
+                if os.path.basename(dll_file).startswith(("concrt", "msvcp",
+                   "vcruntime")):
                     os.remove(dll_file)
 
     def package_info(self):

--- a/recipes/easy_profiler/all/conanfile.py
+++ b/recipes/easy_profiler/all/conanfile.py
@@ -20,7 +20,7 @@ class EasyProfilerConan(ConanFile):
         "shared": False,
         "fPIC": True
     }
-    short_path = True
+    short_paths = True
 
     _cmake = None
 

--- a/recipes/easy_profiler/all/conanfile.py
+++ b/recipes/easy_profiler/all/conanfile.py
@@ -20,6 +20,7 @@ class EasyProfilerConan(ConanFile):
         "shared": False,
         "fPIC": True
     }
+    short_path = True
 
     _cmake = None
 

--- a/recipes/easy_profiler/all/conanfile.py
+++ b/recipes/easy_profiler/all/conanfile.py
@@ -60,10 +60,14 @@ class easy_profilerConan(ConanFile):
         return self._cmake
 
     def package(self):
-        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy("LICENSE.MIT", dst="licenses", src=self._source_subfolder)
+        self.copy("LICENSE.APACHE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        os.remove(os.path.join(self.package_folder, "LICENSE.MIT"))
+        os.remove(os.path.join(self.package_folder, "LICENSE.APACHE"))
 
     def package_info(self):
         self.cpp_info.libs = ["easy_profiler"]

--- a/recipes/easy_profiler/all/conanfile.py
+++ b/recipes/easy_profiler/all/conanfile.py
@@ -42,7 +42,7 @@ class EasyProfilerConan(ConanFile):
             del self.options.fPIC
         # The windows build seems to be giving problems due to certain symbols
         # not being exported properly for static libraries.
-        if self.options.shared is False and self.settings.os == "Windows":
+        if not self.options.shared and self.settings.os == "Windows":
             raise ConanInvalidConfiguration("Must be built as shared on \
               Windows")
 

--- a/recipes/easy_profiler/all/test_package/CMakeLists.txt
+++ b/recipes/easy_profiler/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
@@ -6,3 +6,4 @@ conan_basic_setup()
 
 add_executable(${PROJECT_NAME} example.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/easy_profiler/all/test_package/CMakeLists.txt
+++ b/recipes/easy_profiler/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} example.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/easy_profiler/all/test_package/conanfile.py
+++ b/recipes/easy_profiler/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            src = os.path.join(self.source_folder, "tng_example.tng")
+            self.run("{} {}".format(os.path.join("bin", "test_package"), src), run_environment=True)

--- a/recipes/easy_profiler/all/test_package/conanfile.py
+++ b/recipes/easy_profiler/all/test_package/conanfile.py
@@ -12,5 +12,4 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self.settings):
-            src = os.path.join(self.source_folder, "tng_example.tng")
-            self.run("{} {}".format(os.path.join("bin", "test_package"), src), run_environment=True)
+            self.run( os.path.join("bin", "test_package"), run_environment=True)

--- a/recipes/easy_profiler/all/test_package/example.cpp
+++ b/recipes/easy_profiler/all/test_package/example.cpp
@@ -12,14 +12,7 @@
 #include <easy/arbitrary_value.h>
 #include <easy/reader.h>
 
-std::condition_variable cv;
-std::mutex cv_m;
-int g_i = 0;
-
-int OBJECTS = 500;
-int MODELLING_STEPS = 1500;
-int RENDER_STEPS = 1500;
-int RESOURCE_LOADING_COUNT = 50;
+int RENDER_STEPS = 300;
 
 //#define SAMPLE_NETWORK_TEST
 
@@ -30,184 +23,12 @@ void localSleep(uint64_t magic=200000)
     for (; i < magic; ++i);
 }
 
-void loadingResources(){
-    EASY_FUNCTION(profiler::colors::DarkCyan);
-    localSleep();
-//    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-}
-
-void prepareMath(){
-    EASY_FUNCTION(profiler::colors::Green);
-    uint64_t sum = 0;
-    int* intarray = new int[OBJECTS];
-    for (int i = 0; i < OBJECTS; ++i)
-    {
-        intarray[i] = i * i;
-        sum += i * i;
-    }
-    delete[] intarray;
-    //std::this_thread::sleep_for(std::chrono::milliseconds(3));
-
-    EASY_VALUE("sum", sum, profiler::colors::Blue);
-}
-
-void calcIntersect(){
-    EASY_FUNCTION(profiler::colors::Gold);
-    //int* intarray = new int[OBJECTS * OBJECTS];
-    int* intarray = new int[OBJECTS];
-    for (int i = 0; i < OBJECTS; ++i)
-    {
-        for (int j = i; j < OBJECTS; ++j)
-            //intarray[i * OBJECTS + j] = i * j - i / 2 + (OBJECTS - j) * 5;
-            intarray[j] = i * j - i / 2 + (OBJECTS - j) * 5;
-    }
-    delete[] intarray;
-    //std::this_thread::sleep_for(std::chrono::milliseconds(4));
-}
-
-double multModel(double i)
-{
-    EASY_FUNCTION(profiler::colors::PaleGold);
-    return i * sin(i) * cos(i);
-}
-
-void calcPhys(){
-    EASY_FUNCTION(profiler::colors::Amber);
-    double* intarray = new double[OBJECTS];
-    for (int i = 0; i < OBJECTS; ++i)
-        intarray[i] = multModel(double(i)) + double(i / 3) - double((OBJECTS - i) / 2);
-    calcIntersect();
-    delete[] intarray;
-}
-
-double calcSubbrain(int i)
-{
-    EASY_FUNCTION(profiler::colors::Navy);
-    auto val = i * i * i - i / 10 + (OBJECTS - i) * 7 ;
-    EASY_VALUE("subbrainResult", val, profiler::colors::DarkRed);
-    return val;
-}
-
-void calcBrain(){
-    EASY_FUNCTION(profiler::colors::LightBlue);
-    double* intarray = new double[OBJECTS];
-    for (int i = 0; i < OBJECTS; ++i)
-        intarray[i] = calcSubbrain(i) + double(i * 180 / 3);
-    delete[] intarray;
-    //std::this_thread::sleep_for(std::chrono::milliseconds(3));
-}
-
-void calculateBehavior(){
-    EASY_FUNCTION(profiler::colors::Blue);
-    calcPhys();
-    calcBrain();
-}
-
-void modellingStep(){
-    EASY_FUNCTION();
-    prepareMath();
-    calculateBehavior();
-}
-
-void prepareRender(){
-    EASY_FUNCTION(profiler::colors::Brick);
-    localSleep();
-    //std::this_thread::sleep_for(std::chrono::milliseconds(8));
-
-}
-
-int multPhys(int i)
-{
-    EASY_FUNCTION(profiler::colors::Red700, profiler::ON);
-    return i * i * i * i / 100;
-}
-
-int calcPhysicForObject(int i)
-{
-    EASY_FUNCTION(profiler::colors::Red);
-    return  multPhys(i) + i / 3 - (OBJECTS - i) * 15;
-}
-
-void calculatePhysics(){
-    EASY_FUNCTION(profiler::colors::Red);
-    unsigned int* intarray = new unsigned int[OBJECTS];
-    for (int i = 0; i < OBJECTS; ++i)
-        intarray[i] = calcPhysicForObject(i);
-    delete[] intarray;
-    //std::this_thread::sleep_for(std::chrono::milliseconds(8));
-}
-
-void quadratic_loop(uint64_t n)
-{
-    EASY_FUNCTION(profiler::colors::Blue);
-    EASY_VALUE("N", n);
-    volatile int i = 0;
-    for (; i < n; ++i)
-        localSleep(n);
-}
-
-void frame(uint64_t n){
-    EASY_FUNCTION(profiler::colors::Magenta);
-    prepareRender();
-    calculatePhysics();
-    quadratic_loop(n);
-}
-
-void loadingResourcesThread(){
-    //std::unique_lock<std::mutex> lk(cv_m);
-    //cv.wait(lk, []{return g_i == 1; });
-    EASY_THREAD("Resource loading");
-#ifdef SAMPLE_NETWORK_TEST
-    while (true) {
-#else
-    for(int i = 0; i < RESOURCE_LOADING_COUNT; i++){
-#endif
-        loadingResources();
-        EASY_EVENT("Resources Loading!", profiler::colors::Cyan);
-        localSleep(1200000);
-        //std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    }
-}
-
-void modellingThread(){
-    //std::unique_lock<std::mutex> lk(cv_m);
-    //cv.wait(lk, []{return g_i == 1; });
-    EASY_THREAD("Modelling");
-    uint64_t step = 0;
-#ifdef SAMPLE_NETWORK_TEST
-    while (true) {
-#else
-    for (int i = 0; i < MODELLING_STEPS; i++){
-#endif
-        EASY_END_BLOCK;
-        EASY_NONSCOPED_BLOCK("Frame", true, 15., profiler::ON, -5.f, profiler::colors::Red);
-        modellingStep();
-
-        localSleep(1200000);
-
-        ++step;
-        double vals[] = {(double)step, sin((double)step), cos((double)step)};
-        EASY_VALUE("step", vals, profiler::colors::Gold, EASY_VIN(step));
-        if (step > 10000000)
-            step = 0;
-
-        EASY_TEXT("Test String", "Some short text. Hey!", profiler::colors::Red);
-        //std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    }
-    EASY_END_BLOCK;
-}
-
 void renderThread(){
-    //std::unique_lock<std::mutex> lk(cv_m);
-    //cv.wait(lk, []{return g_i == 1; });
     EASY_THREAD("Render");
     uint64_t n = 20;
-#ifdef SAMPLE_NETWORK_TEST
-    while (true) {
-#else
-    for (int i = 0; i < RENDER_STEPS; i++){
-#endif
-        frame(n);
+
+    for (int i = 0; i < RENDER_STEPS; i++)
+    {
         localSleep(1200000);
         n += 20;
         if (n >= 700)
@@ -220,87 +41,13 @@ void renderThread(){
 
 int main(int argc, char* argv[])
 {
-    if (argc > 1 && argv[1]){
-        OBJECTS = std::atoi(argv[1]);
-    }
-    if (argc > 2 && argv[2]){
-        MODELLING_STEPS = std::atoi(argv[2]);
-    }
-    if (argc > 3 && argv[3]){
-        RENDER_STEPS = std::atoi(argv[3]);
-    }
-    if (argc > 4 && argv[4]){
-        RESOURCE_LOADING_COUNT = std::atoi(argv[4]);
-    }
+  #ifndef SAMPLE_NETWORK_TEST
+      EASY_PROFILER_ENABLE;
+  #endif
+      EASY_MAIN_THREAD;
+      profiler::startListen();
 
-    std::cout << "Objects count: " << OBJECTS << std::endl;
-    std::cout << "Render steps: " << MODELLING_STEPS << std::endl;
-    std::cout << "Modelling steps: " << RENDER_STEPS << std::endl;
-    std::cout << "Resource loading count: " << RESOURCE_LOADING_COUNT << std::endl;
+      renderThread();
 
-    auto start = std::chrono::system_clock::now();
-
-#ifndef SAMPLE_NETWORK_TEST
-    EASY_PROFILER_ENABLE;
-#endif
-
-    EASY_MAIN_THREAD;
-    profiler::startListen();
-
-#ifdef EASY_CONSTEXPR_AVAILABLE
-    constexpr int grrr[] {2, -3, 4};
-    auto pppp = &grrr;
-    EASY_ARRAY("threads count", grrr, 3, false, true, "blabla", profiler::colors::Blue/*, EASY_VIN("threads count")*/, profiler::OFF);
-#endif
-
-    int* intPtr = new int(2);
-    EASY_VALUE("count", *intPtr);
-
-    std::vector<std::thread> threads;
-    //for (int i=0; i < 3; i++)
-    {
-        threads.emplace_back(loadingResourcesThread);
-        threads.emplace_back(renderThread);
-        threads.emplace_back(modellingThread);
-    }
-
-    cv_m.lock();
-    g_i = 1;
-    cv_m.unlock();
-    cv.notify_all();
-
-#ifndef SAMPLE_NETWORK_TEST
-    std::atomic_bool stop;
-    stop = false;
-    auto frame_time_printer_thread = std::thread([&stop]()
-    {
-        while (!stop.load(std::memory_order_acquire))
-        {
-            std::cout << "Frame time: max " << profiler::main_thread::frameTimeLocalMax() << " us // avg " << profiler::main_thread::frameTimeLocalAvg() << " us\n";
-            std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        }
-    });
-#endif
-
-    modellingThread();
-
-#ifndef SAMPLE_NETWORK_TEST
-    stop.store(true, std::memory_order_release);
-    frame_time_printer_thread.join();
-#endif
-
-    for(auto& t : threads)
-        t.join();
-
-    auto end = std::chrono::system_clock::now();
-    auto elapsed =
-            std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-
-    std::cout << "Elapsed time: " << elapsed.count() << " usec" << std::endl;
-
-    auto blocks_count = profiler::dumpBlocksToFile("test.prof");
-
-    std::cout << "Blocks count: " << blocks_count << std::endl;
-
-    return 0;
+      return 0;
 }

--- a/recipes/easy_profiler/all/test_package/example.cpp
+++ b/recipes/easy_profiler/all/test_package/example.cpp
@@ -1,0 +1,306 @@
+//#define FULL_DISABLE_PROFILER
+#include <chrono>
+#include <thread>
+#include <vector>
+#include <iostream>
+#include <condition_variable>
+#include <cstdlib>
+#include <math.h>
+
+#define BUILD_WITH_EASY_PROFILER
+#include <easy/profiler.h>
+#include <easy/arbitrary_value.h>
+#include <easy/reader.h>
+
+std::condition_variable cv;
+std::mutex cv_m;
+int g_i = 0;
+
+int OBJECTS = 500;
+int MODELLING_STEPS = 1500;
+int RENDER_STEPS = 1500;
+int RESOURCE_LOADING_COUNT = 50;
+
+//#define SAMPLE_NETWORK_TEST
+
+void localSleep(uint64_t magic=200000)
+{
+    //PROFILER_BEGIN_FUNCTION_BLOCK_GROUPED(profiler::colors::Blue);
+    volatile int i = 0;
+    for (; i < magic; ++i);
+}
+
+void loadingResources(){
+    EASY_FUNCTION(profiler::colors::DarkCyan);
+    localSleep();
+//    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+}
+
+void prepareMath(){
+    EASY_FUNCTION(profiler::colors::Green);
+    uint64_t sum = 0;
+    int* intarray = new int[OBJECTS];
+    for (int i = 0; i < OBJECTS; ++i)
+    {
+        intarray[i] = i * i;
+        sum += i * i;
+    }
+    delete[] intarray;
+    //std::this_thread::sleep_for(std::chrono::milliseconds(3));
+
+    EASY_VALUE("sum", sum, profiler::colors::Blue);
+}
+
+void calcIntersect(){
+    EASY_FUNCTION(profiler::colors::Gold);
+    //int* intarray = new int[OBJECTS * OBJECTS];
+    int* intarray = new int[OBJECTS];
+    for (int i = 0; i < OBJECTS; ++i)
+    {
+        for (int j = i; j < OBJECTS; ++j)
+            //intarray[i * OBJECTS + j] = i * j - i / 2 + (OBJECTS - j) * 5;
+            intarray[j] = i * j - i / 2 + (OBJECTS - j) * 5;
+    }
+    delete[] intarray;
+    //std::this_thread::sleep_for(std::chrono::milliseconds(4));
+}
+
+double multModel(double i)
+{
+    EASY_FUNCTION(profiler::colors::PaleGold);
+    return i * sin(i) * cos(i);
+}
+
+void calcPhys(){
+    EASY_FUNCTION(profiler::colors::Amber);
+    double* intarray = new double[OBJECTS];
+    for (int i = 0; i < OBJECTS; ++i)
+        intarray[i] = multModel(double(i)) + double(i / 3) - double((OBJECTS - i) / 2);
+    calcIntersect();
+    delete[] intarray;
+}
+
+double calcSubbrain(int i)
+{
+    EASY_FUNCTION(profiler::colors::Navy);
+    auto val = i * i * i - i / 10 + (OBJECTS - i) * 7 ;
+    EASY_VALUE("subbrainResult", val, profiler::colors::DarkRed);
+    return val;
+}
+
+void calcBrain(){
+    EASY_FUNCTION(profiler::colors::LightBlue);
+    double* intarray = new double[OBJECTS];
+    for (int i = 0; i < OBJECTS; ++i)
+        intarray[i] = calcSubbrain(i) + double(i * 180 / 3);
+    delete[] intarray;
+    //std::this_thread::sleep_for(std::chrono::milliseconds(3));
+}
+
+void calculateBehavior(){
+    EASY_FUNCTION(profiler::colors::Blue);
+    calcPhys();
+    calcBrain();
+}
+
+void modellingStep(){
+    EASY_FUNCTION();
+    prepareMath();
+    calculateBehavior();
+}
+
+void prepareRender(){
+    EASY_FUNCTION(profiler::colors::Brick);
+    localSleep();
+    //std::this_thread::sleep_for(std::chrono::milliseconds(8));
+
+}
+
+int multPhys(int i)
+{
+    EASY_FUNCTION(profiler::colors::Red700, profiler::ON);
+    return i * i * i * i / 100;
+}
+
+int calcPhysicForObject(int i)
+{
+    EASY_FUNCTION(profiler::colors::Red);
+    return  multPhys(i) + i / 3 - (OBJECTS - i) * 15;
+}
+
+void calculatePhysics(){
+    EASY_FUNCTION(profiler::colors::Red);
+    unsigned int* intarray = new unsigned int[OBJECTS];
+    for (int i = 0; i < OBJECTS; ++i)
+        intarray[i] = calcPhysicForObject(i);
+    delete[] intarray;
+    //std::this_thread::sleep_for(std::chrono::milliseconds(8));
+}
+
+void quadratic_loop(uint64_t n)
+{
+    EASY_FUNCTION(profiler::colors::Blue);
+    EASY_VALUE("N", n);
+    volatile int i = 0;
+    for (; i < n; ++i)
+        localSleep(n);
+}
+
+void frame(uint64_t n){
+    EASY_FUNCTION(profiler::colors::Magenta);
+    prepareRender();
+    calculatePhysics();
+    quadratic_loop(n);
+}
+
+void loadingResourcesThread(){
+    //std::unique_lock<std::mutex> lk(cv_m);
+    //cv.wait(lk, []{return g_i == 1; });
+    EASY_THREAD("Resource loading");
+#ifdef SAMPLE_NETWORK_TEST
+    while (true) {
+#else
+    for(int i = 0; i < RESOURCE_LOADING_COUNT; i++){
+#endif
+        loadingResources();
+        EASY_EVENT("Resources Loading!", profiler::colors::Cyan);
+        localSleep(1200000);
+        //std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+}
+
+void modellingThread(){
+    //std::unique_lock<std::mutex> lk(cv_m);
+    //cv.wait(lk, []{return g_i == 1; });
+    EASY_THREAD("Modelling");
+    uint64_t step = 0;
+#ifdef SAMPLE_NETWORK_TEST
+    while (true) {
+#else
+    for (int i = 0; i < MODELLING_STEPS; i++){
+#endif
+        EASY_END_BLOCK;
+        EASY_NONSCOPED_BLOCK("Frame", true, 15., profiler::ON, -5.f, profiler::colors::Red);
+        modellingStep();
+
+        localSleep(1200000);
+
+        ++step;
+        double vals[] = {(double)step, sin((double)step), cos((double)step)};
+        EASY_VALUE("step", vals, profiler::colors::Gold, EASY_VIN(step));
+        if (step > 10000000)
+            step = 0;
+
+        EASY_TEXT("Test String", "Some short text. Hey!", profiler::colors::Red);
+        //std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    EASY_END_BLOCK;
+}
+
+void renderThread(){
+    //std::unique_lock<std::mutex> lk(cv_m);
+    //cv.wait(lk, []{return g_i == 1; });
+    EASY_THREAD("Render");
+    uint64_t n = 20;
+#ifdef SAMPLE_NETWORK_TEST
+    while (true) {
+#else
+    for (int i = 0; i < RENDER_STEPS; i++){
+#endif
+        frame(n);
+        localSleep(1200000);
+        n += 20;
+        if (n >= 700)
+            n = 20;
+        //std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+int main(int argc, char* argv[])
+{
+    if (argc > 1 && argv[1]){
+        OBJECTS = std::atoi(argv[1]);
+    }
+    if (argc > 2 && argv[2]){
+        MODELLING_STEPS = std::atoi(argv[2]);
+    }
+    if (argc > 3 && argv[3]){
+        RENDER_STEPS = std::atoi(argv[3]);
+    }
+    if (argc > 4 && argv[4]){
+        RESOURCE_LOADING_COUNT = std::atoi(argv[4]);
+    }
+
+    std::cout << "Objects count: " << OBJECTS << std::endl;
+    std::cout << "Render steps: " << MODELLING_STEPS << std::endl;
+    std::cout << "Modelling steps: " << RENDER_STEPS << std::endl;
+    std::cout << "Resource loading count: " << RESOURCE_LOADING_COUNT << std::endl;
+
+    auto start = std::chrono::system_clock::now();
+
+#ifndef SAMPLE_NETWORK_TEST
+    EASY_PROFILER_ENABLE;
+#endif
+
+    EASY_MAIN_THREAD;
+    profiler::startListen();
+
+#ifdef EASY_CONSTEXPR_AVAILABLE
+    constexpr int grrr[] {2, -3, 4};
+    auto pppp = &grrr;
+    EASY_ARRAY("threads count", grrr, 3, false, true, "blabla", profiler::colors::Blue/*, EASY_VIN("threads count")*/, profiler::OFF);
+#endif
+
+    int* intPtr = new int(2);
+    EASY_VALUE("count", *intPtr);
+
+    std::vector<std::thread> threads;
+    //for (int i=0; i < 3; i++)
+    {
+        threads.emplace_back(loadingResourcesThread);
+        threads.emplace_back(renderThread);
+        threads.emplace_back(modellingThread);
+    }
+
+    cv_m.lock();
+    g_i = 1;
+    cv_m.unlock();
+    cv.notify_all();
+
+#ifndef SAMPLE_NETWORK_TEST
+    std::atomic_bool stop;
+    stop = false;
+    auto frame_time_printer_thread = std::thread([&stop]()
+    {
+        while (!stop.load(std::memory_order_acquire))
+        {
+            std::cout << "Frame time: max " << profiler::main_thread::frameTimeLocalMax() << " us // avg " << profiler::main_thread::frameTimeLocalAvg() << " us\n";
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        }
+    });
+#endif
+
+    modellingThread();
+
+#ifndef SAMPLE_NETWORK_TEST
+    stop.store(true, std::memory_order_release);
+    frame_time_printer_thread.join();
+#endif
+
+    for(auto& t : threads)
+        t.join();
+
+    auto end = std::chrono::system_clock::now();
+    auto elapsed =
+            std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+    std::cout << "Elapsed time: " << elapsed.count() << " usec" << std::endl;
+
+    auto blocks_count = profiler::dumpBlocksToFile("test.prof");
+
+    std::cout << "Blocks count: " << blocks_count << std::endl;
+
+    return 0;
+}

--- a/recipes/easy_profiler/config.yml
+++ b/recipes/easy_profiler/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.1.0":
+    folder: all


### PR DESCRIPTION
**easy_profiler/2.1.0**

Tested on Linux Mint 20 using gcc9 and clang 9

easy_profiler is a profiling tool with a user interface. Unfortunately the user interface is built using Qt so it is disabled during building. 

The compile definition `BUILD_WITH_EASY_PROFILER` should be set for any project that plans to enable the profiling. This definition is NOT added to the conan definitions because profiling can be compile-time disabled even when the library is linked

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

