### PR TITLE
Fix .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,8 +14,8 @@ max_line_length = 200
 [*.yml]
 tab_width = 2
 
-[{Makefile, Makefile.am, Makefile.in}]
+[{Makefile,Makefile.am,Makefile.in}]
 indent_style = tab
 
-[*.{diff, patch}]
+[*.{diff,patch}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
Fix editorconfig by removing spaces.

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

