### PR TITLE
Add TOC to 'docs' folder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Specify library name and version:  **lib/1.0**
 
-- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
+- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.mdt) for contributing.
 - [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
 - [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
 - [ ] I've tried at least one configuration locally with the

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ This repository includes a Continuous Integration system that will build automat
 
 ### Documentation
 
-* If you want to learn how to contribute new recipes, please read [docs/how_to_add_packages.md](docs/how_to_add_packages.md).
-* Most common questions are listed in [docs/faqs.md](docs/faqs.md).
-* The conan-center hook errors reported by CCI Bot can be found in the [docs/error_knowledge_base.md](docs/error_knowledge_base.md).
+All the documentation is available in this same repository in the [`docs/` subfoler](docs/README.md).
+
+This is a list of shortcuts to some interesting topics:
+
+* If you want to learn how to **contribute new recipes**, please read [docs/how_to_add_packages.md](docs/how_to_add_packages.md).
+* **FAQ**: most common questions are listed in [docs/faqs.md](docs/faqs.md).
+* The conan-center **hook errors** reported by CCI Bot can be found in the [docs/error_knowledge_base.md](docs/error_knowledge_base.md).
 * The internal changes related to infrastructure can be checked in [docs/changelog.md](docs/changelog.md).
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+<img src="../assets/JFrogConanCenter.png" width="600"/>
+
+# Documentation
+
+* [Code of conduct](code_of_conduct.md)
+* [Changelog](changelog.md)
+
+* User documentation
+  + [Contributing to Conan Center Index](contributing.md)
+  + [Adding Packages to ConanCenter](how_to_add_packages.md)
+  + [Supported platforms and configurations](supported_platforms_and_configurations.md)
+  + [Errors from the conan-center hook (KB-Hxxx)](error_knowledge_base.md)
+  + [FAQs](faqs.md)
+

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ### 4-August-2020 - 20:19 CEST
 
 - [engineering] Remove short-paths home after creating packages.

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -1,0 +1,16 @@
+# Code of conduct
+
+
+Try to be polite, CCI maintainers and contributors are really willing to help and we enjoy it.
+
+Please keep in mind these points:
+
+- There are limited resources/time and not all issues/pull requests can be considered as well as we would like.
+- ``conan-io`` maintainers can tag/close/modify any opened issue and it should not be interpreted as a rude or disrespectful action. It
+  **always** responds to organizational purposes. A closed issue can be perfectly reopened or further commented.
+- It is very hard to keep the project in good health in terms of technical debt, usability, serviceability, etc. If the proposed feature is
+  not clearly stated, enough information is not provided or it is not sure that would be a good feature for the future development of the project, it won't be accepted. The community plays a very important role during this discussion so it strongly encouraged to
+  explain the value of a feature for the community, the needed documentation and its use cases.
+- Backwards compatibility and not breaking users' packages is very important and it won't be done unless there are very good reasons.
+- You should not get bothered if you feel unattended, CCI is an Open Source project, not a commercial product. Try to explain what you
+  really need and we will try to help you.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,5 @@
-Contributing to Conan Center Index
-==================================
+# Contributing to Conan Center Index
+
 
 The following summarizes the process for contributing to the CCI (Conan Center Index) project.
 
@@ -54,20 +54,3 @@ We use the following tags to control the status of the issues:
 - **question**: Further information is requested .
 - **upstream update**: Bump a new package version.
 - **conan.io/center**: Issues and features related to Web UI .
-
-Code of conduct
----------------
-
-Try to be polite, CCI maintainers and contributors are really willing to help and we enjoy it.
-
-Please keep in mind these points:
-
-- There are limited resources/time and not all issues/pull requests can be considered as well as we would like.
-- ``conan-io`` maintainers can tag/close/modify any opened issue and it should not be interpreted as a rude or disrespectful action. It
-  **always** responds to organizational purposes. A closed issue can be perfectly reopened or further commented.
-- It is very hard to keep the project in good health in terms of technical debt, usability, serviceability, etc. If the proposed feature is
-  not clearly stated, enough information is not provided or it is not sure that would be a good feature for the future development of the project, it won't be accepted. The community plays a very important role during this discussion so it strongly encouraged to
-  explain the value of a feature for the community, the needed documentation and its use cases.
-- Backwards compatibility and not breaking users' packages is very important and it won't be done unless there are very good reasons.
-- You should not get bothered if you feel unattended, CCI is an Open Source project, not a commercial product. Try to explain what you
-  really need and we will try to help you.

--- a/docs/error_knowledge_base.md
+++ b/docs/error_knowledge_base.md
@@ -1,4 +1,5 @@
-## Errors from the conan-center hook (KB-Hxxx)
+# Errors from the conan-center hook (KB-Hxxx)
+
 
 #### **<a name="KB-H001">#KB-H001</a>: "DEPRECATED GLOBAL CPPSTD"**
 

--- a/docs/error_knowledge_base.md
+++ b/docs/error_knowledge_base.md
@@ -156,7 +156,7 @@ class SomeRecipe(ConanFile):
     exports = "LICENSE.md" # not allowed
 ```
 
-There is a complete explanation in the [FAQ](https://github.com/conan-io/conan-center-index/wiki/FAQ#should-recipes-export-a-recipes-license).
+There is a complete explanation in the [FAQ](faqs.md#should-recipes-export-a-recipes-license).
 
 #### **<a name="KB-H024">#KB-H024</a>: "TEST PACKAGE FOLDER"**
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -1,3 +1,6 @@
+# FAQs
+
+
 This section gathers the most common questions from the community related to packages and usability of this repository.
 
 ## What is the policy on recipe name collisions?

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -74,7 +74,7 @@ Currently, the Jenkins orchestration library for this build service is not avail
 
 ## Why not x86 binaries?
 
-As described in the [Supported platforms and configurations](https://github.com/conan-io/conan-center-index/wiki/Supported-Platforms-And-Configurations), only the x86_64 architecture is available for download, the rest must be built from sources. The reasons behind this decision are:
+As described in the [Supported platforms and configurations](supported_platforms_and_configurations.md), only the x86_64 architecture is available for download, the rest must be built from sources. The reasons behind this decision are:
 
 * Few users need different pre-built packages that are not x86_64 packages, this number is less than 10% of total users (data obtained through the download counter from Bintray), and tends to decrease over the years;
 * Some OS are putting the x86 as obsolete, examples [macOS](https://developer.apple.com/documentation/macos-release-notes/macos-catalina-10_15-release-notes) and Ubuntu 20.04;

--- a/docs/how_to_add_packages.md
+++ b/docs/how_to_add_packages.md
@@ -18,7 +18,7 @@ When the pull request is reviewed and merged, those packages are published to ce
 
 The [conan-center-index](https://github.com/conan-io/conan-center-index) (this repository) contains recipes for the [conan-center](https://bintray.com/conan/conan-center) repository.
 
-To contribute with a Conan recipe into the `conan-center` repository you can submit a [Pull Request](https://github.com/conan-io/conan-center-index/pulls) to the **master branch** of this repository. The connected **continuous integration system** will generate binary packages automatically for the most common platforms and compilers. See [the Supported Platforms and Configurations page](https://github.com/conan-io/conan-center-index/wiki/Supported-Platforms-And-Configurations) to know the generated configurations. For a C++ library, the system is currently generating more than 100 binary packages.
+To contribute with a Conan recipe into the `conan-center` repository you can submit a [Pull Request](https://github.com/conan-io/conan-center-index/pulls) to the **master branch** of this repository. The connected **continuous integration system** will generate binary packages automatically for the most common platforms and compilers. See [the Supported Platforms and Configurations page](supported_platforms_and_configurations.md) to know the generated configurations. For a C++ library, the system is currently generating more than 100 binary packages.
 
 > ⚠️ **Note**: This CI service is not a testing service, it is a binary building service for package **releases**. Unit tests shouldn't be built nor ran in recipes by default. Before submitting a PR it is mandatory to run at least a local package creation.
 
@@ -149,4 +149,4 @@ Call `conan create . lib/1.0@` in the folder of the recipe using the profile you
 
 ### Debugging failed builds
 
-   Go to the [Error Knowledge Base](https://github.com/conan-io/conan-center-index/wiki/Error-Knowledge-Base) page to know more.
+   Go to the [Error Knowledge Base](error_knowledge_base.md) page to know more.

--- a/docs/supported_platforms_and_configurations.md
+++ b/docs/supported_platforms_and_configurations.md
@@ -1,3 +1,6 @@
+# Supported platforms and configurations
+
+
 - For a **C++** library (with ``"shared"`` option) the system is generating **130** binary packages.
 - For a **pure C** library (with ``"shared"`` option but without ``compiler.libcxx``) the system generates **110** binary packages.
 - A package is also generated for those recipes with the `"header_only"` option.


### PR DESCRIPTION
Adds a TOC to `docs/` folder and updates links from wiki to docs.

Related https://github.com/conan-io/conan-center-index/issues/2283

(on top of https://github.com/conan-io/conan-center-index/pull/2481)
