### PR TITLE
lzma_sdk: Fix building for other architectures

### DIFF
--- a/recipes/lzma_sdk/9.20/conanfile.py
+++ b/recipes/lzma_sdk/9.20/conanfile.py
@@ -22,7 +22,7 @@ class PackageLzmaSdk(ConanFile):
     license = ("LZMA-exception",)
     homepage = "https://www.7-zip.org/sdk.html"
     topics = ("conan", "lzma", "zip", "compression", "decompression")
-    settings = "os_build", "arch_build", "compiler"
+    settings = "os", "arch", "compiler"
 
     def build_requirements(self):
         if self.settings.compiler != "Visual Studio" and tools.os_info.is_windows and os.environ.get("CONAN_BASH_PATH", None) is None:
@@ -48,23 +48,21 @@ class PackageLzmaSdk(ConanFile):
         return {
             'x86_64': 'AMD64',
             'x86': 'x86',
-        }[str(self.settings.arch_build)]
+        }[str(self.settings.arch)]
 
     @property
     def _autotools_build_dirs(self):
-        es = ".exe" if self.settings.os_build == "Windows" else ""
+        es = ".exe" if self.settings.os == "Windows" else ""
         return (
             [os.path.join("C","Util","7z"), [["7zDec{}".format(es)], []]],
             [os.path.join("CPP","7zip","Bundles","LzmaCon"), [["lzma{}".format(es)],[]]]
         )
 
     def _build_msvc(self):
-        env_build = VisualStudioBuildEnvironment(self)
-        with tools.environment_append(env_build.vars):
-            vcvars = tools.vcvars_command(self.settings)
-            for make_dir, _ in self._msvc_build_dirs:
+        for make_dir, _ in self._msvc_build_dirs:
+            with tools.vcvars(self.settings):
                 with tools.chdir(make_dir):
-                    self.run("%s && nmake /f makefile NEW_COMPILER=1 CPU=%s" % (vcvars, self._msvc_cpu))
+                    self.run("nmake /f makefile NEW_COMPILER=1 CPU=%s" % self._msvc_cpu)
 
     def _build_autotools(self):
         env_build = AutoToolsBuildEnvironment(self)
@@ -72,7 +70,7 @@ class PackageLzmaSdk(ConanFile):
             for make_dir, _ in self._autotools_build_dirs:
                 with tools.chdir(make_dir):
                     extra_args = ""
-                    if self.settings.os_build == "Windows":
+                    if self.settings.os == "Windows":
                         extra_args += " IS_MINGW=1"
                     self.run("make -f makefile.gcc all%s" % extra_args)
 

--- a/recipes/lzma_sdk/9.20/test_package/conanfile.py
+++ b/recipes/lzma_sdk/9.20/test_package/conanfile.py
@@ -1,8 +1,10 @@
-from conans import ConanFile
+from conans import ConanFile, tools
 
 
 class TestPackage(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
 
     def test(self):
-        self.run("7zDec")
-        self.run("lzma")
+        if not tools.cross_building(self.settings):
+            self.run("7zDec", run_environment=True)
+            self.run("lzma", run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lzma_sdk/9.20**

The recipe uses `arch_build` and `os_build`, the settings which indicate which architecture and os we're building on, to decide
which platform we're building for, which isn't correct when cross compiling. Fix this by using `arch` and `os` instead.

Also, simplify `_build_msvc` by using `tools.vcvars`.

Replaces #2100.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
