### PR TITLE
7zip: Fix building for other architectures

### DIFF
--- a/recipes/7zip/19.00/test_package/conanfile.py
+++ b/recipes/7zip/19.00/test_package/conanfile.py
@@ -1,7 +1,9 @@
-from conans import ConanFile
+from conans import ConanFile, tools
 
 
 class TestPackage(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
     
     def test(self):
-        self.run("7z.exe")
+        if not tools.cross_building(self.settings):
+            self.run("7z.exe")


### PR DESCRIPTION
Specify library name and version:  **7zip/19.00**

The recipe uses `arch_build` and `os_build`, the settings which indicate which architecture and os we're building on, to decide
which platform we're building for, which isn't correct when cross compiling. Fix this by using `arch` and `os` instead.

Replaces #2100.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
