### PR TITLE
etc2comp: don't lie about cxx flags

### DIFF
--- a/recipes/etc2comp/all/CMakeLists.txt
+++ b/recipes/etc2comp/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/etc2comp/all/conandata.yml
+++ b/recipes/etc2comp/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "cci.20170424":
     url: "https://github.com/google/etc2comp/archive/9cd0f9cae0f32338943699bb418107db61bb66f2.tar.gz"
     sha256: "719f88aab5dc30c9e4a53c4a5925e22149d0371a16fbe45a1c3a79525a975266"
+patches:
+  "cci.20170424":
+    - patch_file: "patches/fix-cmake.patch"
+      base_path: "source_subfolder"

--- a/recipes/etc2comp/all/patches/fix-cmake.patch
+++ b/recipes/etc2comp/all/patches/fix-cmake.patch
@@ -1,0 +1,34 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,18 +12,8 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-cmake_minimum_required(VERSION 2.8.9)
++cmake_minimum_required(VERSION 3.1)
+ project(EtcTest)
+ 
+ set (CMAKE_CXX_STANDARD 11)
+-IF (APPLE)
+-	set (CMAKE_CXX_FLAGS "-I/usr/include/i386-linux-gnu/c++/4.8 -I/usr/include/c++/4.8 -std=c++11 -g3 -Wall -O3")
+-ELSE ()
+-	IF (WIN32)
+-		set (CMAKE_CXX_FLAGS "-I/usr/include/i386-linux-gnu/c++/4.8 -I/usr/include/c++/4.8 -W4 /EHsc")
+-	ELSE()
+-		set (CMAKE_CXX_FLAGS "-I/usr/include/i386-linux-gnu/c++/4.8 -I/usr/include/c++/4.8 -std=c++11 -pthread -g3 -Wall -O2")
+-	ENDIF()
+-ENDIF ()
+ ADD_SUBDIRECTORY(EtcLib)
+-ADD_SUBDIRECTORY(EtcTool)
+--- a/EtcLib/CMakeLists.txt
++++ b/EtcLib/CMakeLists.txt
+@@ -22,3 +22,9 @@ file(GLOB SOURCES
+ 	${PROJECT_SOURCE_DIR}/Etc/*.cpp
+ 	${PROJECT_SOURCE_DIR}/EtcCodec/*.cpp)
+ ADD_LIBRARY(EtcLib ${SOURCES})
++set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
++set(THREADS_PREFER_PTHREAD_FLAG TRUE)
++find_package(Threads REQUIRED)
++if(CMAKE_USE_PTHREADS_INIT)
++  target_link_libraries(EtcLib PRIVATE Threads::Threads)
++endif()


### PR DESCRIPTION
Specify library name and version:  **etc2comp/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Top `etc2comp` CMakeLists.txt overrides `CMAKE_CXX_FLAGS`, and thereby lies to users: https://github.com/google/etc2comp/blob/master/CMakeLists.txt