### PR TITLE
ncurses: set TERMINFO environment variable

### DIFF
--- a/recipes/ncurses/all/conanfile.py
+++ b/recipes/ncurses/all/conanfile.py
@@ -203,3 +203,7 @@ class NCursesConan(ConanFile):
             bin_path = os.path.join(self.package_folder, "bin")
             self.output.info("Appending PATH environment variable: {}".format(bin_path))
             self.env_info.PATH.append(bin_path)
+
+        terminfo = os.path.join(self.package_folder, "bin", "share", "terminfo")
+        self.output.info("Setting TERMINFO environment variable: {}".format(terminfo))
+        self.env_info.TERMINFO = terminfo


### PR DESCRIPTION
Specify library name and version:  **ncurses/6.2**

Required by the curses module of python: #1510

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
