### PR TITLE
utf8proc: fix pkgconfig name

### DIFF
--- a/recipes/utf8proc/all/conanfile.py
+++ b/recipes/utf8proc/all/conanfile.py
@@ -62,6 +62,7 @@ class Utf8ProcConan(ConanFile):
         cmake.install()
 
     def package_info(self):
+        self.cpp_info.names["pkg_config"] = "libutf8proc"
         self.cpp_info.libs = ["utf8proc_static" if self.settings.compiler == "Visual Studio" and not self.options.shared else "utf8proc"]
         if not self.options.shared:
             self.cpp_info.defines = ["UTF8PROC_STATIC"]


### PR DESCRIPTION
Specify library name and version:  **utf8proc/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

pkgconfig name: https://github.com/JuliaStrings/utf8proc/blob/08f9999a0698639f15d07b12c0065a4494f2d504/Makefile#L112