### PR TITLE
zeromq: fix pkgconfig and cmake names

### DIFF
--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -43,7 +43,7 @@ class ZeroMQConan(ConanFile):
 
     def requirements(self):
         if self.options.encryption == "libsodium":
-            self.requires.add("libsodium/1.0.18")
+            self.requires("libsodium/1.0.18")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -98,28 +98,19 @@ class ZeroMQConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "CMake"))
 
     def package_info(self):
+        # TODO: CMake imported target shouldn't be namespaced
         self.cpp_info.names["cmake_find_package"] = "ZeroMQ"
         self.cpp_info.names["cmake_find_package_multi"] = "ZeroMQ"
-        if self.settings.compiler == "Visual Studio":
-            version = "_".join(self.version.split("."))
-            if self.settings.build_type == "Debug":
-                runtime = "-gd" if self.options.shared else "-sgd"
-            else:
-                runtime = "" if self.options.shared else "-s"
-            library_name = "libzmq-mt%s-%s" % (runtime, version)
-            if not os.path.isfile(os.path.join(self.package_folder, "lib", library_name)):
-                # unfortunately Visual Studio and Ninja generators produce different file names
-                toolset = {"12": "v120",
-                           "14": "v140",
-                           "15": "v141",
-                           "16": "v142"}.get(str(self.settings.compiler.version))
-                library_name = "libzmq-%s-mt%s-%s" % (toolset, runtime, version)
-            self.cpp_info.libs = [library_name]
-        else:
-            self.cpp_info.libs = ["zmq"]
+        self.cpp_info.names["pkg_config"] = "libzmq"
+        libzmq_target = "libzmq" if self.options.shared else "libzmq-static"
+        self.cpp_info.components["libzmq"].names["cmake_find_package"] = libzmq_target
+        self.cpp_info.components["libzmq"].names["cmake_find_package_multi"] = libzmq_target
+        self.cpp_info.components["libzmq"].libs = tools.collect_libs(self)
         if self.settings.os == "Windows":
-            self.cpp_info.system_libs = ["iphlpapi", "ws2_32"]
+            self.cpp_info.components["libzmq"].system_libs = ["iphlpapi", "ws2_32"]
         elif self.settings.os == "Linux":
-            self.cpp_info.system_libs = ["pthread", "rt", "m"]
+            self.cpp_info.components["libzmq"].system_libs = ["pthread", "rt", "m"]
         if not self.options.shared:
-            self.cpp_info.defines.append("ZMQ_STATIC")
+            self.cpp_info.components["libzmq"].defines.append("ZMQ_STATIC")
+        if self.options.encryption == "libsodium":
+            self.cpp_info.components["libzmq"].requires = ["libsodium::libsodium"]

--- a/recipes/zeromq/all/test_package/CMakeLists.txt
+++ b/recipes/zeromq/all/test_package/CMakeLists.txt
@@ -1,17 +1,20 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
-
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 option(WITH_LIBSODIUM "zeromq is built with libsodium")
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup()
 
-find_package(ZeroMQ REQUIRED)
+find_package(ZeroMQ REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ZeroMQ::ZeroMQ)
+# TODO: remove ZeroMQ:: namespace when fixed in conanfile.py
+if(ZEROMQ_SHARED)
+  target_link_libraries(${PROJECT_NAME} ZeroMQ::libzmq)
+else()
+  target_link_libraries(${PROJECT_NAME} ZeroMQ::libzmq-static)
+endif()
 
 if(WITH_LIBSODIUM)
   target_compile_definitions(${PROJECT_NAME} PRIVATE "WITH_LIBSODIUM")

--- a/recipes/zeromq/all/test_package/conanfile.py
+++ b/recipes/zeromq/all/test_package/conanfile.py
@@ -4,11 +4,12 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
         cmake.definitions["WITH_LIBSODIUM"] = self.options["zeromq"].encryption == "libsodium"
+        cmake.definitions["ZEROMQ_SHARED"] = self.options["zeromq"].shared
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **zeromq/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Also use `tools.collect_libs`, because previous logic was broken for Visual Studio and Ninja generator.