### PR TITLE
Update changelog (17-August-2020)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 17-August-2020 - 11:20 CEST
+
+ - Raise error if zero packages are generated
+ - Remove "No beta user" label if corresponding check pass
+ - [engineering] Unify catchs and simplify slackSend function
+ - [engineering] Pipeline step to create all packages in stages
+ - [engineering] Pipeline step to compute and reduce 'packageID'
+ - [engineering] Simplify 'ComputePackageIDs' command
 
 ### 12-August-2020 - 10:12 CEST
 


### PR DESCRIPTION
Update changelog:

### 17-August-2020 - 11:20 CEST

 - Raise error if zero packages are generated
 - Remove "No beta user" label if corresponding check pass
 - [engineering] Unify catchs and simplify slackSend function
 - [engineering] Pipeline step to create all packages in stages
 - [engineering] Pipeline step to compute and reduce 'packageID'
 - [engineering] Simplify 'ComputePackageIDs' command

