### PR TITLE
toml11: add 3.5.0 + fix includedir

### DIFF
--- a/recipes/toml11/all/conandata.yml
+++ b/recipes/toml11/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
-    "3.1.0":
-      url: https://github.com/ToruNiina/toml11/archive/v3.1.0.tar.gz
-      sha256: 3a118f32e5343998f37be9807c72fd11c3168fe12a5b1abfdc0f1e60de6380a4
-    "3.4.0":
-      url: https://github.com/ToruNiina/toml11/archive/v3.4.0.tar.gz
-      sha256: bc6d733efd9216af8c119d8ac64a805578c79cc82b813e4d1d880ca128bd154d
+  "3.1.0":
+    url: https://github.com/ToruNiina/toml11/archive/v3.1.0.tar.gz
+    sha256: 3a118f32e5343998f37be9807c72fd11c3168fe12a5b1abfdc0f1e60de6380a4
+  "3.4.0":
+    url: https://github.com/ToruNiina/toml11/archive/v3.4.0.tar.gz
+    sha256: bc6d733efd9216af8c119d8ac64a805578c79cc82b813e4d1d880ca128bd154d
+  "3.5.0":
+    url: https://github.com/ToruNiina/toml11/archive/v3.5.0.tar.gz
+    sha256: fc613874c6e80dc740134a7353cf23c7f834b59cd601af84ab535ee16a53b1c3

--- a/recipes/toml11/all/conanfile.py
+++ b/recipes/toml11/all/conanfile.py
@@ -9,9 +9,19 @@ class Toml11Conan(ConanFile):
     description = "TOML for Modern C++"
     topics = ("toml", "c-plus-plus-11", "c-plus-plus", "parser", "serializer")
     license = "MIT"
+    settings = "compiler"
     no_copy_source = True
 
-    _source_subfolder = "source_subfolder"
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def configure(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 11)
+
+    def package_id(self):
+        self.info.header_only()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -19,11 +29,9 @@ class Toml11Conan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def package(self):
-        self.copy("*.hpp", dst="include/toml11", src=self._source_subfolder)
-        self.copy("*.hpp",
-                  dst="include/toml11/toml",
-                  src=os.path.join(self._source_subfolder, "include"))
+        self.copy("toml.hpp", dst=os.path.join("include", "toml11"), src=self._source_subfolder)
+        self.copy("*.hpp", dst=os.path.join("include", "toml11", "toml"), src=os.path.join(self._source_subfolder, "toml"))
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
 
     def package_info(self):
-        self.info.header_only()
+        self.cpp_info.includedirs.append(os.path.join("include", "toml11"))

--- a/recipes/toml11/all/test_package/CMakeLists.txt
+++ b/recipes/toml11/all/test_package/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
-project(toml11test CXX)
+project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)
+find_package(toml11 REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} toml11::toml11)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/toml11/all/test_package/conanfile.py
+++ b/recipes/toml11/all/test_package/conanfile.py
@@ -1,9 +1,9 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 import os
 
-class Toml11TestConan(ConanFile):
+class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -11,5 +11,6 @@ class Toml11TestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        os.chdir("bin")
-        self.run(".%stoml11test" % os.sep)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/toml11/all/test_package/test_package.cpp
+++ b/recipes/toml11/all/test_package/test_package.cpp
@@ -1,4 +1,4 @@
-#include <toml11/toml.hpp>
+#include <toml.hpp>
 #include <iostream>
 
 int main()

--- a/recipes/toml11/config.yml
+++ b/recipes/toml11/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "3.4.0":
     folder: all
+  "3.5.0":
+    folder: all


### PR DESCRIPTION
Also fix includedir to match official one

Specify library name and version:  **toml11/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
