### PR TITLE
timsort: fix cmake names

### DIFF
--- a/recipes/timsort/all/conanfile.py
+++ b/recipes/timsort/all/conanfile.py
@@ -1,7 +1,8 @@
 import os
 
-from conans import CMake, ConanFile, tools
+from conans import ConanFile, tools
 
+required_conan_version = ">=1.28.0"
 
 class TimsortConan(ConanFile):
     name = "timsort"
@@ -10,9 +11,19 @@ class TimsortConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/timsort/cpp-TimSort"
     license = "MIT"
+    settings = "compiler"
     no_copy_source = True
 
-    _source_subfolder = "source_subfolder"
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def configure(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 11)
+
+    def package_id(self):
+        self.info.header_only()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -23,5 +34,10 @@ class TimsortConan(ConanFile):
         self.copy("*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
 
-    def package_id(self):
-        self.info.header_only()
+    def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "gfx-timsort"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "gfx-timsort"
+        self.cpp_info.names["cmake_find_package"] = "gfx"
+        self.cpp_info.names["cmake_find_package_multi"] = "gfx"
+        self.cpp_info.components["gfx-timsort"].names["cmake_find_package"] = "timsort"
+        self.cpp_info.components["gfx-timsort"].names["cmake_find_package_multi"] = "timsort"

--- a/recipes/timsort/all/test_package/CMakeLists.txt
+++ b/recipes/timsort/all/test_package/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required(VERSION 2.8.11)
-
+cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+conan_basic_setup()
 
-add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
-target_link_libraries(${CMAKE_PROJECT_NAME} CONAN_PKG::timsort)
-set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+find_package(gfx-timsort REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} gfx::timsort)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/timsort/all/test_package/conanfile.py
+++ b/recipes/timsort/all/test_package/conanfile.py
@@ -1,11 +1,11 @@
-import os.path
+import os
 
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 
 
-class TimsortTestConan(ConanFile):
+class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -13,5 +13,6 @@ class TimsortTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **timsort/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

https://github.com/timsort/cpp-TimSort/blob/298928ce37e2954956320e764a862b9b1dbc51a7/CMakeLists.txt#L33