### PR TITLE
aws-c-common: fix cmake imported target name + system libs on Windows

### DIFF
--- a/recipes/aws-c-common/all/conanfile.py
+++ b/recipes/aws-c-common/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import CMake, ConanFile, tools
 import os
 
+required_conan_version = ">=1.28.0"
 
 class AwsCCommon(ConanFile):
     name = "aws-c-common"
@@ -67,10 +68,16 @@ class AwsCCommon(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-common"))
 
     def package_info(self):
-        self.cpp_info.libs = ["aws-c-common"]
+        self.cpp_info.filenames["cmake_find_package"] = "aws-c-common"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-common"
+        self.cpp_info.names["cmake_find_package"] = "AWS"
+        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
+        self.cpp_info.components["aws-c-common-lib"].names["cmake_find_package"] = "aws-c-common"
+        self.cpp_info.components["aws-c-common-lib"].names["cmake_find_package_multi"] = "aws-c-common"
+        self.cpp_info.components["aws-c-common-lib"].libs = ["aws-c-common"]
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs = ["m", "pthread", "rt"]
+            self.cpp_info.components["aws-c-common-lib"].system_libs = ["m", "pthread", "rt"]
         if not self.options.shared:
             if tools.is_apple_os(self.settings.os):
-                self.cpp_info.frameworks = ["CoreFoundation"]
-        self.cpp_info.builddirs = [os.path.join("lib", "cmake")]
+                self.cpp_info.components["aws-c-common-lib"].frameworks = ["CoreFoundation"]
+        self.cpp_info.components["aws-c-common-lib"].builddirs = [os.path.join("lib", "cmake")]

--- a/recipes/aws-c-common/all/conanfile.py
+++ b/recipes/aws-c-common/all/conanfile.py
@@ -77,6 +77,8 @@ class AwsCCommon(ConanFile):
         self.cpp_info.components["aws-c-common-lib"].libs = ["aws-c-common"]
         if self.settings.os == "Linux":
             self.cpp_info.components["aws-c-common-lib"].system_libs = ["m", "pthread", "rt"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.components["aws-c-common-lib"].system_libs = ["bcrypt", "ws2_32"]
         if not self.options.shared:
             if tools.is_apple_os(self.settings.os):
                 self.cpp_info.components["aws-c-common-lib"].frameworks = ["CoreFoundation"]

--- a/recipes/aws-c-common/all/test_package/CMakeLists.txt
+++ b/recipes/aws-c-common/all/test_package/CMakeLists.txt
@@ -1,8 +1,10 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(aws-c-common REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} AWS::aws-c-common)

--- a/recipes/aws-c-common/all/test_package/conanfile.py
+++ b/recipes/aws-c-common/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **aws-c-common/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

:warning: Hooks don't see buildirs in components (not even sure that is makes sense, but global buildirs can't be used with components).