### PR TITLE
bitserializer: add options and components

### DIFF
--- a/recipes/bitserializer/0.10/conanfile.py
+++ b/recipes/bitserializer/0.10/conanfile.py
@@ -2,6 +2,7 @@ from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.28.0"
 
 class BitserializerConan(ConanFile):
     name = "bitserializer"
@@ -10,9 +11,18 @@ class BitserializerConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://bitbucket.org/Pavel_Kisliak/bitserializer"
     license = "MIT"
-    settings = ("os", "compiler",)
+    settings = "os", "compiler"
     no_copy_source = True
-    requires = ("rapidjson/1.1.0")
+    options = {
+        "with_cpprestsdk": [True, False],
+        "with_rapidjson": [True, False],
+        "with_pugixml": [True, False]
+    }
+    default_options = {
+        "with_cpprestsdk": True,
+        "with_rapidjson": True,
+        "with_pugixml": True
+    }
 
     @property
     def _supported_compilers(self):
@@ -37,6 +47,17 @@ class BitserializerConan(ConanFile):
         except KeyError:
             self.output.warn("This recipe has no support for the current compiler. Please consider adding it.")
 
+    def requirements(self):
+        if self.options.with_cpprestsdk:
+            self.requires("cpprestsdk/2.10.16")
+        if self.options.with_rapidjson:
+            self.requires("rapidjson/1.1.0")
+        if self.options.with_pugixml:
+            self.requires("pugixml/1.10")
+
+    def package_id(self):
+        self.info.header_only()
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         # Find and rename folder in the extracted sources
@@ -48,14 +69,25 @@ class BitserializerConan(ConanFile):
 
     def package(self):
         self.copy(pattern="license.txt", dst="licenses", src=self._source_subfolder)
-        # Install Core
-        include_folder = os.path.join(self._source_subfolder, "include")
-        self.copy(pattern=os.path.join("bitserializer", "*.h"), dst="include", src=include_folder)
-
-    def package_id(self):
-        self.info.header_only()
+        self.copy(pattern="*.h", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
     def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "bitserializer"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "bitserializer"
+        self.cpp_info.names["cmake_find_package"] = "BitSerializer"
+        self.cpp_info.names["cmake_find_package_multi"] = "BitSerializer"
+        # core
+        self.cpp_info.components["core"].names["cmake_find_package"] = "core"
+        self.cpp_info.components["core"].names["cmake_find_package_multi"] = "core"
         if self.settings.compiler == "gcc" or (self.settings.os == "Linux" and self.settings.compiler == "clang"):
             if tools.Version(self.settings.compiler.version) < 9:
-                self.cpp_info.libs = ["stdc++fs"]
+                self.cpp_info.components["core"].system_libs = ["stdc++fs"]
+        # cpprestjson-archive
+        if self.options.with_cpprestsdk:
+            self.cpp_info.components["cpprestjson-archive"].requires = ["core", "cpprestsdk::cpprestsdk"]
+        # rapidjson-archive
+        if self.options.with_rapidjson:
+            self.cpp_info.components["rapidjson-archive"].requires = ["core", "rapidjson::rapidjson"]
+        # pugixml-archive
+        if self.options.with_rapidjson:
+            self.cpp_info.components["pugixml-archive"].requires = ["core", "pugixml::pugixml"]

--- a/recipes/bitserializer/0.10/test_package/CMakeLists.txt
+++ b/recipes/bitserializer/0.10/test_package/CMakeLists.txt
@@ -1,9 +1,19 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(bitserializer REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME}
+    BitSerializer::core
+    $<$<BOOL:${WITH_CPPRESTSDK}>:BitSerializer::cpprestjson-archive>
+    $<$<BOOL:${WITH_RAPIDJSON}>:BitSerializer::rapidjson-archive>
+    $<$<BOOL:${WITH_PUGIXML}>:BitSerializer::pugixml-archive>)
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+    $<$<BOOL:${WITH_CPPRESTSDK}>:"WITH_CPPRESTSDK">
+    $<$<BOOL:${WITH_RAPIDJSON}>:"WITH_RAPIDJSON">
+    $<$<BOOL:${WITH_PUGIXML}>:"WITH_PUGIXML">)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/recipes/bitserializer/0.10/test_package/conanfile.py
+++ b/recipes/bitserializer/0.10/test_package/conanfile.py
@@ -4,10 +4,13 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["WITH_CPPRESTSDK"] = self.options["bitserializer"].with_cpprestsdk
+        cmake.definitions["WITH_RAPIDJSON"] = self.options["bitserializer"].with_rapidjson
+        cmake.definitions["WITH_PUGIXML"] = self.options["bitserializer"].with_pugixml
         cmake.configure()
         cmake.build()
 

--- a/recipes/bitserializer/0.10/test_package/test_package.cpp
+++ b/recipes/bitserializer/0.10/test_package/test_package.cpp
@@ -2,11 +2,20 @@
 // ToDo: Remove when new version of RapidJson will be available
 #define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING
 
+#include <bitserializer/bit_serializer.h>
+#ifdef WITH_CPPRESTSDK
+#include <bitserializer/cpprestjson_archive.h>
+#endif
+#ifdef WITH_RAPIDJSON
+#include <bitserializer/rapidjson_archive.h>
+#endif
+#ifdef WITH_PUGIXML
+#include <bitserializer/pugixml_archive.h>
+#endif
+
 #include <iostream>
 #include <sstream>
 #include <filesystem>
-#include "bitserializer/bit_serializer.h"
-#include "bitserializer/rapidjson_archive.h"
 
 class CTest
 {
@@ -48,5 +57,13 @@ int main() {
 	// Some compilers does not link filesystem automatically
 	std::cout << "Testing the link of C++17 filesystem: " << std::filesystem::temp_directory_path() << std::endl;
 
+#ifdef WITH_CPPRESTSDK
+	TestArchive<BitSerializer::Json::CppRest::JsonArchive>("Implementation based on cpprestsdk");
+#endif
+#ifdef WITH_RAPIDJSON
 	TestArchive<BitSerializer::Json::RapidJson::JsonArchive>("Implementation based on RapidJson");
+#endif
+#ifdef WITH_PUGIXML
+	TestArchive<BitSerializer::Xml::PugiXml::XmlArchive>("Implementation based on pugixml");
+#endif
 }


### PR DESCRIPTION
Specify library name and version:  **bitserializer/0.10**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

`bitserializer` optionally depends on `cpprestsdk`, `rapidjson`, `pugixml` and `rapidyaml` (the last one is not yet in CCI).
CMakeLists is quite neat, so it's straightforward to translate in conan components: https://bitbucket.org/Pavel_Kisliak/bitserializer/src/master/CMakeLists.txt