### PR TITLE
bitsery: fix cmake names

### DIFF
--- a/recipes/bitsery/all/conanfile.py
+++ b/recipes/bitsery/all/conanfile.py
@@ -21,6 +21,9 @@ class BitseryConan(ConanFile):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "11")
 
+    def package_id(self):
+        self.info.header_only()
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = "bitsery-" + self.version
@@ -28,7 +31,10 @@ class BitseryConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="*.h", dst=os.path.join("include", "bitsery"), src=os.path.join(self._source_subfolder, "include", "bitsery"))
+        self.copy(pattern="*.h", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
-    def package_id(self):
-        self.info.header_only()
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "Bitsery"
+        self.cpp_info.names["cmake_find_package_multi"] = "Bitsery"
+        self.cpp_info.components["bitserylib"].names["cmake_find_package"] = "bitsery"
+        self.cpp_info.components["bitserylib"].names["cmake_find_package_multi"] = "bitsery"

--- a/recipes/bitsery/all/test_package/CMakeLists.txt
+++ b/recipes/bitsery/all/test_package/CMakeLists.txt
@@ -1,14 +1,11 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_executable(${PROJECT_NAME} test_package.cpp)
-set_target_properties(
-    ${PROJECT_NAME} PROPERTIES
+find_package(Bitsery REQUIRED CONFIG)
 
-    CXX_STANDARD 11
-    CXX_STANDARD_REQUIRED ON
-)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} Bitsery::bitsery)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)

--- a/recipes/bitsery/all/test_package/conanfile.py
+++ b/recipes/bitsery/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **bitsery/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

cmake names: https://github.com/fraillt/bitsery/blob/master/CMakeLists.txt