### PR TITLE
box2d: restore default cmake names

### DIFF
--- a/recipes/box2d/2.4.x/conanfile.py
+++ b/recipes/box2d/2.4.x/conanfile.py
@@ -62,5 +62,3 @@ class Box2dConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["box2d"]
-        self.cpp_info.names["cmake_find_package"] = "Box2D"
-        self.cpp_info.names["cmake_find_package_multi"] = "Box2D"


### PR DESCRIPTION
Specify library name and version:  **box2d/2.4.x**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

box2d doesn't export its targets, and doesn't have official module file provided by CMake. There are only unofficial custom module files in some projects.
But https://github.com/erincatto/box2d/pull/630 proposes to use `box2d` as config file name and `box2d::box2d` as imported target, so better not suggesting unofficial names in CCI.