### PR TITLE
czmq: fix pkgconfig name and partially cmake imported target

### DIFF
--- a/recipes/czmq/all/CMakeLists.txt
+++ b/recipes/czmq/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/czmq/all/conanfile.py
+++ b/recipes/czmq/all/conanfile.py
@@ -48,8 +48,7 @@ class CzmqConan(ConanFile):
             self.requires("libcurl/7.71.1")
         if self.options.with_lz4:
             self.requires("lz4/1.9.2")
-        if self.settings.os != "Windows":
-            if self.options.with_libuuid:
+        if self.options.get_safe("with_libuuid"):
                 self.requires("libuuid/1.0.3")
 
     def source(self):
@@ -100,3 +99,10 @@ class CzmqConan(ConanFile):
             self.cpp_info.components["libczmq"].system_libs.append("rpcrt4")
         if not self.options.shared:
             self.cpp_info.components["libczmq"].defines.append("CZMQ_STATIC")
+        self.cpp_info.components["libczmq"].requires = ["openssl::openssl", "zeromq::zeromq"]
+        if self.options.with_libcurl:
+            self.cpp_info.components["libczmq"].requires.append("libcurl::libcurl")
+        if self.options.with_lz4:
+            self.cpp_info.components["libczmq"].requires.append("lz4::lz4")
+        if self.options.get_safe("with_libuuid"):
+            self.cpp_info.components["libczmq"].requires.append("libuuid::libuuid")

--- a/recipes/czmq/all/conanfile.py
+++ b/recipes/czmq/all/conanfile.py
@@ -45,7 +45,7 @@ class CzmqConan(ConanFile):
         self.requires("openssl/1.1.1g")  # zdigest depends on openssl
         self.requires("zeromq/4.3.2")
         if self.options.with_libcurl:
-            self.requires("libcurl/7.69.1")
+            self.requires("libcurl/7.71.1")
         if self.options.with_lz4:
             self.requires("lz4/1.9.2")
         if self.settings.os != "Windows":

--- a/recipes/czmq/all/conanfile.py
+++ b/recipes/czmq/all/conanfile.py
@@ -84,14 +84,19 @@ class CzmqConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
+        # TODO: CMake imported target shouldn't be namespaced
+        self.cpp_info.names["pkg_config"] = "libczmq"
+        czmq_target = "czmq" if self.options.shared else "czmq-static"
+        self.cpp_info.components["libczmq"].names["cmake_find_package"] = czmq_target
+        self.cpp_info.components["libczmq"].names["cmake_find_package_multi"] = czmq_target
         if self.settings.compiler == "Visual Studio":
-            self.cpp_info.libs = ["czmq" if self.options.shared else "libczmq"]
-            self.cpp_info.system_libs.append("rpcrt4")
+            self.cpp_info.components["libczmq"].libs = ["czmq" if self.options.shared else "libczmq"]
+            self.cpp_info.components["libczmq"].system_libs.append("rpcrt4")
         else:
-            self.cpp_info.libs = ["czmq"]
+            self.cpp_info.components["libczmq"].libs = ["czmq"]
             if self.settings.os == "Linux":
-                self.cpp_info.system_libs.extend(["pthread", "m"])
+                self.cpp_info.components["libczmq"].system_libs.extend(["pthread", "m"])
         if self.settings.os == "Windows":
-            self.cpp_info.system_libs.append("rpcrt4")
+            self.cpp_info.components["libczmq"].system_libs.append("rpcrt4")
         if not self.options.shared:
-            self.cpp_info.defines.append("CZMQ_STATIC")
+            self.cpp_info.components["libczmq"].defines.append("CZMQ_STATIC")

--- a/recipes/czmq/all/test_package/CMakeLists.txt
+++ b/recipes/czmq/all/test_package/CMakeLists.txt
@@ -1,13 +1,18 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
-
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(czmq REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+# TODO: remove czmq:: namespace when fixed in conanfile.py
+if(CZMQ_SHARED)
+  target_link_libraries(${PROJECT_NAME} czmq::czmq)
+else()
+  target_link_libraries(${PROJECT_NAME} czmq::czmq-static)
+endif()
 
 if(WITH_LIBSODIUM)
   target_compile_definitions(${PROJECT_NAME} PRIVATE "WITH_LIBSODIUM")

--- a/recipes/czmq/all/test_package/conanfile.py
+++ b/recipes/czmq/all/test_package/conanfile.py
@@ -4,11 +4,12 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
         cmake.definitions["WITH_LIBSODIUM"] = self.options["zeromq"].encryption == "libsodium"
+        cmake.definitions["CZMQ_SHARED"] = self.options["czmq"].shared
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **czmq/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

For reviewers:
- pkgconfig: https://github.com/zeromq/czmq/blob/4a3bad047544e6540998ee73b20cd79a7e871a4a/CMakeLists.txt#L463
- cmake:
  - targets: https://github.com/zeromq/czmq/blob/4a3bad047544e6540998ee73b20cd79a7e871a4a/CMakeLists.txt#L396 and https://github.com/zeromq/czmq/blob/4a3bad047544e6540998ee73b20cd79a7e871a4a/CMakeLists.txt#L429
  - config file: https://github.com/zeromq/czmq/blob/4a3bad047544e6540998ee73b20cd79a7e871a4a/CMakeLists.txt#L497
  - no namespace: https://github.com/zeromq/czmq/blob/4a3bad047544e6540998ee73b20cd79a7e871a4a/CMakeLists.txt#L494