### PR TITLE
[hotfix] Backward-cpp is static by default

### DIFF
--- a/recipes/backward-cpp/all/conanfile.py
+++ b/recipes/backward-cpp/all/conanfile.py
@@ -23,7 +23,7 @@ class BackwardCppConan(ConanFile):
     default_options = {
        "stack_walking": "unwind",
        "stack_details": "dwarf",
-       "shared": True,
+       "shared": False,
        "fPIC": True
     }
 
@@ -35,16 +35,16 @@ class BackwardCppConan(ConanFile):
 
     def _has_stack_details(self, type):
         return False if self.settings.os == "Windows" else self.options.stack_details == type
-    
+
     def _supported_os(self):
         return ["Linux", "Macos", "Android", "Windows"] if tools.Version(self.version) >= "1.5" \
                else ["Linux", "Macos", "Android"]
-    
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
             del self.options.stack_details
-    
+
     def configure(self):
         if self.settings.os not in self._supported_os():
             raise ConanInvalidConfiguration("upstream backward-cpp v{0} is not \
@@ -54,12 +54,12 @@ class BackwardCppConan(ConanFile):
            not self._has_stack_details("backtrace_symbol"):
             raise ConanInvalidConfiguration("only stack_details=backtrace_symbol"
                                             " is supported on Macos")
-        
+
     def requirements(self):
         if self.settings.os in ["Linux", "Android"] and \
            self._has_stack_details("dwarf"):
             self.requires("libdwarf/20191104")
-    
+
     def system_requirements(self):
         required_package = None
         if self.settings.os == "Linux":
@@ -82,7 +82,7 @@ class BackwardCppConan(ConanFile):
                     required_package = "binutils"
                 elif tools.os_info.is_freebsd:
                     required_package = "libbfd"
-        
+
         if required_package != None:
             installer = tools.SystemPackageTool()
             if not installer.installed(required_package):
@@ -130,7 +130,7 @@ class BackwardCppConan(ConanFile):
 
         self.cpp_info.defines.append('BACKWARD_HAS_UNWIND={}'.format(int(self._has_stack_walking("unwind"))))
         self.cpp_info.defines.append('BACKWARD_HAS_BACKTRACE={}'.format(int(self._has_stack_walking("backtrace"))))
-        
+
         self.cpp_info.defines.append('BACKWARD_HAS_BACKTRACE_SYMBOL={}'.format(int(self._has_stack_details("backtrace_symbol"))))
         self.cpp_info.defines.append('BACKWARD_HAS_DW={}'.format(int(self._has_stack_details("dw"))))
         self.cpp_info.defines.append('BACKWARD_HAS_BFD={}'.format(int(self._has_stack_details("bfd"))))
@@ -141,11 +141,8 @@ class BackwardCppConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.extend(["dl"])
             if self._has_stack_details("dw"):
-                self.cpp_info.system_libs.extend(["dw"])           
+                self.cpp_info.system_libs.extend(["dw"])
             if self._has_stack_details("bfd"):
                 self.cpp_info.system_libs.extend(["bfd"])
         if self.settings.os == "Windows":
             self.cpp_info.system_libs.extend(["psapi", "dbghelp"])
-
-
-        

--- a/recipes/backward-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/backward-cpp/all/test_package/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
 
-# Force test_package to be generated in build_folder (CMAKE_BINARY_DIR) 
-# so we get same behaviour between Unix Makefiles & Visual studio generator 
+# Force test_package to be generated in build_folder (CMAKE_BINARY_DIR)
+# so we get same behaviour between Unix Makefiles & Visual studio generator
 
 # First for the generic no-config case (e.g. with mingw)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
There is no restriction related to shared option: https://github.com/bombela/backward-cpp/blob/v1.5/CMakeLists.txt#L81

Specify library name and version:  **backward-cpp/1.5**

Related to https://github.com/conan-io/hooks/issues/217

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
