### PR TITLE
blake2 uses static lib by default

### DIFF
--- a/recipes/libb2/all/CMakeLists.txt
+++ b/recipes/libb2/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.4)
 project(b2 C)
 
 include("conanbuildinfo.cmake")
@@ -46,4 +46,3 @@ install(TARGETS ${CMAKE_PROJECT_NAME}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libb2
         )
-

--- a/recipes/libb2/all/conanfile.py
+++ b/recipes/libb2/all/conanfile.py
@@ -15,7 +15,7 @@ class libb2Conan(ConanFile):
     exports_sources = ["CMakeLists.txt"]
     generators = ["cmake"]
     options = {"fPIC": [True, False], "shared": [True, False], "use_sse": [True, False], "use_neon": [True, False]}
-    default_options = {"fPIC": True, "shared": True, "use_sse": False, "use_neon": False}
+    default_options = {"fPIC": True, "shared": False, "use_sse": False, "use_neon": False}
     _cmake = None
 
     @property

--- a/recipes/libb2/all/test_package/CMakeLists.txt
+++ b/recipes/libb2/all/test_package/CMakeLists.txt
@@ -1,10 +1,9 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
-
-set(CMAKE_CXX_STANDARD 11)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_executable(example example.cpp)
 target_link_libraries(example ${CONAN_LIBS})
+set_property(TARGET example PROPERTY CXX_STANDARD 11)


### PR DESCRIPTION
Specify library name and version:  **libb2/20190723**

There is no restriction building Blake2 as static lib: https://github.com/BLAKE2/BLAKE2/pull/59#commitcomment-34632790

related to https://github.com/conan-io/hooks/issues/217

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
