### PR TITLE
libepoxy as static by default

### DIFF
--- a/recipes/libepoxy/all/conanfile.py
+++ b/recipes/libepoxy/all/conanfile.py
@@ -23,7 +23,7 @@ class EpoxyConan(ConanFile):
         "x11": [True, False]
     }
     default_options = {
-        "shared": True, #shared is the default of native meson projects
+        "shared": False,
         "fPIC": True,
         "glx": True,
         "egl": False,

--- a/recipes/libepoxy/all/test_package/CMakeLists.txt
+++ b/recipes/libepoxy/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Libepoxy does not show any restriction for shared/static option

Specify library name and version:  **libepoxy/1.5.4**

Related to https://github.com/conan-io/hooks/issues/217

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
