### PR TITLE
Remove shared option for libsigcpp

### DIFF
--- a/recipes/libsigcpp/3.0.0/conanfile.py
+++ b/recipes/libsigcpp/3.0.0/conanfile.py
@@ -13,8 +13,6 @@ class LibSigCppConan(ConanFile):
     description = "libsigc++ implements a typesafe callback system for standard C++."
     topics = ("conan", "libsigcpp", "callback")
     settings = "os", "compiler", "arch", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": True, "fPIC": True}
     exports_sources = ["CMakeLists.txt", "*.patch"]
     generators = "cmake"
 
@@ -34,10 +32,6 @@ class LibSigCppConan(ConanFile):
         supported_compilers = [("apple-clang", 10), ("clang", 6), ("gcc", 7), ("Visual Studio", 15.7)]
         compiler, version = self.settings.compiler, Version(self.settings.compiler.version)
         return any(compiler == sc[0] and version >= sc[1] for sc in supported_compilers)
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
 
     def configure(self):
         compiler_version = Version(self.settings.compiler.version)

--- a/recipes/libsigcpp/3.0.0/conanfile.py
+++ b/recipes/libsigcpp/3.0.0/conanfile.py
@@ -35,8 +35,6 @@ class LibSigCppConan(ConanFile):
 
     def configure(self):
         compiler_version = Version(self.settings.compiler.version)
-        if not self.options.shared:
-            raise ConanInvalidConfiguration("This library supported shared option only")
         if self.settings.compiler.cppstd and \
            not self.settings.compiler.cppstd in self._supported_cppstd:
           raise ConanInvalidConfiguration("This library requires c++17 standard or higher."

--- a/recipes/libsigcpp/3.0.0/test_package/CMakeLists.txt
+++ b/recipes/libsigcpp/3.0.0/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 
 PROJECT(test_package CXX)
 

--- a/recipes/libsigcpp/3.0.0/test_package/conanfile.py
+++ b/recipes/libsigcpp/3.0.0/test_package/conanfile.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import os
 from conans import ConanFile, CMake, tools
 


### PR DESCRIPTION
Specify library name and version:  **libsigcpp/3.0.0**

The project libsigcpp is only built as shared lib: 
https://github.com/libsigcplusplus/libsigcplusplus/blob/3.0.0/sigc++/CMakeLists.txt#L26

I also remove fPIC as there is no reason for building shared without fPIC.

Related to https://github.com/conan-io/hooks/issues/217

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
