### PR TITLE
vorbis: fix cmake_find_package name

### DIFF
--- a/recipes/vorbis/all/CMakeLists.txt
+++ b/recipes/vorbis/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/vorbis/all/CMakeLists.txt
+++ b/recipes/vorbis/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-add_subdirectory("source_subfolder")
+add_subdirectory(source_subfolder)

--- a/recipes/vorbis/all/conandata.yml
+++ b/recipes/vorbis/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "1.3.6":
     url: "https://github.com/xiph/vorbis/archive/v1.3.6.tar.gz"
     sha256: "43fc4bc34f13da15b8acfa72fd594678e214d1cab35fc51d3a54969a725464eb"
+patches:
+  "1.3.6":
+    - patch_file: "patches/0001-linux-link-m.patch"
+      base_path: "source_subfolder"

--- a/recipes/vorbis/all/conandata.yml
+++ b/recipes/vorbis/all/conandata.yml
@@ -6,5 +6,5 @@ patches:
   "1.3.6":
     - patch_file: "patches/0001-linux-link-m.patch"
       base_path: "source_subfolder"
-    - patch_file: "patches/0002-use-ogg-cmake_find_package-target.patch"
-      base_path: "source_subfolder"
+#    - patch_file: "patches/0002-use-ogg-cmake_find_package-target.patch"
+#      base_path: "source_subfolder"

--- a/recipes/vorbis/all/conandata.yml
+++ b/recipes/vorbis/all/conandata.yml
@@ -6,3 +6,5 @@ patches:
   "1.3.6":
     - patch_file: "patches/0001-linux-link-m.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0002-use-ogg-cmake_find_package-target.patch"
+      base_path: "source_subfolder"

--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -1,6 +1,5 @@
 from conans import ConanFile, tools, CMake
 import os
-import glob
 
 
 class VorbisConan(ConanFile):
@@ -10,11 +9,16 @@ class VorbisConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://xiph.org/vorbis/"
     license = "BSD-3-Clause"
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = "CMakeLists.txt", "patches/**"
     settings = "os", "arch", "build_type", "compiler"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
-    requires = "ogg/1.3.4"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
     generators = "cmake"
 
     _cmake = None
@@ -22,6 +26,9 @@ class VorbisConan(ConanFile):
     @property
     def _source_subfolder(self):
         return  "source_subfolder"
+
+    def requirements(self):
+        self.requires("ogg/1.3.4")
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -44,14 +51,6 @@ class VorbisConan(ConanFile):
         return self._cmake
 
     def build(self):
-        # if self.settings.os == "Windows":
-        #     with tools.chdir(self._source_subfolder):
-        #         tools.replace_in_file("vorbis.pc.in", "Libs.private: -lm", "Libs.private:")
-        # elif self.settings.os == "Linux":
-        #     if "LDFLAGS" in os.environ:
-        #         os.environ["LDFLAGS"] = os.environ["LDFLAGS"] + " -lm"
-        #     else:
-        #         os.environ["LDFLAGS"] = "-lm"
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -63,8 +62,6 @@ class VorbisConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        # self.cpp_info.filenames["cmake_find_package_multi"] = "Vorbis"
-        # self.cpp_info.filenames["cmake_find_package_multi"] = "Vorbis"
         self.cpp_info.names["cmake_find_package"] = "Vorbis"
         self.cpp_info.names["cmake_find_package_multi"] = "Vorbis"
 
@@ -93,5 +90,3 @@ class VorbisConan(ConanFile):
 
         if self.settings.os == "Linux":
             self.cpp_info.components["libvorbis"].system_libs.append("m")
-            self.cpp_info.components["libvorbisenc"].system_libs.append("m")
-            self.cpp_info.components["libvorbisfile"].system_libs.append("m")

--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -93,3 +93,5 @@ class VorbisConan(ConanFile):
 
         if self.settings.os == "Linux":
             self.cpp_info.components["libvorbis"].system_libs.append("m")
+            self.cpp_info.components["libvorbisenc"].system_libs.append("m")
+            self.cpp_info.components["libvorbisfile"].system_libs.append("m")

--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -91,6 +91,5 @@ class VorbisConan(ConanFile):
         self.cpp_info.components["Enc"].requires.append("libvorbisenc")
         self.cpp_info.components["File"].requires.append("libvorbisenc")
 
-        if not self.options.shared:
-            if self.settings.os == "Linux":
-                self.cpp_info.components["libvorbis"].system_libs.append("m")
+        if self.settings.os == "Linux":
+            self.cpp_info.components["libvorbis"].system_libs.append("m")

--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -11,12 +11,17 @@ class VorbisConan(ConanFile):
     homepage = "https://xiph.org/vorbis/"
     license = "BSD-3-Clause"
     exports_sources = ["CMakeLists.txt"]
-    _source_subfolder = "source_subfolder"
     settings = "os", "arch", "build_type", "compiler"
     options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {'shared': False, 'fPIC': True}
+    default_options = {"shared": False, "fPIC": True}
     requires = "ogg/1.3.4"
     generators = "cmake"
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return  "source_subfolder"
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -31,45 +36,61 @@ class VorbisConan(ConanFile):
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure()
+        return self._cmake
+
     def build(self):
-        if self.settings.os == 'Windows':
-            with tools.chdir(self._source_subfolder):
-                tools.replace_in_file('vorbis.pc.in', 'Libs.private: -lm', 'Libs.private:')
-        elif self.settings.os == "Linux":
-            if 'LDFLAGS' in os.environ:
-                os.environ['LDFLAGS'] = os.environ['LDFLAGS'] + ' -lm'
-            else:
-                os.environ['LDFLAGS'] = '-lm'
-        cmake = CMake(self)
-        cmake.configure()
+        # if self.settings.os == "Windows":
+        #     with tools.chdir(self._source_subfolder):
+        #         tools.replace_in_file("vorbis.pc.in", "Libs.private: -lm", "Libs.private:")
+        # elif self.settings.os == "Linux":
+        #     if "LDFLAGS" in os.environ:
+        #         os.environ["LDFLAGS"] = os.environ["LDFLAGS"] + " -lm"
+        #     else:
+        #         os.environ["LDFLAGS"] = "-lm"
+        cmake = self._configure_cmake()
         cmake.build()
 
     def package(self):
-        self.copy("include/vorbis/*", ".", "%s" % self._source_subfolder, keep_path=True)
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
 
-        if self.settings.compiler == "Visual Studio":
-            if self.options.shared:
-                self.copy(pattern="*.dll", dst="bin", keep_path=False)
-            self.copy(pattern="*.lib", dst="lib", keep_path=False)
-        else:
-            if self.options.shared:
-                if self.settings.os == "Macos":
-                    self.copy(pattern="*.dylib", dst="lib", keep_path=False)
-                elif self.settings.os == "Windows":
-                    self.copy(pattern="*.dll.a", dst="lib", keep_path=False)
-                    self.copy(pattern="*.dll", dst="bin", keep_path=False)
-                else:
-                    self.copy(pattern="*.so*", dst="lib", keep_path=False)
-            else:
-                self.copy(pattern="*.a", dst="lib", keep_path=False)
-        for pdb_file in glob.glob(os.path.join(self.package_folder, "bin", "*.pdb")):
-            os.unlink(pdb_file)
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.libs = ['vorbisfile', 'vorbisenc', 'vorbis']
-        if self.settings.os == "Linux":
-            self.cpp_info.system_libs.append("m")
-        self.cpp_info.names["cmake_find_package"] = 'VORBIS'
-        self.cpp_info.names["cmake_find_package_multi"] = 'VORBIS'
-        self.cpp_info.names['pkg_config'] = 'vorbis'
+        # self.cpp_info.filenames["cmake_find_package_multi"] = "Vorbis"
+        # self.cpp_info.filenames["cmake_find_package_multi"] = "Vorbis"
+        self.cpp_info.names["cmake_find_package"] = "Vorbis"
+        self.cpp_info.names["cmake_find_package_multi"] = "Vorbis"
+
+        self.cpp_info.components["libvorbis"].libs = ["vorbis"]
+        self.cpp_info.components["libvorbis"].requires = ["ogg::ogg"]
+        self.cpp_info.components["libvorbis"].names["pkgconfig"] = "vorbis"
+        self.cpp_info.components["libvorbis"].names["cmake_find_package"] = "vorbis"
+        self.cpp_info.components["libvorbis"].names["cmake_find_package_multi"] = "vorbis"
+
+        self.cpp_info.components["libvorbisenc"].libs = ["vorbisenc"]
+        self.cpp_info.components["libvorbisenc"].requires = ["libvorbis"]
+        self.cpp_info.components["libvorbisenc"].names["pkgconfig"] = "vorbisenc"
+        self.cpp_info.components["libvorbisenc"].names["cmake_find_package"] = "vorbisenc"
+        self.cpp_info.components["libvorbisenc"].names["cmake_find_package_multi"] = "vorbisenc"
+
+        self.cpp_info.components["libvorbisfile"].libs = ["vorbisfile"]
+        self.cpp_info.components["libvorbisfile"].requires = ["libvorbis"]
+        self.cpp_info.components["libvorbisfile"].names["pkgconfig"] = "vorbisfile"
+        self.cpp_info.components["libvorbisfile"].names["cmake_find_package"] = "vorbisfile"
+        self.cpp_info.components["libvorbisfile"].names["cmake_find_package_multi"] = "vorbisfile"
+
+        # VorbisConfig.cmake defines components 'Enc' and 'File',
+        # which create the imported targets Vorbs::vorbisenc and Vorbis::vorbisfile
+        self.cpp_info.components["Enc"].requires.append("libvorbisenc")
+        self.cpp_info.components["File"].requires.append("libvorbisenc")
+
+        if not self.options.shared:
+            if self.settings.os == "Linux":
+                self.cpp_info.components["libvorbis"].system_libs.append("m")

--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -19,7 +19,7 @@ class VorbisConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     _cmake = None
 
@@ -51,6 +51,8 @@ class VorbisConan(ConanFile):
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/vorbis/all/patches/0001-linux-link-m.patch
+++ b/recipes/vorbis/all/patches/0001-linux-link-m.patch
@@ -1,0 +1,10 @@
+--- lib/CMakeLists.txt
++++ lib/CMakeLists.txt
+@@ -106,3 +106,7 @@
+     )
+     target_link_libraries(vorbis ${OGG_LIBRARIES})
+ endif()
++
++if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
++    target_link_libraries(vorbis m)
++endif()

--- a/recipes/vorbis/all/patches/0002-use-ogg-cmake_find_package-target.patch
+++ b/recipes/vorbis/all/patches/0002-use-ogg-cmake_find_package-target.patch
@@ -1,0 +1,31 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -53,17 +53,17 @@
+ message(STATUS "Configuring ${PROJECT_NAME} ${PROJECT_VERSION}")
+ 
+ # Find ogg dependency
+-if(NOT OGG_ROOT)
+-    find_package(PkgConfig QUIET)
+-    pkg_check_modules(PC_OGG QUIET ogg)
+-    find_path(OGG_INCLUDE_DIRS NAMES ogg/ogg.h HINTS ${PC_OGG_INCLUDE_DIRS} PATH_SUFFIXES ogg)
+-    find_library(OGG_LIBRARIES NAMES ogg HINTS ${PC_OGG_LIBRARY_DIRS})
+-else()
+-    find_path(OGG_INCLUDE_DIRS NAMES ogg/ogg.h HINTS ${OGG_ROOT}/include PATH_SUFFIXES ogg)
+-    find_library(OGG_LIBRARIES NAMES ogg HINTS ${OGG_ROOT}/lib ${OGG_ROOT}/lib64)
+-endif()
+-include(FindPackageHandleStandardArgs)
+-find_package_handle_standard_args(OGG DEFAULT_MSG OGG_INCLUDE_DIRS OGG_LIBRARIES)
++find_package(Ogg REQUIRED)
++set(OGG_LIBRARIES Ogg::ogg)
++set(OGG_INCLUDE_DIRS "${Ogg_INCLUDE_DIRS}")
++#    find_path(OGG_INCLUDE_DIRS NAMES ogg/ogg.h HINTS ${PC_OGG_INCLUDE_DIRS} PATH_SUFFIXES ogg)
++#    find_library(OGG_LIBRARIES NAMES ogg HINTS ${PC_OGG_LIBRARY_DIRS})
++#else()
++#    find_path(OGG_INCLUDE_DIRS NAMES ogg/ogg.h HINTS ${OGG_ROOT}/include PATH_SUFFIXES ogg)
++#    find_library(OGG_LIBRARIES NAMES ogg HINTS ${OGG_ROOT}/lib ${OGG_ROOT}/lib64)
++#endif()
++#include(FindPackageHandleStandardArgs)
++#find_package_handle_standard_args(OGG DEFAULT_MSG OGG_INCLUDE_DIRS OGG_LIBRARIES)
+ 
+ add_subdirectory(lib)
+ 

--- a/recipes/vorbis/all/test_package/CMakeLists.txt
+++ b/recipes/vorbis/all/test_package/CMakeLists.txt
@@ -1,7 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
-
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/vorbis/all/test_package/CMakeLists.txt
+++ b/recipes/vorbis/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(Vorbis REQUIRED COMPONENTS Enc)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE Vorbis::vorbisenc)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/vorbis/all/test_package/conanfile.py
+++ b/recipes/vorbis/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/vorbis/all/test_package/conanfile.py
+++ b/recipes/vorbis/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        with tools.chdir("bin"):
-            self.run("test_package < %s > sample.ogg" % os.path.join(self.source_folder, '8kadpcm.wav'),
-                     run_environment=True)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run("{} < {} > sample.ogg".format(bin_path, os.path.join(self.source_folder, '8kadpcm.wav')), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  vorbis

Required by new libsndfile version cmake script

https://github.com/xiph/vorbis/blob/master/cmake/VorbisConfig.cmake.in

- [ ]  Depends on ogg #2608

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
