### PR TITLE
xkbcommon as static library by default

### DIFF
--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -19,7 +19,7 @@ class XkbcommonConan(ConanFile):
         "docs": [True, False]
     }
     default_options = {
-        "shared": True,
+        "shared": False,
         "fPIC": True,
         "with_x11": True,
         "with_wayland": False,
@@ -81,4 +81,3 @@ class XkbcommonConan(ConanFile):
             self.cpp_info.components['libxkbcommon-x11'].name = 'xkbcommon-x11'
             self.cpp_info.components['libxkbcommon-x11'].requires = ['libxkbcommon']
             self.cpp_info.components['libxkbcommon-x11'].requires.extend(['xorg::xcb', 'xorg::xcb-xkb'])
-

--- a/recipes/xkbcommon/all/test_package/CMakeLists.txt
+++ b/recipes/xkbcommon/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
xkbcommon has a bug related to static lib, but it's working now and there is no restriction:
https://github.com/xkbcommon/libxkbcommon/pull/85

Specify library name and version:  **xkbcommon/0.10.0**

Related to https://github.com/conan-io/hooks/issues/217

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
