### PR TITLE
Use botan as static library by default

### DIFF
--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -29,7 +29,7 @@ class BotanConan(ConanFile):
     default_options = {'amalgamation': True,
                        'with_bzip2': False,
                        'with_openssl': False,
-                       'shared': True,
+                       'shared': False,
                        'fPIC': True,
                        'single_amalgamation': False,
                        'with_sqlite3': False,

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -1,7 +1,7 @@
 import os
 from conans import ConanFile, tools
 from conans.errors import ConanException, ConanInvalidConfiguration
-from conans.model.version import Version
+from conans.tools import Version
 
 
 class BotanConan(ConanFile):
@@ -57,7 +57,7 @@ class BotanConan(ConanFile):
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.6")
         if self.options.with_openssl:
-            self.requires("openssl/1.0.2t")
+            self.requires("openssl/1.0.2u")
         if self.options.with_zlib:
             self.requires("zlib/1.2.11")
         if self.options.with_sqlite3:

--- a/recipes/botan/all/test_package/CMakeLists.txt
+++ b/recipes/botan/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Specify library name and version:  **botan/2.15.0**

Botan supports static library, no restriction found.

Related: https://github.com/conan-io/hooks/issues/217

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
