### PR TITLE
autoconf: use os/arch to allow conan cross building

### DIFF
--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -10,7 +10,7 @@ class AutoconfConan(ConanFile):
     topics = ("conan", "autoconf", "configure", "build")
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
     exports_sources = "patches/**"
-    settings = "os_build", "arch_build"
+    settings = "os", "arch"
     _autotools = None
 
     @property
@@ -42,7 +42,7 @@ class AutoconfConan(ConanFile):
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         datarootdir = self._datarootdir
         prefix = self.package_folder
-        if self.settings.os_build == "Windows":
+        if self.settings.os == "Windows":
             datarootdir = tools.unix_path(datarootdir)
             prefix = tools.unix_path(prefix)
         conf_args = [
@@ -68,7 +68,7 @@ class AutoconfConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "info"))
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "man"))
 
-        if self.settings.os_build == "Windows":
+        if self.settings.os == "Windows":
             binpath = os.path.join(self.package_folder, "bin")
             for filename in os.listdir(binpath):
                 fullpath = os.path.join(binpath, filename)
@@ -90,25 +90,25 @@ class AutoconfConan(ConanFile):
         self.env_info.AC_MACRODIR = ac_macrodir
 
         autoconf = os.path.join(self.package_folder, "bin", "autoconf")
-        if self.settings.os_build == "Windows":
+        if self.settings.os == "Windows":
             autoconf = tools.unix_path(autoconf) + ".exe"
         self.output.info("Setting AUTOCONF to {}".format(autoconf))
         self.env_info.AUTOCONF = autoconf
 
         autoreconf = os.path.join(self.package_folder, "bin", "autoreconf")
-        if self.settings.os_build == "Windows":
+        if self.settings.os == "Windows":
             autoreconf = tools.unix_path(autoreconf) + ".exe"
         self.output.info("Setting AUTORECONF to {}".format(autoreconf))
         self.env_info.AUTORECONF = autoreconf
 
         autoheader = os.path.join(self.package_folder, "bin", "autoheader")
-        if self.settings.os_build == "Windows":
+        if self.settings.os == "Windows":
             autoheader = tools.unix_path(autoheader) + ".exe"
         self.output.info("Setting AUTOHEADER to {}".format(autoheader))
         self.env_info.AUTOHEADER = autoheader
 
         autom4te = os.path.join(self.package_folder, "bin", "autom4te")
-        if self.settings.os_build == "Windows":
+        if self.settings.os == "Windows":
             autom4te = tools.unix_path(autom4te) + ".exe"
         self.output.info("Setting AUTOM4TE to {}".format(autom4te))
         self.env_info.AUTOM4TE = autom4te


### PR DESCRIPTION
Specify library name and version:  **autoconf/2.69**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
