### PR TITLE
freetype: Add option with_brotli

### DIFF
--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -62,7 +62,7 @@ class FreetypeConan(ConanFile):
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.get_safe("with_brotli"):
-            self.requires("brotli/1.0.7")
+            self.requires("brotli/1.0.9")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -21,13 +21,15 @@ class FreetypeConan(ConanFile):
         "with_png": [True, False],
         "with_zlib": [True, False],
         "with_bzip2": [True, False],
+        "with_brotli": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_png": True,
         "with_zlib": True,
-        "with_bzip2": True
+        "with_bzip2": True,
+        "with_brotli": True
     }
 
     _cmake = None
@@ -43,6 +45,8 @@ class FreetypeConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if tools.Version(self.version) < "2.10.2":
+            del self.options.with_brotli
 
     def configure(self):
         if self.options.shared:
@@ -57,6 +61,8 @@ class FreetypeConan(ConanFile):
             self.requires("zlib/1.2.11")
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
+        if self.options.get_safe("with_brotli"):
+            self.requires("brotli/1.0.7")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -76,6 +82,9 @@ class FreetypeConan(ConanFile):
         # TODO: Harfbuzz can be added as an option as soon as it is available.
         self._cmake.definitions["FT_WITH_HARFBUZZ"] = False
         self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz"] = True
+        if "with_brotli" in self.options:
+            self._cmake.definitions["FT_WITH_BROTLI"] = self.options.with_brotli
+            self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_BrotliDec"] = not self.options.with_brotli
         self._cmake.configure(build_dir=self._build_subfolder)
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **freetype/2.10.x**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This adds support for the `FT_WITH_BROTLI` configuration macro in FreeType, which was [added in version 2.10.2](https://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/CMakeLists.txt?h=VER-2-10-2#n71).

By default, FreeType's build system tries to be clever about which features are enabled: If it can detect an optional dependency on the system, it will enable it, otherwise it will be disabled. Crucially, *the search is not limited to the Conan package tree*; it also searches in `/usr` and could pick up `libbrotli` there. (That happened in my case, leading to linker errors down the line because the Brotli version on my system was incompatible with the FreeType version from conan-center.) Therefore, it is important that all of the optional dependencies are included in the conanfile.