### PR TITLE
libx265: fix sha256, switch sources and pass conan center checks

### DIFF
--- a/recipes/libx265/all/conandata.yml
+++ b/recipes/libx265/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   3.2.1:
-    url: "https://bitbucket.org/multicoreware/x265/downloads/x265_3.2.1.tar.gz"
-    sha256: "7cf8ed2927fcb2914cdca51c974594770da705cb43288beea62b69c53725b5d7"
+    url: "https://github.com/videolan/x265/archive/3.2.1.tar.gz"
+    sha256: "b5ee7ea796a664d6e2763f9c0ae281fac5d25892fc2cb134698547103466a06a"
 patches:
   3.2.1:
     - patch_file: "patches/0001-remove_register_classifier.patch"

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -48,7 +48,7 @@ class Libx265Conan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        os.rename("x265_{}".format(self.version), self._source_subfolder)
+        os.rename("x265-{}".format(self.version), self._source_subfolder)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/libx265/all/test_package/CMakeLists.txt
+++ b/recipes/libx265/all/test_package/CMakeLists.txt
@@ -1,7 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
-
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()


### PR DESCRIPTION
Specify library name and version:  **libx265/3.2.1**

Fixes #2587.
Fixes #2497.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
