### PR TITLE
benchmark: move system libs to proper cpp_info field

### DIFF
--- a/recipes/benchmark/all/CMakeLists.txt
+++ b/recipes/benchmark/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")

--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -82,8 +82,8 @@ class BenchmarkConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
-            self.cpp_info.libs.extend(["pthread", "rt"])
+            self.cpp_info.system_libs.extend(["pthread", "rt"])
         elif self.settings.os == "Windows":
-            self.cpp_info.libs.append("shlwapi")
+            self.cpp_info.system_libs.append("shlwapi")
         elif self.settings.os == "SunOS":
-            self.cpp_info.libs.append("kstat")
+            self.cpp_info.system_libs.append("kstat")

--- a/recipes/benchmark/all/test_package/CMakeLists.txt
+++ b/recipes/benchmark/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
**benchmark/1.5.0**

Fix location of system library dependencies.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
