### PR TITLE
inja: fix CMake imported target + cleanup

### DIFF
--- a/recipes/inja/all/CMakeLists.txt
+++ b/recipes/inja/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.11)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory(source_subfolder)

--- a/recipes/inja/all/conanfile.py
+++ b/recipes/inja/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 from conans import ConanFile, tools
 
+required_conan_version = ">=1.28.0"
 
 class InjaConan(ConanFile):
     name = "inja"
@@ -10,13 +11,16 @@ class InjaConan(ConanFile):
     description = "Inja is a template engine for modern C++, loosely inspired by jinja for python"
     topics = ("conan", "jinja2", "string templates", "templates engine")
     no_copy_source = True
-    requires = (
-        "nlohmann_json/3.9.0"
-    )
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def requirements(self):
+        self.requires("nlohmann_json/3.9.1")
+
+    def package_id(self):
+        self.info.header_only()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -28,4 +32,10 @@ class InjaConan(ConanFile):
         self.copy("*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
     def package_info(self):
-        self.info.header_only()
+        self.cpp_info.filenames["cmake_find_package"] = "inja"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "inja"
+        self.cpp_info.names["cmake_find_package"] = "pantor"
+        self.cpp_info.names["cmake_find_package_multi"] = "pantor"
+        self.cpp_info.components["libinja"].names["cmake_find_package"] = "inja"
+        self.cpp_info.components["libinja"].names["cmake_find_package_multi"] = "inja"
+        self.cpp_info.components["libinja"].requires = ["nlohmann_json::nlohmann_json"]

--- a/recipes/inja/all/test_package/CMakeLists.txt
+++ b/recipes/inja/all/test_package/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-include (${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
-target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})
-set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+find_package(inja REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} pantor::inja)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/inja/all/test_package/conanfile.py
+++ b/recipes/inja/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/inja/config.yml
+++ b/recipes/inja/config.yml
@@ -1,4 +1,3 @@
----
 versions:
   "3.0.0":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **inja/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

namespace of imported target is `pantor`: https://github.com/pantor/inja/blob/02394683b151cdb520c8fb636f3bda77ed4f965d/CMakeLists.txt#L175