### PR TITLE
libxslt: Define LIBXSLT_STATIC for static builds

### DIFF
--- a/recipes/libxslt/all/conanfile.py
+++ b/recipes/libxslt/all/conanfile.py
@@ -178,6 +178,8 @@ class LibxsltConan(ConanFile):
             else:
                 self.cpp_info.libs = ['lib%s_a' % l for l in self.cpp_info.libs]
         self.cpp_info.includedirs.append(os.path.join("include", "libxslt"))
+        if not self.options.shared:
+            self.cpp_info.defines = ["LIBXSLT_STATIC"]
         if self.settings.os == "Linux" or self.settings.os == "Macos":
             self.cpp_info.system_libs.append('m')
         if self.settings.os == "Windows":

--- a/recipes/libxslt/all/test_package/CMakeLists.txt
+++ b/recipes/libxslt/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(libxslt_tutorial)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Avoids windows link warning:
```
LINK : warning LNK4286: symbol 'xsltMaxDepth' defined in 'libxslt_a.lib(transform.obj)' is imported by '...'
```

Specify library name and version:  **libxslt/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
