### PR TITLE
kangaru: fix package id + use cmake wrapper + cache cmake

### DIFF
--- a/recipes/kangaru/all/CMakeLists.txt
+++ b/recipes/kangaru/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/kangaru/all/conandata.yml
+++ b/recipes/kangaru/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "4.2.4":
-    url: "https://github.com/gracicot/kangaru/archive/v4.2.4.zip"
-    sha256: "85a145b684f564bde1ad14b3dbbc4761e55b861c89d348888f3da4e18db72351"
+    url: "https://github.com/gracicot/kangaru/archive/v4.2.4.tar.gz"
+    sha256: "0ef74825d98165c26919ce01026533b6594faa584ea93c2f275e1f275bda9dc5"
 patches:
   "4.2.4":
      - patch_file: "patches/fix-cmake.patch"

--- a/recipes/kangaru/all/conandata.yml
+++ b/recipes/kangaru/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "4.2.4":
     url: "https://github.com/gracicot/kangaru/archive/v4.2.4.zip"
     sha256: "85a145b684f564bde1ad14b3dbbc4761e55b861c89d348888f3da4e18db72351"
+patches:
+  "4.2.4":
+     - patch_file: "patches/fix-cmake.patch"
+       base_path: "source_subfolder"

--- a/recipes/kangaru/all/conanfile.py
+++ b/recipes/kangaru/all/conanfile.py
@@ -28,6 +28,10 @@ class KangaruConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    def configure(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 11)
+
     def package_id(self):
         self.info.header_only()
 

--- a/recipes/kangaru/all/conanfile.py
+++ b/recipes/kangaru/all/conanfile.py
@@ -10,30 +10,43 @@ class KangaruConan(ConanFile):
               "DI", "IoC", "inversion of control")
     homepage = "https://github.com/gracicot/kangaru/wiki"
     url = "https://github.com/conan-io/conan-center-index"
-
+    exports_sources = ["CMakeLists.txt", "patches/**"]
+    generators = "cmake"
     settings = "os", "compiler", "build_type", "arch"
     options = {"reverse_destruction": [True, False],
                "no_exception": [True, False]}
     default_options = {"reverse_destruction": True,
                        "no_exception": False}
-    no_copy_source = True
+
+    _cmake = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def package_id(self):
+        self.info.header_only()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename(self.name + "-" + self.version, self._source_subfolder)
 
     def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["KANGARU_REVERSE_DESTRUCTION"] = self.options.reverse_destruction
-        cmake.definitions["KANGARU_NO_EXCEPTION"] = self.options.no_exception
-        cmake.configure(source_folder=self._source_subfolder)
-        return cmake
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["KANGARU_REVERSE_DESTRUCTION"] = self.options.reverse_destruction
+        self._cmake.definitions["KANGARU_NO_EXCEPTION"] = self.options.no_exception
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -42,6 +55,3 @@ class KangaruConan(ConanFile):
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib"))
         self.copy(os.path.join(self._source_subfolder, "LICENSE"), "licenses")
-
-    def package_id(self):
-        self.info.header_only()

--- a/recipes/kangaru/all/conanfile.py
+++ b/recipes/kangaru/all/conanfile.py
@@ -33,7 +33,7 @@ class KangaruConan(ConanFile):
             tools.check_min_cppstd(self, 11)
 
     def package_id(self):
-        self.info.header_only()
+        self.info.settings.clear()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/kangaru/all/patches/fix-cmake.patch
+++ b/recipes/kangaru/all/patches/fix-cmake.patch
@@ -1,0 +1,38 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,7 +31,7 @@ endif()
+ 
+ configure_file(
+ 	cmake/config/config.hpp.in
+-	generated/include/kangaru/detail/config.hpp
++	${CMAKE_CURRENT_BINARY_DIR}/generated/include/kangaru/detail/config.hpp
+ 	@ONLY
+ )
+ 
+@@ -48,7 +48,7 @@ target_compile_features(kangaru INTERFACE cxx_std_11)
+ target_include_directories(kangaru INTERFACE
+ 	$<INSTALL_INTERFACE:${KANGARU_INSTALL_INCLUDE_DIR}>
+ 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-	$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/generated/include>
++	$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated/include>
+ )
+ 
+ if(KANGARU_BUILD_EXAMPLES)
+@@ -82,7 +82,7 @@ if(KANGARU_INSTALL)
+ 	# build tree package config
+ 	configure_file(
+ 		cmake/config/kangaruBuildConfig.cmake.in
+-		kangaruConfig.cmake
++		${CMAKE_CURRENT_BINARY_DIR}/kangaruConfig.cmake
+ 		@ONLY
+ 	)
+ 	
+@@ -95,7 +95,7 @@ if(KANGARU_INSTALL)
+ 	)
+ 	
+ 	install(
+-		DIRECTORY include/kangaru ${CMAKE_BINARY_DIR}/generated/include/kangaru
++		DIRECTORY include/kangaru ${CMAKE_CURRENT_BINARY_DIR}/generated/include/kangaru
+ 		DESTINATION ${KANGARU_INSTALL_INCLUDE_DIR} FILES_MATCHING PATTERN "*.hpp"
+ 	)
+ 	

--- a/recipes/kangaru/all/test_package/CMakeLists.txt
+++ b/recipes/kangaru/all/test_package/CMakeLists.txt
@@ -1,10 +1,12 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(kangaru REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} kangaru::kangaru) # TODO: remove kangaru:: namespace when fixed in cpp_info of conanfile.py
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/recipes/kangaru/all/test_package/conanfile.py
+++ b/recipes/kangaru/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **kangaru/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

cmake wrapper requires a patch, submitted to upstream: https://github.com/gracicot/kangaru/pull/99