### PR TITLE
libpqxx: fix cmake import target + delete fPIC option if shared

### DIFF
--- a/recipes/libpqxx/all/conanfile.py
+++ b/recipes/libpqxx/all/conanfile.py
@@ -32,6 +32,9 @@ class LibpqxxRecipe(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
         compiler = str(self.settings.compiler)
         compiler_version = Version(self.settings.compiler.version.value)
 

--- a/recipes/libpqxx/all/conanfile.py
+++ b/recipes/libpqxx/all/conanfile.py
@@ -92,7 +92,7 @@ class LibpqxxRecipe(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.libs = ["pqxx"]
-
+        self.cpp_info.components["pqxx"].libs = ["pqxx"]
+        self.cpp_info.components["pqxx"].requires = ["libpq::libpq"]
         if self.settings.os == "Windows":
-            self.cpp_info.system_libs = ["wsock32", "ws2_32"]
+            self.cpp_info.components["pqxx"].system_libs = ["wsock32", "ws2_32"]

--- a/recipes/libpqxx/all/conanfile.py
+++ b/recipes/libpqxx/all/conanfile.py
@@ -16,7 +16,7 @@ class LibpqxxRecipe(ConanFile):
     exports_sources = ["CMakeLists.txt", "patches/*"]
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
-    requires = "libpq/11.5"
+
     _cmake = None
 
     @property
@@ -50,6 +50,9 @@ class LibpqxxRecipe(ConanFile):
 
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "17")
+
+    def requirements(self):
+        self.requires("libpq/12.2")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/libpqxx/all/test_package/CMakeLists.txt
+++ b/recipes/libpqxx/all/test_package/CMakeLists.txt
@@ -1,11 +1,13 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.8)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(libpqxx REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} libpqxx::pqxx)
 set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON

--- a/recipes/libpqxx/all/test_package/conanfile.py
+++ b/recipes/libpqxx/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **libpqxx/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

config file: https://github.com/jtv/libpqxx/blob/78b3e1bb9afed96dd7950e9913d2b26676cb9b13/CMakeLists.txt#L39
exported target: https://github.com/jtv/libpqxx/blob/78b3e1bb9afed96dd7950e9913d2b26676cb9b13/src/CMakeLists.txt#L63 + https://github.com/jtv/libpqxx/blob/78b3e1bb9afed96dd7950e9913d2b26676cb9b13/CMakeLists.txt#L48
