### PR TITLE
cpp-taskflow: fix hooks + deprecated attribute

### DIFF
--- a/recipes/cpp-taskflow/all/conanfile.py
+++ b/recipes/cpp-taskflow/all/conanfile.py
@@ -1,9 +1,9 @@
 import os
-
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 from conans.model.version import Version
 
+required_conan_version = ">=1.28.0"
 
 class CppTaskflowConan(ConanFile):
     name = "cpp-taskflow"
@@ -12,16 +12,15 @@ class CppTaskflowConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/cpp-taskflow/cpp-taskflow"
     license = "MIT"
-
     no_copy_source = True
-
     settings = "os", "compiler"
+    deprecated = "taskflow"
 
-    _source_subfolder = "source_subfolder"
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
     def configure(self):
-        self.output.warn("[DEPRECATED] Package 'cpp-taskflow/{0}' is being deprecated. Change yours to require 'taskflow/{0}' instead".format(self.version))
-
         compiler = str(self.settings.compiler)
         compiler_version = tools.Version(self.settings.compiler.version)
         min_req_cppstd = "17" if tools.Version(self.version) <= "2.2.0" else "14"

--- a/recipes/cpp-taskflow/all/test_package/CMakeLists.txt
+++ b/recipes/cpp-taskflow/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Specify library name and version:  **cpp-taskflow/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
