### PR TITLE
flatbuffers: fix cmake names + cache cmake

### DIFF
--- a/recipes/flatbuffers/all/CMakeLists.txt
+++ b/recipes/flatbuffers/all/CMakeLists.txt
@@ -1,7 +1,6 @@
-cmake_minimum_required(VERSION 2.8.11)
-project(conancmakewrapper)
+cmake_minimum_required(VERSION 3.4)
+project(cmake_wrapper)
 
-message(STATUS "Conan FlatBuffers Wrapper")
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 

--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -31,6 +31,15 @@ class FlatbuffersConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.header_only:
+            del self.options.fPIC
+            del self.options.shared
+        elif self.options.shared:
+            del self.options.fPIC
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 11)
+
     def package_id(self):
         if self.options.header_only:
             self.info.header_only()

--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -1,5 +1,3 @@
-"""Conan recipe package for Google FlatBuffers
-"""
 import glob
 import os
 import shutil
@@ -19,6 +17,8 @@ class FlatbuffersConan(ConanFile):
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
 
+    _cmake = None
+
     @property
     def _source_subfolder(self):
         return "source_subfolder"
@@ -27,24 +27,30 @@ class FlatbuffersConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def package_id(self):
+        if self.options.header_only:
+            self.info.header_only()
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
     def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["FLATBUFFERS_BUILD_TESTS"] = False
-        cmake.definitions["FLATBUFFERS_BUILD_SHAREDLIB"] = self.options.shared
-        cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = not self.options.shared
-        cmake.definitions["FLATBUFFERS_BUILD_FLATC"] = False
-        cmake.definitions["FLATBUFFERS_BUILD_FLATHASH"] = False
-        cmake.configure(build_folder=self._build_subfolder)
-        return cmake
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["FLATBUFFERS_BUILD_TESTS"] = False
+        self._cmake.definitions["FLATBUFFERS_BUILD_SHAREDLIB"] = self.options.shared
+        self._cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = not self.options.shared
+        self._cmake.definitions["FLATBUFFERS_BUILD_FLATC"] = False
+        self._cmake.definitions["FLATBUFFERS_BUILD_FLATHASH"] = False
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
 
     def build(self):
         if not self.options.header_only:
@@ -65,10 +71,6 @@ class FlatbuffersConan(ConanFile):
                 tools.mkdir(os.path.join(self.package_folder, "bin"))
                 for dll_path in glob.glob(os.path.join(self.package_folder, "lib", "*.dll")):
                     shutil.move(dll_path, os.path.join(self.package_folder, "bin", os.path.basename(dll_path)))
-
-    def package_id(self):
-        if self.options.header_only:
-            self.info.header_only()
 
     def package_info(self):
         if not self.options.header_only:

--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -24,10 +24,6 @@ class FlatbuffersConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -59,7 +55,7 @@ class FlatbuffersConan(ConanFile):
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = not self.options.shared
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATC"] = False
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATHASH"] = False
-        self._cmake.configure(build_folder=self._build_subfolder)
+        self._cmake.configure()
         return self._cmake
 
     def build(self):

--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from conans import ConanFile, CMake, tools
 
+required_conan_version = ">=1.28.0"
 
 class FlatbuffersConan(ConanFile):
     name = "flatbuffers"
@@ -82,7 +83,14 @@ class FlatbuffersConan(ConanFile):
                     shutil.move(dll_path, os.path.join(self.package_folder, "bin", os.path.basename(dll_path)))
 
     def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "Flatbuffers"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "Flatbuffers"
+        self.cpp_info.names["cmake_find_package"] = "flatbuffers"
+        self.cpp_info.names["cmake_find_package_multi"] = "flatbuffers"
         if not self.options.header_only:
-            self.cpp_info.libs = tools.collect_libs(self)
+            cmake_target = "flatbuffers_shared" if self.options.shared else "flatbuffers"
+            self.cpp_info.components["libflatbuffers"].names["cmake_find_package"] = cmake_target
+            self.cpp_info.components["libflatbuffers"].names["cmake_find_package_multi"] = cmake_target
+            self.cpp_info.components["libflatbuffers"].libs = tools.collect_libs(self)
             if self.settings.os == "Linux":
-                self.cpp_info.system_libs.append("m")
+                self.cpp_info.components["libflatbuffers"].system_libs.append("m")

--- a/recipes/flatbuffers/all/test_package/CMakeLists.txt
+++ b/recipes/flatbuffers/all/test_package/CMakeLists.txt
@@ -1,14 +1,18 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(Flatbuffers REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-
-if (FLATBUFFERS_HEADER_ONLY)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE FLATBUFFERS_HEADER_ONLY=1)
-endif(FLATBUFFERS_HEADER_ONLY)
-
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+if(FLATBUFFERS_HEADER_ONLY)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE FLATBUFFERS_HEADER_ONLY)
+endif()
+if(FLATBUFFERS_SHARED)
+  target_link_libraries(${PROJECT_NAME} flatbuffers::flatbuffers_shared)
+else()
+  target_link_libraries(${PROJECT_NAME} flatbuffers::flatbuffers)
+endif()
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/flatbuffers/all/test_package/conanfile.py
+++ b/recipes/flatbuffers/all/test_package/conanfile.py
@@ -1,17 +1,15 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, CMake, tools
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
         cmake.definitions["FLATBUFFERS_HEADER_ONLY"] = self.options["flatbuffers"].header_only
+        cmake.definitions["FLATBUFFERS_SHARED"] = not self.options["flatbuffers"].header_only and self.options["flatbuffers"].shared
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **flatbuffers/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

config file: https://github.com/google/flatbuffers/blob/49f4948f06e6130b00c42be729ca989786c24575/CMakeLists.txt#L553
static target: https://github.com/google/flatbuffers/blob/49f4948f06e6130b00c42be729ca989786c24575/CMakeLists.txt#L572
shared target: https://github.com/google/flatbuffers/blob/49f4948f06e6130b00c42be729ca989786c24575/CMakeLists.txt#L611