### PR TITLE
Pass --enable-debug to libcurl when build_type is Debug

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -226,6 +226,9 @@ class LibcurlConan(ConanFile):
         if not self.options.with_ldap:
             params.append("--disable-ldap")
 
+        if self.settings.build_type == "Debug":
+           params.append("--enable-debug")
+
         # Cross building flags
         if tools.cross_building(self.settings):
             if self.settings.os == "Linux" and "arm" in self.settings.arch:


### PR DESCRIPTION
Specify library name and version:  **libcurl/7.71.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Fixes #2697