### PR TITLE
libwebsockets: partially fix cmake names + del fPIC option if shared

### DIFF
--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -190,10 +190,6 @@ class LibwebsocketsConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -425,7 +421,7 @@ class LibwebsocketsConan(ConanFile):
 
 
 
-        self._cmake.configure(build_folder=self._build_subfolder)
+        self._cmake.configure()
         return self._cmake
 
     def _patch_sources(self):

--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -451,13 +451,40 @@ class LibwebsocketsConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        # TOTO: CMake imported target shouldn't be namespaced
+        cmake_target = "websockets_shared" if self.options.shared else "websockets"
+        pkgconfig_name = "libwebsockets" if self.options.shared else "libwebsockets_static"
+        self.cpp_info.names["cmake_find_package"] = "Libwebsockets"
+        self.cpp_info.names["cmake_find_package_multi"] = "Libwebsockets"
+        self.cpp_info.names["pkg_config"] = pkgconfig_name
+        self.cpp_info.components["_libwebsockets"].names["cmake_find_package"] = cmake_target
+        self.cpp_info.components["_libwebsockets"].names["cmake_find_package_multi"] = cmake_target
+        self.cpp_info.components["_libwebsockets"].names["pkgconfig_name"] = pkgconfig_name
+        self.cpp_info.components["_libwebsockets"].libs = tools.collect_libs(self)
         if self.settings.os == "Windows":
-            self.cpp_info.system_libs.append("ws2_32")
+            self.cpp_info.components["_libwebsockets"].system_libs.append("ws2_32")
         elif self.settings.os == "Linux":
-            self.cpp_info.system_libs.extend(["dl", "m"])
-
-        if self.options.shared:
-            self.cpp_info.names["pkg_config"] = "libwebsockets"
-        else:
-            self.cpp_info.names["pkg_config"] = "libwebsockets_static"
+            self.cpp_info.components["_libwebsockets"].system_libs.extend(["dl", "m"])
+        if self.options.with_libuv:
+            self.cpp_info.components["_libwebsockets"].requires.append("libuv::libuv")
+        if self.options.with_libevent == "libevent":
+            self.cpp_info.components["_libwebsockets"].requires.append("libevent::libevent")
+        elif self.options.with_libevent == "libev":
+            self.cpp_info.components["_libwebsockets"].requires.append("libev::libev")
+        if self.options.with_zlib == "zlib":
+            self.cpp_info.components["_libwebsockets"].requires.append("zlib::zlib")
+        elif self.options.with_zlib == "miniz":
+            self.cpp_info.components["_libwebsockets"].requires.append("miniz::miniz")
+        if self.options.with_libmount:
+            self.cpp_info.components["_libwebsockets"].requires.append("libmount::libmount")
+        if self.options.with_sqlite3:
+            self.cpp_info.components["_libwebsockets"].requires.append("sqlite3::sqlite3")
+        if self.options.with_ssl == "openssl":
+            self.cpp_info.components["_libwebsockets"].requires.append("openssl::openssl")
+        elif self.options.with_ssl in ["mbedtls-apache", "mbedtls-gpl"]:
+            self.cpp_info.components["_libwebsockets"].requires.append("mbedtls::mbedtls")
+        elif self.options.with_ssl == "wolfssl":
+            self.cpp_info.components["_libwebsockets"].requires.append("wolfssl::wolfssl")
+        if self.options.with_hubbub:
+            # TODO - Add hubbub package when available.
+            pass

--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -447,7 +447,7 @@ class LibwebsocketsConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        # TOTO: CMake imported target shouldn't be namespaced
+        # TODO: CMake imported target shouldn't be namespaced
         cmake_target = "websockets_shared" if self.options.shared else "websockets"
         pkgconfig_name = "libwebsockets" if self.options.shared else "libwebsockets_static"
         self.cpp_info.names["cmake_find_package"] = "Libwebsockets"

--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -199,6 +199,8 @@ class LibwebsocketsConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
@@ -237,7 +239,6 @@ class LibwebsocketsConan(ConanFile):
         if self.options.with_hubbub:
             raise ConanInvalidConfiguration("Library hubbub not implemented (yet) in CCI")
             # TODO - Add hubbub package when available.
-          
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/libwebsockets/all/test_package/CMakeLists.txt
+++ b/recipes/libwebsockets/all/test_package/CMakeLists.txt
@@ -1,9 +1,16 @@
-cmake_minimum_required(VERSION 2.8.11)
-project(test_package)
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(Libwebsockets REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+# TODO: remove Libwebsockets:: namespace when fixed in cpp_info of recipe
+if(LIBWEBSOCKETS_SHARED)
+  target_link_libraries(${PROJECT_NAME} Libwebsockets::websockets_shared)
+else()
+  target_link_libraries(${PROJECT_NAME} Libwebsockets::websockets)
+endif()
 set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)

--- a/recipes/libwebsockets/all/test_package/conanfile.py
+++ b/recipes/libwebsockets/all/test_package/conanfile.py
@@ -4,13 +4,14 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["LIBWEBSOCKETS_SHARED"] = self.options["libwebsockets"].shared
         cmake.configure()
         cmake.build()
-        
+
     def test(self):
         if not tools.cross_building(self.settings):
             self.run(os.path.join("bin", "test_package"), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **libwebsockets/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

config file: https://github.com/warmcat/libwebsockets/blob/27841ba451e069ce85ffe49a99a6b404ef468813/CMakeLists.txt#L935
export targets (no namespace): https://github.com/warmcat/libwebsockets/blob/27841ba451e069ce85ffe49a99a6b404ef468813/CMakeLists.txt#L943
targets can be quickly found here: https://github.com/warmcat/libwebsockets/blob/dd3bae8c7147891507020e22f28781e8a4357456/lib/CMakeLists.txt#L250