### PR TITLE
libcurl/7.71.1 : fix wolfssl path not specified to configure

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -199,7 +199,8 @@ class LibcurlConan(ConanFile):
             openssl_path = self.deps_cpp_info["openssl"].rootpath.replace("\\", "/")
             params.append("--with-ssl=%s" % openssl_path)
         elif self.options.with_wolfssl:
-            params.append("--with-wolfssl")
+            wolfssl_path = self.deps_cpp_info["wolfssl"].rootpath.replace("\\", "/")
+            params.append("--with-wolfssl=%s" % wolfssl_path)
             params.append("--without-ssl")
         else:
             params.append("--without-ssl")


### PR DESCRIPTION
similar to openssl, wolfssl path needs to be specified while
executing configure script for libcurl with-wolfssl option

Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
