### PR TITLE
Remove lingering BSL license statements.

### DIFF
--- a/recipes/lyra/all/test_package/CMakeLists.txt
+++ b/recipes/lyra/all/test_package/CMakeLists.txt
@@ -1,8 +1,3 @@
-# Copyright Rene Rivera 2019
-# Distributed under the Boost Software License, Version 1.0.
-# (See accompanying file LICENSE.txt or copy at
-# http://www.boost.org/LICENSE_1_0.txt)
-
 cmake_minimum_required(VERSION 3.0.0)
 project(test_package CXX)
 

--- a/recipes/lyra/all/test_package/test.cpp
+++ b/recipes/lyra/all/test_package/test.cpp
@@ -1,10 +1,3 @@
-/*
-Copyright Rene Rivera 2019
-Distributed under the Boost Software License, Version 1.0.
-(See accompanying file LICENSE.txt or copy at
-http://www.boost.org/LICENSE_1_0.txt)
-*/
-
 #include <lyra/lyra.hpp>
 
 int main(int argc, const char** argv)


### PR DESCRIPTION
Not ideal as MIT is a more restrictive license than BS. And of
questionable benefit as it was present only in the test sources.
But it makes things slightly more consistent.

Specify library name and version:  **lyra/x.y**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
