### PR TITLE
pcre: add components + cache cmake + several fixes

### DIFF
--- a/recipes/pcre/all/CMakeLists.txt
+++ b/recipes/pcre/all/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
-message(STATUS "Conan CMake Wrapper")
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 

--- a/recipes/pcre/all/conanfile.py
+++ b/recipes/pcre/all/conanfile.py
@@ -108,13 +108,28 @@ class PCREConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        if self.settings.os == "Windows" and self.settings.build_type == "Debug":
-            self.cpp_info.libs = ["pcreposixd", "pcred"]
-        else:
-            self.cpp_info.libs = ["pcreposix", "pcre"]
-        if not self.options.shared:
-            self.cpp_info.defines.append("PCRE_STATIC=1")
-        self.cpp_info.names["pkg_config"] = "libpcre"
-
         self.cpp_info.names["cmake_find_package"] = "PCRE"
         self.cpp_info.names["cmake_find_package_multi"] = "PCRE"
+        # pcre
+        self.cpp_info.components["libpcre"].names["pkg_config"] = "libpcre"
+        self.cpp_info.components["libpcre"].libs = [self._lib_name("pcre")]
+        if self.options.with_bzip2:
+            self.cpp_info.components["libpcre"].requires.append("bzip2::bzip2")
+        if self.options.with_zlib:
+            self.cpp_info.components["libpcre"].requires.append("zlib::zlib")
+        if not self.options.shared:
+            self.cpp_info.components["libpcre"].defines.append("PCRE_STATIC=1")
+        # pcreposix
+        self.cpp_info.components["libpcreposix"].names["pkg_config"] = "libpcreposix"
+        self.cpp_info.components["libpcreposix"].libs = [self._lib_name("pcreposix")]
+        self.cpp_info.components["libpcreposix"].requires = ["libpcre"]
+        # pcrecpp
+        if self.options.build_pcrecpp:
+            self.cpp_info.components["libpcrecpp"].names["pkg_config"] = "libpcrecpp"
+            self.cpp_info.components["libpcrecpp"].libs = [self._lib_name("pcrecpp")]
+            self.cpp_info.components["libpcrecpp"].requires = ["libpcre"]
+
+    def _lib_name(self, name):
+        if self.settings.os == "Windows" and self.settings.build_type == "Debug":
+            return name + "d"
+        return name

--- a/recipes/pcre/all/conanfile.py
+++ b/recipes/pcre/all/conanfile.py
@@ -24,15 +24,15 @@ class PCREConan(ConanFile):
         "with_unicode_properties": [True, False]
     }
     default_options = {
-        'shared': False,
-        'fPIC': True,
-        'with_bzip2': True,
-        'with_zlib': True,
-        'with_jit': False,
-        'build_pcrecpp': False,
-        'build_pcregrep': False,
-        'with_utf': False,
-        'with_unicode_properties': False
+        "shared": False,
+        "fPIC": True,
+        "with_bzip2": True,
+        "with_zlib": True,
+        "with_jit": False,
+        "build_pcrecpp": False,
+        "build_pcregrep": False,
+        "with_utf": False,
+        "with_unicode_properties": False
     }
 
     @property
@@ -104,13 +104,13 @@ class PCREConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        if self.settings.os == "Windows" and self.settings.build_type == 'Debug':
-            self.cpp_info.libs = ['pcreposixd', 'pcred']
+        if self.settings.os == "Windows" and self.settings.build_type == "Debug":
+            self.cpp_info.libs = ["pcreposixd", "pcred"]
         else:
-            self.cpp_info.libs = ['pcreposix', 'pcre']
+            self.cpp_info.libs = ["pcreposix", "pcre"]
         if not self.options.shared:
             self.cpp_info.defines.append("PCRE_STATIC=1")
-        self.cpp_info.names['pkg_config'] = 'libpcre'
+        self.cpp_info.names["pkg_config"] = "libpcre"
 
         self.cpp_info.names["cmake_find_package"] = "PCRE"
         self.cpp_info.names["cmake_find_package_multi"] = "PCRE"

--- a/recipes/pcre/all/conanfile.py
+++ b/recipes/pcre/all/conanfile.py
@@ -129,6 +129,11 @@ class PCREConan(ConanFile):
             self.cpp_info.components["libpcrecpp"].libs = [self._lib_name("pcrecpp")]
             self.cpp_info.components["libpcrecpp"].requires = ["libpcre"]
 
+        if self.options.build_pcregrep:
+            bin_path = os.path.join(self.package_folder, "bin")
+            self.output.info("Appending PATH environment variable: {}".format(bin_path))
+            self.env_info.PATH.append(bin_path)
+
     def _lib_name(self, name):
         if self.settings.os == "Windows" and self.settings.build_type == "Debug":
             return name + "d"

--- a/recipes/pcre/all/conanfile.py
+++ b/recipes/pcre/all/conanfile.py
@@ -50,6 +50,8 @@ class PCREConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         if not self.options.build_pcrecpp:
             del self.settings.compiler.libcxx
             del self.settings.compiler.cppstd

--- a/recipes/pcre/all/test_package/CMakeLists.txt
+++ b/recipes/pcre/all/test_package/CMakeLists.txt
@@ -6,6 +6,3 @@ conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-if (PCRE_STATIC)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE PCRE_STATIC=1)
-endif (PCRE_STATIC)


### PR DESCRIPTION
Specify library name and version:  **pcre/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Modifications:
- add components (pkgconfig): see https://www.pcre.org/original/readme.txt
- add `build_pcre_8`, `build_pcre_16` and `build_pcre_32` options
- `zlib` and `bzip2` are optional dependencies of `pcregrep` executable
- cache cmake
- add `pcrecpp` lib in cpp_info if `build_pcrecpp=True`
- add bin to PATH env var for `pcregrep` executable if `build_pcregrep=True`
- delete fPIC option if shared

I think that CMake names shouldn't have been added, because they are unofficial. Anyway, I didn't remove those lines.