### PR TITLE
pcre2: add components + delete fPIC if shared

### DIFF
--- a/recipes/pcre2/all/conanfile.py
+++ b/recipes/pcre2/all/conanfile.py
@@ -51,6 +51,8 @@ class PCREConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
         if not self.options.build_pcre2grep:

--- a/recipes/pcre2/all/conanfile.py
+++ b/recipes/pcre2/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 
 
@@ -15,19 +16,23 @@ class PCREConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "with_bzip2": [True, False],
         "build_pcre2_8": [True, False],
         "build_pcre2_16": [True, False],
         "build_pcre2_32": [True, False],
+        "build_pcre2grep": [True, False],
+        "with_zlib": [True, False],
+        "with_bzip2": [True, False],
         "support_jit": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_bzip2": True,
         "build_pcre2_8": True,
         "build_pcre2_16": True,
         "build_pcre2_32": True,
+        "build_pcre2grep": True,
+        "with_zlib": True,
+        "with_bzip2": True,
         "support_jit": False
     }
 
@@ -41,11 +46,6 @@ class PCREConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -53,11 +53,24 @@ class PCREConan(ConanFile):
     def configure(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+        if not self.options.build_pcre2grep:
+            del self.options.with_zlib
+            del self.options.with_bzip2
+        if not self.options.build_pcre2_8 and not self.options.build_pcre2_16 and not self.options.build_pcre2_32:
+            raise ConanInvalidConfiguration("At least one of build_pcre2_8, build_pcre2_16 or build_pcre2_32 must be enabled")
+        if self.options.build_pcre2grep and not self.options.build_pcre2_8:
+            raise ConanInvalidConfiguration("build_pcre2_8 must be enabled for the pcre2grep program")
 
     def requirements(self):
-        self.requires("zlib/1.2.11")
-        if self.options.with_bzip2:
+        if self.options.get_safe("with_zlib"):
+            self.requires("zlib/1.2.11")
+        if self.options.get_safe("with_bzip2"):
             self.requires("bzip2/1.0.8")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_cmake(self):
         if self._cmake:
@@ -90,26 +103,46 @@ class PCREConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        def library_name(library):
-            if self.settings.build_type == "Debug" and self.settings.os == "Windows":
-                library += "d"
-            if self.settings.compiler == "gcc" and self.settings.os == "Windows" and self.options.shared:
-                library += ".dll"
-            return library
-
-        # May need components for
-        # ./lib/pkgconfig/libpcre2-32.pc
-        # ./lib/pkgconfig/libpcre2-8.pc
-        # ./lib/pkgconfig/libpcre2-posix.pc
-        # ./lib/pkgconfig/libpcre2-16.pc
-
         self.cpp_info.names["pkg_config"] = "libpcre2"
-        self.cpp_info.libs = [library_name("pcre2-posix")]
         if self.options.build_pcre2_8:
-            self.cpp_info.libs.append(library_name("pcre2-8"))
+            # pcre2-8
+            self.cpp_info.components["pcre2-8"].names["pkg_config"] = "libpcre2-8"
+            self.cpp_info.components["pcre2-8"].libs = [self._lib_name("pcre2-8")]
+            if not self.options.shared:
+                self.cpp_info.components["pcre2-8"].defines.append("PCRE2_STATIC")
+            # pcre2-posix
+            self.cpp_info.components["pcre2-posix"].names["pkg_config"] = "libpcre2-posix"
+            self.cpp_info.components["pcre2-posix"].libs = [self._lib_name("pcre2-posix")]
+            self.cpp_info.components["pcre2-posix"].requires = ["pcre2-8"]
+        # pcre2-16
         if self.options.build_pcre2_16:
-            self.cpp_info.libs.append(library_name("pcre2-16"))
+            self.cpp_info.components["pcre2-16"].names["pkg_config"] = "libpcre2-16"
+            self.cpp_info.components["pcre2-16"].libs = [self._lib_name("pcre2-16")]
+            if not self.options.shared:
+                self.cpp_info.components["pcre2-16"].defines.append("PCRE2_STATIC")
+        # pcre2-32
         if self.options.build_pcre2_32:
-            self.cpp_info.libs.append(library_name("pcre2-32"))
-        if not self.options.shared:
-            self.cpp_info.defines.append("PCRE2_STATIC")
+            self.cpp_info.components["pcre2-32"].names["pkg_config"] = "libpcre2-32"
+            self.cpp_info.components["pcre2-32"].libs = [self._lib_name("pcre2-32")]
+            if not self.options.shared:
+                self.cpp_info.components["pcre2-32"].defines.append("PCRE2_STATIC")
+
+        if self.options.build_pcre2grep:
+            bin_path = os.path.join(self.package_folder, "bin")
+            self.output.info("Appending PATH environment variable: {}".format(bin_path))
+            self.env_info.PATH.append(bin_path)
+            # FIXME: This is a workaround to avoid ConanException. zlib and bzip2
+            # are optional requirements of pcre2grep executable, not of any pcre2 lib.
+            if self.options.with_zlib:
+                self.cpp_info.components["pcre2-8"].requires.append("zlib::zlib")
+            if self.options.with_bzip2:
+                self.cpp_info.components["pcre2-8"].requires.append("bzip2::bzip2")
+
+    def _lib_name(self, name):
+        libname = name
+        if self.settings.os == "Windows":
+            if self.settings.build_type == "Debug":
+                libname += "d"
+            if self.settings.compiler == "gcc" and self.options.shared:
+                libname += ".dll"
+        return libname

--- a/recipes/pcre2/all/conanfile.py
+++ b/recipes/pcre2/all/conanfile.py
@@ -22,13 +22,13 @@ class PCREConan(ConanFile):
         "support_jit": [True, False]
     }
     default_options = {
-        'shared': False,
-        'fPIC': True,
-        'with_bzip2': True,
-        'build_pcre2_8': True,
-        'build_pcre2_16': True,
-        'build_pcre2_32': True,
-        'support_jit': False
+        "shared": False,
+        "fPIC": True,
+        "with_bzip2": True,
+        "build_pcre2_8": True,
+        "build_pcre2_16": True,
+        "build_pcre2_32": True,
+        "support_jit": False
     }
 
     _cmake = None

--- a/recipes/pcre2/all/test_package/CMakeLists.txt
+++ b/recipes/pcre2/all/test_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-if (PCRE2_STATIC)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE PCRE2_STATIC=1)
-endif (PCRE2_STATIC)

--- a/recipes/pcre2/all/test_package/conanfile.py
+++ b/recipes/pcre2/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -8,12 +8,11 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        if self.settings.os == "Windows" and not self.options['pcre2'].shared:
-            cmake.definitions['PCRE2_STATIC'] = True
         cmake.configure()
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        arguments = "%sw+ Bincrafters" % ("\\" if self.settings.os == "Windows" else "\\\\")
-        self.run("%s %s" % (bin_path, arguments), run_environment=True)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            arguments = "%sw+ Bincrafters" % ("\\" if self.settings.os == "Windows" else "\\\\")
+            self.run("%s %s" % (bin_path, arguments), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **pcre2/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

In detail:
- add components (pkg-config)
- add `with_zlib` and `build_pcre2grep` options
- add bin to PATH env var if `build_pcre2grep=True`
- `zlib` and `bzip2` are optional dependencies of `pcre2grep` executable
- `pcre2-posix` lib is built only if `build_pcre2_8=True`
- add checks:
  - `pcre2grep` executable can't be built if `build_pcre2_8` option is disabled
  - at least one of `build_pcre2_8`, `build_pcre2_16` or `build_pcre2_32` must be enabled

/cc @ericLemanissier 