### PR TITLE
xorg: expose system version of each component

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -33,6 +33,7 @@ class ConanXOrg(ConanFile):
         self.cpp_info.components[name].includedirs = include_dirs
         self.cpp_info.components[name].cflags = cflags
         self.cpp_info.components[name].cxxflags = cflags
+        self.cpp_info.components[name].version = pkg_config.version[0]
 
     def system_requirements(self):
         if tools.os_info.is_linux and self.settings.os == "Linux":

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, tools
 from conans.errors import ConanException
 
+required_conan_version = ">=1.29"
 
 class ConanXOrg(ConanFile):
     name = "xorg"

--- a/recipes/xorg/all/test_package/CMakeLists.txt
+++ b/recipes/xorg/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Specify library name and version:  **xorg/system**

With conan 1.29.0 (including https://github.com/conan-io/conan/pull/7524 and https://github.com/conan-io/conan/pull/7534) it is now possible to expose the version of system packages via component.version attribute.
This should fix https://github.com/bincrafters/community/issues/1254

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.