### PR TITLE
Make jsoncpp:fPIC=False work on 1.9.3

### DIFF
--- a/recipes/jsoncpp/all/conanfile.py
+++ b/recipes/jsoncpp/all/conanfile.py
@@ -37,8 +37,8 @@ class JsoncppConan(ConanFile):
 
         if self.settings.os != "Windows" and not self.options.shared and not self.options.fPIC:
             tools.replace_in_file(os.path.join(self._source_subfolder, "src", "lib_json", "CMakeLists.txt"),
-                                  "set_target_properties( jsoncpp_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)",
-                                  "set_target_properties( jsoncpp_lib PROPERTIES POSITION_INDEPENDENT_CODE OFF)")
+                                  "POSITION_INDEPENDENT_CODE ON",
+                                  "POSITION_INDEPENDENT_CODE OFF")
         if tools.Version(self.version) > "1.9.0":
             tools.replace_in_file(os.path.join(self._source_subfolder, "src", "lib_json", "CMakeLists.txt"),
                                   "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>",

--- a/recipes/jsoncpp/all/conanfile.py
+++ b/recipes/jsoncpp/all/conanfile.py
@@ -35,19 +35,10 @@ class JsoncppConan(ConanFile):
                                   "explicit operator bool()",
                                   "operator bool()")
 
-        lib_json_cmake = os.path.join(self._source_subfolder, "src", "lib_json", "CMakeLists.txt")
-        if tools.Version(self.version) >= "1.9.3":
-            tools.replace_in_file(
-                lib_json_cmake,
-                "POSITION_INDEPENDENT_CODE ON",
-                ""
-            )
-        else:
-            tools.replace_in_file(
-                lib_json_cmake,
-                "set_target_properties( jsoncpp_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)",
-                ""
-            )
+        if self.settings.os != "Windows" and not self.options.shared and not self.options.fPIC:
+            tools.replace_in_file(os.path.join(self._source_subfolder, "src", "lib_json", "CMakeLists.txt"),
+                                  "POSITION_INDEPENDENT_CODE ON",
+                                  "POSITION_INDEPENDENT_CODE OFF")
         if tools.Version(self.version) > "1.9.0":
             tools.replace_in_file(os.path.join(self._source_subfolder, "src", "lib_json", "CMakeLists.txt"),
                                   "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>",

--- a/recipes/jsoncpp/all/conanfile.py
+++ b/recipes/jsoncpp/all/conanfile.py
@@ -35,10 +35,19 @@ class JsoncppConan(ConanFile):
                                   "explicit operator bool()",
                                   "operator bool()")
 
-        if self.settings.os != "Windows" and not self.options.shared and not self.options.fPIC:
-            tools.replace_in_file(os.path.join(self._source_subfolder, "src", "lib_json", "CMakeLists.txt"),
-                                  "POSITION_INDEPENDENT_CODE ON",
-                                  "POSITION_INDEPENDENT_CODE OFF")
+        lib_json_cmake = os.path.join(self._source_subfolder, "src", "lib_json", "CMakeLists.txt")
+        if tools.Version(self.version) >= "1.9.3":
+            tools.replace_in_file(
+                lib_json_cmake,
+                "POSITION_INDEPENDENT_CODE ON",
+                ""
+            )
+        else:
+            tools.replace_in_file(
+                lib_json_cmake,
+                "set_target_properties( jsoncpp_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)",
+                ""
+            )
         if tools.Version(self.version) > "1.9.0":
             tools.replace_in_file(os.path.join(self._source_subfolder, "src", "lib_json", "CMakeLists.txt"),
                                   "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>",

--- a/recipes/jsoncpp/all/test_package/CMakeLists.txt
+++ b/recipes/jsoncpp/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 SET(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
Specify library name and version:  **jsoncpp/1.9.3**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
