### PR TITLE
fftw3: fix cpp_info for precision != double

### DIFF
--- a/recipes/fftw/all/conanfile.py
+++ b/recipes/fftw/all/conanfile.py
@@ -2,6 +2,7 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.28.0"
 
 class FFTWConan(ConanFile):
     name = "fftw"
@@ -85,16 +86,34 @@ class FFTWConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "FFTW3"
-        self.cpp_info.names["cmake_find_package_multi"] = "FFTW3"
-        self.cpp_info.components["fftwlib"].names["cmake_find_package"] = "fftw3"
-        self.cpp_info.components["fftwlib"].names["cmake_find_package_multi"] = "fftw3"
+        prec_suffix = self._prec_suffix[str(self.options.precision)]
+        cmake_config_name = "FFTW3" + prec_suffix
+        cmake_namespace = "FFTW3"
+        cmake_target_name = "fftw3" + prec_suffix
+        pkgconfig_name = "fftw" + prec_suffix
+        lib_name = "fftw3" + prec_suffix
+        self.cpp_info.filenames["cmake_find_package"] = cmake_config_name
+        self.cpp_info.filenames["cmake_find_package_multi"] = cmake_config_name
+        self.cpp_info.names["cmake_find_package"] = cmake_namespace
+        self.cpp_info.names["cmake_find_package_multi"] = cmake_namespace
+        self.cpp_info.names["pkg_config"] = pkgconfig_name
+        self.cpp_info.components["fftwlib"].names["cmake_find_package"] = cmake_target_name
+        self.cpp_info.components["fftwlib"].names["cmake_find_package_multi"] = cmake_target_name
+        self.cpp_info.components["fftwlib"].names["pkg_config"] = pkgconfig_name
         if self.options.openmp:
-            self.cpp_info.components["fftwlib"].libs.append("fftw3_omp")
+            self.cpp_info.components["fftwlib"].libs.append(lib_name + "_omp")
         if self.options.threads and not self.options.combinedthreads:
-            self.cpp_info.components["fftwlib"].libs.append("fftw3_threads")
-        self.cpp_info.components["fftwlib"].libs.append("fftw3")
+            self.cpp_info.components["fftwlib"].libs.append(lib_name + "_threads")
+        self.cpp_info.components["fftwlib"].libs.append(lib_name)
         if self.settings.os == "Linux":
             self.cpp_info.components["fftwlib"].system_libs.append("m")
             if self.options.threads:
                 self.cpp_info.components["fftwlib"].system_libs.append("pthread")
+
+    @property
+    def _prec_suffix(self):
+        return {
+            "double": "",
+            "single": "f",
+            "longdouble": "l"
+        }

--- a/recipes/fftw/all/test_package/CMakeLists.txt
+++ b/recipes/fftw/all/test_package/CMakeLists.txt
@@ -1,16 +1,26 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
+option(ENABLE_DOUBLE_PRECISION "Enable FFTW single precision" ON)
 option(ENABLE_SINGLE_PRECISION "Enable FFTW single precision" OFF)
 option(ENABLE_LONG_DOUBLE_PRECISION "Enable FFTW single precision" OFF)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-find_package(FFTW3 REQUIRED CONFIG)
+if(ENABLE_SINGLE_PRECISION)
+  find_package(FFTW3f REQUIRED CONFIG)
+elseif(ENABLE_LONG_DOUBLE_PRECISION)
+  find_package(FFTW3l REQUIRED CONFIG)
+else()
+  find_package(FFTW3 REQUIRED CONFIG)
+endif()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} FFTW3::fftw3)
+target_link_libraries(${PROJECT_NAME}
+  $<$<BOOL:${ENABLE_DOUBLE_PRECISION}>:FFTW3::fftw3>
+  $<$<BOOL:${ENABLE_SINGLE_PRECISION}>:FFTW3::fftw3f>
+  $<$<BOOL:${ENABLE_LONG_DOUBLE_PRECISION}>:FFTW3::fftw3l>)
 
 target_compile_options(${PROJECT_NAME} PRIVATE
     $<$<BOOL:${ENABLE_SINGLE_PRECISION}>:-DENABLE_SINGLE_PRECISION=1>

--- a/recipes/fftw/all/test_package/conanfile.py
+++ b/recipes/fftw/all/test_package/conanfile.py
@@ -8,6 +8,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["ENABLE_DOUBLE_PRECISION"] = self.options["fftw"].precision == "double"
         cmake.definitions["ENABLE_SINGLE_PRECISION"] = self.options["fftw"].precision == "single"
         cmake.definitions["ENABLE_LONG_DOUBLE_PRECISION"] = self.options["fftw"].precision == "longdouble"
         cmake.configure()


### PR DESCRIPTION
Specify library name and version:  **fftw/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

closes https://github.com/conan-io/conan-center-index/issues/2746

That's sad, but from upstream `CMakeLists.txt`:
- if double precision (default):
pkg-config file: fftw.pc
CMake config file: FFTW3Config.cmake
CMake imported target: FFTW3::fftw3
libs name: fftw3, fftw3_omp, fftw3_threads
- if single precision:
pkg-config file: fftwf.pc
CMake config file: FFTW3fConfig.cmake
CMake imported target: FFTW3::fftw3f
libs name: fftw3f, fftw3f_omp, fftw3f_threads
- if longdouble precision:
pkg-config filepkgconfig: fftwl.pc
CMake config file: FFTW3lConfig.cmake
CMake imported target: FFTW3::fftw3l
libs name: fftw3l, fftw3l_omp, fftw3l_threads
