### PR TITLE
jemalloc: fix Clang --gcc-toolchain issue

### DIFF
--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -111,8 +111,8 @@ class JemallocConan(ConanFile):
         return build_type
 
     def _patch_sources(self):
+        makefile_in = os.path.join(self._source_subfolder, "Makefile.in")
         if self.settings.os == "Windows":
-            makefile_in = os.path.join(self._source_subfolder, "Makefile.in")
             tools.replace_in_file(makefile_in,
                                   "DSO_LDFLAGS = @DSO_LDFLAGS@",
                                   "DSO_LDFLAGS = @DSO_LDFLAGS@ -Wl,--out-implib,lib/libjemalloc.a")
@@ -123,6 +123,9 @@ class JemallocConan(ConanFile):
                                   "\t$(INSTALL) -d $(LIBDIR)\n"
                                   "\t$(INSTALL) -m 755 $(objroot)lib/$(LIBJEMALLOC).$(SOREV) $(BINDIR)\n"
                                   "\t$(INSTALL) -m 644 $(objroot)lib/libjemalloc.a $(LIBDIR)")
+        tools.replace_in_file(makefile_in,
+                              "CC_MM = @CC_MM@",
+                              "CC_MM =")
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
Compilers like Clang may require --gcc-toolchain= to find std headers.
If jemalloc only uses preprocessor flags, dependency generation fails.

Disable generation of dependency files to avoid the issue with compiler
flags.

Fixes #2754
Also see jemalloc/jemalloc#1927

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
