### PR TITLE
Zulu OpenJDK distribution

### DIFF
--- a/recipes/zulu-openjdk/all/conandata.yml
+++ b/recipes/zulu-openjdk/all/conandata.yml
@@ -1,0 +1,12 @@
+sources:
+  "11.0.8":
+    url: {
+      "Windows": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-win_x64.zip",
+      "Linux": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-linux_x64.tar.gz",
+      "Macos": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-macosx_x64.tar.gz",
+    }
+    sha256: {
+      "Windows": "3602ed7bae52898c540c2d3ae3230c081cf061b219d14fb9ac15a47f4226d307",
+      "Linux": "f8aee4ab30ca11ab3c8f401477df0e455a9d6b06f2710b2d1b1ddcf06067bc79",
+      "Macos": "1ed070ea9a27030bcca4d7c074dec1d205d3f3506166d36faf4d1b9e083ab365",
+    }

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -43,6 +43,8 @@ class ZuluOpenJDK(ConanFile):
 
     def package_info(self):
         self.cpp_info.includedirs.append(self._jni_folder)
+        self.cpp_info.libdirs = ["lib"]
+        self.cpp_info.libs = tools.collect_libs(self)
 
         java_home = os.path.join(self.package_folder)
         bin_path = os.path.join(java_home, "bin")

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -22,12 +22,10 @@ class ZuluOpenJDK(ConanFile):
         return os.path.join("include", folder)
 
     def configure(self):
-        # Checking against self.settings.* would prevent cross-building profiles from working
-        # TODO, I think for the new, 2 profile builds, this can be done ...
-        if tools.detected_architecture() != "x86_64":
+        if self.settings.arch != "x86_64":
             raise ConanInvalidConfiguration("Unsupported Architecture.  This package currently only supports x86_64.")
-        if platform.system() not in ["Windows", "Darwin", "Linux"]:
-            raise ConanInvalidConfiguration("Unsupported System. This package currently only support Linux/Darwin/Windows")
+        if self.settings.os not in ["Windows", "Macos", "Linux"]:
+            raise ConanInvalidConfiguration("Unsupported os. This package currently only support Linux/Macos/Windows")
 
     def source(self):
         url = self.conan_data["sources"][self.version]["url"][str(self.settings.os)]
@@ -51,7 +49,7 @@ class ZuluOpenJDK(ConanFile):
         self.cpp_info.libdirs = ["lib"]
         self.cpp_info.libs = tools.collect_libs(self)
 
-        java_home = os.path.join(self.package_folder)
+        java_home = self.package_folder
         bin_path = os.path.join(java_home, "bin")
 
         self.output.info("Creating JAVA_HOME environment variable with : {0}".format(java_home))

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -28,14 +28,7 @@ class ZuluOpenJDK(ConanFile):
         url = self.conan_data["sources"][self.version]["url"][str(self.settings.os)]
         checksum = self.conan_data["sources"][self.version]["sha256"][str(self.settings.os)]
         tools.get(url, sha256=checksum)
-        filename = os.path.basename(url)
-        if filename.endswith(".zip"):
-            extracted_dir = filename.rstrip(".zip")
-        elif filename.endswith(".tar.gz"):
-            extracted_dir = filename.rstrip(".tar.gz")
-        else:
-            raise Exception("Unexpected source file extension, expected '.zip' or '.tar.gz'")
-        os.rename(extracted_dir, "sources")
+        os.rename(glob.glob("zulu*")[0], self._source_subfolder)
 
     def build(self):
         pass # nothing to do, but this shall trigger no warnings ;-)

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -12,7 +12,7 @@ class ZuluOpenJDK(ConanFile):
     settings = "os", "arch"
 
     @property
-    def jni_folder(self):
+    def _jni_folder(self):
         folder = {"Linux": "linux", "Darwin": "darwin", "Windows": "win32"}.get(platform.system())
         return os.path.join("include", folder)
 

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, tools
-import os, platform
+from conans.errors import ConanInvalidConfiguration
+import os, platform, glob
 
 
 class ZuluOpenJDK(ConanFile):
@@ -38,10 +39,10 @@ class ZuluOpenJDK(ConanFile):
         pass # nothing to do, but this shall trigger no warnings ;-)
 
     def package(self):
-        self.copy(pattern="*", dst=".", src="sources")
+        self.copy(pattern="*", dst=".", src=self._source_subfolder)
 
     def package_info(self):
-        self.cpp_info.includedirs.append(self.jni_folder)
+        self.cpp_info.includedirs.append(self._jni_folder)
 
         java_home = os.path.join(self.package_folder)
         bin_path = os.path.join(java_home, "bin")

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -6,7 +6,9 @@ class ZuluOpenJDK(ConanFile):
     name = "zulu-openjdk"
     url = "https://github.com/conan-io/conan-center-index/"
     description = "A OpenJDK distribution"
+    homepage = "https://www.azul.com"
     license = "https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-terms-of-use/"
+    topics = ("java", "jdk")
     settings = "os", "arch"
 
     @property

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -18,7 +18,7 @@ class ZuluOpenJDK(ConanFile):
 
     @property
     def _jni_folder(self):
-        folder = {"Linux": "linux", "Macos": "darwin", "Windows": "win32"}.get(self.settings.os)
+        folder = {"Linux": "linux", "Macos": "darwin", "Windows": "win32"}.get(str(self.settings.os))
         return os.path.join("include", folder)
 
     def configure(self):

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -1,0 +1,54 @@
+from conans import ConanFile, tools
+import os, platform
+
+
+class ZuluOpenJDK(ConanFile):
+    name = "zulu-openjdk"
+    url = "https://github.com/conan-io/conan-center-index/"
+    description = "A OpenJDK distribution"
+    license = "https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-terms-of-use/"
+    settings = "os", "arch"
+
+    @property
+    def jni_folder(self):
+        folder = {"Linux": "linux", "Darwin": "darwin", "Windows": "win32"}.get(platform.system())
+        return os.path.join("include", folder)
+
+    def config_options(self):
+        # Checking against self.settings.* would prevent cross-building profiles from working
+        # TODO, I think for the new, 2 profile builds, this can be done ...
+        if tools.detected_architecture() != "x86_64":
+            raise Exception("Unsupported Architecture.  This package currently only supports x86_64.")
+        if platform.system() not in ["Windows", "Darwin", "Linux"]:
+            raise Exception("Unsupported System. This package currently only support Linux/Darwin/Windows")
+
+    def source(self):
+        url = self.conan_data["sources"][self.version]["url"][str(self.settings.os)]
+        checksum = self.conan_data["sources"][self.version]["sha256"][str(self.settings.os)]
+        tools.get(url, sha256=checksum)
+        filename = os.path.basename(url)
+        if filename.endswith(".zip"):
+            extracted_dir = filename.rstrip(".zip")
+        elif filename.endswith(".tar.gz"):
+            extracted_dir = filename.rstrip(".tar.gz")
+        else:
+            raise Exception("Unexpected source file extension, expected '.zip' or '.tar.gz'")
+        os.rename(extracted_dir, "sources")
+
+    def build(self):
+        pass # nothing to do, but this shall trigger no warnings ;-)
+
+    def package(self):
+        self.copy(pattern="*", dst=".", src="sources")
+
+    def package_info(self):
+        self.cpp_info.includedirs.append(self.jni_folder)
+
+        java_home = os.path.join(self.package_folder)
+        bin_path = os.path.join(java_home, "bin")
+
+        self.output.info("Creating JAVA_HOME environment variable with : {0}".format(java_home))
+        self.env_info.JAVA_HOME = java_home
+
+        self.output.info("Appending PATH environment variable with : {0}".format(bin_path))
+        self.env_info.path.append(bin_path)

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -20,7 +20,7 @@ class ZuluOpenJDK(ConanFile):
         # Checking against self.settings.* would prevent cross-building profiles from working
         # TODO, I think for the new, 2 profile builds, this can be done ...
         if tools.detected_architecture() != "x86_64":
-            raise Exception("Unsupported Architecture.  This package currently only supports x86_64.")
+            raise ConanInvalidConfiguration("Unsupported Architecture.  This package currently only supports x86_64.")
         if platform.system() not in ["Windows", "Darwin", "Linux"]:
             raise Exception("Unsupported System. This package currently only support Linux/Darwin/Windows")
 

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -22,7 +22,7 @@ class ZuluOpenJDK(ConanFile):
         if tools.detected_architecture() != "x86_64":
             raise ConanInvalidConfiguration("Unsupported Architecture.  This package currently only supports x86_64.")
         if platform.system() not in ["Windows", "Darwin", "Linux"]:
-            raise Exception("Unsupported System. This package currently only support Linux/Darwin/Windows")
+            raise ConanInvalidConfiguration("Unsupported System. This package currently only support Linux/Darwin/Windows")
 
     def source(self):
         url = self.conan_data["sources"][self.version]["url"][str(self.settings.os)]

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
-import os, platform, glob
+import os, glob
 
 
 class ZuluOpenJDK(ConanFile):

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -18,7 +18,7 @@ class ZuluOpenJDK(ConanFile):
 
     @property
     def _jni_folder(self):
-        folder = {"Linux": "linux", "Darwin": "darwin", "Windows": "win32"}.get(platform.system())
+        folder = {"Linux": "linux", "Macos": "darwin", "Windows": "win32"}.get(self.settings.os)
         return os.path.join("include", folder)
 
     def configure(self):

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -56,4 +56,4 @@ class ZuluOpenJDK(ConanFile):
         self.env_info.JAVA_HOME = java_home
 
         self.output.info("Appending PATH environment variable with : {0}".format(bin_path))
-        self.env_info.path.append(bin_path)
+        self.env_info.PATH.append(bin_path)

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -16,7 +16,7 @@ class ZuluOpenJDK(ConanFile):
         folder = {"Linux": "linux", "Darwin": "darwin", "Windows": "win32"}.get(platform.system())
         return os.path.join("include", folder)
 
-    def config_options(self):
+    def configure(self):
         # Checking against self.settings.* would prevent cross-building profiles from working
         # TODO, I think for the new, 2 profile builds, this can be done ...
         if tools.detected_architecture() != "x86_64":

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -12,6 +12,10 @@ class ZuluOpenJDK(ConanFile):
     settings = "os", "arch"
 
     @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
     def _jni_folder(self):
         folder = {"Linux": "linux", "Darwin": "darwin", "Windows": "win32"}.get(platform.system())
         return os.path.join("include", folder)

--- a/recipes/zulu-openjdk/all/test_package/conanfile.py
+++ b/recipes/zulu-openjdk/all/test_package/conanfile.py
@@ -3,6 +3,9 @@ import subprocess
 
 class TestPackage(ConanFile):
 
+    def build(self):
+        pass # nothing to build, but tests should not warn
+
     def test(self):
         output = subprocess.run(['java', '--version'], stdout=subprocess.PIPE)
         version_info = output.stdout.decode('utf-8')

--- a/recipes/zulu-openjdk/all/test_package/conanfile.py
+++ b/recipes/zulu-openjdk/all/test_package/conanfile.py
@@ -1,4 +1,6 @@
 from conans import ConanFile
+from conans.client import output
+from six import StringIO
 import subprocess
 
 class TestPackage(ConanFile):
@@ -7,8 +9,10 @@ class TestPackage(ConanFile):
         pass # nothing to build, but tests should not warn
 
     def test(self):
-        output = subprocess.run(['java', '--version'], stdout=subprocess.PIPE)
-        version_info = output.stdout.decode('utf-8')
+        test_cmd = ['java', '--version']
+        output = StringIO()
+        self.run(test_cmd, output=output)
+        version_info = output.getvalue()
         if "Zulu" in version_info:
             pass
         else:

--- a/recipes/zulu-openjdk/all/test_package/conanfile.py
+++ b/recipes/zulu-openjdk/all/test_package/conanfile.py
@@ -1,0 +1,12 @@
+from conans import ConanFile
+import subprocess
+
+class TestPackage(ConanFile):
+
+    def test(self):
+        output = subprocess.run(['java', '--version'], stdout=subprocess.PIPE)
+        version_info = output.stdout.decode('utf-8')
+        if "Zulu" in version_info:
+            pass
+        else:
+            raise Exception("java call seems not use the Zulu bin")

--- a/recipes/zulu-openjdk/all/test_package/conanfile.py
+++ b/recipes/zulu-openjdk/all/test_package/conanfile.py
@@ -1,7 +1,6 @@
 from conans import ConanFile
-from conans.client import output
 from six import StringIO
-import subprocess
+
 
 class TestPackage(ConanFile):
 

--- a/recipes/zulu-openjdk/config.yml
+++ b/recipes/zulu-openjdk/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "11.0.8":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **Zulu OpenJDK/11.0.0 LTS**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I was testing this with hooks enabled on my machine and I konw that there are post hooks that fail, but I find this is wrong

An existing OpenJDK is usful and required for a variety  of tools, antlr, or https://github.com/cross-language-cpp/djinni 
It falls basically under the tools section. 
The content is as it is, and the folder layout also. 