### PR TITLE
rttr: fix cmake imported target + cache cmake + del fPIC if shared

### DIFF
--- a/recipes/rttr/all/conandata.yml
+++ b/recipes/rttr/all/conandata.yml
@@ -2,3 +2,9 @@ sources:
   "0.9.6":
     url: "https://github.com/rttrorg/rttr/archive/v0.9.6.tar.gz"
     sha256: "058554f8644450185fd881a6598f9dee7ef85785cbc2bb5a5526a43225aa313f"
+patches:
+  "0.9.6":
+    - patch_file: "patches/001_fix_build_without_RTTI.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/002_fix_license_installer.patch"
+      base_path: "source_subfolder"

--- a/recipes/rttr/all/conanfile.py
+++ b/recipes/rttr/all/conanfile.py
@@ -77,7 +77,15 @@ class RTTRConan(ConanFile):
             os.remove(pdb)
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
-
+        self.cpp_info.filenames["cmake_find_package"] = "rttr"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "rttr"
+        self.cpp_info.names["cmake_find_package"] = "RTTR"
+        self.cpp_info.names["cmake_find_package_multi"] = "RTTR"
+        cmake_target = "Core" if self.options.shared else "Core_Lib"
+        self.cpp_info.components["_rttr"].names["cmake_find_package"] = cmake_target
+        self.cpp_info.components["_rttr"].names["cmake_find_package_multi"] = cmake_target
+        self.cpp_info.components["_rttr"].libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs.extend(["dl", "pthread"])
+            self.cpp_info.components["_rttr"].system_libs = ["dl", "pthread"]
+        if self.options.shared:
+            self.cpp_info.components["_rttr"].defines = ["RTTR_DLL"]

--- a/recipes/rttr/all/conanfile.py
+++ b/recipes/rttr/all/conanfile.py
@@ -53,13 +53,9 @@ class RTTRConan(ConanFile):
 
         return cmake
 
-    def _patch_sources(self):
-        tools.patch(patch_file="patches/001_fix_build_without_RTTI.patch", base_path=self._source_subfolder)
-        tools.patch(patch_file="patches/002_fix_license_installer.patch", base_path=self._source_subfolder)
-
     def build(self):
-        self._patch_sources()
-
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/rttr/all/conanfile.py
+++ b/recipes/rttr/all/conanfile.py
@@ -36,6 +36,12 @@ class RTTRConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 11)
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = "{}-{}".format(self.name, self.version)

--- a/recipes/rttr/all/conanfile.py
+++ b/recipes/rttr/all/conanfile.py
@@ -26,7 +26,11 @@ class RTTRConan(ConanFile):
         "with_rtti": False,
     }
 
-    _source_subfolder = "source_subfolder"
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -38,20 +42,18 @@ class RTTRConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_cmake(self):
-        cmake = CMake(self)
-
-        cmake.definitions["BUILD_DOCUMENTATION"] = False
-        cmake.definitions["BUILD_EXAMPLES"] = False
-        cmake.definitions["BUILD_UNIT_TESTS"] = False
-        cmake.definitions["BUILD_WITH_RTTI"] = self.options.with_rtti
-        cmake.definitions["BUILD_PACKAGE"] = False
-
-        cmake.definitions["BUILD_RTTR_DYNAMIC"] = self.options.shared
-        cmake.definitions["BUILD_STATIC"] = not self.options.shared
-
-        cmake.configure()
-
-        return cmake
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["BUILD_DOCUMENTATION"] = False
+        self._cmake.definitions["BUILD_EXAMPLES"] = False
+        self._cmake.definitions["BUILD_UNIT_TESTS"] = False
+        self._cmake.definitions["BUILD_WITH_RTTI"] = self.options.with_rtti
+        self._cmake.definitions["BUILD_PACKAGE"] = False
+        self._cmake.definitions["BUILD_RTTR_DYNAMIC"] = self.options.shared
+        self._cmake.definitions["BUILD_STATIC"] = not self.options.shared
+        self._cmake.configure()
+        return self._cmake
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/rttr/all/conanfile.py
+++ b/recipes/rttr/all/conanfile.py
@@ -1,12 +1,11 @@
 import os
 import glob
 from conans import ConanFile, tools, CMake
-from conans.errors import ConanInvalidConfiguration
 
 
 class RTTRConan(ConanFile):
     name = "rttr"
-    description = "Run Time Type Reflection library"   
+    description = "Run Time Type Reflection library"
     topics = ("conan", "reflection", "rttr", )
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/rttrorg/rttr"
@@ -40,7 +39,7 @@ class RTTRConan(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self)
-        
+
         cmake.definitions["BUILD_DOCUMENTATION"] = False
         cmake.definitions["BUILD_EXAMPLES"] = False
         cmake.definitions["BUILD_UNIT_TESTS"] = False
@@ -51,7 +50,7 @@ class RTTRConan(ConanFile):
         cmake.definitions["BUILD_STATIC"] = not self.options.shared
 
         cmake.configure()
-        
+
         return cmake
 
     def _patch_sources(self):
@@ -68,13 +67,10 @@ class RTTRConan(ConanFile):
         self.copy("LICENSE.txt", src=os.path.join(self.source_folder, self._source_subfolder), dst="licenses")
         cmake = self._configure_cmake()
         cmake.install()
-
         tools.rmdir(os.path.join(self.package_folder, "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
-
-        pdb_files = glob.glob(os.path.join(self.package_folder, 'bin', '*.pdb'), recursive=True)
-        for pdb in pdb_files:
-            os.unlink(pdb)
+        for pdb in glob.glob(os.path.join(self.package_folder, "bin", "*.pdb")):
+            os.remove(pdb)
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/rttr/all/test_package/CMakeLists.txt
+++ b/recipes/rttr/all/test_package/CMakeLists.txt
@@ -1,11 +1,15 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_EXTENSIONS OFF)
+find_package(rttr REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+if(RTTR_SHARED)
+  target_link_libraries(${PROJECT_NAME} RTTR::Core)
+else()
+  target_link_libraries(${PROJECT_NAME} RTTR::Core_Lib)
+endif()

--- a/recipes/rttr/all/test_package/conanfile.py
+++ b/recipes/rttr/all/test_package/conanfile.py
@@ -4,10 +4,11 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["RTTR_SHARED"] = self.options["rttr"].shared
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **rttr/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

You can check config file and targets here: https://github.com/rttrorg/rttr/blob/master/src/rttr/CMakeLists.txt#L226 (then look at `EXPORT_NAME` properties).

target name is also a little bit different if linked to static runtime lib (`RTTR::Core_STL` if shared else `RTTR::Core_Lib_STL`) : https://github.com/rttrorg/rttr/blob/b16fccf0fbbbf94064bf2a6c7c47f2b910ab31f1/src/rttr/CMakeLists.txt#L130
But this logic was not implemented in this PR.