### PR TITLE
libuvc: fix CMake imported target

### DIFF
--- a/recipes/libuvc/all/conanfile.py
+++ b/recipes/libuvc/all/conanfile.py
@@ -44,7 +44,7 @@ class LibuvcConan(ConanFile):
     def requirements(self):
         self.requires("libusb/1.0.23")
         if self.options.jpeg_turbo:
-            self.requires("libjpeg-turbo/2.0.4")
+            self.requires("libjpeg-turbo/2.0.5")
         else:
             self.requires("libjpeg/9d")
 

--- a/recipes/libuvc/all/conanfile.py
+++ b/recipes/libuvc/all/conanfile.py
@@ -2,6 +2,7 @@ import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.28.0"
 
 class LibuvcConan(ConanFile):
     name = "libuvc"
@@ -14,7 +15,6 @@ class LibuvcConan(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False], "jpeg_turbo": [True, False]}
     default_options = {"shared": False, "fPIC": True, "jpeg_turbo": False}
     generators = "cmake", "cmake_find_package"
-    requires = "libusb/1.0.23"
     exports_sources = ["CMakeLists.txt", "patches/*"]
     _cmake = None
 
@@ -37,20 +37,21 @@ class LibuvcConan(ConanFile):
             # Upstream issues, e.g.:
             # https://github.com/libuvc/libuvc/issues/100
             # https://github.com/libuvc/libuvc/issues/105
-            raise ConanInvalidConfiguration("'{}' is not compatible with Windows.".format(self.name))
+            raise ConanInvalidConfiguration("libuvc is not compatible with Visual Studio.")
         if self.options.shared:
             del self.options.fPIC
+
+    def requirements(self):
+        self.requires("libusb/1.0.23")
+        if self.options.jpeg_turbo:
+            self.requires("libjpeg-turbo/2.0.4")
+        else:
+            self.requires("libjpeg/9d")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
-
-    def requirements(self):
-        if self.options.jpeg_turbo:
-            self.requires("libjpeg-turbo/2.0.4")
-        else:
-            self.requires("libjpeg/9d")
 
     def _configure_cmake(self):
         if not self._cmake:
@@ -73,4 +74,17 @@ class LibuvcConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.filenames["cmake_find_package"] = "libuvc"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "libuvc"
+        self.cpp_info.names["cmake_find_package"] = "LibUVC"
+        self.cpp_info.names["cmake_find_package_multi"] = "LibUVC"
+        self.cpp_info.names["pkg_config"] = "libuvc"
+        cmake_target = "UVCShared" if self.options.shared else "UVCStatic"
+        self.cpp_info.components["_libuvc"].names["cmake_find_package"] = cmake_target
+        self.cpp_info.components["_libuvc"].names["cmake_find_package_multi"] = cmake_target
+        self.cpp_info.components["_libuvc"].names["pkg_config"] = "libuvc"
+        self.cpp_info.components["_libuvc"].libs = tools.collect_libs(self)
+        self.cpp_info.components["_libuvc"].requires = [
+            "libusb::libusb",
+            "libjpeg-turbo::libjpeg-turbo" if self.options.jpeg_turbo else "libjpeg::libjpeg"
+        ]

--- a/recipes/libuvc/all/test_package/CMakeLists.txt
+++ b/recipes/libuvc/all/test_package/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(libuvc REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+if(LIBUVC_SHARED)
+  target_link_libraries(${PROJECT_NAME} LibUVC::UVCShared)
+else()
+  target_link_libraries(${PROJECT_NAME} LibUVC::UVCStatic)
+endif()

--- a/recipes/libuvc/all/test_package/conanfile.py
+++ b/recipes/libuvc/all/test_package/conanfile.py
@@ -4,10 +4,11 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["LIBUVC_SHARED"] = self.options["libuvc"].shared
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **libuvc/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Target is exported in master branch, but not in 0.0.6 (there is only a config file without target).

config file: https://github.com/libuvc/libuvc/blob/master/libuvcConfig.cmake
namespace: https://github.com/libuvc/libuvc/blob/05e7ba682d5761b05a9b212ef84775068fbc94e3/CMakeLists.txt#L174
shared: https://github.com/libuvc/libuvc/blob/05e7ba682d5761b05a9b212ef84775068fbc94e3/CMakeLists.txt#L71
static: https://github.com/libuvc/libuvc/blob/05e7ba682d5761b05a9b212ef84775068fbc94e3/CMakeLists.txt#L87