### PR TITLE
Add TinyXML as the "cmake_find_package" name for tinyxml

### DIFF
--- a/recipes/tinyxml/all/conanfile.py
+++ b/recipes/tinyxml/all/conanfile.py
@@ -70,3 +70,4 @@ class TinyXmlConan(ConanFile):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.options.with_stl:
             self.cpp_info.defines = ["TIXML_USE_STL"]
+        self.cpp_info.names["cmake_find_package"] = "TinyXML"

--- a/recipes/tinyxml/all/conanfile.py
+++ b/recipes/tinyxml/all/conanfile.py
@@ -71,3 +71,4 @@ class TinyXmlConan(ConanFile):
         if self.options.with_stl:
             self.cpp_info.defines = ["TIXML_USE_STL"]
         self.cpp_info.names["cmake_find_package"] = "TinyXML"
+        self.cpp_info.names["cmake_find_package_multi"] = "TinyXML"


### PR DESCRIPTION
Specify library name and version:  **tinyxml/2.6.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Many CMake projects that include `tinyxml` use the name `TinyXML` instead. See [urdfdom](https://github.com/ros/urdfdom/blob/master/cmake/FindTinyXML.cmake), [dart](https://github.com/dartsim/dart/blob/master/cmake/FindTinyXML.cmake) and [GOTURN](https://github.com/davheld/GOTURN/blob/master/cmake/Modules/FindTinyXML.cmake) for example.