### PR TITLE
Re-enables missing gtest-1.10.0.patch

### DIFF
--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -12,6 +12,5 @@ patches:
   "1.10.0":
     - patch_file: "patches/gtest-1.10.0.patch"
       base_path: "source_subfolder"
-  "1.10.0":
     - patch_file: "patches/gtest-1.10.0-override.patch"
       base_path: "source_subfolder"


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Fixes #2841