### PR TITLE
pcre2: pass build_pcre2grep option to build

### DIFF
--- a/recipes/pcre2/all/conanfile.py
+++ b/recipes/pcre2/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 import os
 
 
-class PCREConan(ConanFile):
+class PCRE2Conan(ConanFile):
     name = "pcre2"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.pcre.org/"
@@ -79,6 +79,9 @@ class PCREConan(ConanFile):
             return self._cmake
 
         self._cmake = CMake(self)
+        self._cmake.definitions["PCRE2_BUILD_PCRE2GREP"] = self.options.build_pcre2grep
+        self._cmake.definitions["PCRE2_SUPPORT_LIBZ"] = self.options.get_safe("with_zlib", False)
+        self._cmake.definitions["PCRE2_SUPPORT_LIBBZ2"] = self.options.get_safe("with_bzip2", False)
         self._cmake.definitions["PCRE2_BUILD_TESTS"] = False
         if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
             runtime = not self.options.shared and "MT" in self.settings.compiler.runtime


### PR DESCRIPTION
Specify library name and version:  **pcre2/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

https://github.com/conan-io/conan-center-index/pull/2740 added `build_pcre2grep` but forgot to pass its value to CMake during build stage (this option is ON by default).