### PR TITLE
cpp-httplib: add brotli support + fix windows system libs

### DIFF
--- a/recipes/cpp-httplib/all/conanfile.py
+++ b/recipes/cpp-httplib/all/conanfile.py
@@ -63,5 +63,7 @@ class CpphttplibConan(ConanFile):
         if self.options.get_safe("with_brotli"):
             self.cpp_info.defines.append("CPPHTTPLIB_BROTLI_SUPPORT")
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.system_libs = ["pthread"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["crypt32", "cryptui", "ws2_32"]
         self.cpp_info.includedirs = ["include", os.path.join("include", "httplib")]

--- a/recipes/cpp-httplib/all/conanfile.py
+++ b/recipes/cpp-httplib/all/conanfile.py
@@ -9,20 +9,41 @@ class CpphttplibConan(ConanFile):
     topics = ("conan", "cpp-httplib", "http", "https", "header-only")
     homepage = "https://github.com/yhirose/cpp-httplib"
     url = "https://github.com/conan-io/conan-center-index"
-    settings = "os"
-    options = {"with_openssl": [True, False], "with_zlib": [True, False]}
-    default_options = {"with_openssl": False, "with_zlib": False}
     no_copy_source = True
+    settings = "os", "compiler"
+    options = {
+        "with_openssl": [True, False],
+        "with_zlib": [True, False],
+        "with_brotli": [True, False]
+    }
+    default_options = {
+        "with_openssl": False,
+        "with_zlib": False,
+        "with_brotli": False
+    }
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def config_options(self):
+        if tools.Version(self.version) < "0.7.2":
+            del self.options.with_brotli
+
+    def configure(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 11)
 
     def requirements(self):
         if self.options.with_openssl:
             self.requires("openssl/1.1.1g")
         if self.options.with_zlib:
             self.requires("zlib/1.2.11")
+        if self.options.get_safe("with_brotli"):
+            self.requires("brotli/1.0.7")
+
+    def package_id(self):
+        self.info.header_only()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -32,9 +53,6 @@ class CpphttplibConan(ConanFile):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         self.copy("httplib.h", dst=os.path.join("include", "httplib"), src=self._source_subfolder)
 
-    def package_id(self):
-        self.info.header_only()
-
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "httplib"
         self.cpp_info.names["cmake_find_package_multi"] = "httplib"
@@ -42,6 +60,8 @@ class CpphttplibConan(ConanFile):
             self.cpp_info.defines.append("CPPHTTPLIB_OPENSSL_SUPPORT")
         if self.options.with_zlib:
             self.cpp_info.defines.append("CPPHTTPLIB_ZLIB_SUPPORT")
+        if self.options.get_safe("with_brotli"):
+            self.cpp_info.defines.append("CPPHTTPLIB_BROTLI_SUPPORT")
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")
         self.cpp_info.includedirs = ["include", os.path.join("include", "httplib")]

--- a/recipes/cpp-httplib/all/test_package/CMakeLists.txt
+++ b/recipes/cpp-httplib/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(httplib REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} httplib::httplib)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/cpp-httplib/all/test_package/conanfile.py
+++ b/recipes/cpp-httplib/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **cpp-httplib/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Modifications:
- add brotli support if version >= 0.7.2: https://github.com/yhirose/cpp-httplib/releases/tag/v0.7.2
  Definition to add in `cpp_info` if brotli enabled: https://github.com/yhirose/cpp-httplib/blob/342c3ab2930e6639ead484bca88a9dd7a8724239/CMakeLists.txt#L234
- fix system libs on windows: https://github.com/yhirose/cpp-httplib/blob/342c3ab2930e6639ead484bca88a9dd7a8724239/CMakeLists.txt#L220 (there are `#pragma comment(lib, "ws2_32.lib")` stuff in public header file, but it only works with msvc).