### PR TITLE
Bumps zeromq to 4.3.3

### DIFF
--- a/recipes/zeromq/all/conandata.yml
+++ b/recipes/zeromq/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "4.3.2":
     url: "https://github.com/zeromq/libzmq/archive/v4.3.2.tar.gz"
     sha256: "02ecc88466ae38cf2c8d79f09cfd2675ba299a439680b64ade733e26a349edeb"
+  "4.3.3":
+    url: "https://github.com/zeromq/libzmq/archive/v4.3.3.tar.gz"
+    sha256: "c4fd999d67cd12872a8604162f2b1cf5b5a02fb807a88215f0f96bd50331b166"
 patches:
   "4.3.2":
     - base_path: "source_subfolder"

--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -67,8 +67,9 @@ class ZeroMQConan(ConanFile):
         return self._cmake
 
     def _patch_sources(self):
-        for patch in self.conan_data["patches"][self.version]:
-            tools.patch(**patch)
+        if self.version in self.conan_data["patches"]:
+            for patch in self.conan_data["patches"][self.version]:
+                tools.patch(**patch)
         os.unlink(os.path.join(self._source_subfolder, "builds", "cmake", "Modules", "FindSodium.cmake"))
 
         if self.options.encryption == "libsodium":

--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -67,7 +67,7 @@ class ZeroMQConan(ConanFile):
         return self._cmake
 
     def _patch_sources(self):
-        if self.version in self.conan_data["patches"]:
+        if "patches" in self.conan_data and self.version in self.conan_data["patches"]:
             for patch in self.conan_data["patches"][self.version]:
                 tools.patch(**patch)
         os.unlink(os.path.join(self._source_subfolder, "builds", "cmake", "Modules", "FindSodium.cmake"))

--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -67,9 +67,8 @@ class ZeroMQConan(ConanFile):
         return self._cmake
 
     def _patch_sources(self):
-        if "patches" in self.conan_data and self.version in self.conan_data["patches"]:
-            for patch in self.conan_data["patches"][self.version]:
-                tools.patch(**patch)
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         os.unlink(os.path.join(self._source_subfolder, "builds", "cmake", "Modules", "FindSodium.cmake"))
 
         if self.options.encryption == "libsodium":

--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -97,6 +97,7 @@ class ZeroMQConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
         tools.rmdir(os.path.join(self.package_folder, "CMake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         # TODO: CMake imported target shouldn't be namespaced

--- a/recipes/zeromq/config.yml
+++ b/recipes/zeromq/config.yml
@@ -1,3 +1,5 @@
 versions:
   "4.3.2":
+    folder: all  
+  "4.3.3":
     folder: all

--- a/recipes/zeromq/config.yml
+++ b/recipes/zeromq/config.yml
@@ -1,5 +1,5 @@
 versions:
   "4.3.2":
-    folder: all  
+    folder: all
   "4.3.3":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **zeromq/4.3.3**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Not sure if the patch handling is correct, but 4.3.3 does not require the patches of 4.3.2.

Tested with MSVC, MinGW (without libsodium), QNX Neutrino (without libsodium) and Ubuntu 20.04 (using WSL2).
