### PR TITLE
meson: workaround upstream change

### DIFF
--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -105,6 +105,8 @@ class PkgConfConan(ConanFile):
         self.env_info.PATH.append(bindir)
 
         pkg_config = os.path.join(bindir, "pkgconf").replace("\\", "/")
+        if self.setting.os == "Windows":
+            pkg_config.append(".exe")
         self.output.info("Setting PKG_CONFIG env var: {}".format(pkg_config))
         self.env_info.PKG_CONFIG = pkg_config
 

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -46,7 +46,7 @@ class PkgConfConan(ConanFile):
         os.rename("pkgconf-pkgconf-{}".format(self.version), self._source_subfolder)
 
     def build_requirements(self):
-        self.build_requires("meson/0.53.2")
+        self.build_requires("meson/0.54.2")
 
     @property
     def _sharedstatedir(self):


### PR DESCRIPTION
found by @madebr on https://github.com/mesonbuild/meson/issues/7701

Specify library name and version:  **lib/1.0**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
