### PR TITLE
f2c: add f2c/20200425 recipe

### DIFF
--- a/recipes/f2c/all/conandata.yml
+++ b/recipes/f2c/all/conandata.yml
@@ -1,0 +1,12 @@
+sources:
+  "20200425":
+    - url: "http://www.netlib.org/f2c/src.tgz"
+      sha256: "75cea7d59ae2a704959132938d7e014f9c62602fce1ad1be996ac187ebf95c72"
+    - url: "http://www.netlib.org/f2c/libf2c.zip"
+      sha256: "ca404070e9ce0a9aaa6a71fc7d5489d014ade952c5d6de7efb88de8e24f2e8e0"
+patches:
+  "20200425":
+    - patch_file: "patches/0001-f2c-conan-flags.patch"
+      base_path: "source_subfolder_f2c"
+    - patch_file: "patches/0002-libf2c-conan-flags.patch"
+      base_path: "source_subfolder_libf2c"

--- a/recipes/f2c/all/conanfile.py
+++ b/recipes/f2c/all/conanfile.py
@@ -1,0 +1,110 @@
+from conans import AutoToolsBuildEnvironment, ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class F2cConan(ConanFile):
+    name = "f2c"
+    description = "Fortran to C99 compiler"
+    topics = ["conan", "f2c", "fortran", "c", "compiler", "transpiler", "netlib"]
+    homepage = "http://www.netlib.org/f2c/"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "MIT"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    exports_sources = "patches/**"
+
+    @property
+    def _source_subfolder_f2c(self):
+        return "source_subfolder_f2c"
+
+    @property
+    def _source_subfolder_libf2c(self):
+        return "source_subfolder_libf2c"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.shared
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.get_safe("shared"):
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+        if self.settings.compiler == "Visual Studio" and self.settings.arch == "x86_64":
+            raise ConanInvalidConfiguration("64-bit MSVC builds are not working")
+
+    def build_requirements(self):
+        if tools.os_info.is_windows:
+            if self.settings.compiler != "Visual Studio":
+                self.build_requires("msys2/20200517")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version][0])
+        os.rename("src", self._source_subfolder_f2c)
+
+        tools.mkdir(self._source_subfolder_libf2c)
+        with tools.chdir(self._source_subfolder_libf2c):
+            tools.get(**self.conan_data["sources"][self.version][1])
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        autotools = AutoToolsBuildEnvironment(self)
+        if self.settings.os == "Windows" and self.settings.compiler != "Visual Studio":
+            autotools.defines.append("NO_MKDTEMP")
+        if self.settings.os == "Windows":
+            autotools.defines.extend(["STRICT", "WIN32_LEAN_AND_MEAN", "NOMINMAX", "MSDOS"])
+        if self.settings.compiler == "Visual Studio":
+            if self.settings.build_type == "Debug":
+                autotools.link_flags.append("-debug")
+        vars = autotools.vars
+        vars["CFLAGS"] += " " + vars["CPPFLAGS"]
+        with tools.environment_append(vars):
+            with tools.chdir(self._source_subfolder_f2c):
+                if self.settings.compiler == "Visual Studio":
+                    with tools.vcvars(self.settings):
+                        self.run("nmake f2c.exe -f makefile.vc", run_environment=True)
+                else:
+                    self.run("make f2c -f makefile.u", run_environment=True, win_bash=tools.os_info.is_windows)
+
+            with tools.chdir(self._source_subfolder_libf2c):
+                if self.settings.compiler == "Visual Studio":
+                    with tools.vcvars(self.settings):
+                        self.run("nmake all -f makefile.vc", run_environment=True)
+                else:
+                    tgt = "libf2c.so" if self.options.get_safe("shared") else "libf2c.a"
+                    self.run("make TARGET={} -f makefile.u".format(tgt), run_environment=True, win_bash=tools.os_info.is_windows)
+
+    def package(self):
+        self.copy("Notice", src=self._source_subfolder_f2c, dst="licenses")
+
+        # Copy f2c executable
+        self.copy("f2c.exe", src=self._source_subfolder_f2c, dst="bin")
+        self.copy("f2c", src=self._source_subfolder_f2c, dst="bin")
+
+        # Copy f2c header
+        self.copy("f2c.h", src=self._source_subfolder_f2c, dst="include")
+
+        # Copy libf2c libraries (=support libraries for f2c)
+        self.copy("vcf2c.lib", src=self._source_subfolder_libf2c, dst="lib")
+        self.copy("libf2c.a", src=self._source_subfolder_libf2c, dst="lib")
+        self.copy("libf2c.so", src=self._source_subfolder_libf2c, dst="lib")
+
+    def package_info(self):
+        libname = "vcf2c" if self.settings.compiler == "Visual Studio" else "f2c"
+        self.cpp_info.libs = [libname]
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs = ["m"]
+
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)

--- a/recipes/f2c/all/conanfile.py
+++ b/recipes/f2c/all/conanfile.py
@@ -31,12 +31,13 @@ class F2cConan(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.shared
             del self.options.fPIC
 
     def configure(self):
-        if self.options.get_safe("shared"):
+        if self.options.shared:
             del self.options.fPIC
+            if self.settings.os == "Windows":
+                raise ConanInvalidConfiguration("libf2c cannot be built as a shared library on Windows")
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
         if self.settings.compiler == "Visual Studio" and self.settings.arch == "x86_64":

--- a/recipes/f2c/all/patches/0001-f2c-conan-flags.patch
+++ b/recipes/f2c/all/patches/0001-f2c-conan-flags.patch
@@ -1,0 +1,33 @@
+--- makefile.vc
++++ makefile.vc
+@@ -4,7 +4,7 @@
+ #	nmake .
+ 
+ CC = cl
+-CFLAGS = -Ot1 -nologo -DNO_LONG_LONG
++CFLAGS = -nologo $(CFLAGS)
+ 
+ .c.obj:
+ 	$(CC) -c $(CFLAGS) $*.c
+@@ -17,7 +17,7 @@
+ checkfirst: xsum.out
+ 
+ f2c.exe: $(OBJECTS)
+-	$(CC) -Fef2c.exe $(OBJECTS) setargv.obj
++	$(CC) -Fef2c.exe $(OBJECTS) setargv.obj -link $(LDFLAGS)
+ 
+ $(OBJECTS): defs.h ftypes.h defines.h machdefs.h sysdep.h
+ 
+--- makefile.u
++++ makefile.u
+@@ -1,8 +1,8 @@
+ #	Makefile for f2c, a Fortran 77 to C converter
+ 
+ .SUFFIXES: .c .o
+-CC = cc
+-CFLAGS = -O
++CC ?= cc
++CFLAGS ?= -O
+ SHELL = /bin/sh
+ YACC = yacc
+ YFLAGS =

--- a/recipes/f2c/all/patches/0002-libf2c-conan-flags.patch
+++ b/recipes/f2c/all/patches/0002-libf2c-conan-flags.patch
@@ -1,0 +1,57 @@
+--- makefile.vc
++++ makefile.vc
+@@ -6,7 +6,7 @@
+ # to the objects in the "w =" list below.
+ 
+-CC = cl
+-CFLAGS = -DUSE_CLOCK -DMSDOS -DNO_ONEXIT -Ot1 -DNO_My_ctype -DNO_ISATTY
++CC = cl -nologo
++CFLAGS = -DUSE_CLOCK -DMSDOS -DNO_ONEXIT -DNO_My_ctype -DNO_ISATTY $(CFLAGS)
+ 
+ .c.obj:
+ 	$(CC) -c $(CFLAGS) $*.c
+--- makefile.u
++++ makefile.u
+@@ -13,7 +13,7 @@
+ # to the CFLAGS = line below.
+ 
+ .SUFFIXES: .c .o
+-CC = cc
++CC ?= cc
+ SHELL = /bin/sh
+-CFLAGS = -O
++#CFLAGS = -O 
+ 
+@@ -69,7 +69,7 @@
+ OFILES = $(MISC) $(POW) $(CX) $(DCX) $(REAL) $(DBL) $(INT) \
+ 	$(HALF) $(CMP) $(EFL) $(CHAR) $(I77) $(TIME)
+ 
+-all: f2c.h signal1.h sysdep1.h libf2c.a
++all: f2c.h signal1.h sysdep1.h $(TARGET)
+ 
+ libf2c.a: $(OFILES)
+ 	ar r libf2c.a $?
+@@ -86,7 +86,7 @@
+ ## arrange for $DYLD_LIBRARY_PATH to include the directory containing libf2c.so.
+ 
+ libf2c.so: $(OFILES)
+-	$(CC) -shared -o libf2c.so $(OFILES)
++	$(CC) -shared -o libf2c.so $(OFILES) $(LDFLAGS)
+ 
+ ### If your system lacks ranlib, you don't need it; see README.
+ 
+@@ -183,10 +183,10 @@
+ xwsne.o:	fmt.h
+ 
+ arith.h: arithchk.c
+-	$(CC) $(CFLAGS) -DNO_FPINIT arithchk.c -lm ||\
+-	 $(CC) -DNO_LONG_LONG $(CFLAGS) -DNO_FPINIT arithchk.c -lm
+-	./a.out >arith.h
+-	rm -f a.out arithchk.o
++	$(CC) $(CFLAGS) -DNO_FPINIT arithchk.c -lm -o exechk ||\
++	 $(CC) -DNO_LONG_LONG $(CFLAGS) -DNO_FPINIT arithchk.c -lm -o exechk 
++	./exechk >arith.h
++	rm -f exechk.exe exechk arithchk.o
+ 
+ check:
+ 	xsum Notice README abort_.c arithchk.c backspac.c c_abs.c c_cos.c \

--- a/recipes/f2c/all/test_package/CMakeLists.txt
+++ b/recipes/f2c/all/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup()
+
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/cylarea.c
+    COMMAND "${CMAKE_COMMAND}" -E make_directory tmp
+    COMMAND f2c -c -Ttmp "${PROJECT_SOURCE_DIR}/cylarea.f"
+    DEPENDS "${PROJECT_SOURCE_DIR}/cylarea.f"
+)
+
+add_executable(${PROJECT_NAME} test_package.c ${PROJECT_BINARY_DIR}/cylarea.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/f2c/all/test_package/conanfile.py
+++ b/recipes/f2c/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings, skip_x64_x86=True):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/f2c/all/test_package/cylarea.f
+++ b/recipes/f2c/all/test_package/cylarea.f
@@ -1,0 +1,15 @@
+      SUBROUTINE CYLAREA( R, H, V )
+      REAL R, H, V
+      REAL PI
+
+      PARAMETER ( PI = 3.141592653589793 )
+
+      PRINT*,"arguments of cylarea are ", R, " and ", H
+
+      V = 2 * PI * R * (R + H)
+
+      PRINT*,"I will return ", V
+
+      RETURN
+
+      END

--- a/recipes/f2c/all/test_package/test_package.c
+++ b/recipes/f2c/all/test_package/test_package.c
@@ -1,0 +1,14 @@
+#include "f2c.h"
+
+extern int cylarea_(real *r__, real *h__, real *v);
+
+#include <stdio.h>
+
+int main() {
+    float r, h, a;
+    r = 2.f;
+    h = 5.f;
+    cylarea_(&r, &h, &a);
+    printf("Area of cylinder with r=%f, h=%f is %f.\n", r, h, a);
+    return 0;
+}

--- a/recipes/f2c/config.yml
+++ b/recipes/f2c/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "20200425":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **f2c/20200425**

A problem with this package is that the download url will always have the latest version.
As you can see in `conandata.yml`, the source urls contain no versioning.
This means that as soon as a new version is released, this recipe will stop working.
I don't know how to handle this...



- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
