### PR TITLE
Fix arrow/1.0.0 Debug build with parquet=True

### DIFF
--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -12,3 +12,5 @@ patches:
       patch_file: "patches/1.0.0-0003-fix-shared-msvc.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/1.0.0-0004-mallctl-takes-size_t.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/1.0.0-0005-thrift-debugbuild.patch"

--- a/recipes/arrow/all/patches/1.0.0-0005-thrift-debugbuild.patch
+++ b/recipes/arrow/all/patches/1.0.0-0005-thrift-debugbuild.patch
@@ -1,0 +1,38 @@
+--- cpp/cmake_modules/FindThrift.cmake
++++ cpp/cmake_modules/FindThrift.cmake
+@@ -39,12 +39,14 @@
+   endif()
+ endfunction(EXTRACT_THRIFT_VERSION)
+
+-if(MSVC AND NOT THRIFT_MSVC_STATIC_LIB_SUFFIX)
+-  set(THRIFT_MSVC_STATIC_LIB_SUFFIX md)
++if(MSVC AND NOT THRIFT_STATIC_LIB_SUFFIX)
++  set(THRIFT_STATIC_LIB_SUFFIX md)
++elseif(${UPPERCASE_BUILD_TYPE} STREQUAL "DEBUG")
++  set(THRIFT_STATIC_LIB_SUFFIX d)
+ endif()
+
+ if(Thrift_ROOT)
+-  find_library(THRIFT_STATIC_LIB thrift${THRIFT_MSVC_STATIC_LIB_SUFFIX}
++  find_library(THRIFT_STATIC_LIB thrift${THRIFT_STATIC_LIB_SUFFIX}
+                PATHS ${Thrift_ROOT}
+                PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib")
+   find_path(THRIFT_INCLUDE_DIR thrift/Thrift.h
+@@ -61,7 +63,7 @@
+
+     list(APPEND THRIFT_PC_LIBRARY_DIRS "${THRIFT_PC_LIBDIR}")
+
+-    find_library(THRIFT_STATIC_LIB thrift${THRIFT_MSVC_STATIC_LIB_SUFFIX}
++    find_library(THRIFT_STATIC_LIB thrift${THRIFT_STATIC_LIB_SUFFIX}
+                  PATHS ${THRIFT_PC_LIBRARY_DIRS}
+                  NO_DEFAULT_PATH)
+     find_program(THRIFT_COMPILER thrift
+@@ -70,7 +72,7 @@
+                  PATH_SUFFIXES "bin")
+     set(THRIFT_VERSION ${THRIFT_PC_VERSION})
+   else()
+-    find_library(THRIFT_STATIC_LIB thrift${THRIFT_MSVC_STATIC_LIB_SUFFIX}
++    find_library(THRIFT_STATIC_LIB thrift${THRIFT_STATIC_LIB_SUFFIX}
+                  PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib")
+     find_path(THRIFT_INCLUDE_DIR thrift/Thrift.h PATH_SUFFIXES "include")
+     find_program(THRIFT_COMPILER thrift PATH_SUFFIXES "bin")


### PR DESCRIPTION
- Add patch with debug suffix to FindThrift.cmake
- Enable patch for 1.0.0 build

Specify library name and version:  **arrow/1.0.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [N/A] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This PR fixes the issue https://github.com/conan-io/conan-center-index/issues/2881