### PR TITLE
jasper: restore jpegturbo option (deprecated) + del fPIC if shared

### DIFF
--- a/recipes/jasper/all/conanfile.py
+++ b/recipes/jasper/all/conanfile.py
@@ -54,7 +54,7 @@ class JasperConan(ConanFile):
 
     def requirements(self):
         if self.options.with_libjpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/2.0.4")
+            self.requires("libjpeg-turbo/2.0.5")
         elif self.options.with_libjpeg == "libjpeg":
             self.requires("libjpeg/9d")
 

--- a/recipes/jasper/all/conanfile.py
+++ b/recipes/jasper/all/conanfile.py
@@ -17,11 +17,13 @@ class JasperConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_libjpeg": ["libjpeg", "libjpeg-turbo"],
+        "jpegturbo": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_libjpeg": "libjpeg",
+        "jpegturbo": False
     }
 
     _cmake = None
@@ -41,6 +43,12 @@ class JasperConan(ConanFile):
     def configure(self):
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
+
+        # Handle deprecated libjpeg option
+        self.output.warn("jpegturbo option is deprecated, use with_libjpeg option instead.")
+        if self.options.with_libjpeg == "libjpeg" and self.options.jpegturbo:
+            self.options.with_libjpeg == "libjpeg-turbo"
+        del self.options.jpegturbo
 
     def requirements(self):
         if self.options.with_libjpeg == "libjpeg-turbo":

--- a/recipes/jasper/all/conanfile.py
+++ b/recipes/jasper/all/conanfile.py
@@ -93,6 +93,9 @@ class JasperConan(ConanFile):
                     os.unlink(dll_file)
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "Jasper"
+        self.cpp_info.names["cmake_find_package_multi"] = "Jasper"
+        self.cpp_info.names["pkg_config"] = "jasper"
         self.cpp_info.libs = ["jasper"]
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("m")

--- a/recipes/jasper/all/conanfile.py
+++ b/recipes/jasper/all/conanfile.py
@@ -41,6 +41,8 @@ class JasperConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
 

--- a/recipes/jasper/all/conanfile.py
+++ b/recipes/jasper/all/conanfile.py
@@ -47,9 +47,10 @@ class JasperConan(ConanFile):
         del self.settings.compiler.libcxx
 
         # Handle deprecated libjpeg option
-        self.output.warn("jpegturbo option is deprecated, use with_libjpeg option instead.")
+        if self.options.jpegturbo:
+            self.output.warn("jpegturbo option is deprecated, use with_libjpeg option instead.")
         if self.options.with_libjpeg == "libjpeg" and self.options.jpegturbo:
-            self.options.with_libjpeg == "libjpeg-turbo"
+            self.options.with_libjpeg = "libjpeg-turbo"
         del self.options.jpegturbo
 
     def requirements(self):


### PR DESCRIPTION
Specify library name and version:  **jasper/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

closes https://github.com/conan-io/conan-center-index/issues/2883