### PR TITLE
libgettext: fix msvc's lib name

### DIFF
--- a/recipes/libgettext/all/conanfile.py
+++ b/recipes/libgettext/all/conanfile.py
@@ -123,7 +123,7 @@ class GetTextConan(ConanFile):
 
     def package_info(self):
         if self._is_msvc and self.options.shared:
-            self.cpp_info.libs = ["gnuintl.dll.lib"]
+            self.cpp_info.libs = ["gnuintl.dll"]
         else:
             self.cpp_info.libs = ["gnuintl"]
         if self.settings.os == "Macos":


### PR DESCRIPTION
MSVC' shared library file is named gnuintl.dll.lib, but it's counterproductive to specify the extension
in cpp_info.libs, eg it confuses qt which searches for non existing gnuintl.dll.lib.lib

Specify library name and version:  **libgettext/***

fixes https://github.com/bincrafters/community/issues/1268

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
