### PR TITLE
Glib: On Darwin, use system iconv instead of the GNU iconv library

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -151,6 +151,8 @@ class GLibConan(ConanFile):
             self.cpp_info.components["glib-2.0"].requires.append("pcre::pcre")
         if self.settings.os != "Linux":
             self.cpp_info.components["glib-2.0"].requires.append("libgettext::libgettext")
+        if tools.is_apple_os(self.settings.os):
+            self.cpp_info.components["glib-2.0"].system_libs = ["iconv"]
 
         self.cpp_info.components["gmodule-no-export-2.0"].libs = ["gmodule-2.0"]
         if self.settings.os == "Linux":

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -71,9 +71,6 @@ class GLibConan(ConanFile):
             # for Linux, gettext is provided by libc
             self.requires("libgettext/0.20.1")
 
-        if tools.is_apple_os(self.settings.os):
-            self.requires("libiconv/1.16")
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
@@ -154,8 +151,6 @@ class GLibConan(ConanFile):
             self.cpp_info.components["glib-2.0"].requires.append("pcre::pcre")
         if self.settings.os != "Linux":
             self.cpp_info.components["glib-2.0"].requires.append("libgettext::libgettext")
-        if tools.is_apple_os(self.settings.os):
-            self.cpp_info.components["glib-2.0"].requires.append("libiconv::libiconv")
 
         self.cpp_info.components["gmodule-no-export-2.0"].libs = ["gmodule-2.0"]
         if self.settings.os == "Linux":


### PR DESCRIPTION
Specify library name and version:  **Glib/2.66.0**

On Mac OS, there is a separate iconv shared library installed, so IMO the dependency to the libiconv package on Mac OS is unnecessary. It also prevents cross-compiling, as meson's `find_library` within glib doesn't respect conan's LDFLAGS and fails to find the conan-provided libiconv, even though the SDK provides a library `libiconv.2.4.0.tbd` that can be linked by simply passing `-liconv` to the linker.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
