### PR TITLE
libgit2: Rename 0.28.x recipe folder

### DIFF
--- a/recipes/libgit2/0.28.x/CMakeLists.txt
+++ b/recipes/libgit2/0.28.x/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/libgit2/0.28.x/conandata.yml
+++ b/recipes/libgit2/0.28.x/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "0.28.5":
+    url: "https://github.com/libgit2/libgit2/archive/v0.28.5.tar.gz"
+    sha256: "2b7b68aee6f123bc84cc502a9c12738435b8054e7d628962e091cd2a25be4f42"
+  "0.28.3":
+    url: "https://github.com/libgit2/libgit2/archive/v0.28.3.tar.gz"
+    sha256: "ee5344730fe11ce7c86646e19c2d257757be293f5a567548d398fb3af8b8e53b"

--- a/recipes/libgit2/0.28.x/conanfile.py
+++ b/recipes/libgit2/0.28.x/conanfile.py
@@ -1,0 +1,160 @@
+from conans import ConanFile, tools, CMake
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class LibGit2Conan(ConanFile):
+    name = "libgit2"
+    description = "libgit2 is a portable, pure C implementation of the Git core methods provided as a re-entrant linkable library with a solid API"
+    topics = ("conan", "libgit2", "git", "scm", )
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://libgit2.org/"
+    license = ("GPL-2.0-linking-exception",)
+    exports_sources = "CMakeLists.txt",
+    generators = "cmake", "cmake_find_package",
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "threadsafe": [True, False],
+        "with_iconv": [True, False],
+        "with_libssh2": [True, False],
+        "with_https": [False, "openssl", "mbedtls", "winhttp", "security"],
+        "with_sha1": ["collisiondetection", "commoncrypto", "openssl", "mbedtls", "generic", "win32"],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "threadsafe": True,
+        "with_iconv": False,
+        "with_libssh2": True,
+        "with_https": "openssl",
+        "with_sha1": "collisiondetection",
+    }
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows" or self.options.shared:
+            del self.options.fPIC
+
+        if not tools.is_apple_os(self.settings.os):
+            del self.options.with_iconv
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.cppstd
+        del self.settings.compiler.libcxx
+
+        if self.options.with_https == "security":
+            if not tools.is_apple_os(self.settings.os):
+                raise ConanInvalidConfiguration("security is only valid for Apple products")
+        elif self.options.with_https == "winhttp":
+            if self.settings.os != "Windows":
+                raise ConanInvalidConfiguration("winhttp is only valid on Windows")
+
+        if self.options.with_sha1 == "win32":
+            if self.settings.os != "Windows":
+                raise ConanInvalidConfiguration("win32 is only valid on Windows")
+
+    @property
+    def _need_openssl(self):
+        return "openssl" in (self.options.with_https, self.options.with_sha1)
+
+    @property
+    def _need_mbedtls(self):
+        return "mbedtls" in (self.options.with_https, self.options.with_sha1)
+
+    def requirements(self):
+        self.requires("zlib/1.2.11")
+        self.requires("http_parser/2.9.4")
+        if self.options.with_libssh2:
+            self.requires("libssh2/1.9.0")
+        if self._need_openssl:
+            self.requires("openssl/1.1.1g")
+        if self._need_mbedtls:
+            self.requires("mbedtls/2.16.3-gpl")
+        if tools.is_apple_os(self.settings.os) and self.options.with_iconv:
+            self.requires("libiconv/1.16")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "{}-{}".format(self.name, self.version)
+        os.rename(extracted_dir, self._source_subfolder)
+
+    _cmake_https = {
+        "openssl": "OpenSSL",
+        "winhttp": "WinHTTP",
+        "security": "SecureTransport",
+        "mbedtls": "mbedTLS",
+        False: "OFF",
+    }
+
+    _cmake_sha1 = {
+        "collisiondetection": "CollisionDetection",
+        "commoncrypto": "CommonCrypto",
+        "openssl": "OpenSSL",
+        "mbedtls": "mbedTLS",
+        "generic": "Generic",
+        "win32": "Win32",
+    }
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["THREADSAFE"] = self.options.threadsafe
+        cmake.definitions["USE_SSH"] = self.options.with_libssh2
+
+        if tools.is_apple_os(self.settings.os):
+            cmake.definitions["USE_ICONV"] = self.options.with_iconv
+        else:
+            cmake.definitions["USE_ICONV"] = False
+
+        cmake.definitions["USE_HTTPS"] = self._cmake_https[str(self.options.with_https)]
+        cmake.definitions["SHA1_BACKEND"] = self._cmake_sha1[str(self.options.with_sha1)]
+
+        cmake.definitions["BUILD_CLAR"] = False
+        cmake.definitions["BUILD_EXAMPLES"] = False
+
+        if self.settings.compiler == "Visual Studio":
+            cmake.definitions["STATIC_CRT"] = "MT" in str(self.settings.compiler.runtime)
+
+        cmake.configure()
+
+        return cmake
+
+    def _patch_sources(self):
+        tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
+                              "FIND_PKGLIBRARIES(LIBSSH2 libssh2)",
+                              "FIND_PACKAGE(libssh2 REQUIRED)\n"
+                              "\tSET(LIBSSH2_FOUND ON)\n"
+                              "\tSET(LIBSSH2_INCLUDE_DIRS ${libssh2_INCLUDE_DIRS})\n"
+                              "\tSET(LIBSSH2_LIBRARIES ${libssh2_LIBRARIES})\n"
+                              "\tSET(LIBSSH2_LIBRARY_DIRS ${libssh2_LIB_DIRS})")
+        tools.save("FindOpenSSL.cmake",
+                   "set(OPENSSL_FOUND ${OpenSSL_FOUND})\n"
+                   "set(OPENSSL_INCLUDE_DIR ${OpenSSL_INCLUDE_DIRS})\n"
+                   "set(OPENSSL_LIBRARIES ${OpenSSL_LIBRARIES})\n",
+                   append=True)
+
+    def build(self):
+        self._patch_sources()
+
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("COPYING", src=os.path.join(self.source_folder, self._source_subfolder), dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["git2"]
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["winhttp", "rpcrt4", "crypt32"])
+        if self.settings.os == "Linux" and self.options.threadsafe:
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/libgit2/0.28.x/conanfile.py
+++ b/recipes/libgit2/0.28.x/conanfile.py
@@ -128,7 +128,7 @@ class LibGit2Conan(ConanFile):
     def _patch_sources(self):
         tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
                               "FIND_PKGLIBRARIES(LIBSSH2 libssh2)",
-                              "FIND_PACKAGE(libssh2 REQUIRED)\n"
+                              "FIND_PACKAGE(Libssh2 REQUIRED)\n"
                               "\tSET(LIBSSH2_FOUND ON)\n"
                               "\tSET(LIBSSH2_INCLUDE_DIRS ${libssh2_INCLUDE_DIRS})\n"
                               "\tSET(LIBSSH2_LIBRARIES ${libssh2_LIBRARIES})\n"

--- a/recipes/libgit2/0.28.x/conanfile.py
+++ b/recipes/libgit2/0.28.x/conanfile.py
@@ -130,9 +130,9 @@ class LibGit2Conan(ConanFile):
                               "FIND_PKGLIBRARIES(LIBSSH2 libssh2)",
                               "FIND_PACKAGE(Libssh2 REQUIRED)\n"
                               "\tSET(LIBSSH2_FOUND ON)\n"
-                              "\tSET(LIBSSH2_INCLUDE_DIRS ${libssh2_INCLUDE_DIRS})\n"
-                              "\tSET(LIBSSH2_LIBRARIES ${libssh2_LIBRARIES})\n"
-                              "\tSET(LIBSSH2_LIBRARY_DIRS ${libssh2_LIB_DIRS})")
+                              "\tSET(LIBSSH2_INCLUDE_DIRS ${Libssh2_INCLUDE_DIRS})\n"
+                              "\tSET(LIBSSH2_LIBRARIES ${Libssh2_LIBRARIES})\n"
+                              "\tSET(LIBSSH2_LIBRARY_DIRS ${Libssh2_LIB_DIRS})")
         tools.save("FindOpenSSL.cmake",
                    "set(OPENSSL_FOUND ${OpenSSL_FOUND})\n"
                    "set(OPENSSL_INCLUDE_DIR ${OpenSSL_INCLUDE_DIRS})\n"

--- a/recipes/libgit2/0.28.x/test_package/CMakeLists.txt
+++ b/recipes/libgit2/0.28.x/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/libgit2/0.28.x/test_package/conanfile.py
+++ b/recipes/libgit2/0.28.x/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libgit2/0.28.x/test_package/test_package.cpp
+++ b/recipes/libgit2/0.28.x/test_package/test_package.cpp
@@ -1,0 +1,35 @@
+#include "git2.h"
+
+#include <cstdlib>
+#include <iostream>
+
+int main()
+{
+    git_libgit2_init();
+    int versionMajor, versionMinor, versionRev;
+    git_libgit2_version(&versionMajor, &versionMinor, &versionRev);
+
+    std::cout << "libgit2 v" << versionMajor << "." << versionMinor << "." << versionRev << std::endl;
+
+    std::cout << "Compile Features:" << std::endl;
+
+    int features = git_libgit2_features();
+
+    if (features & GIT_FEATURE_THREADS)
+        std::cout << " - Thread safe" << std::endl;
+    else
+        std::cout << " - Single thread only" << std::endl;
+
+    if (features & GIT_FEATURE_HTTPS)
+        std::cout << " - TLS (openssl, mbedtls, winhttp or security)" << std::endl;
+    else
+        std::cout << " - No TLS" << std::endl;
+
+    if (features & GIT_FEATURE_SSH)
+        std::cout << " - SSH (libssh2)" << std::endl;
+    else
+        std::cout << " - No SSH support" << std::endl;
+
+    git_libgit2_shutdown();
+    return EXIT_SUCCESS;
+}

--- a/recipes/libgit2/config.yml
+++ b/recipes/libgit2/config.yml
@@ -1,8 +1,8 @@
 versions:
   "0.28.5":
-    folder: "all"
+    folder: "0.28.x"
   "0.28.3":
-    folder: "all"
+    folder: "0.28.x"
   "0.27.10":
     folder: "0.27.x"
   "0.27.9":


### PR DESCRIPTION
Specify library name and version:  **libgit2/0.28.x**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This PR moves the libgit2 0.28 recipe from `all` to `0.28.x` folder. This is a step for adding the 1.x.x recipe. Below 1.0.0, each minor version need its own recipe (because options changed). The next step will be to add the 1.x.x version recipe.