### PR TITLE
Use the correct find_package name

### DIFF
--- a/recipes/libalsa/all/conanfile.py
+++ b/recipes/libalsa/all/conanfile.py
@@ -70,3 +70,5 @@ class LibalsaConan(ConanFile):
         self.cpp_info.libs = ["asound"]
         self.cpp_info.system_libs = ["dl", "m", "rt", "pthread"]
         self.cpp_info.names['pkg_config'] = 'alsa'
+        self.cpp_info.names["cmake_find_package"] = "ALSA"
+        self.cpp_info.names["cmake_find_package_multi"] = "ALSA"


### PR DESCRIPTION
Specify library name and version:  **libalsa**
The "official" name for the `FindPackage.cmake` of `libalsa` is `FindALSA.cmake`. Using the "official" name makes the Conan integration more straightforward.

https://github.com/Kitware/CMake/blob/master/Modules/FindALSA.cmake

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
.