### PR TITLE
cmake: add 3.16.9, 3.17.5, 3.18.3 + update OpenSSL + exclude unsupported compilers

### DIFF
--- a/recipes/cmake/3.x.x/conandata.yml
+++ b/recipes/cmake/3.x.x/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "3.16.8":
     sha256: 177434021132686cb901fea7db9fa2345efe48d566b998961594d5cc346ac588
     url: https://cmake.org/files/v3.16/cmake-3.16.8.tar.gz
+  "3.16.9":
+    sha256: 1708361827a5a0de37d55f5c9698004c035abb1de6120a376d5d59a81630191f
+    url: https://cmake.org/files/v3.16/cmake-3.16.9.tar.gz
   "3.17.0":
     sha256: b74c05b55115eacc4fa2b77a814981dbda05cdc95a53e279fe16b7b272f00847
     url: https://cmake.org/files/v3.17/cmake-3.17.0.tar.gz
@@ -35,6 +38,9 @@ sources:
   "3.17.4":
     sha256: 86985d73d0a63ec99c236aab5287316e252164f33d7c4cb160954a980c71f36f
     url: https://cmake.org/files/v3.17/cmake-3.17.4.tar.gz
+  "3.17.5":
+    sha256: 8c3083d98fd93c1228d5e4e40dbff2dd88f4f7b73b9fa24a2938627b8bc28f1a
+    url: https://cmake.org/files/v3.17/cmake-3.17.5.tar.gz
   "3.18.0":
     sha256: 83b4ffcb9482a73961521d2bafe4a16df0168f03f56e6624c419c461e5317e29
     url: https://github.com/Kitware/CMake/releases/download/v3.18.0/cmake-3.18.0.tar.gz

--- a/recipes/cmake/3.x.x/conandata.yml
+++ b/recipes/cmake/3.x.x/conandata.yml
@@ -50,6 +50,9 @@ sources:
   "3.18.2":
     sha256: 5d4e40fc775d3d828c72e5c45906b4d9b59003c9433ff1b36a1cb552bbd51d7e
     url: https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2.tar.gz
+  "3.18.3":
+    sha256: 2c89f4e30af4914fd6fb5d00f863629812ada848eee4e2d29ec7e456d7fa32e5
+    url: https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3.tar.gz
   "3.18.4":
     sha256: 597c61358e6a92ecbfad42a9b5321ddd801fc7e7eca08441307c9138382d4f77
     url: https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4.tar.gz

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -36,6 +36,30 @@ class CMakeConan(ConanFile):
         if self.settings.os == "Macos" and self.settings.arch == "x86":
             raise ConanInvalidConfiguration("CMake does not support x86 for macOS")
 
+        minimal_cpp_standard = "11"
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, minimal_cpp_standard)
+
+        minimal_version = {
+            "gcc": "5",
+            "clang": "3.3",
+            "apple-clang": "9",
+            "Visual Studio": "15",
+        }
+
+        compiler = str(self.settings.compiler)
+        if compiler not in minimal_version:
+            self.output.warn(
+                "{} recipe lacks information about the {} compiler standard version support".format(self.name, compiler))
+            self.output.warn(
+                "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
+            return
+
+        version = tools.Version(self.settings.compiler.version)
+        if version < minimal_version[compiler]:
+            raise ConanInvalidConfiguration(
+                "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
+
     def requirements(self):
         if self._with_openssl:
             self.requires("openssl/1.1.1h")

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -44,7 +44,7 @@ class CMakeConan(ConanFile):
             "gcc": "5",
             "clang": "3.3",
             "apple-clang": "9",
-            "Visual Studio": "15",
+            "Visual Studio": "14",
         }
 
         compiler = str(self.settings.compiler)

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -102,6 +102,7 @@ class CMakeConan(ConanFile):
 
     def package_id(self):
         self.info.options.with_openssl = self._with_openssl
+        del self.info.settings.compiler
 
     def package_info(self):
         minor = self._minor_version()

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -72,6 +72,8 @@ class CMakeConan(ConanFile):
     def _configure_cmake(self):
         if not self._cmake:
             self._cmake = CMake(self)
+            if not self.settings.compiler.cppstd:
+                self._cmake.definitions["CMAKE_CXX_STANDARD"] = 11
             self._cmake.definitions["CMAKE_BOOTSTRAP"] = False
             if self.settings.os == "Linux":
                 self._cmake.definitions["CMAKE_USE_OPENSSL"] = self._with_openssl

--- a/recipes/cmake/config.yml
+++ b/recipes/cmake/config.yml
@@ -13,6 +13,8 @@ versions:
     folder: "3.x.x"
   "3.16.8":
     folder: "3.x.x"
+  "3.16.9":
+    folder: "3.x.x"
   "3.17.0":
     folder: "3.x.x"
   "3.17.1":
@@ -22,6 +24,8 @@ versions:
   "3.17.3":
     folder: "3.x.x"
   "3.17.4":
+    folder: "3.x.x"
+  "3.17.5":
     folder: "3.x.x"
   "3.18.0":
     folder: "3.x.x"

--- a/recipes/cmake/config.yml
+++ b/recipes/cmake/config.yml
@@ -33,5 +33,7 @@ versions:
     folder: "3.x.x"
   "3.18.2":
     folder: "3.x.x"
+  "3.18.3":
+    folder: "3.x.x"
   "3.18.4":
     folder: "3.x.x"


### PR DESCRIPTION
Specify library name and version:  **cmake/3.16.9**, **cmake/3.17.5** , **cmake/3.18.3**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
