### PR TITLE
libjpeg-turbo: add provides attribute

### DIFF
--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -10,6 +10,7 @@ class LibjpegTurboConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libjpeg-turbo.org"
     license = "BSD-3-Clause, Zlib"
+    provides = "libjpeg"
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"


### PR DESCRIPTION
Specify library name and version:  **libjpeg-turbo/***

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

first step for virtual-libjpeg package : https://github.com/conan-io/conan-center-index/issues/2894