### PR TITLE
openexr: add std library to system libs

### DIFF
--- a/recipes/openexr/2.x/conanfile.py
+++ b/recipes/openexr/2.x/conanfile.py
@@ -107,3 +107,7 @@ class OpenEXRConan(ConanFile):
 
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")
+
+        stdlib = tools.stdcpp_library(self)
+        if not self.options.shared and stdlib:
+            self.cpp_info.system_libs.append(stdlib)

--- a/recipes/openexr/2.x/test_package/CMakeLists.txt
+++ b/recipes/openexr/2.x/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Specify library name and version:  **openexr/2.***

it is needed to compile  imagemagick : https://travis-ci.com/github/bincrafters/conan-imagemagick/jobs/386954528#L1705
https://github.com/bincrafters/conan-imagemagick/runs/1133215468?check_suite_focus=true#step:5:1662

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
