### PR TITLE
m4: disable hardening because not all systems link ssp library by default

### DIFF
--- a/recipes/m4/all/conandata.yml
+++ b/recipes/m4/all/conandata.yml
@@ -18,3 +18,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0008-open-files-in-binary-mode.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0009-disable-hardening-in-source.patch"
+      base_path: "source_subfolder"

--- a/recipes/m4/all/patches/0009-disable-hardening-in-source.patch
+++ b/recipes/m4/all/patches/0009-disable-hardening-in-source.patch
@@ -1,0 +1,16 @@
+This requires linking to ssp on some systems, which might not always present.
+If this is really desired:
+* add `-lssp` to LDFLAGS, and
+* add `-D_FORTIFY_SOURCE=2` to CPPFLAGS/CFLAGS
+
+--- lib/config.hin
++++ lib/config.hin
+@@ -96,7 +96,7 @@
+ /* Enable compile-time and run-time bounds-checking, and some warnings,
+       without upsetting newer glibc. */
+    #if defined __OPTIMIZE__ && __OPTIMIZE__
+-   # define _FORTIFY_SOURCE 2
++   //# define _FORTIFY_SOURCE 2
+    #endif
+   
+ 


### PR DESCRIPTION
Specify library name and version:  **m4/1.4.18**

Fixes #2915

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
