### PR TITLE
hana: simplify recipe + fix cmake filename

### DIFF
--- a/recipes/hana/all/conanfile.py
+++ b/recipes/hana/all/conanfile.py
@@ -3,6 +3,8 @@ from conans.errors import ConanInvalidConfiguration
 import os
 
 
+required_conan_version = ">=1.28.0"
+
 class HanaConan(ConanFile):
     name = "hana"
     url = "https://github.com/conan-io/conan-center-index"
@@ -45,3 +47,11 @@ class HanaConan(ConanFile):
     def package(self):
         self.copy("LICENSE.md", dst="licenses", src=self._source_subfolder)
         self.copy("*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
+
+    def package_info(self):
+        # TODO: CMake imported target shouldn't be namespaced (waiting https://github.com/conan-io/conan/issues/7615 to be implemented)
+        self.cpp_info.filenames["cmake_find_package"] = "Hana"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "Hana"
+        self.cpp_info.names["cmake_find_package"] = "hana"
+        self.cpp_info.names["cmake_find_package_multi"] = "hana"
+        self.cpp_info.names["pkg_config"] = "hana"

--- a/recipes/hana/all/conanfile.py
+++ b/recipes/hana/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, tools, CMake
+from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
@@ -12,7 +12,6 @@ class HanaConan(ConanFile):
     topics = ("hana", "metaprogramming", "boost")
     settings = "compiler"
     no_copy_source = True
-    exports_sources = "CMakeLists.txt"
 
     _compiler_cpp14_support = {
         "gcc": "4.9.3",
@@ -25,10 +24,6 @@ class HanaConan(ConanFile):
     def _source_subfolder(self):
         return "_source_subfolder"
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("hana-" + self.version, self._source_subfolder)
-
     def configure(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "14")
@@ -40,14 +35,13 @@ class HanaConan(ConanFile):
         except KeyError:
             self.output.warn("This recipe might not support the compiler. Consider adding it.")
 
-    def package(self):
-        cmake = CMake(self)
-        cmake.configure(source_folder=self._source_subfolder)
-        cmake.install()
-
-        self.copy("LICENSE.md", dst="licenses", src=self._source_subfolder)
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-
     def package_id(self):
         self.info.header_only()
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("hana-" + self.version, self._source_subfolder)
+
+    def package(self):
+        self.copy("LICENSE.md", dst="licenses", src=self._source_subfolder)
+        self.copy("*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))

--- a/recipes/hana/all/test_package/CMakeLists.txt
+++ b/recipes/hana/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(Hana REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} hana::hana) # TODO: remove hana:: namespace when fixed in conanfile.py of hana
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)

--- a/recipes/hana/all/test_package/conanfile.py
+++ b/recipes/hana/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **hana/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Modifications:
- No need to install through CMakeLists, relevant part of build/installation for conan is just a copy of header files without any modifications.
- package_info:
  - Official CMake config file is `HanaConfig.cmake`
  - Imported CMake target should be `hana` (no namespace), but it can't be modeled in conan generators currently.
  - pkg-config filename is `hana.pc` (so default value is fine, but it's enforced to clearly state that it's properly taken into account in the recipe).