### PR TITLE
add openssl/1.1.1h and remove versions we don't build

### DIFF
--- a/recipes/openssl/1.x.x/conandata.yml
+++ b/recipes/openssl/1.x.x/conandata.yml
@@ -1,61 +1,4 @@
 sources:
-  1.0.2:
-    sha256: 8c48baf3babe0d505d16cfc0cf272589c66d3624264098213db0fb00034728e9
-    url: https://www.openssl.org/source/openssl-1.0.2.tar.gz
-  1.0.2a:
-    sha256: 15b6393c20030aab02c8e2fe0243cb1d1d18062f6c095d67bca91871dc7f324a
-    url: https://www.openssl.org/source/openssl-1.0.2a.tar.gz
-  1.0.2b:
-    sha256: d5d488cc9f0a07974195a7427094ea3cab9800a4e90178b989aa621fbc238e3f
-    url: https://www.openssl.org/source/openssl-1.0.2b.tar.gz
-  1.0.2c:
-    sha256: 0038ba37f35a6367c58f17a7a7f687953ef8ce4f9684bbdec63e62515ed36a83
-    url: https://www.openssl.org/source/openssl-1.0.2c.tar.gz
-  1.0.2d:
-    sha256: 671c36487785628a703374c652ad2cebea45fa920ae5681515df25d9f2c9a8c8
-    url: https://www.openssl.org/source/openssl-1.0.2d.tar.gz
-  1.0.2e:
-    sha256: e23ccafdb75cfcde782da0151731aa2185195ac745eea3846133f2e05c0e0bff
-    url: https://www.openssl.org/source/openssl-1.0.2e.tar.gz
-  1.0.2f:
-    sha256: 932b4ee4def2b434f85435d9e3e19ca8ba99ce9a065a61524b429a9d5e9b2e9c
-    url: https://www.openssl.org/source/openssl-1.0.2f.tar.gz
-  1.0.2g:
-    sha256: b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33
-    url: https://www.openssl.org/source/openssl-1.0.2g.tar.gz
-  1.0.2h:
-    sha256: 1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919
-    url: https://www.openssl.org/source/openssl-1.0.2h.tar.gz
-  1.0.2i:
-    sha256: 9287487d11c9545b6efb287cdb70535d4e9b284dd10d51441d9b9963d000de6f
-    url: https://www.openssl.org/source/openssl-1.0.2i.tar.gz
-  1.0.2j:
-    sha256: e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431
-    url: https://www.openssl.org/source/openssl-1.0.2j.tar.gz
-  1.0.2k:
-    sha256: 6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0
-    url: https://www.openssl.org/source/openssl-1.0.2k.tar.gz
-  1.0.2l:
-    sha256: ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c
-    url: https://www.openssl.org/source/openssl-1.0.2l.tar.gz
-  1.0.2m:
-    sha256: 8c6ff15ec6b319b50788f42c7abc2890c08ba5a1cdcd3810eb9092deada37b0f
-    url: https://www.openssl.org/source/openssl-1.0.2m.tar.gz
-  1.0.2n:
-    sha256: 370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe
-    url: https://www.openssl.org/source/openssl-1.0.2n.tar.gz
-  1.0.2o:
-    sha256: ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
-    url: https://www.openssl.org/source/openssl-1.0.2o.tar.gz
-  1.0.2p:
-    sha256: 50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00
-    url: https://www.openssl.org/source/openssl-1.0.2p.tar.gz
-  1.0.2q:
-    sha256: 5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684
-    url: https://www.openssl.org/source/openssl-1.0.2q.tar.gz
-  1.0.2r:
-    sha256: ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
-    url: https://www.openssl.org/source/openssl-1.0.2r.tar.gz
   1.0.2s:
     sha256: cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96
     url: https://www.openssl.org/source/openssl-1.0.2s.tar.gz
@@ -65,54 +8,12 @@ sources:
   1.0.2u:
     sha256: ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
     url: https://www.openssl.org/source/openssl-1.0.2u.tar.gz
-  1.1.0:
-    sha256: f5c69ff9ac1472c80b868efc1c1c0d8dcfc746d29ebe563de2365dd56dbd8c82
-    url: https://www.openssl.org/source/openssl-1.1.0.tar.gz
-  1.1.0a:
-    sha256: c2e696e34296cde2c9ec5dcdad9e4f042cd703932591d395c389de488302442b
-    url: https://www.openssl.org/source/openssl-1.1.0a.tar.gz
-  1.1.0b:
-    sha256: a45de072bf9be4dea437230aaf036000f0e68c6a665931c57e76b5b036cef6f7
-    url: https://www.openssl.org/source/openssl-1.1.0b.tar.gz
-  1.1.0c:
-    sha256: fc436441a2e05752d31b4e46115eb89709a28aef96d4fe786abe92409b2fd6f5
-    url: https://www.openssl.org/source/openssl-1.1.0c.tar.gz
-  1.1.0d:
-    sha256: 7d5ebb9e89756545c156ff9c13cf2aa6214193b010a468a3bc789c3c28fe60df
-    url: https://www.openssl.org/source/openssl-1.1.0d.tar.gz
-  1.1.0e:
-    sha256: 57be8618979d80c910728cfc99369bf97b2a1abd8f366ab6ebdee8975ad3874c
-    url: https://www.openssl.org/source/openssl-1.1.0e.tar.gz
-  1.1.0f:
-    sha256: 12f746f3f2493b2f39da7ecf63d7ee19c6ac9ec6a4fcd8c229da8a522cb12765
-    url: https://www.openssl.org/source/openssl-1.1.0f.tar.gz
-  1.1.0g:
-    sha256: de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af
-    url: https://www.openssl.org/source/openssl-1.1.0g.tar.gz
-  1.1.0h:
-    sha256: 5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517
-    url: https://www.openssl.org/source/openssl-1.1.0h.tar.gz
-  1.1.0i:
-    sha256: ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99
-    url: https://www.openssl.org/source/openssl-1.1.0i.tar.gz
-  1.1.0j:
-    sha256: 31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246
-    url: https://www.openssl.org/source/openssl-1.1.0j.tar.gz
   1.1.0k:
     sha256: efa4965f4f773574d6cbda1cf874dbbe455ab1c0d4f906115f867d30444470b1
     url: https://www.openssl.org/source/openssl-1.1.0k.tar.gz
   1.1.0l:
     sha256: 74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148
     url: https://www.openssl.org/source/openssl-1.1.0l.tar.gz
-  1.1.1:
-    sha256: 2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d
-    url: https://www.openssl.org/source/openssl-1.1.1.tar.gz
-  1.1.1a:
-    sha256: fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41
-    url: https://www.openssl.org/source/openssl-1.1.1a.tar.gz
-  1.1.1b:
-    sha256: 5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b
-    url: https://www.openssl.org/source/openssl-1.1.1b.tar.gz
   1.1.1c:
     sha256: f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90
     url: https://www.openssl.org/source/openssl-1.1.1c.tar.gz

--- a/recipes/openssl/1.x.x/conandata.yml
+++ b/recipes/openssl/1.x.x/conandata.yml
@@ -128,3 +128,6 @@ sources:
   1.1.1g:
     sha256: ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
     url: https://www.openssl.org/source/openssl-1.1.1g.tar.gz
+  1.1.1h:
+    sha256: 5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9
+    url: https://www.openssl.org/source/openssl-1.1.1h.tar.gz

--- a/recipes/openssl/1.x.x/test_package/CMakeLists.txt
+++ b/recipes/openssl/1.x.x/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 project(OpenSSLTests)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -19,3 +19,5 @@ versions:
     folder: "1.x.x"
   1.1.1g:
     folder: "1.x.x"
+  1.1.1h:
+    folder: "1.x.x"


### PR DESCRIPTION
Specify library name and version:  **openssl/1.1.1h**

closes #2987

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

___________________________

https://www.openssl.org/news/openssl-1.1.1-notes.html
