### PR TITLE
fixed broken crosscompile as autoreconf doesnt work this way with cross

### DIFF
--- a/recipes/libelf/all/conanfile.py
+++ b/recipes/libelf/all/conanfile.py
@@ -67,8 +67,6 @@ class LibelfConan(ConanFile):
     def _configure_autotools(self):
         if self._autotools:
             return self._autotools
-        with tools.chdir(self._source_subfolder):
-            self.run("autoreconf -fiv", run_environment=True)
         args = ["--enable-shared={}".format("yes" if self.options.shared else "no")]
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         self._autotools.configure(configure_dir=self._source_subfolder, args=args)

--- a/recipes/libelf/all/conanfile.py
+++ b/recipes/libelf/all/conanfile.py
@@ -67,6 +67,11 @@ class LibelfConan(ConanFile):
     def _configure_autotools(self):
         if self._autotools:
             return self._autotools
+        
+        if not tools.cross_building(self.settings):
+            with tools.chdir(self._source_subfolder):
+                self.run("autoreconf -fiv", run_environment=True)
+
         args = ["--enable-shared={}".format("yes" if self.options.shared else "no")]
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         self._autotools.configure(configure_dir=self._source_subfolder, args=args)


### PR DESCRIPTION
Specify library name and version:  libelf/0.8.13

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Worked before #2838 
when running with -pr:h x86 -pr:b aarch64 i ran into the following issue 
```
checking build system type... x86_64-pc-linux-gnu
checking host system type... Invalid configuration `aarch64-linux-gnu': machine `aarch64' not recognized
configure: error: /bin/bash source_subfolder/config.sub aarch64-linux-gnu failed
```
This bug was introduced in #2838 . After disabling the running of autoreconf the problem went away.
I do not know the correct path to make autoconf work properly with pr:b -pr:h but untill thats resolved i suggest not using it by merging this PR or reverting the #2838 (which introduces some new features for windows) 