### PR TITLE
openblas: fix pkgconfig name and add CMake component

### DIFF
--- a/recipes/openblas/all/test_package/CMakeLists.txt
+++ b/recipes/openblas/all/test_package/CMakeLists.txt
@@ -1,8 +1,10 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(OpenBLAS REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} OpenBLAS::OpenBLAS)

--- a/recipes/openblas/all/test_package/conanfile.py
+++ b/recipes/openblas/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **openblas/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Modifications:
- Official pkg_config filename is `openblas.pc`, not `OpenBLAS.pc`
- CMake:
  - config file:
    - CMake imported target is always `OpenBLAS::OpenBLAS` (so previous revision was correct)
    - config file also defines one and only one component: `openmp`, `pthread` or `serial`.
  - So this transparent CMake integration will work with this PR:
    ```cmake
       find_package(OpenBLAS REQUIRED pthread CONFIG)
       target_link_libraries(myapp OpenBLAS::OpenBLAS)
    ```
  - module file should be `FindBLAS.cmake`, but it's so specific that it's better not trying to mimic this one.
