### PR TITLE
rocksdb: fix CMake imported target + access of with_ttb option

### DIFF
--- a/recipes/rocksdb/all/conanfile.py
+++ b/recipes/rocksdb/all/conanfile.py
@@ -158,11 +158,10 @@ class RocksDB(ConanFile):
             for file in glob.glob(os.path.join(self.package_folder, "lib", static_lib_name)):
                 os.remove(file)
 
-
     def _remove_cpp_headers(self):
         for path in glob.glob(os.path.join(self.package_folder, "include", "rocksdb", "*")):
             if path != os.path.join(self.package_folder, "include", "rocksdb", "c.h"):
-                if os.path.isfile(path): 
+                if os.path.isfile(path):
                     os.remove(path)
                 else:
                     shutil.rmtree(path)
@@ -175,7 +174,6 @@ class RocksDB(ConanFile):
         if self.options.shared:
             self._remove_static_libraries()
             self._remove_cpp_headers() # Force stable ABI for shared libraries
-
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):

--- a/recipes/rocksdb/all/conanfile.py
+++ b/recipes/rocksdb/all/conanfile.py
@@ -177,12 +177,29 @@ class RocksDB(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "RocksDB"
         self.cpp_info.names["cmake_find_package_multi"] = "RocksDB"
-        self.cpp_info.libs = tools.collect_libs(self)
+        cmake_target = "rocksdb-shared" if self.options.shared else "rocksdb"
+        self.cpp_info.components["librocksdb"].names["cmake_find_package"] = cmake_target
+        self.cpp_info.components["librocksdb"].names["cmake_find_package_multi"] = cmake_target
+        self.cpp_info.components["librocksdb"].libs = tools.collect_libs(self)
         if self.settings.os == "Windows":
-            self.cpp_info.system_libs = ["Shlwapi.lib", "Rpcrt4.lib"]
+            self.cpp_info.components["librocksdb"].system_libs = ["shlwapi", "rpcrt4"]
             if self.options.shared:
-                self.cpp_info.defines = ["ROCKSDB_DLL"]
+                self.cpp_info.components["librocksdb"].defines = ["ROCKSDB_DLL"]
         elif self.settings.os == "Linux":
-            self.cpp_info.system_libs = ["pthread", "m"]
+            self.cpp_info.components["librocksdb"].system_libs = ["pthread", "m"]
         if self.options.lite:
-            self.cpp_info.defines.append("ROCKSDB_LITE")
+            self.cpp_info.components["librocksdb"].defines.append("ROCKSDB_LITE")
+        if self.options.with_gflags:
+            self.cpp_info.components["librocksdb"].requires.append("gflags::gflags")
+        if self.options.with_snappy:
+            self.cpp_info.components["librocksdb"].requires.append("snappy::snappy")
+        if self.options.with_lz4:
+            self.cpp_info.components["librocksdb"].requires.append("lz4::lz4")
+        if self.options.with_zlib:
+            self.cpp_info.components["librocksdb"].requires.append("zlib::zlib")
+        if self.options.with_zstd:
+            self.cpp_info.components["librocksdb"].requires.append("zstd::zstd")
+        if self.options.get_safe("with_tbb"):
+            self.cpp_info.components["librocksdb"].requires.append("tbb::tbb")
+        if self.options.with_jemalloc:
+            self.cpp_info.components["librocksdb"].requires.append("jemalloc::jemalloc")

--- a/recipes/rocksdb/all/conanfile.py
+++ b/recipes/rocksdb/all/conanfile.py
@@ -62,11 +62,9 @@ class RocksDB(ConanFile):
         if self.settings.arch != "x86_64":
             del self.options.with_tbb
 
-        minimal_cpp_standard = "11"
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, minimal_cpp_standard)
-
     def configure(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 11)
         if self.settings.arch not in ["x86_64", "ppc64le", "ppc64", "mips64", "armv8"]:
             raise ConanInvalidConfiguration("Rocksdb requires 64 bits")
 

--- a/recipes/rocksdb/all/conanfile.py
+++ b/recipes/rocksdb/all/conanfile.py
@@ -102,7 +102,7 @@ class RocksDB(ConanFile):
         self._cmake.definitions["WITH_LZ4"] = self.options.with_lz4
         self._cmake.definitions["WITH_ZLIB"] = self.options.with_zlib
         self._cmake.definitions["WITH_ZSTD"] = self.options.with_zstd
-        self._cmake.definitions["WITH_TBB"] = self.options.with_tbb
+        self._cmake.definitions["WITH_TBB"] = self.options.get_safe("with_tbb", False)
         self._cmake.definitions["WITH_JEMALLOC"] = self.options.with_jemalloc
         self._cmake.definitions["ROCKSDB_BUILD_SHARED"] = self.options.shared
         self._cmake.definitions["ROCKSDB_LIBRARY_EXPORTS"] = self.settings.os == "Windows" and self.options.shared
@@ -146,7 +146,7 @@ class RocksDB(ConanFile):
             self.requires("zlib/1.2.11")
         if self.options.with_zstd:
             self.requires("zstd/1.3.8")
-        if self.options.with_tbb:
+        if self.options.get_safe("with_tbb"):
             self.requires("tbb/2019_u9")
         if self.options.with_jemalloc:
             self.requires("jemalloc/5.2.1")

--- a/recipes/rocksdb/all/conanfile.py
+++ b/recipes/rocksdb/all/conanfile.py
@@ -76,6 +76,22 @@ class RocksDB(ConanFile):
         if self.settings.build_type == "Debug":
             self.options.use_rtti = True  # Rtti are used in asserts for debug mode...
 
+    def requirements(self):
+        if self.options.with_gflags:
+            self.requires("gflags/2.2.2")
+        if self.options.with_snappy:
+            self.requires("snappy/1.1.8")
+        if self.options.with_lz4:
+            self.requires("lz4/1.9.2")
+        if self.options.with_zlib:
+            self.requires("zlib/1.2.11")
+        if self.options.with_zstd:
+            self.requires("zstd/1.4.5")
+        if self.options.get_safe("with_tbb"):
+            self.requires("tbb/2020.2")
+        if self.options.with_jemalloc:
+            self.requires("jemalloc/5.2.1")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = "{name}-{version}".format(
@@ -134,22 +150,6 @@ class RocksDB(ConanFile):
         self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()
-
-    def requirements(self):
-        if self.options.with_gflags:
-            self.requires("gflags/2.2.2")
-        if self.options.with_snappy:
-            self.requires("snappy/1.1.7")
-        if self.options.with_lz4:
-            self.requires("lz4/1.9.2")
-        if self.options.with_zlib:
-            self.requires("zlib/1.2.11")
-        if self.options.with_zstd:
-            self.requires("zstd/1.3.8")
-        if self.options.get_safe("with_tbb"):
-            self.requires("tbb/2019_u9")
-        if self.options.with_jemalloc:
-            self.requires("jemalloc/5.2.1")
 
     def _remove_static_libraries(self):
         for static_lib_name in ["lib*.a", "{}.lib".format(self.name)]:

--- a/recipes/rocksdb/all/test_package/CMakeLists.txt
+++ b/recipes/rocksdb/all/test_package/CMakeLists.txt
@@ -1,14 +1,18 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-if(NOT ROCKSDB_DLL)
-    add_executable(test_package_cpp test_package.cpp)
-    target_link_libraries(test_package_cpp ${CONAN_LIBS})
-    set_property(TARGET test_package_cpp PROPERTY CXX_STANDARD 11)
-endif()
+find_package(RocksDB REQUIRED CONFIG)
 
-add_executable(test_package_stable_abi test_package_stable_abi.cpp)
-target_link_libraries(test_package_stable_abi ${CONAN_LIBS})
+add_executable(${PROJECT_NAME}_stable_abi test_package_stable_abi.cpp)
+if(ROCKSDB_SHARED)
+  target_link_libraries(${PROJECT_NAME}_stable_abi RocksDB::rocksdb-shared)
+else()
+  target_link_libraries(${PROJECT_NAME}_stable_abi RocksDB::rocksdb)
+
+  add_executable(${PROJECT_NAME}_cpp test_package.cpp)
+  target_link_libraries(${PROJECT_NAME}_cpp RocksDB::rocksdb)
+  set_property(TARGET ${PROJECT_NAME}_cpp PROPERTY CXX_STANDARD 11)
+endif()

--- a/recipes/rocksdb/all/test_package/conanfile.py
+++ b/recipes/rocksdb/all/test_package/conanfile.py
@@ -4,12 +4,11 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["ROCKSDB_DLL"] = self.options["rocksdb"].shared
-
+        cmake.definitions["ROCKSDB_SHARED"] = self.options["rocksdb"].shared
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **rocksdb/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

closes https://github.com/conan-io/conan-center-index/issues/2967

CMake targets: https://github.com/facebook/rocksdb/blob/0ce9b3a22d366f664ac21cfb742966b8683cebec/CMakeLists.txt#L881
exported here: https://github.com/facebook/rocksdb/blob/0ce9b3a22d366f664ac21cfb742966b8683cebec/CMakeLists.txt#L1002
