### PR TITLE
Fix builds for OpenSSL < 1.0.2d

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -552,6 +552,11 @@ class OpenSSLConan(ConanFile):
             # /Library/Developer/CommandLineTools/usr/bin/ar: internal ranlib command failed
             if self.settings.os == "Macos" and self._full_version < "1.1.0":
                 parallel = False
+
+            # Building in parallel for versions less than 1.0.2d causes errors
+            # See https://github.com/openssl/openssl/issues/298
+            if self._full_version < "1.0.2d":
+                parallel = False
             command.append(("-j%s" % tools.cpu_count()) if parallel else "-j1")
         self.run(" ".join(command), win_bash=self._win_bash)
 


### PR DESCRIPTION
Enabling "make" parallelisation when building OpenSSL < 1.0.2d
causes errors. This commit modifies the OpenSSL 1.x.x recipe to
disable parallel builds for versions less than 1.0.2d.

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
