### PR TITLE
zstd: fix pkg-config name

### DIFF
--- a/recipes/zstd/all/conanfile.py
+++ b/recipes/zstd/all/conanfile.py
@@ -68,6 +68,7 @@ class ZstdConan(ConanFile):
 
     def package_info(self):
         zstd_cmake = "libzstd_shared" if self.options.shared else "libzstd_static"
+        self.cpp_info.components["zstdlib"].names["pkg_config"] = "libzstd"
         self.cpp_info.components["zstdlib"].names["cmake_find_package"] = zstd_cmake
         self.cpp_info.components["zstdlib"].names["cmake_find_package_multi"] = zstd_cmake
         self.cpp_info.components["zstdlib"].libs = tools.collect_libs(self)


### PR DESCRIPTION
Specify library name and version:  **zstd/***

see https://github.com/facebook/zstd/blob/dev/lib/libzstd.pc.in and https://packages.debian.org/fr/sid/amd64/libzstd-dev/filelist

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
