### PR TITLE
brotli: add 1.0.9 + don't force PIC

### DIFF
--- a/recipes/brotli/all/conandata.yml
+++ b/recipes/brotli/all/conandata.yml
@@ -1,8 +1,14 @@
 sources:
+  "1.0.9":
+    url: https://github.com/google/brotli/archive/v1.0.9.tar.gz
+    sha256: f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46
   "1.0.7":
     url: https://github.com/google/brotli/archive/v1.0.7.tar.gz
     sha256: 4c61bfb0faca87219ea587326c467b95acb25555b53d1a421ffa3c8a9296ee2c
 patches:
+  "1.0.9":
+    - base_path: "source_subfolder"
+      patch_file: "patches/0002-target-props.patch"
   "1.0.7":
     - base_path: "source_subfolder"
       patch_file: "patches/0001-target-props.patch"

--- a/recipes/brotli/all/patches/0001-target-props.patch
+++ b/recipes/brotli/all/patches/0001-target-props.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index fc45f80..d6b69f3 100644
+index fc45f80..e3b0dbf 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -152,8 +152,17 @@ foreach(lib brotlicommon brotlidec brotlienc)
+@@ -152,15 +152,24 @@ foreach(lib brotlicommon brotlidec brotlienc)
    target_compile_definitions(${lib} PUBLIC "BROTLI_SHARED_COMPILATION" )
    string(TOUPPER "${lib}" LIB)
    set_target_properties (${lib} PROPERTIES DEFINE_SYMBOL "${LIB}_SHARED_COMPILATION" )
@@ -20,6 +20,14 @@ index fc45f80..d6b69f3 100644
  foreach(lib brotlicommon brotlidec brotlienc brotlicommon-static brotlidec-static brotlienc-static)
    target_link_libraries(${lib} ${LIBM_LIBRARY})
    set_property(TARGET ${lib} APPEND PROPERTY INCLUDE_DIRECTORIES ${BROTLI_INCLUDE_DIRS})
+   set_target_properties(${lib} PROPERTIES
+     VERSION "${BROTLI_ABI_COMPATIBILITY}.${BROTLI_ABI_AGE}.${BROTLI_ABI_REVISION}"
+     SOVERSION "${BROTLI_ABI_COMPATIBILITY}"
+-    POSITION_INDEPENDENT_CODE TRUE)
++  )
+   set_property(TARGET ${lib} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${BROTLI_INCLUDE_DIRS}")
+ endforeach()
+ 
 @@ -184,27 +193,33 @@ endif()
  # Build the brotli executable
  add_executable(brotli ${BROTLI_CLI_C})

--- a/recipes/brotli/all/patches/0002-target-props.patch
+++ b/recipes/brotli/all/patches/0002-target-props.patch
@@ -1,0 +1,60 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -183,6 +183,16 @@ foreach(lib IN LISTS BROTLI_SHARED_LIBS)
+   set_target_properties (${lib} PROPERTIES DEFINE_SYMBOL "${LIB}_SHARED_COMPILATION")
+ endforeach()
+ 
++if(BUILD_SHARED_LIBS)
++  foreach(lib IN LISTS BROTLI_STATIC_LIBS)
++    set_target_properties(${lib} PROPERTIES EXCLUDE_FROM_ALL ON EXCLUDE_FROM_DEFAULT ON)
++  endforeach()
++else()
++  foreach(lib IN LISTS BROTLI_SHARED_LIBS)
++    set_target_properties(${lib} PROPERTIES EXCLUDE_FROM_ALL ON EXCLUDE_FROM_DEFAULT ON)
++  endforeach()
++endif()
++
+ foreach(lib IN LISTS BROTLI_SHARED_LIBS BROTLI_STATIC_LIBS)
+   target_link_libraries(${lib} ${LIBM_LIBRARY})
+   set_property(TARGET ${lib} APPEND PROPERTY INCLUDE_DIRECTORIES ${BROTLI_INCLUDE_DIRS})
+@@ -190,7 +200,6 @@ foreach(lib IN LISTS BROTLI_SHARED_LIBS BROTLI_STATIC_LIBS)
+     VERSION "${BROTLI_ABI_COMPATIBILITY}.${BROTLI_ABI_AGE}.${BROTLI_ABI_REVISION}"
+     SOVERSION "${BROTLI_ABI_COMPATIBILITY}")
+   if(NOT BROTLI_EMSCRIPTEN)
+-    set_target_properties(${lib} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+   endif()
+   set_property(TARGET ${lib} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${BROTLI_INCLUDE_DIRS}")
+ endforeach()
+@@ -217,15 +226,13 @@ endif()
+ # Build the brotli executable
+ add_executable(brotli ${BROTLI_CLI_C})
+ target_link_libraries(brotli ${BROTLI_LIBRARIES_STATIC})
++set_target_properties(brotli PROPERTIES EXCLUDE_FROM_ALL ON EXCLUDE_FROM_DEFAULT ON)
+ 
+ # Installation
+ if(NOT BROTLI_EMSCRIPTEN)
+ if(NOT BROTLI_BUNDLED_MODE)
+-  install(
+-    TARGETS brotli
+-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+-  )
+ 
++  if(BUILD_SHARED_LIBS)
+   install(
+     TARGETS ${BROTLI_LIBRARIES_CORE}
+     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+@@ -233,12 +240,14 @@ if(NOT BROTLI_BUNDLED_MODE)
+     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+   )
+ 
++  else()
+   install(
+     TARGETS ${BROTLI_LIBRARIES_CORE_STATIC}
+     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+   )
++  endif()
+ 
+   install(
+     DIRECTORY ${BROTLI_INCLUDE_DIRS}/brotli

--- a/recipes/brotli/all/test_package/CMakeLists.txt
+++ b/recipes/brotli/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/brotli/config.yml
+++ b/recipes/brotli/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.9":
+    folder: all
   "1.0.7":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **brotli/1.0.9**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

closes https://github.com/conan-io/conan-center-index/issues/2923