### PR TITLE
libuv: add version 1.40.0

### DIFF
--- a/recipes/libuv/all/conandata.yml
+++ b/recipes/libuv/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "1.38.1":
     url: "https://github.com/libuv/libuv/archive/v1.38.1.zip"
     sha256: "0359369492742eb2a36312fffe26f80bcffe4cec981a4fd72d182b061ee14890"
+  "1.40.0":
+    url: "https://github.com/libuv/libuv/archive/v1.40.0.zip"
+    sha256: "61366e30d8484197dc9e4a94dbd98a0ba52fb55cb6c6d991af1f3701b10f322b"
 patches:
   "1.34.2":
     - base_path: "source_subfolder"
@@ -18,3 +21,6 @@ patches:
   "1.38.1":
     - base_path: "source_subfolder"
       patch_file: "patches/1.38.1/fix-cmake.patch"
+  "1.40.0":
+    - base_path: "source_subfolder"
+      patch_file: "patches/1.40.0/fix-cmake.patch"

--- a/recipes/libuv/all/patches/1.40.0/fix-cmake.patch
+++ b/recipes/libuv/all/patches/1.40.0/fix-cmake.patch
@@ -1,0 +1,75 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e648b00..080f403 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -326,13 +326,17 @@ if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|Linux|NetBSD|OpenBSD")
+   list(APPEND uv_test_libraries util)
+ endif()
+ 
+-add_library(uv SHARED ${uv_sources})
+-target_compile_definitions(uv
+-  INTERFACE
+-    USING_UV_SHARED=1
+-  PRIVATE
+-    BUILDING_UV_SHARED=1
+-    ${uv_defines})
++add_library(uv ${uv_sources})
++get_target_property(target_type uv TYPE)
++if (target_type STREQUAL "SHARED_LIBRARY")
++  target_compile_definitions(uv
++    INTERFACE
++      USING_UV_SHARED=1
++    PRIVATE
++      BUILDING_UV_SHARED=1
++  )
++endif()
++target_compile_definitions(uv PRIVATE ${uv_defines})
+ target_compile_options(uv PRIVATE ${uv_cflags})
+ target_include_directories(uv
+   PUBLIC
+@@ -342,17 +346,6 @@ target_include_directories(uv
+     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+ target_link_libraries(uv ${uv_libraries})
+ 
+-add_library(uv_a STATIC ${uv_sources})
+-target_compile_definitions(uv_a PRIVATE ${uv_defines})
+-target_compile_options(uv_a PRIVATE ${uv_cflags})
+-target_include_directories(uv_a
+-  PUBLIC
+-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+-  PRIVATE
+-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+-target_link_libraries(uv_a ${uv_libraries})
+-
+ if(LIBUV_BUILD_TESTS)
+   # Small hack: use ${uv_test_sources} now to get the runner skeleton,
+   # before the actual tests are added.
+@@ -595,19 +588,18 @@ if(UNIX OR MINGW)
+   configure_file(libuv-static.pc.in libuv-static.pc @ONLY)
+ 
+   install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+-  install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
+-  install(FILES ${PROJECT_BINARY_DIR}/libuv.pc ${PROJECT_BINARY_DIR}/libuv-static.pc
+-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+-  install(TARGETS uv LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  install(TARGETS uv_a ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++  install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses)
++  install(TARGETS uv
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ endif()
+ 
+ if(MSVC)
+   install(DIRECTORY include/ DESTINATION include)
+-  install(FILES LICENSE DESTINATION .)
+-  install(TARGETS uv uv_a
+-          RUNTIME DESTINATION lib/$<CONFIG>
+-          ARCHIVE DESTINATION lib/$<CONFIG>)
++  install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses)
++  install(TARGETS uv
++    RUNTIME DESTINATION bin
++    ARCHIVE DESTINATION lib)
+ endif()
+ 
+ message(STATUS "summary of build options:

--- a/recipes/libuv/all/test_package/CMakeLists.txt
+++ b/recipes/libuv/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/libuv/config.yml
+++ b/recipes/libuv/config.yml
@@ -5,3 +5,5 @@ versions:
         folder: all
     "1.38.1":
         folder: all
+    "1.40.0":
+        folder: all


### PR DESCRIPTION
Specify library name and version:  **libuv/1.40.0**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.  **Recipe run with Conan 1.29.2.**
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.  **Static and shared variants were built using clang 10 on Kubuntu 20.04; no errors emitted from the conan-center hooks.**

This PR adds libuv 1.40.0 (released 2020-09-26) to the libuv recipe.  The CMake patch needed some hunk boundary updates that are also included in this PR.
