### PR TITLE
poco: use openssl 1.1.1h instead of 1.1.1g

### DIFF
--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -135,7 +135,7 @@ class PocoConan(ConanFile):
         if self.options.enable_netssl or \
                 self.options.enable_crypto or \
                 self.options.get_safe("enable_jwt", False):
-            self.requires("openssl/1.1.1g")
+            self.requires("openssl/1.1.1h")
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):


### PR DESCRIPTION
**poco/1.10.1**

Update openssl to v1.1.1.h, which avoids conflicts with thrift 0.13.0
