### PR TITLE
Enable libc++ for jemalloc

### DIFF
--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -52,6 +52,10 @@ class JemallocConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.settings.compiler.get_safe("libcxx") == "libc++" and \
+                self.settings.compiler == "clang" and \
+                tools.Version(self.settings.compiler.version) < "10":
+            raise ConanInvalidConfiguration("old libc++ versions are missing a mutex implementation")
         if self.settings.compiler == "Visual Studio" and self.settings.compiler.version != "15":
             # https://github.com/jemalloc/jemalloc/issues/1703
             raise ConanInvalidConfiguration("Only Visual Studio 15 2017 is supported.  Please fix this if other versions are supported")

--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -55,7 +55,7 @@ class JemallocConan(ConanFile):
         if self.settings.compiler.get_safe("libcxx") == "libc++" and \
                 self.settings.compiler == "clang" and \
                 tools.Version(self.settings.compiler.version) < "10":
-            raise ConanInvalidConfiguration("old libc++ versions are missing a mutex implementation")
+            raise ConanInvalidConfiguration("clang and libc++ version {} (< 10) is missing a mutex implementation".format(self.settings.compiler.version))
         if self.settings.compiler == "Visual Studio" and self.settings.compiler.version != "15":
             # https://github.com/jemalloc/jemalloc/issues/1703
             raise ConanInvalidConfiguration("Only Visual Studio 15 2017 is supported.  Please fix this if other versions are supported")

--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -52,8 +52,6 @@ class JemallocConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if self.settings.compiler.get_safe("libcxx") == "libc++":
-            raise ConanInvalidConfiguration("libc++ is missing a mutex implementation.  Remove this when it is added")
         if self.settings.compiler == "Visual Studio" and self.settings.compiler.version != "15":
             # https://github.com/jemalloc/jemalloc/issues/1703
             raise ConanInvalidConfiguration("Only Visual Studio 15 2017 is supported.  Please fix this if other versions are supported")

--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -52,7 +52,8 @@ class JemallocConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if self.settings.compiler.get_safe("libcxx") == "libc++" and \
+        if self.options.enable_cxx and \
+                self.settings.compiler.get_safe("libcxx") == "libc++" and \
                 self.settings.compiler == "clang" and \
                 tools.Version(self.settings.compiler.version) < "10":
             raise ConanInvalidConfiguration("clang and libc++ version {} (< 10) is missing a mutex implementation".format(self.settings.compiler.version))

--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -56,6 +56,10 @@ class JemallocConan(ConanFile):
                 self.settings.compiler == "clang" and \
                 tools.Version(self.settings.compiler.version) < "10":
             raise ConanInvalidConfiguration("clang and libc++ version {} (< 10) is missing a mutex implementation".format(self.settings.compiler.version))
+        if self.settings.compiler == "Visual Studio" and \
+                self.options.shared and \
+                "MT" in self.settings.compiler.runtime:
+            raise ConanInvalidConfiguration("Visual Studio build for shared library with MT runtime is not supported")
         if self.settings.compiler == "Visual Studio" and self.settings.compiler.version != "15":
             # https://github.com/jemalloc/jemalloc/issues/1703
             raise ConanInvalidConfiguration("Only Visual Studio 15 2017 is supported.  Please fix this if other versions are supported")

--- a/recipes/jemalloc/all/test_package/conanfile.py
+++ b/recipes/jemalloc/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, CMake
 import os
 
 


### PR DESCRIPTION
Specify library name and version:  **jemalloc/5.2.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.


Configuration:
```
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=clang
compiler.libcxx=libc++
compiler.version=10
os=Linux
os_build=Linux
[options]
[build_requires]
[env]
CC=/usr/bin/clang-10
CXX=/usr/bin/clang++-10
```

Seems to work just fine.