### PR TITLE
jasper: add 2.0.21 + change to new officials source url and homepage

### DIFF
--- a/recipes/jasper/all/conandata.yml
+++ b/recipes/jasper/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.21":
+    url: "https://github.com/jasper-software/jasper/archive/version-2.0.21.tar.gz"
+    sha256: "2482def06dfaa33b8d93cbe992a29723309f3c2b6e75674423a52fc82be10418"
   "2.0.19":
     url: "https://github.com/jasper-software/jasper/archive/version-2.0.19.tar.gz"
     sha256: "b9d16162a088617ada36450f2374d72165377cb64b33ed197c200bcfb73ec76c"

--- a/recipes/jasper/all/conandata.yml
+++ b/recipes/jasper/all/conandata.yml
@@ -1,13 +1,13 @@
 sources:
   "2.0.19":
-    url: "https://github.com/mdadams/jasper/archive/version-2.0.19.zip"
-    sha256: "4306c70d5b5141b06ba088a13ce6f46355f9394922eba8a7dd6577bd66d712a3"
+    url: "https://github.com/jasper-software/jasper/archive/version-2.0.19.tar.gz"
+    sha256: "b9d16162a088617ada36450f2374d72165377cb64b33ed197c200bcfb73ec76c"
   "2.0.16":
-    url: "https://github.com/mdadams/jasper/archive/version-2.0.16.zip"
-    sha256: "912495d1074de635fe36884085214cf389403e51f1075d50c6008602e8d9480a"
+    url: "https://github.com/jasper-software/jasper/archive/version-2.0.16.tar.gz"
+    sha256: "f1d8b90f231184d99968f361884e2054a1714fdbbd9944ba1ae4ebdcc9bbfdb1"
   "2.0.14":
-    url: "https://github.com/mdadams/jasper/archive/version-2.0.14.zip"
-    sha256: "05de26be16cf7356f73e8202c0bf4e05597e2c2698a7100d8603253d65f8a790"
+    url: "https://github.com/jasper-software/jasper/archive/version-2.0.14.tar.gz"
+    sha256: "85266eea728f8b14365db9eaf1edc7be4c348704e562bb05095b9a077cf1a97b"
 patches:
   "2.0.16":
     - patch_file: "patches/fix-exported-symbols.patch"

--- a/recipes/jasper/all/conanfile.py
+++ b/recipes/jasper/all/conanfile.py
@@ -6,7 +6,7 @@ from conans import ConanFile, CMake, tools
 class JasperConan(ConanFile):
     name = "jasper"
     license = "JasPer License Version 2.0"
-    homepage = "https://github.com/mdadams/jasper"
+    homepage = "https://jasper-software.github.io/jasper"
     url = "https://github.com/conan-io/conan-center-index"
     topics = ("conan", "jasper", "tool-kit", "coding")
     description = "JasPer Image Processing/Coding Tool Kit"

--- a/recipes/jasper/config.yml
+++ b/recipes/jasper/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.21":
+    folder: all
   "2.0.19":
     folder: all
   "2.0.16":


### PR DESCRIPTION
Specify library name and version:  **jasper/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
