### PR TITLE
Enable use of OpenMesh IO libraries with static linking

### DIFF
--- a/recipes/openmesh/all/conanfile.py
+++ b/recipes/openmesh/all/conanfile.py
@@ -79,6 +79,8 @@ class OpenmeshConan(ConanFile):
         self.cpp_info.components["openmeshcore"].names["cmake_find_package"] = "OpenMeshCore"
         self.cpp_info.components["openmeshcore"].names["cmake_find_package_multi"] = "OpenMeshCore"
         self.cpp_info.components["openmeshcore"].libs = [self._get_decorated_lib("OpenMeshCore")]
+        if not self.options.shared:
+            self.cpp_info.components["openmeshcore"].defines = ["OM_STATIC_BUILD"]
         if self.settings.compiler == "Visual Studio":
             self.cpp_info.components["openmeshcore"].defines.append("_USE_MATH_DEFINES")
         # OpenMeshTools

--- a/recipes/openmesh/all/test_package/test_package.cpp
+++ b/recipes/openmesh/all/test_package/test_package.cpp
@@ -40,7 +40,7 @@ int main()
   face_vhandles.push_back(vhandle[2]);
   face_vhandles.push_back(vhandle[3]);
   mesh.add_face(face_vhandles);
- 
+
   face_vhandles.clear();
   face_vhandles.push_back(vhandle[7]);
   face_vhandles.push_back(vhandle[6]);
@@ -76,5 +76,10 @@ int main()
   face_vhandles.push_back(vhandle[4]);
   mesh.add_face(face_vhandles);
 
+  std::cout << "Writing mesh as obj to stdout\n";
+  if (!OpenMesh::IO::write_mesh(mesh, std::cout, "obj")) {
+    std::cerr << "Unable to write mesh to stdout" << std::endl;
+    return -1;
+  }
   return 0;
 }


### PR DESCRIPTION
 **OpenMesh/8.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

The OpenMesh IO libraries require the definition of `OM_STATIC_BUILD` when linking statically. See [Docs](https://www.graphics.rwth-aachen.de/media/openmesh_static/Documentations/OpenMesh-Doc-Latest/a01236.html#a18286a792ebf896872f5e26182fc5c7b) for details.
