### PR TITLE
cwalk: fix hooks

### DIFF
--- a/recipes/cwalk/all/CMakeLists.txt
+++ b/recipes/cwalk/all/CMakeLists.txt
@@ -4,4 +4,6 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 add_subdirectory("source_subfolder")

--- a/recipes/cwalk/all/conandata.yml
+++ b/recipes/cwalk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.3":
+    url: "https://github.com/likle/cwalk/archive/v1.2.3.zip"
+    sha256: "0d6a560c6d0083aeaf5715ddafcda003e00f783959192fb88dc6c40b5fa9242f"
   "1.2.2":
     url: "https://github.com/likle/cwalk/archive/v1.2.2.zip"
     sha256: "62094c2bb8882fd57fe7ea00fb196e6065b363e8ca57f9c693c19f4912747d88"

--- a/recipes/cwalk/all/conanfile.py
+++ b/recipes/cwalk/all/conanfile.py
@@ -17,16 +17,18 @@ class CwalkConan(ConanFile):
     generators = "cmake"
 
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {'shared': False, 'fPIC': True}
+    options = {
+        "shared": [True, False], 
+        "fPIC": [True, False]
+    }
+    default_options = {
+        "shared": False, 
+        "fPIC": True
+    }
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -42,14 +44,13 @@ class CwalkConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = self.options.shared and self.settings.os == "Windows"
-        cmake.configure(build_folder=self._build_subfolder)
+        cmake.configure()
         cmake.build(target="cwalk")
 
     def package(self):
         include_dir = os.path.join(self._source_subfolder, 'include')
-        lib_dir = os.path.join(self._build_subfolder, "lib")
-        bin_dir = os.path.join(self._build_subfolder, "bin")
+        lib_dir ="lib"
+        bin_dir = "bin"
 
         self.copy("LICENSE.md", dst="licenses", src=self._source_subfolder)
         self.copy("cwalk.h", dst="include", src=include_dir)

--- a/recipes/cwalk/all/test_package/CMakeLists.txt
+++ b/recipes/cwalk/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/cwalk/config.yml
+++ b/recipes/cwalk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.3":
+    folder: all
   "1.2.2":
     folder: all
   "1.1.0":


### PR DESCRIPTION
fix hooks
add 1.2.3
remove build subfolder
move CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to CMakeLists.txt

Specify library name and version:  **cwalk/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
