### PR TITLE
fontconfig: regenerate package

### DIFF
--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -73,6 +73,7 @@ class FontconfigConan(ConanFile):
             if os.path.islink(f):
                 os.unlink(f)
 
+
     def package_info(self):
         self.cpp_info.libs = ["fontconfig"]
         if self.settings.os == "Linux":


### PR DESCRIPTION
after addition of option freetype:with_bortli
in d22a4361d06e5471a8040745e49e649f6667ee51

Specify library name and version:  **fontconfig/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
