### PR TITLE
cmake: ignore MSB warnings

### DIFF
--- a/recipes/cmake/3.x.x/conandata.yml
+++ b/recipes/cmake/3.x.x/conandata.yml
@@ -44,3 +44,49 @@ sources:
   "3.18.2":
     sha256: 5d4e40fc775d3d828c72e5c45906b4d9b59003c9433ff1b36a1cb552bbd51d7e
     url: https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2.tar.gz
+patches:
+  "3.16.2":
+    - patch_file: "patches/3.16.x-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.16.3":
+    - patch_file: "patches/3.16.x-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.16.4":
+    - patch_file: "patches/3.16.x-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.16.5":
+    - patch_file: "patches/3.16.x-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.16.6":
+    - patch_file: "patches/3.16.x-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.16.7":
+    - patch_file: "patches/3.16.x-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.16.8":
+    - patch_file: "patches/3.16.x-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.17.0":
+    - patch_file: "patches/3.17.0-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.17.1":
+    - patch_file: "patches/3.17.0-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.17.2":
+    - patch_file: "patches/3.17.0-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.17.3":
+    - patch_file: "patches/3.17.0-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.17.4":
+    - patch_file: "patches/3.17.0-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.18.0":
+    - patch_file: "patches/3.17.0-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.18.1":
+    - patch_file: "patches/3.17.0-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder
+  "3.18.2":
+    - patch_file: "patches/3.17.0-0001-ignore-MSBXXX-warnings.patch"
+      base_path: source_subfolder

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -19,8 +19,12 @@ class CMakeConan(ConanFile):
     default_options = {
         "with_openssl": "auto",
     }
+    exports_sources = "patches/**"
 
-    _source_subfolder = "source_subfolder"
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
     _cmake = None
 
     def _minor_version(self):
@@ -38,7 +42,7 @@ class CMakeConan(ConanFile):
 
     def requirements(self):
         if self._with_openssl:
-            self.requires("openssl/1.1.1g")
+            self.requires("openssl/1.1.1h")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -57,6 +61,8 @@ class CMakeConan(ConanFile):
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "project(CMake)",
                               "project(CMake)\ninclude(\"{}/conanbuildinfo.cmake\")\nconan_basic_setup()".format(

--- a/recipes/cmake/3.x.x/patches/3.16.x-0001-ignore-MSBXXX-warnings.patch
+++ b/recipes/cmake/3.x.x/patches/3.16.x-0001-ignore-MSBXXX-warnings.patch
@@ -5,7 +5,7 @@
      # Filter out MSBuild output that looks like a warning.
      string(REGEX REPLACE " +0 Warning\\(s\\)" "" check_output "${check_output}")
 +    # Filter out MSBuild output that looks like a warning.
-+    string(REGEX REPLACE " warning MSB[0-9]{4}" "" check_output "${check_output}")
++    string(REGEX REPLACE "[^\n]*warning MSB[0-9][0-9][0-9][0-9][^\n]*" "" check_output "${check_output}")
      # Filter out warnings caused by user flags.
      string(REGEX REPLACE "[^\n]*warning:[^\n]*-Winvalid-command-line-argument[^\n]*" "" check_output "${check_output}")
      # Filter out warnings caused by local configuration.

--- a/recipes/cmake/3.x.x/patches/3.16.x-0001-ignore-MSBXXX-warnings.patch
+++ b/recipes/cmake/3.x.x/patches/3.16.x-0001-ignore-MSBXXX-warnings.patch
@@ -1,0 +1,11 @@
+--- Source/Checks/cm_cxx_features.cmake
++++ Source/Checks/cm_cxx_features.cmake
+@@ -17,6 +17,8 @@
+     set(check_output "${OUTPUT}")
+     # Filter out MSBuild output that looks like a warning.
+     string(REGEX REPLACE " +0 Warning\\(s\\)" "" check_output "${check_output}")
++    # Filter out MSBuild output that looks like a warning.
++    string(REGEX REPLACE " warning MSB[0-9]{4}" "" check_output "${check_output}")
+     # Filter out warnings caused by user flags.
+     string(REGEX REPLACE "[^\n]*warning:[^\n]*-Winvalid-command-line-argument[^\n]*" "" check_output "${check_output}")
+     # Filter out warnings caused by local configuration.

--- a/recipes/cmake/3.x.x/patches/3.17.0-0001-ignore-MSBXXX-warnings.patch
+++ b/recipes/cmake/3.x.x/patches/3.17.0-0001-ignore-MSBXXX-warnings.patch
@@ -1,0 +1,11 @@
+--- Source/Checks/cm_cxx_features.cmake
++++ Source/Checks/cm_cxx_features.cmake
+@@ -21,6 +21,8 @@
+     set(check_output "${OUTPUT}")
+     # Filter out MSBuild output that looks like a warning.
+     string(REGEX REPLACE " +0 Warning\\(s\\)" "" check_output "${check_output}")
++    # Filter out MSBuild output that looks like a warning.
++    string(REGEX REPLACE " warning MSB[0-9]{4}" "" check_output "${check_output}")
+     # Filter out warnings caused by user flags.
+     string(REGEX REPLACE "[^\n]*warning:[^\n]*-Winvalid-command-line-argument[^\n]*" "" check_output "${check_output}")
+     # Filter out warnings caused by local configuration.

--- a/recipes/cmake/3.x.x/patches/3.17.0-0001-ignore-MSBXXX-warnings.patch
+++ b/recipes/cmake/3.x.x/patches/3.17.0-0001-ignore-MSBXXX-warnings.patch
@@ -5,7 +5,7 @@
      # Filter out MSBuild output that looks like a warning.
      string(REGEX REPLACE " +0 Warning\\(s\\)" "" check_output "${check_output}")
 +    # Filter out MSBuild output that looks like a warning.
-+    string(REGEX REPLACE " warning MSB[0-9]{4}" "" check_output "${check_output}")
++    string(REGEX REPLACE "[^\n]*warning MSB[0-9][0-9][0-9][0-9][^\n]*" "" check_output "${check_output}")
      # Filter out warnings caused by user flags.
      string(REGEX REPLACE "[^\n]*warning:[^\n]*-Winvalid-command-line-argument[^\n]*" "" check_output "${check_output}")
      # Filter out warnings caused by local configuration.


### PR DESCRIPTION
Specify library name and version:  **cmake/all**

I will push the patch upstream but want to test it first on CI.

update:
- [x] https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5348

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
