### PR TITLE
libpq: fix configure for mingw + bump msys2/openssl + fix invalid conf message

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -48,7 +48,7 @@ class LibpqConan(ConanFile):
         if self.options.with_zlib:
             self.requires("zlib/1.2.11")
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1g")
+            self.requires("openssl/1.1.1h")
 
     def build_requirements(self):
         if self.settings.compiler == "Visual Studio":

--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -127,6 +127,8 @@ class LibpqConan(ConanFile):
                         if not self.options.shared:
                             self.run("perl build.pl libpgport")
         else:
+            if self.settings.os == "Windows":
+                tools.replace_in_file(os.path.join(self._source_subfolder, "configure"), 'LIBS="-lz ', 'LIBS="')
             autotools = self._configure_autotools()
             with tools.chdir(os.path.join(self._source_subfolder, "src", "backend")):
                 autotools.make(args=self._make_args, target="generated-headers")

--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -40,9 +40,8 @@ class LibpqConan(ConanFile):
     def configure(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-        if self.settings.compiler != "Visual Studio" and self.settings.os == "Windows":
-            if self.options.shared:
-                raise ConanInvalidConfiguration("static mingw build is not possible")
+        if self.settings.compiler != "Visual Studio" and self.settings.os == "Windows" and self.options.shared:
+            raise ConanInvalidConfiguration("shared mingw build is not possible")
 
     def requirements(self):
         if self.options.with_zlib:

--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -21,12 +21,6 @@ class LibpqConan(ConanFile):
     default_options = {'shared': False, 'fPIC': True, 'with_zlib': True, 'with_openssl': False, 'disable_rpath': False}
     _autotools = None
 
-    def build_requirements(self):
-        if self.settings.compiler == "Visual Studio":
-            self.build_requires("strawberryperl/5.30.0.1")
-        elif tools.os_info.is_windows:
-            if "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != 'msys2':
-                self.build_requires("msys2/20190524")
     @property
     def _source_subfolder(self):
         return "source_subfolder"
@@ -55,6 +49,13 @@ class LibpqConan(ConanFile):
             self.requires("zlib/1.2.11")
         if self.options.with_openssl:
             self.requires("openssl/1.1.1g")
+
+    def build_requirements(self):
+        if self.settings.compiler == "Visual Studio":
+            self.build_requires("strawberryperl/5.30.0.1")
+        elif tools.os_info.is_windows:
+            if "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != 'msys2':
+                self.build_requires("msys2/20200517")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **libpq/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I've recently updated MinGW (MinGW 8.0.0 with gcc 10.). It seems more strict with unknown libs in linker command line. `-lz` doesn't work anymore (should be `-zlib` with MinGW).
Removing `-lz` in `LIBS` variable in `configure` is fine, since `LIBS` is already populated by `AutoToolsBuildEnvironment`