### PR TITLE
meson: bump ninja

### DIFF
--- a/recipes/meson/all/conanfile.py
+++ b/recipes/meson/all/conanfile.py
@@ -10,7 +10,7 @@ class MesonInstallerConan(ConanFile):
     homepage = "https://github.com/mesonbuild/meson"
     license = "Apache-2.0"
     no_copy_source = True
-    requires = "ninja/1.10.0"
+
     _source_subfolder = "source_subfolder"
     _meson_cmd = """@echo off
 CALL python %~dp0/meson.py %*
@@ -19,6 +19,9 @@ CALL python %~dp0/meson.py %*
 meson_dir=$(dirname "$0")
 exec "$meson_dir/meson.py" "$@"
 """
+
+    def requirements(self):
+        self.requires("ninja/1.10.1")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/meson/all/conanfile.py
+++ b/recipes/meson/all/conanfile.py
@@ -23,6 +23,9 @@ exec "$meson_dir/meson.py" "$@"
     def requirements(self):
         self.requires("ninja/1.10.1")
 
+    def package_id(self):
+        self.info.header_only()
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = "meson-" + self.version
@@ -51,6 +54,3 @@ exec "$meson_dir/meson.py" "$@"
 
         self._chmod_plus_x(os.path.join(meson_root, "meson"))
         self._chmod_plus_x(os.path.join(meson_root, "meson.py"))
-
-    def package_id(self):
-        self.info.header_only()


### PR DESCRIPTION
Specify library name and version:  **meson/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

bump ninja to avoid errors like `ninja: error: FindFirstFileExA`. Though, I'm not sure that current meson package ensures that ninja packaged by conan is used at consume time...