### PR TITLE
add cgltf/1.8

### DIFF
--- a/recipes/cgltf/all/conandata.yml
+++ b/recipes/cgltf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8":
+    url: "https://github.com/jkuhlmann/cgltf/archive/v1.8.tar.gz"
+    sha256: "65f4b00c234bc526c3143bb93ed811803fb761cdf25370a378632c8478375938"
   "1.7":
     url: "https://github.com/jkuhlmann/cgltf/archive/v1.7.tar.gz"
     sha256: "a2c16bbfbc3efcddd004e6fb2dd86e664966163b3f70a030b2bb70a89015130b"

--- a/recipes/cgltf/config.yml
+++ b/recipes/cgltf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8":
+    folder: all
   "1.7":
     folder: all
   "1.6":


### PR DESCRIPTION
Specify library name and version:  **cgltf/1.8**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I'm really wondering if `cgltf` (as well as `stb`) recipe shouldn't build a lib (`CGLTF_IMPLEMENTATION` and `CGLTF_WRITE_IMPLEMENTATION` defined at build time) instead of providing a header only lib relying on consumers to define those macro in only one compilation unit (ODR violation waiting to break downstream builds).