### PR TITLE
openal/1.19.1: fix build on gcc 10

### DIFF
--- a/recipes/openal/all/conandata.yml
+++ b/recipes/openal/all/conandata.yml
@@ -9,3 +9,5 @@ patches:
   "1.19.1":
     - base_path: "source_subfolder"
       patch_file: "patches/1.19.1/patch.diff"
+    - base_path: "source_subfolder"
+      patch_file: "patches/1.19.1/gcc-10-fnocommon.patch"

--- a/recipes/openal/all/patches/1.19.1/gcc-10-fnocommon.patch
+++ b/recipes/openal/all/patches/1.19.1/gcc-10-fnocommon.patch
@@ -1,0 +1,15 @@
+--- a/Alc/bformatdec.h	2018-10-11 18:05:31.000000000 -0400
++++ b/Alc/bformatdec.h	2020-10-10 21:01:08.842986977 -0400
+@@ -24,9 +24,9 @@
+ /* NOTE: These are scale factors as applied to Ambisonics content. Decoder
+  * coefficients should be divided by these values to get proper N3D scalings.
+  */
+-const ALfloat N3D2N3DScale[MAX_AMBI_COEFFS];
+-const ALfloat SN3D2N3DScale[MAX_AMBI_COEFFS];
+-const ALfloat FuMa2N3DScale[MAX_AMBI_COEFFS];
++extern const ALfloat N3D2N3DScale[MAX_AMBI_COEFFS];
++extern const ALfloat SN3D2N3DScale[MAX_AMBI_COEFFS];
++extern const ALfloat FuMa2N3DScale[MAX_AMBI_COEFFS];
+ 
+ 
+ struct AmbDecConf;


### PR DESCRIPTION
Specify library name and version:  **openal/1.19.1**

This fixes a duplicate symbol error when OpenAL 1.19.1 is built on GCC 10 and you link to it. GCC 10 now sets `-fno-common` by default which breaks OpenAL due to a missing `extern`s in its headers. This pull request adds a patch adding the missing `extern`s.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
