### PR TITLE
Use host mac version setting

### DIFF
--- a/recipes/libx264/all/conanfile.py
+++ b/recipes/libx264/all/conanfile.py
@@ -88,7 +88,7 @@ class LibX264Conan(ConanFile):
                 self._autotools.flags.append('-FS')
             if tools.is_apple_os(self.settings.os) and self.settings.get_safe("os.version"):
                 mac_version_min = tools.apple_deployment_target_flag(self.settings.os,
-                                                               self.settings.os.version)
+                                                                     self.settings.os.version)
                 args.append("--extra-cflags=%s" % mac_version_min)
             self._autotools.configure(args=args, build=False, vars=self._override_env, configure_dir=self._source_subfolder)
         return self._autotools

--- a/recipes/libx264/all/conanfile.py
+++ b/recipes/libx264/all/conanfile.py
@@ -86,6 +86,10 @@ class LibX264Conan(ConanFile):
                 self._autotools.flags.append('-%s' % str(self.settings.compiler.runtime))
                 # cannot open program database ... if multiple CL.EXE write to the same .PDB file, please use /FS
                 self._autotools.flags.append('-FS')
+            if tools.is_apple_os(self.settings.os) and self.settings.get_safe("os.version"):
+                mac_version_min = tools.apple_deployment_target_flag(self.settings.os,
+                                                               self.settings.os.version)
+                args.append("--extra-cflags=%s" % mac_version_min)
             self._autotools.configure(args=args, build=False, vars=self._override_env, configure_dir=self._source_subfolder)
         return self._autotools
 

--- a/recipes/libx264/all/conanfile.py
+++ b/recipes/libx264/all/conanfile.py
@@ -87,9 +87,8 @@ class LibX264Conan(ConanFile):
                 # cannot open program database ... if multiple CL.EXE write to the same .PDB file, please use /FS
                 self._autotools.flags.append('-FS')
             if tools.is_apple_os(self.settings.os) and self.settings.get_safe("os.version"):
-                mac_version_min = tools.apple_deployment_target_flag(self.settings.os,
-                                                                     self.settings.os.version)
-                args.append("--extra-cflags=%s" % mac_version_min)
+                self._autotools.flags.append(tools.apple_deployment_target_flag(self.settings.os,
+                                                                                self.settings.os.version))
             self._autotools.configure(args=args, build=False, vars=self._override_env, configure_dir=self._source_subfolder)
         return self._autotools
 


### PR DESCRIPTION
Specify library name and version:  **x264/xxxxx**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This PR fix a problem when linking on MacOS where I had these warnings:

```
ld: warning: object file (/Users/martin/.conan/data/libx264/20190605/_/_/package/164ce1f22baa425c7ab7ceb8e7c38914db295c36/lib/libx264.a(api.o)) was built for newer macOS version (10.15) than being linked (10.13)
ld: warning: object file (/Users/martin/.conan/data/libx264/20190605/_/_/package/164ce1f22baa425c7ab7ceb8e7c38914db295c36/lib/libx264.a(base.o)) was built for newer macOS version (10.15) than being linked (10.13)
ld: warning: object file (/Users/martin/.conan/data/libx264/20190605/_/_/package/164ce1f22baa425c7ab7ceb8e7c38914db295c36/lib/libx264.a(encoder-10.o)) was built for newer macOS version (10.15) than being linked (10.13)
ld: warning: object file (/Users/martin/.conan/data/libx264/20190605/_/_/package/164ce1f22baa425c7ab7ceb8e7c38914db295c36/lib/libx264.a(bitstream-10.o)) was built for newer macOS version (10.15) than being linked (10.13)
ld: warning: object file (/Users/martin/.conan/data/libx264/20190605/_/_/package/164ce1f22baa425c7ab7ceb8e7c38914db295c36/lib/libx264.a(encoder-8.o)) was built for newer macOS version (10.15) than being linked (10.13)
...
```
