### PR TITLE
add depot_tools cci.20201009

### DIFF
--- a/recipes/depot_tools/all/conandata.yml
+++ b/recipes/depot_tools/all/conandata.yml
@@ -1,3 +1,5 @@
 sources:
   "20200407":
     url: "https://chromium.googlesource.com/chromium/tools/depot_tools/+archive/48c5c9c50455c625c58dab2fbb0904cac467168c.tar.gz"
+  "cci.20201009":
+    url: "https://chromium.googlesource.com/chromium/tools/depot_tools.git/+archive/b073999c6f90103a36a923e63ae8cf7a5c9c6c8c.tar.gz"

--- a/recipes/depot_tools/config.yml
+++ b/recipes/depot_tools/config.yml
@@ -1,3 +1,5 @@
 versions:
   "20200407":
     folder: all
+  "cci.20201009":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **depot_tools/cci.20201009**

This attempts an update to the `depot_tools` package that was added to CCI in April and wasn't touched since. I'm hoping to use the new version to contribute [the bincrafters recipe for crashpad](https://github.com/bincrafters/conan-crashpad) later on.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
