### PR TITLE
Link boost coroutine_exe against CONAN_LIBS

### DIFF
--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -52,7 +52,7 @@ IF(NOT HEADER_ONLY)
 
     if (WITH_COROUTINE)
         ADD_EXECUTABLE(coroutine_exe coroutine.cpp)
-        TARGET_LINK_LIBRARIES(coroutine_exe ${Boost_LIBRARIES})
+        TARGET_LINK_LIBRARIES(coroutine_exe ${CONAN_LIBS})
     endif()
 
     if (WITH_CHRONO)


### PR DESCRIPTION
This allows boost to be built on Ubuntu 18.04 with older CMake that does not know about newer Boost versions and wouldn't add the boost_context lib to coroutine_exe in the static linking case.

This fixes: #3159

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
