### PR TITLE
fix openssl/** build with shared and fPIC option for OS Neutrino

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -483,6 +483,9 @@ class OpenSSLConan(ConanFile):
         {defines}
         includes => add({includes}),
         lflags => add("{lflags}"),
+        {shared_target}
+        {shared_cflag}
+        {shared_extension}
         {cc}
         {cxx}
         {ar}
@@ -522,6 +525,15 @@ class OpenSSLConan(ConanFile):
             ancestor = '[ "%s", asm("%s") ]' % (self._ancestor_target, self._asm_target)
         else:
             ancestor = '[ "%s" ]' % self._ancestor_target
+        shared_cflag = ''
+        shared_extension = ''
+        shared_target = ''
+        if self.settings.os == 'Neutrino':
+            if self.options.shared:
+                shared_extension = 'shared_extension => ".so.\$(SHLIB_VERSION_NUMBER)",'
+                shared_target = 'shared_target  => "gnu-shared",'
+            if self.options.fPIC:
+                shared_cflag='shared_cflag => "-fPIC",'
 
         config = config_template.format(targets=targets,
                                         target=self._target,
@@ -535,6 +547,9 @@ class OpenSSLConan(ConanFile):
                                         defines=defines,
                                         includes=includes,
                                         perlasm_scheme=perlasm_scheme,
+                                        shared_target=shared_target,
+                                        shared_extension=shared_extension,
+                                        shared_cflag=shared_cflag,
                                         lflags=" ".join(env_build.link_flags))
         self.output.info("using target: %s -> %s" % (self._target, self._ancestor_target))
         self.output.info(config)


### PR DESCRIPTION
Specify library name and version:  **openssl/_**

Fix build options(shared, fPIC) for OS Neutrino.
By default openssl doesn't know about 'shared' build for QNX/Neutrino 

- [*] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [*] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [*] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [*] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
