### PR TITLE
mpark-variant: simplify recipe + fix cmake names

### DIFF
--- a/recipes/mpark-variant/all/CMakeLists.txt
+++ b/recipes/mpark-variant/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory("source_subfolder")

--- a/recipes/mpark-variant/all/conandata.yml
+++ b/recipes/mpark-variant/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  1.4.0:
+  "1.4.0":
     url: "https://github.com/mpark/variant/archive/v1.4.0.tar.gz"
     sha256: "8f6b28ab3640b5d76d5b6664dda7257a4405ce59179220431b8fd196c79b2ecb"

--- a/recipes/mpark-variant/all/conanfile.py
+++ b/recipes/mpark-variant/all/conanfile.py
@@ -1,5 +1,4 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conans import ConanFile, tools
 import os
 
 
@@ -10,44 +9,25 @@ class VariantConan(ConanFile):
     description = "C++17 std::variant for C++11/14/17"
     license = "BSL-1.0"
     exports_sources = ["CMakeLists.txt"]
-    generators = "cmake"
     topics = ("conan", "variant", "mpark-variant")
+    settings = "compiler"
 
-    settings = "os", "arch", "compiler", "build_type"
-
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
-    _cmake = None
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
     def configure(self):
-        if self.settings.get_safe("cppstd"):
+        if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "11")
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "variant-" + self.version
-
-        # Work to remove 'deps' directory, just to be sure.
-        tools.rmdir(os.path.join(extracted_dir, "3rdparty"))
-
-        os.rename(extracted_dir, self._source_subfolder)
-
-    def _configure_cmake(self):
-        if not self._cmake:
-            self._cmake = CMake(self)
-            self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
-
-    def build(self):
-        cmake = self._configure_cmake()
-        cmake.build()
-
-    def package(self):
-        cmake = self._configure_cmake()
-        cmake.install()
-        self.copy(pattern="LICENSE.md", dst="licenses", src=self._source_subfolder)
-        tools.rmdir(os.path.join(self.package_folder, "lib"))
 
     def package_id(self):
         self.info.header_only()
 
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "variant-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        self.copy(pattern="LICENSE.md", dst="licenses", src=self._source_subfolder)
+        self.copy("*", dst="include", src=os.path.join(self._source_subfolder, "include"))

--- a/recipes/mpark-variant/all/conanfile.py
+++ b/recipes/mpark-variant/all/conanfile.py
@@ -31,3 +31,8 @@ class VariantConan(ConanFile):
     def package(self):
         self.copy(pattern="LICENSE.md", dst="licenses", src=self._source_subfolder)
         self.copy("*", dst="include", src=os.path.join(self._source_subfolder, "include"))
+
+    def package_info(self):
+        # TODO: CMake imported target shouldn't be namespaced (waiting https://github.com/conan-io/conan/issues/7615 to be implemented)
+        self.cpp_info.names["cmake_find_package"] = "mpark_variant"
+        self.cpp_info.names["cmake_find_package_multi"] = "mpark_variant"

--- a/recipes/mpark-variant/all/test_package/CMakeLists.txt
+++ b/recipes/mpark-variant/all/test_package/CMakeLists.txt
@@ -4,6 +4,8 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(mpark_variant REQUIRED CONFIG)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} mpark_variant::mpark_variant) # TODO: Remove mpark_variant:: namespace when fixed in conanfile
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/mpark-variant/all/test_package/conanfile.py
+++ b/recipes/mpark-variant/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/mpark-variant/config.yml
+++ b/recipes/mpark-variant/config.yml
@@ -1,3 +1,3 @@
 versions:
-    "1.4.0":
-      folder: all
+  "1.4.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **mpark-variant/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This recipe doesn't really require to call CMake (nor to remove third_party folder in `source()`), copying header files is enough and save from CMake configuration.
CMake Config file: https://github.com/mpark/variant/blob/4988879a9f5a95d72308eca2b1779db6ed9b135d/CMakeLists.txt#L51
Exported Target (and no namespace just below in `install(EXPORT mpark_variant ...`): https://github.com/mpark/variant/blob/4988879a9f5a95d72308eca2b1779db6ed9b135d/CMakeLists.txt#L42