### PR TITLE
Add timsort/1.2.1 and timsort/2.0.1

### DIFF
--- a/recipes/timsort/all/conandata.yml
+++ b/recipes/timsort/all/conandata.yml
@@ -2,6 +2,12 @@ sources:
   "1.2.0":
     sha256: 3a189cb8717efbf0442da1d62109b7e881c158ab8167f8997e79cdb3a2cd7c9a
     url: https://github.com/timsort/cpp-TimSort/archive/v1.2.0.tar.gz
+  "1.2.1":
+    sha256: 4f32285926330c97290b102c92c4ae8c308f46f70488d383595ae5f191e1de55
+    url: https://github.com/timsort/cpp-TimSort/archive/v1.2.1.tar.gz
   "2.0.0":
     sha256: 6cb23b0efb83e1d4f6eab58cddd35b36ca49cd927a46294575b9c0d304a2e833
     url: https://github.com/timsort/cpp-TimSort/archive/v2.0.0.tar.gz
+  "2.0.1":
+    sha256: 5c7fe16ca8ead3a86691cb64c373b9ca634add6b6539254baa58f4e254e865c6
+    url: https://github.com/timsort/cpp-TimSort/archive/v2.0.1.tar.gz

--- a/recipes/timsort/all/conanfile.py
+++ b/recipes/timsort/all/conanfile.py
@@ -20,7 +20,8 @@ class TimsortConan(ConanFile):
 
     def configure(self):
         if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 11)
+            if tools.Version(self.version) >= "2.0.0":
+                tools.check_min_cppstd(self, 11)
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/timsort/config.yml
+++ b/recipes/timsort/config.yml
@@ -1,5 +1,9 @@
 versions:
-  1.2.0:
+  "1.2.0":
     folder: all
-  2.0.0:
+  "1.2.1":
+    folder: all
+  "2.0.0":
+    folder: all
+  "2.0.1":
     folder: all


### PR DESCRIPTION
Specify library name and versions:  **timsort/1.2.1** and **timsort/2.0.1**

This also relaxes the recipe's restrictions on the required C++ version since the 1.x.y branch targets C++03.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
