### PR TITLE
argtable3: add argtable3/3.1.5 recipe

### DIFF
--- a/recipes/argtable3/all/CMakeLists.txt
+++ b/recipes/argtable3/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/argtable3/all/CMakeLists.txt
+++ b/recipes/argtable3/all/CMakeLists.txt
@@ -4,4 +4,8 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+    link_libraries(m)
+endif()
+
 add_subdirectory(source_subfolder)

--- a/recipes/argtable3/all/conandata.yml
+++ b/recipes/argtable3/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "3.1.5":
+    url: "https://github.com/argtable/argtable3/archive/v3.1.5.1c1bb23.tar.gz"
+    sha256: "e2435562ece10bbf52c21811fe6ec25a3574054886cb56d483e5c17451329bb4"
+patches:
+  "3.1.5":
+    - patch_file: "patches/3.1.5-0001-cmake-fixes.patch"
+      base_path: "source_subfolder"

--- a/recipes/argtable3/all/conanfile.py
+++ b/recipes/argtable3/all/conanfile.py
@@ -70,7 +70,7 @@ class Argtable3Conan(ConanFile):
         self.cpp_info.libs = ["argtable3" if self.options.shared else "argtable3_static"]
         if not self.options.shared:
             if self.settings.os == "Linux":
-                self.settings.system_libs.append("m")
+                self.cpp_info.system_libs.append("m")
         # FIXME: the cmake targets are exported without namespace
         self.cpp_info.filenames["cmake_find_package"] = "Argtable3"
         self.cpp_info.filenames["cmake_find_package_config"] = "Argtable3"

--- a/recipes/argtable3/all/conanfile.py
+++ b/recipes/argtable3/all/conanfile.py
@@ -63,10 +63,14 @@ class Argtable3Conan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
 
+        tools.rmdir(os.path.join(self.package_folder, "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.libs = ["argtable3" if self.options.shared else "argtable3_static"]
+        if not self.options.shared:
+            if self.settings.os == "Linux":
+                self.settings.system_libs.append("m")
         # FIXME: the cmake targets are exported without namespace
         self.cpp_info.filenames["cmake_find_package"] = "Argtable3"
         self.cpp_info.filenames["cmake_find_package_config"] = "Argtable3"

--- a/recipes/argtable3/all/conanfile.py
+++ b/recipes/argtable3/all/conanfile.py
@@ -1,0 +1,72 @@
+from conans import CMake, ConanFile, tools
+import glob
+import os
+
+
+class Argtable3Conan(ConanFile):
+    name = "argtable3"
+    description = "A single-file, ANSI C, command-line parsing library that parses GNU-style command-line options."
+    topics = ("conan", "argtable3", "command", "line", "argument", "parse", "parsing", "getopt")
+    license = "BSD-3-clause"
+    homepage = "https://www.argtable.org/"
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "arch", "compiler", "build_type"
+    exports_sources = "CMakeLists.txt", "patches/**"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    generators = "cmake"
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename(glob.glob("argtable3-*")[0], self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["ARGTABLE3_ENABLE_TESTS"] = False
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        # The initial space is important (the cmake script does OFFSET 0)
+        tools.save(os.path.join(self._source_subfolder, "version.tag"), " {}.0\n".format(self.version))
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["argtable3" if self.options.shared else "argtable3_static"]
+        # FIXME: the cmake targets are exported without namespace
+        self.cpp_info.filenames["cmake_find_package"] = "Argtable3"
+        self.cpp_info.filenames["cmake_find_package_config"] = "Argtable3"

--- a/recipes/argtable3/all/patches/3.1.5-0001-cmake-fixes.patch
+++ b/recipes/argtable3/all/patches/3.1.5-0001-cmake-fixes.patch
@@ -1,0 +1,59 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -90,7 +90,7 @@ if(APPLE)
+ endif()
+ 
+ add_subdirectory(src)
+-add_subdirectory(examples)
++#add_subdirectory(examples)
+ 
+ if(ARGTABLE3_ENABLE_TESTS)
+   enable_testing()
+--- src/CMakeLists.txt
++++ src/CMakeLists.txt
+@@ -44,7 +44,7 @@
+ endif()
+ 
+ add_definitions(-D_XOPEN_SOURCE=700)
+-
++if(BUILD_SHARED_LIBS)
+ if(WIN32)
+   set(COMPANY_NAME "The Argtable3 Project")
+   set(FILE_DESC "ANSI C command-line parsing library")
+@@ -62,13 +62,13 @@
+   add_library(argtable3 SHARED ${ARGTABLE3_SRC_FILES})
+ endif()
+ target_include_directories(argtable3 PRIVATE ${PROJECT_SOURCE_DIR}/src)
+-
+-add_library(argtable3_static STATIC ${ARGTABLE3_SRC_FILES})
+-target_include_directories(argtable3 PRIVATE ${PROJECT_SOURCE_DIR}/src)
+-
+-set_target_properties(argtable3 argtable3_static PROPERTIES
++set_target_properties(argtable3 PROPERTIES
+   VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
+   SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
++target_include_directories(argtable3 PRIVATE ${PROJECT_SOURCE_DIR}/src)
++else()
++add_library(argtable3_static STATIC ${ARGTABLE3_SRC_FILES})
++endif()
+ 
+ include(GNUInstallDirs)
+ if(UNIX OR MSYS OR MINGW)
+@@ -76,14 +76,16 @@
+ elseif(WIN32)
+   set(ARGTABLE3_INSTALL_CMAKEDIR "cmake")
+ endif()
+-
++if(BUILD_SHARED_LIBS)
+ install(TARGETS argtable3
+   EXPORT ${ARGTABLE3_PACKAGE_NAME}Config
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++else()
+ install(TARGETS argtable3_static
+   EXPORT ${ARGTABLE3_PACKAGE_NAME}Config  
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++endif()
+ install(FILES "${PROJECT_SOURCE_DIR}/src/argtable3.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ install(EXPORT ${ARGTABLE3_PACKAGE_NAME}Config DESTINATION ${ARGTABLE3_INSTALL_CMAKEDIR})

--- a/recipes/argtable3/all/test_package/CMakeLists.txt
+++ b/recipes/argtable3/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/argtable3/all/test_package/conanfile.py
+++ b/recipes/argtable3/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run("{} --help".format(bin_path), run_environment=True)

--- a/recipes/argtable3/all/test_package/test_package.c
+++ b/recipes/argtable3/all/test_package/test_package.c
@@ -1,0 +1,55 @@
+// Fetched from https://www.argtable.org/
+
+#include "argtable3.h"
+
+/* global arg_xxx structs */
+struct arg_lit *verb, *help, *version;
+struct arg_int *level;
+struct arg_file *o, *file;
+struct arg_end *end;
+
+int main(int argc, char *argv[])
+{
+    /* the global arg_xxx structs are initialised within the argtable */
+    void *argtable[] = {
+        help    = arg_litn(NULL, "help", 0, 1, "display this help and exit"),
+        version = arg_litn(NULL, "version", 0, 1, "display version info and exit"),
+        level   = arg_intn(NULL, "level", "<n>", 0, 1, "foo value"),
+        verb    = arg_litn("v", "verbose", 0, 1, "verbose output"),
+        o       = arg_filen("o", NULL, "myfile", 0, 1, "output file"),
+        file    = arg_filen(NULL, NULL, "<file>", 1, 100, "input files"),
+        end     = arg_end(20),
+    };
+
+    int exitcode = 0;
+    char progname[] = "util.exe";
+
+    int nerrors;
+    nerrors = arg_parse(argc,argv,argtable);
+
+    /* special case: '--help' takes precedence over error reporting */
+    if (help->count > 0)
+    {
+        printf("Usage: %s", progname);
+        arg_print_syntax(stdout, argtable, "\n");
+        printf("Demonstrate command-line parsing in argtable3.\n\n");
+        arg_print_glossary(stdout, argtable, "  %-25s %s\n");
+        exitcode = 0;
+        goto exit;
+    }
+
+    /* If the parser returned any errors then display them and exit */
+    if (nerrors > 0)
+    {
+        /* Display the error details contained in the arg_end struct.*/
+        arg_print_errors(stdout, end, progname);
+        printf("Try '%s --help' for more information.\n", progname);
+        exitcode = 1;
+        goto exit;
+    }
+
+exit:
+    /* deallocate each non-null entry in argtable[] */
+    arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+    return exitcode;
+}

--- a/recipes/argtable3/config.yml
+++ b/recipes/argtable3/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.1.5":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **argtable3/3.1.5**

The `3` is in the name of the recipe because the name of the github project is argtable3.
See https://github.com/argtable/argtable3

Also, argtable2 is available at http://argtable.sourceforge.net/

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
