### PR TITLE
Fix mpir/3.0.0 compilation on macos 10.15.7 with apple-clang 12

### DIFF
--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -103,6 +103,9 @@ class MpirConan(ConanFile):
             args.append("--disable-silent-rules")
             args.append("--enable-cxx" if self.options.get_safe("enable_cxx") else "--disable-cxx")
             args.append("--enable-gmpcompat" if self.options.enable_gmpcompat else "--disable-gmpcompat")
+
+            # compiler checks are written for C89 but compilers that default to C99 treat implicit functions as error
+            self._autotools.flags.append("-Wno-implicit-function-declaration")            
             self._autotools.configure(args=args)
         return self._autotools
 

--- a/recipes/mpir/all/test_package/CMakeLists.txt
+++ b/recipes/mpir/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
apple-clang 12 seems to default to C99 which does not play well with existing autotools compiler checks.
Adding '-Wno-implicit-function-declaration' fixes the issue on my side.

Fixes #3212

Specify library name and version:  **mpir/3.0.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
