### PR TITLE
tinyexr: patch in build() instead of source() + link with pthread

### DIFF
--- a/recipes/tinyexr/all/conanfile.py
+++ b/recipes/tinyexr/all/conanfile.py
@@ -55,7 +55,7 @@ class TinyExrConan(ConanFile):
             license_content.append(content_lines[i][:-1])
         return "\n".join(license_content)
 
-    def build():
+    def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
 

--- a/recipes/tinyexr/all/conanfile.py
+++ b/recipes/tinyexr/all/conanfile.py
@@ -1,5 +1,4 @@
 import os
-import glob
 from conans import ConanFile, tools
 
 
@@ -10,6 +9,8 @@ class TinyExrConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     license = "BSD-3-Clause"
     topics = ("conan", "exr", "header-only")
+    exports_sources = ["patches/*"]
+    settings = "os"
     options = {
         "with_z": ["zlib", "miniz"],
         "with_piz": [True, False],
@@ -24,8 +25,6 @@ class TinyExrConan(ConanFile):
         "with_thread": False,
         "with_openmp": False,
     }
-    exports_sources = "patches/**"
-    no_copy_source = True
 
     @property
     def _source_subfolder(self):
@@ -45,10 +44,8 @@ class TinyExrConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = glob.glob('tinyexr-*/')[0]
+        extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
-        for patch in self.conan_data["patches"].get(self.version, []):
-            tools.patch(**patch)
 
     @property
     def _extracted_license(self):
@@ -59,6 +56,8 @@ class TinyExrConan(ConanFile):
         return "\n".join(license_content)
 
     def package(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), self._extracted_license)
         self.copy("tinyexr.h", dst="include", src=self._source_subfolder)
 
@@ -71,3 +70,6 @@ class TinyExrConan(ConanFile):
         self.cpp_info.defines.append("TINYEXR_USE_ZFP=" + ( "1" if self.options.with_zfp else "0"))
         self.cpp_info.defines.append("TINYEXR_USE_THREAD=" + ( "1" if self.options.with_zfp else "0"))
         self.cpp_info.defines.append("TINYEXR_USE_OPENMP=" + ( "1" if self.options.with_zfp else "0"))
+
+        if self.settings.os == "Linux" and self.options.with_thread:
+            self.cpp_info.system_libs = ["pthread"]

--- a/recipes/tinyexr/all/conanfile.py
+++ b/recipes/tinyexr/all/conanfile.py
@@ -55,9 +55,11 @@ class TinyExrConan(ConanFile):
             license_content.append(content_lines[i][:-1])
         return "\n".join(license_content)
 
-    def package(self):
+    def build():
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
+
+    def package(self):
         tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), self._extracted_license)
         self.copy("tinyexr.h", dst="include", src=self._source_subfolder)
 


### PR DESCRIPTION
when using with_thread on Linux

Specify library name and version:  **tinyexr/1.0.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
