### PR TITLE
freetype: add freetype/2.10.4

### DIFF
--- a/recipes/freetype/all/CMakeLists.txt
+++ b/recipes/freetype/all/CMakeLists.txt
@@ -1,9 +1,7 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_subdirectory(source_subfolder)
-
-set(DEST_DIR "${CMAKE_INSTALL_PREFIX}")

--- a/recipes/freetype/all/conandata.yml
+++ b/recipes/freetype/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "2.10.4":
+    url: [
+      "https://download.savannah.gnu.org/releases/freetype/freetype-2.10.4.tar.gz",
+      "https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/freetype-2.10.4.tar.gz/download",
+    ]
+    sha256: "5eab795ebb23ac77001cfb68b7d4d50b5d6c7469247b0b01b2c953269f658dac"
   "2.10.2":
     url: [
       "https://download.savannah.gnu.org/releases/freetype/freetype-2.10.2.tar.gz",

--- a/recipes/freetype/config.yml
+++ b/recipes/freetype/config.yml
@@ -1,9 +1,9 @@
 versions:
-  "2.10.0":
-    folder: all
-  "2.10.1":
+  "2.10.4":
     folder: all
   "2.10.2":
     folder: all
-  "2.10.4":
+  "2.10.1":
+    folder: all
+  "2.10.0":
     folder: all

--- a/recipes/freetype/config.yml
+++ b/recipes/freetype/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "2.10.2":
     folder: all
+  "2.10.4":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **freetype/2.10.4**


See https://www.freetype.org/

> See FreeType 2.10.4
> 2020-10-20
> 
> This is an emergency release, fixing a severe vulnerability in embedded PNG bitmap handling (see [here](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15999) for more).
> 
> All users should update immediately.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
