### PR TITLE
gperf: Fix build target and support macOS deployment target

### DIFF
--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -8,7 +8,7 @@ class GperfConan(ConanFile):
     homepage = "https://www.gnu.org/software/gperf"
     description = "GNU gperf is a perfect hash function generator"
     topics = ("conan", "gperf", "hash-generator", "hash")
-    settings = "os_build", "arch_build", "compiler"
+    settings = "os", "arch", "compiler"
     _source_subfolder = "source_subfolder"
     _autotools = None
 
@@ -18,10 +18,10 @@ class GperfConan(ConanFile):
 
     @property
     def _is_mingw_windows(self):
-        return self.settings.os_build == "Windows" and tools.os_info.is_windows and self.settings.compiler == "gcc"
+        return self.settings.os == "Windows" and tools.os_info.is_windows and self.settings.compiler == "gcc"
 
     def build_requirements(self):
-        if self.settings.os_build == "Windows" and tools.os_info.is_windows:
+        if self.settings.os == "Windows" and tools.os_info.is_windows:
             if "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != 'msys2':
                 self.build_requires("msys2/20190524")
 
@@ -47,8 +47,12 @@ class GperfConan(ConanFile):
                             "STRIP=:",
                             "AR={}/build-aux/ar-lib lib".format(cwd),
                             "RANLIB=:"])
-            elif self.settings.compiler == "gcc" and self.settings.os_build == "Windows":
-                args.append("LDFLAGS=-static -static-libgcc")
+            elif self.settings.compiler == "gcc" and self.settings.os == "Windows":
+                self._autotools.link_flags.extend(["-static", "-static-libgcc"])
+            elif tools.is_apple_os(self.settings.os) and self.settings.get_safe("os.version"):
+                target = tools.apple_deployment_target_flag(self.settings.os, self.settings.os.version)
+                self._autotools.flags.append(target)
+
             self._autotools.configure(args=args)
         return self._autotools
 


### PR DESCRIPTION
The recipe uses `arch_build` and `os_build`, the settings which indicate which architecture and os we're building on, to decide which platform we're building for, which isn't correct when cross compiling. Fix this by using `arch` and `os` instead.

Also, add support for specifying a version of macOS to target.

Specify library name and version:  **gperf/3.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
