### PR TITLE
poppler-data: no backslashes in define (to appetize cmake's FindPkgConfig)

### DIFF
--- a/recipes/poppler-data/all/conanfile.py
+++ b/recipes/poppler-data/all/conanfile.py
@@ -67,4 +67,4 @@ class PopplerDataConan(ConanFile):
         self.cpp_info.bindirs = []
         self.cpp_info.includedirs = []
         self.user_info.datadir = self._poppler_datadir
-        self.cpp_info.defines = ["POPPLER_DATADIR={}".format(self._poppler_datadir)]
+        self.cpp_info.defines = ["POPPLER_DATADIR={}".format(self._poppler_datadir.replace("\\", "//"))]


### PR DESCRIPTION
cmake's FindPKgConfig does not like backslashes in defines (on MSVC@Windows)
So replace them with forward slashes.

Required for poppler: #2799


Specify library name and version:  **poppler-data/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
