### PR TITLE
ninja/1.10.x: remove compiler from package_id

### DIFF
--- a/recipes/ninja/1.10.x/conanfile.py
+++ b/recipes/ninja/1.10.x/conanfile.py
@@ -16,6 +16,9 @@ class NinjaConan(ConanFile):
     _source_subfolder = "source_subfolder"
     _cmake = None
 
+    def package_id(self):
+        del self.info.settings.compiler
+
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake


### PR DESCRIPTION
Specify library name and version:  **ninja/1.10.x**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

___________________

Fixes https://github.com/conan-io/conan-center-index/issues/3231

See also https://github.com/conan-io/conan-center-index/issues/3157#issuecomment-714565227