### PR TITLE
Add patches for gcc5 compile breaks

### DIFF
--- a/recipes/folly/all/conandata.yml
+++ b/recipes/folly/all/conandata.yml
@@ -34,3 +34,7 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0012-compiler-flags.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0014-find-librt.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0015-benchmark-format-macros.patch"
+      base_path: "source_subfolder"

--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -179,7 +179,7 @@ class FollyConan(ConanFile):
         if Version(self.version) >= "2020.08.10.00":
             self.cpp_info.components["libfolly"].requires.append("fmt::fmt")
         if self.settings.os == "Linux":
-            self.cpp_info.components["libfolly"].system_libs.extend(["pthread", "dl"])
+            self.cpp_info.components["libfolly"].system_libs.extend(["pthread", "dl", "rt"])
         elif self.settings.os == "Windows":
             self.cpp_info.components["libfolly"].system_libs.extend(["ws2_32", "Iphlpapi", "Crypt32"])
         if (self.settings.os == "Linux" and self.settings.compiler == "clang" and

--- a/recipes/folly/all/patches/0014-find-librt.patch
+++ b/recipes/folly/all/patches/0014-find-librt.patch
@@ -9,7 +9,7 @@ index 6b8b308c7..908d72d51 100644
 +if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 +  find_library(LIBRT rt)
 +  if (LIBRT)
-+    set(CMAKE_REQUIRED_LIBRARIES "rt")
++    list(APPEND CMAKE_REQUIRED_LIBRARIES "rt")
 +  endif()
 +endif()
 +

--- a/recipes/folly/all/patches/0014-find-librt.patch
+++ b/recipes/folly/all/patches/0014-find-librt.patch
@@ -6,7 +6,7 @@ index 6b8b308c7..908d72d51 100644
    CMAKE_REQUIRED_FLAGS
    "${CMAKE_REQUIRED_FLAGS}")
  
-+if (UNIX)
++if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 +  find_library(LIBRT rt)
 +  if (LIBRT)
 +    set(CMAKE_REQUIRED_LIBRARIES "rt")

--- a/recipes/folly/all/patches/0014-find-librt.patch
+++ b/recipes/folly/all/patches/0014-find-librt.patch
@@ -1,0 +1,18 @@
+diff --git a/CMake/FollyConfigChecks.cmake b/CMake/FollyConfigChecks.cmake
+index 6b8b308c7..908d72d51 100644
+--- a/CMake/FollyConfigChecks.cmake
++++ b/CMake/FollyConfigChecks.cmake
+@@ -83,6 +83,13 @@ string(REGEX REPLACE
+   CMAKE_REQUIRED_FLAGS
+   "${CMAKE_REQUIRED_FLAGS}")
+ 
++if (UNIX)
++  find_library(LIBRT rt)
++  if (LIBRT)
++    set(CMAKE_REQUIRED_LIBRARIES "rt")
++  endif()
++endif()
++
+ check_symbol_exists(pthread_atfork pthread.h FOLLY_HAVE_PTHREAD_ATFORK)
+ 
+ # Unfortunately check_symbol_exists() does not work for memrchr():

--- a/recipes/folly/all/patches/0015-benchmark-format-macros.patch
+++ b/recipes/folly/all/patches/0015-benchmark-format-macros.patch
@@ -1,0 +1,15 @@
+diff --git a/folly/Benchmark.cpp b/folly/Benchmark.cpp
+index 389ee46a1..390b7674b 100644
+--- a/folly/Benchmark.cpp
++++ b/folly/Benchmark.cpp
+@@ -16,6 +16,10 @@
+ 
+ // @author Andrei Alexandrescu (andrei.alexandrescu@fb.com)
+ 
++#ifndef __STDC_FORMAT_MACROS
++#define __STDC_FORMAT_MACROS 1
++#endif
++
+ #include <folly/Benchmark.h>
+ 
+ #include <algorithm>


### PR DESCRIPTION
Specify library name and version:  **folly/2020.08.10**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Fixes #3331 