### PR TITLE
mpir require msys2 only if build platform is windows

### DIFF
--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -45,7 +45,7 @@ class MpirConan(ConanFile):
 
     def build_requirements(self):
         self.build_requires("yasm/1.3.0")
-        if self.settings.os == "Windows" and self.settings.compiler != "Visual Studio" and \
+        if tools.os_info.is_windows and self.settings.compiler != "Visual Studio" and \
            "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != "msys2":
             self.build_requires("msys2/20200517")
 
@@ -105,7 +105,7 @@ class MpirConan(ConanFile):
             args.append("--enable-gmpcompat" if self.options.enable_gmpcompat else "--disable-gmpcompat")
 
             # compiler checks are written for C89 but compilers that default to C99 treat implicit functions as error
-            self._autotools.flags.append("-Wno-implicit-function-declaration")            
+            self._autotools.flags.append("-Wno-implicit-function-declaration")
             self._autotools.configure(args=args)
         return self._autotools
 


### PR DESCRIPTION
Specify library name and version:  **mpir/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
