### PR TITLE
calceph: require msys2 only if build platform is windows

### DIFF
--- a/recipes/calceph/all/conanfile.py
+++ b/recipes/calceph/all/conanfile.py
@@ -46,7 +46,7 @@ class CalcephConan(ConanFile):
                 raise ConanInvalidConfiguration("calceph doesn't support shared builds with Visual Studio yet")
 
     def build_requirements(self):
-        if self.settings.os == "Windows" and self.settings.compiler != "Visual Studio" and \
+        if tools.os_info.is_windows and self.settings.compiler != "Visual Studio" and \
            "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != "msys2":
             self.build_requires("msys2/20200517")
 


### PR DESCRIPTION
Specify library name and version:  **calceph/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
