### PR TITLE
glib: static by default on non windows platforms

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -19,7 +19,7 @@ class GLibConan(ConanFile):
                "with_elf": [True, False],
                "with_selinux": [True, False],
                "with_mount": [True, False]}
-    default_options = {"shared": True,
+    default_options = {"shared": False,
                        "fPIC": True,
                        "with_pcre": True,
                        "with_elf": True,
@@ -46,6 +46,7 @@ class GLibConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+            self.options.shared = True
         if self.settings.os != "Linux":
             del self.options.with_mount
             del self.options.with_selinux


### PR DESCRIPTION
this is necessary until https://gitlab.gnome.org/GNOME/glib/-/issues/692 is fixed
Building as static solves a lot of issues on macos, caused by SIP

Specify library name and version:  **glib/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
