### PR TITLE
introduce portaudio package

### DIFF
--- a/recipes/portaudio/all/conandata.yml
+++ b/recipes/portaudio/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "v190600.2020-10-29":
+    sha256: 36c7232f70fd0b27bc5d671fb75102e6c27d7f89c1b1e3d07ef17b779a0f281c
+    url: https://github.com/PortAudio/portaudio/archive/88c71a6ec478ed693adf86d1ff08134273c1e5e7.zip

--- a/recipes/portaudio/all/conanfile.py
+++ b/recipes/portaudio/all/conanfile.py
@@ -1,0 +1,93 @@
+import os
+from conans import ConanFile, CMake, AutoToolsBuildEnvironment, tools
+from conans.tools import os_info, SystemPackageTool, download, untargz, replace_in_file, unzip
+
+class ConanRecipe(ConanFile):
+    name = "portaudio"
+    version = "v190600.2020-10-29"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = ["cmake", "txt"]
+    description = "Conan package for the Portaudio library"
+    homepage = "http://www.portaudio.com"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("audio")
+    license = "http://www.portaudio.com/license.html"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    commit = "88c71a6ec478ed693adf86d1ff08134273c1e5e7"
+    portaudio_folder = "source"
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def source(self):
+        tarball = self.conan_data["sources"][self.version]
+        tools.get(tarball['url'], destination=".")
+        tools.rename("portaudio-{}".format(self.commit), "source")
+
+    def build(self):
+        cmake = CMake(self)
+        if self.settings.os == "Windows":
+            cmake.definitions["MSVS"] = self.settings.compiler == "Visual Studio"
+
+        if self.settings.os == "Windows" and self.settings.compiler == "gcc":
+            cmake.definitions["PA_USE_WDMKS"] = "OFF"
+            cmake.definitions["PA_USE_WDMKS_DEVICE_INFO"] = "OFF"
+            cmake.definitions["PA_USE_WASAPI"] = "OFF"
+
+        if self.options.shared:
+            cmake.definitions["PA_BUILD_SHARED"] = "ON"
+            cmake.definitions["PA_BUILD_STATIC"] = "OFF"
+        else:
+            cmake.definitions["PA_BUILD_SHARED"] = "OFF"
+            cmake.definitions["PA_BUILD_STATIC"] = "ON"
+
+        if self.settings.os == "Linux":
+            cmake.definitions["PA_USE_ALSA"] = "ON"
+            cmake.definitions["PA_USE_JACK"] = "ON"
+
+        cmake.configure(source_folder=self.portaudio_folder)
+        cmake.build()
+
+    def package(self):
+        self.copy("*.h", dst="include", src=os.path.join(self.portaudio_folder, "include"))
+        self.copy(pattern="LICENSE*", dst="licenses", src=self.portaudio_folder,  ignore_case=True, keep_path=False)
+
+        if self.settings.os == "Windows":
+            if self.settings.compiler == "Visual Studio":
+                self.copy(pattern="*.lib", dst="lib", keep_path=False)
+                if self.options.shared:
+                    self.copy(pattern="*.dll", dst="bin", keep_path=False)
+                self.copy(pattern="*.pdb", dst="bin", keep_path=False)
+            else:
+                if self.options.shared:
+                    self.copy(pattern="*.dll.a", dst="lib", keep_path=False)
+                    self.copy(pattern="*.dll", dst="bin", keep_path=False)
+                else:
+                    self.copy(pattern="*static.a", dst="lib", keep_path=False)
+
+        else:
+            if self.options.shared:
+                if self.settings.os == "Macos":
+                    self.copy(pattern="*.dylib", dst="lib", keep_path=False)
+                else:
+                    self.copy(pattern="*.so*", dst="lib", keep_path=False)
+            else:
+                self.copy("*.a", dst="lib", keep_path=False)
+
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+
+        if self.settings.os == "Macos":
+            self.cpp_info.frameworks = ["CoreAudio", "AudioToolbox", "AudioUnit", "CoreServices", "Carbon"]
+
+        if self.settings.os == "Windows" and self.settings.compiler == "gcc" and not self.options.shared:
+            self.cpp_info.system_libs = ['winmm']
+
+        if self.settings.os == "Linux" and not self.options.shared:
+            self.cpp_info.system_libs = ['jack', "asound", "m", "pthread"]
+

--- a/recipes/portaudio/all/test_package/CMakeLists.txt
+++ b/recipes/portaudio/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.2)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})

--- a/recipes/portaudio/all/test_package/conanfile.py
+++ b/recipes/portaudio/all/test_package/conanfile.py
@@ -1,0 +1,20 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class PortaudioTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
+        # in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            os.chdir("bin")
+            self.run(".%sexample" % os.sep)

--- a/recipes/portaudio/all/test_package/example.cpp
+++ b/recipes/portaudio/all/test_package/example.cpp
@@ -1,0 +1,7 @@
+#include <portaudio.h>
+
+int main()
+{
+    Pa_Initialize();
+    Pa_Terminate();
+}

--- a/recipes/portaudio/config.yml
+++ b/recipes/portaudio/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "v190600.2020-10-29":
+    folder: all


### PR DESCRIPTION
this package is based on the package from jgsogo [1], but
* migrated to use cmake on all platforms instead of cmake/autotools
* updated to newer snapshot from github
* modernized/simplified `package_info`
* removed `SystemPackageTool` use on linux (note: libjack and libasound
  will still be required)

[1] https://github.com/jgsogo/conan-portaudio

Specify library name and version:  **portaudio/v190600.2020-10-29**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
