### PR TITLE
boost: no quotes around compiler (os.environ["CXX"])

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -591,10 +591,6 @@ class BoostConan(ConanFile):
 
         # CXX FLAGS
         cxx_flags = []
-        # Extract CXXFLAGS from CXX
-        if tools.get_env("CXX"):
-            cxx_flags.extend(shlex.split(tools.get_env("CXX"))[1:])
-
         # fPIC DEFINITION
         if self.settings.os != "Windows":
             if self.options.fPIC:
@@ -706,7 +702,7 @@ class BoostConan(ConanFile):
     @property
     def _cxx(self):
         if "CXX" in os.environ:
-            return shlex.split(tools.get_env("CXX"))[0]
+            return os.environ["CXX"]
         if tools.is_apple_os(self.settings.os) and self.settings.compiler == "apple-clang":
             return tools.XCRun(self.settings).cxx
         compiler_version = str(self.settings.compiler.version)
@@ -757,7 +753,7 @@ class BoostConan(ConanFile):
 
         # Specify here the toolset with the binary if present if don't empty parameter :
         contents += '\nusing "%s" : %s : ' % (self._toolset, self._toolset_version)
-        contents += ' "%s"' % self._cxx.replace("\\", "/")
+        contents += ' %s' % self._cxx.replace("\\", "/")
 
         if tools.is_apple_os(self.settings.os):
             if self.settings.compiler == "apple-clang":
@@ -774,6 +770,8 @@ class BoostConan(ConanFile):
             contents += '<cxxflags>"%s" ' % os.environ["CXXFLAGS"]
         if "CFLAGS" in os.environ:
             contents += '<cflags>"%s" ' % os.environ["CFLAGS"]
+        if "CPPFLAGS" in os.environ:
+            contents += '<compileflags>"%s" ' % os.environ["CPPFLAGS"]
         if "LDFLAGS" in os.environ:
             contents += '<linkflags>"%s" ' % os.environ["LDFLAGS"]
         if "ASFLAGS" in os.environ:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -591,6 +591,10 @@ class BoostConan(ConanFile):
 
         # CXX FLAGS
         cxx_flags = []
+        # Extract CXXFLAGS from CXX
+        if tools.get_env("CXX"):
+            cxx_flags.extend(shlex.split(tools.get_env("CXX"))[1:])
+
         # fPIC DEFINITION
         if self.settings.os != "Windows":
             if self.options.fPIC:
@@ -702,7 +706,7 @@ class BoostConan(ConanFile):
     @property
     def _cxx(self):
         if "CXX" in os.environ:
-            return os.environ["CXX"]
+            return shlex.split(tools.get_env("CXX"))[0]
         if tools.is_apple_os(self.settings.os) and self.settings.compiler == "apple-clang":
             return tools.XCRun(self.settings).cxx
         compiler_version = str(self.settings.compiler.version)


### PR DESCRIPTION
Specify library name and version:  **boost/all**

Fixes #2996

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
