### PR TITLE
concurrentqueue: add version 1.0.2

### DIFF
--- a/recipes/concurrentqueue/all/conandata.yml
+++ b/recipes/concurrentqueue/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.0.1":
     url: https://github.com/cameron314/concurrentqueue/archive/v1.0.1.zip
     sha256: b31dca11745ef331756109af838e3689462fbbc2c52dda9f7e1c416778f1f35b
+  "1.0.2":
+    url: https://github.com/cameron314/concurrentqueue/archive/v1.0.2.zip
+    sha256: 6dc85de0e38a014471fe3c653e3e21dc38a5f069cfc031a90fa59f0a45f7584f

--- a/recipes/concurrentqueue/all/test_package/CMakeLists.txt
+++ b/recipes/concurrentqueue/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/concurrentqueue/config.yml
+++ b/recipes/concurrentqueue/config.yml
@@ -2,3 +2,5 @@
 versions:
   "1.0.1":
     folder: all
+  "1.0.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **concurrentqueue/1.0.2**

concurrentqueue v1.0.2 was [released on 2020-09-25](https://github.com/cameron314/concurrentqueue/releases/tag/v1.0.2).

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.  **Tested with Conan 1.31.0.**
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.  **concurrentqueue/1.0.2 builds with no errors using clang 10.**

This PR also includes a commit to bump the test package's CMake requirement to CMake 3.1, which I think should address the hook validation failure reported in #2232.