### PR TITLE
openssl: generate ossl_static.pdb for every build. It is usefull for building openssl with _CL_=/Z7 enviroment

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -582,8 +582,7 @@ class OpenSSLConan(ConanFile):
     def _make(self):
         with tools.chdir(self._source_subfolder):
             # workaround for clang-cl not producing .pdb files
-            if self._is_clangcl:
-                tools.save("ossl_static.pdb", "")
+            tools.save("ossl_static.pdb", "")
             args = " ".join(self._configure_args)
             self.output.info(self._configure_args)
 


### PR DESCRIPTION
Here is small fix to fix openssl build with _CL_=/Z7 enviroment.
Currently it fails because ossl_static.pdb is not generated.
I believe it is ok to create ossl_static.pdb file for every build (not clang only), to make openssl perl script happy.

Specify library name and version:  openssl/*

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
