### PR TITLE
Gsoap fix

### DIFF
--- a/recipes/gsoap/all/CMakeLists.txt
+++ b/recipes/gsoap/all/CMakeLists.txt
@@ -18,11 +18,14 @@ if(${BUILD_TOOLS})
   include(${CMAKE_SOURCE_DIR}/src/soapcpp2.cmake)
   include(${CMAKE_SOURCE_DIR}/src/wsdl2h.cmake)
 
-  install(FILES ${CMAKE_SOURCE_DIR}/${GSOAP_PATH}/gsoap/typemap.dat DESTINATION res)
-  install(DIRECTORY ${CMAKE_SOURCE_DIR}/${GSOAP_PATH}/gsoap/import DESTINATION .
-          FILES_MATCHING PATTERN "*.h")
+
 endif()
 
+# Including the plugin source/headers import headers and typemap
+install(FILES ${CMAKE_SOURCE_DIR}/${GSOAP_PATH}/gsoap/typemap.dat DESTINATION res)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/${GSOAP_PATH}/gsoap/plugin DESTINATION . FILES_MATCHING PATTERN "*.h" PATTERN "*.c")
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/${GSOAP_PATH}/gsoap/import DESTINATION .
+                FILES_MATCHING PATTERN "*.h" )
 # Libraries
 if(${BUILD_GSOAP})
   include(${CMAKE_SOURCE_DIR}/src/gsoap.cmake)


### PR DESCRIPTION
Specify library name and version:  gsoap/all

Avoids building gsoap tools when cross compiling.. (not doable as it builds a host tool to build another host tool)
exports the gsoap plugin structure often used by projects


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
