### PR TITLE
xkbcommon: add 1.0.1 + cache meson + bump build_requirements

### DIFF
--- a/recipes/xkbcommon/all/conandata.yml
+++ b/recipes/xkbcommon/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.1":
+    url: "https://github.com/xkbcommon/libxkbcommon/archive/xkbcommon-1.0.1.tar.gz"
+    sha256: "270e2ad4ce5699f633e49042114cb68a5697fa1ed45b65c1d96a833cfac20954"
   "0.10.0":
     url: "https://github.com/xkbcommon/libxkbcommon/archive/xkbcommon-0.10.0.tar.gz"
     sha256: "9b4635cf5d9fc0fb9611ceec1780aafc0944299e9a29ab09c18ec2633923b9c3"

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -25,8 +25,16 @@ class XkbcommonConan(ConanFile):
         "with_wayland": False,
         "docs": False
     }
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
+
+    _meson = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
 
     def configure(self):
         if self.settings.os != "Linux":
@@ -47,6 +55,8 @@ class XkbcommonConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_meson(self):
+        if self._meson:
+            return self._meson
         defs={
             "enable-wayland": self.options.with_wayland,
             "enable-docs": self.options.docs,
@@ -54,13 +64,13 @@ class XkbcommonConan(ConanFile):
             "libdir": os.path.join(self.package_folder, "lib"),
             "default_library": ("shared" if self.options.shared else "static")}
 
-        meson = Meson(self)
-        meson.configure(
+        self._meson = Meson(self)
+        self._meson.configure(
             defs=defs,
             source_folder=self._source_subfolder,
             build_folder=self._build_subfolder,
             pkg_config_paths=self.build_folder)
-        return meson
+        return self._meson
 
     def build(self):
         meson = self._configure_meson()

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -104,6 +104,7 @@ class XkbcommonConan(ConanFile):
         meson = self._configure_meson()
         meson.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.components["libxkbcommon"].libs = ["xkbcommon"]

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -24,9 +24,11 @@ class XkbcommonConan(ConanFile):
         "fPIC": True,
         "with_x11": True,
         "with_wayland": False,
-        "xkbregistry": False, # FIXME: should be True, but requires pkg_config generator which will improperly model xorg pkg-config files
+        "xkbregistry": True,
         "docs": False
     }
+
+    generators = "pkg_config"
 
     _meson = None
 
@@ -51,8 +53,6 @@ class XkbcommonConan(ConanFile):
             raise ConanInvalidConfiguration("This library is only compatible with Linux")
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-        if self.options.get_safe("xkbregistry"):
-            raise ConanInvalidConfiguration("xkbregistry can't be enabled yet.")
 
     def requirements(self):
         self.requires("xorg/system")
@@ -79,6 +79,12 @@ class XkbcommonConan(ConanFile):
             "default_library": ("shared" if self.options.shared else "static")}
         if self._has_xkbregistry_option:
             defs["enable-xkbregistry"] = self.options.xkbregistry
+
+        # workaround for https://github.com/conan-io/conan-center-index/issues/3377
+        # FIXME: do not remove this pkg-config file once xorg recipe fixed
+        xeyboard_config_pkgfile = os.path.join(self.build_folder, "xkeyboard-config.pc")
+        if os.path.isfile(xeyboard_config_pkgfile):
+            os.remove(xeyboard_config_pkgfile)
 
         self._meson = Meson(self)
         self._meson.configure(

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -16,6 +16,7 @@ class XkbcommonConan(ConanFile):
         "fPIC": [True, False],
         "with_x11": [True, False],
         "with_wayland": [True, False],
+        "xkbregistry": [True, False],
         "docs": [True, False]
     }
     default_options = {
@@ -23,6 +24,7 @@ class XkbcommonConan(ConanFile):
         "fPIC": True,
         "with_x11": True,
         "with_wayland": False,
+        "xkbregistry": False, # FIXME: should be True, but requires pkg_config generator which will improperly model xorg pkg-config files
         "docs": False
     }
 
@@ -36,14 +38,26 @@ class XkbcommonConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    @property
+    def _has_xkbregistry_option(self):
+        return tools.Version(self.version) >= "1.0.0"
+
+    def config_options(self):
+        if not self._has_xkbregistry_option:
+            del self.options.xkbregistry
+
     def configure(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("This library is only compatible with Linux")
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+        if self.options.get_safe("xkbregistry"):
+            raise ConanInvalidConfiguration("xkbregistry can't be enabled yet.")
 
     def requirements(self):
         self.requires("xorg/system")
+        if self.options.get_safe("xkbregistry"):
+            self.requires("libxml2/2.9.10")
 
     def build_requirements(self):
         self.build_requires("meson/0.56.0")
@@ -63,6 +77,8 @@ class XkbcommonConan(ConanFile):
             "enable-x11": self.options.with_x11,
             "libdir": os.path.join(self.package_folder, "lib"),
             "default_library": ("shared" if self.options.shared else "static")}
+        if self._has_xkbregistry_option:
+            defs["enable-xkbregistry"] = self.options.xkbregistry
 
         self._meson = Meson(self)
         self._meson.configure(
@@ -73,8 +89,9 @@ class XkbcommonConan(ConanFile):
         return self._meson
 
     def build(self):
-        meson = self._configure_meson()
-        meson.build()
+        with tools.run_environment(self):
+            meson = self._configure_meson()
+            meson.build()
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
@@ -83,11 +100,19 @@ class XkbcommonConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.components['libxkbcommon'].libs = ['xkbcommon']
-        self.cpp_info.components['libxkbcommon'].name = 'xkbcommon'
-        self.cpp_info.components['libxkbcommon'].requires = ['xorg::xkeyboard-config']
+        self.cpp_info.components["libxkbcommon"].libs = ["xkbcommon"]
+        self.cpp_info.components["libxkbcommon"].name = "xkbcommon"
+        self.cpp_info.components["libxkbcommon"].requires = ["xorg::xkeyboard-config"]
         if self.options.with_x11:
-            self.cpp_info.components['libxkbcommon-x11'].libs = ['xkbcommon-x11']
-            self.cpp_info.components['libxkbcommon-x11'].name = 'xkbcommon-x11'
-            self.cpp_info.components['libxkbcommon-x11'].requires = ['libxkbcommon']
-            self.cpp_info.components['libxkbcommon-x11'].requires.extend(['xorg::xcb', 'xorg::xcb-xkb'])
+            self.cpp_info.components["libxkbcommon-x11"].libs = ["xkbcommon-x11"]
+            self.cpp_info.components["libxkbcommon-x11"].name = "xkbcommon-x11"
+            self.cpp_info.components["libxkbcommon-x11"].requires = ["libxkbcommon", "xorg::xcb", "xorg::xcb-xkb"]
+        if self.options.get_safe("xkbregistry"):
+            self.cpp_info.components["libxkbregistry"].libs = ["xkbregistry"]
+            self.cpp_info.components["libxkbregistry"].name = "xkbregistry"
+            self.cpp_info.components["libxkbregistry"].requires = ["libxml2::libxml2"]
+
+        if tools.Version(self.version) >= "1.0.0":
+            bin_path = os.path.join(self.package_folder, "bin")
+            self.output.info("Appending PATH environment variable: {}".format(bin_path))
+            self.env_info.PATH.append(bin_path)

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -34,12 +34,12 @@ class XkbcommonConan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
-    def build_requirements(self):
-        self.build_requires("meson/0.54.2")
-        self.build_requires("bison/3.5.3")
-
     def requirements(self):
         self.requires("xorg/system")
+
+    def build_requirements(self):
+        self.build_requires("meson/0.56.0")
+        self.build_requires("bison/3.7.1")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/xkbcommon/config.yml
+++ b/recipes/xkbcommon/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.1":
+    folder: all
   "0.10.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **xkbcommon/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

`xkbregistry` option default value should be True, but it can't be enabled. Indeed, it would require to use `pkg_config` generator because this component depends on `libxml2`. But `xorg` recipe doesn't (can't?) properly model pkg-config files, in particular it lacks a very important variable at build time for xkbcommon. See https://github.com/conan-io/conan-center-index/issues/3377