### PR TITLE
bugfix paho-mqtt-c: remove force dynamic linking since there is a check anyway

### DIFF
--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -32,6 +32,8 @@ class PahoMqttcConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+            if tools.Version(self.version) < "1.3.4": # Static linking before 1.3.4 isn't supported on Windows
+                self.options.shared = True
 
     def configure(self):
         del self.settings.compiler.cppstd

--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -32,9 +32,6 @@ class PahoMqttcConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        # Static linking before 1.3.4 isn't supported
-        if tools.Version(self.version) < "1.3.4":
-            self.options.shared = True
 
     def configure(self):
         del self.settings.compiler.cppstd


### PR DESCRIPTION
Specify library name and version:  **paho-mqtt-c/1.3.x**

The removed lines caused a problem when using lock files

```
ERROR: paho-mqtt-c/1.3.1: paho-mqtt-cpp/1.1 tried to change paho-mqtt-c/1.3.1 option shared to False
but it was already defined as True
```

since there is a check later anyway, and forcing surprising options should not happen anyway, I think removing this is the best option.
Alternative, it could be intended, so setting shared happens only on Windows, but personally do not find that every exciting

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.


