### PR TITLE
libcurl: add support for c-ares

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -34,7 +34,8 @@ class LibcurlConan(ConanFile):
                "with_nghttp2": [True, False],
                "with_zlib": [True, False],
                "with_brotli": [True, False],
-               "with_zstd": [True, False]
+               "with_zstd": [True, False],
+               "with_c_ares": [True, False],
                }
     default_options = {"shared": False,
                        "fPIC": True,
@@ -53,7 +54,8 @@ class LibcurlConan(ConanFile):
                        "with_nghttp2": False,
                        "with_zlib": True,
                        "with_brotli": False,
-                       "with_zstd": False
+                       "with_zstd": False,
+                       "with_c_ares": False,
                        }
 
     _autotools = None
@@ -151,6 +153,8 @@ class LibcurlConan(ConanFile):
             self.requires("brotli/1.0.9")
         if self.options.get_safe("with_zstd"):
             self.requires("zstd/1.4.5")
+        if self.options.get_safe("with_c_ares"):
+            self.requires("c-ares/1.16.1")
 
     def package_id(self):
         # Deprecated options
@@ -269,6 +273,10 @@ class LibcurlConan(ConanFile):
 
         if self.settings.build_type == "Debug":
            params.append("--enable-debug")
+
+        if self.options.with_c_ares:
+            params.append("--enable-ares")
+            params.append("--enable-threaded-resolver")
 
         # Cross building flags
         if tools.cross_building(self.settings):
@@ -486,6 +494,8 @@ class LibcurlConan(ConanFile):
         if self._has_zstd_option:
             self._cmake.definitions["CURL_ZSTD"] = self.options.with_zstd
         self._cmake.definitions["CMAKE_USE_LIBSSH2"] = self.options.with_libssh2
+        self._cmake.definitions["ENABLE_ARES"] = self.options.with_c_ares
+
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
@@ -578,3 +588,5 @@ class LibcurlConan(ConanFile):
             self.cpp_info.components["curl"].requires.append("brotli::brotli")
         if self.options.get_safe("with_zstd"):
             self.cpp_info.components["curl"].requires.append("zstd::zstd")
+        if self.options.get_safe("with_c_ares"):
+            self.cpp_info.components["curl"].requires.append("c-ares::c-ares")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -153,7 +153,7 @@ class LibcurlConan(ConanFile):
             self.requires("brotli/1.0.9")
         if self.options.get_safe("with_zstd"):
             self.requires("zstd/1.4.5")
-        if self.options.get_safe("with_c_ares"):
+        if self.options.with_c_ares:
             self.requires("c-ares/1.16.1")
 
     def package_id(self):
@@ -588,5 +588,5 @@ class LibcurlConan(ConanFile):
             self.cpp_info.components["curl"].requires.append("brotli::brotli")
         if self.options.get_safe("with_zstd"):
             self.cpp_info.components["curl"].requires.append("zstd::zstd")
-        if self.options.get_safe("with_c_ares"):
+        if self.options.with_c_ares:
             self.cpp_info.components["curl"].requires.append("c-ares::c-ares")


### PR DESCRIPTION
c-ares is required for threaded resolvers.

Specify library name and version:  **libcurl**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
