### PR TITLE
MSVC 15.9 is an invalid CMake version

### DIFF
--- a/recipes/uwebsockets/all/conanfile.py
+++ b/recipes/uwebsockets/all/conanfile.py
@@ -27,7 +27,7 @@ class UwebsocketsConan(ConanFile):
             tools.check_min_cppstd(self, minimal_cpp_standard)
 
         minimal_version = {
-            "Visual Studio": "15.9",
+            "Visual Studio": "15",
             "gcc": "7",
             "clang": "5",
             "apple-clang": "10"

--- a/recipes/uwebsockets/all/test_package/CMakeLists.txt
+++ b/recipes/uwebsockets/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Specify library name and version:  **uwebsocket/18.3.0**

Related to: https://stackoverflow.com/questions/64694269/getting-uwebsockets-for-visual-2017-via-conan

- Visual Studio 15.9 is not a default version in settings.yml
- CMake only supports major versions for Generators, therefore, cmake -G "Visual Studio 15.9 2017 x64" is invalid.

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
