### PR TITLE
Add libx265/3.4

### DIFF
--- a/recipes/libx265/all/conandata.yml
+++ b/recipes/libx265/all/conandata.yml
@@ -1,8 +1,14 @@
 sources:
-  3.2.1:
+  "3.2.1":
     url: "https://github.com/videolan/x265/archive/3.2.1.tar.gz"
     sha256: "b5ee7ea796a664d6e2763f9c0ae281fac5d25892fc2cb134698547103466a06a"
+  "3.4":
+    url: "https://github.com/videolan/x265/archive/3.4.tar.gz"
+    sha256: "544d147bf146f8994a7bf8521ed878c93067ea1c7c6e93ab602389be3117eaaf"
 patches:
-  3.2.1:
+  "3.2.1":
+    - patch_file: "patches/0001-remove_register_classifier.patch"
+      base_path: "source_subfolder"
+  "3.4":
     - patch_file: "patches/0001-remove_register_classifier.patch"
       base_path: "source_subfolder"

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -8,7 +8,7 @@ class Libx265Conan(ConanFile):
     description = "x265 is the leading H.265 / HEVC encoder software library"
     topics = ("conan", "libx265", "codec", "video", "H.265")
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = " https://bitbucket.org/multicoreware/x265"
+    homepage = "https://www.videolan.org/developers/x265.html"
     exports_sources = ["CMakeLists.txt", "patches/*"]
     generators = "cmake"
     license = ("GPL-2.0-only", "commercial")  # https://bitbucket.org/multicoreware/x265/src/default/COPYING

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -113,6 +113,8 @@ class Libx265Conan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "x265"
+        self.cpp_info.names["cmake_find_package_multi"] = "x265"
         self.cpp_info.names["pkg_config"] = "x265"
         self.cpp_info.libs = ["x265"]
         if self.settings.os == "Linux":

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -113,8 +113,6 @@ class Libx265Conan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "x265"
-        self.cpp_info.names["cmake_find_package_multi"] = "x265"
         self.cpp_info.names["pkg_config"] = "x265"
         self.cpp_info.libs = ["x265"]
         if self.settings.os == "Linux":

--- a/recipes/libx265/config.yml
+++ b/recipes/libx265/config.yml
@@ -1,3 +1,5 @@
 versions:
   "3.2.1":
     folder: "all"
+  "3.4":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **libx265/3.4**

- Version bump (no upstream build changes)
- Fix homepage
- Changed cmake name to x265

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
