### PR TITLE
libx265: fix shared ilbrary with assembly

### DIFF
--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -1,5 +1,4 @@
 from conans import CMake, ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
 import os
 import shutil
 

--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -25,7 +25,7 @@ class Libx265Conan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "assembly": False,
+        "assembly": True,
         "bit_depth": 8,
         "HDR10": False,
         "SVG_HEVC_encoder": False,

--- a/recipes/libx265/all/test_package/CMakeLists.txt
+++ b/recipes/libx265/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(NO_OUTPUT_DIRS)
+conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/libx265/all/test_package/CMakeLists.txt
+++ b/recipes/libx265/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(NO_OUTPUT_DIRS)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/libx265/all/test_package/CMakeLists.txt
+++ b/recipes/libx265/all/test_package/CMakeLists.txt
@@ -7,7 +7,6 @@ conan_basic_setup()
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 
-
 option(TEST_LIBRARY "Build test library")
 if(TEST_LIBRARY)
     # Test building a shared library.

--- a/recipes/libx265/all/test_package/CMakeLists.txt
+++ b/recipes/libx265/all/test_package/CMakeLists.txt
@@ -4,5 +4,17 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+
+
+option(TEST_LIBRARY "Build test library")
+if(TEST_LIBRARY)
+    # Test building a shared library.
+    # a static libx265.a on Linux requires linker flags to avoid PIC related relocation errors.
+    add_library(test_library SHARED test_library.c)
+    target_link_libraries(test_library ${CONAN_LIBS})
+
+    target_compile_definitions(${PROJECT_NAME} PRIVATE WITH_LIB)
+    target_link_libraries(${PROJECT_NAME} test_library)
+endif()

--- a/recipes/libx265/all/test_package/conanfile.py
+++ b/recipes/libx265/all/test_package/conanfile.py
@@ -1,6 +1,8 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanException
 import os
+import glob
+import shutil
 
 
 class TestPackageConan(ConanFile):
@@ -21,6 +23,9 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
+        # Copy all libraries so in bin folder so we don't need any LD_LIBRARY_PATH/DYLD_LIBRARY_PATH (which might conflict with run_environment argument of self.run)
+        for fn in glob.glob(os.path.join("lib", "*")):
+            shutil.copy(src=fn, dst="bin")
         if not tools.cross_building(self.settings):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/libx265/all/test_package/conanfile.py
+++ b/recipes/libx265/all/test_package/conanfile.py
@@ -17,10 +17,12 @@ class TestPackageConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions["TEST_LIBRARY"] = self._test_shared_library
+        cmake.definitions["CMAKE_INSTALL_PREFIX"] = self.build_folder.replace("\\", "/")
         cmake.configure()
         cmake.build()
 
     def test(self):
         if not tools.cross_building(self.settings):
-            bin_path = os.path.join(".", "test_package")
-            self.run(bin_path, run_environment=True)
+            with tools.environment_append({"LD_LIBRARY_PATH": "bin", "DYLD_LIBRARY_PATH": "bin"}):
+                bin_path = os.path.join("bin", "test_package")
+                self.run(bin_path, run_environment=True)

--- a/recipes/libx265/all/test_package/conanfile.py
+++ b/recipes/libx265/all/test_package/conanfile.py
@@ -17,12 +17,10 @@ class TestPackageConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions["TEST_LIBRARY"] = self._test_shared_library
-        cmake.definitions["CMAKE_INSTALL_PREFIX"] = self.build_folder.replace("\\", "/")
         cmake.configure()
         cmake.build()
 
     def test(self):
         if not tools.cross_building(self.settings):
-            with tools.environment_append({"LD_LIBRARY_PATH": "bin", "DYLD_LIBRARY_PATH": "bin"}):
-                bin_path = os.path.join("bin", "test_package")
-                self.run(bin_path, run_environment=True)
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libx265/all/test_package/conanfile.py
+++ b/recipes/libx265/all/test_package/conanfile.py
@@ -23,9 +23,10 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        # Copy all libraries so in bin folder so we don't need any LD_LIBRARY_PATH/DYLD_LIBRARY_PATH (which might conflict with run_environment argument of self.run)
+        # Copy all libraries to current and bin folderso we don't need any LD_LIBRARY_PATH/DYLD_LIBRARY_PATH/PATH (which might conflict with run_environment argument of self.run)
         for fn in glob.glob(os.path.join("lib", "*")):
             shutil.copy(src=fn, dst="bin")
+            shutil.copy(src=fn, dst=".")
         if not tools.cross_building(self.settings):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/libx265/all/test_package/conanfile.py
+++ b/recipes/libx265/all/test_package/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanException
 import os
 
 
@@ -6,8 +7,16 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 
+    @property
+    def _test_shared_library(self):
+        try:
+            return self.options["libx265"].fPIC
+        except ConanException:
+            return True
+
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["TEST_LIBRARY"] = self._test_shared_library
         cmake.configure()
         cmake.build()
 

--- a/recipes/libx265/all/test_package/conanfile.py
+++ b/recipes/libx265/all/test_package/conanfile.py
@@ -22,5 +22,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
+            bin_path = os.path.join(".", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/libx265/all/test_package/test_library.c
+++ b/recipes/libx265/all/test_package/test_library.c
@@ -1,9 +1,18 @@
 #include "x265.h"
 
-#include <cstdlib>
+#include <stdlib.h>
 
-int main()
-{
+#ifdef _WIN32
+# define TEST_EXPORT __declspec(dllexport)
+#else
+# define TEST_EXPORT __attribute__ ((visibility("default")))
+#endif
+
+TEST_EXPORT const char *test_library_version(void) {
+    return x265_version_str;
+}
+
+TEST_EXPORT void test_library_something(void) {
     x265_param * param = x265_param_alloc();
     x265_param_default(param);
     param->sourceWidth = 640;
@@ -13,5 +22,4 @@ int main()
     x265_encoder * encoder = x265_encoder_open(param);
     x265_encoder_close(encoder);
     x265_param_free(param);
-    return EXIT_SUCCESS;
 }

--- a/recipes/libx265/all/test_package/test_package.c
+++ b/recipes/libx265/all/test_package/test_package.c
@@ -1,0 +1,30 @@
+#include "x265.h"
+
+#include <stdlib.h>
+
+#ifdef WITH_LIB
+# ifdef _WIN32
+#  define TEST_IMPORT __declspec(dllimport)
+# else
+#  define TEST_EXPORT
+# endif
+
+#endif
+
+int main()
+{
+    x265_param * param = x265_param_alloc();
+    x265_param_default(param);
+    param->sourceWidth = 640;
+    param->sourceHeight = 480;
+    param->fpsNum = 25;
+    param->fpsDenom = 1;
+    x265_encoder * encoder = x265_encoder_open(param);
+    x265_encoder_close(encoder);
+    x265_param_free(param);
+#ifdef WITH_LIB
+    test_library_version();
+    test_library_something();
+#endif
+    return EXIT_SUCCESS;
+}

--- a/recipes/libx265/all/test_package/test_package.c
+++ b/recipes/libx265/all/test_package/test_package.c
@@ -6,9 +6,11 @@
 # ifdef _WIN32
 #  define TEST_IMPORT __declspec(dllimport)
 # else
-#  define TEST_EXPORT
+#  define TEST_IMPORT
 # endif
 
+TEST_IMPORT const char *test_library_version(void);
+TEST_IMPORT void test_library_something(void);
 #endif
 
 int main()


### PR DESCRIPTION
Second libx265 patch of the day!!!

Fixes #3435

Specify library name and version:  **libx265/all**


This patch also adds tools.stdcpp_library in package_info


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
