### PR TITLE
libffi: reformat recipe to current standard (and rebuild all packages)

### DIFF
--- a/recipes/libffi/all/conanfile.py
+++ b/recipes/libffi/all/conanfile.py
@@ -22,8 +22,26 @@ class LibffiConan(ConanFile):
         "fPIC": True,
     }
     exports_sources = "patches/**"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
     _autotools = None
-    _source_subfolder = "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def build_requirements(self):
+        if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:
+            self.build_requires("msys2/20200517")
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -47,20 +65,6 @@ class LibffiConan(ConanFile):
 
                 # https://android.googlesource.com/platform/external/libffi/+/7748bd0e4a8f7d7c67b2867a3afdd92420e95a9f
                 tools.replace_in_file(sysv_s_src, "stmeqia", "stmiaeq")
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
-
-    def build_requirements(self):
-        if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:
-            self.build_requires("msys2/20190524")
 
     @contextmanager
     def _build_context(self):
@@ -91,14 +95,12 @@ class LibffiConan(ConanFile):
         if self._autotools:
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        yes_no = lambda v: "yes" if v else "no"
         config_args = [
-            "--enable-debug" if self.settings.build_type == "Debug" else "--disable-debug",
-            "--prefix={}".format(tools.unix_path(self.package_folder)),
+            "--enable-debug={}".format(yes_no(self.settings.build_type == "Debug")),
+            "--enable-shared={}".format(yes_no(self.options.shared)),
+            "--enable-static={}".format(yes_no(not self.options.shared)),
         ]
-        if self.options.shared:
-            config_args.extend(["--enable-shared", "--disable-static"])
-        else:
-            config_args.extend(["--disable-shared", "--enable-static"])
         self._autotools.defines.append("FFI_BUILDING")
         if self.options.shared:
             self._autotools.defines.append("FFI_BUILDING_DLL")
@@ -142,8 +144,7 @@ class LibffiConan(ConanFile):
         else:
             with self._build_context():
                 autotools = self._configure_autotools()
-                with tools.chdir(self.build_folder):
-                    autotools.install()
+                autotools.install()
 
             tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
             tools.rmdir(os.path.join(self.package_folder, "share"))

--- a/recipes/libffi/all/test_package/conanfile.py
+++ b/recipes/libffi/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -12,5 +12,6 @@ class TclTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **libffi/all**

This PR has 2 aims:
1. Rebuid all packages, as some are missing.
See e.g. [this c3i bot message](https://github.com/conan-io/conan-center-index/pull/1510#issuecomment-723331196).
Touching the recipe was suggested by @ericLemanissier [here](https://github.com/conan-io/conan-center-index/pull/3135#issuecomment-723329337)
2. Reformat the recipe so that it is up to par with *current recipe standards*.


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
