### PR TITLE
leptonica: Fix turning off options, no memmove on macOS < 13

### DIFF
--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -81,8 +81,6 @@ class LeptonicaConan(ConanFile):
         cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_PNG'] = not self.options.with_png
         cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_TIFF'] = not self.options.with_tiff
         cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_JPEG'] = not self.options.with_jpeg
-        cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_webp'] = not self.options.with_webp
-        cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_openjp2'] = not self.options.with_openjpeg
 
         cmake.definitions['SW_BUILD'] = False
 

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -111,6 +111,21 @@ class LeptonicaConan(ConanFile):
                                   "if(NOT JP2K)",
                                   "if(FALSE)")
 
+        # Remove detection of fmemopen() on macOS < 10.13
+        # CheckFunctionExists will find it in the link library.
+        # There's no error because it's not including the header with the
+        # deprecation macros.
+        if self.settings.os == 'Macos':
+            if tools.Version(self.settings.os.version) < '10.13':
+                configure_cmake = os.path.join(self._source_subfolder,
+                                               'cmake',
+                                               'Configure.cmake')
+                tools.replace_in_file(configure_cmake,
+                                      'set(functions_list\n    '
+                                      'fmemopen\n    fstatat\n)',
+                                      'set(functions_list\n    '
+                                      'fstatat\n)')
+
         # upstream uses obsolete FOO_LIBRARY that is not generated
         # by cmake_find_package generator (upstream PR 456)
         if tools.Version(self.version) <= '1.78.0':

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -90,10 +90,26 @@ class LeptonicaConan(ConanFile):
         return cmake
 
     def build(self):
+        cmake_original = os.path.join(self._source_subfolder,
+                                      "CMakeListsOriginal.txt")
         # disable pkgconfig
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeListsOriginal.txt"),
+        tools.replace_in_file(cmake_original,
                               "if (PKG_CONFIG_FOUND)",
                               "if (FALSE)")
+
+        # short out conditionals that don't respect
+        # CMAKE_DISABLE_FIND_PACKAGE_x
+        if not self.options.with_webp:
+            tools.replace_in_file(cmake_original,
+                                  "if(NOT WEBP)",
+                                  "if(FALSE)")
+            tools.replace_in_file(cmake_original,
+                                  "if(NOT WEBPMUX)",
+                                  "if(FALSE)")
+        if not self.options.with_openjpeg:
+            tools.replace_in_file(cmake_original,
+                                  "if(NOT JP2K)",
+                                  "if(FALSE)")
 
         # upstream uses obsolete FOO_LIBRARY that is not generated
         # by cmake_find_package generator (upstream PR 456)

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -115,7 +115,7 @@ class LeptonicaConan(ConanFile):
         # CheckFunctionExists will find it in the link library.
         # There's no error because it's not including the header with the
         # deprecation macros.
-        if self.settings.os == 'Macos':
+        if self.settings.os == 'Macos' and self.settings.os.version:
             if tools.Version(self.settings.os.version) < '10.13':
                 configure_cmake = os.path.join(self._source_subfolder,
                                                'cmake',

--- a/recipes/leptonica/all/test_package/CMakeLists.txt
+++ b/recipes/leptonica/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Specify library name and version:  **leptonica/1.79.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
