### PR TITLE
openexr: fix order of libraries

### DIFF
--- a/recipes/openexr/2.x/conanfile.py
+++ b/recipes/openexr/2.x/conanfile.py
@@ -96,10 +96,10 @@ class OpenEXRConan(ConanFile):
         self.cpp_info.libs = ["IlmImf{}".format(lib_suffix),
                               "IlmImfUtil{}".format(lib_suffix),
                               "IlmThread{}".format(lib_suffix),
-                              "Iex{}".format(lib_suffix),
-                              "IexMath{}".format(lib_suffix),
                               "Imath{}".format(lib_suffix),
-                              "Half{}".format(lib_suffix)]
+                              "Half{}".format(lib_suffix),
+                              "IexMath{}".format(lib_suffix),
+                              "Iex{}".format(lib_suffix)]
 
         self.cpp_info.includedirs = [os.path.join("include", "OpenEXR"), "include"]
         if self.options.shared and self.settings.os == "Windows":


### PR DESCRIPTION
**openexr/2.x**

Fixes linker errors caused by incorrect order of OpenEXR libraries (`IexMath` depends on `Iex` and should be listed in that order).

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
