### PR TITLE
libx264/*: remove apple_deployment_target_flag

### DIFF
--- a/recipes/libx264/all/conanfile.py
+++ b/recipes/libx264/all/conanfile.py
@@ -86,9 +86,6 @@ class LibX264Conan(ConanFile):
                 self._autotools.flags.append('-%s' % str(self.settings.compiler.runtime))
                 # cannot open program database ... if multiple CL.EXE write to the same .PDB file, please use /FS
                 self._autotools.flags.append('-FS')
-            if tools.is_apple_os(self.settings.os) and self.settings.get_safe("os.version"):
-                self._autotools.flags.append(tools.apple_deployment_target_flag(self.settings.os,
-                                                                                self.settings.os.version))
             build_canonical_name = None
             host_canonical_name = None
             if self.settings.compiler == "Visual Studio":


### PR DESCRIPTION
Minimum conan version: 1.31.0

Since `apple_deployment_target_flag` is set by conan since version 1.31.0 (https://github.com/conan-io/conan/pull/7862), I removed this specific formula code.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
