### PR TITLE
botan/*: Remove apple_deployment_target_flag

### DIFF
--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -248,10 +248,8 @@ class BotanConan(ConanFile):
             botan_extra_cxx_flags.append('-fPIC')
 
         if self.settings.os == "Macos" and self.settings.os.version:
-            macos_min_version = tools.apple_deployment_target_flag(self.settings.os,
-                                                                   self.settings.os.version)
             macos_sdk_path = "-isysroot {}".format(tools.XCRun(self.settings).sdk_path)
-            botan_extra_cxx_flags.extend([macos_min_version, macos_sdk_path])
+            botan_extra_cxx_flags.append(macos_sdk_path)
 
         # This is to work around botan's configure script that *replaces* its
         # standard (platform dependent) flags in presence of an environment


### PR DESCRIPTION
Minimum conan version: 1.31.0

Since `apple_deployment_target_flag` is set by conan since version 1.31.0 (https://github.com/conan-io/conan/pull/7862), I removed this specific formula code.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
