### PR TITLE
cyrus-sasl: fix pkg-config/hooks + bump dependencies + allow static + disable with_gssapi until krb5 recipe available

### DIFF
--- a/recipes/cyrus-sasl/all/conandata.yml
+++ b/recipes/cyrus-sasl/all/conandata.yml
@@ -2,4 +2,3 @@ sources:
   "2.1.27":
     url: "https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.27/cyrus-sasl-2.1.27.tar.gz"
     sha256: 26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5
-

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -77,13 +77,13 @@ class CyrusSaslConan(ConanFile):
 
     def requirements(self):
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1h")
+            self.requires("openssl/1.1.1i")
         if self.options.with_postgresql:
-            self.requires("libpq/13.0")
+            self.requires("libpq/13.1")
         if self.options.with_mysql:
             self.requires("libmysqlclient/8.0.17")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.33.0")
+            self.requires("sqlite3/3.34.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -35,7 +35,7 @@ class CyrusSaslConan(ConanFile):
         "with_sqlite3": [True, False],
     }
     default_options = {
-        "shared": True,
+        "shared": False,
         "fPIC": True,
         "with_openssl": True,
         "with_cram": True,
@@ -69,10 +69,6 @@ class CyrusSaslConan(ConanFile):
         if self.settings.os == "Windows":
             raise ConanInvalidConfiguration(
                 "Cyrus SASL package is not compatible with Windows yet."
-            )
-        if self.options.with_gssapi and not self.options.shared:
-            raise ConanInvalidConfiguration(
-                "Cyrus SASL package cannot link statically to libkrb5"
             )
 
     def requirements(self):

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -43,7 +43,7 @@ class CyrusSaslConan(ConanFile):
         "with_scram": True,
         "with_otp": True,
         "with_krb4": True,
-        "with_gssapi": True,
+        "with_gssapi": False, # FIXME: should be True
         "with_plain": True,
         "with_anon": True,
         "with_postgresql": False,
@@ -80,6 +80,9 @@ class CyrusSaslConan(ConanFile):
             self.requires("libmysqlclient/8.0.17")
         if self.options.with_sqlite3:
             self.requires("sqlite3/3.34.0")
+        if self.options.with_gssapi:
+            raise ConanInvalidConfiguration("with_gssapi requires krb5 recipe, not yet available in CCI")
+            self.requires("krb5/1.18.3")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -35,7 +35,7 @@ class CyrusSaslConan(ConanFile):
         "with_sqlite3": [True, False],
     }
     default_options = {
-        "shared": False,
+        "shared": True,
         "fPIC": True,
         "with_openssl": True,
         "with_cram": True,

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -77,13 +77,13 @@ class CyrusSaslConan(ConanFile):
 
     def requirements(self):
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1g")
+            self.requires("openssl/1.1.1h")
         if self.options.with_postgresql:
-            self.requires("libpq/12.2")
+            self.requires("libpq/13.0")
         if self.options.with_mysql:
             self.requires("libmysqlclient/8.0.17")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.32.3")
+            self.requires("sqlite3/3.33.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -193,6 +193,7 @@ class CyrusSaslConan(ConanFile):
             os.remove(la_file)
 
     def package_info(self):
+        self.cpp_info.names["pkg_config"] = "libsasl2"
         self.cpp_info.libs = tools.collect_libs(self)
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bindir))

--- a/recipes/cyrus-sasl/all/test_package/CMakeLists.txt
+++ b/recipes/cyrus-sasl/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Specify library name and version:  **cyrus-sasl/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

default shared value is set to True, otherwise all recipes in CCI depending on this one won't be able to build without overriding this option...
I believe that the default combination of options should never raise (if another combination of options can work for a given triplet, it should be prefered than the one which raise).