### PR TITLE
libepoxy: shared by default on windows

### DIFF
--- a/recipes/libepoxy/all/conanfile.py
+++ b/recipes/libepoxy/all/conanfile.py
@@ -43,6 +43,7 @@ class EpoxyConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+            self.options.shared = True
         if self.settings.os != "Linux":
             del self.options.glx
             del self.options.egl


### PR DESCRIPTION
Specify library name and version:  **libepoxy/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
