### PR TITLE
Remove ibverbs dependency from libpcap

### DIFF
--- a/recipes/libpcap/all/conanfile.py
+++ b/recipes/libpcap/all/conanfile.py
@@ -28,6 +28,7 @@ class LibPcapConan(ConanFile):
     # TODO: Add dbus-glib when available
     # TODO: Add libnl-genl when available
     # TODO: Add libbluetooth when available
+    # TODO: Add libibverbs when available
 
     @property
     def _source_subfolder(self):
@@ -61,7 +62,13 @@ class LibPcapConan(ConanFile):
             configure_args = ["--enable-shared" if self.options.shared else "--disable-shared"]
             configure_args.append("--disable-universal" if not self.options.enable_universal else "")
             configure_args.append("--enable-usb" if self.options.enable_libusb else "--disable-usb")
-            configure_args.extend(["--without-libnl", "--disable-bluetooth", "--disable-packet-ring", "--disable-dbus"])
+            configure_args.extend([
+                "--without-libnl",
+                "--disable-bluetooth",
+                "--disable-packet-ring",
+                "--disable-dbus",
+                "--disable-rdma"
+            ])
             if tools.cross_building(self.settings):
                 target_os = "linux" if self.settings.os == "Linux" else "null"
                 configure_args.append("--with-pcap=%s" % target_os)


### PR DESCRIPTION
Specify library name and version:  **libpcap/1.9.1**

The problem is if you build the package on a system with libibverbs installed, CMakeLists.txt for libpcap will detect it and link with it, but then when linking our application with conan::libpcap, linker won't find ibverbs symbols.

It is easy to reproduce:
1. Install libibverbs-dev
2. Checkout conan-center-index
3. Try to create a libpcap package
4. Get linker errors
/home/ivanfefer/.conan/data/libpcap/1.9.1/_/_/package/<bla-bla>/lib/libpcap.a(pcap-rdmasniff.o): In function 'rdmasniff_cleanup':
pcap-rdmasniff.c:(.text+0x82): undefined reference to 'ibv_dereg_mr'
pcap-rdmasniff.c:(.text+0xb2): undefined reference to 'ibv_destroy_qp'
pcap-rdmasniff.c:(.text+0xbb): undefined reference to 'ibv_destroy_cq'
pcap-rdmasniff.c:(.text+0xc4): undefined reference to 'ibv_dealloc_pd'
pcap-rdmasniff.c:(.text+0xcd): undefined reference to 'ibv_destroy_comp_channel'
pcap-rdmasniff.c:(.text+0xd6): undefined reference to 'bv_close_device'
5. Also, even if you remove the libibverbs-dev package, conan will not rebuild libpcap because it won't detect the environment change.

Because there is no package for ibverbs, I suggest disabling it.

After this fix, steps I mentioned above don't reproduce the problem.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
