### PR TITLE
oatpp: allow gcc<5  and shared on windows

### DIFF
--- a/recipes/oatpp/all/CMakeLists.txt
+++ b/recipes/oatpp/all/CMakeLists.txt
@@ -1,7 +1,11 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.4)
 project(cmake_wrapper)
 
 include("conanbuildinfo.cmake")
 conan_basic_setup()
+
+if(MSVC AND BUILD_SHARED_LIBS)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 
 add_subdirectory(source_subfolder)

--- a/recipes/oatpp/all/conandata.yml
+++ b/recipes/oatpp/all/conandata.yml
@@ -8,3 +8,10 @@ sources:
   "1.2.0":
     url: "https://github.com/oatpp/oatpp/archive/1.2.0.tar.gz"
     sha256: "7f55669827ece429b6d85f4403b76da717d3fdf0e92721e9a0229cf8168e8e37"
+patches:
+  "1.0.0":
+    - patch_file: "patches/put-time-gcc-lt5-1.1.0.patch"
+      base_path: "source_subfolder"
+  "1.1.0":
+    - patch_file: "patches/put-time-gcc-lt5-1.1.1.patch"
+      base_path: "source_subfolder"

--- a/recipes/oatpp/all/conanfile.py
+++ b/recipes/oatpp/all/conanfile.py
@@ -14,7 +14,7 @@ class OatppConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
-    exports_sources = "CMakeLists.txt"
+    exports_sources = ["CMakeLists.txt", "patches/**"]
     _cmake = None
 
     @property
@@ -38,9 +38,6 @@ class OatppConan(ConanFile):
         if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration("oatpp can not be built as shared library on Windows")
 
-        if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "5":
-            raise ConanInvalidConfiguration("oatpp requires GCC >=5")
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("oatpp-{0}".format(self.version), self._source_subfolder)
@@ -56,6 +53,8 @@ class OatppConan(ConanFile):
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/oatpp/all/conanfile.py
+++ b/recipes/oatpp/all/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
 import os
 
 
@@ -35,9 +34,6 @@ class OatppConan(ConanFile):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
 
-        if self.settings.os == "Windows" and self.options.shared:
-            raise ConanInvalidConfiguration("oatpp can not be built as shared library on Windows")
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("oatpp-{0}".format(self.version), self._source_subfolder)
@@ -48,7 +44,6 @@ class OatppConan(ConanFile):
 
         self._cmake = CMake(self)
         self._cmake.definitions["OATPP_BUILD_TESTS"] = False
-        self._cmake.definitions["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 

--- a/recipes/oatpp/all/patches/put-time-gcc-lt5-1.1.0.patch
+++ b/recipes/oatpp/all/patches/put-time-gcc-lt5-1.1.0.patch
@@ -1,0 +1,28 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -93,6 +93,9 @@ endif()
+ if(OATPP_DISABLE_LOGE)
+     add_definitions(-DOATPP_DISABLE_LOGE)
+ endif()
++if(CMAKE_COMPILER_IS_GNUCXX AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 5.0)
++    add_definitions(-DOATPP_DISABLE_STD_PUT_TIME)
++endif()
+ 
+ message("\n############################################################################\n")
+ 
+--- a/src/oatpp/core/base/Environment.cpp
++++ b/src/oatpp/core/base/Environment.cpp
+@@ -93,7 +93,13 @@ void DefaultLogger::log(v_int32 priority, const std::string& tag, const std::str
+     time_t seconds = (time_t)std::chrono::duration_cast<std::chrono::seconds>(time).count();
+     struct tm now;
+     localtime_r(&seconds, &now);
++#ifdef OATPP_DISABLE_STD_PUT_TIME
++	  char timeBuffer[50];
++    strftime(timeBuffer, sizeof(timeBuffer), m_config.timeFormat, &now);
++    std::cout << timeBuffer;
++#else
+     std::cout << std::put_time(&now, m_config.timeFormat);
++#endif
+     indent = true;
+   }
+ 

--- a/recipes/oatpp/all/patches/put-time-gcc-lt5-1.1.1.patch
+++ b/recipes/oatpp/all/patches/put-time-gcc-lt5-1.1.1.patch
@@ -1,0 +1,28 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -93,6 +93,9 @@ endif()
+ if(OATPP_DISABLE_LOGE)
+     add_definitions(-DOATPP_DISABLE_LOGE)
+ endif()
++if(CMAKE_COMPILER_IS_GNUCXX AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 5.0)
++    add_definitions(-DOATPP_DISABLE_STD_PUT_TIME)
++endif()
+ 
+ message("\n############################################################################\n")
+ 
+--- a/src/oatpp/core/base/Environment.cpp
++++ b/src/oatpp/core/base/Environment.cpp
+@@ -93,7 +93,13 @@ void DefaultLogger::log(v_int32 priority, const std::string& tag, const std::str
+     time_t seconds = std::chrono::duration_cast<std::chrono::seconds>(time).count();
+     struct tm now;
+     localtime_r(&seconds, &now);
++#ifdef OATPP_DISABLE_STD_PUT_TIME
++	  char timeBuffer[50];
++    strftime(timeBuffer, sizeof(timeBuffer), m_config.timeFormat, &now);
++    std::cout << timeBuffer;
++#else
+     std::cout << std::put_time(&now, m_config.timeFormat);
++#endif
+     indent = true;
+   }
+ 


### PR DESCRIPTION
Specify library name and version:  **oatpp/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

gcc<5 allowed: patch from https://github.com/oatpp/oatpp/pull/254