### PR TITLE
verilator: bison does not need -y (yacc) flag

### DIFF
--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -73,7 +73,12 @@ class VerilatorConan(ConanFile):
         conf_args = [
             "--datarootdir={}/bin/share".format(tools.unix_path(self.package_folder)),
         ]
-        self._autotools.configure(args=conf_args, configure_dir=os.path.join(self.build_folder, self._source_subfolder))
+        yacc = tools.get_env("YACC")
+        if yacc:
+            if yacc.endswith(" -y"):
+                yacc = yacc[:-3]
+        with tools.environment_append({"YACC": yacc}):
+            self._autotools.configure(args=conf_args, configure_dir=os.path.join(self.build_folder, self._source_subfolder))
         return self._autotools
 
     @property

--- a/recipes/verilator/all/test_package/CMakeLists.txt
+++ b/recipes/verilator/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")


### PR DESCRIPTION
Specify library name and version:  **verilator/all**

Fixes #3524

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
