### PR TITLE
[Issue 3577] Add a patch to get libuuid to build on AIX.

### DIFF
--- a/recipes/libuuid/all/conandata.yml
+++ b/recipes/libuuid/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "1.0.3":
     url: "https://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz"
     sha256: "46af3275291091009ad7f1b899de3d0cea0252737550e7919d17237997db5644"
+patches:
+  "1.0.3":
+    - patch_file: "patches/0001-Check-for-HAVE_SYS_SYSCALL_H.patch"
+      base_path: "source_subfolder"

--- a/recipes/libuuid/all/conanfile.py
+++ b/recipes/libuuid/all/conanfile.py
@@ -11,6 +11,7 @@ class LibuuidConan(ConanFile):
     license = "BSD-3-Clause"
     topics = ("conan", "libuuid", "uuid", "unique-id", "unique-identifier")
     settings = "os", "arch", "compiler", "build_type"
+    exports_sources = "patches/**"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
     _source_subfolder = "source_subfolder"
@@ -19,6 +20,10 @@ class LibuuidConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename(self.name + "-" + self.version, self._source_subfolder)
+
+    def _patch_sources(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
 
     def config_options(self):
         if self.settings.os == 'Windows':
@@ -43,6 +48,7 @@ class LibuuidConan(ConanFile):
         return self._autotools
 
     def build(self):
+        self._patch_sources()
         with tools.chdir(self._source_subfolder):
             autotools = self._configure_autotools()
             autotools.make()

--- a/recipes/libuuid/all/patches/0001-Check-for-HAVE_SYS_SYSCALL_H.patch
+++ b/recipes/libuuid/all/patches/0001-Check-for-HAVE_SYS_SYSCALL_H.patch
@@ -1,0 +1,32 @@
+From 32dba1f82848e2bf4e2546dac06296fa7b387dff Mon Sep 17 00:00:00 2001
+From: Rob Boehne <robb@datalogics.com>
+Date: Mon, 16 Nov 2020 09:06:42 -0600
+Subject: [PATCH] Check for HAVE_SYS_SYSCALL_H
+
+Fix a compilation error on systems without sys/syscall.h by applying the same checks used elsewhere.
+---
+ randutils.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/randutils.c b/randutils.c
+index 80893d3..8bf3af6 100644
+--- a/randutils.c
++++ b/randutils.c
+@@ -11,9 +11,14 @@
+ #include <fcntl.h>
+ #include <stdlib.h>
+ #include <string.h>
++
++#if defined(HAVE_SYS_TIME_H)
+ #include <sys/time.h>
++#endif
+ 
++#if defined(__linux__) && defined(HAVE_SYS_SYSCALL_H)
+ #include <sys/syscall.h>
++#endif
+ 
+ #include "randutils.h"
+ 
+-- 
+2.15.2
+

--- a/recipes/libuuid/all/test_package/CMakeLists.txt
+++ b/recipes/libuuid/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Add a patch to libuuid to use the Autoconf macro `HAVE_SYS_SYSCALL_H` in `randutils.c` the way they are used elsewhere.

Resolves #3577 

 **libuuid/1.0.3**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
