### PR TITLE
[oatpp-websocket] Use OATPP_MODULES_LOCATION=INSTALLED

### DIFF
--- a/recipes/oatpp-websocket/all/conanfile.py
+++ b/recipes/oatpp-websocket/all/conanfile.py
@@ -57,11 +57,7 @@ class OatppWebSocketConan(ConanFile):
 
         self._cmake = CMake(self)
         self._cmake.definitions["OATPP_BUILD_TESTS"] = False
-        self._cmake.definitions["OATPP_MODULES_LOCATION"] = "CUSTOM"
-        self._cmake.definitions["OATPP_DIR_LIB"] = os.path.join(
-            self.deps_cpp_info["oatpp"].rootpath, self.deps_cpp_info["oatpp"].libdirs[0]
-        )
-        self._cmake.definitions["OATPP_DIR_SRC"] = self.deps_cpp_info["oatpp"].include_paths[0]
+        self._cmake.definitions["OATPP_MODULES_LOCATION"] = "INSTALLED"
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **oatpp-websocket/1.2.0**

As suggested in #3544

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
