### PR TITLE
cairo: add pthread system lib

### DIFF
--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -58,7 +58,7 @@ class CairoConan(ConanFile):
         if self.options.with_freetype:
             self.requires("freetype/2.10.4")
         if self.options.get_safe("with_fontconfig", False):
-            self.requires("fontconfig/2.13.91")
+            self.requires("fontconfig/2.13.92")
         if self.settings.os == 'Linux':
             if self.options.with_xlib or self.options.with_xlib_xrender or self.options.with_xcb:
                 self.requires("xorg/system")

--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -213,6 +213,7 @@ class CairoConan(ConanFile):
             if self.options.with_fontconfig:
                 self.cpp_info.components["cairo_"].requires.append("fontconfig::fontconfig")
         if self.settings.os == "Linux":
+            self.cpp_info.components["cairo_"].system_libs = ["pthread"]
             if self.options.with_xcb:
                 self.cpp_info.components["cairo_"].requires.extend(["xorg::xcb-shm", "xorg::xcb"])
             if self.options.with_xlib_xrender:


### PR DESCRIPTION
Specify library name and version:  **cairo/***

this should fix this error on gcc 4.9 (when compiling pango)
```
/home/conan/w/cci_PR-3459/.conan/data/cairo/1.17.2/_/_/package/694e5508bd0ca7f32f3f2db6e088673a2d232e59/lib/libcairo.a(cairo-device.o): In function `_cairo_device_init':
cairo-device.c:(.text+0x6e): undefined reference to `pthread_mutexattr_init'
cairo-device.c:(.text+0x7b): undefined reference to `pthread_mutexattr_settype'
cairo-device.c:(.text+0x8f): undefined reference to `pthread_mutexattr_destroy'
```

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
