### PR TITLE
cairo: add pthread compilation flag too

### DIFF
--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -214,6 +214,8 @@ class CairoConan(ConanFile):
                 self.cpp_info.components["cairo_"].requires.append("fontconfig::fontconfig")
         if self.settings.os == "Linux":
             self.cpp_info.components["cairo_"].system_libs = ["pthread"]
+            self.cpp_info.components["cairo_"].cflags = ["-pthread"]
+            self.cpp_info.components["cairo_"].cxxflags = ["-pthread"]
             if self.options.with_xcb:
                 self.cpp_info.components["cairo_"].requires.extend(["xorg::xcb-shm", "xorg::xcb"])
             if self.options.with_xlib_xrender:


### PR DESCRIPTION
Specify library name and version:  **cairo/***

This follows #3601, sorry for the double PR. This time I tested that it actually fixes the issue when building pango.

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
