### PR TITLE
add botan/2.17.2

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -29,3 +29,6 @@ patches:
        base_path: "sources"
      - patch_file: "patches/fix-unrecognized-linker-flag.patch"
        base_path: "sources"
+  "2.17.2":
+     - patch_file: "patches/vs2015-install-fix.patch"
+       base_path: "sources"

--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "2.17.1":
     url: "https://github.com/randombit/botan/archive/2.17.1.tar.gz"
     sha256: "ca562c00e61663c418bd9fdc6c70bdeaedafba8bef328cb6046a1d6390d39a71"
+  "2.17.2":
+    url: "https://github.com/randombit/botan/archive/2.17.2.tar.gz"
+    sha256: "3d99da64573abab6d6e8036a45f8c567a57721c8f23850e05aadd84fc2e0075c"
 patches:
   "2.12.1":
      - patch_file: "patches/dll-dir.patch"

--- a/recipes/botan/all/patches/vs2015-install-fix.patch
+++ b/recipes/botan/all/patches/vs2015-install-fix.patch
@@ -1,0 +1,56 @@
+From 42317bbcc7fe715b0a9f066bb52ed3c59dcc257e Mon Sep 17 00:00:00 2001
+From: Hannes Rantzsch <hannes.rantzsch@nexenio.com>
+Date: Tue, 1 Dec 2020 09:40:38 +0100
+Subject: [PATCH] Backport a fix for a build issue in VS 2015
+
+See https://github.com/randombit/botan/pull/2526 for details
+---
+ configure.py               |  2 +-
+ src/build-data/makefile.in | 10 +++++-----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/configure.py b/configure.py
+index 88eeaa575..f7affad72 100755
+--- a/configure.py
++++ b/configure.py
+@@ -1994,7 +1994,7 @@ def create_template_vars(source_paths, build_paths, options, modules, cc, arch,
+     def choose_python_exe():
+         exe = sys.executable
+ 
+-        if exe[1] == ':': # Windows style paths
++        if options.os == 'mingw':  # mingw doesn't handle the backslashes in the absolute path well
+             return exe.replace('\\', '/')
+ 
+         return exe
+diff --git a/src/build-data/makefile.in b/src/build-data/makefile.in
+index 4d68ab1ec..b215bebb5 100644
+--- a/src/build-data/makefile.in
++++ b/src/build-data/makefile.in
+@@ -48,19 +48,19 @@ docs: %{doc_stamp_file}
+ %{endif}
+ 
+ %{doc_stamp_file}: %{doc_dir}/*.rst %{doc_dir}/api_ref/*.rst %{doc_dir}/dev_ref/*.rst
+-	$(PYTHON_EXE) $(SCRIPTS_DIR)/build_docs.py --build-dir="%{build_dir}"
++	"$(PYTHON_EXE)" "$(SCRIPTS_DIR)/build_docs.py" --build-dir="%{build_dir}"
+ 
+ clean:
+-	$(PYTHON_EXE) $(SCRIPTS_DIR)/cleanup.py --build-dir="%{build_dir}"
++	"$(PYTHON_EXE)" "$(SCRIPTS_DIR)/cleanup.py" --build-dir="%{build_dir}"
+ 
+ distclean:
+-	$(PYTHON_EXE) $(SCRIPTS_DIR)/cleanup.py --build-dir="%{build_dir}" --distclean
++	"$(PYTHON_EXE)" "$(SCRIPTS_DIR)/cleanup.py" --build-dir="%{build_dir}" --distclean
+ 
+ install: %{install_targets}
+-	$(PYTHON_EXE) $(SCRIPTS_DIR)/install.py --prefix="%{prefix}" --build-dir="%{build_dir}" --bindir=%{bindir} --libdir=%{libdir} --docdir=%{docdir} --includedir=%{includedir}
++	"$(PYTHON_EXE)" "$(SCRIPTS_DIR)/install.py" --prefix="%{prefix}" --build-dir="%{build_dir}" --bindir="%{bindir}" --libdir="%{libdir}" --docdir="%{docdir}" --includedir="%{includedir}"
+ 
+ check: tests
+-	$(PYTHON_EXE) $(SCRIPTS_DIR)/check.py --build-dir="%{build_dir}"
++	"$(PYTHON_EXE)" "$(SCRIPTS_DIR)/check.py" --build-dir="%{build_dir}"
+ 
+ # Object Files
+ LIBOBJS = %{join lib_objs}
+-- 
+2.29.2
+

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "2.17.1":
     folder: all
+  "2.17.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **botan/2.17.2**

Bumping patch version of Botan. Release notes: https://github.com/randombit/botan/blob/master/news.rst#version-2172-2020-11-13

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
