### PR TITLE
bitsery: add version 5.2.1

### DIFF
--- a/recipes/bitsery/all/conandata.yml
+++ b/recipes/bitsery/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "5.1.0":
     url: "https://github.com/fraillt/bitsery/archive/v5.1.0.tar.gz"
     sha256: "8f46667db5d0b62fdaab33612108498bcbcbe9cfa48d2cd220b2129734440a8d"
+  "5.2.1":
+    url: "https://github.com/fraillt/bitsery/archive/v5.2.1.tar.gz"
+    sha256: "1e2ee66827c55ef82eaf6ef4c87a2c5b3a010dfe6c770eb0feeb3f0c35254d00"

--- a/recipes/bitsery/config.yml
+++ b/recipes/bitsery/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "5.1.0":
     folder: all
+  "5.2.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [conan-center-bot](https://github.com/qchateau/conan-center-bot)

Specify library name and version:  **bitsery/5.2.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I've modified the bot following your latest comments, and it now tried to keep the yaml format untouched. Also, the issue at https://github.com/conan-io/conan-center-index/issues/3470 now generates the updates in branches of my fork and you can open PR (such as this one) in one click from the issue if there are no errors with the updated recipe.