### PR TITLE
at-spi2-atk/2.38.0

### DIFF
--- a/recipes/at-spi2-atk/all/conandata.yml
+++ b/recipes/at-spi2-atk/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.38.0":
+    url: "http://ftp.gnome.org/pub/gnome/sources/at-spi2-atk/2.38/at-spi2-atk-2.38.0.tar.xz"
+    sha256: "cfa008a5af822b36ae6287f18182c40c91dd699c55faa38605881ed175ca464f"

--- a/recipes/at-spi2-atk/all/conanfile.py
+++ b/recipes/at-spi2-atk/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, Meson, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 
 
@@ -29,6 +30,10 @@ class AtSPI2AtkConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+    
+    def validate(self):
+        if self.settings.os not in ("Linux", "FreeBSD"):
+            raise ConanInvalidConfiguration("at-spi2-atk is only supported on Linux and FreeBSD")
 
     def configure(self):
         if self.options.shared:

--- a/recipes/at-spi2-atk/all/conanfile.py
+++ b/recipes/at-spi2-atk/all/conanfile.py
@@ -1,7 +1,5 @@
 from conans import ConanFile, Meson, tools
-from conans.errors import ConanInvalidConfiguration
 import os
-import shutil
 
 
 class AtSPI2AtkConan(ConanFile):
@@ -22,6 +20,8 @@ class AtSPI2AtkConan(ConanFile):
         "fPIC": True,
         }
 
+    _meson = None
+
     @property
     def _source_subfolder(self):
         return "source_subfolder"
@@ -37,7 +37,7 @@ class AtSPI2AtkConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def build_requirements(self):
-        self.build_requires('meson/0.54.2')
+        self.build_requires('meson/0.56.1')
         self.build_requires('pkgconf/1.7.3')
 
     def requirements(self):
@@ -52,11 +52,13 @@ class AtSPI2AtkConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_meson(self):
-        meson = Meson(self)
+        if self._meson:
+            return self._meson
+        self._meson = Meson(self)
         args=[]
         args.append('--wrap-mode=nofallback')
-        meson.configure(build_folder=self._build_subfolder, source_folder=self._source_subfolder, pkg_config_paths='.', args=args)
-        return meson
+        self._meson.configure(build_folder=self._build_subfolder, source_folder=self._source_subfolder, pkg_config_paths='.', args=args)
+        return self._meson
 
     def build(self):
         meson = self._configure_meson()

--- a/recipes/at-spi2-atk/all/conanfile.py
+++ b/recipes/at-spi2-atk/all/conanfile.py
@@ -43,6 +43,7 @@ class AtSPI2AtkConan(ConanFile):
     def requirements(self):
         self.requires('at-spi2-core/2.38.0')
         self.requires('atk/2.36.0')
+        self.requires('glib/2.67.1')
         self.requires('libxml2/2.9.10')
 
     def source(self):

--- a/recipes/at-spi2-atk/all/conanfile.py
+++ b/recipes/at-spi2-atk/all/conanfile.py
@@ -22,8 +22,13 @@ class AtSPI2AtkConan(ConanFile):
         "fPIC": True,
         }
 
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
 
     def configure(self):
         if self.options.shared:
@@ -32,10 +37,8 @@ class AtSPI2AtkConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def build_requirements(self):
-        if not tools.which('meson'):
-            self.build_requires('meson/0.54.2')
-        if not tools.which('pkg-config'):
-            self.build_requires('pkgconf/1.7.3')
+        self.build_requires('meson/0.54.2')
+        self.build_requires('pkgconf/1.7.3')
 
     def requirements(self):
         self.requires('at-spi2-core/2.38.0')

--- a/recipes/at-spi2-atk/all/conanfile.py
+++ b/recipes/at-spi2-atk/all/conanfile.py
@@ -1,0 +1,70 @@
+from conans import ConanFile, Meson, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+import shutil
+
+
+class AtSPI2AtkConan(ConanFile):
+    name = "at-spi2-atk"
+    description = "library that bridges ATK to At-Spi2 D-Bus service."
+    topics = ("conan", "atk", "accessibility")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://gitlab.gnome.org/GNOME/at-spi2-atk"
+    license = "LGPL-2.1-or-later"
+    generators = "pkg_config"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        }
+
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def build_requirements(self):
+        if not tools.which('meson'):
+            self.build_requires('meson/0.54.2')
+        if not tools.which('pkg-config'):
+            self.build_requires('pkgconf/1.7.3')
+
+    def requirements(self):
+        self.requires('at-spi2-core/2.38.0')
+        self.requires('atk/2.36.0')
+        self.requires('libxml2/2.9.10')
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def _configure_meson(self):
+        meson = Meson(self)
+        args=[]
+        args.append('--wrap-mode=nofallback')
+        meson.configure(build_folder=self._build_subfolder, source_folder=self._source_subfolder, pkg_config_paths='.', args=args)
+        return meson
+
+    def build(self):
+        meson = self._configure_meson()
+        meson.build()
+
+    def package(self):
+        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
+        meson = self._configure_meson()
+        meson.install()
+        tools.rmdir(os.path.join(self.package_folder, 'lib', 'pkgconfig'))
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.includedirs = [os.path.join('include', 'at-spi2-atk', '2.0')]
+        self.cpp_info.names['pkg_config'] = 'atk-bridge-2.0'

--- a/recipes/at-spi2-atk/all/test_package/CMakeLists.txt
+++ b/recipes/at-spi2-atk/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/at-spi2-atk/all/test_package/conanfile.py
+++ b/recipes/at-spi2-atk/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/at-spi2-atk/all/test_package/test_package.c
+++ b/recipes/at-spi2-atk/all/test_package/test_package.c
@@ -1,0 +1,51 @@
+/*
+ * AT-SPI - Assistive Technology Service Provider Interface
+ * (Gnome Accessibility Project; https://wiki.gnome.org/Accessibility)
+ *
+ * Copyright (c) 2014 Samsung Electronics Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/*
+ * Testing AT-SPI requires both a test application and AT client.
+ * Test applications are built using the Dummy ATK implementation: MyAtk.
+ * This file contains the entry point for all test applications.
+ * The test will provide its own implementation of atk_get_root,
+ * and as such provide all the application state for the test.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <glib.h>
+#include <atk/atk.h>
+#include <atk-bridge.h>
+
+
+
+static GMainLoop *mainloop;
+
+int main (int argc, char *argv[])
+{
+  atk_bridge_adaptor_init (NULL, NULL);
+
+  mainloop = g_main_loop_new (NULL, FALSE);
+
+  atk_bridge_adaptor_cleanup();
+
+  return 0;
+}

--- a/recipes/at-spi2-atk/config.yml
+++ b/recipes/at-spi2-atk/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.38.0":
+    folder: all


### PR DESCRIPTION
this is a port of https://github.com/bincrafters/conan-at-spi2-atk

Specify library name and version:  **at-spi2-atk/2.38.0**

give FreeBSD a free ride

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.