### PR TITLE
shared-mime-info system

### DIFF
--- a/recipes/shared-mime-info/config.yml
+++ b/recipes/shared-mime-info/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "system":
+    folder: "system"

--- a/recipes/shared-mime-info/system/conanfile.py
+++ b/recipes/shared-mime-info/system/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, tools
+
+class ConanSharedMimeInfo(ConanFile):
+    name = "shared-mime-info"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "GPLv2"
+    homepage = "https://freedesktop.org/wiki/Software/shared-mime-info/"
+    description = "The shared-mime-info package contains the core database of common types and the update-mime-database command used to extend it."
+    settings = {"os": "Linux"}
+    topics = ("conan", "shared-mime-info")
+
+    def package_id(self):
+        self.info.header_only()
+
+    def system_requirements(self):
+        if tools.os_info.is_linux and self.settings.os == "Linux":
+            package_tool = tools.SystemPackageTool(conanfile=self, default_mode="verify")
+            package_tool.install(update=True, packages=["shared-mime-info"])

--- a/recipes/shared-mime-info/system/test_package/conanfile.py
+++ b/recipes/shared-mime-info/system/test_package/conanfile.py
@@ -1,0 +1,10 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.run("update-mime-database -v", run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **shared-mime-info/system**

I considered making it a non system package, but unfortunately building shared-mime-info requires

- itstool, which needs libxml2 python module
- xmlto program

shared-mime-info has no library or headers anyway, it's just an executable with some data, and a .pc file giving only the version.

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
