### PR TITLE
cairo: add cairo-xlib component

### DIFF
--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -241,3 +241,7 @@ class CairoConan(ConanFile):
                 self.cpp_info.components["cairo-ft"].requires = ["cairo_", "freetype::freetype"]
             self.cpp_info.components["cairo-pdf"].names["pkg_config"] = "cairo-pdf"
             self.cpp_info.components["cairo-pdf"].requires = ["cairo_", "zlib::zlib"]
+
+        if self.settings.os == "Linux":
+            self.cpp_info.components["cairo-xlib"].names["pkg_config"] = "cairo-xlib"
+            self.cpp_info.components["cairo-xlib"].requires = ["cairo_", "xorg::x11", "xorg::xext"]


### PR DESCRIPTION
Specify library name and version:  **cairo/***

this component is required by gtk

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
