### PR TITLE
yasm: use arch/os/compiler/build_type

### DIFF
--- a/recipes/yasm/all/conanfile.py
+++ b/recipes/yasm/all/conanfile.py
@@ -2,14 +2,16 @@ from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
 import os
 
 
-class YASMInstallerConan(ConanFile):
+class YASMConan(ConanFile):
     name = "yasm"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/yasm/yasm"
-    description = 'Yasm is a complete rewrite of the NASM assembler under the "new" BSD License'
+    description = "Yasm is a complete rewrite of the NASM assembler under the 'new' BSD License"
     topics = ("conan", "yasm", "installer", "assembler")
     license = "BSD-2-Clause"
-    settings = "os_build", "arch_build", "compiler"
+    settings = "os", "arch", "compiler", "build_type"
+
+    _autotools = None
 
     @property
     def _source_subfolder(self):
@@ -24,50 +26,50 @@ class YASMInstallerConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = 'yasm-%s' % self.version
+        extracted_dir = "yasm-%s" % self.version
         os.rename(extracted_dir, self._source_subfolder)
-        tools.download('https://raw.githubusercontent.com/yasm/yasm/bcc01c59d8196f857989e6ae718458c296ca20e3/YASM-VERSION-GEN.bat',
-                       os.path.join(self._source_subfolder, 'YASM-VERSION-GEN.bat'))
-
-    def build(self):
-        if self.settings.os_build == 'Windows':
-            self._build_vs()
-        else:
-            self._build_configure()
+        tools.download("https://raw.githubusercontent.com/yasm/yasm/bcc01c59d8196f857989e6ae718458c296ca20e3/YASM-VERSION-GEN.bat",
+                       os.path.join(self._source_subfolder, "YASM-VERSION-GEN.bat"))
 
     def _build_vs(self):
-        with tools.chdir(os.path.join(self._source_subfolder, 'Mkfiles', 'vc10')):
-            with tools.vcvars(self.settings, arch=str(self.settings.arch_build), force=True):
+        with tools.chdir(os.path.join(self._source_subfolder, "Mkfiles", "vc10")):
+            with tools.vcvars(self.settings, force=True):
                 msbuild = MSBuild(self)
-                if self.settings.arch_build == "x86":
-                    msbuild.build_env.link_flags.append('/MACHINE:X86')
-                elif self.settings.arch_build == "x86_64":
-                    msbuild.build_env.link_flags.append('/SAFESEH:NO /MACHINE:X64')
-                msbuild.build(project_file="yasm.sln", arch=str(self.settings.arch_build), build_type="Release",
+                if self.settings.arch== "x86":
+                    msbuild.build_env.link_flags.append("/MACHINE:X86")
+                elif self.settings.arch== "x86_64":
+                    msbuild.build_env.link_flags.append("/SAFESEH:NO /MACHINE:X64")
+                msbuild.build(project_file="yasm.sln",
                               targets=["yasm"], platforms={"x86": "Win32"}, force_vcvars=True)
 
-    def _build_configure(self):
-        with tools.chdir(self._source_subfolder):
-            cc = os.environ.get('CC', 'gcc')
-            cxx = os.environ.get('CXX', 'g++')
-            if self.settings.arch_build == 'x86':
-                cc += ' -m32'
-                cxx += ' -m32'
-            elif self.settings.arch_build == 'x86_64':
-                cc += ' -m64'
-                cxx += ' -m64'
-            env_build = AutoToolsBuildEnvironment(self)
-            env_build_vars = env_build.vars
-            env_build_vars.update({'CC': cc, 'CXX': cxx})
-            env_build.configure(vars=env_build_vars)
-            env_build.make(vars=env_build_vars)
-            env_build.install(vars=env_build_vars)
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        yes_no = lambda v: "yes" if v else "no"
+        conf_args = [
+            "--enable-debug={}".format(yes_no(self.settings.build_type == "Debug")),
+            "--disable-rpath",
+            "--disable-nls",
+        ]
+        self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder)
+        return self._autotools
+
+    def build(self):
+        if self.settings.compiler == "Visual Studio":
+            self._build_vs()
+        else:
+            autotools = self._configure_autotools()
+            autotools.make()
 
     def package(self):
         self.copy(pattern="BSD.txt", dst="licenses", src=self._source_subfolder)
         self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        if self.settings.os_build == 'Windows':
-            self.copy(pattern='*.exe', src=self._source_subfolder, dst='bin', keep_path=False)
+        if self.settings.compiler == "Visual Studio":
+            self.copy(pattern="*.exe", src=self._source_subfolder, dst="bin", keep_path=False)
+        else:
+            autotools = self._configure_autotools()
+            autotools.install()
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):

--- a/recipes/yasm/all/test_package/conanfile.py
+++ b/recipes/yasm/all/test_package/conanfile.py
@@ -1,8 +1,9 @@
-from conans import ConanFile
-import os
+from conans import ConanFile, tools
 
 
 class TestPackage(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
 
     def test(self):
-        self.run("yasm --help", run_environment=True)
+        if not tools.cross_building(self.settings):
+            self.run("yasm --help", run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **yasm/all**

- use arch+os+compiler+build_type in settings
- the same approach as cmake is used and `settings.compiler` is removed in `package_id` (unchanged)

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
