### PR TITLE
libsndfile: ogg/flac/opus/vorbus are recommended dependencies (not required) + remove sqlite dependency

### DIFF
--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
 import os
 
 

--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -57,7 +57,7 @@ class LibsndfileConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
         if self.options.with_sqlite != "deprecated":
-            raise ConanInvalidConfiguration("with_sqlite is a deprecated option. Do not use.")
+            self.output.warn("with_sqlite is a deprecated option. Do not use.")
         del self.options.with_sqlite
 
     def source(self):

--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -18,6 +18,7 @@ class LibsndfileConan(ConanFile):
         "experimental": [True, False],
         "with_alsa": [True, False],
         "with_sqlite": ["deprecated", True, False],
+        "with_flac_opus_vorbis": [True, False],
     }
     default_options = {
         "shared": False,
@@ -26,6 +27,8 @@ class LibsndfileConan(ConanFile):
         "experimental": False,
         "with_alsa": False,
         "with_sqlite": "deprecated",
+        "with_flac_opus_vorbis": True,
+
     }
     exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake", "cmake_find_package"
@@ -39,10 +42,11 @@ class LibsndfileConan(ConanFile):
     def requirements(self):
         if self.options.get_safe("with_alsa"):
             self.requires("libalsa/1.2.2")
-        self.requires("flac/1.3.3")
-        self.requires("ogg/1.3.4")
-        self.requires("opus/1.3.1")
-        self.requires("vorbis/1.3.7")
+        if self.options.with_flac_opus_vorbis:
+            self.requires("ogg/1.3.4")
+            self.requires("vorbis/1.3.7")
+            self.requires("flac/1.3.3")
+            self.requires("opus/1.3.1")
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -64,6 +68,15 @@ class LibsndfileConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_Sndio"] = True  # FIXME: missing sndio cci recipe (check whether it is really required)
+        self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_Speex"] = True  # FIXME: missing sndio cci recipe (check whether it is really required)
+        self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_SQLite3"] = True  # only used for regtest
+        if not self.options.with_flac_opus_vorbis:
+            self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_Ogg"] = True
+            self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_Vorbis"] = True
+            self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_FLAC"] = True
+            self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_Opus"] = True
+        self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_ALSA"] = not self.options.get_safe("with_alsa", False)
         self._cmake.definitions["BUILD_PROGRAMS"] = self.options.programs
         self._cmake.definitions["BUILD_EXAMPLES"] = False
         self._cmake.definitions["BUILD_TESTING"] = False
@@ -97,7 +110,8 @@ class LibsndfileConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "SndFile"
         self.cpp_info.names["pkg_config"] = "sndfile"
         self.cpp_info.components["sndfile"].libs = ["sndfile"]
-        self.cpp_info.components["sndfile"].requires = ["flac::flac", "ogg::ogg", "opus::opus", "vorbis::vorbis"]
+        if self.options.with_flac_opus_vorbis:
+            self.cpp_info.components["sndfile"].requires.extend(["ogg::ogg", "vorbis::vorbis", "flac::flac", "opus::opus"])
         if not self.options.shared:
             if self.settings.os == "Linux":
                 self.cpp_info.components["sndfile"].system_libs = ["m", "dl", "pthread", "rt"]

--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -18,7 +18,7 @@ class LibsndfileConan(ConanFile):
         "experimental": [True, False],
         "with_alsa": [True, False],
         "with_sqlite": ["deprecated", True, False],
-        "with_flac_opus_vorbis": [True, False],
+        "with_external_libs": [True, False],
     }
     default_options = {
         "shared": False,
@@ -27,7 +27,7 @@ class LibsndfileConan(ConanFile):
         "experimental": False,
         "with_alsa": False,
         "with_sqlite": "deprecated",
-        "with_flac_opus_vorbis": True,
+        "with_external_libs": True,
 
     }
     exports_sources = ["CMakeLists.txt", "patches/**"]
@@ -42,7 +42,7 @@ class LibsndfileConan(ConanFile):
     def requirements(self):
         if self.options.get_safe("with_alsa"):
             self.requires("libalsa/1.2.2")
-        if self.options.with_flac_opus_vorbis:
+        if self.options.with_external_libs:
             self.requires("ogg/1.3.4")
             self.requires("vorbis/1.3.7")
             self.requires("flac/1.3.3")
@@ -71,7 +71,8 @@ class LibsndfileConan(ConanFile):
         self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_Sndio"] = True  # FIXME: missing sndio cci recipe (check whether it is really required)
         self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_Speex"] = True  # FIXME: missing sndio cci recipe (check whether it is really required)
         self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_SQLite3"] = True  # only used for regtest
-        if not self.options.with_flac_opus_vorbis:
+        self._cmake.definitions["ENABLE_EXTERNAL_LIBS"] = self.options.with_external_libs
+        if not self.options.with_external_libs:
             self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_Ogg"] = True
             self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_Vorbis"] = True
             self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_FLAC"] = True
@@ -86,7 +87,6 @@ class LibsndfileConan(ConanFile):
         if self.settings.compiler == "Visual Studio":
             self._cmake.definitions["ENABLE_STATIC_RUNTIME"] = "MT" in str(self.settings.compiler.runtime)
         self._cmake.definitions["BUILD_REGTEST"] = False
-        self._cmake.definitions["ENABLE_EXTERNAL_LIBS"] = True
         self._cmake.configure()
         return self._cmake
 
@@ -111,7 +111,7 @@ class LibsndfileConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "SndFile"
         self.cpp_info.names["pkg_config"] = "sndfile"
         self.cpp_info.components["sndfile"].libs = ["sndfile"]
-        if self.options.with_flac_opus_vorbis:
+        if self.options.with_external_libs:
             self.cpp_info.components["sndfile"].requires.extend(["ogg::ogg", "vorbis::vorbis", "flac::flac", "opus::opus"])
         if not self.options.shared:
             if self.settings.os == "Linux":

--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -76,7 +76,8 @@ class LibsndfileConan(ConanFile):
             self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_Vorbis"] = True
             self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_FLAC"] = True
             self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_Opus"] = True
-        self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_ALSA"] = not self.options.get_safe("with_alsa", False)
+        if not self.options.get_safe("with_alsa", False):
+            self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_ALSA"] = True
         self._cmake.definitions["BUILD_PROGRAMS"] = self.options.programs
         self._cmake.definitions["BUILD_EXAMPLES"] = False
         self._cmake.definitions["BUILD_TESTING"] = False


### PR DESCRIPTION
Specify library name and version:  **libsndfile/***

- sqlite3 is only used by regtest, which is not built
- ogg/flac/opus/vorbus are recommended dependencies, not absolutely required (so make them optional)

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
