### PR TITLE
bitsery: add version 5.2.1

### DIFF
--- a/recipes/bitsery/all/conandata.yml
+++ b/recipes/bitsery/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.2.1":
+    url: "https://github.com/fraillt/bitsery/archive/v5.2.1.tar.gz"
+    sha256: "1e2ee66827c55ef82eaf6ef4c87a2c5b3a010dfe6c770eb0feeb3f0c35254d00"
   "5.2.0":
     url: "https://github.com/fraillt/bitsery/archive/v5.2.0.tar.gz"
     sha256: "99f47bca227abb6b9e8030703dcc402ab930ff3bf0a87c89c3f0fb9536cad448"

--- a/recipes/bitsery/config.yml
+++ b/recipes/bitsery/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.2.1":
+    folder: all
   "5.2.0":
     folder: all
   "5.1.0":


### PR DESCRIPTION
Generated and committed by [conan-center-bot](https://github.com/qchateau/conan-center-bot)

Specify library name and version:  **bitsery/5.2.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.


New try, this time the CLA bot should not be a problem. Just like last time, the content of the PR has been automatically generated, I opened this PR in one click.