### PR TITLE
rec2: add 2.0.3 release

### DIFF
--- a/recipes/re2c/all/conandata.yml
+++ b/recipes/re2c/all/conandata.yml
@@ -2,7 +2,13 @@ sources:
   "1.3":
     url: "https://github.com/skvadrik/re2c/releases/download/1.3/re2c-1.3.tar.xz"
     sha256: "f37f25ff760e90088e7d03d1232002c2c2672646d5844fdf8e0d51a5cd75a503"
+  "2.0.3":
+    url: "https://github.com/skvadrik/re2c/releases/download/2.0.3/re2c-2.0.3.tar.xz"
+    sha256: "b2bc1eb8aaaa21ff2fcd26507b7e6e72c5e3d887e58aa515c2155fb17d744278"
 patches:
   "1.3":
+    - patch_file: "patches/0001-add-msvc_cl-sh.patch"
+      base_path: ""
+  "2.0.3":
     - patch_file: "patches/0001-add-msvc_cl-sh.patch"
       base_path: ""

--- a/recipes/re2c/all/conandata.yml
+++ b/recipes/re2c/all/conandata.yml
@@ -12,3 +12,5 @@ patches:
   "2.0.3":
     - patch_file: "patches/0001-add-msvc_cl-sh.patch"
       base_path: ""
+    - patch_file: "patches/2.0.3-0001-add-missing-include.patch"
+      base_path: "source_subfolder"

--- a/recipes/re2c/all/conanfile.py
+++ b/recipes/re2c/all/conanfile.py
@@ -27,6 +27,9 @@ class Re2CConan(ConanFile):
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
 
+    def package_id(self):
+        del self.info.settings.compiler
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("re2c-{}".format(self.version), self._source_subfolder)

--- a/recipes/re2c/all/patches/2.0.3-0001-add-missing-include.patch
+++ b/recipes/re2c/all/patches/2.0.3-0001-add-missing-include.patch
@@ -1,0 +1,11 @@
+--- src/compile.cc
++++ src/compile.cc
+@@ -4,7 +4,7 @@
+ #include <ostream>
+ #include <string>
+ #include <vector>
+-
++#include <cctype>
+ #include "src/adfa/adfa.h"
+ #include "src/codegen/code.h"
+ #include "src/compile.h"

--- a/recipes/re2c/all/test_package/CMakeLists.txt
+++ b/recipes/re2c/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/re2c/config.yml
+++ b/recipes/re2c/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.3":
     folder: "all"
+  "2.0.3":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **re2c/2.0.3**

- Bump version
- fix hooks in test_package
- delete compiler in package_id (such as cmake recipe)

kudos to @qchateau for his bot at https://qchateau.github.io/conan-center-bot/#/updatable

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

1. 