### PR TITLE
ixwebsocket: add version 11.0.4

### DIFF
--- a/recipes/ixwebsocket/all/conandata.yml
+++ b/recipes/ixwebsocket/all/conandata.yml
@@ -14,3 +14,6 @@ sources:
   "10.4.0":
     url: "https://github.com/machinezone/IXWebSocket/archive/v10.4.0.tar.gz"
     sha256: "5bdeef08a66d3c143e7fd8b02820ed5ee5c7848e4fa043132cbeef4ea18cd326"
+  "11.0.4":
+    url: "https://github.com/machinezone/IXWebSocket/archive/v11.0.4.tar.gz"
+    sha256: "deebfa04bd6bd930b2f7c0daba8674c8e8bc273a3d735b1877b1f4bb2c0e8596"

--- a/recipes/ixwebsocket/config.yml
+++ b/recipes/ixwebsocket/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "10.4.0":
     folder: all
+  "11.0.4":
+    folder: all


### PR DESCRIPTION
Generated and committed by [conan-center-bot](https://github.com/qchateau/conan-center-bot)

Specify library name and version:  **ixwebsocket/11.0.4**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
