### PR TITLE
libepoxy: enable egl by default

### DIFF
--- a/recipes/libepoxy/all/conanfile.py
+++ b/recipes/libepoxy/all/conanfile.py
@@ -63,6 +63,8 @@ class EpoxyConan(ConanFile):
         if self.settings.os == "Linux":
             if self.options.x11:
                 self.requires("xorg/system")
+            if self.options.egl:
+                self.requires("egl/system")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/libepoxy/all/conanfile.py
+++ b/recipes/libepoxy/all/conanfile.py
@@ -25,13 +25,19 @@ class EpoxyConan(ConanFile):
         "shared": False,
         "fPIC": True,
         "glx": True,
-        "egl": False,
+        "egl": True,
         "x11": True
     }
 
     _meson = None
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
+    
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+    
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
 
     def configure(self):
         del self.settings.compiler.libcxx
@@ -71,9 +77,9 @@ class EpoxyConan(ConanFile):
         defs["docs"] = "false"
         defs["tests"] = "false"
         for opt in ["glx", "egl"]:
-            defs[opt] = "yes" if self.settings.os == "Linux" and getattr(self.options, opt) else "no"
+            defs[opt] = "yes" if self.options.get_safe(opt, False) else "no"
         for opt in ["x11"]:
-            defs[opt] = "true" if self.settings.os == "Linux" and getattr(self.options, opt) else "false"
+            defs[opt] = "true" if self.options.get_safe(opt, False) else "false"
         args=[]
         args.append("--wrap-mode=nofallback")
         self._meson.configure(defs=defs, build_folder=self._build_subfolder, source_folder=self._source_subfolder, pkg_config_paths=[self.install_folder], args=args)


### PR DESCRIPTION
Specify library name and version:  **libepoxy/***

it seems to be needed by gtk when wayland is enbled

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.