### PR TITLE
lerc: add version 2.2

### DIFF
--- a/recipes/lerc/all/conandata.yml
+++ b/recipes/lerc/all/conandata.yml
@@ -1,8 +1,14 @@
 sources:
+  "2.2":
+    url: "https://github.com/Esri/lerc/archive/v2.2.tar.gz"
+    sha256: "abc0c5c149144d39a8b351ff5a9a5940c0f66ba908ecf717d58f8f71065d11fe"
   "2.1":
     url: "https://github.com/Esri/lerc/archive/v2.1.tar.gz"
     sha256: "7c48de40cd5f09319de4b39c417ff4eec4ad4b6aa5d6144f6ffa9b10d18ec94e"
 patches:
+  "2.2":
+    - patch_file: "patches/add-CMakeLists-and-static.patch"
+      base_path: "source_subfolder"
   "2.1":
     - patch_file: "patches/add-CMakeLists-and-static.patch"
       base_path: "source_subfolder"

--- a/recipes/lerc/all/test_package/CMakeLists.txt
+++ b/recipes/lerc/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/lerc/config.yml
+++ b/recipes/lerc/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.2":
+    folder: all
   "2.1":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **lerc/2.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
