### PR TITLE
opusfile: add version 0.12

### DIFF
--- a/recipes/opusfile/all/conandata.yml
+++ b/recipes/opusfile/all/conandata.yml
@@ -1,8 +1,15 @@
 sources:
+  "0.12":
+    url: "https://github.com/xiph/opusfile/archive/v0.12.tar.gz"
+    sha256: "a20a1dff1cdf0719d1e995112915e9966debf1470ee26bb31b2f510ccf00ef40"
   "0.11":
     url: "https://github.com/xiph/opusfile/archive/v0.11.tar.gz"
     sha256: "c2105cffc59545ffc0d2a65069e2f222a1712bbe579911ac0a3d3660edbbec57"
 patches:
+  "0.12":
+    # patch taken from https://github.com/xiph/opusfile/issues/13#issuecomment-425349836 for OpenSSL 1.1.1 support
+    - patch_file: "patches/001-disable-cert-store-integration.patch"
+      base_path: "source_subfolder"
   "0.11":
     # patch taken from https://github.com/xiph/opusfile/issues/13#issuecomment-425349836 for OpenSSL 1.1.1 support
     - patch_file: "patches/001-disable-cert-store-integration.patch"

--- a/recipes/opusfile/config.yml
+++ b/recipes/opusfile/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.12":
+    folder: all
   "0.11":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **opusfile/0.12**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
