### PR TITLE
libgit2/1.0.1: add an option to specify the regex backend to use

### DIFF
--- a/recipes/libgit2/all/conanfile.py
+++ b/recipes/libgit2/all/conanfile.py
@@ -67,6 +67,7 @@ class LibGit2Conan(ConanFile):
             if self.settings.os != "Windows":
                 raise ConanInvalidConfiguration("win32 is only valid on Windows")
 
+        self.options.with_regex = self._with_regex
         if self.options.with_regex == "regcomp" or self.options.with_regex == "regcomp_l":
             if self.settings.compiler == "Visual Studio":
                 raise ConanInvalidConfiguration("{} isn't supported by Visual Studio".format(self.options.with_regex))
@@ -143,7 +144,7 @@ class LibGit2Conan(ConanFile):
         cmake.definitions["BUILD_EXAMPLES"] = False
         cmake.definitions["USE_HTTP_PARSER"] = "system"
 
-        cmake.definitions["REGEX_BACKEND"] = self._with_regex
+        cmake.definitions["REGEX_BACKEND"] = self.options.with_regex
 
         if self.settings.compiler == "Visual Studio":
             cmake.definitions["STATIC_CRT"] = "MT" in str(self.settings.compiler.runtime)

--- a/recipes/libgit2/all/conanfile.py
+++ b/recipes/libgit2/all/conanfile.py
@@ -22,6 +22,7 @@ class LibGit2Conan(ConanFile):
         "with_https": [False, "openssl", "mbedtls", "winhttp", "security"],
         "with_sha1": ["collisiondetection", "commoncrypto", "openssl", "mbedtls", "generic", "win32"],
         "with_ntlmclient": [True, False],
+        "with_regex": ["default", "builtin", "pcre", "pcre2"],
     }
     default_options = {
         "shared": False,
@@ -32,6 +33,7 @@ class LibGit2Conan(ConanFile):
         "with_https": "openssl",
         "with_sha1": "collisiondetection",
         "with_ntlmclient": True,
+        "with_regex": "default",
     }
 
     @property
@@ -84,6 +86,10 @@ class LibGit2Conan(ConanFile):
             self.requires("mbedtls/2.16.3-gpl")
         if tools.is_apple_os(self.settings.os) and self.options.with_iconv:
             self.requires("libiconv/1.16")
+        if self.options.with_regex == "pcre":
+            self.requires("pcre/8.44")
+        elif self.options.with_regex == "pcre2":
+            self.requires("pcre2/10.35")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -123,6 +129,9 @@ class LibGit2Conan(ConanFile):
         cmake.definitions["BUILD_CLAR"] = False
         cmake.definitions["BUILD_EXAMPLES"] = False
         cmake.definitions["USE_HTTP_PARSER"] = "system"
+
+        if self.options.with_regex != "default":
+            cmake.definitions["REGEX_BACKEND"] = self.options.with_regex
 
         if self.settings.compiler == "Visual Studio":
             cmake.definitions["STATIC_CRT"] = "MT" in str(self.settings.compiler.runtime)


### PR DESCRIPTION
Specify library name and version:  **libgit2/1.0.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Since version 1.0, libgit2 expose an option to specify the regex backend to use. This option isn't currently exposed in the conan recipe.