### PR TITLE
utf8proc: add version 2.6.0

### DIFF
--- a/recipes/utf8proc/all/conandata.yml
+++ b/recipes/utf8proc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.0":
+    url: "https://github.com/JuliaStrings/utf8proc/archive/v2.6.0.tar.gz"
+    sha256: "b36ce1534b8035e7febd95c031215ed279ee9d31cf9b464e28b4c688133b22c5"
   "2.5.0":
     url: "https://github.com/JuliaStrings/utf8proc/archive/v2.5.0.tar.gz"
     sha256: "d4e8dfc898cfd062493cb7f42d95d70ccdd3a4cd4d90bec0c71b47cca688f1be"

--- a/recipes/utf8proc/config.yml
+++ b/recipes/utf8proc/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.6.0":
+    folder: all
   "2.5.0":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **utf8proc/2.6.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
