### PR TITLE
wt: fix broken usage of getattr

### DIFF
--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -153,7 +153,7 @@ class WtConan(ConanFile):
 
         def _gather_libs(p):
             libs = self.deps_cpp_info[p].libs + self.deps_cpp_info[p].system_libs
-            if not getattr(self.options[p], "shared", False):
+            if "shared" not in self.options[p] or not self.options[p].shared:
                 for dep in self.deps_cpp_info[p].public_deps:
                     for l in _gather_libs(dep):
                         if not l in libs:

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -153,11 +153,10 @@ class WtConan(ConanFile):
 
         def _gather_libs(p):
             libs = self.deps_cpp_info[p].libs + self.deps_cpp_info[p].system_libs
-            if "shared" not in self.options[p] or not self.options[p].shared:
-                for dep in self.deps_cpp_info[p].public_deps:
-                    for l in _gather_libs(dep):
-                        if not l in libs:
-                            libs.append(l)
+            for dep in self.deps_cpp_info[p].public_deps:
+                for l in _gather_libs(dep):
+                    if not l in libs:
+                        libs.append(l)
             return libs
 
         if self.options.with_ssl:


### PR DESCRIPTION
Specify library name and version:  **wt/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.