### PR TITLE
xmlsec: add version 1.2.31

### DIFF
--- a/recipes/xmlsec/all/conandata.yml
+++ b/recipes/xmlsec/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.31":
+    url: "https://github.com/lsh123/xmlsec/archive/xmlsec-1_2_31.tar.gz"
+    sha256: "3d975c7c945b6f8f84e956934b562f794fa6b469d78d913190d3a1c32d1a3ddb"
   "1.2.30":
     url: "https://github.com/lsh123/xmlsec/archive/xmlsec-1_2_30.tar.gz"
     sha256: "57f6a5f3b9f2d17859a5583dc0b23f47130cc1c909ed6caf596ab0cd388237ec"

--- a/recipes/xmlsec/config.yml
+++ b/recipes/xmlsec/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.2.31":
+    folder: all
   "1.2.30":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **xmlsec/1.2.31**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
