### PR TITLE
cwalk: add version 1.2.5

### DIFF
--- a/recipes/cwalk/all/conandata.yml
+++ b/recipes/cwalk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.5":
+    url: "https://github.com/likle/cwalk/archive/v1.2.5.tar.gz"
+    sha256: "55a24deb602a7bee822e48bda50e454d102649a8cb064300a6dabc8f0405646f"
   "1.2.2":
     url: "https://github.com/likle/cwalk/archive/v1.2.2.zip"
     sha256: "62094c2bb8882fd57fe7ea00fb196e6065b363e8ca57f9c693c19f4912747d88"

--- a/recipes/cwalk/config.yml
+++ b/recipes/cwalk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.5":
+    folder: all
   "1.2.2":
     folder: all
   "1.1.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cwalk/1.2.5**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.


closes #3087 