### PR TITLE
Update cpr

### DIFF
--- a/recipes/cpr/all/conandata.yml
+++ b/recipes/cpr/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "1.5.0":
     sha256: "a1727794541bac6d1bb73c9c27ac3ef5b0d64edcc4f81dc8d79b3cf31b6144e9"
     url: https://github.com/whoshuu/cpr/archive/1.5.0.tar.gz
+  "1.5.2":
+    sha256: "6fc9102dd63b549912d7af1ec95ee41ece1a2fe27f759864306b07f6fcf24fe1"
+    url: https://github.com/whoshuu/cpr/archive/1.5.2.tar.gz
 patches:
   "1.3.0":
     - patch_file: "patches/001-fix-curl-define.patch"
@@ -29,4 +32,7 @@ patches:
     - patch_file: "patches/001-1.5.0-curl-global-scope.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/002-1.5.0-not_search_for_openssl.patch"
+      base_path: "source_subfolder"
+  "1.5.2":
+    - patch_file: "patches/001-1.5.2-curl-global-scope.patch"
       base_path: "source_subfolder"

--- a/recipes/cpr/all/conanfile.py
+++ b/recipes/cpr/all/conanfile.py
@@ -34,9 +34,8 @@ class CprConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        if self.options.with_openssl:
-            # If using OpenSSL, we need it to be active in libcurl too
-            self.options["libcurl"].with_openssl = True
+        if self.options.with_openssl and self.options["libcurl"].with_ssl != "openssl":
+            raise ConanInvalidConfiguration("cpr requires libcurl to be built with the option with_ssl=\"openssl\".")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/cpr/all/conanfile.py
+++ b/recipes/cpr/all/conanfile.py
@@ -34,8 +34,6 @@ class CprConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        if self.options.with_openssl and self.options["libcurl"].with_ssl != "openssl":
-            raise ConanInvalidConfiguration("cpr requires libcurl to be built with the option with_ssl=\"openssl\".")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -66,6 +64,8 @@ class CprConan(ConanFile):
         return cmake
 
     def build(self):
+        if self.options.with_openssl and self.options["libcurl"].with_ssl != "openssl":
+            raise ConanInvalidConfiguration("cpr requires libcurl to be built with the option with_ssl=\"openssl\".")
         self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/cpr/all/patches/001-1.5.2-curl-global-scope.patch
+++ b/recipes/cpr/all/patches/001-1.5.2-curl-global-scope.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c065227..3ed93b8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -55,7 +55,7 @@ include(cmake/code_coverage.cmake)
+ 
+ # Curl configuration
+ if(USE_SYSTEM_CURL)
+-    find_package(CURL COMPONENTS PROTOCOLS HTTP HTTPS FEATURES SSL)
++    find_package(CURL)
+     if (CURL_FOUND)
+         set(SSL_ENABLED ON CACHE INTERNAL "" FORCE)
+     else()
+diff --git a/cpr/CMakeLists.txt b/cpr/CMakeLists.txt
+index 563b785..a7ccbdf 100644
+--- a/cpr/CMakeLists.txt
++++ b/cpr/CMakeLists.txt
+@@ -20,7 +20,8 @@ add_library(cpr
+ 
+ add_library(cpr::cpr ALIAS cpr)
+ 
+-target_link_libraries(cpr PUBLIC CURL::libcurl) # todo should be private, but first dependencys in ssl_options need to be removed
++target_link_libraries(cpr PUBLIC ${CURL_LIBRARIES}) # todo should be private, but first dependencys in ssl_options need to be removed
++target_include_directories(cpr PUBLIC ${CURL_INCLUDE_DIRS})
+ 
+ # Set version for shared libraries.
+ set_target_properties(cpr

--- a/recipes/cpr/config.yml
+++ b/recipes/cpr/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "1.5.0":
     folder: all
+  "1.5.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **cpr/1.5.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Fixes #3321

Admittedly, I have no idea whether this is close to working. Works on my Linux machine, but that's about it. The reason behind the error listed in #3470 is that the patch is out of date - that part of the patch is easy to fix. Minor changes in the CMake caused curl-global-scope.patch to be incorrect. I've bumped that, and cleared out `find_package(CURL COMPONENTS ...)` as this caused problems locally. I have no idea whether or not this makes sense or even should be done, as I don't really use CMake myself - improvements to the patch are welcome. Found the fix by comparing it to an old version of CPR, which didn't contain `COMPONENTS` in the `find_package`.