### PR TITLE
Update libnghttp2/1.42.0 + bump deps

### DIFF
--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -5,6 +5,9 @@ sources:
   "1.40.0":
     sha256: 82758e13727945f2408d0612762e4655180b039f058d5ff40d055fa1497bd94f
     url: https://github.com/nghttp2/nghttp2/releases/download/v1.40.0/nghttp2-1.40.0.tar.bz2
+  "1.42.0":
+    sha256: 10473848c2636fa9de6b469b04d0a0336cf8268486f7a6bde7cb2d0634736624
+    url: https://github.com/nghttp2/nghttp2/releases/download/v1.42.0/nghttp2-1.42.0.tar.bz2
 patches:
   "1.39.2":
     - patch_file: "patches/fix-addNghttp2IncludesPathCMake.patch"
@@ -19,4 +22,11 @@ patches:
     - patch_file: "patches/fix-findLibevent.cmake"
       base_path: "source_subfolder"
     - patch_file: "patches/nghttp_static_include_directories.patch"
+      base_path: "source_subfolder"
+  "1.42.0":
+    - patch_file: "patches/fix-findJemalloc.cmake"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-findLibevent.cmake"
+      base_path: "source_subfolder"
+    - patch_file: "patches/nghttp_static_include_directories_1.42.0.patch"
       base_path: "source_subfolder"

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -45,13 +45,13 @@ class Nghttp2Conan(ConanFile):
     def requirements(self):
         self.requires("zlib/1.2.11")
         if self.options.with_app:
-            self.requires("openssl/1.1.1d")
-            self.requires("c-ares/1.15.0")
-            self.requires("libev/4.27")
-            self.requires("libevent/2.1.11")
-            self.requires("libxml2/2.9.9")
+            self.requires("openssl/1.1.1h")
+            self.requires("c-ares/1.17.1")
+            self.requires("libev/4.33")
+            self.requires("libevent/2.1.12")
+            self.requires("libxml2/2.9.10")
         if self.options.with_hpack:
-            self.requires("jansson/2.12")
+            self.requires("jansson/2.13.1")
         if self.options.with_jemalloc:
             self.requires("jemalloc/5.2.1")
         if self.options.with_asio:

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -78,6 +78,10 @@ class Nghttp2Conan(ConanFile):
 
         cmake.definitions["ENABLE_ASIO_LIB"] = "ON" if self.options.with_asio else "OFF"
 
+        if tools.Version(self.version) >= "1.42.0":
+            # backward-incompatible change in 1.42.0
+            cmake.definitions["STATIC_LIB_SUFFIX"] = "_static"
+
         if self.options.with_app:
             cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath
         if self.options.with_asio:

--- a/recipes/libnghttp2/all/patches/nghttp_static_include_directories_1.42.0.patch
+++ b/recipes/libnghttp2/all/patches/nghttp_static_include_directories_1.42.0.patch
@@ -1,0 +1,12 @@
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -60,6 +60,9 @@ endif()
+ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
+   # Static library (for unittests because of symbol visibility)
+   add_library(nghttp2_static STATIC ${NGHTTP2_SOURCES})
++  target_include_directories(nghttp2_static INTERFACE
++    ${CMAKE_CURRENT_BINARY_DIR}/includes
++    ${CMAKE_CURRENT_SOURCE_DIR}/includes)
+   set_target_properties(nghttp2_static PROPERTIES
+     COMPILE_FLAGS "${WARNCFLAGS}"
+     VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}

--- a/recipes/libnghttp2/config.yml
+++ b/recipes/libnghttp2/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "1.40.0":
     folder: all
+  "1.42.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libnghttp2/1.42.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.


- If fuzzy patches were allowed (KB-H030), only one patch for includes would be enough. Copied a patch.
- Upstream broke static library name, fixed it for 1.42.0
- Bumped deps
