### PR TITLE
vulkan-headers: add version 1.2.162

### DIFF
--- a/recipes/vulkan-headers/all/conandata.yml
+++ b/recipes/vulkan-headers/all/conandata.yml
@@ -62,3 +62,6 @@ sources:
   "1.2.154.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.2.154.0.tar.gz"
     sha256: "a0528ade4dd3bd826b960ba4ccabc62e92ecedc3c70331b291e0a7671b3520f9"
+  "1.2.162":
+    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.162.tar.gz"
+    sha256: "deab1a7a28ad3e0a7a0a1c4cd9c54758dce115a5f231b7205432d2bbbfb4d456"

--- a/recipes/vulkan-headers/config.yml
+++ b/recipes/vulkan-headers/config.yml
@@ -41,3 +41,5 @@ versions:
     folder: all
   "1.2.154.0":
     folder: all
+  "1.2.162":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **vulkan-headers/1.2.162**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
