### PR TITLE
xsimd: add version 7.4.9

### DIFF
--- a/recipes/xsimd/all/conandata.yml
+++ b/recipes/xsimd/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.4.9":
+    url: "https://github.com/xtensor-stack/xsimd/archive/7.4.9.tar.gz"
+    sha256: "f6601ffb002864ec0dc6013efd9f7a72d756418857c2d893be0644a2f041874e"
   "7.4.8":
     sha256: 318676faae48d2082440df9f161a95303a3f29c3f0b03ff32ca24063b12f5699
     url: https://github.com/xtensor-stack/xsimd/archive/7.4.8.tar.gz

--- a/recipes/xsimd/config.yml
+++ b/recipes/xsimd/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.4.9":
+    folder: all
   "7.4.8":
     folder: all
   "7.4.6":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **xsimd/7.4.9**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
