### PR TITLE
pugixml: add version 1.11

### DIFF
--- a/recipes/pugixml/all/conandata.yml
+++ b/recipes/pugixml/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.11":
+    url: "https://github.com/zeux/pugixml/archive/v1.11.tar.gz"
+    sha256: "79b5e3a50dca0c150ab5fd282e23dd1da00760073a7040ca8dde4e031330add2"
   "1.10":
     sha256: 55f399fbb470942410d348584dc953bcaec926415d3462f471ef350f29b5870a
     url: https://github.com/zeux/pugixml/releases/download/v1.10/pugixml-1.10.tar.gz

--- a/recipes/pugixml/all/test_package/CMakeLists.txt
+++ b/recipes/pugixml/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/pugixml/config.yml
+++ b/recipes/pugixml/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.11":
+    folder: "all"
   "1.10":
     folder: "all"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **pugixml/1.11**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
