### PR TITLE
libxcrypt: add version 4.4.17

### DIFF
--- a/recipes/libxcrypt/all/conandata.yml
+++ b/recipes/libxcrypt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.4.17":
+    url: "https://github.com/besser82/libxcrypt/archive/v4.4.17.tar.gz"
+    sha256: "7665168d0409574a03f7b484682e68334764c29c21ca5df438955a381384ca07"
   "4.4.16":
     sha256: "a98f65b8baffa2b5ba68ee53c10c0a328166ef4116bce3baece190c8ce01f375"
     url: "https://github.com/besser82/libxcrypt/archive/v4.4.16.tar.gz"

--- a/recipes/libxcrypt/all/test_package/CMakeLists.txt
+++ b/recipes/libxcrypt/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/libxcrypt/config.yml
+++ b/recipes/libxcrypt/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "4.4.17":
+    folder: all
   "4.4.16":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libxcrypt/4.4.17**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
