### PR TITLE
add botan/2.17.0

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -14,6 +14,9 @@ sources:
   "2.16.0":
     url: "https://github.com/randombit/botan/archive/2.16.0.tar.gz"
     sha256: "8f448b97120e884d755b946045753876d688b01f48f5e6a1cf37aebd5afecbe5"
+  "2.17.0":
+    url: "https://github.com/randombit/botan/archive/2.17.0.tar.gz"
+    sha256: "32874e4e14bf11428e1bc4919e5ee174a68e2f480d37bc79ed015b2b5ef87fef"
   "2.17.1":
     url: "https://github.com/randombit/botan/archive/2.17.1.tar.gz"
     sha256: "ca562c00e61663c418bd9fdc6c70bdeaedafba8bef328cb6046a1d6390d39a71"

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -9,5 +9,7 @@ versions:
     folder: all
   "2.16.0":
     folder: all
+  "2.17.0":
+    folder: all
   "2.17.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **botan/2.17.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Adding this for completeness, and to observe another data point for the build issue we're currently investigating for the recipe [with 2.17.2](https://github.com/conan-io/conan-center-index/pull/3607) (see [here also](https://github.com/randombit/botan/pull/2526)). 