### PR TITLE
json-c: add version 0.15

### DIFF
--- a/recipes/json-c/all/conandata.yml
+++ b/recipes/json-c/all/conandata.yml
@@ -5,9 +5,12 @@ sources:
   "0.14":
     url: "https://github.com/json-c/json-c/archive/json-c-0.14-20200419.tar.gz"
     sha256: "ec4eb70e0f6c0d707b9b1ec646cf7c860f4abb3562a90ea6e4d78d177fd95303"
+  "0.15":
+    url: "https://github.com/json-c/json-c/archive/json-c-0.15-20200726.tar.gz"
+    sha256: "4ba9a090a42cf1e12b84c64e4464bb6fb893666841d5843cc5bef90774028882"
 patches:
   "0.13.1":
-     - patch_file: "patches/fix-cmake-0.13.1.patch"
-       base_path: "source_subfolder"
-     - patch_file: "patches/fix-exported-symbols-0.13.1.patch"
-       base_path: "source_subfolder"
+    - patch_file: "patches/fix-cmake-0.13.1.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-exported-symbols-0.13.1.patch"
+      base_path: "source_subfolder"

--- a/recipes/json-c/all/conanfile.py
+++ b/recipes/json-c/all/conanfile.py
@@ -57,6 +57,11 @@ class JSONCConan(ConanFile):
                                   "execute_process(COMMAND ./configure --host %s " % host)
 
         self._cmake = CMake(self)
+
+        if tools.Version(self.version) >= "0.15":
+            self._cmake.definitions["BUILD_STATIC_LIBS"] = not self.options.shared
+            self._cmake.definitions["DISABLE_STATIC_FPIC"] = not self.options.get_safe("fPIC", True)
+
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 

--- a/recipes/json-c/all/test_package/CMakeLists.txt
+++ b/recipes/json-c/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/json-c/config.yml
+++ b/recipes/json-c/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "0.14":
     folder: all
+  "0.15":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **json-c/0.15**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
