### PR TITLE
doctest: add version 2.4.1

### DIFF
--- a/recipes/doctest/2.x.x/conandata.yml
+++ b/recipes/doctest/2.x.x/conandata.yml
@@ -14,3 +14,6 @@ sources:
   "2.4.0":
     url: "https://github.com/onqtam/doctest/archive/2.4.0.tar.gz"
     sha256: "f689f48e92c088928d88d8481e769c8e804f0a608b484ab8ef3d6ab6045b5444"
+  "2.4.1":
+    url: "https://github.com/onqtam/doctest/archive/2.4.1.tar.gz"
+    sha256: "0a0f0be21ee23e36ff6b8b9d63c06a7792e04cce342e1df3dee0e40d1e21b9f0"

--- a/recipes/doctest/config.yml
+++ b/recipes/doctest/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: 2.x.x
   2.4.0:
     folder: 2.x.x
+  "2.4.1":
+    folder: 2.x.x


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **doctest/2.4.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
