### PR TITLE
[cppunit] fix missing symbols when shared on windows

### DIFF
--- a/recipes/cppunit/all/conanfile.py
+++ b/recipes/cppunit/all/conanfile.py
@@ -67,6 +67,8 @@ class CppunitConan(ConanFile):
         if self._autotools:
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        if self.settings.os == "Windows" and self.options.shared:
+            self._autotools.defines.append("CPPUNIT_BUILD_DLL")
         if self.settings.compiler == "Visual Studio":
             self._autotools.flags.append("-FS")
             self._autotools.cxx_flags.append("-EHsc")

--- a/recipes/cppunit/all/test_package/CMakeLists.txt
+++ b/recipes/cppunit/all/test_package/CMakeLists.txt
@@ -6,3 +6,4 @@ conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/cppunit/all/test_package/test_package.cpp
+++ b/recipes/cppunit/all/test_package/test_package.cpp
@@ -33,3 +33,102 @@ main()
   std::cout << "was succesful? " << result.wasSuccessful() << "\n";
   return 0;
 }
+
+#ifndef CPP_UNIT_EXAMPLETESTCASE_H
+#define CPP_UNIT_EXAMPLETESTCASE_H
+
+#include <cppunit/extensions/HelperMacros.h>
+
+/*
+ * A test case that is designed to produce
+ * example errors and failures
+ *
+ */
+
+class ExampleTestCase : public CPPUNIT_NS::TestFixture
+{
+  CPPUNIT_TEST_SUITE( ExampleTestCase );
+  CPPUNIT_TEST( example );
+  CPPUNIT_TEST( anotherExample );
+  CPPUNIT_TEST( testAdd );
+  CPPUNIT_TEST( testEquals );
+  CPPUNIT_TEST_SUITE_END();
+
+protected:
+  double m_value1;
+  double m_value2;
+
+public:
+  void setUp();
+
+protected:
+  void example();
+  void anotherExample();
+  void testAdd();
+  void testEquals();
+};
+
+
+#endif
+
+#include <cppunit/config/SourcePrefix.h>
+
+CPPUNIT_TEST_SUITE_REGISTRATION( ExampleTestCase );
+
+void ExampleTestCase::example()
+{
+  CPPUNIT_ASSERT_DOUBLES_EQUAL( 1.0, 1.1, 0.05 );
+  CPPUNIT_ASSERT( 1 == 0 );
+  CPPUNIT_ASSERT( 1 == 1 );
+}
+
+
+void ExampleTestCase::anotherExample()
+{
+  CPPUNIT_ASSERT (1 == 2);
+}
+
+void ExampleTestCase::setUp()
+{
+  m_value1 = 2.0;
+  m_value2 = 3.0;
+}
+
+void ExampleTestCase::testAdd()
+{
+  double result = m_value1 + m_value2;
+  CPPUNIT_ASSERT( result == 6.0 );
+}
+
+
+void ExampleTestCase::testEquals()
+{
+  long* l1 = new long(12);
+  long* l2 = new long(12);
+
+  CPPUNIT_ASSERT_EQUAL( 12, 12 );
+  CPPUNIT_ASSERT_EQUAL( 12L, 12L );
+  CPPUNIT_ASSERT_EQUAL( *l1, *l2 );
+
+  delete l1;
+  delete l2;
+
+  CPPUNIT_ASSERT( 12L == 12L );
+  CPPUNIT_ASSERT_EQUAL( 12, 13 );
+  CPPUNIT_ASSERT_DOUBLES_EQUAL( 12.0, 11.99, 0.5 );
+}
+
+class FixtureTest : public CPPUNIT_NS::TestFixture
+{
+};
+
+CPPUNIT_TEST_FIXTURE(FixtureTest, testEquals)
+{
+  CPPUNIT_ASSERT_EQUAL( 12, 12 );
+}
+
+CPPUNIT_TEST_FIXTURE(FixtureTest, testAdd)
+{
+  double result = 2.0 + 2.0;
+  CPPUNIT_ASSERT( result == 4.0 );
+}


### PR DESCRIPTION
…when using shared=True

Specify library name and version:  **cppunit/1.15.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I am unable to run this locally on windows, any suggestions?

```sh
cppunit/1.15.1: run_in_windows_bash: C:\.conan\64fb9a\1\bin\usr\bin\bash.exe --login -c ^"cd \^"/c/users/chris mcarthur/.conan/data/cppunit/1.15.1/_/_/build/127af201a4cdf8111e2e08540525c245c9b3b99e\^" ^&^& PATH=\^"/c/.conan/64fb9a/1/bin/usr/bin:/c/users/chris mcarthur/.conan/data/automake/1.16.2/_/_/package/3e48e69237f7f2196164383ef9dedf0f93cbf249/bin:/c/users/chris mcarthur/.conan/data/autoconf/2.69/_/_/package/ca33edce272a279b24f87dc0d4cf5bbdcffbc187/bin:/c/users/chris mcarthur/.conan/data/m4/1.4.18/_/_/package/3fb49604f9c2f729b85ba3115852006824e72cab/bin:$PATH\^" ^&^& \^"/c/users/chris mcarthur/.conan/data/cppunit/1.15.1/_/_/build/127af201a4cdf8111e2e08540525c245c9b3b99e/source_subfolder\^"/configure --enable-shared=yes --enable-static=no --enable-debug=no --enable-doxygen=no --enable-dot=no --enable-werror=no --enable-html-docs=no \^"--prefix=C:/Users/Chris McArthur/.conan/data/cppunit/1.15.1/_/_/package/127af201a4cdf8111e2e08540525c245c9b3b99e\^"  ^"
configure: loading site script /mingw64/etc/config.site
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... configure: error: unsafe srcdir value: '/c/users/chris mcarthur/.conan/data/cppunit/1.15.1/_/_/build/127af201a4cdf8111e2e08540525c245c9b3b99e/source_subfolder'
cppunit/1.15.1:
cppunit/1.15.1: ERROR: Package '127af201a4cdf8111e2e08540525c245c9b3b99e' build failed
cppunit/1.15.1: WARN: Build folder C:\Users\Chris McArthur\.conan\data\cppunit\1.15.1\_\_\build\127af201a4cdf8111e2e08540525c245c9b3b99e
ERROR: cppunit/1.15.1: Error in build() method, line 88
        autotools = self._configure_autotools()
while calling '_configure_autotools', line 83
        self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder)
        ConanException: Error 1 while executing "/c/users/chris mcarthur/.conan/data/cppunit/1.15.1/_/_/build/127af201a4cdf8111e2e08540525c245c9b3b99e/source_subfolder"/configure --enable-shared=yes --enable-static=no --enable-debug=no --enable-doxygen=no --enable-dot=no --enable-werror=no --enable-html-docs=no "--prefix=C:/Users/Chris McArthur/.conan/data/cppunit/1.15.1/_/_/package/127af201a4cdf8111e2e08540525c245c9b3b99e"
```