### PR TITLE
libpq/*: remove dylibs if not shared on mac os

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -160,7 +160,11 @@ class LibpqConan(ConanFile):
             else:
                 globs = [os.path.join(self.package_folder, "lib", "*.a")]
         else:
-            globs = [os.path.join(self.package_folder, "lib", "libpq.so*"), os.path.join(self.package_folder, "bin", "*.dll")]
+            globs = [
+                os.path.join(self.package_folder, "lib", "libpq.so*"),
+                os.path.join(self.package_folder, "bin", "*.dll"),
+                os.path.join(self.package_folder, "lib", "libpq*.dylib")
+            ]
         if self.settings.os == "Windows":
             os.unlink(os.path.join(self.package_folder, "lib", "libpq.dll"))
         for globi in globs:


### PR DESCRIPTION
Specify library name and version:  **libpq/***

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

On macos, dylibs weren't removed in case of static build.
