### PR TITLE
taywee-args: add version 6.2.4

### DIFF
--- a/recipes/taywee-args/all/conandata.yml
+++ b/recipes/taywee-args/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.2.4":
+    url: "https://github.com/Taywee/args/archive/6.2.4.tar.gz"
+    sha256: "dcc6d0d6b941eb40eeeb5741917d557944f3880e0dea9096147d0bdd89c34654"
   "6.2.3":
     url: "https://github.com/Taywee/args/archive/6.2.3.tar.gz"
     sha256: "c202d15fc4b30519a08bae7df9e6f4fdc40ac2434ba65d83a108ebbf6e4822c2"

--- a/recipes/taywee-args/config.yml
+++ b/recipes/taywee-args/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "6.2.4":
+    folder: all
   "6.2.3":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **taywee-args/6.2.4**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
