### PR TITLE
xorg: don't generate pkg_config files

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -35,6 +35,7 @@ class ConanXOrg(ConanFile):
         self.cpp_info.components[name].cflags = cflags
         self.cpp_info.components[name].cxxflags = cflags
         self.cpp_info.components[name].version = pkg_config.version[0]
+        self.cpp_info.components[name].filenames["pkg_config"] = name + "_system"
 
     def system_requirements(self):
         if tools.os_info.is_linux and self.settings.os == "Linux":


### PR DESCRIPTION
in a dependency graph which as both xorg/system and freetype/X, both recipe generate freetype2.pc. This change makes sure that the one generated by freetype recipe is used.

Specify library name and version:  **xorg/system**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
