### PR TITLE
bullet3: add version 3.07

### DIFF
--- a/recipes/bullet3/all/conandata.yml
+++ b/recipes/bullet3/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "3.06":
     url: "https://github.com/bulletphysics/bullet3/archive/3.06.tar.gz"
     sha256: "217c1d198ee00be7e40d4cb4d79882e37ef4a06cbfbe11f5fbc207c347a57020"
+  "3.07":
+    url: "https://github.com/bulletphysics/bullet3/archive/3.07.tar.gz"
+    sha256: "068ecf8acbf256d3976eebee75d7d6f5af16c049f10f6b2d8ba28bb638bef3b0"

--- a/recipes/bullet3/config.yml
+++ b/recipes/bullet3/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "3.06":
     folder: all
+  "3.07":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **bullet3/3.07**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
