### PR TITLE
structopt: add version 0.1.1

### DIFF
--- a/recipes/structopt/all/conandata.yml
+++ b/recipes/structopt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.1":
+    url: "https://github.com/p-ranav/structopt/archive/v0.1.1.tar.gz"
+    sha256: "a813250b3325e462df613fe6b0730a5f93012b1a5a09810f88943ebac5b178bb"
   "0.1.0":
     url: "https://github.com/p-ranav/structopt/archive/v0.1.0.tar.gz"
     sha256: "a0552e81312cfafcc5319a25c0571ca2470f43461e9f3f72e5f9d89ea4139505"

--- a/recipes/structopt/config.yml
+++ b/recipes/structopt/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.1.1":
+    folder: "all"
   "0.1.0":
     folder: "all"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **structopt/0.1.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
