### PR TITLE
libraw: add version 0.20.2

### DIFF
--- a/recipes/libraw/all/conandata.yml
+++ b/recipes/libraw/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "0.20.0":
     url: "https://github.com/LibRaw/LibRaw/archive/0.20.0.tar.gz"
     sha256: "f38cd2620d5adc32d2c9f51cd0dc66d72c75671f1c81dfd13d30c45c6be80d40"
+  "0.20.2":
+    url: "https://github.com/LibRaw/LibRaw/archive/0.20.2.tar.gz"
+    sha256: "02df7d403b34602b769bb38e5bf7d4258e075eeefbe980b6832e6e1491989d60"

--- a/recipes/libraw/config.yml
+++ b/recipes/libraw/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "0.20.0":
     folder: all
+  "0.20.2":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libraw/0.20.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
