### PR TITLE
libwebsockets: add version 4.1.6

### DIFF
--- a/recipes/libwebsockets/all/conandata.yml
+++ b/recipes/libwebsockets/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "4.1.4":
     sha256: 00da77b4b89db3e0b1a2778f756f08d55d7f6b1632e18d981fc399c412866147
     url: https://github.com/warmcat/libwebsockets/archive/v4.1.4.tar.gz
+  "4.1.6":
+    url: "https://github.com/warmcat/libwebsockets/archive/v4.1.6.tar.gz"
+    sha256: "402e9a8df553c9cd2aff5d7a9758e9e5285bf3070c82539082864633db3deb83"

--- a/recipes/libwebsockets/config.yml
+++ b/recipes/libwebsockets/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "4.1.4":
     folder: all
+  "4.1.6":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libwebsockets/4.1.6**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
