### PR TITLE
ctre: add version 3.3.4

### DIFF
--- a/recipes/ctre/all/conandata.yml
+++ b/recipes/ctre/all/conandata.yml
@@ -1,16 +1,16 @@
 sources:
   "2.8.2":
     url: https://github.com/hanickadot/compile-time-regular-expressions/archive/v2.8.2.tar.gz
-    sha256: f89494f52ec31e5854fff3d2c5825474201476636c5d82a9365dad5188396314 
+    sha256: f89494f52ec31e5854fff3d2c5825474201476636c5d82a9365dad5188396314
   "2.8.4":
     url: https://github.com/hanickadot/compile-time-regular-expressions/archive/v2.8.4.tar.gz
-    sha256: 99b981857f1b66cab5e71161ae74deca268ed39a96ec6507def92d4f445cadd6 
+    sha256: 99b981857f1b66cab5e71161ae74deca268ed39a96ec6507def92d4f445cadd6
   "2.9.2":
     url: https://github.com/hanickadot/compile-time-regular-expressions/archive/v2.9.2.tar.gz
-    sha256: 763cb6f26e6fc68b4c98a809efbf55aab1a21c7773da8150d41c31baf5f8b711 
+    sha256: 763cb6f26e6fc68b4c98a809efbf55aab1a21c7773da8150d41c31baf5f8b711
   "2.10":
     url: https://github.com/hanickadot/compile-time-regular-expressions/archive/v2.10.tar.gz
-    sha256: 2e166b672c5a733b5448bb9fc83db54d92852c39e3e19097b79307cc6a327c31 
+    sha256: 2e166b672c5a733b5448bb9fc83db54d92852c39e3e19097b79307cc6a327c31
   "3.0.1":
     url: https://github.com/hanickadot/compile-time-regular-expressions/archive/v3.0.1.tar.gz
     sha256: 0838ce0af9e9e89ffc10854dc98c88b2dd40d1866ceaf0dc6c1663d6c39882cc
@@ -23,3 +23,6 @@ sources:
   "3.3.2":
     url: https://github.com/hanickadot/compile-time-regular-expressions/archive/v3.3.2.tar.gz
     sha256: adb1b52ed58ffd5631f37564bb0baf5fd8716dad640970d31c8093943a0e7486
+  "3.3.4":
+    url: "https://github.com/hanickadot/compile-time-regular-expressions/archive/v3.3.4.tar.gz"
+    sha256: "8161f0d3100fc690590f475aa9acb70163ed7f2922e35e13136dececc52c49a9"

--- a/recipes/ctre/config.yml
+++ b/recipes/ctre/config.yml
@@ -1,4 +1,3 @@
----
 versions:
   "2.8.2":
     folder: all
@@ -15,4 +14,6 @@ versions:
   "3.2":
     folder: all
   "3.3.2":
+    folder: all
+  "3.3.4":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **ctre/3.3.4**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
