### PR TITLE
jasper: add version 2.0.22

### DIFF
--- a/recipes/jasper/all/conandata.yml
+++ b/recipes/jasper/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.22":
+    url: "https://github.com/jasper-software/jasper/archive/version-2.0.22.tar.gz"
+    sha256: "afc4166bff29b8a0dc46ed5e8d6a208d7976fccfd0b1146e3400c8b2948794a2"
   "2.0.21":
     url: "https://github.com/jasper-software/jasper/archive/version-2.0.21.tar.gz"
     sha256: "2482def06dfaa33b8d93cbe992a29723309f3c2b6e75674423a52fc82be10418"

--- a/recipes/jasper/config.yml
+++ b/recipes/jasper/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.22":
+    folder: all
   "2.0.21":
     folder: all
   "2.0.19":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **jasper/2.0.22**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
