### PR TITLE
xorg: add xcb-dri3

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -42,7 +42,7 @@ class ConanXOrg(ConanFile):
             if tools.os_info.with_apt:
                 packages = ["xorg-dev", "libx11-xcb-dev", "libxcb-render0-dev", "libxcb-render-util0-dev", "libxcb-xkb-dev",
                             "libxcb-icccm4-dev", "libxcb-image0-dev", "libxcb-keysyms1-dev", "libxcb-randr0-dev", "libxcb-shape0-dev",
-                            "libxcb-sync-dev", "libxcb-xfixes0-dev", "libxcb-xinerama0-dev", "xkb-data"]
+                            "libxcb-sync-dev", "libxcb-xfixes0-dev", "libxcb-xinerama0-dev", "xkb-data", "libxcb-dri3-dev"]
                 if (tools.os_info.linux_distro == "ubuntu" and tools.os_info.os_version < "15") or (tools.os_info.linux_distro == "debian" and tools.os_info.os_version < "12"):
                     packages.append( "libxcb-util0-dev" )
                 else:
@@ -75,5 +75,6 @@ class ConanXOrg(ConanFile):
                      "xscrnsaver", "xt", "xtst", "xv", "xvmc", "xxf86vm", "xtrans",
                      "xcb-xkb", "xcb-icccm", "xcb-image", "xcb-keysyms", "xcb-randr", "xcb-render",
                      "xcb-renderutil", "xcb-shape", "xcb-shm", "xcb-sync", "xcb-xfixes",
-                     "xcb-xinerama", "xcb", "xkeyboard-config", "xcb-atom", "xcb-aux", "xcb-event", "xcb-util"]:
+                     "xcb-xinerama", "xcb", "xkeyboard-config", "xcb-atom", "xcb-aux", "xcb-event", "xcb-util",
+                     "xcb-dri3"]:
             self._fill_cppinfo_from_pkgconfig(name)


### PR DESCRIPTION
required by chromium https://pastebin.ubuntu.com/p/9D33mPJfYM/

Specify library name and version:  **xorg/all**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
