### PR TITLE
add mgs v0.1.1

### DIFF
--- a/recipes/mgs/all/conandata.yml
+++ b/recipes/mgs/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  0.1.1:
+    url: https://github.com/theodelrieu/mgs/releases/download/v0.1.1/mgs.zip
+    sha256: 416da1936d29c1bb6529c2ab05b89733eb041b6c228a39f6b6077d80195c1e71

--- a/recipes/mgs/all/conanfile.py
+++ b/recipes/mgs/all/conanfile.py
@@ -1,0 +1,21 @@
+from conans import ConanFile, CMake, tools
+from fnmatch import fnmatch
+import os
+
+
+class MgsConan(ConanFile):
+    name = "mgs"
+    version = "0.1.1"
+    license = "MIT"
+    _source_subfolder = "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename(self.name, self._source_subfolder)
+
+    def package(self):
+        for subfolder in ("include", "lib"):
+            self.copy("*",
+                      src=os.path.join(self._source_subfolder, subfolder),
+                      dst=subfolder)
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")

--- a/recipes/mgs/all/test_package/CMakeLists.txt
+++ b/recipes/mgs/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.10.0)
+project(PackageTest CXX)
+set(CMAKE_CXX_STANDARD 14)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(mgs COMPONENTS base64)
+add_executable(example example.cpp)
+target_link_libraries(example mgs::base64)

--- a/recipes/mgs/all/test_package/conanfile.py
+++ b/recipes/mgs/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
+        # in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.run(os.path.join("bin", "example"), run_environment=True)

--- a/recipes/mgs/all/test_package/example.cpp
+++ b/recipes/mgs/all/test_package/example.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+#include <mgs/base64.hpp>
+
+int main() {
+  std::cout << mgs::base64::encode("Hello, World!") << std::endl;
+}

--- a/recipes/mgs/config.yml
+++ b/recipes/mgs/config.yml
@@ -1,0 +1,3 @@
+versions:
+    "0.1.1":
+      folder: all


### PR DESCRIPTION
Specify library name and version:  **mgs/0.1.1**

Hi, figured I could add this library of mine in CCI :)

More info about the library can be found [here](https://github.com/theodelrieu/mgs).

I'm wondering if using components in the recipe would be useful, since I've already provided CMake config files. Looking forward to your inputs!

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
