### PR TITLE
cppcheck: add version 2.3

### DIFF
--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -1,8 +1,14 @@
 sources:
+  "2.3":
+    url: "https://github.com/danmar/cppcheck/archive/2.3.tar.gz"
+    sha256: "3c622628ebf46f68909c7a96743b07b6207894a0772fbe802603732152ab1035"
   "2.2":
     url: "https://github.com/danmar/cppcheck/archive/2.2.tar.gz"
     sha256: "ad96290a1842c5934bf9c4268cb270953f3078d4ce33a9a53922d6cb6daf61aa"
 patches:
+  "2.3":
+    - patch_file: "patches/0001-cmake-source-dir.patch"
+      base_path: "source_subfolder"
   "2.2":
     - patch_file: "patches/0001-cmake-source-dir.patch"
       base_path: "source_subfolder"

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.3":
+    folder: all
   "2.2":
     folder: all
 


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cppcheck/2.3**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
