### PR TITLE
glib: remove iconv from system libs

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -150,7 +150,6 @@ class GLibConan(ConanFile):
         if self.settings.os == "Windows":
             self.cpp_info.components["glib-2.0"].system_libs.extend(["ws2_32", "ole32", "shell32", "user32", "advapi32"])
         if self.settings.os == "Macos":
-            self.cpp_info.components["glib-2.0"].system_libs.append("iconv")
             self.cpp_info.components["glib-2.0"].system_libs.append("resolv")
             self.cpp_info.components["glib-2.0"].frameworks.extend(["Foundation", "CoreServices", "CoreFoundation"])
         self.cpp_info.components["glib-2.0"].includedirs.append(os.path.join("include", "glib-2.0"))


### PR DESCRIPTION
is is already present as a conan requirement

Specify library name and version:  **glib/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
