### PR TITLE
tl: fix compiler version checks

### DIFF
--- a/recipes/tl/all/conanfile.py
+++ b/recipes/tl/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 

--- a/recipes/tl/all/conanfile.py
+++ b/recipes/tl/all/conanfile.py
@@ -13,7 +13,7 @@ class TlConan(ConanFile):
     license = "CC0-1.0"
     no_copy_source = True
     _source_subfolder = "tl"
-    
+
     def configure(self):
         minimal_cpp_standard = "14"
         if self.settings.compiler.cppstd:
@@ -26,18 +26,22 @@ class TlConan(ConanFile):
             "Visual Studio": "15"
         }
 
+        def lt_compiler_version(version1, version2):
+            v1, *v1_res = version1.split(".", 1)
+            v2, *v2_res = version2.split(".", 1)
+            if v1 == v2 and v1_res and v2_res:
+                return lt_compiler_version(v1_res, v2_res)
+            return v1 < v2
+
         compiler = str(self.settings.compiler)
         if compiler not in minimal_version:
             self.output.warn(
-                "%s recipe lacks information about the %s compiler standard version support" % (self.name, compiler))
+                "{} recipe lacks information about the {} compiler standard version support".format(self.name, compiler))
             self.output.warn(
-                "%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
-            return
-
-        version = tools.Version(self.settings.compiler.version)
-        if version < minimal_version[compiler]:
+                "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
+        elif lt_compiler_version(str(self.settings.compiler.version), minimal_version[compiler]):
             raise ConanInvalidConfiguration(
-                "%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
+                "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/tl/all/conanfile.py
+++ b/recipes/tl/all/conanfile.py
@@ -12,7 +12,10 @@ class TlConan(ConanFile):
     settings = "compiler"
     license = "CC0-1.0"
     no_copy_source = True
-    _source_subfolder = "tl"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
     def configure(self):
         minimal_cpp_standard = "14"

--- a/recipes/tl/all/conanfile.py
+++ b/recipes/tl/all/conanfile.py
@@ -29,11 +29,11 @@ class TlConan(ConanFile):
             "Visual Studio": "15"
         }
 
-        def lt_compiler_version(version1, version2):
+        def lazy_lt_compiler_version(version1, version2):
             v1, *v1_res = version1.split(".", 1)
             v2, *v2_res = version2.split(".", 1)
             if v1 == v2 and v1_res and v2_res:
-                return lt_compiler_version(v1_res, v2_res)
+                return lazy_lt_compiler_version(v1_res, v2_res)
             return v1 < v2
 
         compiler = str(self.settings.compiler)
@@ -42,7 +42,7 @@ class TlConan(ConanFile):
                 "{} recipe lacks information about the {} compiler standard version support".format(self.name, compiler))
             self.output.warn(
                 "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
-        elif lt_compiler_version(str(self.settings.compiler.version), minimal_version[compiler]):
+        elif lazy_lt_compiler_version(str(self.settings.compiler.version), minimal_version[compiler]):
             raise ConanInvalidConfiguration(
                 "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
 

--- a/recipes/tl/all/conanfile.py
+++ b/recipes/tl/all/conanfile.py
@@ -29,12 +29,11 @@ class TlConan(ConanFile):
             "Visual Studio": "15"
         }
 
-        def lazy_lt_compiler_version(version1, version2):
-            v1, *v1_res = version1.split(".", 1)
-            v2, *v2_res = version2.split(".", 1)
-            if v1 == v2 and v1_res and v2_res:
-                return lazy_lt_compiler_version(v1_res, v2_res)
-            return v1 < v2
+        def lazy_lt_semver(v1, v2):
+            lv1 = v1.split(".")
+            lv2 = v2.split(".")
+            min_length = min(len(lv1), len(lv2))
+            return lv1[:min_length] < lv2[:min_length]
 
         compiler = str(self.settings.compiler)
         if compiler not in minimal_version:
@@ -42,7 +41,7 @@ class TlConan(ConanFile):
                 "{} recipe lacks information about the {} compiler standard version support".format(self.name, compiler))
             self.output.warn(
                 "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
-        elif lazy_lt_compiler_version(str(self.settings.compiler.version), minimal_version[compiler]):
+        elif lazy_lt_semver(str(self.settings.compiler.version), minimal_version[compiler]):
             raise ConanInvalidConfiguration(
                 "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
 

--- a/recipes/tl/all/test_package/conanfile.py
+++ b/recipes/tl/all/test_package/conanfile.py
@@ -7,8 +7,6 @@ class ExpectedTestConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
-        # in "test_package"
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **tl/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I'm trying to fix recipes which doesn't behave as expected while checking min compiler version (too restrictive) in `configure()`