### PR TITLE
(#3847) [swig] Remove code to run `strip` on binaries during packaging.

### DIFF
--- a/recipes/swig/all/conanfile.py
+++ b/recipes/swig/all/conanfile.py
@@ -113,14 +113,6 @@ class SwigConan(ConanFile):
             autotools = self._configure_autotools()
             autotools.install()
 
-        if self.settings.compiler != "Visual Studio":
-            with tools.chdir(os.path.join(self.package_folder, "bin")):
-                strip = (tools.get_env("STRIP") or tools.which("strip")).replace("\\", "/")
-                ext = ".exe" if tools.os_info.is_windows else ""
-                if strip:
-                    self.run("{} swig{}".format(strip, ext), win_bash=tools.os_info.is_windows)
-                    self.run("{} ccache-swig{}".format(strip, ext), win_bash=tools.os_info.is_windows)
-
     @property
     def _swiglibdir(self):
         return os.path.join(self.package_folder, "bin", "swiglib").replace("\\", "/")


### PR DESCRIPTION
Fixes #3847 
After failing to build swig/4.0.2@_/_ in the packaging step on AIX 7.1, I disabled the stripping.  After investigating, I found
that `swig` was the only package in conan-center-index that attempted to strip it's binaries.
Every other instance of "STRIP" in the repository was explicitly disabling it in the build by passing "STRIP=:" in the environment, so for consistency and simplicity the recipe has been altered to eliminate that step.

Specify library name and version:  **swig/4.0.[12]**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
