### PR TITLE
HDF5 repo update - Switched repo from live-clones to HDFGroup

### DIFF
--- a/recipes/hdf5/all/conandata.yml
+++ b/recipes/hdf5/all/conandata.yml
@@ -1,15 +1,15 @@
 sources:
   "1.12.0":
-    url: "https://github.com/live-clones/hdf5/archive/hdf5-1_12_0.tar.gz"
+    url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_12_0.tar.gz"
     sha256: "c64ffec2539ae6b6041f97952a40b0893c3c0df4d5b1c0177fb8aba567808158"
   "1.10.6":
-    url: "https://github.com/live-clones/hdf5/archive/hdf5-1_10_6.tar.gz"
+    url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_10_6.tar.gz"
     sha256: "e524b374b1c6f14f1aa87595c0761608c861fe7838549dab84639ae564ff48e8"
   "1.10.5":
-    url: "https://github.com/live-clones/hdf5/archive/hdf5-1_10_5.tar.gz"
+    url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_10_5.tar.gz"
     sha256: "22a4a48f94b013e9fd482c0bb0251de02ff9963787a107c5dde26a3f903b3b90"
   "1.8.21":
-    url: "https://github.com/live-clones/hdf5/archive/hdf5-1_8_21.tar.gz"
+    url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_8_21.tar.gz"
     sha256: "753520e34a576a64809b8e02d9c015d6126f7974f678c7417a60492d835a88f4"
 patches:
   "1.12.0":


### PR DESCRIPTION
I received this error when trying to build HDF5 in my project. 

```
ERROR: hdf5/1.12.0: Error in source() method, line 74
	tools.get(**self.conan_data["sources"][self.version])
	NotFoundException: Not found: https://github.com/live-clones/hdf5/archive/hdf5-1_12_0.tar.gz
```

A quick search shows that `https://github.com/live-clones/hdf5`   doesn't exist (or doesn't exist anymore). I'm not sure why this was even chosen as the "official" repo to download the archives, considering `https://github.com/HDFGroup/hdf5` is the official repo.

I updated the yml file to change the location of where the tar balls are found. It seems the sha256 sums haven't changed. 

I tested out: 1.12., 1.10.6, 1.10.5 and 1.8.21 on my Linux Mint 20 system. They all built.

If there is some other reason why this alternative repo was chosen, and why we shouldn't be using HDF5Group, feel free to cancel this merge request.


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
