### PR TITLE
fix: zulu-openjdk package info 

### DIFF
--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -46,6 +46,7 @@ class ZuluOpenJDK(ConanFile):
 
     def package_info(self):
         self.cpp_info.includedirs.append(self._jni_folder)
+        self.cpp_info.libdirs = []
 
         java_home = self.package_folder
         bin_path = os.path.join(java_home, "bin")

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -46,8 +46,6 @@ class ZuluOpenJDK(ConanFile):
 
     def package_info(self):
         self.cpp_info.includedirs.append(self._jni_folder)
-        self.cpp_info.libdirs = ["lib"]
-        self.cpp_info.libs = tools.collect_libs(self)
 
         java_home = self.package_folder
         bin_path = os.path.join(java_home, "bin")


### PR DESCRIPTION
Specify library name and version:  **zulu-openjdk/11.0.8**

adding all the libraries in the lib dir was unfortunately an error , they are not required

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
