### PR TITLE
IXWebSocket: prior to 11.0.4, C++14 was required, but 11.0.4 is C++11…

### DIFF
--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -49,7 +49,11 @@ class IXWebSocketConan(ConanFile):
 
     def configure(self):
         if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 14)
+            # Prior to 11.0.4, C++14 was required, but 11.0.4 is C++11 compatible
+            if tools.Version(self.version) >= "11.0.4":
+                tools.check_min_cppstd(self, 11)
+            else:
+                tools.check_min_cppstd(self, 14)
         if self.options.tls == "applessl" and not tools.is_apple_os(self.settings.os):
             raise ConanInvalidConfiguration("Can only use Apple SSL on Apple.")
         elif not self._can_use_openssl() and self.options.tls == "openssl":


### PR DESCRIPTION
… compatible

Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
