### PR TITLE
cfitsio: allow implicit function declaration for apple-clang 12+

### DIFF
--- a/recipes/cfitsio/all/patches/fix-cmake-3.470.patch
+++ b/recipes/cfitsio/all/patches/fix-cmake-3.470.patch
@@ -99,7 +99,7 @@
      editcol.c edithdu.c eval_f.c eval_l.c eval_y.c
      f77_wrap1.c f77_wrap2.c f77_wrap3.c f77_wrap4.c
      fits_hcompress.c fits_hdecompress.c fitscore.c
-@@ -123,27 +133,102 @@ SET(SRC_FILES
+@@ -123,27 +133,105 @@ SET(SRC_FILES
  
  # Only include zlib source files if we are building a shared library.
  # Users will need to link their executable with zlib independently.
@@ -196,6 +196,9 @@
  ADD_LIBRARY(${LIB_NAME} ${LIB_TYPE} ${H_FILES} ${SRC_FILES})
 -TARGET_LINK_LIBRARIES(${LIB_NAME} ${PTHREADS_LIBRARY} ${M_LIB} ${CURL_LIBRARIES})
 +TARGET_LINK_LIBRARIES(${LIB_NAME} ${LINK_LIBS} ${M_LIB})
++if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "12")
++    TARGET_COMPILE_OPTIONS(${LIB_NAME} PRIVATE -Wno-error=implicit-function-declaration)
++endif()
  
  SET_TARGET_PROPERTIES(${LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION} SOVERSION ${${PROJECT_NAME}_MAJOR_VERSION})
 -install(TARGETS ${LIB_NAME} DESTINATION ${LIB_DESTINATION})
@@ -212,7 +215,7 @@
  
      ENABLE_TESTING()
  
-@@ -173,7 +258,7 @@ IF (BUILD_SHARED_LIBS)
+@@ -173,7 +261,7 @@ IF (BUILD_SHARED_LIBS)
        set_target_properties(FPack Funpack PROPERTIES LINK_FLAGS "setargv.obj")
      endif(MSVC)
  

--- a/recipes/cfitsio/all/patches/fix-cmake-3.490.patch
+++ b/recipes/cfitsio/all/patches/fix-cmake-3.490.patch
@@ -95,7 +95,7 @@
      editcol.c edithdu.c eval_f.c eval_l.c eval_y.c
      f77_wrap1.c f77_wrap2.c f77_wrap3.c f77_wrap4.c
      fits_hcompress.c fits_hdecompress.c fitscore.c
-@@ -128,30 +135,102 @@ SET(SRC_FILES
+@@ -128,30 +135,105 @@ SET(SRC_FILES
  
  # Only include zlib source files if we are building a shared library.
  # Users will need to link their executable with zlib independently.
@@ -195,6 +195,9 @@
 -    TARGET_LINK_LIBRARIES(${LIB_NAME} ${CURL_LIBRARIES})
 -ENDIF(CURL_FOUND)
 +TARGET_LINK_LIBRARIES(${LIB_NAME} ${LINK_LIBS} ${M_LIB})
++if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "12")
++    TARGET_COMPILE_OPTIONS(${LIB_NAME} PRIVATE -Wno-error=implicit-function-declaration)
++endif()
  
  SET_TARGET_PROPERTIES(${LIB_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_VERSION} SOVERSION ${${PROJECT_NAME}_MAJOR_VERSION})
 -install(TARGETS ${LIB_NAME} DESTINATION ${LIB_DESTINATION})
@@ -211,7 +214,7 @@
  
      ENABLE_TESTING()
  
-@@ -181,7 +260,7 @@ IF (BUILD_SHARED_LIBS)
+@@ -181,7 +263,7 @@ IF (BUILD_SHARED_LIBS)
        set_target_properties(FPack Funpack PROPERTIES LINK_FLAGS "setargv.obj")
      endif(MSVC)
  


### PR DESCRIPTION
Specify library name and version:  **cfitsio/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

cfitsio relies on several implicit function declarations, which is not allowed in apple-clang 12 (same issue than https://github.com/conan-io/conan-center-index/pull/3670)