### PR TITLE
boost: add boost/1.75.0

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -34,6 +34,12 @@ sources:
       "https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.bz2"
     ]
     sha256: "83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1"
+  1.75.0:
+    url: [
+      "https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2",
+      "https://sourceforge.net/projects/boost/files/boost/1.75.0/boost_1_75_0.tar.bz2"
+    ]
+    sha256: "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb"
 patches:
   1.69.0:
     - patch_file: "patches/boost_build_asmflags.patch"

--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -1,27 +1,27 @@
 sources:
-  1.69.0:
-    url: [
-      "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2",
-      "https://sourceforge.net/projects/boost/files/boost/1.69.0/boost_1_69_0.tar.bz2",
-    ]
-    sha256: "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406"
-  1.70.0:
-    url: [
-      "https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2",
-      "https://sourceforge.net/projects/boost/files/boost/1.70.0/boost_1_70_0.tar.bz2",
-    ]
-    sha256: "430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778"
-  1.71.0:
-    url: [
-      "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2",
-    ]
-    sha256: "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee"
-  1.72.0:
-    url: [
-      "https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2",
-      "https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2",
-    ]
-    sha256: "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722"
+#  1.69.0:
+#    url: [
+#      "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2",
+#      "https://sourceforge.net/projects/boost/files/boost/1.69.0/boost_1_69_0.tar.bz2",
+#    ]
+#    sha256: "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406"
+#  1.70.0:
+#    url: [
+#      "https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2",
+#      "https://sourceforge.net/projects/boost/files/boost/1.70.0/boost_1_70_0.tar.bz2",
+#    ]
+#    sha256: "430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778"
+#  1.71.0:
+#    url: [
+#      "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2",
+#    ]
+#    sha256: "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee"
+#  1.72.0:
+#    url: [
+#      "https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2",
+#      "https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2",
+#    ]
+#    sha256: "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722"
   1.73.0:
     url: [
       "https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.bz2",
@@ -41,54 +41,54 @@ sources:
     ]
     sha256: "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb"
 patches:
-  1.69.0:
-    - patch_file: "patches/boost_build_asmflags.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/python_base_prefix.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/static_object_init.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/support_msvc_2019.patch"
-      base_path: "source_subfolder"
-  1.70.0:
-    - patch_file: "patches/0001-beast-fix-moved-from-executor.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/bcp_namespace_issues_1_70.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/python_base_prefix.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/solaris_pthread_data.patch"
-      base_path: "source_subfolder"
-  1.71.0:
-    - patch_file: "patches/bcp_namespace_issues_1_71.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/python_base_prefix.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/solaris_pthread_data.patch"
-      base_path: "source_subfolder"
-  1.72.0:
-    - patch_file: "patches/bcp_namespace_issues_1_72.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/python_base_prefix.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/solaris_pthread_data.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0001-revert-cease-dependence-on-range.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/boost_log_filesystem_no_deprecated_1_72.patch"
-      base_path: "source_subfolder"
+#  1.69.0:
+#    - patch_file: "patches/boost_build_asmflags.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/python_base_prefix.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/static_object_init.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/support_msvc_2019.patch"
+#      base_path: "source_subfolder"
+#  1.70.0:
+#    - patch_file: "patches/0001-beast-fix-moved-from-executor.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/bcp_namespace_issues_1_70.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/python_base_prefix.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/solaris_pthread_data.patch"
+#      base_path: "source_subfolder"
+#  1.71.0:
+#    - patch_file: "patches/bcp_namespace_issues_1_71.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/python_base_prefix.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/solaris_pthread_data.patch"
+#      base_path: "source_subfolder"
+#  1.72.0:
+#    - patch_file: "patches/bcp_namespace_issues_1_72.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/python_base_prefix.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/solaris_pthread_data.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/0001-revert-cease-dependence-on-range.patch"
+#      base_path: "source_subfolder"
+#    - patch_file: "patches/boost_log_filesystem_no_deprecated_1_72.patch"
+#      base_path: "source_subfolder"
   1.73.0:
     - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
       base_path: "source_subfolder"

--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -1,27 +1,27 @@
 sources:
-#  1.69.0:
-#    url: [
-#      "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2",
-#      "https://sourceforge.net/projects/boost/files/boost/1.69.0/boost_1_69_0.tar.bz2",
-#    ]
-#    sha256: "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406"
-#  1.70.0:
-#    url: [
-#      "https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2",
-#      "https://sourceforge.net/projects/boost/files/boost/1.70.0/boost_1_70_0.tar.bz2",
-#    ]
-#    sha256: "430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778"
-#  1.71.0:
-#    url: [
-#      "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2",
-#    ]
-#    sha256: "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee"
-#  1.72.0:
-#    url: [
-#      "https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2",
-#      "https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2",
-#    ]
-#    sha256: "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722"
+  1.69.0:
+    url: [
+      "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2",
+      "https://sourceforge.net/projects/boost/files/boost/1.69.0/boost_1_69_0.tar.bz2",
+    ]
+    sha256: "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406"
+  1.70.0:
+    url: [
+      "https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2",
+      "https://sourceforge.net/projects/boost/files/boost/1.70.0/boost_1_70_0.tar.bz2",
+    ]
+    sha256: "430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778"
+  1.71.0:
+    url: [
+      "https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2",
+    ]
+    sha256: "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee"
+  1.72.0:
+    url: [
+      "https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2",
+      "https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2",
+    ]
+    sha256: "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722"
   1.73.0:
     url: [
       "https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.bz2",
@@ -41,60 +41,65 @@ sources:
     ]
     sha256: "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb"
 patches:
-#  1.69.0:
-#    - patch_file: "patches/boost_build_asmflags.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/python_base_prefix.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/static_object_init.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/support_msvc_2019.patch"
-#      base_path: "source_subfolder"
-#  1.70.0:
-#    - patch_file: "patches/0001-beast-fix-moved-from-executor.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/bcp_namespace_issues_1_70.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/python_base_prefix.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/solaris_pthread_data.patch"
-#      base_path: "source_subfolder"
-#  1.71.0:
-#    - patch_file: "patches/bcp_namespace_issues_1_71.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/python_base_prefix.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/solaris_pthread_data.patch"
-#      base_path: "source_subfolder"
-#  1.72.0:
-#    - patch_file: "patches/bcp_namespace_issues_1_72.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/python_base_prefix.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/solaris_pthread_data.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/0001-revert-cease-dependence-on-range.patch"
-#      base_path: "source_subfolder"
-#    - patch_file: "patches/boost_log_filesystem_no_deprecated_1_72.patch"
-#      base_path: "source_subfolder"
+  1.69.0:
+    - patch_file: "patches/boost_build_asmflags.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/python_base_prefix.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/static_object_init.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/support_msvc_2019.patch"
+      base_path: "source_subfolder"
+  1.70.0:
+    - patch_file: "patches/0001-beast-fix-moved-from-executor.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/bcp_namespace_issues_1_70.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/python_base_prefix.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/solaris_pthread_data.patch"
+      base_path: "source_subfolder"
+  1.71.0:
+    - patch_file: "patches/bcp_namespace_issues_1_71.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/python_base_prefix.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/solaris_pthread_data.patch"
+      base_path: "source_subfolder"
+  1.72.0:
+    - patch_file: "patches/bcp_namespace_issues_1_72.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/boost_core_qnx_cxx_provide___cxa_get_globals.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/python_base_prefix.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/solaris_pthread_data.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0001-revert-cease-dependence-on-range.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/boost_log_filesystem_no_deprecated_1_72.patch"
+      base_path: "source_subfolder"
   1.73.0:
     - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/python_base_prefix.patch"
       base_path: "source_subfolder"
   1.74.0:
+    - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter_since_1_74.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/python_base_prefix_since_1_74.patch"
+      base_path: "source_subfolder"
+  1.75.0:
     - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter_since_1_74.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/python_base_prefix_since_1_74.patch"

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -691,6 +691,9 @@ class BoostConan(ConanFile):
     def _build_flags(self):
         flags = self._build_cross_flags
 
+        # Stop at the first error. No need to continue building.
+        flags.append("-q")
+
         # https://www.boost.org/doc/libs/1_70_0/libs/context/doc/html/context/architectures.html
         if self._b2_os:
             flags.append("target-os=%s" % self._b2_os)
@@ -822,6 +825,11 @@ class BoostConan(ConanFile):
                       "--abbreviate-paths"])
         if self.options.debug_level:
             flags.append("-d%d" % self.options.debug_level)
+
+        if self._with_iconv:
+            flags.append("-sICONV_PATH={}".format(self.deps_cpp_info["libiconv"].rootpath))
+        if self._with_icu:
+            flags.append("-sICU_PATH={}".format(self.deps_cpp_info["icu"].rootpath))
         return flags
 
     @property

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -201,11 +201,6 @@ class BoostConan(ConanFile):
             if "without_{}".format(opt_name) not in self.options:
                 raise ConanException("{} has the configure options {} which is not available in conanfile.py".format(self._dependency_filename, opt_name))
 
-        # Remove options not supported by this version of boost
-        for dep_name in CONFIGURE_OPTIONS:
-            if dep_name not in self._configure_options:
-                delattr(self.options, "without_{}".format(dep_name))
-
         # json requires a c++11-able compiler: change default to not build on compiler with too old default c++ standard or to low compiler.cppstd
         version_cxx11_standard = self._min_compiler_version_default_cxx11
         if self.settings.compiler.cppstd:
@@ -213,6 +208,11 @@ class BoostConan(ConanFile):
                 self.options.without_json = True
         elif tools.Version(self.settings.compiler.version) < version_cxx11_standard:
             self.options.without_json = True
+
+        # Remove options not supported by this version of boost
+        for dep_name in CONFIGURE_OPTIONS:
+            if dep_name not in self._configure_options:
+                delattr(self.options, "without_{}".format(dep_name))
 
     @property
     def _configure_options(self):

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -132,6 +132,8 @@ class BoostConan(ConanFile):
         return {
             "gcc": 5,
             "clang": 5,
+            "apple-clang": 8,  # guess
+            "Visual Studio": 14,  # guess
         }.get(str(self.settings.compiler))
 
     def export(self):
@@ -202,12 +204,14 @@ class BoostConan(ConanFile):
                 raise ConanException("{} has the configure options {} which is not available in conanfile.py".format(self._dependency_filename, opt_name))
 
         # json requires a c++11-able compiler: change default to not build on compiler with too old default c++ standard or to low compiler.cppstd
-        version_cxx11_standard = self._min_compiler_version_default_cxx11
         if self.settings.compiler.cppstd:
             if not tools.valid_min_cppstd(self, 11):
                 self.options.without_json = True
-        elif tools.Version(self.settings.compiler.version) < version_cxx11_standard:
-            self.options.without_json = True
+        else:
+            version_cxx11_standard = self._min_compiler_version_default_cxx11
+            if version_cxx11_standard:
+                if tools.Version(self.settings.compiler.version) < version_cxx11_standard:
+                    self.options.without_json = True
 
         # Remove options not supported by this version of boost
         for dep_name in CONFIGURE_OPTIONS:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -238,8 +238,6 @@ class BoostConan(ConanFile):
         return self._dependencies["configure_options"]
 
     def configure(self):
-        if self.settings.compiler != "Visual Studio":
-            raise ConanInvalidConfiguration("I build only MSVC")
         if self.options.without_locale:
             self.options.i18n_backend = None
         else:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -258,11 +258,12 @@ class BoostConan(ConanFile):
 
         if not self.options.get_safe("without_json", True):
             # json requires a c++11-able compiler.
-            version_cxx11_standard = self._min_compiler_version_default_cxx11
             if self.settings.compiler.cppstd:
                 tools.check_min_cppstd(self, 11)
-            elif tools.Version(self.settings.compiler.version) < version_cxx11_standard:
-                raise ConanInvalidConfiguration("Boost.json requires a c++11 compiler (please set compiler.cppstd or use a newer compiler)")
+            else:
+                version_cxx11_standard = self._min_compiler_version_default_cxx11
+                if tools.Version(self.settings.compiler.version) < version_cxx11_standard:
+                    raise ConanInvalidConfiguration("Boost.json requires a c++11 compiler (please set compiler.cppstd or use a newer compiler)")
 
     def build_requirements(self):
         if not self.options.header_only:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -67,7 +67,6 @@ class BoostConan(ConanFile):
 
     _options = None
 
-
     options = {
         "shared": [True, False],
         "header_only": [True, False],
@@ -239,6 +238,8 @@ class BoostConan(ConanFile):
         return self._dependencies["configure_options"]
 
     def configure(self):
+        if self.settings.compiler != "Visual Studio":
+            raise ConanInvalidConfiguration("I build only MSVC")
         if self.options.without_locale:
             self.options.i18n_backend = None
         else:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -129,10 +129,11 @@ class BoostConan(ConanFile):
 
     @property
     def _min_compiler_version_default_cxx11(self):
+        # Minimum compiler version having c++ standard >= 11
         return {
-            "gcc": 5,
-            "clang": 5,
-            "apple-clang": 8,  # guess
+            "gcc": 6,
+            "clang": 6,
+            "apple-clang": 12,  # guess
             "Visual Studio": 14,  # guess
         }.get(str(self.settings.compiler))
 

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1259,3 +1259,10 @@ class BoostConan(ConanFile):
                         self.cpp_info.components["_libboost"].cxxflags.append("-pthread")
                         self.cpp_info.components["_libboost"].sharedlinkflags.extend(["-pthread","--shared-memory"])
                         self.cpp_info.components["_libboost"].exelinkflags.extend(["-pthread","--shared-memory"])
+            elif self.settings.os == "iOS":
+                if self.options.multithreading:
+                    # https://github.com/conan-io/conan-center-index/issues/3867
+                    # runtime crashes occur when using the default platform-specific reference counter/atomic
+                    self.cpp_info.components["headers"].extend(["BOOST_AC_USE_PTHREADS", "BOOST_SP_USE_PTHREADS"])
+                else:
+                    self.cpp_info.components["headers"].extend(["BOOST_AC_DISABLE_THREADS", "BOOST_SP_DISABLE_THREADS"])

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1218,10 +1218,10 @@ class BoostConan(ConanFile):
                         if self.options.get_safe(requirement, None) == False:
                             continue
                         conan_requirement = self._option_to_conan_requirement(requirement)
-                        if not conan_requirement:
+                        if conan_requirement not in self.requires:
                             continue
-                        if conan_requirement in ("icu", "iconv"):
-                            if conan_requirement != self.options.get_safe("i18n_backend"):
+                        if module == "locale" and requirement in ("icu", "iconv"):
+                            if requirement != self.options.get_safe("i18n_backend"):
                                 continue
                         self.cpp_info.components[module].requires.append("{0}::{0}".format(conan_requirement))
 

--- a/recipes/boost/all/dependencies/dependencies-1.73.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.73.0.yml
@@ -16,6 +16,7 @@ configure_options:
 - log
 - math
 - mpi
+- nowide
 - program_options
 - python
 - random

--- a/recipes/boost/all/dependencies/dependencies-1.74.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.74.0.yml
@@ -16,6 +16,7 @@ configure_options:
 - log
 - math
 - mpi
+- nowide
 - program_options
 - python
 - random

--- a/recipes/boost/all/dependencies/dependencies-1.75.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.75.0.yml
@@ -1,0 +1,279 @@
+configure_options:
+- atomic
+- chrono
+- container
+- context
+- contract
+- coroutine
+- date_time
+- exception
+- fiber
+- filesystem
+- graph
+- graph_parallel
+- iostreams
+- json
+- locale
+- log
+- math
+- mpi
+- program_options
+- python
+- random
+- regex
+- serialization
+- stacktrace
+- system
+- test
+- thread
+- timer
+- type_erasure
+- wave
+dependencies:
+  atomic: []
+  chrono:
+  - system
+  container: []
+  context:
+  - thread
+  contract:
+  - exception
+  - thread
+  coroutine:
+  - context
+  - exception
+  - system
+  - thread
+  date_time: []
+  exception: []
+  fiber:
+  - context
+  - filesystem
+  fiber_numa:
+  - fiber
+  filesystem:
+  - system
+  graph:
+  - math
+  - random
+  - regex
+  - serialization
+  graph_parallel:
+  - filesystem
+  - graph
+  - mpi
+  - random
+  - serialization
+  iostreams:
+  - random
+  - regex
+  json:
+  - container
+  - exception
+  - system
+  locale:
+  - thread
+  log:
+  - atomic
+  - container
+  - date_time
+  - exception
+  - filesystem
+  - locale
+  - random
+  - regex
+  - system
+  - thread
+  log_setup:
+  - log
+  math:
+  - atomic
+  math_c99:
+  - math
+  math_c99f:
+  - math
+  math_c99l:
+  - math
+  math_tr1:
+  - math
+  math_tr1f:
+  - math
+  math_tr1l:
+  - math
+  mpi:
+  - graph
+  - serialization
+  mpi_python:
+  - mpi
+  - python
+  nowide:
+  - filesystem
+  numpy:
+  - python
+  prg_exec_monitor:
+  - test
+  program_options: []
+  python: []
+  random:
+  - math
+  - system
+  regex: []
+  serialization: []
+  stacktrace: []
+  stacktrace_addr2line:
+  - stacktrace
+  stacktrace_backtrace:
+  - stacktrace
+  stacktrace_basic:
+  - stacktrace
+  stacktrace_noop:
+  - stacktrace
+  stacktrace_windbg:
+  - stacktrace
+  stacktrace_windbg_cached:
+  - stacktrace
+  system: []
+  test:
+  - exception
+  test_exec_monitor:
+  - test
+  thread:
+  - atomic
+  - chrono
+  - container
+  - date_time
+  - exception
+  - system
+  timer:
+  - chrono
+  - system
+  type_erasure:
+  - thread
+  unit_test_framework:
+  - prg_exec_monitor
+  - test
+  - test_exec_monitor
+  wave:
+  - filesystem
+  - serialization
+  wserialization:
+  - serialization
+libs:
+  atomic:
+  - boost_atomic
+  chrono:
+  - boost_chrono
+  container:
+  - boost_container
+  context:
+  - boost_context
+  contract:
+  - boost_contract
+  coroutine:
+  - boost_coroutine
+  date_time:
+  - boost_date_time
+  exception:
+  - boost_exception
+  fiber:
+  - boost_fiber
+  fiber_numa:
+  - boost_fiber_numa
+  filesystem:
+  - boost_filesystem
+  graph:
+  - boost_graph
+  graph_parallel:
+  - boost_graph_parallel
+  iostreams:
+  - boost_iostreams
+  json:
+  - boost_json
+  locale:
+  - boost_locale
+  log:
+  - boost_log
+  log_setup:
+  - boost_log_setup
+  math: []
+  math_c99:
+  - boost_math_c99
+  math_c99f:
+  - boost_math_c99f
+  math_c99l:
+  - boost_math_c99l
+  math_tr1:
+  - boost_math_tr1
+  math_tr1f:
+  - boost_math_tr1f
+  math_tr1l:
+  - boost_math_tr1l
+  mpi:
+  - boost_mpi
+  mpi_python:
+  - boost_mpi_python
+  nowide:
+  - boost_nowide
+  numpy:
+  - boost_numpy{py_major}{py_minor}
+  prg_exec_monitor:
+  - boost_prg_exec_monitor
+  program_options:
+  - boost_program_options
+  python:
+  - boost_python{py_major}{py_minor}
+  random:
+  - boost_random
+  regex:
+  - boost_regex
+  serialization:
+  - boost_serialization
+  stacktrace: []
+  stacktrace_addr2line:
+  - boost_stacktrace_addr2line
+  stacktrace_backtrace:
+  - boost_stacktrace_backtrace
+  stacktrace_basic:
+  - boost_stacktrace_basic
+  stacktrace_noop:
+  - boost_stacktrace_noop
+  stacktrace_windbg:
+  - boost_stacktrace_windbg
+  stacktrace_windbg_cached:
+  - boost_stacktrace_windbg_cached
+  system:
+  - boost_system
+  test: []
+  test_exec_monitor:
+  - boost_test_exec_monitor
+  thread:
+  - boost_thread
+  timer:
+  - boost_timer
+  type_erasure:
+  - boost_type_erasure
+  unit_test_framework:
+  - boost_unit_test_framework
+  wave:
+  - boost_wave
+  wserialization:
+  - boost_wserialization
+requirements:
+  iostreams:
+  - bzip2
+  - lzma
+  - zlib
+  - zstd
+  locale:
+  - iconv
+  - icu
+  python:
+  - python
+  regex:
+  - icu
+  stacktrace:
+  - backtrace
+static_only:
+- boost_exception
+- boost_test_exec_monitor
+version: 1.75.0

--- a/recipes/boost/all/dependencies/dependencies-1.75.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.75.0.yml
@@ -17,6 +17,7 @@ configure_options:
 - log
 - math
 - mpi
+- nowide
 - program_options
 - python
 - random

--- a/recipes/boost/all/rebuild-dependencies.py
+++ b/recipes/boost/all/rebuild-dependencies.py
@@ -38,6 +38,7 @@ CONFIGURE_OPTIONS = (
     "graph",
     "graph_parallel",
     "iostreams",
+    "json",
     "locale",
     "log",
     "math",
@@ -149,6 +150,9 @@ class BoostDependencyBuilder(object):
             print("Re-init git submodules")
             subprocess.check_call(["git", "submodule", "update", "--init"])
 
+            print("Removing unknown files/directories")
+            subprocess.check_call(["git", "clean", "-d", "-f"])
+
     def do_install_boostdep(self):
         with tools.chdir(str(self.boost_path)):
             print("Installing boostdep/{}".format(self.boostdep_version))
@@ -224,8 +228,8 @@ class BoostDependencyBuilder(object):
     def do_boostdep_collect(self) -> BoostDependencies:
         with tools.chdir(str(self.boost_path)):
             with tools.environment_append({"PATH": self._bin_paths}):
-                buildables = subprocess.check_output(["boostdep", "--list-buildable"])
-                buildables = buildables.decode().splitlines()
+                buildables = subprocess.check_output(["boostdep", "--list-buildable"], text=True)
+                buildables = buildables.splitlines()
                 log.debug("`boostdep --list--buildable` returned these buildables: %s", buildables)
 
                 # modules = subprocess.check_output(["boostdep", "--list-modules"])
@@ -234,10 +238,18 @@ class BoostDependencyBuilder(object):
                 dep_modules = buildables
 
                 dependency_tree = {}
-                for module in dep_modules:
-                    module_ts_output = subprocess.check_output(["boostdep", "--track-sources", module])
-                    mod_deps = re.findall("\n([A-Za-z_-]+):\n", module_ts_output.decode())
-                    dependency_tree[module] = mod_deps
+                buildable_dependencies = subprocess.check_output(["boostdep", "--list-buildable-dependencies"], text=True)
+                log.debug("boosdep --list-buildable-dependencies returnes: %s", buildable_dependencies)
+                for line in buildable_dependencies.splitlines():
+                    if re.match(r"^[\s]*#.*", line):
+                        continue
+                    match = re.match(r"([\S]+)\s*=\s*([^;]+)\s*;\s*", line)
+                    if not match:
+                        continue
+                    master = match.group(1)
+                    dependencies = re.split(r"\s+", match.group(2).strip())
+                    dependency_tree[master] = dependencies
+
                 log.debug("Using `boostdep --track-sources`, the following dependency tree was calculated:")
                 log.debug(pprint.pformat(dependency_tree))
 
@@ -307,6 +319,12 @@ class BoostDependencyBuilder(object):
 
         if "mpi_python" in deptree and "python" not in deptree["mpi_python"]:
             deptree["mpi_python"].append("python")
+
+        # Break random/math dependency cycle
+        try:
+            deptree["math"].remove("random")
+        except ValueError:
+            pass
 
         remaining_tree = self.detect_cycles(deptree)
         if remaining_tree:
@@ -389,7 +407,6 @@ class BoostDependencyBuilder(object):
         elif isinstance(item, list):
             return list(cls._sort_item(e) for e in sorted(item))
         else:
-            print("UNKNOWN", type(item), item)
             return item
 
     def do_create_dependency_file(self) -> None:
@@ -413,7 +430,7 @@ def main(args=None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--verbose", dest="verbose", action="store_true", help="verbose output")
     parser.add_argument("-t", dest="tmppath", help="temporary folder where to clone boost (default is system temporary folder)")
-    parser.add_argument("-d", dest="boostdep_version", default="1.74.0", type=str, help="boostdep version")
+    parser.add_argument("-d", dest="boostdep_version", default="1.75.0", type=str, help="boostdep version")
     parser.add_argument("-u", dest="git_url", default=BOOST_GIT_URL, help="boost git url")
     parser.add_argument("-U", dest="git_update", action="store_true", help="update the git repo")
     parser.add_argument("-o", dest="outputdir", default=None, type=Path, help="output dependency dir")

--- a/recipes/boost/all/rebuild-dependencies.py
+++ b/recipes/boost/all/rebuild-dependencies.py
@@ -43,6 +43,7 @@ CONFIGURE_OPTIONS = (
     "log",
     "math",
     "mpi",
+    "nowide",
     "program_options",
     "python",
     "random",
@@ -455,7 +456,6 @@ def main(args=None) -> int:
     ns.outputdir.mkdir(exist_ok=True)
 
     git_update_done = False
-    boostdep_installed = False
 
     if ns.boost_version is None:
         conan_data = yaml.safe_load(Path("conandata.yml").open())
@@ -484,9 +484,7 @@ def main(args=None) -> int:
 
         boost_collector.do_git_submodule_update()
 
-        if not boostdep_installed:
-            boost_collector.do_install_boostdep()
-            boostdep_installed = True
+        boost_collector.do_install_boostdep()
 
         boost_collector.do_create_dependency_file()
     return 0

--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -35,6 +35,12 @@ if(NOT HEADER_ONLY)
         target_link_libraries(chrono_exe PRIVATE Boost::chrono)
     endif()
 
+    if(WITH_JSON)
+        find_package(Boost COMPONENTS json REQUIRED)
+        add_executable(json_exe json.cpp)
+        target_link_libraries(json_exe PRIVATE Boost::json)
+    endif()
+
     if(WITH_PYTHON)
         find_package(Boost COMPONENTS python REQUIRED)
         add_library(hello_ext MODULE python.cpp)

--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -35,10 +35,22 @@ if(NOT HEADER_ONLY)
         target_link_libraries(chrono_exe PRIVATE Boost::chrono)
     endif()
 
+    if(WITH_FIBER)
+        find_package(Boost COMPONENTS fiber REQUIRED)
+        add_executable(fiber_exe fiber.cpp)
+        target_link_libraries(fiber_exe PRIVATE Boost::fiber)
+    endif()
+
     if(WITH_JSON)
         find_package(Boost COMPONENTS json REQUIRED)
         add_executable(json_exe json.cpp)
         target_link_libraries(json_exe PRIVATE Boost::json)
+    endif()
+
+    if(WITH_NOWIDE)
+        find_package(Boost COMPONENTS nowide REQUIRED)
+        add_executable(nowide_exe nowide.cpp)
+        target_link_libraries(nowide_exe PRIVATE Boost::nowide)
     endif()
 
     if(WITH_LOCALE)

--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -41,6 +41,12 @@ if(NOT HEADER_ONLY)
         target_link_libraries(json_exe PRIVATE Boost::json)
     endif()
 
+    if(WITH_LOCALE)
+        find_package(Boost COMPONENTS locale REQUIRED)
+        add_executable(locale_exe locale.cpp)
+        target_link_libraries(locale_exe PRIVATE Boost::locale)
+    endif()
+
     if(WITH_PYTHON)
         find_package(Boost COMPONENTS python REQUIRED)
         add_library(hello_ext MODULE python.cpp)

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -7,11 +7,11 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "arch", "build_type"
     generators = "cmake", "cmake_find_package"
 
-    def _boost_option(self, name):
+    def _boost_option(self, name, default):
         try:
-            return getattr(self.options["boost"], name)
+            return getattr(self.options["boost"], name, default)
         except (AttributeError, ConanException):
-            return False
+            return default
 
     def build(self):
         # FIXME: tools.vcvars added for clang-cl. Remove once conan supports clang-cl properly. (https://github.com/conan-io/conan-center-index/pull/1453)
@@ -30,7 +30,7 @@ class TestPackageConan(ConanFile):
             cmake.definitions["WITH_TEST"] = not self.options["boost"].without_test
             cmake.definitions["WITH_COROUTINE"] = not self.options["boost"].without_coroutine
             cmake.definitions["WITH_CHRONO"] = not self.options["boost"].without_chrono
-            cmake.definitions["WITH_JSON"] = not self._boost_option("without_json")
+            cmake.definitions["WITH_JSON"] = not self._boost_option("without_json", True)
             cmake.configure()
             cmake.build()
 

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -30,6 +30,7 @@ class TestPackageConan(ConanFile):
             cmake.definitions["WITH_TEST"] = not self.options["boost"].without_test
             cmake.definitions["WITH_COROUTINE"] = not self.options["boost"].without_coroutine
             cmake.definitions["WITH_CHRONO"] = not self.options["boost"].without_chrono
+            cmake.definitions["WITH_LOCALE"] = not self.options["boost"].without_locale
             cmake.definitions["WITH_JSON"] = not self._boost_option("without_json", True)
             cmake.configure()
             cmake.build()
@@ -50,6 +51,8 @@ class TestPackageConan(ConanFile):
             self.run(os.path.join("bin", "coroutine_exe"), run_environment=True)
         if not self.options["boost"].without_chrono:
             self.run(os.path.join("bin", "chrono_exe"), run_environment=True)
+        if not self.options["boost"].without_locale:
+            self.run(os.path.join("bin", "locale_exe"), run_environment=True)
         if not self._boost_option("without_json", True):
             self.run(os.path.join("bin", "json_exe"), run_environment=True)
         if not self.options["boost"].without_python:

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -50,7 +50,7 @@ class TestPackageConan(ConanFile):
             self.run(os.path.join("bin", "coroutine_exe"), run_environment=True)
         if not self.options["boost"].without_chrono:
             self.run(os.path.join("bin", "chrono_exe"), run_environment=True)
-        if not self._boost_option("without_json"):
+        if not self._boost_option("without_json", False):
             self.run(os.path.join("bin", "json_exe"), run_environment=True)
         if not self.options["boost"].without_python:
             with tools.environment_append({"PYTHONPATH": "{}:{}".format("bin", "lib")}):

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -50,7 +50,7 @@ class TestPackageConan(ConanFile):
             self.run(os.path.join("bin", "coroutine_exe"), run_environment=True)
         if not self.options["boost"].without_chrono:
             self.run(os.path.join("bin", "chrono_exe"), run_environment=True)
-        if not self._boost_option("without_json", False):
+        if not self._boost_option("without_json", True):
             self.run(os.path.join("bin", "json_exe"), run_environment=True)
         if not self.options["boost"].without_python:
             with tools.environment_append({"PYTHONPATH": "{}:{}".format("bin", "lib")}):

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -30,7 +30,9 @@ class TestPackageConan(ConanFile):
             cmake.definitions["WITH_TEST"] = not self.options["boost"].without_test
             cmake.definitions["WITH_COROUTINE"] = not self.options["boost"].without_coroutine
             cmake.definitions["WITH_CHRONO"] = not self.options["boost"].without_chrono
+            cmake.definitions["WITH_FIBER"] = not self.options["boost"].without_fiber
             cmake.definitions["WITH_LOCALE"] = not self.options["boost"].without_locale
+            cmake.definitions["WITH_NOWIDE"] = not self._boost_option("without_nowide", True)
             cmake.definitions["WITH_JSON"] = not self._boost_option("without_json", True)
             cmake.configure()
             cmake.build()
@@ -51,8 +53,12 @@ class TestPackageConan(ConanFile):
             self.run(os.path.join("bin", "coroutine_exe"), run_environment=True)
         if not self.options["boost"].without_chrono:
             self.run(os.path.join("bin", "chrono_exe"), run_environment=True)
+        if not self.options["boost"].without_fiber:
+            self.run(os.path.join("bin", "fiber_exe"), run_environment=True)
         if not self.options["boost"].without_locale:
             self.run(os.path.join("bin", "locale_exe"), run_environment=True)
+        if not self._boost_option("without_nowide", True):
+            self.run("{} {}".format(os.path.join("bin", "nowide_exe"), os.path.join(self.source_folder, "conanfile.py")), run_environment=True)
         if not self._boost_option("without_json", True):
             self.run(os.path.join("bin", "json_exe"), run_environment=True)
         if not self.options["boost"].without_python:

--- a/recipes/boost/all/test_package/fiber.cpp
+++ b/recipes/boost/all/test_package/fiber.cpp
@@ -1,0 +1,130 @@
+//          Copyright Nat Goodspeed + Oliver Kowalke 2015.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#include <boost/assert.hpp>
+
+#include <boost/fiber/all.hpp>
+
+#include <boost/fiber/detail/thread_barrier.hpp>
+
+static std::size_t fiber_count{ 0 };
+static std::mutex mtx_count{};
+static boost::fibers::condition_variable_any cnd_count{};
+typedef std::unique_lock< std::mutex > lock_type;
+
+/*****************************************************************************
+ *   example fiber function
+ *****************************************************************************/
+//[fiber_fn_ws
+void whatevah( char me) {
+    try {
+        std::thread::id my_thread = std::this_thread::get_id(); /**< get ID of initial thread >*/
+        {
+            std::ostringstream buffer;
+            buffer << "fiber " << me << " started on thread " << my_thread << '\n';
+            std::cout << buffer.str() << std::flush;
+        }
+        for ( unsigned i = 0; i < 10; ++i) { /**< loop ten times >*/
+            boost::this_fiber::yield(); /**< yield to other fibers >*/
+            std::thread::id new_thread = std::this_thread::get_id(); /**< get ID of current thread >*/
+            if ( new_thread != my_thread) { /**< test if fiber was migrated to another thread >*/
+                my_thread = new_thread;
+                std::ostringstream buffer;
+                buffer << "fiber " << me << " switched to thread " << my_thread << '\n';
+                std::cout << buffer.str() << std::flush;
+            }
+        }
+    } catch ( ... ) {
+    }
+    lock_type lk( mtx_count);
+    if ( 0 == --fiber_count) { /**< Decrement fiber counter for each completed fiber. >*/
+        lk.unlock();
+        cnd_count.notify_all(); /**< Notify all fibers waiting on `cnd_count`. >*/
+    }
+}
+//]
+
+/*****************************************************************************
+ *   example thread function
+ *****************************************************************************/
+//[thread_fn_ws
+void thread( boost::fibers::detail::thread_barrier * b) {
+    std::ostringstream buffer;
+    buffer << "thread started " << std::this_thread::get_id() << std::endl;
+    std::cout << buffer.str() << std::flush;
+    boost::fibers::use_scheduling_algorithm< boost::fibers::algo::shared_work >(); /**<
+                                                                                    Install the scheduling algorithm `boost::fibers::algo::shared_work` in order to
+                                                                                    join the work sharing.
+                                                                                    >*/
+    b->wait(); /**< sync with other threads: allow them to start processing >*/
+    lock_type lk( mtx_count);
+    cnd_count.wait( lk, [](){ return 0 == fiber_count; } ); /**<
+                                                             Suspend main fiber and resume worker fibers in the meanwhile.
+                                                             Main fiber gets resumed (e.g returns from `condition_variable_any::wait()`)
+                                                             if all worker fibers are complete.
+                                                             >*/
+    BOOST_ASSERT( 0 == fiber_count);
+}
+//]
+
+/*****************************************************************************
+ *   main()
+ *****************************************************************************/
+int main( int argc, char *argv[]) {
+    std::cout << "main thread started " << std::this_thread::get_id() << std::endl;
+    //[main_ws
+    boost::fibers::use_scheduling_algorithm< boost::fibers::algo::shared_work >(); /*<
+                                                                                    Install the scheduling algorithm `boost::fibers::algo::shared_work` in the main thread
+                                                                                    too, so each new fiber gets launched into the shared pool.
+                                                                                    >*/
+
+    for ( char c : std::string("abcdefghijklmnopqrstuvwxyz")) { /*<
+                                                                 Launch a number of worker fibers; each worker fiber picks up a character
+                                                                 that is passed as parameter to fiber-function `whatevah`.
+                                                                 Each worker fiber gets detached.
+                                                                 >*/
+        boost::fibers::fiber([c](){ whatevah( c); }).detach();
+        ++fiber_count; /*< Increment fiber counter for each new fiber. >*/
+    }
+    boost::fibers::detail::thread_barrier b( 4);
+    std::thread threads[] = { /*<
+                               Launch a couple of threads that join the work sharing.
+                               >*/
+        std::thread( thread, & b),
+        std::thread( thread, & b),
+        std::thread( thread, & b)
+    };
+    b.wait(); /*< sync with other threads: allow them to start processing >*/
+    {
+        lock_type/*< `lock_type` is typedef'ed as __unique_lock__< [@http://en.cppreference.com/w/cpp/thread/mutex `std::mutex`] > >*/ lk( mtx_count);
+        cnd_count.wait( lk, [](){ return 0 == fiber_count; } ); /*<
+                                                                 Suspend main fiber and resume worker fibers in the meanwhile.
+                                                                 Main fiber gets resumed (e.g returns from `condition_variable_any::wait()`)
+                                                                 if all worker fibers are complete.
+                                                                 >*/
+    } /*<
+       Releasing lock of mtx_count is required before joining the threads, otherwise
+       the other threads would be blocked inside condition_variable::wait() and
+       would never return (deadlock).
+       >*/
+    BOOST_ASSERT( 0 == fiber_count);
+    for ( std::thread & t : threads) { /*< wait for threads to terminate >*/
+        t.join();
+    }
+    //]
+    std::cout << "done." << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/recipes/boost/all/test_package/json.cpp
+++ b/recipes/boost/all/test_package/json.cpp
@@ -1,0 +1,18 @@
+#include <boost/json.hpp>
+using namespace boost::json;
+
+#include <string>
+#include <iostream>
+
+int main() {
+    object obj;
+    obj[ "pi" ] = 3.141;
+    obj[ "happy" ] = true;
+    obj[ "name" ] = "Boost";
+    obj[ "nothing" ] = nullptr;
+    obj[ "answer" ].emplace_object()["everything"] = 42;
+    obj[ "list" ] = { 1, 0, 2 };
+    obj[ "object" ] = { {"currency", "USD"}, {"value", 42.99} };
+    std::string s = serialize(obj);
+    std::cout << s << '\n';
+}

--- a/recipes/boost/all/test_package/locale.cpp
+++ b/recipes/boost/all/test_package/locale.cpp
@@ -1,0 +1,56 @@
+//
+//  Copyright (c) 2009-2011 Artyom Beilis (Tonkikh)
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+#include <boost/locale.hpp>
+#include <iostream>
+#include <iomanip>
+#include <ctime>
+int main()
+{
+    using namespace boost::locale;
+    generator gen;
+    std::locale::global(gen(""));
+    std::cout.imbue(std::locale());
+    // Setup environment
+    boost::locale::date_time now;
+    date_time start=now;
+    // Set the first day of the first month of this year
+    start.set(period::month(),now.minimum(period::month()));
+    start.set(period::day(),start.minimum(period::day()));
+    int current_year = period::year(now);
+    // Display current year
+    std::cout << format("{1,ftime='%Y'}") % now << std::endl;
+    //
+    // Run forward untill current year is the date
+    //
+    for(now=start; period::year(now) == current_year;) {
+        // Print heading of month
+        if(calendar().is_gregorian())
+            std::cout << format("{1,ftime='%B'}") % now <<std::endl;
+        else
+            std::cout << format("{1,ftime='%B'} ({1,ftime='%Y-%m-%d',locale=en} - {2,locale=en,ftime='%Y-%m-%d'})")
+                % now
+                % date_time(now,now.maximum(period::day())*period::day()) << std::endl;
+        int first = calendar().first_day_of_week();
+        // Print weeks days
+        for(int i=0;i<7;i++) {
+            date_time tmp(now,period::day_of_week() * (first + i));
+            std::cout << format("{1,w=8,ftime='%a'} ") % tmp;
+        }
+        std::cout << std::endl;
+        int current_month = now / period::month();
+        int skip = now / period::day_of_week_local() - 1;
+        for(int i=0;i<skip*9;i++)
+            std::cout << ' ';
+        for(;now / period::month() == current_month ;now += period::day()) {
+            std::cout << format("{1,w=8,ftime='%e'} ") % now;
+            if(now / period::day_of_week_local() == 7)
+                std::cout << std::endl;
+        }
+        std::cout << std::endl;
+    }
+}

--- a/recipes/boost/all/test_package/nowide.cpp
+++ b/recipes/boost/all/test_package/nowide.cpp
@@ -1,0 +1,26 @@
+#include <boost/nowide/args.hpp>
+#include <boost/nowide/fstream.hpp>
+#include <boost/nowide/iostream.hpp>
+int main(int argc,char **argv)
+{
+    boost::nowide::args a(argc,argv); // Fix arguments - make them UTF-8
+    if(argc!=2) {
+        boost::nowide::cerr << "Usage: file_name" << std::endl; // Unicode aware console
+        return 1;
+    }
+    boost::nowide::ifstream f(argv[1]); // argv[1] - is UTF-8
+    if(!f) {
+        // the console can display UTF-8
+        boost::nowide::cerr << "Can't open " << argv[1] << std::endl;
+        return 1;
+    }
+    int total_lines = 0;
+    while(f) {
+        if(f.get() == '\n')
+            total_lines++;
+    }
+    f.close();
+    // the console can display UTF-8
+    boost::nowide::cout << "File " << argv[1] << " has " << total_lines << " lines" << std::endl;
+    return 0;
+}

--- a/recipes/boost/all/test_package/nowide.cpp
+++ b/recipes/boost/all/test_package/nowide.cpp
@@ -1,3 +1,5 @@
+// This include fixes the following error on MSVC2019/static/MD with boost/1.73.0:
+// error C2027: use of undefined type 'std::basic_ios<char,std::char_traits<char>>'
 #include <ios>
 
 #include <boost/nowide/args.hpp>

--- a/recipes/boost/all/test_package/nowide.cpp
+++ b/recipes/boost/all/test_package/nowide.cpp
@@ -1,3 +1,5 @@
+#include <ios>
+
 #include <boost/nowide/args.hpp>
 #include <boost/nowide/fstream.hpp>
 #include <boost/nowide/iostream.hpp>

--- a/recipes/boost/config.yml
+++ b/recipes/boost/config.yml
@@ -11,3 +11,5 @@ versions:
       folder: all
     1.74.0:
       folder: all
+    1.75.0:
+      folder: all

--- a/recipes/boost/config.yml
+++ b/recipes/boost/config.yml
@@ -1,12 +1,12 @@
 versions:
-    1.69.0:
-      folder: all
-    1.70.0:
-      folder: all
-    1.71.0:
-      folder: all
-    1.72.0:
-      folder: all
+#    1.69.0:
+#      folder: all
+#    1.70.0:
+#      folder: all
+#    1.71.0:
+#      folder: all
+#    1.72.0:
+#      folder: all
     1.73.0:
       folder: all
     1.74.0:

--- a/recipes/boost/config.yml
+++ b/recipes/boost/config.yml
@@ -1,12 +1,12 @@
 versions:
-#    1.69.0:
-#      folder: all
-#    1.70.0:
-#      folder: all
-#    1.71.0:
-#      folder: all
-#    1.72.0:
-#      folder: all
+    1.69.0:
+      folder: all
+    1.70.0:
+      folder: all
+    1.71.0:
+      folder: all
+    1.72.0:
+      folder: all
     1.73.0:
       folder: all
     1.74.0:


### PR DESCRIPTION
Specify library name and version:  **boost/1.75.0**

Fixes #3899: assertions are still here, but the options have correct(er) defaults
Fixes #3895: allow building with a static icu dependency (`-o boost:i18n_backend=icu`)
Fixes #3890: fix building with Android
Fixes #3869: libsuffix of a versioned layout is calculated correctly (:crossed_fingers:) now
Fixes #3867: define `BOOST_(AS|SP)_USE_PTHREADS`
Fixes #3863: this adds 1.75.0
Fixes #3522: this line has been changed by the layout change
Fixes #3205: test_package uses targets now
Fixes #1925: boost uses components now

- The dependency generator needed a modification because boostdep emitted a circular dependency between `math` and `random`.
- I've also modified the main conanfile bit: before, the code would emit an error when a circular dependency was detected. Now it passes through. Conan itself will complain when components have circular dependencies.
- add json option + test json libary (json is also available header-only, but that is not tested)
- fix layout suffix
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
