### PR TITLE
libsystemd/all: Make version compatible with original .pc file

### DIFF
--- a/recipes/libsystemd/all/conanfile.py
+++ b/recipes/libsystemd/all/conanfile.py
@@ -152,4 +152,8 @@ class LibsystemdConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["systemd"]
+        # FIXME: this `.version` should only happen for the `pkg_config`
+        #  generator (see https://github.com/conan-io/conan/issues/8202)
+        # systemd uses only major version in its .pc file
+        self.cpp_info.version = tools.Version(self.version).major
         self.cpp_info.system_libs = ["rt", "pthread", "dl"]


### PR DESCRIPTION
Original libsystemd.pc file contains only major version.
E.g. '246' instead of '246.6'.
libsystemd.pc should looks like this:
```
Name: systemd
Description: systemd Library
URL: https://www.freedesktop.org/wiki/Software/systemd
Version: 246
Libs: -L${libdir} -lsystemd
Cflags: -I${includedir}
```

Specify library name and version:  **libsystemd/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
