### PR TITLE
[gperf] Patch gperf to remove register storage classifier (deprecated in C++17)

### DIFF
--- a/recipes/gperf/all/conandata.yml
+++ b/recipes/gperf/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "3.1":
     url: "https://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"
     sha256: "588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
+patches:
+  "3.1":
+    - patch_file: "patches/0001-remove_register_classifier.patch"
+      base_path: "source_subfolder"

--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -8,6 +8,7 @@ class GperfConan(ConanFile):
     homepage = "https://www.gnu.org/software/gperf"
     description = "GNU gperf is a perfect hash function generator"
     topics = ("conan", "gperf", "hash-generator", "hash")
+    exports_sources = ["patches/*"]
     settings = "os", "arch", "compiler"
     _source_subfolder = "source_subfolder"
     _autotools = None
@@ -61,7 +62,12 @@ class GperfConan(ConanFile):
             autotools = self._configure_autotools()
             autotools.make()
 
+    def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+    
     def build(self):
+        self._patch_sources()
         if self._is_msvc:
             with tools.vcvars(self.settings):
                 self._build_configure()

--- a/recipes/gperf/all/patches/0001-remove_register_classifier.patch
+++ b/recipes/gperf/all/patches/0001-remove_register_classifier.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/getline.cc b/lib/getline.cc
+index c57c633..0984a7c 100644
+--- a/lib/getline.cc
++++ b/lib/getline.cc
+@@ -55,7 +55,7 @@ getstr (char **lineptr, size_t *n, FILE *stream, char terminator, size_t offset)
+ 
+   for (;;)
+     {
+-      register int c = getc (stream);
++      int c = getc (stream);
+ 
+       /* We always want at least one char left in the buffer, since we
+          always (unless we get an error while reading the first char)


### PR DESCRIPTION
Specify library name and version:  **gperf/3.1**

I will open patch request upstream time permitting. The `register` storage specifier does not compile in newer versions of Clang.

- [✓] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [✓] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [✓] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [✓] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
