### PR TITLE
Fix an upstream bug in PostgreSQL BLOB extractor

### DIFF
--- a/recipes/poco/all/conandata.yml
+++ b/recipes/poco/all/conandata.yml
@@ -36,3 +36,5 @@ patches:
   1.10.1:
     - patch_file: patches/1.10.1.patch
       base_path: source_subfolder
+    - patch_file: patches/1.10.1-fix-postgresql-blob-extractor.patch
+      base_path: source_subfolder

--- a/recipes/poco/all/patches/1.10.1-fix-postgresql-blob-extractor.patch
+++ b/recipes/poco/all/patches/1.10.1-fix-postgresql-blob-extractor.patch
@@ -1,0 +1,10 @@
+--- Data/PostgreSQL/src/Extractor.cpp	2020-02-17 13:47:53.000000000 +0300
++++ Data/PostgreSQL/src/Extractor.cpp	2020-12-11 17:37:34.929302500 +0300
+@@ -317,6 +317,7 @@
+ 
+ 	const char * pBLOB = reinterpret_cast<const char*>(outputParameter.pData());
+ 	std::size_t BLOBSize  = outputParameter.size();
++	val = Poco::Data::BLOB(); // don't share contents with _default
+ 
+ 	if	(	'\\' == pBLOB[0]
+ 		 && 'x'  == pBLOB[1]	// preamble to BYTEA data format in text form is \x


### PR DESCRIPTION
Specify library name and version:  **poco/1.10.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I've tested the fix locally and already submitted https://github.com/pocoproject/poco/pull/3166 but would like to have the working package in the meantime (the best scenario will be including this fix into poco 1.10.2, but I don't expect it to be done soon)