### PR TITLE
automake: add arch/compiler to settings and remove it in package_id

### DIFF
--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -23,6 +23,10 @@ class AutomakeConan(ConanFile):
         [major, minor, _] = self.version.split(".", 2)
         return '{}.{}'.format(major, minor)
 
+    def configure(self):
+        del self.settings.compiler.cppstd
+        del self.settings.compiler.libcxx
+
     def requirements(self):
         self.requires("autoconf/2.69")
         # automake requires perl-Thread-Queue package

--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -11,7 +11,7 @@ class AutomakeConan(ConanFile):
     exports_sources = ["patches/**"]
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
 
-    settings = "os"
+    settings = "os", "arch", "compiler"
     _autotools = None
 
     @property
@@ -23,18 +23,21 @@ class AutomakeConan(ConanFile):
         [major, minor, _] = self.version.split(".", 2)
         return '{}.{}'.format(major, minor)
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
-
     def requirements(self):
         self.requires("autoconf/2.69")
         # automake requires perl-Thread-Queue package
 
+    def package_id(self):
+        del self.settings.arch
+        del self.settings.compiler
+
     def build_requirements(self):
-        if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ \
-                and tools.os_info.detect_windows_subsystem() != "msys2":
-            self.build_requires("msys2/20190524")
+        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/20200517")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
 
     @property
     def _datarootdir(self):

--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -28,8 +28,8 @@ class AutomakeConan(ConanFile):
         # automake requires perl-Thread-Queue package
 
     def package_id(self):
-        del self.settings.arch
-        del self.settings.compiler
+        del self.info.settings.arch
+        del self.info.settings.compiler
 
     def build_requirements(self):
         if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):


### PR DESCRIPTION
Specify library name and version:  **automake/all**


Fixes #3891


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
