### PR TITLE
autoconf: add compiler to settings (which is then removed in package_id

### DIFF
--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -10,7 +10,7 @@ class AutoconfConan(ConanFile):
     topics = ("conan", "autoconf", "configure", "build")
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
     exports_sources = "patches/**"
-    settings = "os", "arch"
+    settings = "os", "arch", "compiler"
     _autotools = None
 
     @property
@@ -23,6 +23,12 @@ class AutoconfConan(ConanFile):
 
     def requirements(self):
         self.requires("m4/1.4.18")
+
+    def package_id(self):
+        del self.info.settings.arch
+        del self.info.settings.compiler
+        # The m4 requirement does not change the contents of this package
+        self.info.requires.clear()
 
     def build_requirements(self):
         if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:
@@ -75,10 +81,6 @@ class AutoconfConan(ConanFile):
                 if not os.path.isfile(fullpath):
                     continue
                 os.rename(fullpath, fullpath + ".exe")
-
-    def package_id(self):
-        # The m4 requirement does not change the contents of this package
-        self.info.requires.clear()
 
     def package_info(self):
         bin_path = os.path.join(self.package_folder, "bin")


### PR DESCRIPTION
Specify library name and version:  **autoconf/all**

Add compiler to `settings` to satisfy conan v2 checks.



- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
