### PR TITLE
#3907: add component info in conanfile.py, add cmake helper module, e…

### DIFF
--- a/recipes/flatcc/all/FlatccGenerateSources.cmake
+++ b/recipes/flatcc/all/FlatccGenerateSources.cmake
@@ -1,0 +1,88 @@
+
+# Use the following function to generate C source files from flatbuffer definition files:
+#
+# flatcc_generate_sources(GENERATED_SOURCE_DIRECTORY <directory where to write source files>
+#                         GENERATE_BUILDER
+#                         GENERATE_VERIFIER
+#                         EXPECTED_OUTPUT_FILES <list of files that flatcc is supposed to generate>
+#                         DEFINITION_FILES <list of flatbuffer definition files (.fbs)>
+# )
+#
+# GENERATE_BUILDER and GENERATE_VERIFIER are boolean options. When specified they will instruct
+# flatcc to generate builder / verifier source code.
+#
+# With cross-compiling you should provide the directory where the flatcc compiler executable is located
+# in environment variable FLATCC_BUILD_BIN_PATH. If you use Conan and add flatcc as a build requirement
+# this will be done automatically.
+
+
+function(flatcc_generate_sources)
+
+    # parse function arguments
+    set(OUTPREFIX "FLATCC") #variables created by 'cmake_parse_arguments' will be prefixed with this
+    set(NO_VAL_ARGS GENERATE_BUILDER GENERATE_VERIFIER)
+    set(SINGLE_VAL_ARGS GENERATED_SOURCE_DIRECTORY)
+    set(MULTI_VAL_ARGS DEFINITION_FILES EXPECTED_OUTPUT_FILES CC_OPTIONS)
+
+    cmake_parse_arguments(${OUTPREFIX}
+                          "${NO_VAL_ARGS}"
+                          "${SINGLE_VAL_ARGS}"
+                          "${MULTI_VAL_ARGS}"
+                          ${ARGN}
+    )
+    if (GENERATED_SOURCE_DIRECTORY IN_LIST FLATCC_KEYWORDS_MISSING_VALUES)
+        message(FATAL_ERROR "No directory provided after GENERATED_SOURCE_DIRECTORY keyword")
+    endif()
+    if (NOT FLATCC_GENERATED_SOURCE_DIRECTORY)
+        set(FLATCC_GENERATED_SOURCE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    endif()
+    message(STATUS "Flatcc sources will be generated in directory ${FLATCC_GENERATED_SOURCE_DIRECTORY}")
+
+    if (FLATCC_GENERATE_BUILDER)
+        list(APPEND FLATCC_CC_OPTIONS --builder)
+    endif()
+    if (FLATCC_GENERATE_VERIFIER)
+        list(APPEND FLATCC_CC_OPTIONS --verifier)
+    endif()
+
+    if (FLATCC_DEFINITION_FILES)
+        if (NOT EXISTS ${FLATCC_GENERATED_SOURCE_DIRECTORY})
+            file(MAKE_DIRECTORY ${FLATCC_GENERATED_SOURCE_DIRECTORY})
+        endif()
+
+        message(VERBOSE "Executing command ${FLATCC_COMPILER} ${FLATCC_CC_OPTIONS} -o ${FLATCC_GENERATED_SOURCE_DIRECTORY} ${FLATCC_DEFINITION_FILES}")
+        add_custom_command(OUTPUT ${FLATCC_EXPECTED_OUTPUT_FILES}
+                           COMMAND ${FLATCC_COMPILER} ${FLATCC_CC_OPTIONS} -o ${FLATCC_GENERATED_SOURCE_DIRECTORY} ${FLATCC_DEFINITION_FILES}
+                           WORKING_DIRECTORY ${FLATCC_GENERATED_SOURCE_DIRECTORY})
+    else()
+        message(WARNING "No flatbuffer definition files provided, no sources will be generated")
+    endif()
+
+endfunction()
+
+
+#### Main ####
+
+#When cross-compiling user can provide location of the flatbuffers to C compiler in build arch via
+#environment variable FLATCC_BUILD_BIN_PATH
+set(FLATCC_BIN_PATH "$ENV{FLATCC_BUILD_BIN_PATH}")
+if (FLATCC_BIN_PATH)
+    #user provided location where asn1c compiler executable is installed
+    find_program(FLATCC_COMPILER flatcc
+                 PATHS ${FLATCC_BIN_PATH}
+                 NO_DEFAULT_PATH
+                 NO_SYSTEM_ENVIRONMENT_PATH
+                 NO_CMAKE_SYSTEM_PATH
+)
+else()
+    #Find compiler exe in current install location
+    find_program(FLATCC_COMPILER flatcc
+                NO_SYSTEM_ENVIRONMENT_PATH
+                NO_CMAKE_SYSTEM_PATH
+    )
+endif()
+
+
+if (NOT FLATCC_COMPILER)
+    message(FATAL_ERROR "Could not locate the flatcc compiler executable")
+endif()


### PR DESCRIPTION
Specify library name and version:  **flatcc/0.6.0**
- added component information
- added a cmake module with cmake helper function
- fixed a cross-compile problem

Resolves #3907 

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
