### PR TITLE
#3909: add component info to libnl recipe

### DIFF
--- a/recipes/libnl/all/conanfile.py
+++ b/recipes/libnl/all/conanfile.py
@@ -67,6 +67,17 @@ class LibNlConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.includedirs = [os.path.join('include', 'libnl3')]
-        self.cpp_info.libs = ["nl-3", "nl-cli-3", "nl-genl-3", "nl-idiag-3", "nl-nf-3", "nl-route-3"]
-        self.cpp_info.system_libs = ["pthread", "m"]
+        self.cpp_info.components["nl"].libs = ["nl-3"]
+        self.cpp_info.components["nl"].includedirs = [os.path.join('include', 'libnl3')]
+        if not tools.os_info.is_windows:
+            self.cpp_info.components["nl"].system_libs = ["pthread", "m"]
+        self.cpp_info.components["nl-route"].libs = ["nl-route-3"]
+        self.cpp_info.components["nl-route"].requires = ["nl"]
+        self.cpp_info.components["nl-genl"].libs = ["nl-genl-3"]
+        self.cpp_info.components["nl-genl"].requires = ["nl"]
+        self.cpp_info.components["nl-nf"].libs = ["nl-nf-3"]
+        self.cpp_info.components["nl-nf"].requires = ["nl-route"]
+        self.cpp_info.components["nl-cli"].libs = ["nl-cli-3"]
+        self.cpp_info.components["nl-cli"].requires = ["nl-nf", "nl-genl"]
+        self.cpp_info.components["nl-idiag"].libs = ["nl-idiag-3"]
+        self.cpp_info.components["nl-idiag"].requires = ["nl"]


### PR DESCRIPTION
Specify library name and version:  **libnl/3.2.25**

Add component information to libnl recipe. 

Resolves #3909 .

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
