### PR TITLE
libpq: cross-building support for MSVC

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -108,6 +108,10 @@ class LibpqConan(ConanFile):
                        'MD': 'MultiThreadedDLL',
                        'MDd': 'MultiThreadedDebugDLL'}.get(str(self.settings.compiler.runtime))
             msbuild_project_pm = os.path.join(self._source_subfolder, "src", "tools", "msvc", "MSBuildProject.pm")
+            tools.replace_in_file(msbuild_project_pm, "</Link>", """</Link>
+    <Lib>
+      <TargetMachine>$targetmachine</TargetMachine>
+    </Lib>""")
             tools.replace_in_file(msbuild_project_pm, "'MultiThreadedDebugDLL'", "'%s'" % runtime)
             tools.replace_in_file(msbuild_project_pm, "'MultiThreadedDLL'", "'%s'" % runtime)
             config_default_pl = os.path.join(self._source_subfolder, "src", "tools", "msvc", "config_default.pl")


### PR DESCRIPTION
Specify library name and version:  **libpq any version**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

`x86` build currently fails when MSVC environment is initialized as follows:
``` 
[vcvarsall.bat] Environment initialized for: 'x64_x86'
```
(as `conan-package-tools` do). Build failure:
```
LINK : warning LNK4068: /MACHINE not specified; defaulting to X64 [C:\Users\ContainerAdministrator\.conan\data\libpq\11.5\_\_\build\65f9c48d8db97c2452d8c20e4a76f51abc311127\source_subfolder\libpq.vcxproj]
.\Release\libpq\encnames.obj : fatal error LNK1112: module machine type 'x86' conflicts with target machine type 'x64' [C:\Users\ContainerAdministrator\.conan\data\libpq\11.5\_\_\build\65f9c48d8db97c2452d8c20e4a76f51abc311127\source_subfolder\libpq.vcxproj]
Done Building Project "C:\Users\ContainerAdministrator\.conan\data\libpq\11.5\_\_\build\65f9c48d8db97c2452d8c20e4a76f51abc311127\source_subfolder\libpq.vcxproj" (default targets) -- FAILED.
Build FAILED.
```
This PR fixes that.