### PR TITLE
mpir: add m4 to build_requires

### DIFF
--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -44,7 +44,8 @@ class MpirConan(ConanFile):
             del self.settings.compiler.cppstd
 
     def build_requirements(self):
-        self.build_requires("m4/1.4.18")
+        if self.settings.compiler != "Visual Studio":
+            self.build_requires("m4/1.4.18")
         self.build_requires("yasm/1.3.0")
         if tools.os_info.is_windows and self.settings.compiler != "Visual Studio" and \
            "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != "msys2":

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -44,6 +44,7 @@ class MpirConan(ConanFile):
             del self.settings.compiler.cppstd
 
     def build_requirements(self):
+        self.build_requires("m4/1.4.18")
         self.build_requires("yasm/1.3.0")
         if tools.os_info.is_windows and self.settings.compiler != "Visual Studio" and \
            "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != "msys2":


### PR DESCRIPTION
To fix

checking for suitable m4... configure: error: No usable m4 in $PATH or /usr/5bin

Specify library name and version:  **mpir/3.0.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
