### PR TITLE
ezc3d: add version 1.3.8

### DIFF
--- a/recipes/ezc3d/all/conandata.yml
+++ b/recipes/ezc3d/all/conandata.yml
@@ -1,8 +1,14 @@
 sources:
+  "1.3.8":
+    url: "https://github.com/pyomeca/ezc3d/archive/Release_1.3.8.tar.gz"
+    sha256: "888cb191c7939b31891e93356aa5bfcf21edb8785d3b5d4d9ec215984bc8b83e"
   "1.3.7":
     url: "https://github.com/pyomeca/ezc3d/archive/Release_1.3.7.tar.gz"
     sha256: "17cd3d4e20840710d58b8987c01ef0f880bc0c063ab52e0cb86ba41665ec33a0"
 patches:
+  "1.3.8":
+    - patch_file: "patches/fix-export-symbols.patch"
+      base_path: "source_subfolder"
   "1.3.7":
     - patch_file: "patches/fix-export-symbols.patch"
       base_path: "source_subfolder"

--- a/recipes/ezc3d/all/conandata.yml
+++ b/recipes/ezc3d/all/conandata.yml
@@ -6,9 +6,6 @@ sources:
     url: "https://github.com/pyomeca/ezc3d/archive/Release_1.3.7.tar.gz"
     sha256: "17cd3d4e20840710d58b8987c01ef0f880bc0c063ab52e0cb86ba41665ec33a0"
 patches:
-  "1.3.8":
-    - patch_file: "patches/fix-export-symbols.patch"
-      base_path: "source_subfolder"
   "1.3.7":
     - patch_file: "patches/fix-export-symbols.patch"
       base_path: "source_subfolder"

--- a/recipes/ezc3d/config.yml
+++ b/recipes/ezc3d/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.3.8":
+    folder: all
   "1.3.7":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **ezc3d/1.3.8**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
