### PR TITLE
stlab: add version 1.5.4

### DIFF
--- a/recipes/stlab/all/conandata.yml
+++ b/recipes/stlab/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.4":
+    url: "https://github.com/stlab/libraries/archive/v1.5.4.tar.gz"
+    sha256: "87306f58f6614f4a1ca54dda52fedff7e610d3b3dae035829657bac77bc33640"
   1.5.2:
     url: https://github.com/stlab/libraries/archive/v1.5.2.tar.gz
     sha256: a82eb013e51d0bb3ee2050f0eda31e11997cb4ca74d2abfdc2c8249c5c67c9fb

--- a/recipes/stlab/config.yml
+++ b/recipes/stlab/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.5.4":
+    folder: all
   1.5.2:
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **stlab/1.5.4**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
