### PR TITLE
qpoases/3.2.1

### DIFF
--- a/recipes/qpoases/all/CMakeLists.txt
+++ b/recipes/qpoases/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/qpoases/all/CMakeLists.txt
+++ b/recipes/qpoases/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/qpoases/all/conandata.yml
+++ b/recipes/qpoases/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.2.1":
+    url: "https://github.com/coin-or/qpOASES/archive/releases/3.2.1.tar.gz"
+    sha256: "a7d153b4e23ee66bd50cdb6e84291d0084d9967a9c788a4d873440a6b10ca13b"

--- a/recipes/qpoases/all/conanfile.py
+++ b/recipes/qpoases/all/conanfile.py
@@ -56,6 +56,4 @@ class ConanRecipe(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "qpOASES"
         self.cpp_info.names["cmake_find_package_multi"] = "qpOASES"
 
-        self.cpp_info.components["qpOASES"].names["cmake_find_package"] = "qpOASES"
-        self.cpp_info.components["qpOASES"].names["cmake_find_package_multi"] = "qpOASES"
-        self.cpp_info.components["qpOASES"].libs = ["qpOASES"]
+        self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/qpoases/all/conanfile.py
+++ b/recipes/qpoases/all/conanfile.py
@@ -17,11 +17,8 @@ class ConanRecipe(ConanFile):
     generators = "cmake"
 
     settings = "os", "arch", "compiler", "build_type"
-    options = {
-        "fPIC": [True, False],
-        "shared": [False],
-    }
-    default_options = {"fPIC": True, "shared": False}
+    options = {"fPIC": [True, False]}
+    default_options = {"fPIC": True}
 
     _cmake = None
 

--- a/recipes/qpoases/all/conanfile.py
+++ b/recipes/qpoases/all/conanfile.py
@@ -1,4 +1,3 @@
-import glob
 import os
 from conans import ConanFile, CMake, tools
 
@@ -36,7 +35,7 @@ class ConanRecipe(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = glob.glob("qpOASES-*/")[0]
+        extracted_dir = "qpOASES-releases-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_cmake(self):

--- a/recipes/qpoases/all/conanfile.py
+++ b/recipes/qpoases/all/conanfile.py
@@ -30,6 +30,10 @@ class ConanRecipe(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = glob.glob("qpOASES-*/")[0]

--- a/recipes/qpoases/all/conanfile.py
+++ b/recipes/qpoases/all/conanfile.py
@@ -1,0 +1,61 @@
+import glob
+import os
+from conans import ConanFile, CMake, tools
+
+
+class ConanRecipe(ConanFile):
+    name = "qpoases"
+
+    description = "Open-source C++ implementation of the recently proposed online active set strategy."
+    topics = ("conan", "container", "parametric", "quadratic", "programming")
+
+    homepage = "https://github.com/coin-or/qpOASES"
+    url = "https://github.com/conan-io/conan-center-index"
+
+    license = "LGPL-2.1"
+
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+        "shared": [False],
+    }
+    default_options = {"fPIC": True, "shared": False}
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = glob.glob("qpOASES-*/")[0]
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["QPOASES_BUILD_EXAMPLES"] = False
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "qpOASES"
+        self.cpp_info.names["cmake_find_package_multi"] = "qpOASES"
+
+        self.cpp_info.components["qpOASES"].names["cmake_find_package"] = "qpOASES"
+        self.cpp_info.components["qpOASES"].names["cmake_find_package_multi"] = "qpOASES"
+        self.cpp_info.components["qpOASES"].libs = ["qpOASES"]

--- a/recipes/qpoases/all/test_package/CMakeLists.txt
+++ b/recipes/qpoases/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.10)
+project(test_package CXX)
+
+find_package(qpOASES REQUIRED)
+
+add_executable(test_package test_package.cpp)
+
+target_link_libraries(test_package PRIVATE qpOASES::qpOASES)

--- a/recipes/qpoases/all/test_package/CMakeLists.txt
+++ b/recipes/qpoases/all/test_package/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
+include("${CMAKE_BINARY_DIR}/conanbuild.info.cmake")
+conan_basic_setup(TARGETS)
+
 find_package(qpOASES REQUIRED)
 
 add_executable(test_package test_package.cpp)

--- a/recipes/qpoases/all/test_package/CMakeLists.txt
+++ b/recipes/qpoases/all/test_package/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
+set(CMAKE_CXX_STANDARD 11)
+
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup(TARGETS)
 

--- a/recipes/qpoases/all/test_package/CMakeLists.txt
+++ b/recipes/qpoases/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
 find_package(qpOASES REQUIRED)

--- a/recipes/qpoases/all/test_package/CMakeLists.txt
+++ b/recipes/qpoases/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
-include("${CMAKE_BINARY_DIR}/conanbuild.info.cmake")
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup(TARGETS)
 
 find_package(qpOASES REQUIRED)

--- a/recipes/qpoases/all/test_package/conanfile.py
+++ b/recipes/qpoases/all/test_package/conanfile.py
@@ -13,4 +13,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self.settings):
-            self.run("test_package", run_environment=True)
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/qpoases/all/test_package/conanfile.py
+++ b/recipes/qpoases/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake_find_package"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/qpoases/all/test_package/conanfile.py
+++ b/recipes/qpoases/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.run("test_package", run_environment=True)

--- a/recipes/qpoases/all/test_package/test_package.cpp
+++ b/recipes/qpoases/all/test_package/test_package.cpp
@@ -1,0 +1,62 @@
+// from: https://github.com/coin-or/qpOASES/blob/master/examples/example1.cpp
+
+#include <qpOASES.hpp>
+
+
+/** Example for qpOASES main function using the QProblem class. */
+int main( )
+{
+	USING_NAMESPACE_QPOASES
+
+	/* Setup data of first QP. */
+	real_t H[2*2] = { 1.0, 0.0, 0.0, 0.5 };
+	real_t A[1*2] = { 1.0, 1.0 };
+	real_t g[2] = { 1.5, 1.0 };
+	real_t lb[2] = { 0.5, -2.0 };
+	real_t ub[2] = { 5.0, 2.0 };
+	real_t lbA[1] = { -1.0 };
+	real_t ubA[1] = { 2.0 };
+
+	/* Setup data of second QP. */
+	real_t g_new[2] = { 1.0, 1.5 };
+	real_t lb_new[2] = { 0.0, -1.0 };
+	real_t ub_new[2] = { 5.0, -0.5 };
+	real_t lbA_new[1] = { -2.0 };
+	real_t ubA_new[1] = { 1.0 };
+
+
+	/* Setting up QProblem object. */
+	QProblem example( 2,1 );
+
+	Options options;
+	example.setOptions( options );
+
+	/* Solve first QP. */
+	int_t nWSR = 10;
+	example.init( H,g,A,lb,ub,lbA,ubA, nWSR );
+
+	/* Get and print solution of first QP. */
+	real_t xOpt[2];
+	real_t yOpt[2+1];
+	example.getPrimalSolution( xOpt );
+	example.getDualSolution( yOpt );
+	printf( "\nxOpt = [ %e, %e ];  yOpt = [ %e, %e, %e ];  objVal = %e\n\n", 
+			xOpt[0],xOpt[1],yOpt[0],yOpt[1],yOpt[2],example.getObjVal() );
+	
+	/* Solve second QP. */
+	nWSR = 10;
+	example.hotstart( g_new,lb_new,ub_new,lbA_new,ubA_new, nWSR );
+
+	/* Get and print solution of second QP. */
+	example.getPrimalSolution( xOpt );
+	example.getDualSolution( yOpt );
+	printf( "\nxOpt = [ %e, %e ];  yOpt = [ %e, %e, %e ];  objVal = %e\n\n", 
+			xOpt[0],xOpt[1],yOpt[0],yOpt[1],yOpt[2],example.getObjVal() );
+
+	example.printOptions();
+	/*example.printProperties();*/
+
+	/*getGlobalMessageHandler()->listAllMessages();*/
+
+	return 0;
+}

--- a/recipes/qpoases/config.yml
+++ b/recipes/qpoases/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.2.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **qpoases/3.2.1**

I got 3 open points/questions to the community:
- [x] The library has only [one STATIC target](https://github.com/coin-or/qpOASES/blob/master/CMakeLists.txt#L107), so I want to disable shared. Is the way I did this correct? Bonus: Do I need `fPIC` at all?
```python
    options = {
        "fPIC": [True, False],
        "shared": [False],
    }
```
- [x] The current library exports a target called `qpOASES` (no leading `qpOASES::`). This target is not available with the conan package anymore, so existing consumers have to rewrite their CML, right?
- [x] I had to add a component named `qpOASES::qpOASES` to make it all work, any ideas why? SOLVED: `self.cpp_info.libs = tools.collect_libs(self)` was missing


### The important stuff:

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
