### PR TITLE
add botan/2.17.3

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -23,6 +23,9 @@ sources:
   "2.17.2":
     url: "https://github.com/randombit/botan/archive/2.17.2.tar.gz"
     sha256: "3d99da64573abab6d6e8036a45f8c567a57721c8f23850e05aadd84fc2e0075c"
+  "2.17.3":
+    url: "https://github.com/randombit/botan/archive/2.17.3.tar.gz"
+    sha256: "544c62e43be0c60fff7ac8707ee99fe134c75bef06bded217d04f0a4b333519a"
 patches:
   "2.12.1":
      - patch_file: "patches/dll-dir.patch"

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -15,3 +15,5 @@ versions:
     folder: all
   "2.17.2":
     folder: all
+  "2.17.3":
+    folder: all


### PR DESCRIPTION
Signed-off-by: Rene Meusel <rene@renemeusel.de>

Specify library name and version:  **botan/2.17.3**

Note that this botan release [contains the patch](https://github.com/randombit/botan/pull/2526) introduced [in the 2.17.2 recipe](https://github.com/conan-io/conan-center-index/pull/3607). Naturally, this recipe version won't require it anymore.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
