### PR TITLE
[boost] Allow apple-clang version 10 for nowide and C++ 11

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -137,7 +137,7 @@ class BoostConan(ConanFile):
         return {
             "gcc": 6,
             "clang": 6,
-            "apple-clang": 12,  # guess
+            "apple-clang": 10,
             "Visual Studio": 14,  # guess
         }.get(str(self.settings.compiler))
 
@@ -147,7 +147,7 @@ class BoostConan(ConanFile):
         return {
             "gcc": 5,
             "clang": 5,
-            "apple-clang": 12,  # guess
+            "apple-clang": 10,
             "Visual Studio": 14,  # guess
         }.get(str(self.settings.compiler))
 

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -147,7 +147,6 @@ class BoostConan(ConanFile):
         return {
             "gcc": 5,
             "clang": 5,
-            "apple-clang": 10,
             "Visual Studio": 14,  # guess
         }.get(str(self.settings.compiler))
 

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -225,6 +225,11 @@ class BoostConan(ConanFile):
                     self.options.without_fiber = True
                     self.options.without_json = True
                     self.options.without_nowide = True
+            else:
+                self.options.without_fiber = True
+                self.options.without_json = True
+                self.options.without_nowide = True
+
 
         # Remove options not supported by this version of boost
         for dep_name in CONFIGURE_OPTIONS:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -137,7 +137,6 @@ class BoostConan(ConanFile):
         return {
             "gcc": 6,
             "clang": 6,
-            "apple-clang": 10,
             "Visual Studio": 14,  # guess
         }.get(str(self.settings.compiler))
 


### PR DESCRIPTION
Specify library name and version:  **boost/1.75.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

### Supporting information

This was my build configuration:

```
Configuration:
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=apple-clang
compiler.cppstd=11
compiler.libcxx=libc++
compiler.version=10.0
os=Macos
os.version=10.9
os_build=Macos
[options]
boost:i18n_backend=icu
[build_requires]
[env]
DEVELOPER_DIR=/Applications/Xcode-10.3.app/Contents/Developer
MACOSX_DEPLOYMENT_TARGET=10.9
```

Boost reported:
```
    - std::fstream is moveable and swappable : yes
```

`apple-clang` 10 is `clang` 4.2: [Wikipedia table](https://en.wikipedia.org/wiki/Xcode#Xcode_7.0_-_12.x_(since_Free_On-Device_Development))

...and `clang` 4.2 definitely supports all of C++ 11: [Cppreference compiler support tables](https://en.cppreference.com/w/cpp/compiler_support).