### PR TITLE
pulseaudio/all: Fix local build without FFTW

### DIFF
--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -95,10 +95,11 @@ class PulseAudioConan(ConanFile):
             else:
                 args.extend(["--enable-shared=no", "--enable-static=yes"])
             args.append("--with-udev-rules-dir=%s" % os.path.join(self.package_folder, "bin", "udev", "rules.d"))
+            args.append("--with-systemduserunitdir=%s" % os.path.join(self.build_folder, "ignore"))
             with tools.environment_append({"PKG_CONFIG_PATH": self.build_folder}):
                 with tools.environment_append({
                         "FFTW_CFLAGS": tools.PkgConfig("fftw").cflags,
-                        "FFTW_LIBS": tools.PkgConfig("fftw").libs} if self.options.with_fftw else tools.no_op()):
+                        "FFTW_LIBS": tools.PkgConfig("fftw").libs}) if self.options.with_fftw else tools.no_op():
                     with tools.environment_append(RunEnvironment(self).vars):
                         self._autotools.configure(args=args,  configure_dir=self._source_subfolder)
         return self._autotools


### PR DESCRIPTION
Specify library name and version:  **pulseaudio/13.0**

I was trying to build package with this settings:
```
[requires]
pulseaudio/13.0

[options]
pulseaudio:shared=True
pulseaudio:with_alsa=False
pulseaudio:with_glib=False
pulseaudio:with_fftw=False
pulseaudio:with_x11=False
pulseaudio:with_openssl=False
```
It failed because of typo in the recipe with error:
```
ERROR: pulseaudio/13.0: Error in build() method, line 107
	autotools = self._configure_autotools()
while calling '_configure_autotools', line 99
	with tools.environment_append({
	AttributeError: '_GeneratorContextManager' object has no attribute 'items'
```
After I fixed the typo it started to fail with another error:
```
 /usr/bin/install -c -m 644 pulseaudio.service ../source_subfolder/src/daemon/systemd/user/pulseaudio.socket '/usr/lib/systemd/user'
/usr/bin/install: cannot remove '/usr/lib/systemd/user/pulseaudio.service': Permission denied
/usr/bin/install: cannot remove '/usr/lib/systemd/user/pulseaudio.socket': Permission denied
make[4]: *** [Makefile:11321: install-systemduserunitDATA] Error 1
make[4]: *** Waiting for unfinished jobs....
```
`pulseaudio.service` and `pulseaudio.socket` is not required for the package so I redefined installation path with `systemduserunitdir` option. I don't know better solution to ignore this files.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
