### PR TITLE
resiprocate/1.12.0: Fix recipe in autotools configuration step

### DIFF
--- a/recipes/resiprocate/all/conanfile.py
+++ b/recipes/resiprocate/all/conanfile.py
@@ -35,7 +35,8 @@ class ResiprocateConan(ConanFile):
 
     def configure(self):
         if self.settings.os in ("Windows", "Macos"):
-            raise ConanInvalidConfiguration("reSIProcate is not support on {}.".format(self.settings.os))
+            # FIXME: Visual Studio project & Mac support seems available in resiprocate
+            raise ConanInvalidConfiguration("reSIProcate recipe does not currently support {}.".format(self.settings.os))
         if self.options.shared and self.options.fPIC:
             raise ConanInvalidConfiguration("fPIC option should be False when shared option is True")
 

--- a/recipes/resiprocate/all/conanfile.py
+++ b/recipes/resiprocate/all/conanfile.py
@@ -51,12 +51,16 @@ class ResiprocateConan(ConanFile):
         configure_args = [
             "--enable-shared={}".format(yes_no(self.options.shared)),
             "--enable-static={}".format(yes_no(not self.options.shared)),
-            "--with-ssl={}".format(yes_no(not self.options.with_ssl)),
-            "--with-mysql={}".format(yes_no(not self.options.with_mysql)),
-            "--with-postgresql={}".format(yes_no(not self.options.with_postgresql)),
-            "--with-pic={}".format(yes_no(not self.options.fPIC))
+            "--with-pic={}".format(yes_no(self.options.fPIC))
         ]
 
+        if self.options.with_ssl:
+            configure_args.append("--with-ssl")
+        if self.options.with_mysql:
+            configure_args.append("--with-mysql")
+        if self.options.with_postgresql:
+            configure_args.append("--with-postgresql")
+        
         self._autotools.configure(configure_dir=self._source_subfolder, args=configure_args)
         return self._autotools
 
@@ -73,6 +77,7 @@ class ResiprocateConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["resip", "rutil", "dum", "resipares"]
+        self.cpp_info.system_libs = ["pthread"]
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bin_path))
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/recipes/resiprocate/all/conanfile.py
+++ b/recipes/resiprocate/all/conanfile.py
@@ -33,9 +33,9 @@ class ResiprocateConan(ConanFile):
         if self.settings.os in ("Windows", "Macos"):
             raise ConanInvalidConfiguration("reSIProcate is not support on {}.".format(self.settings.os))
         if self.options.with_ssl:
-            self.requires("openssl/1.1.1h")
+            self.requires("openssl/1.1.1i")
         if self.options.with_postgresql:
-            self.requires("libpq/11.5")
+            self.requires("libpq/11.9")
         if self.options.with_mysql:
             self.requires("libmysqlclient/8.0.17")
 

--- a/recipes/resiprocate/all/conanfile.py
+++ b/recipes/resiprocate/all/conanfile.py
@@ -37,8 +37,8 @@ class ResiprocateConan(ConanFile):
         if self.settings.os in ("Windows", "Macos"):
             # FIXME: Visual Studio project & Mac support seems available in resiprocate
             raise ConanInvalidConfiguration("reSIProcate recipe does not currently support {}.".format(self.settings.os))
-        if self.options.shared and self.options.fPIC:
-            raise ConanInvalidConfiguration("fPIC option should be False when shared option is True")
+        if self.options.shared:
+            del self.options.fPIC
 
     def requirements(self):
         if self.options.with_ssl:
@@ -60,7 +60,7 @@ class ResiprocateConan(ConanFile):
         configure_args = [
             "--enable-shared={}".format(yes_no(self.options.shared)),
             "--enable-static={}".format(yes_no(not self.options.shared)),
-            "--with-pic={}".format(yes_no(self.options.fPIC))
+            "--with-pic={}".format(yes_no(self.options.get_safe("fPIC", True)))
         ]
 
         # These options do not support yes/no

--- a/recipes/resiprocate/all/conanfile.py
+++ b/recipes/resiprocate/all/conanfile.py
@@ -29,9 +29,17 @@ class ResiprocateConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
-    def requirements(self):
+    def config_options(self):
+        if self.settings.os == 'Windows':
+            del self.options.fPIC
+
+    def configure(self):
         if self.settings.os in ("Windows", "Macos"):
             raise ConanInvalidConfiguration("reSIProcate is not support on {}.".format(self.settings.os))
+        if self.options.shared and self.options.fPIC:
+            raise ConanInvalidConfiguration("fPIC option should be False when shared option is True")
+
+    def requirements(self):
         if self.options.with_ssl:
             self.requires("openssl/1.1.1i")
         if self.options.with_postgresql:

--- a/recipes/resiprocate/all/conanfile.py
+++ b/recipes/resiprocate/all/conanfile.py
@@ -54,6 +54,7 @@ class ResiprocateConan(ConanFile):
             "--with-pic={}".format(yes_no(self.options.fPIC))
         ]
 
+        # These options do not support yes/no
         if self.options.with_ssl:
             configure_args.append("--with-ssl")
         if self.options.with_mysql:
@@ -77,7 +78,8 @@ class ResiprocateConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["resip", "rutil", "dum", "resipares"]
-        self.cpp_info.system_libs = ["pthread"]
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs = ["pthread"]
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bin_path))
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
Specify library name and version:  **resiprocate/1.12.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

fixes #3989 
