### PR TITLE
add libatomic in build dependency for Neutrino OS

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -481,8 +481,7 @@ class OpenSSLConan(ConanFile):
         else:
             args.append("-fPIC" if self.options.fPIC else "no-pic")
         if self.settings.os == "Neutrino":
-            args.append("-lsocket no-asm")
-
+            args.append("no-asm -lsocket -latomic")
         if self._full_version < "1.1.0":
             if self.options.get_safe("no_zlib"):
                 args.append("no-zlib")
@@ -799,7 +798,9 @@ class OpenSSLConan(ConanFile):
             if not self.options.no_threads:
                 self.cpp_info.components["crypto"].system_libs.append("pthread")
                 self.cpp_info.components["ssl"].system_libs.append("pthread")
-
+        elif self.settings.os == "Neutrino":
+            self.cpp_info.components["crypto"].system_libs.append("atomic")
+            self.cpp_info.components["ssl"].system_libs.append("atomic")
         self.cpp_info.components["crypto"].names["cmake_find_package"] = "Crypto"
         self.cpp_info.components["crypto"].names["cmake_find_package_multi"] = "Crypto"
         self.cpp_info.components["crypto"].names['pkg_config'] = 'libcrypto'


### PR DESCRIPTION
**openssl/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.


Fix build error on QNX. 
```
....
./libcrypto.a(rsa_lib.o): In function `RSA_up_ref':
rsa_lib.c:(.text+0x37c): undefined reference to `__atomic_fetch_add_4'
./libcrypto.a(threads_pthread.o): In function `CRYPTO_atomic_add':
threads_pthread.c:(.text+0x1cc): undefined reference to `__atomic_is_lock_free'
threads_pthread.c:(.text+0x21c): undefined reference to `__atomic_fetch_add_4'
./libcrypto.a(x509_lu.o): In function `X509_STORE_free':
x509_lu.c:(.text+0x5f4): undefined reference to `__atomic_fetch_sub_4'
./libcrypto.a(x509_lu.o): In function `X509_STORE_up_ref':
x509_lu.c:(.text+0x6bc): undefined reference to `__atomic_fetch_add_4'
./libcrypto.a(x509_set.o): In function `X509_up_ref':
x509_set.c:(.text+0x138): undefined reference to `__atomic_fetch_add_4'
./libcrypto.a(x509cset.o): In function `X509_CRL_up_ref':
x509cset.c:(.text+0xe8): undefined reference to `__atomic_fetch_add_4'
...
```