### PR TITLE
flex: copy CC_FOR_BUILD from CC if it isn't set

### DIFF
--- a/recipes/flex/all/test_package/CMakeLists.txt
+++ b/recipes/flex/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")


### PR DESCRIPTION
Specify library name and version:  **flex/all**

Fixes https://github.com/conan-io/conan-center-index/issues/2073#issuecomment-750446870

Copy `CC` to `CC_FOR_BUILD` when `CC` is set, but `CC_FOR_BUILD` isn't.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
