### PR TITLE
Fix to compile libbsd/0.10.0 on Xcode 12

### DIFF
--- a/recipes/libbsd/all/conanfile.py
+++ b/recipes/libbsd/all/conanfile.py
@@ -48,6 +48,8 @@ class LibBsdConan(ConanFile):
         if self._autotools:
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        if tools.is_apple_os(self.settings.os):
+            self._autotools.flags.append("-Wno-error=implicit-function-declaration")
         conf_args = [
         ]
         if self.options.shared:


### PR DESCRIPTION
Here is a PR that allows to configure and compile libbsd/0.10.0 on recent MacOS with new Xcode 12.

Fixes #3966 

Specify library name and version:  **libbsd/0.10.0 **

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
