### PR TITLE
[gmp] if arch is not x86 and x86_64, the deleted option self.options.enable_fat will cause error

### DIFF
--- a/recipes/gmp/all/conanfile.py
+++ b/recipes/gmp/all/conanfile.py
@@ -37,7 +37,7 @@ class GmpConan(ConanFile):
             raise ConanInvalidConfiguration("Cannot build a shared library using Visual Studio: some error occurs at link time")
         if self.options.shared:
             del self.options.fPIC
-        if hasattr(self.options, 'enable_fat'):
+        if 'enable_fat' in self.options:
             if self.options.enable_fat:
                 del self.options.disable_assembly
         if not self.options.enable_cxx:

--- a/recipes/gmp/all/conanfile.py
+++ b/recipes/gmp/all/conanfile.py
@@ -37,8 +37,9 @@ class GmpConan(ConanFile):
             raise ConanInvalidConfiguration("Cannot build a shared library using Visual Studio: some error occurs at link time")
         if self.options.shared:
             del self.options.fPIC
-        if self.options.enable_fat:
-            del self.options.disable_assembly
+        if hasattr(self.option, 'enable_fat'):
+            if self.options.enable_fat:
+                del self.options.disable_assembly
         if not self.options.enable_cxx:
             del self.settings.compiler.libcxx
             del self.settings.compiler.cppstd

--- a/recipes/gmp/all/conanfile.py
+++ b/recipes/gmp/all/conanfile.py
@@ -37,7 +37,7 @@ class GmpConan(ConanFile):
             raise ConanInvalidConfiguration("Cannot build a shared library using Visual Studio: some error occurs at link time")
         if self.options.shared:
             del self.options.fPIC
-        if hasattr(self.option, 'enable_fat'):
+        if hasattr(self.options, 'enable_fat'):
             if self.options.enable_fat:
                 del self.options.disable_assembly
         if not self.options.enable_cxx:

--- a/recipes/gmp/all/conanfile.py
+++ b/recipes/gmp/all/conanfile.py
@@ -37,9 +37,8 @@ class GmpConan(ConanFile):
             raise ConanInvalidConfiguration("Cannot build a shared library using Visual Studio: some error occurs at link time")
         if self.options.shared:
             del self.options.fPIC
-        if 'enable_fat' in self.options:
-            if self.options.enable_fat:
-                del self.options.disable_assembly
+        if self.options.get_safe("enable_fat"):
+            del self.options.disable_assembly
         if not self.options.enable_cxx:
             del self.settings.compiler.libcxx
             del self.settings.compiler.cppstd


### PR DESCRIPTION
if arch is not x86 and x86_64, the deleted option self.options.enable_fat will cause error

Specify library name and version: gmp/6.2.0

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
