### PR TITLE
Add the include directory for the boost::ut target

### DIFF
--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -5,8 +5,8 @@ import os
 
 class UTConan(ConanFile):
     name = "boost-ext-ut"
-    description = "C++17/20 single header/single module, "
-    "macro-free micro Unit Testing Framework"
+    description = ("C++17/20 single header/single module, "
+                   "macro-free micro Unit Testing Framework")
     topics = ("conan", "UT", "header-only", "unit-test", "tdd", "bdd")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://boost-ext.github.io/ut/"

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -69,4 +69,4 @@ class UTConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "boost"
         self.cpp_info.filenames["cmake_find_package"] = "ut"
         self.cpp_info.filenames["cmake_find_package_multi"] = "ut"
-        self.cpp_info.components["ut"].includedirs = ['include']
+        self.cpp_info.components["ut"]

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -69,4 +69,4 @@ class UTConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "boost"
         self.cpp_info.filenames["cmake_find_package"] = "ut"
         self.cpp_info.filenames["cmake_find_package_multi"] = "ut"
-        self.cpp_info.components["ut"].includedirs = []
+        self.cpp_info.components["ut"].includedirs = ['include']

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -69,4 +69,5 @@ class UTConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "boost"
         self.cpp_info.filenames["cmake_find_package"] = "ut"
         self.cpp_info.filenames["cmake_find_package_multi"] = "ut"
-        self.cpp_info.components["ut"]
+        self.cpp_info.components["ut"].names["cmake_find_package"] = "ut"
+        self.cpp_info.components["ut"].names["cmake_find_package_multi"] = "ut"


### PR DESCRIPTION
The [Boost-ext].UT library provides the CMake target `boost::ut`.
This target adds the necessary include directory containing the boost directory with the ut.hpp header file.
I accidentally omitted adding this include directory when I added the boost-ext-ut package to the conan-center-index.
This commit corrects the behavior for the Conan package.
The boost::ut CMake target provided by Conan now includes the necessary include directory.

Specify library name and version:  **boost-ext-ut/1.1.8**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
