### PR TITLE
asio: add version 1.18.1

### DIFF
--- a/recipes/asio/all/conandata.yml
+++ b/recipes/asio/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.18.1":
+    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-18-1.tar.gz"
+    sha256: "39c721b987b7a0d2fe2aee64310bd128cd8cc10f43481604d18cb2d8b342fd40"
   "1.18.0":
     sha256: 820688d1e0387ff55194ae20036cbae0fb3c7d11b7c3f46492369723c01df96f
     url: https://github.com/chriskohlhoff/asio/archive/asio-1-18-0.tar.gz

--- a/recipes/asio/config.yml
+++ b/recipes/asio/config.yml
@@ -1,5 +1,6 @@
----
 versions:
+  "1.18.1":
+    folder: all
   "1.18.0":
     folder: all
   "1.17.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **asio/1.18.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
