### PR TITLE
catch2/2.13.4 fix main target

### DIFF
--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -12,13 +12,12 @@ class ConanRecipe(ConanFile):
     license = "BSL-1.0"
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    no_copy_source=True
-    
     _cmake = None
-    
+
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
     @property
     def _build_subfolder(self):
         return "build_subfolder"
@@ -37,9 +36,13 @@ class ConanRecipe(ConanFile):
         self._cmake.definitions["CATCH_INSTALL_HELPERS"] = "ON"
         self._cmake.configure(
             source_folder=self._source_subfolder,
-            build_folder=self._build_subfolder
+            build_folder=self._build_subfolder,
         )
         return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
 
     def package(self):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
@@ -48,14 +51,17 @@ class ConanRecipe(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
         for cmake_file in ["ParseAndAddCatchTests.cmake", "Catch.cmake", "CatchAddTests.cmake"]:
-            self.copy(cmake_file,
-                      src=os.path.join(self._source_subfolder, "contrib"),
-                      dst=os.path.join("lib", "cmake", "Catch2"))
-
-    def package_id(self):
-        self.info.header_only()
+            self.copy(
+                cmake_file,
+                src=os.path.join(self._source_subfolder, "contrib"),
+                dst=os.path.join("lib", "cmake", "Catch2"),
+            )
 
     def package_info(self):
-        self.cpp_info.builddirs = [os.path.join("lib", "cmake", "Catch2")]
         self.cpp_info.names["cmake_find_package"] = "Catch2"
         self.cpp_info.names["cmake_find_package_multi"] = "Catch2"
+
+        self.cpp_info.components["Catch2WithMain"].builddirs = [os.path.join("lib", "cmake", "Catch2")]
+        self.cpp_info.components["Catch2WithMain"].libs = ["Catch2WithMain"]
+        self.cpp_info.components["Catch2WithMain"].names["cmake_find_package"] = "Catch2WithMain"
+        self.cpp_info.components["Catch2WithMain"].names["cmake_find_package_multi"] = "Catch2WithMain"

--- a/recipes/catch2/2.x.x/test_package/200-standalone.cpp
+++ b/recipes/catch2/2.x.x/test_package/200-standalone.cpp
@@ -1,0 +1,9 @@
+// 200-standalone.cpp
+
+// main() provided by target Catch2::Catch2WithMain
+
+#include <catch2/catch.hpp>
+
+TEST_CASE( "compiles and runs" ) {
+    REQUIRE( true == !false );
+}

--- a/recipes/catch2/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/catch2/2.x.x/test_package/CMakeLists.txt
@@ -7,5 +7,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_executable(${PROJECT_NAME} 000-CatchMain.cpp 100-Fix-Section.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+find_package(Catch2 REQUIRED)
+
+add_executable(test_package 000-CatchMain.cpp 100-Fix-Section.cpp)
+target_link_libraries(test_package PRIVATE Catch2::Catch2)
+
+add_executable(standalone 200-standalone.cpp)
+message(${CONAN_LIBS})
+target_link_libraries(standalone PRIVATE Catch2::Catch2WithMain)

--- a/recipes/catch2/2.x.x/test_package/conanfile.py
+++ b/recipes/catch2/2.x.x/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)
@@ -13,5 +13,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+            self.run(os.path.join("bin", "test_package"), run_environment=True)
+            self.run(os.path.join("bin", "standalone"), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **catch2/2.13.4**

followup for https://github.com/conan-io/conan-center-index/pull/4026 to enable usage of the new introduced target `Catch2::Catch2WithMain`

It is not a header only lib anymore!

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
