### PR TITLE
openh264: fix pkg-config name

### DIFF
--- a/recipes/openh264/all/conanfile.py
+++ b/recipes/openh264/all/conanfile.py
@@ -162,7 +162,7 @@ class OpenH264Conan(ConanFile):
             self.cpp_info.system_libs.extend(["m", "pthread"])
         if self.settings.os == "Android":
             self.cpp_info.system_libs.append("m")
-        self.cpp_info.names["pkg_config"] = "libopenh264"
+        self.cpp_info.names["pkg_config"] = "openh264"
         libcxx = tools.stdcpp_library(self)
         if libcxx:
             self.cpp_info.system_libs.append(libcxx)


### PR DESCRIPTION
https://github.com/cisco/openh264/blob/master/openh264.pc.in

@madebr you changed the name in https://github.com/conan-io/conan-center-index/pull/3696. Was it really intended?

Specify library name and version:  **openh264/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
