### PR TITLE
opusfile: make http (openssl) optional + add opusurl component

### DIFF
--- a/recipes/opusfile/all/conandata.yml
+++ b/recipes/opusfile/all/conandata.yml
@@ -7,10 +7,8 @@ sources:
     sha256: "c2105cffc59545ffc0d2a65069e2f222a1712bbe579911ac0a3d3660edbbec57"
 patches:
   "0.12":
-    # patch taken from https://github.com/xiph/opusfile/issues/13#issuecomment-425349836 for OpenSSL 1.1.1 support
     - patch_file: "patches/001-disable-cert-store-integration.patch"
       base_path: "source_subfolder"
   "0.11":
-    # patch taken from https://github.com/xiph/opusfile/issues/13#issuecomment-425349836 for OpenSSL 1.1.1 support
     - patch_file: "patches/001-disable-cert-store-integration.patch"
       base_path: "source_subfolder"

--- a/recipes/opusfile/all/conanfile.py
+++ b/recipes/opusfile/all/conanfile.py
@@ -11,22 +11,28 @@ class OpusFileConan(ConanFile):
     homepage = "https://github.com/xiph/opusfile"
     license = "BSD-3-Clause"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
-    generators = ["pkg_config"]
-    requires = (
-        "opus/1.3.1",
-        "ogg/1.3.4",
-        "openssl/1.1.1h"
-    )
-    exports = ["patches/*"]
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "http": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "http": True,
+    }
+    generators = "pkg_config"
+    exports_sources = "patches/*"
+
     _autotools = None
-    _source_subfolder = "source_subfolder"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
     @property
     def _is_msvc(self):
-        return self.settings.os == "Windows" and \
-               self.settings.compiler == "Visual Studio"
+        return self.settings.compiler == "Visual Studio"
 
     def config_options(self):
         if self.settings.os == 'Windows':
@@ -38,6 +44,20 @@ class OpusFileConan(ConanFile):
         if self._is_msvc and self.options.shared:
             raise ConanInvalidConfiguration("Opusfile doesn't support building as shared with Visual Studio")
 
+    def requirements(self):
+        self.requires("ogg/1.3.4")
+        self.requires("opus/1.3.1")
+        if self.options.http:
+            self.requires("openssl/1.1.1i")
+
+    def build_requirements(self):
+        if not self._is_msvc:
+            # FIXME: needs libtool for `autoreconf`, but the `configure.ac` file uses `m4_esyscmd` with bash code as argument.
+            # Looks like this does not work with a MSVC-built m4.
+            # self.build_requires("libtool/2.4.6")
+            if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+                self.build_requires("msys2/20200517")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
@@ -47,30 +67,36 @@ class OpusFileConan(ConanFile):
         includedir = os.path.abspath(os.path.join(self._source_subfolder, "include"))
         with tools.chdir(os.path.join(self._source_subfolder, "win32", "VS2015")):
             msbuild = MSBuild(self)
+            build_type = str(self.settings.build_type)
+            if not self.options.http:
+                build_type += "-NoHTTP"
             msbuild.build_env.include_paths.append(includedir)
             msbuild.build(project_file="opusfile.sln", targets=["opusfile"],
-                          platforms={"x86": "Win32"},
+                          platforms={"x86": "Win32"}, build_type=build_type,
                           upgrade_project=False)
 
     def _configure_autotools(self):
-        if not self._autotools:
-            with tools.chdir(self._source_subfolder):
-                self.run("./autogen.sh", win_bash=tools.os_info.is_windows)
-            args = []
-            if self.options.shared:
-                args.extend(["--disable-static", "--enable-shared"])
-            else:
-                args.extend(["--disable-shared", "--enable-static"])
-            self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-            self._autotools.configure(args=args, configure_dir=self._source_subfolder)
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        yes_no = lambda v: "yes" if v else "no"
+        args = [
+            "--enable-shared={}".format(yes_no(self.options.shared)),
+            "--enable-static={}".format(yes_no(not self.options.shared)),
+            "--enable-http={}".format(yes_no(self.options.http)),
+            "--disable-examples",
+        ]
+        self._autotools.configure(args=args, configure_dir=self._source_subfolder)
         return self._autotools
 
     def build(self):
-        for patch in self.conan_data["patches"][self.version]:
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         if self._is_msvc:
             self._build_vs()
         else:
+            with tools.chdir(self._source_subfolder):
+                self.run("./autogen.sh", win_bash=tools.os_info.is_windows, run_environment=True)
             autotools = self._configure_autotools()
             autotools.make()
 
@@ -90,7 +116,16 @@ class OpusFileConan(ConanFile):
             os.remove(os.path.join(self.package_folder, "lib", "libopusurl.la"))
 
     def package_info(self):
-        self.cpp_info.libs = ["opusfile"]
-        self.cpp_info.includedirs.append(os.path.join("include", "opus"))
-        if self.settings.os == "Linux":
-            self.cpp_info.system_libs = ["m", "dl", "pthread"]
+        self.cpp_info.components["libopusfile"].names["pkg_config"] = "opusfile"
+        self.cpp_info.components["libopusfile"].libs = ["opusfile"]
+        self.cpp_info.components["libopusfile"].includedirs.append(os.path.join("include", "opus"))
+        self.cpp_info.components["libopusfile"].requires = ["ogg::ogg", "opus::opus"]
+        if self.options.http:
+            self.cpp_info.components["libopusfile"].requires.append("openssl::openssl")
+        if self.settings.os in ("FreeBSD", "Linux"):
+            self.cpp_info.components["libopusfile"].system_libs = ["m", "dl", "pthread"]
+
+        if not self._is_msvc:
+            self.cpp_info.components["opusurl"].names["pkg_config"] = "opusurl"
+            self.cpp_info.components["opusurl"].libs = ["opusurl"]
+            self.cpp_info.components["opusurl"].requires = ["libopusfile"]

--- a/recipes/opusfile/all/conanfile.py
+++ b/recipes/opusfile/all/conanfile.py
@@ -120,12 +120,15 @@ class OpusFileConan(ConanFile):
         self.cpp_info.components["libopusfile"].libs = ["opusfile"]
         self.cpp_info.components["libopusfile"].includedirs.append(os.path.join("include", "opus"))
         self.cpp_info.components["libopusfile"].requires = ["ogg::ogg", "opus::opus"]
-        if self.options.http:
-            self.cpp_info.components["libopusfile"].requires.append("openssl::openssl")
         if self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.components["libopusfile"].system_libs = ["m", "dl", "pthread"]
 
-        if not self._is_msvc:
+        if self._is_msvc:
+            if self.options.http:
+                self.cpp_info.components["libopusfile"].requires.append("openssl::openssl")
+        else:
             self.cpp_info.components["opusurl"].names["pkg_config"] = "opusurl"
             self.cpp_info.components["opusurl"].libs = ["opusurl"]
             self.cpp_info.components["opusurl"].requires = ["libopusfile"]
+            if self.options.http:
+                self.cpp_info.components["opusurl"].requires.append("openssl::openssl")

--- a/recipes/opusfile/all/patches/001-disable-cert-store-integration.patch
+++ b/recipes/opusfile/all/patches/001-disable-cert-store-integration.patch
@@ -1,3 +1,5 @@
+patch taken from https://github.com/xiph/opusfile/issues/13#issuecomment-425349836 for OpenSSL 1.1.1 support
+
 diff -Nur opusfile-0.11/src/http.c opusfile-0.11-patched/src/http.c
 --- a/src/http.c	2018-09-14 23:25:45.000000000 +0200
 +++ b/src/http.c	2018-09-27 15:42:55.161531800 +0200


### PR DESCRIPTION
Specify library name and version:  **opusfile/all**

- bump openssl
- make *http* (openssl) optional
- add opusurl component (for non-MSVC)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
