### PR TITLE
acado/1.2.2-beta template fix

### DIFF
--- a/recipes/acado/all/conanfile.py
+++ b/recipes/acado/all/conanfile.py
@@ -66,6 +66,15 @@ class AcadoConan(ConanFile):
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
 
+    def deploy(self):
+        # include/acado/code_generation/templates/templates.hpp contains hardcoded paths that need to be adapted
+        new_template_folder = os.path.join(self.package_folder, "include", "acado", "code_generation", "templates")
+        tools.replace_in_file(
+            os.path.join(new_template_folder, "templates.hpp"),
+            "#define TEMPLATE_PATHS",
+            f'#define TEMPLATE_PATHS "{new_template_folder}" \n//',
+        )
+
     def build(self):
         self._patch_sources()
         cmake = self._configure_cmake()


### PR DESCRIPTION
Specify library name and version:  **acado/1.2.2-beta**

The installed file `include/acado/code_generation/templates/templates.hpp` contains hardcoded paths that need to be adapted. Otherwise we get CCI CI paths like `/home/conan/w/cci_PR-3967/.conan/data/acado/1.2.2-beta/_/_/build/6384f4f1a20d5949e786ef62bf18a6d2899555e4/source_subfolder/acado/code_generation/export_templated_file.cpp` 😕 

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
