### PR TITLE
ACADO silence compiler warinings

### DIFF
--- a/recipes/acado/all/conanfile.py
+++ b/recipes/acado/all/conanfile.py
@@ -59,7 +59,12 @@ class AcadoConan(ConanFile):
         self._cmake.definitions["ACADO_INTERNAL"] = False
         self._cmake.definitions["ACADO_BUILD_CGT_ONLY"] = self.options.codegen_only
 
-        self._cmake.definitions["CMAKE_CXX_FLAGS"] = "-w"
+        if self.settings.compiler == "Visual Studio":
+            self._cmake.definitions["CMAKE_C_FLAGS"] = "/w"
+            self._cmake.definitions["CMAKE_CXX_FLAGS"] = "/w"
+        else:
+            self._cmake.definitions["CMAKE_C_FLAGS"] = "-w"
+            self._cmake.definitions["CMAKE_CXX_FLAGS"] = "-w"
 
         self._cmake.configure()
         return self._cmake

--- a/recipes/acado/all/conanfile.py
+++ b/recipes/acado/all/conanfile.py
@@ -59,6 +59,7 @@ class AcadoConan(ConanFile):
         self._cmake.definitions["ACADO_INTERNAL"] = False
         self._cmake.definitions["ACADO_BUILD_CGT_ONLY"] = self.options.codegen_only
 
+        # ACADO logs 170.000 lines of warnings, so we disable them
         self._cmake.definitions["CMAKE_C_FLAGS"] = "-w"
         self._cmake.definitions["CMAKE_CXX_FLAGS"] = "-w"
 

--- a/recipes/acado/all/conanfile.py
+++ b/recipes/acado/all/conanfile.py
@@ -59,6 +59,8 @@ class AcadoConan(ConanFile):
         self._cmake.definitions["ACADO_INTERNAL"] = False
         self._cmake.definitions["ACADO_BUILD_CGT_ONLY"] = self.options.codegen_only
 
+        self._cmake.definitions["CMAKE_CXX_FLAGS"] = "-w"
+
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/acado/all/conanfile.py
+++ b/recipes/acado/all/conanfile.py
@@ -59,12 +59,8 @@ class AcadoConan(ConanFile):
         self._cmake.definitions["ACADO_INTERNAL"] = False
         self._cmake.definitions["ACADO_BUILD_CGT_ONLY"] = self.options.codegen_only
 
-        if self.settings.compiler == "Visual Studio":
-            self._cmake.definitions["CMAKE_C_FLAGS"] = "/w"
-            self._cmake.definitions["CMAKE_CXX_FLAGS"] = "/w"
-        else:
-            self._cmake.definitions["CMAKE_C_FLAGS"] = "-w"
-            self._cmake.definitions["CMAKE_CXX_FLAGS"] = "-w"
+        self._cmake.definitions["CMAKE_C_FLAGS"] = "-w"
+        self._cmake.definitions["CMAKE_CXX_FLAGS"] = "-w"
 
         self._cmake.configure()
         return self._cmake


### PR DESCRIPTION
Specify library name and version:  **acado/1.2.2-beta**

Add `-w` flag to silence warnings, as displaying them takes ~90% of the build time on a hot ccache (roughly 170.000 lines of warning messages are generated 😞 ).

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
