### PR TITLE
libusb: add version 1.0.24

### DIFF
--- a/recipes/libusb/all/conandata.yml
+++ b/recipes/libusb/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.0.23":
     sha256: db11c06e958a82dac52cf3c65cb4dd2c3f339c8a988665110e0d24d19312ad8d
     url: https://github.com/libusb/libusb/releases/download/v1.0.23/libusb-1.0.23.tar.bz2
+  "1.0.24":
+    sha256: 7efd2685f7b327326dcfb85cee426d9b871fd70e22caa15bb68d595ce2a2b12a
+    url: https://github.com/libusb/libusb/releases/download/v1.0.24/libusb-1.0.24.tar.bz2

--- a/recipes/libusb/all/conanfile.py
+++ b/recipes/libusb/all/conanfile.py
@@ -68,7 +68,13 @@ class LibUSBConan(ConanFile):
 
     def _build_visual_studio(self):
         with tools.chdir(self._source_subfolder):
-            solution_file = "libusb_2017.sln"
+            if tools.Version(self.version) >= "1.0.24":
+                solution_file = "libusb_2019.sln"
+            else:
+                solution_file = "libusb_2017.sln"
+
+            if self.settings.compiler.version == "15":
+                solution_file = "libusb_2017.sln"
             if self.settings.compiler.version == "14":
                 solution_file = "libusb_2015.sln"
             if self.settings.compiler.version == "12":

--- a/recipes/libusb/all/conanfile.py
+++ b/recipes/libusb/all/conanfile.py
@@ -104,10 +104,11 @@ class LibUSBConan(ConanFile):
 
     def build(self):
         if self._is_msvc:
-            for vcxproj in ["fxload_2017", "getopt_2017", "hotplugtest_2017", "libusb_dll_2017",
-                            "libusb_static_2017", "listdevs_2017", "stress_2017", "testlibusb_2017", "xusb_2017"]:
-                vcxproj_path = os.path.join(self._source_subfolder, "msvc", "%s.vcxproj" % vcxproj)
-                tools.replace_in_file(vcxproj_path, "<WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>", "")
+            if tools.Version(self.version) < "1.0.24":
+                for vcxproj in ["fxload_2017", "getopt_2017", "hotplugtest_2017", "libusb_dll_2017",
+                                "libusb_static_2017", "listdevs_2017", "stress_2017", "testlibusb_2017", "xusb_2017"]:
+                    vcxproj_path = os.path.join(self._source_subfolder, "msvc", "%s.vcxproj" % vcxproj)
+                    tools.replace_in_file(vcxproj_path, "<WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>", "")
             self._build_visual_studio()
         else:
             autotools = self._configure_autotools()

--- a/recipes/libusb/all/conanfile.py
+++ b/recipes/libusb/all/conanfile.py
@@ -68,20 +68,19 @@ class LibUSBConan(ConanFile):
 
     def _build_visual_studio(self):
         with tools.chdir(self._source_subfolder):
-            if tools.Version(self.version) >= "1.0.24":
-                solution_file = "libusb_2019.sln"
-            else:
-                solution_file = "libusb_2017.sln"
+            # Assume we're using the latest Visual Studio and default to libusb_2019.sln
+            # (or libusb_2017.sln for libusb < 1.0.24).
+            # If we're not using the latest Visual Studio, select an appropriate solution file.
+            solution_msvc_year = 2019 if tools.Version(self.version) >= "1.0.24" else 2017
 
-            if self.settings.compiler.version == "15":
-                solution_file = "libusb_2017.sln"
-            if self.settings.compiler.version == "14":
-                solution_file = "libusb_2015.sln"
-            if self.settings.compiler.version == "12":
-                solution_file = "libusb_2013.sln"
-            elif self.settings.compiler.version == "11":
-                solution_file = "libusb_2012.sln"
-            solution_file = os.path.join("msvc", solution_file)
+            solution_msvc_year = {
+                "11": 2012,
+                "12": 2013,
+                "14": 2015,
+                "15": 2017
+            }.get(str(self.settings.compiler.version), solution_msvc_year)
+
+            solution_file = os.path.join("msvc", "libusb_{}.sln".format(solution_msvc_year))
             platforms = {"x86":"Win32"}
             msbuild = MSBuild(self)
             msbuild.build(solution_file, platforms=platforms, upgrade_project=False)

--- a/recipes/libusb/config.yml
+++ b/recipes/libusb/config.yml
@@ -2,3 +2,5 @@
 versions:
   "1.0.23":
     folder: all
+  "1.0.24":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libusb/1.0.24**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.  **Tested with Conan 1.32.1.**
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated. **Built on x86-64 Linux with gcc 9.3.0.**

