### PR TITLE
Add WiringPi 2.50

### DIFF
--- a/recipes/wiringpi/all/CMakeLists.txt
+++ b/recipes/wiringpi/all/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(wiringPi C)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+FILE(GLOB SRC_FILES source_subfolder/wiringPi/*.c)
+message(STATUS "SRC_FILES: ${SRC_FILES}")
+if(NOT WITH_WPI_EXTENSIONS)
+  list(FILTER SRC_FILES EXCLUDE REGEX ".*wpiExtensions.c")
+  list(FILTER SRC_FILES EXCLUDE REGEX ".*drcNet.c")
+endif()
+
+add_library(${PROJECT_NAME} ${SRC_FILES})
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder/wiringPi)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${CONAN_LIBS})
+
+if(WITH_DEV_LIB)
+    FILE(GLOB SRC_FILES source_subfolder/devLib//*.c)
+    list(FILTER SRC_FILES EXCLUDE REGEX ".*piFaceOld.c")
+    add_library(wiringPiDevLib ${SRC_FILES})
+    target_include_directories(wiringPiDevLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder/devLib
+                                                     ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder/wiringPi)
+endif()
+
+install(TARGETS ${PROJECT_NAME}
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+
+install(DIRECTORY source_subfolder/wiringPi/ DESTINATION include
+        FILES_MATCHING PATTERN "*.h")
+
+if(WITH_DEV_LIB)
+
+    install(TARGETS wiringPiDevLib
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+
+    install(DIRECTORY source_subfolder/devLib/ DESTINATION include
+            FILES_MATCHING PATTERN "*.h")
+endif()

--- a/recipes/wiringpi/all/conandata.yml
+++ b/recipes/wiringpi/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.50":
+    sha256: f1ddf17e876f88e074d4597767e365a1b5ef20414a38754884935b38d8c8e932
+    url: https://github.com/WiringPi/WiringPi/archive/final_official_2.50.tar.gz

--- a/recipes/wiringpi/all/conanfile.py
+++ b/recipes/wiringpi/all/conanfile.py
@@ -1,0 +1,71 @@
+import os
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+
+
+class WiringpiConan(ConanFile):
+    name = "wiringpi"
+    license = "LGPL-3.0"
+    description = "GPIO Interface library for the Raspberry Pi"
+    homepage = "http://wiringpi.com"
+    topics = ("conan", "wiringpi", "gpio", "raspberrypi")
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False],
+               "fPIC": [True, False],
+               "wpi_extensions": [True, False],
+               "with_devlib": [True, False]}
+    default_options = {"shared": False,
+                       "fPIC": True,
+                       "wpi_extensions": False,
+                       "with_devlib": True}
+    exports_sources = ["CMakeLists.txt", "patches/*"]
+    generators = "cmake"
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def validate(self):
+        if self.settings.os in ("Windows", "Macos"):
+            raise ConanInvalidConfiguration("This library is not suitable for Windows/Macos")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("WiringPi-final_official_" + self.version, self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["WITH_WPI_EXTENSIONS"] = self.options.wpi_extensions
+        self._cmake.definitions["WITH_DEV_LIB"] = self.options.with_devlib
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("COPYING*", src=self._source_subfolder, dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["wiringPi"]
+        if self.options.with_devlib:
+            self.cpp_info.libs.append("wiringPiDevLib")
+        if self.options.wpi_extensions:
+            self.cpp_info.libs.append("crypt")
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs = ["pthread", "m", "rt"]

--- a/recipes/wiringpi/all/conanfile.py
+++ b/recipes/wiringpi/all/conanfile.py
@@ -19,7 +19,7 @@ class WiringpiConan(ConanFile):
                        "fPIC": True,
                        "wpi_extensions": False,
                        "with_devlib": True}
-    exports_sources = ["CMakeLists.txt", "patches/*"]
+    exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
     _cmake = None
 

--- a/recipes/wiringpi/all/conanfile.py
+++ b/recipes/wiringpi/all/conanfile.py
@@ -3,6 +3,9 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
 
+required_conan_version = ">=1.32"
+
+
 class WiringpiConan(ConanFile):
     name = "wiringpi"
     license = "LGPL-3.0"

--- a/recipes/wiringpi/all/test_package/CMakeLists.txt
+++ b/recipes/wiringpi/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(test_package test_package.c)
+target_link_libraries(test_package ${CONAN_LIBS})

--- a/recipes/wiringpi/all/test_package/conanfile.py
+++ b/recipes/wiringpi/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/wiringpi/all/test_package/test_package.c
+++ b/recipes/wiringpi/all/test_package/test_package.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "wiringPi.h"
+
+int main(void) {
+    int major = 0;
+    int minor = 0;
+    wiringPiVersion(&major, &minor);
+    printf("WiringPi version: %d.%d\n", major, minor);
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/wiringpi/config.yml
+++ b/recipes/wiringpi/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.50":
+    folder: "all"


### PR DESCRIPTION
It's another migration from Conan Community.

This project is abandoned now, but there is a community fork: https://github.com/WiringPi

Related to https://github.com/conan-community/community/issues/327

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
