### PR TITLE
vorbis: change global package pkg-config file name

### DIFF
--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -66,7 +66,7 @@ class VorbisConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "Vorbis"
         self.cpp_info.names["cmake_find_package_multi"] = "Vorbis"
-        self.cpp_info.names["pkg_config"] = "vorbis_full_package"
+        self.cpp_info.names["pkg_config"] = "vorbis_full_package" # see https://github.com/conan-io/conan-center-index/pull/4173
         # vorbis
         self.cpp_info.components["vorbismain"].names["cmake_find_package"] = "vorbis"
         self.cpp_info.components["vorbismain"].names["cmake_find_package_multi"] = "vorbis"

--- a/recipes/vorbis/all/conanfile.py
+++ b/recipes/vorbis/all/conanfile.py
@@ -66,6 +66,7 @@ class VorbisConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "Vorbis"
         self.cpp_info.names["cmake_find_package_multi"] = "Vorbis"
+        self.cpp_info.names["pkg_config"] = "vorbis_full_package"
         # vorbis
         self.cpp_info.components["vorbismain"].names["cmake_find_package"] = "vorbis"
         self.cpp_info.components["vorbismain"].names["cmake_find_package_multi"] = "vorbis"


### PR DESCRIPTION
this allows to have both a "vorbis_full_package.pc" file which represents the full package, and a `vorbis.pc` file which represents the vorbismain component, so that  dependents like libsndfile actually resolve the full vorbis package.

Specify library name and version:  **vorbis/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.