### PR TITLE
[libjpeg] Update checksums for tarballs

### DIFF
--- a/recipes/libjpeg/all/conandata.yml
+++ b/recipes/libjpeg/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
   "9c":
     url: "http://ijg.org/files/jpegsrc.v9c.tar.gz"
-    sha256: "650250979303a649e21f87b5ccd02672af1ea6954b911342ea491f351ceb7122"
+    sha256: "1e9793e1c6ba66e7e0b6e5fe7fd0f9e935cc697854d5737adec54d93e5b3f730"
   "9d":
     url: "http://ijg.org/files/jpegsrc.v9d.tar.gz"
-    sha256: "99cb50e48a4556bc571dadd27931955ff458aae32f68c4d9c39d624693f69c32"
+    sha256: "6c434a3be59f8f62425b2e3c077e785c9ce30ee5874ea1c270e843f273ba71ee"
 patches:
   "9c":
     - patch_file: "patches/0001-libjpeg-add-msvc-dll-support.patch"


### PR DESCRIPTION
The Independent JPEG Group uploaded new tarballs that removed some control
characters from the beginning of some build files.

Fixes #4151

Specify library name and version:  **libjpeg/9c** **libjpeg/9d**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

The upstream source tarballs had small changes, which are summarized below. These changes appear to remove some control characters from the front of some build files.

`jpegsrc.v9c.tar.gz`:

```
❯ diff -ur jpeg-9c-20200102142831 jpeg-9c
diff -ur jpeg-9c-20200102142831/makeasln.v15 jpeg-9c/makeasln.v15
--- jpeg-9c-20200102142831/makeasln.v15	2010-05-01 15:10:02.000000000 -0500
+++ jpeg-9c/makeasln.v15	2010-05-01 17:10:02.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®
+
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual C++ Express 2010
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cjpeg", "cjpeg.vcxproj", "{2E7FAAD9-2F58-4BDE-81F2-1D6D3FB8BF57}"
diff -ur jpeg-9c-20200102142831/makecfil.v15 jpeg-9c/makecfil.v15
--- jpeg-9c-20200102142831/makecfil.v15	2010-05-02 03:20:38.000000000 -0500
+++ jpeg-9c/makecfil.v15	2010-05-02 05:20:38.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9c-20200102142831/makecvcx.v15 jpeg-9c/makecvcx.v15
--- jpeg-9c-20200102142831/makecvcx.v15	2017-10-11 09:27:46.000000000 -0500
+++ jpeg-9c/makecvcx.v15	2017-10-11 09:27:46.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
diff -ur jpeg-9c-20200102142831/makedfil.v15 jpeg-9c/makedfil.v15
--- jpeg-9c-20200102142831/makedfil.v15	2010-05-02 03:20:38.000000000 -0500
+++ jpeg-9c/makedfil.v15	2010-05-02 05:20:38.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9c-20200102142831/makedvcx.v15 jpeg-9c/makedvcx.v15
--- jpeg-9c-20200102142831/makedvcx.v15	2017-10-11 09:27:46.000000000 -0500
+++ jpeg-9c/makedvcx.v15	2017-10-11 09:27:46.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
diff -ur jpeg-9c-20200102142831/makejfil.v15 jpeg-9c/makejfil.v15
--- jpeg-9c-20200102142831/makejfil.v15	2010-05-01 12:36:54.000000000 -0500
+++ jpeg-9c/makejfil.v15	2010-05-01 14:36:54.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9c-20200102142831/makejsln.v15 jpeg-9c/makejsln.v15
--- jpeg-9c-20200102142831/makejsln.v15	2010-05-01 13:13:08.000000000 -0500
+++ jpeg-9c/makejsln.v15	2010-05-01 15:13:08.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®
+
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual C++ Express 2010
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "jpeg", "jpeg.vcxproj", "{019DBD2A-273D-4BA4-BF86-B5EFE2ED76B1}"
diff -ur jpeg-9c-20200102142831/makejvcx.v15 jpeg-9c/makejvcx.v15
--- jpeg-9c-20200102142831/makejvcx.v15	2017-10-11 09:23:12.000000000 -0500
+++ jpeg-9c/makejvcx.v15	2017-10-11 09:23:12.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
diff -ur jpeg-9c-20200102142831/makerfil.v15 jpeg-9c/makerfil.v15
--- jpeg-9c-20200102142831/makerfil.v15	2010-05-02 03:20:38.000000000 -0500
+++ jpeg-9c/makerfil.v15	2010-05-02 05:20:38.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9c-20200102142831/makervcx.v15 jpeg-9c/makervcx.v15
--- jpeg-9c-20200102142831/makervcx.v15	2017-10-11 09:27:46.000000000 -0500
+++ jpeg-9c/makervcx.v15	2017-10-11 09:27:46.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
diff -ur jpeg-9c-20200102142831/maketfil.v15 jpeg-9c/maketfil.v15
--- jpeg-9c-20200102142831/maketfil.v15	2010-05-02 03:20:38.000000000 -0500
+++ jpeg-9c/maketfil.v15	2010-05-02 05:20:38.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9c-20200102142831/maketvcx.v15 jpeg-9c/maketvcx.v15
--- jpeg-9c-20200102142831/maketvcx.v15	2017-10-11 09:27:46.000000000 -0500
+++ jpeg-9c/maketvcx.v15	2017-10-11 09:27:46.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
diff -ur jpeg-9c-20200102142831/makewfil.v15 jpeg-9c/makewfil.v15
--- jpeg-9c-20200102142831/makewfil.v15	2010-05-02 03:20:38.000000000 -0500
+++ jpeg-9c/makewfil.v15	2010-05-02 05:20:38.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9c-20200102142831/makewvcx.v15 jpeg-9c/makewvcx.v15
--- jpeg-9c-20200102142831/makewvcx.v15	2017-10-11 09:27:46.000000000 -0500
+++ jpeg-9c/makewvcx.v15	2017-10-11 09:27:46.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
```

`jpegsrc.v9d.tar.gz`:

```
❯ diff -ur jpeg-9d-20200127160911 jpeg-9d
diff -ur jpeg-9d-20200127160911/makeasln.v16 jpeg-9d/makeasln.v16
--- jpeg-9d-20200127160911/makeasln.v16	2019-02-07 11:19:48.000000000 -0600
+++ jpeg-9d/makeasln.v16	2019-02-07 12:19:48.000000000 -0600
@@ -1,4 +1,4 @@
-ãØ®
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.329
diff -ur jpeg-9d-20200127160911/makecfil.v16 jpeg-9d/makecfil.v16
--- jpeg-9d-20200127160911/makecfil.v16	2010-05-02 03:20:38.000000000 -0500
+++ jpeg-9d/makecfil.v16	2010-05-02 06:20:38.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9d-20200127160911/makecvcx.v16 jpeg-9d/makecvcx.v16
--- jpeg-9d-20200127160911/makecvcx.v16	2019-04-04 13:12:08.000000000 -0500
+++ jpeg-9d/makecvcx.v16	2019-04-04 14:12:08.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
diff -ur jpeg-9d-20200127160911/makedfil.v16 jpeg-9d/makedfil.v16
--- jpeg-9d-20200127160911/makedfil.v16	2010-05-02 03:20:38.000000000 -0500
+++ jpeg-9d/makedfil.v16	2010-05-02 06:20:38.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9d-20200127160911/makedvcx.v16 jpeg-9d/makedvcx.v16
--- jpeg-9d-20200127160911/makedvcx.v16	2019-04-04 13:12:08.000000000 -0500
+++ jpeg-9d/makedvcx.v16	2019-04-04 14:12:08.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
diff -ur jpeg-9d-20200127160911/makejfil.v16 jpeg-9d/makejfil.v16
--- jpeg-9d-20200127160911/makejfil.v16	2010-05-01 12:36:54.000000000 -0500
+++ jpeg-9d/makejfil.v16	2010-05-01 15:36:54.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9d-20200127160911/makejsln.v16 jpeg-9d/makejsln.v16
--- jpeg-9d-20200127160911/makejsln.v16	2019-02-07 11:05:24.000000000 -0600
+++ jpeg-9d/makejsln.v16	2019-02-07 12:05:24.000000000 -0600
@@ -1,4 +1,4 @@
-ãØ®
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.329
diff -ur jpeg-9d-20200127160911/makejvcx.v16 jpeg-9d/makejvcx.v16
--- jpeg-9d-20200127160911/makejvcx.v16	2019-04-04 13:04:56.000000000 -0500
+++ jpeg-9d/makejvcx.v16	2019-04-04 14:04:56.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
diff -ur jpeg-9d-20200127160911/makerfil.v16 jpeg-9d/makerfil.v16
--- jpeg-9d-20200127160911/makerfil.v16	2010-05-02 03:20:38.000000000 -0500
+++ jpeg-9d/makerfil.v16	2010-05-02 06:20:38.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9d-20200127160911/makervcx.v16 jpeg-9d/makervcx.v16
--- jpeg-9d-20200127160911/makervcx.v16	2019-04-04 13:12:08.000000000 -0500
+++ jpeg-9d/makervcx.v16	2019-04-04 14:12:08.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
diff -ur jpeg-9d-20200127160911/maketfil.v16 jpeg-9d/maketfil.v16
--- jpeg-9d-20200127160911/maketfil.v16	2010-05-02 03:20:38.000000000 -0500
+++ jpeg-9d/maketfil.v16	2010-05-02 06:20:38.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9d-20200127160911/maketvcx.v16 jpeg-9d/maketvcx.v16
--- jpeg-9d-20200127160911/maketvcx.v16	2019-04-04 13:12:08.000000000 -0500
+++ jpeg-9d/maketvcx.v16	2019-04-04 14:12:08.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
diff -ur jpeg-9d-20200127160911/makewfil.v16 jpeg-9d/makewfil.v16
--- jpeg-9d-20200127160911/makewfil.v16	2010-05-02 03:20:38.000000000 -0500
+++ jpeg-9d/makewfil.v16	2010-05-02 06:20:38.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
diff -ur jpeg-9d-20200127160911/makewvcx.v16 jpeg-9d/makewvcx.v16
--- jpeg-9d-20200127160911/makewvcx.v16	2019-04-04 13:12:10.000000000 -0500
+++ jpeg-9d/makewvcx.v16	2019-04-04 14:12:10.000000000 -0500
@@ -1,4 +1,4 @@
-ãØ®<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
```