### PR TITLE
strawberryperl: use os/arch for cross building

### DIFF
--- a/recipes/strawberryperl/all/conanfile.py
+++ b/recipes/strawberryperl/all/conanfile.py
@@ -10,17 +10,17 @@ class StrawberryperlConan(ConanFile):
     homepage = "http://strawberryperl.com"
     url = "https://github.com/conan-io/conan-center-index"
     topics = ("conan", "installer", "perl", "windows")
-    settings = "os_build", "arch_build"
+    settings = "os", "arch"
     short_paths = True
 
     def configure(self):
-        if self.settings.os_build != "Windows":
+        if self.settings.os != "Windows":
             raise ConanInvalidConfiguration("Only windows supported for Strawberry Perl.")
 
     def build(self):
-        arch_build = str(self.settings.arch_build)
-        url = self.conan_data["sources"][self.version]["url"][arch_build]
-        sha256 = self.conan_data["sources"][self.version]["sha256"][arch_build]
+        arch = str(self.settings.arch)
+        url = self.conan_data["sources"][self.version]["url"][arch]
+        sha256 = self.conan_data["sources"][self.version]["sha256"][arch]
         tools.get(url, sha256=sha256)
 
     def package(self):

--- a/recipes/strawberryperl/all/conanfile.py
+++ b/recipes/strawberryperl/all/conanfile.py
@@ -37,3 +37,5 @@ class StrawberryperlConan(ConanFile):
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: %s" % bin_path)
         self.env_info.PATH.append(bin_path)
+
+        self.deps_user_info.perl = os.path.join(self.package_folder, "bin", "perl.exe").replace("\\", "/")

--- a/recipes/strawberryperl/all/test_package/conanfile.py
+++ b/recipes/strawberryperl/all/test_package/conanfile.py
@@ -7,6 +7,6 @@ class DefaultNameConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self):
-            self.run("perl --version")
+            self.run("perl --version", run_environment=True)
             perl_script = os.path.join(self.source_folder, "list_files.pl")
             self.run("perl {}".format(perl_script), run_environment=True)

--- a/recipes/strawberryperl/all/test_package/conanfile.py
+++ b/recipes/strawberryperl/all/test_package/conanfile.py
@@ -1,11 +1,12 @@
 import os
-from conans import ConanFile
+from conans import ConanFile, tools
 
 
 class DefaultNameConan(ConanFile):
     settings = "os", "arch"
 
     def test(self):
-        self.run("perl --version")
-        perl_script = os.path.join(self.source_folder, "list_files.pl")
-        self.run("perl {}".format(perl_script), run_environment=True)
+        if not tools.cross_building(self):
+            self.run("perl --version")
+            perl_script = os.path.join(self.source_folder, "list_files.pl")
+            self.run("perl {}".format(perl_script), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **strawberryperl/all**

Don't use `os_build/os_arch` to enable use in cross building.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
