### PR TITLE
meson: add version 0.56.2

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -47,3 +47,6 @@ sources:
   "0.56.1":
     url: "https://github.com/mesonbuild/meson/archive/0.56.1.tar.gz"
     sha256: "db3545231bb8f3ae3186a1a0f49f0acd239724af91781b783e843b80400f10ec"
+  "0.56.2":
+    url: "https://github.com/mesonbuild/meson/archive/0.56.2.tar.gz"
+    sha256: "aaae961c3413033789248ffe6762589e80b6cf487c334d0b808e31a32c48f35f"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -31,3 +31,5 @@ versions:
     folder: all
   "0.56.1":
     folder: all
+  "0.56.2":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/0.56.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
