### PR TITLE
bullet3: Add double precision define when option is set

### DIFF
--- a/recipes/bullet3/all/conanfile.py
+++ b/recipes/bullet3/all/conanfile.py
@@ -124,3 +124,5 @@ class Bullet3Conan(ConanFile):
         self.cpp_info.includedirs = ["include", os.path.join("include", "bullet")]
         if self.options.extras:
             self.cpp_info.includedirs.append(os.path.join("include", "bullet_robotics"))
+        if self.options.double_precision:
+            self.cpp_info.defines.append("BT_USE_DOUBLE_PRECISION")


### PR DESCRIPTION
Specify library name and version:  **bullet3/all**

When specifying the option `double_precision` you wouldn't also get the `BT_USE_DOUBLE_PRECISION` define you'll need to actually use the package in this configuration. You would likely experience some sort of linker error without it.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
