### PR TITLE
pulseaudio: bump required_conan_version and libcap + minor cosmetic changes

### DIFF
--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -68,7 +68,7 @@ class PulseAudioConan(ConanFile):
 
     def requirements(self):
         self.requires("libsndfile/1.0.30")
-        self.requires("libcap/2.45")
+        self.requires("libcap/2.46")
         if self.options.with_alsa:
             self.requires("libalsa/1.2.4")
         if self.options.with_glib:

--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -2,7 +2,8 @@ from conans import ConanFile, tools, AutoToolsBuildEnvironment, RunEnvironment
 from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.29.0"
+required_conan_version = ">=1.32.0"
+
 
 class PulseAudioConan(ConanFile):
     name = "pulseaudio"

--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -36,20 +36,11 @@ class PulseAudioConan(ConanFile):
         "with_dbus": False,
     }
 
-    build_requires = "gettext/0.20.1", "libtool/2.4.6"
+    _autotools = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
-
-    _autotools = None
-
-    def validate(self):
-        if self.options.get_safe("with_fftw") and self.options["fftw"].precision != "single":
-            raise ConanInvalidConfiguration("Pulse audio cannot use fftw %s precision."
-                                            "Either set option fftw:precision=single"
-                                            "or pulseaudio:with_fftw=False"
-                                            % self.options["fftw"].precision)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -64,7 +55,6 @@ class PulseAudioConan(ConanFile):
         del self.settings.compiler.cppstd
         if not self.options.with_dbus:
             del self.options.with_fftw
-
 
     def requirements(self):
         self.requires("libsndfile/1.0.30")
@@ -81,6 +71,17 @@ class PulseAudioConan(ConanFile):
             self.requires("openssl/1.1.1i")
         if self.options.with_dbus:
             self.requires("dbus/1.12.20")
+
+    def validate(self):
+        if self.options.get_safe("with_fftw") and self.options["fftw"].precision != "single":
+            raise ConanInvalidConfiguration("Pulse audio cannot use fftw %s precision."
+                                            "Either set option fftw:precision=single"
+                                            "or pulseaudio:with_fftw=False"
+                                            % self.options["fftw"].precision)
+
+    def build_requirements(self):
+        self.build_requires("gettext/0.20.1")
+        self.build_requires("libtool/2.4.6")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **pulseaudio/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
