### PR TITLE
Add timsort/1.2.2 and timsort/2.0.2

### DIFF
--- a/recipes/timsort/all/conandata.yml
+++ b/recipes/timsort/all/conandata.yml
@@ -5,9 +5,15 @@ sources:
   "1.2.1":
     sha256: 4f32285926330c97290b102c92c4ae8c308f46f70488d383595ae5f191e1de55
     url: https://github.com/timsort/cpp-TimSort/archive/v1.2.1.tar.gz
+  "1.2.2":
+    sha256: 594a5e59248accd1caa6a9e0f145d91ed9cf5bf1044d46684df1e866a534ee76
+    url: https://github.com/timsort/cpp-TimSort/archive/v1.2.2.tar.gz
   "2.0.0":
     sha256: 6cb23b0efb83e1d4f6eab58cddd35b36ca49cd927a46294575b9c0d304a2e833
     url: https://github.com/timsort/cpp-TimSort/archive/v2.0.0.tar.gz
   "2.0.1":
     sha256: 5c7fe16ca8ead3a86691cb64c373b9ca634add6b6539254baa58f4e254e865c6
     url: https://github.com/timsort/cpp-TimSort/archive/v2.0.1.tar.gz
+  "2.0.2":
+    sha256: df15ac2cea751e573979ff97966f2b3d5d9c35a819c43d9944756974e069b2d7
+    url: https://github.com/timsort/cpp-TimSort/archive/v2.0.2.tar.gz

--- a/recipes/timsort/all/conanfile.py
+++ b/recipes/timsort/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conans import ConanFile, tools
 
-required_conan_version = ">=1.28.0"
+required_conan_version = ">=1.32.0"
 
 class TimsortConan(ConanFile):
     name = "timsort"
@@ -18,7 +18,7 @@ class TimsortConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
-    def configure(self):
+    def validate(self):
         if self.settings.compiler.cppstd:
             if tools.Version(self.version) >= "2.0.0":
                 tools.check_min_cppstd(self, 11)

--- a/recipes/timsort/config.yml
+++ b/recipes/timsort/config.yml
@@ -3,7 +3,11 @@ versions:
     folder: all
   "1.2.1":
     folder: all
+  "1.2.2":
+    folder: all
   "2.0.0":
     folder: all
   "2.0.1":
+    folder: all
+  "2.0.2":
     folder: all


### PR DESCRIPTION
Specify library name and versions:  **timsort/1.2.2** and **timsort/2.0.2**

The standard version checks in the `conanfile.py` were also moved from the `configure()` method to the new `validate()` method.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
