### PR TITLE
Add GFortran 10.2

### DIFF
--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -1,0 +1,13 @@
+sources:
+  "10.2":
+    url:
+      "Windows":
+        url: https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
+        filename: GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
+        sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
+      "Linux":
+        url: https://gfortran.meteodat.ch/download/x86_64/snapshots/gcc-10-20210109.tar.xz
+        sha256: 494e9d881d6d9bb4a5707bfa149f77001599f093090c6c78fdb19cefbacda7b8
+      "Macos":
+        url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz
+        sha256: 2de46f571eefc2b544db4ed6c958c78a5e3e78c4b4b5daab38aabc1b08dd5666

--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -1,13 +1,12 @@
 sources:
   "10.2":
-    url:
-      "Windows":
-        url: https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
-        filename: GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
-        sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
-      "Linux":
-        url: https://gfortran.meteodat.ch/download/x86_64/snapshots/gcc-10-20210109.tar.xz
-        sha256: 494e9d881d6d9bb4a5707bfa149f77001599f093090c6c78fdb19cefbacda7b8
-      "Macos":
-        url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz
-        sha256: 2de46f571eefc2b544db4ed6c958c78a5e3e78c4b4b5daab38aabc1b08dd5666
+    "Windows":
+      url: https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
+      filename: GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
+      sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
+    "Linux":
+      url: https://gfortran.meteodat.ch/download/x86_64/snapshots/gcc-10-20210109.tar.xz
+      sha256: 494e9d881d6d9bb4a5707bfa149f77001599f093090c6c78fdb19cefbacda7b8
+    "Macos":
+      url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz
+      sha256: 2de46f571eefc2b544db4ed6c958c78a5e3e78c4b4b5daab38aabc1b08dd5666

--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -1,12 +1,13 @@
 sources:
   "10.2":
-    "Windows":
-      url: https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
-      filename: GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
-      sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
-    "Linux":
-      url: https://gfortran.meteodat.ch/download/x86_64/snapshots/gcc-10-20210109.tar.xz
-      sha256: 494e9d881d6d9bb4a5707bfa149f77001599f093090c6c78fdb19cefbacda7b8
-    "Macos":
-      url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz
-      sha256: 2de46f571eefc2b544db4ed6c958c78a5e3e78c4b4b5daab38aabc1b08dd5666
+    "url":
+      "Windows":
+        url: https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
+        filename: GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
+        sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
+      "Linux":
+        url: https://gfortran.meteodat.ch/download/x86_64/snapshots/gcc-10-20210109.tar.xz
+        sha256: 494e9d881d6d9bb4a5707bfa149f77001599f093090c6c78fdb19cefbacda7b8
+      "Macos":
+        url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz
+        sha256: 2de46f571eefc2b544db4ed6c958c78a5e3e78c4b4b5daab38aabc1b08dd5666

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -36,11 +36,11 @@ class GFortranConan(ConanFile):
         for it in url.keys():
             if self.settings.os == "Windows"
                 if it == "Windows":
-                filename = url[it]["filename"]
-                tools.download(**url[it])
-                self.run("7z x {0}".format(filename))
-                os.unlink(filename)
-                os.rename("mingw64", "source_subfolder_Windows")
+                    filename = url[it]["filename"]
+                    tools.download(**url[it])
+                    self.run("7z x {0}".format(filename))
+                    os.unlink(filename)
+                    os.rename("mingw64", "source_subfolder_Windows")
             else:
                 tools.get(**url[it])
                 pattern = "gcc-*" if it == "Linux" else "usr"

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -28,9 +28,8 @@ class GFortranConan(ConanFile):
             raise ConanInvalidConfiguration("No binaries available for the OS '{}'.".format(self.settings.os))
 
     def source(self):
-        url = self.conan_data["sources"][self.version]["url"]
+        url = self.conan_data["sources"][self.version]
         for it in url.keys():
-        # for it in ["Windows", "Macos", "Linux"]:
             if it == "Windows":
                 filename = url[it]["filename"]
                 tools.download(**url[it])

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -34,7 +34,8 @@ class GFortranConan(ConanFile):
     def source(self):
         url = self.conan_data["sources"][self.version]["url"]
         for it in url.keys():
-            if self.settings.os == "Windows" and it == "Windows":
+            if self.settings.os == "Windows"
+                if it == "Windows":
                 filename = url[it]["filename"]
                 tools.download(**url[it])
                 self.run("7z x {0}".format(filename))

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -40,7 +40,7 @@ class GFortranConan(ConanFile):
                 self.run("7z x {0}".format(filename))
                 os.unlink(filename)
                 os.rename("mingw64", "source_subfolder_Windows")
-            else:
+            elif it != "Windows":
                 tools.get(**url[it])
                 pattern = "gcc-*" if it == "Linux" else "usr"
                 os.rename(glob.glob(pattern)[0], "source_subfolder_{}".format(it))

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -34,7 +34,7 @@ class GFortranConan(ConanFile):
     def source(self):
         url = self.conan_data["sources"][self.version]["url"]
         for it in url.keys():
-            if self.settings.os == "Windows"
+            if self.settings.os == "Windows":
                 if it == "Windows":
                     filename = url[it]["filename"]
                     tools.download(**url[it])

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -34,7 +34,7 @@ class GFortranConan(ConanFile):
     def source(self):
         url = self.conan_data["sources"][self.version]["url"]
         for it in url.keys():
-            if self.settings.os == "Windows":
+            if self.settings.os == "Windows" and it == "Windows":
                 filename = url[it]["filename"]
                 tools.download(**url[it])
                 self.run("7z x {0}".format(filename))

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -27,10 +27,14 @@ class GFortranConan(ConanFile):
         if str(self.settings.os) not in ("Windows", "Linux", "Macos"):
             raise ConanInvalidConfiguration("No binaries available for the OS '{}'.".format(self.settings.os))
 
+    def build_requirements(self):
+        if self.settings.os == "Windows":
+            self.build_requires("7zip/19.00")
+
     def source(self):
         url = self.conan_data["sources"][self.version]["url"]
         for it in url.keys():
-            if it == "Windows":
+            if self.settings.os == "Windows":
                 filename = url[it]["filename"]
                 tools.download(**url[it])
                 self.run("7z x {0}".format(filename))

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -1,0 +1,63 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+import glob
+
+
+required_conan_version = ">=1.32.0"
+
+
+class GFortranConan(ConanFile):
+    name = "gfortran"
+    description = "The Fortran compiler front end and run-time libraries for GCC"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://gcc.gnu.org/fortran"
+    topics = ("gnu", "gcc", "fortran", "compiler")
+    license = "GPL-3.0-or-later"
+    settings = "os", "arch"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return os.path.join(self.source_folder, "source_subfolder_{}".format(str(self.settings.os)))
+
+    def validate(self):
+        if self.settings.arch != "x86_64":
+            raise ConanInvalidConfiguration("No binaries available for the architecture '{}'.".format(self.settings.arch))
+        if str(self.settings.os) not in ("Windows", "Linux", "Macos"):
+            raise ConanInvalidConfiguration("No binaries available for the OS '{}'.".format(self.settings.os))
+
+    def source(self):
+        url = self.conan_data["sources"][self.version]["url"]
+        for it in url.keys():
+        # for it in ["Windows", "Macos", "Linux"]:
+            if it == "Windows":
+                filename = url[it]["filename"]
+                tools.download(**url[it])
+                self.run("7z x {0}".format(filename))
+                os.unlink(filename)
+                os.rename("mingw64", "source_subfolder_Windows")
+            else:
+                tools.get(**url[it])
+                pattern = "gcc-*" if it == "Linux" else "usr"
+                os.rename(glob.glob(pattern)[0], "source_subfolder_{}".format(it))
+
+    def _extract_license(self):
+        info = tools.load(os.path.join(self.source_folder, "source_subfolder_Linux", "share", "info", "gfortran.info"))
+        license_contents = info[info.find("Version 3"):info.find("END OF TERMS", 1)]
+        tools.save("LICENSE", license_contents)
+
+    def package(self):
+        self._extract_license()
+        self.copy("LICENSE", dst="licenses")
+        self.copy("gfortran*", dst="bin", src=os.path.join(self._source_subfolder, "bin"))
+        self.copy("gfortran", dst="bin", src=os.path.join(self._source_subfolder, "local", "bin"))
+        self.copy("libgfortran.a", dst="lib", src=os.path.join(self._source_subfolder, "lib64"))
+        self.copy("libgfortran.a", dst="lib", src=os.path.join(self._source_subfolder, "local", "lib"))
+        self.copy("libgfortran.a", dst="lib", src=os.path.join(self._source_subfolder, "lib", "gcc", "x86_64-w64-mingw32", "10.2.0"))
+
+    def package_info(self):
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)
+        self.cpp_info.libs = ["gfortran"]

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -34,13 +34,12 @@ class GFortranConan(ConanFile):
     def source(self):
         url = self.conan_data["sources"][self.version]["url"]
         for it in url.keys():
-            if self.settings.os == "Windows":
-                if it == "Windows":
-                    filename = url[it]["filename"]
-                    tools.download(**url[it])
-                    self.run("7z x {0}".format(filename))
-                    os.unlink(filename)
-                    os.rename("mingw64", "source_subfolder_Windows")
+            if self.settings.os == "Windows" and it == "Windows":
+                filename = url[it]["filename"]
+                tools.download(**url[it])
+                self.run("7z x {0}".format(filename))
+                os.unlink(filename)
+                os.rename("mingw64", "source_subfolder_Windows")
             else:
                 tools.get(**url[it])
                 pattern = "gcc-*" if it == "Linux" else "usr"

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -28,7 +28,7 @@ class GFortranConan(ConanFile):
             raise ConanInvalidConfiguration("No binaries available for the OS '{}'.".format(self.settings.os))
 
     def source(self):
-        url = self.conan_data["sources"][self.version]
+        url = self.conan_data["sources"][self.version]["url"]
         for it in url.keys():
             if it == "Windows":
                 filename = url[it]["filename"]

--- a/recipes/gfortran/all/test_package/conanfile.py
+++ b/recipes/gfortran/all/test_package/conanfile.py
@@ -1,0 +1,8 @@
+from conans import ConanFile, tools
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run("gfortran --version", run_environment=True)

--- a/recipes/gfortran/config.yml
+++ b/recipes/gfortran/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "10.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **gfortran/10.2**

GFortran is a requirement for LaPack, which should be moved to CCI too (it's on Conan Community).

Our old recipe installs gfortran with package manager (APT) and works fine, but now we have the opportunity to de-couple them.

As gfortran is part of GCC package, it requires a lot of effort to be built, but GNU page offer us official download for mainstream platform (Windows, OSX, Linux)

As 7z package only works for Windows, we can't download all sources at once. The windows binaries are downloaded only on Windows.

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
