### PR TITLE
[android-ndk] ANDROID_NDK_ROOT environment var should be preset

### DIFF
--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -140,7 +140,16 @@ class AndroidNDKInstallerConan(ConanFile):
         # ndk-build: https://developer.android.com/ndk/guides/ndk-build
         self.env_info.PATH.append(self.package_folder)
 
-        # this is not enough, I can kill that .....
+        # You should use the ANDROID_NDK_ROOT environment variable to indicate where the NDK is located. 
+        # That's what most NDK-related scripts use (inside the NDK, and outside of it).
+        # https://groups.google.com/g/android-ndk/c/qZjhOaynHXc
+        self.output.info('Creating ANDROID_NDK_ROOT environment variable: %s' % self.package_folder)
+        self.env_info.ANDROID_NDK_ROOT = self.package_folder
+
+        self.output.info('Creating ANDROID_NDK_HOME environment variable: %s' % self.package_folder)
+        self.env_info.ANDROID_NDK_HOME = self.package_folder
+
+        #  this is not enough, I can kill that .....
         if not hasattr(self, 'settings_target'):
             return
 
@@ -156,9 +165,6 @@ class AndroidNDKInstallerConan(ConanFile):
         self.output.info('Creating NDK_ROOT environment variable: %s' % self._ndk_root)
         self.env_info.NDK_ROOT = self._ndk_root
         
-        self.output.info('Creating ANDROID_NDK_HOME environment variable: %s' % self.package_folder)
-        self.env_info.ANDROID_NDK_HOME = self.package_folder
-
         self.output.info('Creating CHOST environment variable: %s' % self._llvm_triplet)
         self.env_info.CHOST = self._llvm_triplet
 


### PR DESCRIPTION
- add ANDROID_NDK_ROOT
- expose ANDROID_NDK_ROOT/ANDROID_NDK_HOME variables to virtualenv generator

https://docs.conan.io/en/latest/mastering/virtualenv.html#virtualenv-generator
https://groups.google.com/g/android-ndk/c/qZjhOaynHXc

@andioz 
@a4z 

Specify library name and version:  **android-ndk/all**

Related to https://github.com/openssl/openssl/issues/11205

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
