### PR TITLE
In Pango, make dependencies to libthai, cairo, xft, fontconfig and freetype optional via meson options

### DIFF
--- a/recipes/pango/all/conanfile.py
+++ b/recipes/pango/all/conanfile.py
@@ -43,8 +43,8 @@ class PangoConan(ConanFile):
         if self.options.fontconfig == "auto":
             self.options.fontconfig = not self.settings.os in ["Windows", "Macos"]
 
-        if self.options.xft and self.settings.os != 'Linux' and self.settings.os != 'FreeBSD':
-            raise ConanInvalidConfiguration('Xft can only be used on Linux and FreeBSD')
+        if self.options.xft and not self.settings.os in ["Linux", "FreeBSD"]:
+            raise ConanInvalidConfiguration("Xft can only be used on Linux and FreeBSD")
 
     def build_requirements(self):
         self.build_requires("pkgconf/1.7.3")

--- a/recipes/pango/all/conanfile.py
+++ b/recipes/pango/all/conanfile.py
@@ -130,7 +130,7 @@ class PangoConan(ConanFile):
             self.cpp_info.components['pango_'].requires.append('cairo::cairo_')
         self.cpp_info.components['pango_'].includedirs = [os.path.join(self.package_folder, "include", "pango-1.0")]
         
-        if self.options.with_freetype:
+        if self.options.with_freetype and self.options.with_fontconfig:
             self.cpp_info.components['pangoft2'].libs = ['pangoft2-1.0']
             self.cpp_info.components['pangoft2'].names['pkg_config'] = 'pangoft2'
             self.cpp_info.components['pangoft2'].requires = ['pango_', 'freetype::freetype']

--- a/recipes/pango/all/conanfile.py
+++ b/recipes/pango/all/conanfile.py
@@ -38,10 +38,10 @@ class PangoConan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
-        if(self.options.xft == "auto"):
-            self.options.xft = (self.settings.os == 'Linux' or self.settings.os == 'FreeBSD')
-        if(self.options.fontconfig == "auto"):
-            self.options.fontconfig = (self.settings.os != 'Windows' and self.settings.os != 'Macos')
+        if self.options.xft == "auto":
+            self.options.xft = self.settings.os in ["Linux", "FreeBSD"]
+        if self.options.fontconfig == "auto":
+            self.options.fontconfig = not self.settings.os in ["Windows", "Macos"]
 
         if self.options.xft and self.settings.os != 'Linux' and self.settings.os != 'FreeBSD':
             raise ConanInvalidConfiguration('Xft can only be used on Linux and FreeBSD')

--- a/recipes/pango/all/conanfile.py
+++ b/recipes/pango/all/conanfile.py
@@ -3,7 +3,7 @@ import shutil
 import glob
 
 from conans import ConanFile, tools, Meson, VisualStudioBuildEnvironment
-
+from conans.errors import ConanInvalidConfiguration
 
 class PangoConan(ConanFile):
     name = "pango"
@@ -13,8 +13,8 @@ class PangoConan(ConanFile):
     homepage = "https://www.pango.org/"
     topics = ("conan", "fontconfig", "fonts", "freedesktop")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "libthai": [True, False], "cairo": [True, False], "xft": [True, False, "auto"], "freetype": [True, False], "fontconfig": [True, False, "auto"]}
+    default_options = {"shared": False, "fPIC": True, "libthai": False, "cairo": True, "xft": "auto", "freetype": True, "fontconfig": "auto"}
     generators = "pkg_config"
     _autotools = None
     
@@ -38,16 +38,28 @@ class PangoConan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
+        if(self.options.xft == "auto"):
+            self.options.xft = (self.settings.os == 'Linux' or self.settings.os == 'FreeBSD')
+        if(self.options.fontconfig == "auto"):
+            self.options.fontconfig = (self.settings.os != 'Windows' and self.settings.os != 'Macos')
+
+        if self.options.xft and self.settings.os != 'Linux' and self.settings.os != 'FreeBSD':
+            raise ConanInvalidConfiguration('Xft can only be used on Linux and FreeBSD')
+
     def build_requirements(self):
         self.build_requires("pkgconf/1.7.3")
         self.build_requires("meson/0.54.2")
 
     def requirements(self):
-        if self.settings.os != "Windows":
+        if self.options.freetype:
+            self.requires("freetype/2.10.4")
+
+        if self.options.fontconfig:
             self.requires("fontconfig/2.13.92")
-        if self.settings.os == "Linux":
+        if self.options.xft:
             self.requires("xorg/system")
-        self.requires("cairo/1.17.2")
+        if self.options.cairo:
+            self.requires("cairo/1.17.2")
         self.requires("harfbuzz/2.7.2")
         self.requires("glib/2.67.0")
         self.requires("fribidi/1.0.9")
@@ -60,6 +72,13 @@ class PangoConan(ConanFile):
     def _configure_meson(self):
         defs = dict()
         defs["introspection"] = "disabled"
+
+        defs["libthai"] = "enabled" if self.options.libthai else "disabled"
+        defs["cairo"] = "enabled" if self.options.cairo else "disabled"
+        defs["xft"] = "enabled" if self.options.xft else "disabled"
+        defs["fontconfig"] = "enabled" if self.options.fontconfig else "disabled"
+        defs["freetype"] = "enabled" if self.options.freetype else "disabled"
+
         meson = Meson(self)
         meson.configure(build_folder=self._build_subfolder, source_folder=self._source_subfolder, defs=defs, args=['--wrap-mode=nofallback'])
         return meson
@@ -98,31 +117,38 @@ class PangoConan(ConanFile):
         self.cpp_info.components['pango_'].requires.append('glib::gio-2.0')
         self.cpp_info.components['pango_'].requires.append('fribidi::fribidi')
         self.cpp_info.components['pango_'].requires.append('harfbuzz::harfbuzz')
-        if self.settings.os != "Windows":
+        if self.options.fontconfig:
             self.cpp_info.components['pango_'].requires.append('fontconfig::fontconfig')
-            if self.settings.os == "Linux":
+
+
+        if self.options.xft:
+            self.cpp_info.components['pango_'].requires.append('xorg::xft')
+            # Pango only uses xrender when Xft, fontconfig and freetype are enabled
+            if self.options.fontconfig and self.options.freetype:
                 self.cpp_info.components['pango_'].requires.append('xorg::xrender')
-                self.cpp_info.components['pango_'].requires.append('xorg::xft')
-        self.cpp_info.components['pango_'].requires.append('cairo::cairo_')
+        if self.options.cairo:
+            self.cpp_info.components['pango_'].requires.append('cairo::cairo_')
         self.cpp_info.components['pango_'].includedirs = [os.path.join(self.package_folder, "include", "pango-1.0")]
         
-        if self.settings.os != "Windows":
+        if self.options.freetype:
             self.cpp_info.components['pangoft2'].libs = ['pangoft2-1.0']
             self.cpp_info.components['pangoft2'].names['pkg_config'] = 'pangoft2'
-            self.cpp_info.components['pangoft2'].requires = ['pango_']
+            self.cpp_info.components['pangoft2'].requires = ['pango_', 'freetype::freetype']
             self.cpp_info.components['pangoft2'].includedirs = [os.path.join(self.package_folder, "include", "pango-1.0")]
 
+        if self.options.fontconfig:
             self.cpp_info.components['pangofc'].names['pkg_config'] = 'pangofc'
             self.cpp_info.components['pangofc'].requires = ['pangoft2']
 
+        if self.settings.os != "Windows":
             self.cpp_info.components['pangoroot'].names['pkg_config'] = 'pangoroot'
             self.cpp_info.components['pangoroot'].requires = ['pangoft2']
             
-            if self.settings.os == "Linux":
-                self.cpp_info.components['pangoxft'].libs = ['pangoxft-1.0']
-                self.cpp_info.components['pangoxft'].names['pkg_config'] = 'pangoxft'
-                self.cpp_info.components['pangoxft'].requires = ['pango_', 'pangoft2']
-                self.cpp_info.components['pangoxft'].includedirs = [os.path.join(self.package_folder, "include", "pango-1.0")]
+        if self.options.xft:
+            self.cpp_info.components['pangoxft'].libs = ['pangoxft-1.0']
+            self.cpp_info.components['pangoxft'].names['pkg_config'] = 'pangoxft'
+            self.cpp_info.components['pangoxft'].requires = ['pango_', 'pangoft2']
+            self.cpp_info.components['pangoxft'].includedirs = [os.path.join(self.package_folder, "include", "pango-1.0")]
 
         if self.settings.os == "Windows":
             self.cpp_info.components['pangowin32'].libs = ['pangowin32-1.0']
@@ -130,15 +156,16 @@ class PangoConan(ConanFile):
             self.cpp_info.components['pangowin32'].requires = ['pango_']
             self.cpp_info.components['pangowin32'].system_libs.append('gdi32')
 
-        self.cpp_info.components['pangocairo'].libs = ['pangocairo-1.0']
-        self.cpp_info.components['pangocairo'].names['pkg_config'] = 'pangocairo'
-        self.cpp_info.components['pangocairo'].requires = ['pango_']
-        if self.settings.os != "Windows":
-            self.cpp_info.components['pangocairo'].requires.append('pangoft2')
-        if self.settings.os == "Windows":
-            self.cpp_info.components['pangocairo'].requires.append('pangowin32')
-            self.cpp_info.components['pangocairo'].system_libs.append('gdi32')
-        self.cpp_info.components['pangocairo'].includedirs = [os.path.join(self.package_folder, "include", "pango-1.0")]
+        if self.options.cairo:
+            self.cpp_info.components['pangocairo'].libs = ['pangocairo-1.0']
+            self.cpp_info.components['pangocairo'].names['pkg_config'] = 'pangocairo'
+            self.cpp_info.components['pangocairo'].requires = ['pango_']
+            if self.settings.os != "Windows":
+                self.cpp_info.components['pangocairo'].requires.append('pangoft2')
+            if self.settings.os == "Windows":
+                self.cpp_info.components['pangocairo'].requires.append('pangowin32')
+                self.cpp_info.components['pangocairo'].system_libs.append('gdi32')
+            self.cpp_info.components['pangocairo'].includedirs = [os.path.join(self.package_folder, "include", "pango-1.0")]
 
 
 


### PR DESCRIPTION
Specify library name and version:  **pango/1.48.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
 
To resurrect the [pull request](https://github.com/bincrafters/conan-pango/pull/3) to the old bincrafters repository, I'm submitting this to allow disabling various optional dependencies for pango if you don't need them. Since the corresponding changes to the meson system are already upstream, no patching in the recipe is necessary anymore. The package info now largely depends on the options instead of the OS for more flexibility.