### PR TITLE
poppler: enable gtk

### DIFF
--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -112,8 +112,7 @@ class PopplerConan(ConanFile):
             # FIXME: missing qt recipe
             raise ConanInvalidConfiguration("qt is not (yet) available on cii")
         if self.options.get_safe("with_gtk"):
-            # FIXME: missing gtk recipe
-            raise ConanInvalidConfiguration("gtk is not (yet) available on cii")
+            self.requires("gtk/3.24.24")
         if self.options.with_openjpeg:
             self.requires("openjpeg/2.4.0")
         if self.options.with_lcms:
@@ -202,6 +201,9 @@ class PopplerConan(ConanFile):
             poppler_global = os.path.join(self._source_subfolder, "cpp", "poppler-global.h")
             tools.replace_in_file(poppler_global, "__declspec(dllimport)", "")
             tools.replace_in_file(poppler_global, "__declspec(dllexport)", "")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              "FREETYPE_INCLUDE_DIRS",
+                              "Freetype_INCLUDE_DIRS")
 
 
     def build(self):


### PR DESCRIPTION
also, fix freetype include path

Specify library name and version:  **poppler/***

tested with `-o poppler:with_gtk=True -o poppler:with_glib=True -o poppler:with_cairo=True -o poppler:with_gobject_introspection=False`

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
