### PR TITLE
[mpir] fix consumption of dlls

### DIFF
--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -151,3 +151,5 @@ class MpirConan(ConanFile):
             if self.options.get_safe("enable_cxx"):
                 self.cpp_info.libs.append("gmpxx")
             self.cpp_info.libs.append("gmp")
+        if self.settings.os == "Windows" and self.options.shared:
+            self.cpp_info.defines.append("MSC_USE_DLL")


### PR DESCRIPTION
Specify library name and version:  **mpir/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Ran into this with `conan install mpfr/4.1.0@ -o mpir:shared=True -o mpfr:shared=True -o mpfr:exact_int=mpir` with MSVC.
