### PR TITLE
cyrus-sasl: explicit cpp_info.libs

### DIFF
--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -193,7 +193,7 @@ class CyrusSaslConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.names["pkg_config"] = "libsasl2"
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = ["sasl2"]
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bindir))
         self.env_info.PATH.append(bindir)


### PR DESCRIPTION
Specify library name and version:  **cyrus-sasl/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

`tools.collect_libs(self)` collects `sasl2` and `sasl2.3`, instead of `sasl2` (symbolic link) only.
I have error `ld: library not found for -lsasl2.3` during link step of librdkafka, when librdkafka and cyrus-sasl are shared (librdkafka relies on `pkg_config` generator to consume cyrus-sasl).