### PR TITLE
xapian-core: Fix parallel builds with Visual Studio

### DIFF
--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -87,8 +87,7 @@ class XapianCoreConan(ConanFile):
         self._autotools.link_flags.extend(["-L{}".format(l.replace("\\", "/")) for l in self._autotools.library_paths])
         self._autotools.library_paths = []
         if self.settings.compiler == "Visual Studio":
-            self._autotools.cxx_flags.append("-EHsc")
-            self._autotools.cxx_flags.append("-FS")
+            self._autotools.cxx_flags.extend(["-EHsc", "-FS"])
         conf_args = [
             "--datarootdir={}".format(self._datarootdir.replace("\\", "/")),
             "--disable-documentation",

--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -88,6 +88,7 @@ class XapianCoreConan(ConanFile):
         self._autotools.library_paths = []
         if self.settings.compiler == "Visual Studio":
             self._autotools.cxx_flags.append("-EHsc")
+            self._autotools.cxx_flags.append("-FS")
         conf_args = [
             "--datarootdir={}".format(self._datarootdir.replace("\\", "/")),
             "--disable-documentation",


### PR DESCRIPTION
Specify library name and version:  **xapian-core/1.4.16**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This PR fixex C1041 errors like:
``` 
fatal error C1041: cannot open program database 'vc140.pdb'; if multiple CL.EXE write to the same .PDB file, please use /FS
```