### PR TITLE
winflexbison: Fix for MinSizeRel and RelWithDebInfo

### DIFF
--- a/recipes/winflexbison/all/conanfile.py
+++ b/recipes/winflexbison/all/conanfile.py
@@ -36,12 +36,6 @@ class WinflexbisonConan(ConanFile):
         return self._cmake
 
     def build(self):
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-            'set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${OUTPUT_DEBUG}")',
-            '')
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-            'set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${OUTPUT_RELEASE}")',
-            '')
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -54,7 +48,11 @@ class WinflexbisonConan(ConanFile):
         tools.save("COPYING.GPL3", "\n".join(license_content))
 
     def package(self):
-        self.copy(pattern="*.exe", dst="bin", src="bin", keep_path=False)
+        if self.settings.build_type in ("Release", "Debug"):
+            actual_build_path = "{0}/bin/{1}".format(self._source_subfolder, self.settings.build_type)
+            self.copy(pattern="*.exe", dst="bin", src=actual_build_path, keep_path=False)
+        else:
+            self.copy(pattern="*.exe", dst="bin", src="bin", keep_path=False)
         self.copy(pattern="data/*", dst="bin", src="{}/bison".format(self._source_subfolder), keep_path=True)
         self.copy(pattern="FlexLexer.h", dst="include", src=os.path.join(self._source_subfolder, "flex", "src"), keep_path=False)
 

--- a/recipes/winflexbison/all/conanfile.py
+++ b/recipes/winflexbison/all/conanfile.py
@@ -36,6 +36,12 @@ class WinflexbisonConan(ConanFile):
         return self._cmake
 
     def build(self):
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            'set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${OUTPUT_DEBUG}")',
+            '')
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            'set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${OUTPUT_RELEASE}")',
+            '')
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -48,8 +54,7 @@ class WinflexbisonConan(ConanFile):
         tools.save("COPYING.GPL3", "\n".join(license_content))
 
     def package(self):
-        actual_build_path = "{0}/bin/{1}".format(self._source_subfolder, self.settings.build_type)
-        self.copy(pattern="*.exe", dst="bin", src=actual_build_path, keep_path=False)
+        self.copy(pattern="*.exe", dst="bin", src="bin", keep_path=False)
         self.copy(pattern="data/*", dst="bin", src="{}/bison".format(self._source_subfolder), keep_path=True)
         self.copy(pattern="FlexLexer.h", dst="include", src=os.path.join(self._source_subfolder, "flex", "src"), keep_path=False)
 


### PR DESCRIPTION
Specify library name and version:  **winflexbison/***

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Flex and Bison are missing for MinSizeRel and RelWithDebInfo build types.