### PR TITLE
[msys2] Bump version and support two profiles approach.

### DIFF
--- a/recipes/msys2/all/conandata.yml
+++ b/recipes/msys2/all/conandata.yml
@@ -1,34 +1,40 @@
 sources:
   "20161025":
     - url: [
+             "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20161025.tar.xz",
+             "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20161025.tar.xz"
+      ]
+      sha256: "bb1f1a0b35b3d96bf9c15092da8ce969a84a134f7b08811292fbc9d84d48c65d"
+    - url: [
              "http://repo.msys2.org/distrib/i686/msys2-base-i686-20161025.tar.xz",
              "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20161025.tar.xz",
       ]
       sha256: "8bafd3d52f5a51528a8671c1cae5591b36086d6ea5b1e76e17e390965cf6768f"
-    - url: [
-             "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20161025.tar.xz",
-             "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20161025.tar.xz"
-    ]
-      sha256: "bb1f1a0b35b3d96bf9c15092da8ce969a84a134f7b08811292fbc9d84d48c65d"
   "20190524":
-    - url: [
-             "http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz",
-             "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20190524.tar.xz",
-    ]
-      sha256: "7a463afae8bf6ce8262f010a9a1648d056ad5cefc66d6eb69fe948c57d4ccb53"
     - url: [
              "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz",
              "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20190524.tar.xz",
       ]
       sha256: "168e156fa9f00d90a8445676c023c63be6e82f71487f4e2688ab5cb13b345383"
-  "20200517":
     - url: [
-             "http://repo.msys2.org/distrib/i686/msys2-base-i686-20200517.tar.xz",
-             "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20200517.tar.xz",
-    ]
-      sha256: "4dbdde708a4bcf3c056e8f4f28b1b0e7a3210ffacc6296a7d11fdaf076fd431e"
+             "http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz",
+             "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20190524.tar.xz",
+      ]
+      sha256: "7a463afae8bf6ce8262f010a9a1648d056ad5cefc66d6eb69fe948c57d4ccb53"
+  "20200517":
     - url: [
              "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200517.tar.xz",
              "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20200517.tar.xz",
       ]
       sha256: "c4443113497acb2d2e285d40b929fc55f33f8f669902595ecdf66a655b63dc60"
+    - url: [
+             "http://repo.msys2.org/distrib/i686/msys2-base-i686-20200517.tar.xz",
+             "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20200517.tar.xz",
+      ]
+      sha256: "4dbdde708a4bcf3c056e8f4f28b1b0e7a3210ffacc6296a7d11fdaf076fd431e"
+  "20210105":
+    - url: [
+             "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20210105.tar.xz",
+             "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20210105.tar.xz",
+      ]
+      sha256: "982e54de087d53adfc6a8caf7614d4a7add36dd02dcb0b7838060dd893e9f596"

--- a/recipes/msys2/all/conandata.yml
+++ b/recipes/msys2/all/conandata.yml
@@ -1,40 +1,34 @@
 sources:
-  "20161025":
-    - url: [
-             "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20161025.tar.xz",
-             "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20161025.tar.xz"
-      ]
-      sha256: "bb1f1a0b35b3d96bf9c15092da8ce969a84a134f7b08811292fbc9d84d48c65d"
-    - url: [
-             "http://repo.msys2.org/distrib/i686/msys2-base-i686-20161025.tar.xz",
-             "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20161025.tar.xz",
-      ]
-      sha256: "8bafd3d52f5a51528a8671c1cae5591b36086d6ea5b1e76e17e390965cf6768f"
   "20190524":
-    - url: [
-             "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz",
-             "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20190524.tar.xz",
-      ]
-      sha256: "168e156fa9f00d90a8445676c023c63be6e82f71487f4e2688ab5cb13b345383"
-    - url: [
-             "http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz",
-             "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20190524.tar.xz",
-      ]
-      sha256: "7a463afae8bf6ce8262f010a9a1648d056ad5cefc66d6eb69fe948c57d4ccb53"
+    "x86_64":
+          url: [
+                 "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz",
+                 "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20190524.tar.xz",
+          ]
+          sha256: "168e156fa9f00d90a8445676c023c63be6e82f71487f4e2688ab5cb13b345383"
+    "x86":
+          url: [
+                 "http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz",
+                 "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20190524.tar.xz",
+          ]
+          sha256: "7a463afae8bf6ce8262f010a9a1648d056ad5cefc66d6eb69fe948c57d4ccb53"
   "20200517":
-    - url: [
-             "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200517.tar.xz",
-             "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20200517.tar.xz",
-      ]
-      sha256: "c4443113497acb2d2e285d40b929fc55f33f8f669902595ecdf66a655b63dc60"
-    - url: [
-             "http://repo.msys2.org/distrib/i686/msys2-base-i686-20200517.tar.xz",
-             "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20200517.tar.xz",
-      ]
-      sha256: "4dbdde708a4bcf3c056e8f4f28b1b0e7a3210ffacc6296a7d11fdaf076fd431e"
+    "x86_64":
+          url: [
+                 "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200517.tar.xz",
+                 "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20200517.tar.xz",
+          ]
+          sha256: "c4443113497acb2d2e285d40b929fc55f33f8f669902595ecdf66a655b63dc60"
+    "x86":
+          url: [
+                 "http://repo.msys2.org/distrib/i686/msys2-base-i686-20200517.tar.xz",
+                 "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20200517.tar.xz",
+          ]
+          sha256: "4dbdde708a4bcf3c056e8f4f28b1b0e7a3210ffacc6296a7d11fdaf076fd431e"
   "20210105":
-    - url: [
-             "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20210105.tar.xz",
-             "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20210105.tar.xz",
-      ]
-      sha256: "982e54de087d53adfc6a8caf7614d4a7add36dd02dcb0b7838060dd893e9f596"
+    "x86_64":
+          url: [
+                 "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20210105.tar.xz",
+                 "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20210105.tar.xz",
+          ]
+          sha256: "982e54de087d53adfc6a8caf7614d4a7add36dd02dcb0b7838060dd893e9f596"

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -30,6 +30,10 @@ class MSYS2Conan(ConanFile):
             raise ConanInvalidConfiguration("Only Windows supported")
         if tools.Version(self.version) >= "20210105" and self.settings.arch != "x86_64":
             raise ConanInvalidConfiguration("Only Windows x64 supported")
+        if tools.Version(self.version) <= "20161025"
+            raise ConanInvalidConfiguration("msys2 v.20161025 is no longer supported")    
+
+            
 
     def _download(self, url, sha256):
         from six.moves.urllib.parse import urlparse

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -100,9 +100,11 @@ class MSYS2Conan(ConanFile):
         with tools.chdir(os.path.join(self._msys_dir, "usr", "bin")):
             self._update_very_old_pacman()
 
+            self._kill_pacman()
             # https://www.msys2.org/news/   see  2020-05-31 - Update may fail with "could not open file"
             # update pacman separately first
             self.run('bash -l -c "pacman --noconfirm -Sydd pacman"')
+            self._kill_pacman()
 
             # https://www.msys2.org/docs/ci/
             self.run('bash -l -c "pacman --noconfirm -Syuu"')  # Core update (in case any core packages are outdated)

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -78,23 +78,24 @@ class MSYS2Conan(ConanFile):
             self.run('bash -l -c "pacman -Syu --noconfirm"')
 
     def _kill_pacman(self):
-        taskkill_exe = os.path.join(os.environ['WINDIR'], 'system32', 'taskkill.exe')
+        if self.settings.os == "Windows":
+            taskkill_exe = os.path.join(os.environ['WINDIR'], 'system32', 'taskkill.exe')
 
-        log_out = True
-        if log_out:
-            out = subprocess.PIPE
-            err = subprocess.STDOUT
-        else:
-            out = file(os.devnull, 'w')
-            err = subprocess.PIPE
+            log_out = True
+            if log_out:
+                out = subprocess.PIPE
+                err = subprocess.STDOUT
+            else:
+                out = file(os.devnull, 'w')
+                err = subprocess.PIPE
 
-        if os.path.exists(taskkill_exe):
-            taskkill_cmd = taskkill_exe + ' /f /fi "MODULES eq msys-2.0.dll"'
-            try:
-                proc = subprocess.Popen(taskkill_cmd, stdout=out, stderr=err, bufsize=1)
-            except OSError as e:
-                if e.errno == errno.ENOENT:
-                    raise ConanException("Cannot kill pacman")
+            if os.path.exists(taskkill_exe):
+                taskkill_cmd = taskkill_exe + ' /f /fi "MODULES eq msys-2.0.dll"'
+                try:
+                    proc = subprocess.Popen(taskkill_cmd, stdout=out, stderr=err, bufsize=1)
+                except OSError as e:
+                    if e.errno == errno.ENOENT:
+                        raise ConanException("Cannot kill pacman")
 
     def configure(self):
         self._kill_pacman()

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -26,6 +26,10 @@ class MSYS2Conan(ConanFile):
     }
     settings = "os", "arch"
 
+    def configure(self):
+        self._kill_pacman()
+
+
     def validate(self):
         if self.settings.os != "Windows":
             raise ConanInvalidConfiguration("Only Windows supported")
@@ -159,11 +163,14 @@ class MSYS2Conan(ConanFile):
 
         if (tools.Version(self.version) < "20210105"):
             self._install_pacman_keyring()
-            self._update_pacman()
+            
+        self._update_pacman()
 
         with tools.chdir(os.path.join(self._msys_dir, "usr", "bin")):
             for package in packages:
                 self.run('bash -l -c "pacman -S %s --noconfirm"' % package)
+
+        self._kill_pacman()
 
         # create /tmp dir in order to avoid
         # bash.exe: warning: could not find /tmp, please create!

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -26,9 +26,6 @@ class MSYS2Conan(ConanFile):
     }
     settings = "os", "arch"
 
-    def configure(self):
-        self._kill_pacman()
-
 
     def validate(self):
         if self.settings.os != "Windows":

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -26,9 +26,6 @@ class MSYS2Conan(ConanFile):
         if tools.Version(self.version) >= "20210105" and self.settings.arch != "x86_64":
             raise ConanInvalidConfiguration("Only Windows x64 supported")
 
-    def build_requirements(self):
-        self.build_requires("7zip/19.00")
-
     def _download(self, url, sha256):
         from six.moves.urllib.parse import urlparse
         filename = os.path.basename(urlparse(url[0]).path)
@@ -42,11 +39,7 @@ class MSYS2Conan(ConanFile):
     def source(self):
         arch = 1 if self.settings.arch == "x86" else 0  # index in the sources list
         filename = self._download(**self.conan_data["sources"][self.version][arch])
-        tar_name = filename.replace(".xz", "")
-        self.run("7z.exe x {0}".format(filename))
-        self.run("7z.exe x {0}".format(tar_name))
-        os.unlink(filename)
-        os.unlink(tar_name)
+        tools.unzip(filename)
 
     def build(self):
         packages = []

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -29,11 +29,6 @@ class MSYS2Conan(ConanFile):
     def build_requirements(self):
         self.build_requires("7zip/19.00")
 
-    def source(self):
-        # build tools have to download files in build method when the
-        # source files downloaded will be different based on architecture or OS
-        pass
-
     def _download(self, url, sha256):
         from six.moves.urllib.parse import urlparse
         filename = os.path.basename(urlparse(url[0]).path)
@@ -44,7 +39,7 @@ class MSYS2Conan(ConanFile):
     def _msys_dir(self):
         return "msys64" if (tools.Version(self.version) >= "20210105" or self.settings.arch == "x86_64") else "msys32"
 
-    def build(self):
+    def source(self):
         arch = 1 if self.settings.arch == "x86" else 0  # index in the sources list
         filename = self._download(**self.conan_data["sources"][self.version][arch])
         tar_name = filename.replace(".xz", "")
@@ -53,6 +48,7 @@ class MSYS2Conan(ConanFile):
         os.unlink(filename)
         os.unlink(tar_name)
 
+    def build(self):
         packages = []
         if self.options.packages:
             packages.extend(str(self.options.packages).split(","))

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -104,8 +104,7 @@ class MSYS2Conan(ConanFile):
             # https://www.msys2.org/news/   see  2020-05-31 - Update may fail with "could not open file"
             # update pacman separately first
             self.run('bash -l -c "pacman --noconfirm -Sydd pacman"')
-            self._kill_pacman()
-
+  
             # https://www.msys2.org/docs/ci/
             self.run('bash -l -c "pacman --noconfirm --ask 20 -Syuu"')  # Core update (in case any core packages are outdated)
             self._kill_pacman()

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -107,9 +107,9 @@ class MSYS2Conan(ConanFile):
             self._kill_pacman()
 
             # https://www.msys2.org/docs/ci/
-            self.run('bash -l -c "pacman --noconfirm -Syuu"')  # Core update (in case any core packages are outdated)
+            self.run('bash -l -c "pacman --noconfirm --ask 20 -Syuu"')  # Core update (in case any core packages are outdated)
             self._kill_pacman()
-            self.run('bash -l -c "pacman --noconfirm -Syuu"')  # Normal update
+            self.run('bash -l -c "pacman --noconfirm --ask 20 -Syuu"')  # Normal update
             self._kill_pacman()
             self.run('bash -l -c "pacman -Rc dash --noconfirm"')
 

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -2,7 +2,6 @@ from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 import shutil
-import platform
 
 
 class MSYS2Conan(ConanFile):
@@ -22,9 +21,9 @@ class MSYS2Conan(ConanFile):
     settings = "os", "arch"
 
     def validate(self):
-        if not tools.os_info.is_windows:
+        if self.settings.os != "Windows":
             raise ConanInvalidConfiguration("Only Windows supported")
-        if tools.Version(self.version) >= "20210105" and "86" in platform.machine():
+        if tools.Version(self.version) >= "20210105" and self.settings.arch != "x86_64":
             raise ConanInvalidConfiguration("Only Windows x64 supported")
 
     def build_requirements(self):

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -30,7 +30,7 @@ class MSYS2Conan(ConanFile):
             raise ConanInvalidConfiguration("Only Windows supported")
         if tools.Version(self.version) >= "20210105" and self.settings.arch != "x86_64":
             raise ConanInvalidConfiguration("Only Windows x64 supported")
-        if tools.Version(self.version) <= "20161025"
+        if tools.Version(self.version) <= "20161025":
             raise ConanInvalidConfiguration("msys2 v.20161025 is no longer supported")    
 
             

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -1,8 +1,7 @@
 from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration, ConanException
+from conans.errors import ConanInvalidConfiguration
 import os
 import shutil
-import subprocess
 
 
 class MSYS2Conan(ConanFile):
@@ -33,6 +32,8 @@ class MSYS2Conan(ConanFile):
             raise ConanInvalidConfiguration("Only Windows x64 supported")
         if tools.Version(self.version) <= "20161025":
             raise ConanInvalidConfiguration("msys2 v.20161025 is no longer supported")    
+
+            
 
     def _download(self, url, sha256):
         from six.moves.urllib.parse import urlparse
@@ -77,27 +78,6 @@ class MSYS2Conan(ConanFile):
             self.run('bash -l -c "pacman -Rc dash --noconfirm"')
             self.run('bash -l -c "pacman -Syu --noconfirm"')
 
-    def _kill_pacman(self):
-        taskkill_exe = os.path.join(os.environ['WINDIR'], 'system32', 'taskkill.exe')
-
-        log_out = True
-        if log_out:
-            out = subprocess.PIPE
-            err = subprocess.STDOUT
-        else:
-            out = file(os.devnull, 'w')
-            err = subprocess.PIPE
-
-        if os.path.exists(taskkill_exe):
-            taskkill_cmd = taskkill_exe + ' /f /fi "MODULES eq msys-2.0.dll"'
-            try:
-                proc = subprocess.Popen(taskkill_cmd, stdout=out, stderr=err, bufsize=1)
-            except OSError as e:
-                if e.errno == errno.ENOENT:
-                    raise ConanException("Cannot kill pacman")
-
-    def configure(self):
-        self._kill_pacman()
 
     @property
     def _msys_dir(self):

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -43,8 +43,7 @@ class MSYS2Conan(ConanFile):
 
     @property
     def _msys_dir(self):
-        if tools.Version(self.version) >= "20210105" return "msys64"
-        return "msys64" if self.settings.arch == "x86_64" else "msys32"
+        return "msys64" if (tools.Version(self.version) >= "20210105" or self.settings.arch == "x86_64") else "msys32"
 
     def build(self):
         arch = 1 if self.settings.arch == "x86" else 0  # index in the sources list

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -78,24 +78,23 @@ class MSYS2Conan(ConanFile):
             self.run('bash -l -c "pacman -Syu --noconfirm"')
 
     def _kill_pacman(self):
-        if self.settings.os == "Windows":
-            taskkill_exe = os.path.join(os.environ['WINDIR'], 'system32', 'taskkill.exe')
+        taskkill_exe = os.path.join(os.environ['WINDIR'], 'system32', 'taskkill.exe')
 
-            log_out = True
-            if log_out:
-                out = subprocess.PIPE
-                err = subprocess.STDOUT
-            else:
-                out = file(os.devnull, 'w')
-                err = subprocess.PIPE
+        log_out = True
+        if log_out:
+            out = subprocess.PIPE
+            err = subprocess.STDOUT
+        else:
+            out = file(os.devnull, 'w')
+            err = subprocess.PIPE
 
-            if os.path.exists(taskkill_exe):
-                taskkill_cmd = taskkill_exe + ' /f /fi "MODULES eq msys-2.0.dll"'
-                try:
-                    proc = subprocess.Popen(taskkill_cmd, stdout=out, stderr=err, bufsize=1)
-                except OSError as e:
-                    if e.errno == errno.ENOENT:
-                        raise ConanException("Cannot kill pacman")
+        if os.path.exists(taskkill_exe):
+            taskkill_cmd = taskkill_exe + ' /f /fi "MODULES eq msys-2.0.dll"'
+            try:
+                proc = subprocess.Popen(taskkill_cmd, stdout=out, stderr=err, bufsize=1)
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    raise ConanException("Cannot kill pacman")
 
     def configure(self):
         self._kill_pacman()

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -132,21 +132,17 @@ class MSYS2Conan(ConanFile):
                 err = subprocess.PIPE
 
             if os.path.exists(taskkill_exe):
-                taskkill_cmd1 = taskkill_exe + " /f /t /im pacman.exe"
-                taskkill_cmd2 = taskkill_exe + " /f /im gpg-agent.exe"
-                taskkill_cmd3 = taskkill_exe + " /f /im dirmngr.exe"
-
-                taskkill_cmd4 = taskkill_exe + ' /fi "MODULES eq msys-2.0.dll"'
-
-                try:
-                    proc = subprocess.Popen(taskkill_cmd1, stdout=out, stderr=err, bufsize=1)
-                    proc = subprocess.Popen(taskkill_cmd2, stdout=out, stderr=err, bufsize=1)
-                    proc = subprocess.Popen(taskkill_cmd3, stdout=out, stderr=err, bufsize=1)
-
-                    proc = subprocess.Popen(taskkill_cmd4, stdout=out, stderr=err, bufsize=1)
-                except OSError as e:
-                    if e.errno == errno.ENOENT:
-                        raise ConanException("Cannot kill pacman")
+                taskkill_cmds = [taskkill_exe + " /f /t /im pacman.exe",
+                                 taskkill_exe + " /f /im gpg-agent.exe",
+                                 taskkill_exe + " /f /im dirmngr.exe",
+                                 taskkill_exe + ' /fi "MODULES eq msys-2.0.dll"']
+                for taskkill_cmd in taskkill_cmds:
+                    try:
+                        proc = subprocess.Popen(taskkill_cmd, stdout=out, stderr=err, bufsize=1)
+                        proc.wait()
+                    except OSError as e:
+                        if e.errno == errno.ENOENT:
+                            raise ConanException("Cannot kill pacman")
 
     @property
     def _msys_dir(self):

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -7,7 +7,9 @@ import subprocess
 try:
     import ctypes
     from ctypes import wintypes
-except ImportError, ValueError:
+except ImportError:
+    pass
+except ValueError:
     pass
 
 class lock:

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import subprocess
 
-try
+try:
     import ctypes
     from ctypes import wintypes
 except ImportError:

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -106,14 +106,14 @@ class MSYS2Conan(ConanFile):
                 # update pacman separately first
                 self.run('where bash')
                 self.run('bash --version')  # check bash version, just in case...
-                self.run('bash -l -c "pacman --debug --noconfirm -Sydd pacman"')
+                self.run('bash -l -c "GPGME_DEBUG=9 pacman --debug --noconfirm -Sydd pacman"')
 
                 # https://www.msys2.org/docs/ci/
-                self.run('bash -l -c "pacman --debug --noconfirm --ask 20 -Syuu"')  # Core update (in case any core packages are outdated)
+                self.run('bash -l -c "GPGME_DEBUG=9 pacman --debug --noconfirm --ask 20 -Syuu"')  # Core update (in case any core packages are outdated)
                 self._kill_pacman()
-                self.run('bash -l -c "pacman --debug --noconfirm --ask 20 -Syuu"')  # Normal update
+                self.run('bash -l -c "GPGME_DEBUG=9 pacman --debug --noconfirm --ask 20 -Syuu"')  # Normal update
                 self._kill_pacman()
-                self.run('bash -l -c "pacman --debug -Rc dash --noconfirm"')
+                self.run('bash -l -c "GPGME_DEBUG=9 pacman --debug -Rc dash --noconfirm"')
             except ConanException:
                 self.run('bash -l -c "cat /var/log/pacman.log || echo nolog"')
                 raise

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -7,7 +7,7 @@ import subprocess
 try:
     import ctypes
     from ctypes import wintypes
-except ImportError:
+except ImportError, ValueError:
     pass
 
 class lock:

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -98,19 +98,25 @@ class MSYS2Conan(ConanFile):
 
     def _update_pacman(self):
         with tools.chdir(os.path.join(self._msys_dir, "usr", "bin")):
-            self._update_very_old_pacman()
+            try:
+                self._update_very_old_pacman()
 
-            self._kill_pacman()
-            # https://www.msys2.org/news/   see  2020-05-31 - Update may fail with "could not open file"
-            # update pacman separately first
-            self.run('bash -l -c "pacman --noconfirm -Sydd pacman"')
-  
-            # https://www.msys2.org/docs/ci/
-            self.run('bash -l -c "pacman --noconfirm --ask 20 -Syuu"')  # Core update (in case any core packages are outdated)
-            self._kill_pacman()
-            self.run('bash -l -c "pacman --noconfirm --ask 20 -Syuu"')  # Normal update
-            self._kill_pacman()
-            self.run('bash -l -c "pacman -Rc dash --noconfirm"')
+                self._kill_pacman()
+                # https://www.msys2.org/news/   see  2020-05-31 - Update may fail with "could not open file"
+                # update pacman separately first
+                self.run('where bash')
+                self.run('bash --version')  # check bash version, just in case...
+                self.run('bash -l -c "pacman --debug --noconfirm -Sydd pacman"')
+
+                # https://www.msys2.org/docs/ci/
+                self.run('bash -l -c "pacman --debug --noconfirm --ask 20 -Syuu"')  # Core update (in case any core packages are outdated)
+                self._kill_pacman()
+                self.run('bash -l -c "pacman --debug --noconfirm --ask 20 -Syuu"')  # Normal update
+                self._kill_pacman()
+                self.run('bash -l -c "pacman --debug -Rc dash --noconfirm"')
+            except ConanException:
+                self.run('bash -l -c "cat /var/log/pacman.log || echo nolog"')
+                raise
 
     # https://github.com/msys2/MSYS2-packages/issues/1966
     def _kill_pacman(self):

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -139,7 +139,6 @@ class MSYS2Conan(ConanFile):
                 self.run('bash -l -c "pacman --debug --noconfirm --ask 20 -Syuu"')  # Core update (in case any core packages are outdated)
                 self._kill_pacman()
                 self.run('bash -l -c "pacman --debug --noconfirm --ask 20 -Syuu"')  # Normal update
-                raise Exception("break")
                 self._kill_pacman()
                 self.run('bash -l -c "pacman --debug -Rc dash --noconfirm"')
             except ConanException:

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -4,8 +4,11 @@ import os
 import shutil
 import subprocess
 
-import ctypes
-from ctypes import wintypes
+try
+    import ctypes
+    from ctypes import wintypes
+except ImportError:
+    pass
 
 class lock:
     def __init__(self):

--- a/recipes/msys2/all/test_package/conanfile.py
+++ b/recipes/msys2/all/test_package/conanfile.py
@@ -3,7 +3,10 @@ from conans.errors import ConanException
 from io import StringIO
 
 class TestPackage(ConanFile):
-        
+    
+    def build(self):
+        pass # nothing to do, skip hook warning
+
     def test(self):
         bash = tools.which("bash.exe")
         

--- a/recipes/msys2/config.yml
+++ b/recipes/msys2/config.yml
@@ -5,3 +5,6 @@ versions:
       folder: "all"
     "20200517":
       folder: "all"
+    "20210105":
+      folder: "all"
+  

--- a/recipes/msys2/config.yml
+++ b/recipes/msys2/config.yml
@@ -1,6 +1,4 @@
 versions:
-    "20161025":
-      folder: "all"
     "20190524":
       folder: "all"
     "20200517":


### PR DESCRIPTION
Fixes #4277
Fixes #4355
Fixes #4066

Related to  #4066 
https://github.com/conan-io/conan-center-index/issues/4066#issuecomment-753822953

Related to #1960
Related to #4301

- **Add new version: 20210105**
        https://github.com/msys2/msys2-installer/releases/tag/2021-01-05

- **Support two profiles approach**
        https://docs.conan.io/en/latest/reference/profiles.html#build-profiles-and-host-profiles

- **32-bit MSYS2 no longer supported**
> After this date, we don't plan on building updated **msys-i686** packages nor releasing i686 installers anymore. This is due to increasingly frustrating difficulties with limited 32-bit address space, high penetration of 64-bit systems and Cygwin (our upstream) starting their way to drop 32-bit support as well.
> https://www.msys2.org/news/#2020-05-17-32-bit-msys2-no-longer-actively-supported

- **Update keys**
        https://www.msys2.org/news/#2020-06-29-new-packagers

- **Workarounds for**

1. https://github.com/msys2/MSYS2-packages/issues/1141
2. https://github.com/msys2/MSYS2-packages/issues/1966
3. https://github.com/msys2/MSYS2-packages/issues/1967
4. https://www.msys2.org/news/#2020-05-31-update-may-fail-with-could-not-open-file
5. https://www.msys2.org/news/#2020-05-22-msys2-may-fail-to-start-after-a-msys2-runtime-upgrade


Specify library name and version:  **msys2/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
