### PR TITLE
mosquitto: add version 2.0.5

### DIFF
--- a/recipes/mosquitto/2.x/conandata.yml
+++ b/recipes/mosquitto/2.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.5":
+    url: "https://github.com/eclipse/mosquitto/archive/v2.0.5.tar.gz"
+    sha256: "733b3e62c4cc41d54acb6ed18a4b585564b32a9e560bcf8165ed30d9043780c5"
   "2.0.3":
     url: https://github.com/eclipse/mosquitto/archive/v2.0.3.tar.gz
     sha256: "a0b02ebb32e6bb09da1c15a32eac2332bd803ddbb5129be2d6d584af601adee5"

--- a/recipes/mosquitto/config.yml
+++ b/recipes/mosquitto/config.yml
@@ -1,3 +1,5 @@
 versions:
-    "2.0.3":
-      folder: "2.x"
+  "2.0.5":
+    folder: "2.x"
+  "2.0.3":
+    folder: "2.x"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **mosquitto/2.0.5**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

🤞 