### PR TITLE
mbedtls: add version 2.25.0

### DIFF
--- a/recipes/mbedtls/all/conandata.yml
+++ b/recipes/mbedtls/all/conandata.yml
@@ -11,6 +11,9 @@ sources:
   "2.24.0":
     url: "https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.24.0.tar.gz"
     sha256: "b5a779b5f36d5fc4cba55faa410685f89128702423ad07b36c5665441a06a5f3"
+  "2.25.0":
+    url: "https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.25.0.tar.gz"
+    sha256: "ea2049c2dd4868693998d5a9780e198194be5aea1706ff4a9d4f882f18c0a101"
 patches:
   "2.16.3-apache":
     - patch_file: "patches/0001-visual-studio-shared-apache.patch"

--- a/recipes/mbedtls/config.yml
+++ b/recipes/mbedtls/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "2.24.0":
     folder: all
+  "2.25.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **mbedtls/2.25.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

GCC-9 static and shared passed locally