### PR TITLE
FIX: avoid CVE-2017-18342

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -162,7 +162,7 @@ class BoostConan(ConanFile):
         dependencies_filepath = os.path.join(self.recipe_folder, "dependencies", self._dependency_filename)
         if not os.path.isfile(dependencies_filepath):
             raise ConanException("Cannot find {}".format(dependencies_filepath))
-        return yaml.load(open(dependencies_filepath))
+        return yaml.safe_load(open(dependencies_filepath))
 
     def _all_dependent_modules(self, name):
         dependencies = {name}


### PR DESCRIPTION
**boost/1.73.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Usage of pyyaml::load is unsafe.
Gentoo blocks these calls if pyyaml installed through portage.
See https://bugs.gentoo.org/659348