### PR TITLE
redo cmake patching

### DIFF
--- a/recipes/paho-mqtt-c/all/conandata.yml
+++ b/recipes/paho-mqtt-c/all/conandata.yml
@@ -14,9 +14,6 @@ sources:
   "1.3.6":
     sha256: ecbc2c2000c6d8dcf1a76325312c61ed29db0b010acbd40cb92fcd4c014cd017
     url: https://github.com/eclipse/paho.mqtt.c/archive/v1.3.6.tar.gz
-  "1.3.7":
-    sha256: 19e9f04ddf244ab8c937d7e631ca15cedce7df95712c554107600e80efdaf277
-    url: https://github.com/eclipse/paho.mqtt.c/archive/v1.3.7.tar.gz
   "1.3.8":
     sha256: 4920ff685344cdb0272568bc4414dcf48fcdfc4a98c78b1f3ca49c38417bf391
     url: https://github.com/eclipse/paho.mqtt.c/archive/v1.3.8.tar.gz

--- a/recipes/paho-mqtt-c/all/conandata.yml
+++ b/recipes/paho-mqtt-c/all/conandata.yml
@@ -14,10 +14,12 @@ sources:
   "1.3.6":
     sha256: ecbc2c2000c6d8dcf1a76325312c61ed29db0b010acbd40cb92fcd4c014cd017
     url: https://github.com/eclipse/paho.mqtt.c/archive/v1.3.6.tar.gz
+  "1.3.7":
+    sha256: 19e9f04ddf244ab8c937d7e631ca15cedce7df95712c554107600e80efdaf277
+    url: https://github.com/eclipse/paho.mqtt.c/archive/v1.3.7.tar.gz
   "1.3.8":
     sha256: 4920ff685344cdb0272568bc4414dcf48fcdfc4a98c78b1f3ca49c38417bf391
     url: https://github.com/eclipse/paho.mqtt.c/archive/v1.3.8.tar.gz
-
 patches:
   "1.3.0":
     - patch_file: "patches/0001-fix-MinGW-and-OSX-builds-for-1-3-0.patch"
@@ -46,4 +48,6 @@ patches:
       base_path: "source_subfolder"
   "1.3.8":
     - patch_file: "patches/0002-fix-MinGW-and-OSX-builds-for-1-3-5.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0005-fix-cmake-install-for-1-3-8.patch"
       base_path: "source_subfolder"

--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -8,7 +8,7 @@ class PahoMqttcConan(ConanFile):
     homepage = "https://github.com/eclipse/paho.mqtt.c"
     topics = ("MQTT", "IoT", "eclipse", "SSL", "paho", "C")
     license = "EPL-2.0"
-    description = """Eclipse Paho MQTT C client library for Linux, Windows and MacOS"""
+    description = "Eclipse Paho MQTT C client library for Linux, Windows and MacOS"
     exports_sources = ["CMakeLists.txt", "patches/*"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
@@ -32,7 +32,8 @@ class PahoMqttcConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-            if tools.Version(self.version) < "1.3.4": # Static linking before 1.3.4 isn't supported on Windows
+            # Static linking before 1.3.4 isn't supported on Windows
+            if tools.Version(self.version) < "1.3.4":
                 self.options.shared = True
 
     def configure(self):
@@ -70,7 +71,7 @@ class PahoMqttcConan(ConanFile):
         return self._cmake
 
     def build(self):
-        for patch in self.conan_data["patches"][self.version]:
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -32,9 +32,10 @@ class PahoMqttcConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-            # Static linking before 1.3.4 isn't supported on Windows
-            if tools.Version(self.version) < "1.3.4":
-                self.options.shared = True
+        # There is unsureness if static linking before 1.3.4 did every work.
+        # If you need it, teak here, on Linux and OSX you might have success.
+        if tools.Version(self.version) < "1.3.4":
+            self.options.shared = True
 
     def configure(self):
         del self.settings.compiler.cppstd

--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -2,14 +2,13 @@ import os
 from conans import CMake, ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 
-
 class PahoMqttcConan(ConanFile):
     name = "paho-mqtt-c"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/eclipse/paho.mqtt.c"
     topics = ("MQTT", "IoT", "eclipse", "SSL", "paho", "C")
     license = "EPL-2.0"
-    description = "Eclipse Paho MQTT C client library for Linux, Windows and MacOS"
+    description = """Eclipse Paho MQTT C client library for Linux, Windows and MacOS"""
     exports_sources = ["CMakeLists.txt", "patches/*"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
@@ -33,9 +32,8 @@ class PahoMqttcConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        # Static linking before 1.3.4 isn't supported
-        if tools.Version(self.version) < "1.3.4":
-            self.options.shared = True
+            if tools.Version(self.version) < "1.3.4": # Static linking before 1.3.4 isn't supported on Windows
+                self.options.shared = True
 
     def configure(self):
         del self.settings.compiler.cppstd
@@ -72,7 +70,7 @@ class PahoMqttcConan(ConanFile):
         return self._cmake
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+        for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/paho-mqtt-c/all/patches/0005-fix-cmake-install-for-1-3-8.patch
+++ b/recipes/paho-mqtt-c/all/patches/0005-fix-cmake-install-for-1-3-8.patch
@@ -1,0 +1,544 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 4137d38..9f71d09 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -83,102 +83,162 @@ ADD_LIBRARY(common_obj OBJECT ${common_src})
+ SET_TARGET_PROPERTIES(common_obj PROPERTIES
+     POSITION_INDEPENDENT_CODE ON
+     COMPILE_DEFINITIONS "PAHO_MQTT_EXPORTS=1")
+-ADD_EXECUTABLE(MQTTVersion MQTTVersion.c)
+-SET_TARGET_PROPERTIES(MQTTVersion PROPERTIES
+-    POSITION_INDEPENDENT_CODE ON
+-    COMPILE_DEFINITIONS "PAHO_MQTT_IMPORTS=1")
+ ENDIF()
+ 
+-IF (PAHO_BUILD_STATIC)    
++IF (PAHO_BUILD_STATIC)
+ ADD_LIBRARY(common_obj_static OBJECT ${common_src})
+ SET_TARGET_PROPERTIES(common_obj_static PROPERTIES
+     POSITION_INDEPENDENT_CODE ON
+     COMPILE_DEFINITIONS "PAHO_MQTT_STATIC=1")
+ ENDIF()
+ 
+-IF (PAHO_BUILD_SHARED)
+-    ADD_LIBRARY(paho-mqtt3c SHARED $<TARGET_OBJECTS:common_obj> MQTTClient.c)
+-    ADD_LIBRARY(paho-mqtt3a SHARED $<TARGET_OBJECTS:common_obj> MQTTAsync.c MQTTAsyncUtils.c)
+-    
+-    TARGET_LINK_LIBRARIES(paho-mqtt3c ${LIBS_SYSTEM})
+-    TARGET_LINK_LIBRARIES(paho-mqtt3a ${LIBS_SYSTEM})
+-    TARGET_LINK_LIBRARIES(MQTTVersion paho-mqtt3a paho-mqtt3c ${LIBS_SYSTEM})
+-    
+-    SET_TARGET_PROPERTIES(
+-        paho-mqtt3c paho-mqtt3a PROPERTIES
+-        VERSION ${CLIENT_VERSION}
+-        SOVERSION ${PAHO_VERSION_MAJOR}
+-        COMPILE_DEFINITIONS "PAHO_MQTT_EXPORTS=1")
+-
+-    IF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+-		SET(MQTTCLIENT_ENTRY_POINT _MQTTClient_init)
+-		SET(MQTTASYNC_ENTRY_POINT _MQTTAsync_init)
+-	ELSEIF (NOT WIN32)
+-		SET(MQTTCLIENT_ENTRY_POINT MQTTClient_init)
+-		SET(MQTTASYNC_ENTRY_POINT MQTTAsync_init)
+-	ENDIF()
+-
+-    IF (NOT WIN32)
+-        SET_TARGET_PROPERTIES(
+-            paho-mqtt3c PROPERTIES
+-            LINK_FLAGS "-Wl,-init,${MQTTCLIENT_ENTRY_POINT}")
+-        SET_TARGET_PROPERTIES(
+-            paho-mqtt3a PROPERTIES
+-            LINK_FLAGS "-Wl,-init,${MQTTASYNC_ENTRY_POINT}")
++IF (NOT PAHO_WITH_SSL)
++    IF (PAHO_BUILD_SHARED)
++        IF (PAHO_BUILD_ASYNC)
++            ADD_LIBRARY(paho-mqtt3a SHARED $<TARGET_OBJECTS:common_obj> MQTTAsync.c MQTTAsyncUtils.c)
++            TARGET_LINK_LIBRARIES(paho-mqtt3a ${LIBS_SYSTEM})
++
++            SET_TARGET_PROPERTIES(
++                paho-mqtt3a PROPERTIES
++                VERSION ${CLIENT_VERSION}
++                SOVERSION ${PAHO_VERSION_MAJOR}
++                COMPILE_DEFINITIONS "PAHO_MQTT_EXPORTS=1")
++
++            IF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
++                SET(MQTTASYNC_ENTRY_POINT _MQTTAsync_init)
++            ELSEIF (NOT WIN32)
++                SET(MQTTASYNC_ENTRY_POINT MQTTAsync_init)
++            ENDIF()
++
++            IF (NOT WIN32)
++                SET_TARGET_PROPERTIES(
++                    paho-mqtt3a PROPERTIES
++                    LINK_FLAGS "-Wl,-init,${MQTTASYNC_ENTRY_POINT}")
++            ENDIF()
++
++            FOREACH(TARGET paho-mqtt3a)
++                TARGET_INCLUDE_DIRECTORIES(${TARGET}
++                    PUBLIC
++                        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++                    PRIVATE
++                        ${CMAKE_BINARY_DIR})
++            ENDFOREACH()
++
++            INSTALL(TARGETS paho-mqtt3a
++                EXPORT eclipse-paho-mqtt-cTargets
++                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++
++        ELSE()
++            ADD_LIBRARY(paho-mqtt3c SHARED $<TARGET_OBJECTS:common_obj> MQTTClient.c)
++            TARGET_LINK_LIBRARIES(paho-mqtt3c ${LIBS_SYSTEM})
++
++            SET_TARGET_PROPERTIES(
++                paho-mqtt3c PROPERTIES
++                VERSION ${CLIENT_VERSION}
++                SOVERSION ${PAHO_VERSION_MAJOR}
++                COMPILE_DEFINITIONS "PAHO_MQTT_EXPORTS=1")
++
++            IF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
++                SET(MQTTCLIENT_ENTRY_POINT _MQTTClient_init)
++            ELSEIF (NOT WIN32)
++                SET(MQTTCLIENT_ENTRY_POINT MQTTClient_init)
++            ENDIF()
++
++            IF (NOT WIN32)
++                SET_TARGET_PROPERTIES(
++                    paho-mqtt3c PROPERTIES
++                    LINK_FLAGS "-Wl,-init,${MQTTCLIENT_ENTRY_POINT}")
++            ENDIF()
++
++            FOREACH(TARGET paho-mqtt3c)
++                TARGET_INCLUDE_DIRECTORIES(${TARGET}
++                    PUBLIC
++                        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++                    PRIVATE
++                        ${CMAKE_BINARY_DIR})
++            ENDFOREACH()
++
++            INSTALL(TARGETS paho-mqtt3c
++                EXPORT eclipse-paho-mqtt-cTargets
++                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++
++        ENDIF()
+     ENDIF()
+ 
+-    FOREACH(TARGET paho-mqtt3c paho-mqtt3a)
+-        TARGET_INCLUDE_DIRECTORIES(${TARGET}
+-            PUBLIC
+-                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+-                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+-            PRIVATE
+-                ${CMAKE_BINARY_DIR})
+-    ENDFOREACH()
+-    
+-	INSTALL(TARGETS paho-mqtt3c paho-mqtt3a
+-		EXPORT eclipse-paho-mqtt-cTargets
+-		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+-    INSTALL(TARGETS MQTTVersion
+-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+-ENDIF()
++    IF (PAHO_BUILD_STATIC)
++        IF (PAHO_BUILD_ASYNC)
++            ADD_LIBRARY(paho-mqtt3a-static STATIC $<TARGET_OBJECTS:common_obj_static> MQTTAsync.c MQTTAsyncUtils.c)
++            TARGET_LINK_LIBRARIES(paho-mqtt3a-static ${LIBS_SYSTEM})
+ 
+-IF (PAHO_BUILD_STATIC)
+-    ADD_LIBRARY(paho-mqtt3c-static STATIC $<TARGET_OBJECTS:common_obj_static> MQTTClient.c)
+-    ADD_LIBRARY(paho-mqtt3a-static STATIC $<TARGET_OBJECTS:common_obj_static> MQTTAsync.c MQTTAsyncUtils.c)
+-
+-    TARGET_LINK_LIBRARIES(paho-mqtt3c-static ${LIBS_SYSTEM})
+-    TARGET_LINK_LIBRARIES(paho-mqtt3a-static ${LIBS_SYSTEM})
+-    IF (NOT WIN32)
+-        SET_TARGET_PROPERTIES(paho-mqtt3c-static PROPERTIES OUTPUT_NAME paho-mqtt3c)
+-        SET_TARGET_PROPERTIES(paho-mqtt3a-static PROPERTIES OUTPUT_NAME paho-mqtt3a)
+-    ENDIF()       
+-    SET_TARGET_PROPERTIES(
+-        paho-mqtt3c-static paho-mqtt3a-static PROPERTIES
+-        VERSION ${CLIENT_VERSION}
+-        SOVERSION ${PAHO_VERSION_MAJOR}
+-        COMPILE_DEFINITIONS "PAHO_MQTT_STATIC=1")
+-
+-    FOREACH(TARGET paho-mqtt3c-static paho-mqtt3a-static)
+-        TARGET_INCLUDE_DIRECTORIES(${TARGET}
+-            PUBLIC
+-                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+-                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+-            PRIVATE
+-                ${CMAKE_BINARY_DIR})
+-    ENDFOREACH()
+-
+-    IF (NOT PAHO_BUILD_SHARED)
+-        INSTALL(TARGETS paho-mqtt3c-static paho-mqtt3a-static
+-            EXPORT eclipse-paho-mqtt-cTargets
+-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+-    ELSE()
+-        INSTALL(TARGETS paho-mqtt3c-static paho-mqtt3a-static
+-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++            IF (NOT WIN32)
++                SET_TARGET_PROPERTIES(paho-mqtt3a-static PROPERTIES OUTPUT_NAME paho-mqtt3a)
++            ENDIF()
++            SET_TARGET_PROPERTIES(
++                paho-mqtt3a-static PROPERTIES
++                VERSION ${CLIENT_VERSION}
++                SOVERSION ${PAHO_VERSION_MAJOR}
++                COMPILE_DEFINITIONS "PAHO_MQTT_STATIC=1")
++
++            FOREACH(TARGET paho-mqtt3a-static)
++                TARGET_INCLUDE_DIRECTORIES(${TARGET}
++                    PUBLIC
++                        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++                    PRIVATE
++                        ${CMAKE_BINARY_DIR})
++            ENDFOREACH()
++
++            IF (NOT PAHO_BUILD_SHARED)
++                INSTALL(TARGETS paho-mqtt3a-static
++                    EXPORT eclipse-paho-mqtt-cTargets
++                    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++                    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++                    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++            ELSE()
++                INSTALL(TARGETS paho-mqtt3a-static
++                    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++            ENDIF()
++
++        ELSE()
++            ADD_LIBRARY(paho-mqtt3c-static STATIC $<TARGET_OBJECTS:common_obj_static> MQTTClient.c)
++            TARGET_LINK_LIBRARIES(paho-mqtt3c-static ${LIBS_SYSTEM})
++
++            IF (NOT WIN32)
++                SET_TARGET_PROPERTIES(paho-mqtt3c-static PROPERTIES OUTPUT_NAME paho-mqtt3c)
++            ENDIF()
++            SET_TARGET_PROPERTIES(
++                paho-mqtt3c-static PROPERTIES
++                VERSION ${CLIENT_VERSION}
++                SOVERSION ${PAHO_VERSION_MAJOR}
++                COMPILE_DEFINITIONS "PAHO_MQTT_STATIC=1")
++
++            FOREACH(TARGET paho-mqtt3c-static)
++                TARGET_INCLUDE_DIRECTORIES(${TARGET}
++                    PUBLIC
++                        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++                    PRIVATE
++                        ${CMAKE_BINARY_DIR})
++            ENDFOREACH()
++
++            IF (NOT PAHO_BUILD_SHARED)
++                INSTALL(TARGETS paho-mqtt3c-static
++                    EXPORT eclipse-paho-mqtt-cTargets
++                    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++                    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++                    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++            ELSE()
++                INSTALL(TARGETS paho-mqtt3c-static
++                    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++            ENDIF()
++
++        ENDIF()
+     ENDIF()
+ ENDIF()
+ 
+@@ -196,49 +256,82 @@ IF (PAHO_WITH_SSL)
+     	TARGET_INCLUDE_DIRECTORIES(common_ssl_obj PUBLIC ${OPENSSL_INCLUDE_DIR})
+     	SET_PROPERTY(TARGET common_ssl_obj PROPERTY	POSITION_INDEPENDENT_CODE ON)
+     	SET_PROPERTY(TARGET common_ssl_obj PROPERTY COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_EXPORTS=1")
+-    
+-        ADD_LIBRARY(paho-mqtt3cs SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTClient.c SSLSocket.c)
+-        ADD_LIBRARY(paho-mqtt3as SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTAsync.c MQTTAsyncUtils.c SSLSocket.c)
+-    
+-        SET_TARGET_PROPERTIES(
+-            paho-mqtt3cs paho-mqtt3as PROPERTIES
+-            VERSION ${CLIENT_VERSION}
+-            SOVERSION ${PAHO_VERSION_MAJOR}
+-            COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_EXPORTS=1")
+-
+-        IF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+-		    SET(MQTTCLIENT_ENTRY_POINT _MQTTClient_init)
+-		    SET(MQTTASYNC_ENTRY_POINT _MQTTAsync_init)
+-        ELSEIF (NOT WIN32)
+-            SET(MQTTCLIENT_ENTRY_POINT MQTTClient_init)
+-		    SET(MQTTASYNC_ENTRY_POINT MQTTAsync_init)
+-        ENDIF()
+ 
+-        IF (NOT WIN32)
++        IF (PAHO_BUILD_ASYNC)
++            ADD_LIBRARY(paho-mqtt3as SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTAsync.c MQTTAsyncUtils.c SSLSocket.c)
++
+             SET_TARGET_PROPERTIES(
+-	           paho-mqtt3cs PROPERTIES
+-	           LINK_FLAGS "-Wl,-init,${MQTTCLIENT_ENTRY_POINT}")
+-	        SET_TARGET_PROPERTIES(
+-	           paho-mqtt3as PROPERTIES
+-	           LINK_FLAGS "-Wl,-init,${MQTTASYNC_ENTRY_POINT}")
+-        ENDIF()
++                paho-mqtt3as PROPERTIES
++                VERSION ${CLIENT_VERSION}
++                SOVERSION ${PAHO_VERSION_MAJOR}
++                COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_EXPORTS=1")
++
++            IF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
++                SET(MQTTASYNC_ENTRY_POINT _MQTTAsync_init)
++            ELSEIF (NOT WIN32)
++                SET(MQTTASYNC_ENTRY_POINT MQTTAsync_init)
++            ENDIF()
++
++            IF (NOT WIN32)
++                SET_TARGET_PROPERTIES(
++                   paho-mqtt3as PROPERTIES
++                   LINK_FLAGS "-Wl,-init,${MQTTASYNC_ENTRY_POINT}")
++            ENDIF()
+ 
+-        FOREACH(TARGET paho-mqtt3cs paho-mqtt3as)
+-            TARGET_INCLUDE_DIRECTORIES(${TARGET}
+-                PUBLIC
+-                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+-                    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+-                PRIVATE
+-                    ${CMAKE_BINARY_DIR})
+-            TARGET_LINK_LIBRARIES(${TARGET}
+-                PUBLIC
+-                    OpenSSL::SSL OpenSSL::Crypto ${LIBS_SYSTEM})
+-        ENDFOREACH()
+-        INSTALL(TARGETS paho-mqtt3cs paho-mqtt3as
+-            EXPORT eclipse-paho-mqtt-cTargets
+-            ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+-            LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+-            RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR})
++            FOREACH(TARGET paho-mqtt3as)
++                TARGET_INCLUDE_DIRECTORIES(${TARGET}
++                    PUBLIC
++                        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++                    PRIVATE
++                        ${CMAKE_BINARY_DIR})
++                TARGET_LINK_LIBRARIES(${TARGET}
++                    PUBLIC
++                        OpenSSL::SSL OpenSSL::Crypto ${LIBS_SYSTEM})
++            ENDFOREACH()
++            INSTALL(TARGETS paho-mqtt3as
++                EXPORT eclipse-paho-mqtt-cTargets
++                ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
++                LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
++                RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR})
++        ELSE()
++            ADD_LIBRARY(paho-mqtt3cs SHARED $<TARGET_OBJECTS:common_ssl_obj> MQTTClient.c SSLSocket.c)
++
++            SET_TARGET_PROPERTIES(
++                paho-mqtt3cs PROPERTIES
++                VERSION ${CLIENT_VERSION}
++                SOVERSION ${PAHO_VERSION_MAJOR}
++                COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_EXPORTS=1")
++
++            IF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
++                SET(MQTTCLIENT_ENTRY_POINT _MQTTClient_init)
++            ELSEIF (NOT WIN32)
++                SET(MQTTCLIENT_ENTRY_POINT MQTTClient_init)
++            ENDIF()
++
++            IF (NOT WIN32)
++                SET_TARGET_PROPERTIES(
++                   paho-mqtt3cs PROPERTIES
++                   LINK_FLAGS "-Wl,-init,${MQTTCLIENT_ENTRY_POINT}")
++            ENDIF()
++
++            FOREACH(TARGET paho-mqtt3cs)
++                TARGET_INCLUDE_DIRECTORIES(${TARGET}
++                    PUBLIC
++                        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++                    PRIVATE
++                        ${CMAKE_BINARY_DIR})
++                TARGET_LINK_LIBRARIES(${TARGET}
++                    PUBLIC
++                        OpenSSL::SSL OpenSSL::Crypto ${LIBS_SYSTEM})
++            ENDFOREACH()
++            INSTALL(TARGETS paho-mqtt3cs
++                EXPORT eclipse-paho-mqtt-cTargets
++                ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
++                LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
++                RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR})
++        ENDIF()
+     ENDIF()
+ 
+     IF (PAHO_BUILD_STATIC)
+@@ -248,58 +341,98 @@ IF (PAHO_WITH_SSL)
+     	TARGET_INCLUDE_DIRECTORIES(common_ssl_obj_static PUBLIC ${OPENSSL_INCLUDE_DIR})
+     	SET_PROPERTY(TARGET common_ssl_obj_static PROPERTY POSITION_INDEPENDENT_CODE ON)
+     	SET_PROPERTY(TARGET common_ssl_obj_static PROPERTY COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_STATIC=1")
+-    
+-        ADD_LIBRARY(paho-mqtt3cs-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTClient.c SSLSocket.c)
+-        ADD_LIBRARY(paho-mqtt3as-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTAsync.c MQTTAsyncUtils.c SSLSocket.c)
+-
+-        SET_TARGET_PROPERTIES(
+-            paho-mqtt3cs-static paho-mqtt3as-static PROPERTIES
+-            VERSION ${CLIENT_VERSION}
+-            SOVERSION ${PAHO_VERSION_MAJOR}
+-            COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_STATIC=1")
+-        IF (NOT WIN32)
+-            SET_TARGET_PROPERTIES(paho-mqtt3cs-static PROPERTIES OUTPUT_NAME paho-mqtt3cs)
+-            SET_TARGET_PROPERTIES(paho-mqtt3as-static PROPERTIES OUTPUT_NAME paho-mqtt3as)
+-        ENDIF()
+ 
+-	    IF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+-			SET(MQTTCLIENT_ENTRY_POINT _MQTTClient_init)
+-			SET(MQTTASYNC_ENTRY_POINT _MQTTAsync_init)
+-		ELSEIF (NOT WIN32)
+-			SET(MQTTCLIENT_ENTRY_POINT MQTTClient_init)
+-			SET(MQTTASYNC_ENTRY_POINT MQTTAsync_init)
+-		ENDIF()
+-
+-		IF (NOT WIN32)
+-		    SET_TARGET_PROPERTIES(
+-	            paho-mqtt3cs-static PROPERTIES
+-	            LINK_FLAGS "-Wl,-init,${MQTTCLIENT_ENTRY_POINT}")
+-	        SET_TARGET_PROPERTIES(
+-	            paho-mqtt3as-static PROPERTIES
+-	            LINK_FLAGS "-Wl,-init,${MQTTASYNC_ENTRY_POINT}")
+-	    ENDIF()
+-
+-        IF (NOT PAHO_BUILD_SHARED)
+-            INSTALL(TARGETS paho-mqtt3cs-static paho-mqtt3as-static
+-                EXPORT eclipse-paho-mqtt-cTargets
+-                ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+-                LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
+-                RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR})
++        IF (PAHO_BUILD_ASYNC)
++            ADD_LIBRARY(paho-mqtt3as-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTAsync.c MQTTAsyncUtils.c SSLSocket.c)
++
++            SET_TARGET_PROPERTIES(
++                paho-mqtt3as-static PROPERTIES
++                VERSION ${CLIENT_VERSION}
++                SOVERSION ${PAHO_VERSION_MAJOR}
++                COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_STATIC=1")
++            IF (NOT WIN32)
++                SET_TARGET_PROPERTIES(paho-mqtt3as-static PROPERTIES OUTPUT_NAME paho-mqtt3as)
++            ENDIF()
++
++    	    IF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
++    			SET(MQTTASYNC_ENTRY_POINT _MQTTAsync_init)
++    		ELSEIF (NOT WIN32)
++    			SET(MQTTASYNC_ENTRY_POINT MQTTAsync_init)
++    		ENDIF()
++
++    		IF (NOT WIN32)
++    	        SET_TARGET_PROPERTIES(
++    	            paho-mqtt3as-static PROPERTIES
++    	            LINK_FLAGS "-Wl,-init,${MQTTASYNC_ENTRY_POINT}")
++    	    ENDIF()
++
++            IF (NOT PAHO_BUILD_SHARED)
++                INSTALL(TARGETS paho-mqtt3as-static
++                    EXPORT eclipse-paho-mqtt-cTargets
++                    ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
++                    LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
++                    RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR})
++            ELSE()
++                INSTALL(TARGETS paho-mqtt3as-static
++                    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++            ENDIF()
++            FOREACH(TARGET paho-mqtt3as-static)
++                TARGET_INCLUDE_DIRECTORIES(${TARGET}
++                    PUBLIC
++                        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++                    PRIVATE
++                        ${CMAKE_BINARY_DIR})
++                TARGET_LINK_LIBRARIES(${TARGET}
++                    PUBLIC
++                        OpenSSL::SSL OpenSSL::Crypto ${LIBS_SYSTEM})
++            ENDFOREACH()
+         ELSE()
+-            INSTALL(TARGETS paho-mqtt3cs-static paho-mqtt3as-static
+-                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++            ADD_LIBRARY(paho-mqtt3cs-static STATIC $<TARGET_OBJECTS:common_ssl_obj_static> MQTTClient.c SSLSocket.c)
++
++            SET_TARGET_PROPERTIES(
++                paho-mqtt3cs-static PROPERTIES
++                VERSION ${CLIENT_VERSION}
++                SOVERSION ${PAHO_VERSION_MAJOR}
++                COMPILE_DEFINITIONS "OPENSSL=1;PAHO_MQTT_STATIC=1")
++            IF (NOT WIN32)
++                SET_TARGET_PROPERTIES(paho-mqtt3cs-static PROPERTIES OUTPUT_NAME paho-mqtt3cs)
++            ENDIF()
++
++            IF(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
++                SET(MQTTCLIENT_ENTRY_POINT _MQTTClient_init)
++            ELSEIF (NOT WIN32)
++                SET(MQTTCLIENT_ENTRY_POINT MQTTClient_init)
++            ENDIF()
++
++            IF (NOT WIN32)
++                SET_TARGET_PROPERTIES(
++                    paho-mqtt3cs-static PROPERTIES
++                    LINK_FLAGS "-Wl,-init,${MQTTCLIENT_ENTRY_POINT}")
++            ENDIF()
++
++            IF (NOT PAHO_BUILD_SHARED)
++                INSTALL(TARGETS paho-mqtt3cs-static
++                    EXPORT eclipse-paho-mqtt-cTargets
++                    ARCHIVE DESTINATION  ${CMAKE_INSTALL_LIBDIR}
++                    LIBRARY DESTINATION  ${CMAKE_INSTALL_LIBDIR}
++                    RUNTIME DESTINATION  ${CMAKE_INSTALL_BINDIR})
++            ELSE()
++                INSTALL(TARGETS paho-mqtt3cs-static
++                    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++            ENDIF()
++            FOREACH(TARGET paho-mqtt3cs-static)
++                TARGET_INCLUDE_DIRECTORIES(${TARGET}
++                    PUBLIC
++                        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++                        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
++                    PRIVATE
++                        ${CMAKE_BINARY_DIR})
++                TARGET_LINK_LIBRARIES(${TARGET}
++                    PUBLIC
++                        OpenSSL::SSL OpenSSL::Crypto ${LIBS_SYSTEM})
++            ENDFOREACH()
+         ENDIF()
+-        FOREACH(TARGET paho-mqtt3cs-static paho-mqtt3as-static)
+-            TARGET_INCLUDE_DIRECTORIES(${TARGET}
+-                PUBLIC
+-                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+-                    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+-                PRIVATE
+-                    ${CMAKE_BINARY_DIR})
+-            TARGET_LINK_LIBRARIES(${TARGET}
+-                PUBLIC
+-                    OpenSSL::SSL OpenSSL::Crypto ${LIBS_SYSTEM})
+-        ENDFOREACH()
+     ENDIF()
+ ENDIF()
+ 
+@@ -316,20 +449,3 @@ INSTALL(FILES
+     "${CMAKE_CURRENT_BINARY_DIR}/eclipse-paho-mqtt-cConfigVersion.cmake"
+     DESTINATION lib/cmake/eclipse-paho-mqtt-c)
+ 
+-# Base64 test
+-ADD_EXECUTABLE( Base64Test EXCLUDE_FROM_ALL Base64.c Base64.h )
+-TARGET_COMPILE_DEFINITIONS( Base64Test PUBLIC "-DBASE64_TEST" )
+-IF (PAHO_WITH_SSL)
+-	ADD_EXECUTABLE( Base64TestOpenSSL EXCLUDE_FROM_ALL Base64.c Base64.h )
+-	TARGET_LINK_LIBRARIES( Base64TestOpenSSL OpenSSL::SSL OpenSSL::Crypto)
+-	TARGET_COMPILE_DEFINITIONS( Base64TestOpenSSL PUBLIC "-DBASE64_TEST -DOPENSSL=1" )
+-ENDIF (PAHO_WITH_SSL)
+-
+-# SHA1 test
+-ADD_EXECUTABLE( Sha1Test EXCLUDE_FROM_ALL SHA1.c SHA1.h )
+-TARGET_COMPILE_DEFINITIONS( Sha1Test PUBLIC "-DSHA1_TEST" )
+-IF (PAHO_WITH_SSL)
+-	ADD_EXECUTABLE( Sha1TestOpenSSL EXCLUDE_FROM_ALL SHA1.c SHA1.h )
+-	TARGET_LINK_LIBRARIES( Sha1TestOpenSSL OpenSSL::SSL OpenSSL::Crypto)
+-	TARGET_COMPILE_DEFINITIONS( Sha1TestOpenSSL PUBLIC "-DSHA1_TEST -DOPENSSL=1" )
+-ENDIF (PAHO_WITH_SSL)

--- a/recipes/paho-mqtt-c/config.yml
+++ b/recipes/paho-mqtt-c/config.yml
@@ -9,5 +9,7 @@ versions:
     folder: "all"
   "1.3.6":
     folder: "all"
+  "1.3.7":
+    folder: "all"
   "1.3.8":
     folder: "all"

--- a/recipes/paho-mqtt-c/config.yml
+++ b/recipes/paho-mqtt-c/config.yml
@@ -9,7 +9,5 @@ versions:
     folder: "all"
   "1.3.6":
     folder: "all"
-  "1.3.7":
-    folder: "all"
   "1.3.8":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **paho-mqtt-c/1.3.8**

The current recipe is not usable, see discussion at #4063

This fixes it, by putting back the cmake patches, modified to work with the new sources

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
