### PR TITLE
cairo: add missing windows system libs

### DIFF
--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -205,6 +205,7 @@ class CairoConan(ConanFile):
             self.cpp_info.components["cairo_"].requires.append("freetype::freetype")
 
         if self.settings.os == "Windows":
+            self.cpp_info.components["cairo_"].system_libs.extend(['gdi32','msimg32','user32'])
             if not self.options.shared:
                 self.cpp_info.components["cairo_"].defines.append('CAIRO_WIN32_STATIC_BUILD=1')
         else:


### PR DESCRIPTION
Specify library name and version:  **cairo/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
