### PR TITLE
Add a patch to insert a static cast to the argument of std::abs

### DIFF
--- a/recipes/catch2/2.x.x/conandata.yml
+++ b/recipes/catch2/2.x.x/conandata.yml
@@ -41,3 +41,7 @@ sources:
   2.13.4:
     url: https://github.com/catchorg/Catch2/archive/v2.13.4.tar.gz
     sha256: e7eb70b3d0ac2ed7dcf14563ad808740c29e628edde99e973adad373a2b5e4df
+patches:
+  2.13.4:
+    - patch_file: patches/abs-static-cast.patch
+      base_path: source_subfolder

--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -11,7 +11,7 @@ class ConanRecipe(ConanFile):
     homepage = "https://github.com/catchorg/Catch2"
     url = "https://github.com/conan-io/conan-center-index"
     license = "BSL-1.0"
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake"
     settings = "os", "compiler", "build_type", "arch"
     options = {"fPIC": [True, False], "with_main": [True, False]}
@@ -49,7 +49,13 @@ class ConanRecipe(ConanFile):
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
+    def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            print("aplying patch %s" % (patch,))
+            tools.patch(**patch)
+
     def build(self):
+        self._patch_sources()
         # Catch2 does skip install if included as subproject:
         # https://github.com/catchorg/Catch2/blob/79a5cd795c387e2da58c13e9dcbfd9ea7a2cfb30/CMakeLists.txt#L100-L102
         main_cml = os.path.join(self._source_subfolder, "CMakeLists.txt")

--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -51,7 +51,6 @@ class ConanRecipe(ConanFile):
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            print("aplying patch %s" % (patch,))
             tools.patch(**patch)
 
     def build(self):

--- a/recipes/catch2/2.x.x/patches/abs-static-cast.patch
+++ b/recipes/catch2/2.x.x/patches/abs-static-cast.patch
@@ -1,0 +1,38 @@
+diff --git a/include/internal/catch_matchers_floating.cpp b/include/internal/catch_matchers_floating.cpp
+index bcca0725..40cea7c7 100644
+--- a/include/internal/catch_matchers_floating.cpp
++++ b/include/internal/catch_matchers_floating.cpp
+@@ -55,7 +55,7 @@ namespace {
+             return lhs == rhs;
+         }
+ 
+-        auto ulpDiff = std::abs(lc - rc);
++        auto ulpDiff = std::abs(static_cast<FP>(lc - rc));
+         return static_cast<uint64_t>(ulpDiff) <= maxUlpDiff;
+     }
+ 
+diff --git a/single_include/catch2/catch.hpp b/single_include/catch2/catch.hpp
+index 0384171a..15743e12 100644
+--- a/single_include/catch2/catch.hpp
++++ b/single_include/catch2/catch.hpp
+@@ -1,9 +1,9 @@
+ /*
+  *  Catch v2.13.4
+- *  Generated: 2020-12-29 14:48:00.116107
++ *  Generated: 2021-01-19 09:44:08.909331
+  *  ----------------------------------------------------------
+  *  This file has been merged from multiple headers. Please don't edit it directly
+- *  Copyright (c) 2020 Two Blue Cubes Ltd. All rights reserved.
++ *  Copyright (c) 2021 Two Blue Cubes Ltd. All rights reserved.
+  *
+  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+@@ -11447,7 +11447,7 @@ namespace {
+             return lhs == rhs;
+         }
+ 
+-        auto ulpDiff = std::abs(lc - rc);
++        auto ulpDiff = std::abs(static_cast<FP>(lc - rc));
+         return static_cast<uint64_t>(ulpDiff) <= maxUlpDiff;
+     }
+ 


### PR DESCRIPTION
Add a patch to insert a static cast to the argument of std::abs to make IBM's xlclang++ happy.

Fixes issue #4312 

Specify library name and version:  **catch2/2.13.4**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
