### PR TITLE
libwebp QNX fix

### DIFF
--- a/recipes/libwebp/all/conandata.yml
+++ b/recipes/libwebp/all/conandata.yml
@@ -12,3 +12,5 @@ patches:
   "1.1.0":
     - patch_file: "patches/0001-fix-dll-export.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0002-qnx.patch"
+      base_path: "source_subfolder"

--- a/recipes/libwebp/all/conanfile.py
+++ b/recipes/libwebp/all/conanfile.py
@@ -81,10 +81,6 @@ class LibwebpConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "if(WEBP_BUILD_GIF2WEBP OR WEBP_BUILD_IMG2WEBP)",
                               "if(TRUE)")
-        # fix for QNX that does supply pthread with its lib
-        tools.replace_in_file(os.path.join(self._source_subfolder, "cmake", "deps.cmake"),
-                            'if(CMAKE_USE_PTHREADS_INIT)',
-                            'if(CMAKE_USE_PTHREADS_INIT AND NOT CMAKE_SYSTEM_NAME STREQUAL "QNX")')
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/libwebp/all/conanfile.py
+++ b/recipes/libwebp/all/conanfile.py
@@ -81,6 +81,10 @@ class LibwebpConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "if(WEBP_BUILD_GIF2WEBP OR WEBP_BUILD_IMG2WEBP)",
                               "if(TRUE)")
+        # fix for QNX that does supply pthread with its lib
+        tools.replace_in_file(os.path.join(self._source_subfolder, "cmake", "deps.cmake"),
+                            'if(CMAKE_USE_PTHREADS_INIT)',
+                            'if(CMAKE_USE_PTHREADS_INIT AND NOT CMAKE_SYSTEM_NAME STREQUAL "QNX")')
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/libwebp/all/patches/0002-qnx.patch
+++ b/recipes/libwebp/all/patches/0002-qnx.patch
@@ -7,7 +7,7 @@ index f19c0378..7b2d7cd7 100644
  find_package(Threads)
  if(Threads_FOUND)
 -  if(CMAKE_USE_PTHREADS_INIT)
-+  # work around cmake bug on QNX (https://cmake.org/Bug/view.php?id=11333)
++  # work around cmake bug on QNX (https://chromium-review.googlesource.com/c/webm/libwebp/+/2637274)
 +  if(CMAKE_USE_PTHREADS_INIT AND NOT CMAKE_SYSTEM_NAME STREQUAL "QNX")
      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
    endif()

--- a/recipes/libwebp/all/patches/0002-qnx.patch
+++ b/recipes/libwebp/all/patches/0002-qnx.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/deps.cmake b/cmake/deps.cmake
+index f19c0378..7b2d7cd7 100644
+--- a/cmake/deps.cmake
++++ b/cmake/deps.cmake
+@@ -24,7 +24,8 @@ check_c_source_compiles("
+ # Check for libraries.
+ find_package(Threads)
+ if(Threads_FOUND)
+-  if(CMAKE_USE_PTHREADS_INIT)
++  # work around cmake bug on QNX (https://cmake.org/Bug/view.php?id=11333)
++  if(CMAKE_USE_PTHREADS_INIT AND NOT CMAKE_SYSTEM_NAME STREQUAL "QNX")
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
+   endif()
+   foreach(PTHREAD_TEST HAVE_PTHREAD_PRIO_INHERIT PTHREAD_CREATE_UNDETACHED)


### PR DESCRIPTION
Specify library name and version:  **libwebp**

Just curious, is it ok to have QNX compatibility in CCI?

upstream fix: https://bugs.chromium.org/p/webp/issues/detail?id=498

- 👍 I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- 👍 I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- 👍 I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- 👍 I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
