### PR TITLE
Speedup boost recipe package_info by caching dependencies file

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -129,6 +129,7 @@ class BoostConan(ConanFile):
     short_paths = True
     no_copy_source = True
     exports_sources = ['patches/*']
+    _cached_dependencies = None
 
     def export(self):
         self.copy(self._dependency_filename, src="dependencies", dst="dependencies")
@@ -159,10 +160,12 @@ class BoostConan(ConanFile):
 
     @property
     def _dependencies(self):
-        dependencies_filepath = os.path.join(self.recipe_folder, "dependencies", self._dependency_filename)
-        if not os.path.isfile(dependencies_filepath):
-            raise ConanException("Cannot find {}".format(dependencies_filepath))
-        return yaml.safe_load(open(dependencies_filepath))
+        if self._cached_dependencies is None:
+            dependencies_filepath = os.path.join(self.recipe_folder, "dependencies", self._dependency_filename)
+            if not os.path.isfile(dependencies_filepath):
+                raise ConanException("Cannot find {}".format(dependencies_filepath))
+            self._cached_dependencies = yaml.safe_load(open(dependencies_filepath))
+        return self._cached_dependencies
 
     def _all_dependent_modules(self, name):
         dependencies = {name}
@@ -1318,7 +1321,6 @@ class BoostConan(ConanFile):
                         if requirement != self.options.i18n_backend:
                             continue
                     self.cpp_info.components[module].requires.append("{0}::{0}".format(conan_requirement))
-
             for incomplete_component in incomplete_components:
                 self.output.warn("Boost component '{0}' is missing libraries. Try building boost with '-o boost:without_{0}'.".format(incomplete_component))
 


### PR DESCRIPTION
Specify library name and version:  **boost/all**

Fix: #4203

The file with dependencies was read on each call to `self._dependencies`.
It never changes, so I decided to cache it, and it gave a good speedup and 6 seconds waiting during `package_info` is gone.

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
