### PR TITLE
ios-cmake: correct parameter handling for quoted parameters

### DIFF
--- a/recipes/ios-cmake/all/cmake-wrapper
+++ b/recipes/ios-cmake/all/cmake-wrapper
@@ -19,6 +19,5 @@ if [ $BUILD == "yes" ]; then
 else
   # TODO check if, based on log level, some configurable outbut of these values could be nice to have
   fix_cmake_flags="-DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=BOTH -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=NEVER"
-  cmake_call="cmake $@ ${CONAN_USER_CMAKE_FLAGS} ${fix_cmake_flags}"
-  ${cmake_call}
+  cmake "$@" ${CONAN_USER_CMAKE_FLAGS} ${fix_cmake_flags}
 fi


### PR DESCRIPTION
Specify library name and version:  **ios-cmake/3.1.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This packages uses a `cmake-wrapper` script for calling `cmake`with additional parameters. Unfortunately, the arguments from command line loses quotes, therefore `-G "Unix Makefiles"` is split up into several arguments.

This PR fies this by simply changing the way how cmake is called.

Fixes Issue  https://github.com/conan-io/conan-center-index/issues/4326

Tested with `gtest/1.10.0`.