### PR TITLE
stduuid: Enable vs15+

### DIFF
--- a/recipes/stduuid/all/conanfile.py
+++ b/recipes/stduuid/all/conanfile.py
@@ -32,15 +32,13 @@ class StduuidConan(ConanFile):
         if self.settings.compiler.cppstd and \
            not any([str(self.settings.compiler.cppstd) == std for std in ["17", "20", "gnu17", "gnu20"]]):
             raise ConanInvalidConfiguration("stduuid requires at least c++17")
-        elif compiler == "Visual Studio":
-            if version < "16":
-                raise ConanInvalidConfiguration("stduuid requires at least Visual Studio version 16")
+        elif compiler == "Visual Studio"and version < "15":
+            raise ConanInvalidConfiguration("stduuid requires at least Visual Studio version 15")
         else:
             if ( compiler == "gcc" and version < "7" ) or ( compiler == "clang" and version < "5" ):
                 raise ConanInvalidConfiguration("stduuid requires a compiler that supports at least C++17")
-            elif compiler == "apple-clang":
-                if version < "10":
-                    raise ConanInvalidConfiguration("stduuid requires a compiler that supports at least C++17")
+            elif compiler == "apple-clang"and version < "10":
+                raise ConanInvalidConfiguration("stduuid requires a compiler that supports at least C++17")
 
     def package(self):
         root_dir = self._source_subfolder


### PR DESCRIPTION
Specify library name and version:  **stduuid/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

stduuid/1.0 is compatible with VS 2017.
