### PR TITLE
Eigen: Add option for MPL2-only code.

### DIFF
--- a/recipes/eigen/all/conanfile.py
+++ b/recipes/eigen/all/conanfile.py
@@ -11,6 +11,8 @@ class EigenConan(ConanFile):
     license = "MPL-2.0"
     topics = ("eigen", "algebra", "linear-algebra", "vector", "numerical")
     settings = "os", "compiler", "build_type", "arch"
+    options = {"MPL2_only": [True, False]}
+    default_options = {"MPL2_only": False}
     exports_sources = ["patches/*"]
     no_copy_source = True
 
@@ -46,3 +48,5 @@ class EigenConan(ConanFile):
         self.cpp_info.components["eigen3"].includedirs = [os.path.join("include", "eigen3")]
         if self.settings.os == "Linux":
             self.cpp_info.components["eigen3"].system_libs = ["m"]
+        if self.options.MPL2_only:
+            self.cpp_info.defines = ["EIGEN_MPL2_ONLY"]

--- a/recipes/eigen/all/conanfile.py
+++ b/recipes/eigen/all/conanfile.py
@@ -8,7 +8,7 @@ class EigenConan(ConanFile):
     homepage = "http://eigen.tuxfamily.org"
     description = "Eigen is a C++ template library for linear algebra: matrices, vectors, \
                    numerical solvers, and related algorithms."
-    license = "MPL-2.0"
+    license = ("MPL-2.0", "LGPL-3.0-or-later")
     topics = ("eigen", "algebra", "linear-algebra", "vector", "numerical")
     settings = "os", "compiler", "build_type", "arch"
     options = {"MPL2_only": [True, False]}

--- a/recipes/eigen/all/conanfile.py
+++ b/recipes/eigen/all/conanfile.py
@@ -49,4 +49,4 @@ class EigenConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.components["eigen3"].system_libs = ["m"]
         if self.options.MPL2_only:
-            self.cpp_info.defines = ["EIGEN_MPL2_ONLY"]
+            self.cpp_info.components["eigen3"].defines = ["EIGEN_MPL2_ONLY"]


### PR DESCRIPTION
Specify library name and version:  **eigen/3.x**

Eigen recipe advertises itself as being `MPL-2.0` licenced.
https://github.com/conan-io/conan-center-index/blob/b19b07beef5915423f6571db1045fb0bd7bab92f/recipes/eigen/all/conanfile.py#L11

This is only true if `EIGEN_MPL2_ONLY` is defined. Otherwise it includes code licenced under `LGPL`
http://eigen.tuxfamily.org/index.php?title=Main_Page (See Licence entry)

I added an option to add the define to `cpp_info`, that way packages consuming this recipe can use only the MPL2 code if they want to.
The option is set to `False` by default to not break any current project using the LGPL portion of Eigen.

Closes https://github.com/conan-io/conan-center-index/issues/4333

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
