### PR TITLE
In libgettext, add setting for specifying threading API

### DIFF
--- a/recipes/libgettext/all/conanfile.py
+++ b/recipes/libgettext/all/conanfile.py
@@ -15,8 +15,8 @@ class GetTextConan(ConanFile):
     deprecated = "gettext"
     settings = "os", "arch", "compiler", "build_type"
     exports_sources = ["patches/*.patch"]
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "threads": ["posix", "solaris", "pth", "windows", "disabled", "auto"]}
+    default_options = {"shared": False, "fPIC": True, "threads": "auto"}
 
     @property
     def _source_subfolder(self):
@@ -43,6 +43,9 @@ class GetTextConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+
+        if(self.options.threads == "auto"):
+            self.options.threads = { "Solaris": "solaris", "Windows": "windows" }.get(str(self.settings.os), "posix")
 
     def requirements(self):
         self.requires("libiconv/1.16")
@@ -75,6 +78,7 @@ class GetTextConan(ConanFile):
                 "--disable-csharp",
                 "--disable-libasprintf",
                 "--disable-curses",
+                "--disable-threads" if self.options.threads == "disabled" else ("--enable-threads=" + str(self.options.threads)),
                 "--with-libiconv-prefix=%s" % libiconv_prefix]
         build = None
         host = None


### PR DESCRIPTION
Specify library name and version:  **libgettext/0.20.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

To resurrect/clean up #2969, this PR adds a `threads` option to the `libgettext` recipe to allow explicitly specifying the threading API. This is particularly useful for cross-compiling on Linux for Windows via MinGW, where `./configure` by defaults selects the POSIX API, which will result in a dependency to `libwinpthread-1.dll`. This is particularly silly when used as a dependency by Glib, which _does_ use the Win32 threading API, resulting in Glib DLL's that use both the Win32 API _and_ the MinGW pthread emulation. The `pth` value denotes the [GNU Pth](https://www.gnu.org/software/pth/) cooperative user-space threading library, which probably should not be used as a default.

The default value for the option is `auto`, which gets replaced by a sensible default for the host OS in the `configure` method. This marks the generated package with the correct option, i.e. the threading API that is actually used in the generated binary. This is preferable over a binary where the API depends on what the `./configure` happens to choose on the build machine.