### PR TITLE
cli11 / Fix typo in license name: BDS -> BSD

### DIFF
--- a/recipes/cli11/all/conanfile.py
+++ b/recipes/cli11/all/conanfile.py
@@ -8,7 +8,7 @@ class CLI11Conan(ConanFile):
     description = "A command line parser for C++11 and beyond."
     topics = ("cli-parser", "cpp11", "no-dependencies", "cli", "header-only")
     url = "https://github.com/conan-io/conan-center-index"
-    license = "BDS-3-Clause"
+    license = "BSD-3-Clause"
     settings = "os", "compiler", "build_type", "arch"
 
     @property


### PR DESCRIPTION
Specify library name and version:  **cli11/1.9.1**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This is a typo fix so all the above isn't applicable.