### PR TITLE
Add github action file, to update tables of contents automatically

### DIFF
--- a/.github/workflows/on-push-do-doco.yml
+++ b/.github/workflows/on-push-do-doco.yml
@@ -12,7 +12,10 @@ jobs:
     - name: Run MarkdownSnippets
       run: |
         dotnet tool install --global MarkdownSnippets.Tool
-        mdsnippets ${GITHUB_WORKSPACE}
+        mdsnippets ${GITHUB_WORKSPACE} \
+          --convention InPlaceOverwrite \
+          --exclude-directories 'cmake-build-*' \
+          --toc-level 5
       shell: bash
     - name: Push changes
       run: |

--- a/.github/workflows/on-push-do-doco.yml
+++ b/.github/workflows/on-push-do-doco.yml
@@ -1,9 +1,9 @@
 name: on-push-do-doco
 on:
-  # Only update the docs on main, to reduce the chance of conflicts
+  # Only update the docs on default branch, to reduce the chance of conflicts
   push:
     branches:
-      - main
+      - master
 jobs:
   release:
     runs-on: windows-latest

--- a/.github/workflows/on-push-do-doco.yml
+++ b/.github/workflows/on-push-do-doco.yml
@@ -14,7 +14,7 @@ jobs:
         dotnet tool install --global MarkdownSnippets.Tool
         mdsnippets ${GITHUB_WORKSPACE} \
           --convention InPlaceOverwrite \
-          --exclude-directories 'cmake-build-*' \
+          --exclude-directories 'recipes' \
           --toc-level 5
       shell: bash
     - name: Push changes

--- a/.github/workflows/on-push-do-doco.yml
+++ b/.github/workflows/on-push-do-doco.yml
@@ -1,0 +1,25 @@
+name: on-push-do-doco
+on:
+  # Only update the docs on main, to reduce the chance of conflicts
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run MarkdownSnippets
+      run: |
+        dotnet tool install --global MarkdownSnippets.Tool
+        mdsnippets ${GITHUB_WORKSPACE}
+      shell: bash
+    - name: Push changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git commit -m "[docs] Regenerate tables of contents" -a  || echo "nothing to commit"
+        remote="https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
+        branch="${GITHUB_REF:11}"
+        git push "${remote}" ${branch} || echo "nothing to push"
+      shell: bash

--- a/.github/workflows/on-push-do-doco.yml
+++ b/.github/workflows/on-push-do-doco.yml
@@ -1,11 +1,10 @@
-name: on-push-do-doco
+name: docs_markdown_toc
 on:
-  # Only update the docs on default branch, to reduce the chance of conflicts
   push:
     branches:
       - master
 jobs:
-  release:
+  docs_markdown_toc:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -17,12 +16,10 @@ jobs:
           --exclude-directories 'recipes' \
           --toc-level 5
       shell: bash
-    - name: Push changes
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git commit -m "[docs] Regenerate tables of contents" -a  || echo "nothing to commit"
-        remote="https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
-        branch="${GITHUB_REF:11}"
-        git push "${remote}" ${branch} || echo "nothing to push"
-      shell: bash
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        branch: action-doc-toc
+        commit-message: "[docs] Regenerate tables of contents"
+        title: "[docs] Regenerate tables of contents"
+        body: "Automatic update of the documentation TOCs."


### PR DESCRIPTION
See the original issue #4367, and #4372, which this was a part of.

## Changes made:

1. Added a GitHub Actions file that will trigger the updating of tables of contents markers - and if they are changed, will create a new commit and push

## Things to document, somewhere, for users...

* The tool
  * The tool used to generate the tables of contents ("toc") is [MarkdownSnippets](https://github.com/simonCropp/MarkdownSnippets) - or mdsnippets
  * The tools options are configured in `mdsnippets.json`
  * conan-center-index is only using its toc capability, and not its embedding of example code
* Writing docs
    * To add a table of contents in a new file, place single line `toc` near the start of the .md file - before a level-2 heading (`##`)
    * Headings must be formatted with `##` and not underlines

## Notes on the GitHub Action file

* It runs as user `actions-user`, which will need to ["sign the CLA"](https://github.com/conan-io/conan-center-index/pull/4371#issuecomment-767826930)!
* It only runs on changes committed to master
* It won't create a new commit if nothing changed
* The commit message is in the file - and is `[docs] Regenerate tables of contents`
* Once it has run, the output will be viewable at https://github.com/conan-io/conan-center-index/actions
* It might be worth adding a build badge for that. I'm happy to do that, if wanted...