### PR TITLE
Bumps gtest to 20210126 and adds QNX 7.1 support

### DIFF
--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -5,6 +5,9 @@ sources:
   "1.10.0":
     url: "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
     sha256: "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb"
+  "cci-26012021":
+    url: "https://github.com/google/googletest/archive/273f8cb059a4e7b089731036392422b5ef489791.tar.gz"
+    sha256: "2937e96827aa44b291d42c4f0ffaa6a7637445822cf873d0fa6a889df84b8628"
 patches:
   "1.8.1":
     - patch_file: "patches/gtest-1.8.1.patch"
@@ -13,4 +16,7 @@ patches:
     - patch_file: "patches/gtest-1.10.0.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/gtest-1.10.0-override.patch"
+      base_path: "source_subfolder"
+  "cci-26012021":
+    - patch_file: "patches/gtest-1.10.0.patch"
       base_path: "source_subfolder"

--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -5,7 +5,7 @@ sources:
   "1.10.0":
     url: "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
     sha256: "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb"
-  "cci-20210126":
+  "cci.20210126":
     url: "https://github.com/google/googletest/archive/273f8cb059a4e7b089731036392422b5ef489791.tar.gz"
     sha256: "2937e96827aa44b291d42c4f0ffaa6a7637445822cf873d0fa6a889df84b8628"
 patches:
@@ -17,6 +17,6 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/gtest-1.10.0-override.patch"
       base_path: "source_subfolder"
-  "cci-20210126":
+  "cci.20210126":
     - patch_file: "patches/gtest-1.10.0.patch"
       base_path: "source_subfolder"

--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -5,7 +5,7 @@ sources:
   "1.10.0":
     url: "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
     sha256: "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb"
-  "cci-26012021":
+  "cci-20210126":
     url: "https://github.com/google/googletest/archive/273f8cb059a4e7b089731036392422b5ef489791.tar.gz"
     sha256: "2937e96827aa44b291d42c4f0ffaa6a7637445822cf873d0fa6a889df84b8628"
 patches:
@@ -17,6 +17,6 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/gtest-1.10.0-override.patch"
       base_path: "source_subfolder"
-  "cci-26012021":
+  "cci-20210126":
     - patch_file: "patches/gtest-1.10.0.patch"
       base_path: "source_subfolder"

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -64,7 +64,7 @@ class GTestConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = glob.glob("googletest" + "-*/")[0]
+        extracted_dir = glob.glob("googletest-*/")[0]
         os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_cmake(self):

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -29,11 +29,11 @@ class GTestConan(ConanFile):
     def _minimum_compilers_version(self):
         if self.version == "1.8.1":
             return {
-                "Visual Studio": "13"
+                "Visual Studio": "14"
             }
         else:
             return {
-                "Visual Studio": "15",
+                "Visual Studio": "14",
                 "gcc": "5",
                 "clang": "5",
                 "apple-clang": "9.1",

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -35,7 +35,7 @@ class GTestConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "googletest-release-" + self.version
+        extracted_dir = glob.glob("googletest" + "-*/")[0]
         os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_cmake(self):
@@ -78,6 +78,9 @@ class GTestConan(ConanFile):
         self.cpp_info.components["libgtest"].libs = ["gtest{}".format(self._postfix)]
         if self.settings.os == "Linux":
             self.cpp_info.components["libgtest"].system_libs.append("pthread")
+        
+        if self.settings.os == "Neutrino" and self.settings.os.version == "7.1":
+            self.cpp_info.components["libgtest"].system_libs.append("regex")
 
         if self.options.shared:
             self.cpp_info.components["libgtest"].defines.append("GTEST_LINKED_AS_SHARED_LIBRARY=1")

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -19,6 +19,27 @@ class GTestConan(ConanFile):
     _source_subfolder = "source_subfolder"
 
     @property
+    def _minimum_cpp_standard(self):
+        if self.version == "1.8.1":
+            return 98
+        else:
+            return 11
+
+    @property
+    def _minimum_compilers_version(self):
+        if self.version == "1.8.1":
+            return {
+                "Visual Studio": "13"
+            }
+        else:
+            return {
+                "Visual Studio": "15",
+                "gcc": "5",
+                "clang": "5",
+                "apple-clang": "9.1",
+            }
+        
+    @property
     def _postfix(self):
         return self.options.debug_postfix if self.settings.build_type == "Debug" else ""
 
@@ -29,9 +50,17 @@ class GTestConan(ConanFile):
             del self.options.debug_postfix
 
     def configure(self):
-        if self.settings.os == "Windows":
-            if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version.value) <= "12":
-                raise ConanInvalidConfiguration("Google Test {} does not support Visual Studio <= 12".format(self.version))
+        if self.settings.get_safe("compiler.cppstd"):
+            tools.check_min_cppstd(self, self._minimum_cpp_standard)
+        min_version = self._minimum_compilers_version.get(
+            str(self.settings.compiler))
+        if not min_version:
+            self.output.warn("{} recipe lacks information about the {} compiler support.".format(
+                self.name, self.settings.compiler))
+        else:
+            if tools.Version(self.settings.compiler.version) < min_version:
+                raise ConanInvalidConfiguration("{} requires c++11 support. The current compiler {} {} does not support it.".format(
+                    self.name, self.settings.compiler, self.settings.compiler.version))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/gtest/config.yml
+++ b/recipes/gtest/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "1.10.0":
     folder: all
+  "cci-26012021":
+    folder: all

--- a/recipes/gtest/config.yml
+++ b/recipes/gtest/config.yml
@@ -3,5 +3,5 @@ versions:
     folder: all
   "1.10.0":
     folder: all
-  "cci-26012021":
+  "cci-20210126":
     folder: all

--- a/recipes/gtest/config.yml
+++ b/recipes/gtest/config.yml
@@ -3,5 +3,5 @@ versions:
     folder: all
   "1.10.0":
     folder: all
-  "cci-20210126":
+  "cci.20210126":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **gtest/cci-26012021**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
