### PR TITLE
libcurl: add xp compatibility option

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -37,6 +37,7 @@ class LibcurlConan(ConanFile):
         "with_brotli": [True, False],
         "with_zstd": [True, False],
         "with_c_ares": [True, False],
+        "xp_compatible": [True, False],
     }
     default_options = {
         "shared": False,
@@ -58,6 +59,7 @@ class LibcurlConan(ConanFile):
         "with_brotli": False,
         "with_zstd": False,
         "with_c_ares": False,
+        "xp_compatible": False,
     }
 
     _autotools = None
@@ -91,6 +93,8 @@ class LibcurlConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self.settings.os != "Windows" or not self._is_using_cmake_build:
+            del self.options.xp_compatible
         if not self._has_zstd_option:
             del self.options.with_zstd
         # Default options
@@ -486,6 +490,10 @@ class LibcurlConan(ConanFile):
             self._cmake.definitions["CURL_ZSTD"] = self.options.with_zstd
         self._cmake.definitions["CMAKE_USE_LIBSSH2"] = self.options.with_libssh2
         self._cmake.definitions["ENABLE_ARES"] = self.options.with_c_ares
+        if self.options.get_safe("xp_compatible"):
+            self._cmake.definitions['CURL_TARGET_WINDOWS_VERSION'] = '0x0501'
+            self._cmake.definitions['ENABLE_INET_PTON'] = False
+            self._cmake.definitions['HAVE_INET_PTON'] = False
 
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake

--- a/recipes/libcurl/all/test_package/conanfile.py
+++ b/recipes/libcurl/all/test_package/conanfile.py
@@ -21,7 +21,7 @@ class TestPackageConan(ConanFile):
 
         if "arm" in self.settings.arch:
             self.test_arm()
-        elif tools.cross_building(self.settings) and self.settings.os == "Windows":
+        elif tools.cross_building(self.settings) and self.settings.os == "Windows" and self.settings.compiler != "Visual Studio":
             self.test_mingw_cross()
         else:
             bin_path = os.path.join("bin", "test_package")


### PR DESCRIPTION
Specify library name and version:  **libcurl/\***

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I'm happy to add the option to builds using autotools, but I'm not familiar with it.
