### PR TITLE
Use https instead of http in path to source code

### DIFF
--- a/recipes/m4/all/conandata.yml
+++ b/recipes/m4/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
   "1.4.18":
-    url: "http://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.bz2"
+    url: "https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.bz2"
     sha256: "6640d76b043bc658139c8903e293d5978309bf0f408107146505eca701e67cf6"
 patches:
   "1.4.18":


### PR DESCRIPTION
Specify library name and version:  **m4/1.4.18**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.


Should use `https` in path to download source instead of `http`