### PR TITLE
fix windows lib casing for mingw

### DIFF
--- a/recipes/libdispatch/all/conanfile.py
+++ b/recipes/libdispatch/all/conanfile.py
@@ -63,4 +63,4 @@ class LibDispatchConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.system_libs = ["pthread", "rt"]
         elif self.settings.os == "Windows":
-            self.cpp_info.system_libs = ["ShLwApi", "WS2_32", "WinMM", "synchronization"]
+            self.cpp_info.system_libs = ["Shlwapi", "Ws2_32", "winmm", "synchronization"]


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
