### PR TITLE
[mongo-cxx-driver] do not duplicate version 3.6.2

### DIFF
--- a/recipes/mongo-cxx-driver/all/conandata.yml
+++ b/recipes/mongo-cxx-driver/all/conandata.yml
@@ -5,9 +5,6 @@ sources:
   "3.6.1":
     url: https://github.com/mongodb/mongo-cxx-driver/archive/r3.6.1.tar.gz
     sha256: c6d1b307f7b074d178c4a815d8739195fb4d7870701064bdad6f1f2360ae0af9
-  "3.6.2":
-    url: https://github.com/mongodb/mongo-cxx-driver/archive/r3.6.2.tar.gz
-    sha256: f50a1acb98a473f0850e2766dc7e84c05415dc63b1a2f851b77b12629ac14d62
 patches:
   "3.6.2":
     - patch_file: "patches/dirs_and_tests.patch"
@@ -17,13 +14,6 @@ patches:
     - patch_file: "patches/poly_use_std_define.patch"
       base_path: "source_subfolder"
   "3.6.1":
-    - patch_file: "patches/dirs_and_tests.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/link_conan_boost.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/poly_use_std_define.patch"
-      base_path: "source_subfolder"
-  "3.6.2":
     - patch_file: "patches/dirs_and_tests.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/link_conan_boost.patch"

--- a/recipes/mongo-cxx-driver/config.yml
+++ b/recipes/mongo-cxx-driver/config.yml
@@ -3,5 +3,3 @@ versions:
     folder: all
   "3.6.1":
     folder: all
-  "3.6.2":
-    folder: all


### PR DESCRIPTION
Specify library name and version:  ** mongo-cxx-driver/3.6.2**

Fix: https://github.com/conan-io/conan-center-index/issues/4415

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
