### PR TITLE
opencl-headers: add 2020.12.18 + fix CMake names

### DIFF
--- a/recipes/opencl-headers/all/conandata.yml
+++ b/recipes/opencl-headers/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
-  "2020.03.13":
-    url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2020.03.13.tar.gz"
-    sha256: "664bbe587e5a0a00aac267f645b7c413586e7bc56dca9ff3b00037050d06f476"
+  "2020.12.18":
+    url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2020.12.18.tar.gz"
+    sha256: "5dad6d436c0d7646ef62a39ef6cd1f3eba0a98fc9157808dfc1d808f3705ebc2"
   "2020.06.16":
     url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2020.06.16.tar.gz"
     sha256: "2f5a60e5ac4b127650618c58a7e3b35a84dbf23c1a0ac72eb5e7baf221600e06"
+  "2020.03.13":
+    url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2020.03.13.tar.gz"
+    sha256: "664bbe587e5a0a00aac267f645b7c413586e7bc56dca9ff3b00037050d06f476"

--- a/recipes/opencl-headers/all/conanfile.py
+++ b/recipes/opencl-headers/all/conanfile.py
@@ -1,6 +1,8 @@
 from conans import ConanFile, tools
 import os
 
+required_conan_version = ">=1.28.0"
+
 
 class OpenclHeadersConan(ConanFile):
     name = "opencl-headers"
@@ -25,3 +27,11 @@ class OpenclHeadersConan(ConanFile):
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         self.copy("*", dst=os.path.join("include", "CL"), src=os.path.join(self._source_subfolder, "CL"))
+
+    def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "OpenCLHeaders"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "OpenCLHeaders"
+        self.cpp_info.names["cmake_find_package"] = "OpenCL"
+        self.cpp_info.names["cmake_find_package_multi"] = "OpenCL"
+        self.cpp_info.components["_opencl-headers"].names["cmake_find_package"] = "Headers"
+        self.cpp_info.components["_opencl-headers"].names["cmake_find_package_multi"] = "Headers"

--- a/recipes/opencl-headers/all/test_package/CMakeLists.txt
+++ b/recipes/opencl-headers/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(OpenCLHeaders REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} OpenCL::Headers)

--- a/recipes/opencl-headers/all/test_package/conanfile.py
+++ b/recipes/opencl-headers/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/opencl-headers/config.yml
+++ b/recipes/opencl-headers/config.yml
@@ -1,5 +1,7 @@
 versions:
-  "2020.03.13":
+  "2020.12.18":
     folder: all
   "2020.06.16":
+    folder: all
+  "2020.03.13":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **opencl-headers/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

CMake names:
config file: https://github.com/KhronosGroup/OpenCL-Headers/blob/fb6807bfc9da21a21d69eb8bd07b6fc1f9bb74f4/CMakeLists.txt#L35
target: https://github.com/KhronosGroup/OpenCL-Headers/blob/fb6807bfc9da21a21d69eb8bd07b6fc1f9bb74f4/CMakeLists.txt#L9
namespace: https://github.com/KhronosGroup/OpenCL-Headers/blob/fb6807bfc9da21a21d69eb8bd07b6fc1f9bb74f4/CMakeLists.txt#L43