### PR TITLE
[zlib] remove explicit apple deployment target flag

### DIFF
--- a/recipes/zlib/1.2.11/conanfile.py
+++ b/recipes/zlib/1.2.11/conanfile.py
@@ -65,10 +65,6 @@ class ZlibConan(ConanFile):
         else:
             make_target = "libz.a"
 
-        if tools.is_apple_os(self.settings.os) and self.settings.get_safe("os.version"):
-            target = tools.apple_deployment_target_flag(self.settings.os, self.settings.os.version)
-            env_build.flags.append(target)
-
         env = {}
         if "clang" in str(self.settings.compiler) and tools.get_env("CC") is None and tools.get_env("CXX") is None:
             env = {"CC": "clang", "CXX": "clang++"}


### PR DESCRIPTION
remove explicit [tools.apple_deployment_target_flag](https://docs.conan.io/en/latest/reference/tools.html#tools-apple-deployment-target-flag)

two reasons for the change:
1. since https://github.com/conan-io/conan/pull/7862, `AutoToolsBuildEnvironment` calls [tools.apple_deployment_target_flag](https://docs.conan.io/en/latest/reference/tools.html#tools-apple-deployment-target-flag) on its own
2. https://github.com/conan-io/conan/pull/8263 adds `os.sdk` sub-setting, https://github.com/conan-io/conan/pull/8264 adds `os.subsystem` sub-setting, they need to be passed to the [tools.apple_deployment_target_flag](https://docs.conan.io/en/latest/reference/tools.html#tools-apple-deployment-target-flag)

Specify library name and version:  **zlib/1.2.11**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
