### PR TITLE
[botan] update usage of tools.apple_deployment_target_flag

### DIFF
--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -249,9 +249,12 @@ class BotanConan(ConanFile):
         if self.settings.os != "Windows" and self.options.fPIC:
             botan_extra_cxx_flags.append('-fPIC')
 
-        if self.settings.os == "Macos" and self.settings.os.version:
+        if tools.is_apple_os(self.settings.os):
             macos_min_version = tools.apple_deployment_target_flag(self.settings.os,
-                                                                   self.settings.os.version)
+                                                                   self.settings.get_safe("os.version"),
+                                                                   self.settings.get_safe("os.sdk"),
+                                                                   self.settings.get_safe("os.subsystem"),
+                                                                   self.settings.get_safe("arch"))
             macos_sdk_path = "-isysroot {}".format(tools.XCRun(self.settings).sdk_path)
             botan_extra_cxx_flags.extend([macos_min_version, macos_sdk_path])
 

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -250,13 +250,15 @@ class BotanConan(ConanFile):
             botan_extra_cxx_flags.append('-fPIC')
 
         if tools.is_apple_os(self.settings.os):
-            macos_min_version = tools.apple_deployment_target_flag(self.settings.os,
-                                                                   self.settings.get_safe("os.version"),
-                                                                   self.settings.get_safe("os.sdk"),
-                                                                   self.settings.get_safe("os.subsystem"),
-                                                                   self.settings.get_safe("arch"))
+            if self.settings.get_safe("os.version"):
+                macos_min_version = tools.apple_deployment_target_flag(self.settings.os,
+                                                                       self.settings.get_safe("os.version"),
+                                                                       self.settings.get_safe("os.sdk"),
+                                                                       self.settings.get_safe("os.subsystem"),
+                                                                       self.settings.get_safe("arch"))
+                botan_extra_cxx_flags.append(macos_min_version)
             macos_sdk_path = "-isysroot {}".format(tools.XCRun(self.settings).sdk_path)
-            botan_extra_cxx_flags.extend([macos_min_version, macos_sdk_path])
+            botan_extra_cxx_flags.append(macos_sdk_path)
 
         # This is to work around botan's configure script that *replaces* its
         # standard (platform dependent) flags in presence of an environment

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -250,7 +250,7 @@ class BotanConan(ConanFile):
             botan_extra_cxx_flags.append('-fPIC')
 
         if tools.is_apple_os(self.settings.os):
-            if self.settings.os.get_safe("version"):
+            if self.settings.get_safe("os.version"):
                 macos_min_version = tools.apple_deployment_target_flag(self.settings.os,
                                                                        self.settings.get_safe("os.version"),
                                                                        self.settings.get_safe("os.sdk"),

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -250,7 +250,7 @@ class BotanConan(ConanFile):
             botan_extra_cxx_flags.append('-fPIC')
 
         if tools.is_apple_os(self.settings.os):
-            if self.settings.get_safe("os.version"):
+            if self.settings.os.get_safe("version"):
                 macos_min_version = tools.apple_deployment_target_flag(self.settings.os,
                                                                        self.settings.get_safe("os.version"),
                                                                        self.settings.get_safe("os.sdk"),


### PR DESCRIPTION
https://github.com/conan-io/conan/pull/8263 adds `os.sdk` sub-setting, https://github.com/conan-io/conan/pull/8264 adds `os.subsystem` sub-setting, they need to be passed to the [tools.apple_deployment_target_flag](https://docs.conan.io/en/latest/reference/tools.html#tools-apple-deployment-target-flag)

also, do this for all apple OSes (iOS/tvOS/watchOS/macOS)

Specify library name and version:  **botan/all**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
