### PR TITLE
[libcurl] update usage of tools.apple_deployment_target_flag

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -347,7 +347,7 @@ class LibcurlConan(ConanFile):
     def _build_with_autotools(self):
         with tools.chdir(self._source_subfolder):
             # autoreconf
-            self.run("autoreconf -fiv", win_bash=tools.os_info.is_windows, run_environment=True)
+            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows, run_environment=True)
 
             # fix generated autotools files on alle to have relocateable binaries
             if tools.is_apple_os(self.settings.os):

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -402,7 +402,11 @@ class LibcurlConan(ConanFile):
 
 
                 arch_flag = "-arch {}".format(configure_arch)
-                ios_min_version = tools.apple_deployment_target_flag(self.settings.os, self.settings.os.version)
+                ios_min_version = tools.apple_deployment_target_flag(self.settings.os,
+                                                                     self.settings.get_safe("os.version"),
+                                                                     self.settings.get_safe("os.sdk"),
+                                                                     self.settings.get_safe("os.subsystem"),
+                                                                     self.settings.get_safe("arch"))
                 extra_flag = "-Werror=partial-availability"
 
                 # if we debug, maybe add a -gdwarf-2 , but why would we want that?

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -347,7 +347,7 @@ class LibcurlConan(ConanFile):
     def _build_with_autotools(self):
         with tools.chdir(self._source_subfolder):
             # autoreconf
-            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows, run_environment=True)
+            self.run("{} -fiv".format(tools.get_env("AUTORECONF") or "autoreconf"), win_bash=tools.os_info.is_windows, run_environment=True)
 
             # fix generated autotools files on alle to have relocateable binaries
             if tools.is_apple_os(self.settings.os):

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -347,7 +347,7 @@ class LibcurlConan(ConanFile):
     def _build_with_autotools(self):
         with tools.chdir(self._source_subfolder):
             # autoreconf
-            self.run("./buildconf", win_bash=tools.os_info.is_windows, run_environment=True)
+            self.run("autoreconf -fiv", win_bash=tools.os_info.is_windows, run_environment=True)
 
             # fix generated autotools files on alle to have relocateable binaries
             if tools.is_apple_os(self.settings.os):

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -170,7 +170,7 @@ class LibcurlConan(ConanFile):
            tools.os_info.detect_windows_subsystem() != "msys2":
             self.build_requires("msys2/20200517")
         elif self._is_win_x_android:
-            self.build_requires("ninja/1.10.1")
+            self.build_requires("ninja/1.10.2")
         elif not tools.os_info.is_windows:
             self.build_requires("libtool/2.4.6")
             self.build_requires("pkgconf/1.7.3")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -249,7 +249,7 @@ class LibcurlConan(ConanFile):
             params.append("--without-wolfssl")
 
         if self.options.with_libssh2:
-            params.append("--with-libssh2={}".format(tools.unix_path(self.deps_cpp_info["libssh2"].lib_paths[0])))
+            params.append("--with-libssh2={}".format(tools.unix_path(self.deps_cpp_info["libssh2"].rootpath)))
         else:
             params.append("--without-libssh2")
 
@@ -259,7 +259,7 @@ class LibcurlConan(ConanFile):
             params.append("--without-nghttp2")
 
         if self.options.with_zlib:
-            params.append("--with-zlib={}".format(tools.unix_path(self.deps_cpp_info["zlib"].lib_paths[0])))
+            params.append("--with-zlib={}".format(tools.unix_path(self.deps_cpp_info["zlib"].rootpath)))
         else:
             params.append("--without-zlib")
 


### PR DESCRIPTION
https://github.com/conan-io/conan/pull/8263 adds `os.sdk` sub-setting, https://github.com/conan-io/conan/pull/8264 adds `os.subsystem` sub-setting, they need to be passed to the [tools.apple_deployment_target_flag](https://docs.conan.io/en/latest/reference/tools.html#tools-apple-deployment-target-flag)

P.S. the code to handle iOS in this recipe is **HUGE** mess... e.g. it sets a lot of things manually, which should have been done automatically by the `AutoToolsBuildEnvironment` helper. this has to be cleaned up, but that's for another PR (needs to be checked carefully).

Specify library name and version:  **libcurl/all**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
