### PR TITLE
[ICU] remove explicit apple deployment target flag

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -112,10 +112,6 @@ class ICUBase(ConanFile):
             self._env_build.defines.append("U_STATIC_IMPLEMENTATION")
         if tools.is_apple_os(self.settings.os):
             self._env_build.defines.append("_DARWIN_C_SOURCE")
-            if self.settings.get_safe("os.version"):
-                self._env_build.flags.append(tools.apple_deployment_target_flag(self.settings.os,
-                                                                            self.settings.os.version))
-
         if "msys2" in self.deps_user_info:
             self._env_build.vars["PYTHON"] = tools.unix_path(os.path.join(self.deps_env_info["msys2"].MSYS_BIN, "python"), tools.MSYS2)
         return self._env_build


### PR DESCRIPTION
remove explicit [tools.apple_deployment_target_flag](https://docs.conan.io/en/latest/reference/tools.html#tools-apple-deployment-target-flag)

two reasons for the change:
1. since https://github.com/conan-io/conan/pull/7862, `AutoToolsBuildEnvironment` calls [tools.apple_deployment_target_flag](https://docs.conan.io/en/latest/reference/tools.html#tools-apple-deployment-target-flag) on its own
2. https://github.com/conan-io/conan/pull/8263 adds `os.sdk` sub-setting, https://github.com/conan-io/conan/pull/8264 adds `os.subsystem` sub-setting, they need to be passed to the [tools.apple_deployment_target_flag](https://docs.conan.io/en/latest/reference/tools.html#tools-apple-deployment-target-flag)

Specify library name and version:  **ICU/all**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
