### PR TITLE
[boost] update usage of tools.apple_deployment_target_flag

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -370,10 +370,10 @@ class BoostConan(ConanFile):
         if self._with_lzma:
             self.requires("xz_utils/5.2.5")
         if self._with_zstd:
-            self.requires("zstd/1.4.5")
+            self.requires("zstd/1.4.8")
 
         if self._with_icu:
-            self.requires("icu/68.1")
+            self.requires("icu/68.2")
         elif self._with_iconv:
             self.requires("libiconv/1.16")
 

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -868,7 +868,10 @@ class BoostConan(ConanFile):
         if tools.is_apple_os(self.settings.os):
             if self.settings.get_safe("os.version"):
                 cxx_flags.append(tools.apple_deployment_target_flag(self.settings.os,
-                                                                    self.settings.os.version))
+                                                                    self.settings.get_safe("os.version"),
+                                                                    self.settings.get_safe("os.sdk"),
+                                                                    self.settings.get_safe("os.subsystem"),
+                                                                    self.settings.get_safe("arch")))
 
         if self.settings.os == "iOS":
             if self.options.multithreading:


### PR DESCRIPTION
https://github.com/conan-io/conan/pull/8263 adds `os.sdk` sub-setting, https://github.com/conan-io/conan/pull/8264 adds `os.subsystem` sub-setting, they need to be passed to the [tools.apple_deployment_target_flag](https://docs.conan.io/en/latest/reference/tools.html#tools-apple-deployment-target-flag)

Specify library name and version:  **boost/all**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
