### PR TITLE
cyrus-sasl: fix configure on macos when dependencies are shared

### DIFF
--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -98,6 +98,7 @@ class CyrusSaslConan(ConanFile):
             self._autotools = AutoToolsBuildEnvironment(
                 self, win_bash=tools.os_info.is_windows
             )
+            self._autotools.libs = []
             configure_args = [
                 "--disable-sample",
                 "--disable-macos-framework",


### PR DESCRIPTION
Specify library name and version:  **cyrus-sasl/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

closes https://github.com/conan-io/conan-center-index/issues/4464

I've also tested on Macos with all libraries shared and most options adding dependencies enabled.