### PR TITLE
[libxslt] remove workaround for iOS

### DIFF
--- a/recipes/libxslt/all/conanfile.py
+++ b/recipes/libxslt/all/conanfile.py
@@ -133,13 +133,7 @@ class LibxsltConan(ConanFile):
             value = ("--with-%s" % name) if value else ("--without-%s" % name)
             configure_args.append(value)
 
-        # Disable --build when building for iPhoneSimulator. The configure script halts on
-        # not knowing if it should cross-compile.
-        build = None
-        if self.settings.os == "iOS" and self.settings.arch == "x86_64":
-            build = False
-
-        env_build.configure(args=configure_args, build=build, configure_dir=self._full_source_subfolder)
+        env_build.configure(args=configure_args, configure_dir=self._full_source_subfolder)
         env_build.make(args=["install", "V=1"])
 
     def package(self):


### PR DESCRIPTION
no longer necessary after conan-io/conan#6748

Specify library name and version:  **libxslt/all**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
