### PR TITLE
- add openmpi/4.1.0

### DIFF
--- a/recipes/openmpi/all/conandata.yml
+++ b/recipes/openmpi/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "4.1.0":
+    sha256: 73866fb77090819b6a8c85cb8539638d37d6877455825b74e289d647a39fd5b5
+    url: https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.0.tar.bz2

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -11,7 +11,7 @@ class OpenMPIConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     topics = ("conan", "mpi", "openmpi")
     description = "A High Performance Message Passing Library"
-    license = "https://www.open-mpi.org/community/license.php"
+    license = "BSD-3-Clause"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -62,7 +62,7 @@ class OpenMPIConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ['mpi', 'open-rte', 'open-pal']
         if self.settings.os == "Linux":
-            self.cpp_info.libs.extend(['dl', 'pthread', 'rt', 'util'])
+            self.cpp_info.system_libs = ["dl", "pthread", "rt", "util"]
         self.env_info.MPI_HOME = self.package_folder
         self.env_info.OPAL_PREFIX = self.package_folder
         mpi_bin = os.path.join(self.package_folder, 'bin')

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -11,11 +11,22 @@ class OpenMPIConan(ConanFile):
     description = "A High Performance Message Passing Library"
     license = "https://www.open-mpi.org/community/license.php"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False],
-               "fPIC": [True, False],
-               "fortran": ['yes', 'mpifh', 'usempi', 'usempi80', 'no']}
-    default_options = {'shared': False, 'fPIC': True, 'fortran': 'no'}
-    _source_subfolder = "sources"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "fortran": ["yes", "mpifh", "usempi", "usempi80", "no"]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "fortran": "no"
+    }
+
+    _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
     def configure(self):
         if self.options.shared:

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -17,7 +17,9 @@ class OpenMPIConan(ConanFile):
     default_options = {'shared': False, 'fPIC': True, 'fortran': 'no'}
     _source_subfolder = "sources"
 
-    def config(self):
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
         if self.settings.os == "Windows":

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, tools, AutoToolsBuildEnvironment
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.29.1"
+
 
 class OpenMPIConan(ConanFile):
     name = "openmpi"

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -39,6 +39,7 @@ class OpenMPIConan(ConanFile):
             raise ConanInvalidConfiguration("OpenMPI doesn't support Windows")
 
     def requirements(self):
+        # FIXME : self.requires("libevent/2.1.12") - try to use libevent from conan
         self.requires("zlib/1.2.11")
 
     def source(self):

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -84,8 +84,13 @@ class OpenMPIConan(ConanFile):
         self.cpp_info.libs = ['mpi', 'open-rte', 'open-pal']
         if self.settings.os == "Linux":
             self.cpp_info.system_libs = ["dl", "pthread", "rt", "util"]
+
+        self.output.info("Creating MPI_HOME environment variable: {}".format(self.package_folder))
         self.env_info.MPI_HOME = self.package_folder
+        self.output.info("Creating OPAL_PREFIX environment variable: {}".format(self.package_folder))
         self.env_info.OPAL_PREFIX = self.package_folder
         mpi_bin = os.path.join(self.package_folder, 'bin')
+        self.output.info("Creating MPI_BIN environment variable: {}".format(mpi_bin))
         self.env_info.MPI_BIN = mpi_bin
+        self.output.info("Appending PATH environment variable: {}".format(mpi_bin))
         self.env_info.PATH.append(mpi_bin)

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -1,0 +1,70 @@
+from conans import ConanFile, tools, AutoToolsBuildEnvironment
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class OpenMPIConan(ConanFile):
+    name = "openmpi"
+    homepage = "https://www.open-mpi.org"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("conan", "mpi", "openmpi")
+    description = "A High Performance Message Passing Library"
+    license = "https://www.open-mpi.org/community/license.php"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"shared": [True, False],
+               "fPIC": [True, False],
+               "fortran": ['yes', 'mpifh', 'usempi', 'usempi80', 'no']}
+    default_options = {'shared': False, 'fPIC': True, 'fortran': 'no'}
+    _source_subfolder = "sources"
+
+    def config(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration("OpenMPI doesn't support Windows")
+
+    def requirements(self):
+        self.requires("zlib/1.2.11")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def build(self):
+        with tools.chdir(self._source_subfolder):
+            env_build = AutoToolsBuildEnvironment(self)
+            env_build.fpic = self.options.fPIC
+            args = ['--disable-wrapper-rpath', '--disable-wrapper-runpath']
+            if self.settings.build_type == 'Debug':
+                args.append('--enable-debug')
+            if self.options.shared:
+                args.extend(['--enable-shared', '--disable-static'])
+            else:
+                args.extend(['--enable-static', '--disable-shared'])
+            args.append('--with-pic' if self.options.fPIC else '--without-pic')
+            args.append('--enable-mpi-fortran=%s' % str(self.options.fortran))
+            args.append('--with-zlib=%s' % self.deps_cpp_info['zlib'].rootpath)
+            args.append('--with-zlib-libdir=%s' % self.deps_cpp_info['zlib'].lib_paths[0])
+            args.append('--datarootdir=${prefix}/res')
+            env_build.configure(args=args)
+            env_build.make()
+            env_build.install()
+
+    def package(self):
+        self.copy(pattern="LICENSE", src='sources', dst='licenses')
+
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+        tools.rmdir(os.path.join(self.package_folder, "etc"))
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+
+    def package_info(self):
+        self.cpp_info.libs = ['mpi', 'open-rte', 'open-pal']
+        if self.settings.os == "Linux":
+            self.cpp_info.libs.extend(['dl', 'pthread', 'rt', 'util'])
+        self.env_info.MPI_HOME = self.package_folder
+        self.env_info.OPAL_PREFIX = self.package_folder
+        mpi_bin = os.path.join(self.package_folder, 'bin')
+        self.env_info.MPI_BIN = mpi_bin
+        self.env_info.PATH.append(mpi_bin)

--- a/recipes/openmpi/all/test_package/CMakeLists.txt
+++ b/recipes/openmpi/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(MPI REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/openmpi/all/test_package/conanfile.py
+++ b/recipes/openmpi/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools, RunEnvironment
+from conans import ConanFile, CMake, tools
 import os
 
 

--- a/recipes/openmpi/all/test_package/conanfile.py
+++ b/recipes/openmpi/all/test_package/conanfile.py
@@ -12,6 +12,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        mpiexec = os.path.join(os.environ['MPI_BIN'], 'mpiexec')
-        command = '%s -mca plm_rsh_agent yes -np 2 %s' % (mpiexec, os.path.join("bin", "test_package"))
-        self.run(command, run_environment=True)
+        if not tools.cross_building(self.settings):
+            mpiexec = os.path.join(os.environ['MPI_BIN'], 'mpiexec')
+            command = '%s -mca plm_rsh_agent yes -np 2 %s' % (mpiexec, os.path.join("bin", "test_package"))
+            self.run(command, run_environment=True)

--- a/recipes/openmpi/all/test_package/conanfile.py
+++ b/recipes/openmpi/all/test_package/conanfile.py
@@ -13,7 +13,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         mpiexec = os.path.join(os.environ['MPI_BIN'], 'mpiexec')
-        with open('hostfile', 'w') as f:
-            f.write('localhost slots=2\n')
-        command = '%s --oversubscribe -np 2 --hostfile hostfile %s' % (mpiexec, os.path.join("bin", "test_package"))
+        command = '%s -mca plm_rsh_agent yes -np 2 %s' % (mpiexec, os.path.join("bin", "test_package"))
         self.run(command, run_environment=True)

--- a/recipes/openmpi/all/test_package/conanfile.py
+++ b/recipes/openmpi/all/test_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake, tools, RunEnvironment
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        mpiexec = os.path.join(os.environ['MPI_BIN'], 'mpiexec')
+        with open('hostfile', 'w') as f:
+            f.write('localhost slots=2\n')
+        command = '%s --oversubscribe -np 2 --hostfile hostfile %s' % (mpiexec, os.path.join("bin", "test_package"))
+        self.run(command, run_environment=True)

--- a/recipes/openmpi/all/test_package/test_package.cpp
+++ b/recipes/openmpi/all/test_package/test_package.cpp
@@ -1,0 +1,23 @@
+#include <mpi.h>
+#include <iostream>
+
+int main(int argc, char* argv[])
+{
+  MPI_Init(&argc, &argv);
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  if (rank == 0) {
+    int value = 17;
+    int result = MPI_Send(&value, 1, MPI_INT, 1, 0, MPI_COMM_WORLD);
+    if (result == MPI_SUCCESS)
+      std::cout << "Rank 0 OK!" << std::endl;
+  } else if (rank == 1) {
+    int value;
+    int result = MPI_Recv(&value, 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+    if (result == MPI_SUCCESS && value == 17)
+      std::cout << "Rank 1 OK!" << std::endl;
+  }
+  MPI_Finalize();
+  return 0;
+}

--- a/recipes/openmpi/config.yml
+++ b/recipes/openmpi/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "4.1.0":
+    folder: all


### PR DESCRIPTION
based on https://github.com/bincrafters/conan-openmpi
closes: #1858

not in the scope right now:
- Windows builds
- components (cmake/pkg-config)
- dependencies (e.g. libevent)

Specify library name and version:  **openmpi/4.1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
