### PR TITLE
opencv 4.x: bump dependencies

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -48,10 +48,6 @@ class OpenCVConan(ConanFile):
         return "source_subfolder"
 
     @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
-    @property
     def _contrib_folder(self):
         return "contrib"
 
@@ -258,7 +254,7 @@ class OpenCVConan(ConanFile):
             if "ANDROID_NDK_HOME" in os.environ:
                 self._cmake.definitions["ANDROID_NDK"] = os.environ.get("ANDROID_NDK_HOME")
 
-        self._cmake.configure(build_folder=self._build_subfolder)
+        self._cmake.configure()
         return self._cmake
 
     def build(self):

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -39,6 +39,9 @@ class OpenCVConan(ConanFile):
                        "with_webp": True,
                        "with_gtk": True,
                        "with_quirc": True}
+
+    short_paths = True
+
     exports_sources = "CMakeLists.txt"
     generators = "cmake", "cmake_find_package"
     _cmake = None

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -80,26 +80,26 @@ class OpenCVConan(ConanFile):
         if self.options.with_jpeg == "libjpeg":
             self.requires("libjpeg/9d")
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/2.0.5")
+            self.requires("libjpeg-turbo/2.0.6")
         if self.options.with_jpeg2000 == "jasper":
-            self.requires("jasper/2.0.21")
+            self.requires("jasper/2.0.24")
         elif self.options.with_jpeg2000 == "openjpeg":
-            self.requires("openjpeg/2.3.1")
+            self.requires("openjpeg/2.4.0")
         if self.options.with_png:
             self.requires("libpng/1.6.37")
         if self.options.with_openexr:
-            self.requires("openexr/2.5.3")
+            self.requires("openexr/2.5.4")
         if self.options.with_tiff:
-            self.requires("libtiff/4.1.0")
+            self.requires("libtiff/4.2.0")
         if self.options.with_eigen:
-            self.requires("eigen/3.3.8")
+            self.requires("eigen/3.3.9")
         if self.options.parallel == "tbb":
-            self.requires("tbb/2020.2")
+            self.requires("tbb/2020.3")
         if self.options.with_webp:
             self.requires("libwebp/1.1.0")
         if self.options.contrib:
             self.requires("freetype/2.10.4")
-            self.requires("harfbuzz/2.7.2")
+            self.requires("harfbuzz/2.7.4")
             self.requires("gflags/2.2.2")
             self.requires("glog/0.4.0")
         if self.options.with_quirc:

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -48,6 +48,10 @@ class OpenCVConan(ConanFile):
         return "source_subfolder"
 
     @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    @property
     def _contrib_folder(self):
         return "contrib"
 
@@ -254,7 +258,7 @@ class OpenCVConan(ConanFile):
             if "ANDROID_NDK_HOME" in os.environ:
                 self._cmake.definitions["ANDROID_NDK"] = os.environ.get("ANDROID_NDK_HOME")
 
-        self._cmake.configure()
+        self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
     def build(self):

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -13,32 +13,36 @@ class OpenCVConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     topics = ("computer-vision", "deep-learning", "image-processing")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False],
-               "fPIC": [True, False],
-               "contrib": [True, False],
-               "parallel": [False, "tbb", "openmp"],
-               "with_jpeg": [False, "libjpeg", "libjpeg-turbo"],
-               "with_png": [True, False],
-               "with_tiff": [True, False],
-               "with_jpeg2000": [False, "jasper", "openjpeg"],
-               "with_openexr": [True, False],
-               "with_eigen": [True, False],
-               "with_webp": [True, False],
-               "with_gtk": [True, False],
-               "with_quirc": [True, False]}
-    default_options = {"shared": False,
-                       "fPIC": True,
-                       "parallel": False,
-                       "contrib": False,
-                       "with_jpeg": "libjpeg",
-                       "with_png": True,
-                       "with_tiff": True,
-                       "with_jpeg2000": "jasper",
-                       "with_openexr": True,
-                       "with_eigen": True,
-                       "with_webp": True,
-                       "with_gtk": True,
-                       "with_quirc": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "contrib": [True, False],
+        "parallel": [False, "tbb", "openmp"],
+        "with_jpeg": [False, "libjpeg", "libjpeg-turbo"],
+        "with_png": [True, False],
+        "with_tiff": [True, False],
+        "with_jpeg2000": [False, "jasper", "openjpeg"],
+        "with_openexr": [True, False],
+        "with_eigen": [True, False],
+        "with_webp": [True, False],
+        "with_gtk": [True, False],
+        "with_quirc": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "parallel": False,
+        "contrib": False,
+        "with_jpeg": "libjpeg",
+        "with_png": True,
+        "with_tiff": True,
+        "with_jpeg2000": "jasper",
+        "with_openexr": True,
+        "with_eigen": True,
+        "with_webp": True,
+        "with_gtk": True,
+        "with_quirc": True
+    }
 
     short_paths = True
 


### PR DESCRIPTION
Specify library name and version:  **opencv/4.x.x**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

libtiff 4.2.0 leads to different package id of downstreams due to its new option libdeflate.