### PR TITLE
[docs] Update changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 05-February-2021 - 13:20 CET
+
+ - [job] New job to upgrade Conan version (Windows and Macos workers) #566
+ - [job] New job to validate infrastructure: versions of tools, installed components,... (more checks to be added) #609
+ - [feature] Call external DeleteRepo job to remove repositories from Artifactory after a pull-request is merged #605
+ - [feature] New workflow for pull-requests: use `BuildSingleReference` job and better messages (canary deployment) #602
+ - [engineering] Refactor functions to retrieve information from GitHub API #607
+
 ### 27-January-2021 - 09:37 CET
 
 - Feature: PropulateProperties: Notify alert error if there are orphan packages, but keep going #577


### PR DESCRIPTION
### 05-February-2021 - 13:20 CET

 - [job] New job to upgrade Conan version (Windows and Macos workers) #566
 - [job] New job to validate infrastructure: versions of tools, installed components,... (more checks to be added) #609
 - [feature] Call external DeleteRepo job to remove repositories from Artifactory after a pull-request is merged #605
 - [feature] New workflow for pull-requests: use `BuildSingleReference` job and better messages (canary deployment) #602
 - [engineering] Refactor functions to retrieve information from GitHub API #607

---


 * closes https://github.com/conan-io/conan-center-index/issues/2145 -- We expect the new workflow to be the default with the next release (right now it will affect only some PRs we will use to validate it works as expected). The new workflow includes new messages and a better (IMHO) visualization of the logs.

 * closes https://github.com/conan-io/conan-center-index/issues/1843 -- We need to move forward, and this issue applies to the old PR workflow. Still, there is the problem of getting the logs from builds (if they were successful), but having a look at the URL pattern it should be easy to navigate them and it is something we can add to the new visualization. Let's get feedback from the new messages, we can reopen this issue if needed.