### PR TITLE
fix: zulu-openjdk Conf folder is required to avoid SecurityException

### DIFF
--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -43,6 +43,7 @@ class ZuluOpenJDK(ConanFile):
         self.copy(pattern="*", dst="res", src=os.path.join(self._source_subfolder, "conf"))
         # conf folder is required for security settings, to avoid
         # java.lang.SecurityException: Can't read cryptographic policy directory: unlimited
+        # https://github.com/conan-io/conan-center-index/pull/4491#issuecomment-774555069
         self.copy(pattern="*", dst="conf", src=os.path.join(self._source_subfolder, "conf"))
         self.copy(pattern="*", dst="licenses", src=os.path.join(self._source_subfolder, "legal"))
         self.copy(pattern="*", dst=os.path.join("lib", "jmods"), src=os.path.join(self._source_subfolder, "jmods"))

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -41,6 +41,9 @@ class ZuluOpenJDK(ConanFile):
         self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))
         self.copy(pattern="*", dst="lib", src=os.path.join(self._source_subfolder, "lib"))
         self.copy(pattern="*", dst="res", src=os.path.join(self._source_subfolder, "conf"))
+        # conf folder is required for security settings, to avoid
+        # java.lang.SecurityException: Can't read cryptographic policy directory: unlimited
+        self.copy(pattern="*", dst="conf", src=os.path.join(self._source_subfolder, "conf"))
         self.copy(pattern="*", dst="licenses", src=os.path.join(self._source_subfolder, "legal"))
         self.copy(pattern="*", dst=os.path.join("lib", "jmods"), src=os.path.join(self._source_subfolder, "jmods"))
 


### PR DESCRIPTION
```
Exception in thread "main" java.lang.ExceptionInInitializerError
	at java.base/javax.crypto.JceSecurityManager.<clinit>(JceSecurityManager.java:66)
	at java.base/javax.crypto.Cipher.getConfiguredPermission(Cipher.java:2610)
	at java.base/javax.crypto.Cipher.getMaxAllowedKeyLength(Cipher.java:2634)
	at Test.main(Test.java:6)
Caused by: java.lang.SecurityException: Can not initialize cryptographic mechanism
	at java.base/javax.crypto.JceSecurity.<clinit>(JceSecurity.java:118)
	... 4 more
Caused by: java.lang.SecurityException: Can't read cryptographic policy directory: unlimited
	at java.base/javax.crypto.JceSecurity.setupJurisdictionPolicies(JceSecurity.java:324)
	at java.base/javax.crypto.JceSecurity.access$000(JceSecurity.java:73)
	at java.base/javax.crypto.JceSecurity$1.run(JceSecurity.java:109)
	at java.base/javax.crypto.JceSecurity$1.run(JceSecurity.java:106)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/javax.crypto.JceSecurity.<clinit>(JceSecurity.java:105)
```

Specify library name and version:  **zulu-openjdk/11.0.8**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
