### PR TITLE
Add json_dto/0.2.11 

### DIFF
--- a/recipes/json_dto/all/conandata.yml
+++ b/recipes/json_dto/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.2.11":
+    url: "https://github.com/Stiffstream/json_dto/archive/v.0.2.11.tar.gz"
+    sha256: "9ce409a8210ee78ef5b1e60dfb919186ba6a2e928e391e46f0e1d36049e06b1c"

--- a/recipes/json_dto/all/conanfile.py
+++ b/recipes/json_dto/all/conanfile.py
@@ -1,0 +1,61 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+class JsondtoConan(ConanFile):
+    name = "json_dto"
+    license = "BSD-3-Clause"
+    homepage = "https://github.com/Stiffstream/json_dto"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "A small header-only helper for converting data between json representation and c++ structs"
+    topics = ("JSON", "DTO", "Serialization")
+    generators = "cmake"
+    settings = "os", "compiler", "build_type", "arch"
+    no_copy_source = True
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def requirements(self):
+        self.requires("rapidjson/1.1.0")
+
+    def configure(self):
+        minimal_cpp_standard = "14"
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, minimal_cpp_standard)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+
+        self._cmake = CMake(self)
+        self._cmake.definitions["JSON_DTO_INSTALL"] = True
+        self._cmake.definitions["JSON_DTO_FIND_DEPS"] = False
+        self._cmake.configure(source_folder=self._source_subfolder+"/dev/json_dto")
+        return self._cmake
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-v." + self.version
+        os.rename(extracted_dir, self._source_subfolder )
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        tools.rmdir(os.path.join(self.package_folder, "lib"))
+
+    def package_id(self):
+        self.info.settings.clear()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "json_dto"
+        self.cpp_info.names["cmake_find_package_multi"] = "json_dto"

--- a/recipes/json_dto/all/conanfile.py
+++ b/recipes/json_dto/all/conanfile.py
@@ -8,7 +8,7 @@ class JsondtoConan(ConanFile):
     homepage = "https://github.com/Stiffstream/json_dto"
     url = "https://github.com/conan-io/conan-center-index"
     description = "A small header-only helper for converting data between json representation and c++ structs"
-    topics = ("JSON", "DTO", "Serialization")
+    topics = ("json", "dto", "serialization")
     generators = "cmake"
     settings = "os", "compiler", "build_type", "arch"
     no_copy_source = True
@@ -56,7 +56,7 @@ class JsondtoConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["JSON_DTO_INSTALL"] = True
         self._cmake.definitions["JSON_DTO_FIND_DEPS"] = False
-        self._cmake.configure(source_folder=self._source_subfolder+"/dev/json_dto")
+        self._cmake.configure(source_folder=os.path.join(self._source_subfolder, "dev/json_dto"))
         return self._cmake
 
     def source(self):
@@ -72,7 +72,7 @@ class JsondtoConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib"))
 
     def package_id(self):
-        self.info.settings.clear()
+        self.info.header_only()
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "json_dto"

--- a/recipes/json_dto/all/conanfile.py
+++ b/recipes/json_dto/all/conanfile.py
@@ -56,7 +56,7 @@ class JsondtoConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["JSON_DTO_INSTALL"] = True
         self._cmake.definitions["JSON_DTO_FIND_DEPS"] = False
-        self._cmake.configure(source_folder=os.path.join(self._source_subfolder, "dev/json_dto"))
+        self._cmake.configure(source_folder=os.path.join(self._source_subfolder, "dev", "json_dto"))
         return self._cmake
 
     def source(self):

--- a/recipes/json_dto/all/conanfile.py
+++ b/recipes/json_dto/all/conanfile.py
@@ -73,7 +73,3 @@ class JsondtoConan(ConanFile):
 
     def package_id(self):
         self.info.header_only()
-
-    def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "json_dto"
-        self.cpp_info.names["cmake_find_package_multi"] = "json_dto"

--- a/recipes/json_dto/all/conanfile.py
+++ b/recipes/json_dto/all/conanfile.py
@@ -30,6 +30,24 @@ class JsondtoConan(ConanFile):
         minimal_cpp_standard = "14"
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, minimal_cpp_standard)
+        minimal_version = {
+            "gcc": "5",
+            "clang": "4",
+            "apple-clang": "8",
+            "Visual Studio": "15"
+        }
+        compiler = str(self.settings.compiler)
+        if compiler not in minimal_version:
+            self.output.warn(
+                "%s recipe lacks information about the %s compiler standard version support" % (self.name, compiler))
+            self.output.warn(
+                "%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
+            return
+
+        version = tools.Version(self.settings.compiler.version)
+        if version < minimal_version[compiler]:
+            raise ConanInvalidConfiguration("%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
+
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/json_dto/all/test_package/CMakeLists.txt
+++ b/recipes/json_dto/all/test_package/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.8)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(json_dto REQUIRED)
+
+add_executable(example example.cpp)
+target_link_libraries(example json_dto::json_dto)

--- a/recipes/json_dto/all/test_package/conanfile.py
+++ b/recipes/json_dto/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class JsondtoTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/json_dto/all/test_package/example.cpp
+++ b/recipes/json_dto/all/test_package/example.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <string>
+#include <ctime>
+
+#include <json_dto/pub.hpp>
+
+// Message.
+struct message_t
+{
+  message_t() {}
+
+  message_t(
+    std::string from,
+    std::int64_t when,
+    std::string text )
+    : m_from{ std::move( from ) }
+    , m_when{ when }
+    , m_text{ std::move( text ) }
+  {}
+
+  // Who sent a message.
+  std::string m_from;
+  // When the message was sent (unixtime).
+  std::int64_t m_when;
+  // Message text.
+  std::string m_text;
+
+  template< typename Json_Io >
+  void json_io( Json_Io & io )
+  {
+    io & json_dto::mandatory( "from", m_from )
+      & json_dto::mandatory( "when", m_when )
+      & json_dto::mandatory( "text", m_text );
+  }
+};
+
+const std::string json_data{
+R"JSON({
+  "from" : "json_dto",
+  "when" : 1474884330,
+  "text" : "Hello world!"
+})JSON" };
+
+int
+main( int , char *[] )
+{
+  try
+  {
+    {
+      auto msg = json_dto::from_json< message_t >( json_data );
+
+      const auto t = static_cast< std::time_t >( msg.m_when );
+      std::cout
+        << "Deserialized from JSON:\n"
+        << "\tfrom: " << msg.m_from << "\n"
+        << "\twhen: " << std::ctime( &t )
+        << "\ttext: " << msg.m_text << std::endl;
+    }
+
+    {
+      const message_t msg{ "json_dto", std::time( nullptr ), "Hello once again!" };
+
+      std::cout
+        << "\nSerialized to JSON:\n"
+        << json_dto::to_json( msg ) << std::endl;
+    }
+  }
+  catch( const std::exception & ex )
+  {
+    std::cerr << "Error: " << ex.what() << "." << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/recipes/json_dto/config.yml
+++ b/recipes/json_dto/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.2.11":
+    folder: all


### PR DESCRIPTION
Add json_dto library of v.0.2.11 to conan-index (https://github.com/Stiffstream/json_dto).

Specify library name and version:  **json_dto/0.2.11**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
