### PR TITLE
[zlib] Remove auto tools logic

### DIFF
--- a/recipes/zlib/1.2.11/conanfile.py
+++ b/recipes/zlib/1.2.11/conanfile.py
@@ -1,6 +1,6 @@
 import os
 import stat
-from conans import ConanFile, tools, CMake, AutoToolsBuildEnvironment
+from conans import ConanFile, tools, CMake
 from conans.errors import ConanException
 
 
@@ -42,36 +42,6 @@ class ZlibConan(ConanFile):
         if self.options.minizip:
             self._build_minizip()
 
-    @property
-    def _use_autotools(self):
-        if str(self.settings.os) in ["iOS", "watchOS", "tvOS"]:
-            return False # use a cmake toolchain .... or, find out the special CHOST settings zlib requires, but ...
-        return self.settings.os == "Linux" or tools.is_apple_os(self.settings.os)
-        # ... the  question is, why not always go with cmake and forget about the automake distaster?
-        # this woulds simplify this recipe enorm
-
-    def _build_zlib_autotools(self):
-        env_build = AutoToolsBuildEnvironment(self)
-
-        # configure passes CFLAGS to linker, should be LDFLAGS
-        tools.replace_in_file("../configure", "$LDSHARED $SFLAGS", "$LDSHARED $LDFLAGS")
-        # same thing in Makefile.in, when building tests/example executables
-        tools.replace_in_file("../Makefile.in", "$(CC) $(CFLAGS) -o", "$(CC) $(LDFLAGS) -o")
-
-        # we need to build only libraries without test example and minigzip
-        if self.options.shared:
-            make_target = "libz.%s.dylib" % self.version \
-                if tools.is_apple_os(self.settings.os) else "libz.so.%s" % self.version
-        else:
-            make_target = "libz.a"
-
-        env = {}
-        if "clang" in str(self.settings.compiler) and tools.get_env("CC") is None and tools.get_env("CXX") is None:
-            env = {"CC": "clang", "CXX": "clang++"}
-        with tools.environment_append(env):
-            env_build.configure("../", build=False, host=False, target=False)
-            env_build.make(target=make_target)
-
     def _build_zlib_cmake(self):
         cmake = CMake(self)
         cmake.configure(build_dir=".")
@@ -103,10 +73,7 @@ class ZlibConan(ConanFile):
                                           '#if defined(HAVE_STDARG_H) && (1-HAVE_STDARG_H-1 != 0)')
             tools.mkdir("_build")
             with tools.chdir("_build"):
-                if self._use_autotools:
-                    self._build_zlib_autotools()
-                else:
-                    self._build_zlib_cmake()
+                self._build_zlib_cmake()
 
     def _build_minizip(self):
         minizip_dir = os.path.join(self._source_subfolder, 'contrib', 'minizip')

--- a/recipes/zlib/1.2.11/conanfile.py
+++ b/recipes/zlib/1.2.11/conanfile.py
@@ -1,5 +1,4 @@
 import os
-import stat
 from conans import ConanFile, tools, CMake
 from conans.errors import ConanException
 
@@ -30,12 +29,7 @@ class ZlibConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-
         os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
-        if not tools.os_info.is_windows:
-            configure_file = os.path.join(self._source_subfolder, "configure")
-            st = os.stat(configure_file)
-            os.chmod(configure_file, st.st_mode | stat.S_IEXEC)
 
     def build(self):
         self._build_zlib()


### PR DESCRIPTION
Putting this one out there :)

Makes the recipe possible to use when cross building from Windows.
Also fixes cross build of 1.2.8 on iOS/watchOS/tvOS

If this is not feasible for some reason two things needs to be fixed:

1. `1.2.8` Needs the same fix as `1.2.11`. Use CMake if  `str(self.settings.os) in ["iOS", "watchOS", "tvOS"]`
2. Both recipes need to select CMake/Autotools based on `self.settings_build.os` not `self.settings.os` to work properly when cross building.

If this PR is rejected I can make the two fixes above instead.

Specify library name and version:  **zlib/1.2.8** **zlib/1.2.11**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
