### PR TITLE
Fontconfig: Add version 2.13.93

### DIFF
--- a/recipes/fontconfig/all/conandata.yml
+++ b/recipes/fontconfig/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.13.93":
+    url: "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.13.93.tar.gz"
+    sha256: "0f302a18ee52dde0793fe38b266bf269dfe6e0c0ae140e30d72c6cca5dc08db5"
   "2.13.92":
     url: "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.13.92.tar.gz"
     sha256: "3406a05b83a42231e3df68d02bc0a0cf47b3f2e8f11c8ede62267daf5f130016"

--- a/recipes/fontconfig/config.yml
+++ b/recipes/fontconfig/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.13.93":
+    folder: all
   "2.13.92":
     folder: all
   "2.13.91":


### PR DESCRIPTION
Specify library name and version:  **fontconfig/2.13.93**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This PR adds fontconfig v. 2.13.93 which includes [my MR](https://gitlab.freedesktop.org/fontconfig/fontconfig/-/merge_requests/120) that makes it actually work on Mac OS X out of the box without explicitly configuring font directories.