### PR TITLE
Update libheif/1.11.0 + add libaom-av1, dav1d integration

### DIFF
--- a/recipes/libheif/all/conandata.yml
+++ b/recipes/libheif/all/conandata.yml
@@ -2,7 +2,13 @@ sources:
   "1.9.1":
     sha256: 5f65ca2bd2510eed4e13bdca123131c64067e9dd809213d7aef4dc5e37948bca
     url: https://github.com/strukturag/libheif/releases/download/v1.9.1/libheif-1.9.1.tar.gz
+  "1.11.0":
+    sha256: c550938f56ff6dac83702251a143f87cb3a6c71a50d8723955290832d9960913
+    url: https://github.com/strukturag/libheif/releases/download/v1.11.0/libheif-1.11.0.tar.gz
 patches:
   "1.9.1":
     - base_path: "source_subfolder"
       patch_file: "patches/0001-cmake.patch"
+  "1.11.0":
+    - base_path: "source_subfolder"
+      patch_file: "patches/0001-cmake_1.11.0.patch"

--- a/recipes/libheif/all/conanfile.py
+++ b/recipes/libheif/all/conanfile.py
@@ -15,11 +15,11 @@ class Libheif(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False],
                "with_x265": [True, False],
                "with_dav1d": [True, False],
-               "with_aom": [True, False]}
+               "with_libaomav1": [True, False]}
     default_options = {"shared": False, "fPIC": True,
                        "with_x265": False,
                        "with_dav1d": False,
-                       "with_aom": False}
+                       "with_libaomav1": False}
 
     _cmake = None
 
@@ -31,7 +31,7 @@ class Libheif(ConanFile):
         if self.settings.os == 'Windows':
             del self.options.fPIC
         if tools.Version(self.version) < "1.11.0":
-            del self.options.with_aom
+            del self.options.with_libaomav1
             del self.options.with_dav1d
 
     def configure(self):
@@ -49,9 +49,9 @@ class Libheif(ConanFile):
         self.requires("libde265/1.0.8")
         if self.options.with_x265:
             self.requires("libx265/3.4")
-        if self.options.with_aom:
-            self.requires("aom/2.0.1")
-        if self.options.with_dav1d:
+        if self.options.get_safe('with_libaomav1'):
+            self.requires("libaom-av1/2.0.1")
+        if self.options.get_safe('with_dav1d'):
             self.requires("dav1d/0.8.1")
 
     def _patch_sources(self):
@@ -68,8 +68,8 @@ class Libheif(ConanFile):
         self._cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_X265'] = not self.options.with_x265
         self._cmake.definitions['WITH_X265'] = self.options.with_x265
         # aom
-        self._cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_LibAOM'] = not self.options.get_safe('with_aom', False)
-        self._cmake.definitions['WITH_AOM'] = self.options.get_safe('with_aom', False)
+        self._cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_LibAOM'] = not self.options.get_safe('with_libaomav1', False)
+        self._cmake.definitions['WITH_AOM'] = self.options.get_safe('with_libaomav1', False)
         # dav1d
         self._cmake.definitions['WITH_DAV1D'] = self.options.get_safe('with_dav1d', False)
         self._cmake.configure()
@@ -98,9 +98,9 @@ class Libheif(ConanFile):
         self.cpp_info.components["heif"].requires = ["libde265::libde265"]
         if self.options.with_x265:
             self.cpp_info.components["heif"].requires.append("libx265::libx265")
-        if self.options.with_aom:
-            self.cpp_info.components["heif"].requires.append("aom::aom")
-        if self.options.with_dav1d:
+        if self.options.get_safe('with_libaomav1'):
+            self.cpp_info.components["heif"].requires.append("libaom-av1::libaom-av1")
+        if self.options.get_safe('with_dav1d'):
             self.cpp_info.components["heif"].requires.append("dav1d::dav1d")
 
         self.cpp_info.components["heif"].libs = ["heif"]

--- a/recipes/libheif/all/conanfile.py
+++ b/recipes/libheif/all/conanfile.py
@@ -31,7 +31,8 @@ class Libheif(ConanFile):
         if self.settings.os == 'Windows':
             del self.options.fPIC
         if tools.Version(self.version) < "1.11.0":
-            del self.options.with_libaomav1
+            # dav1d supported since 1.10.0 but usable option `WITH_DAV1D`
+            # for controlling support exists only since 1.11.0
             del self.options.with_dav1d
 
     def configure(self):

--- a/recipes/libheif/all/conanfile.py
+++ b/recipes/libheif/all/conanfile.py
@@ -13,9 +13,13 @@ class Libheif(ConanFile):
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False],
-               "with_x265": [True, False]}
+               "with_x265": [True, False],
+               "with_dav1d": [True, False],
+               "with_aom": [True, False]}
     default_options = {"shared": False, "fPIC": True,
-                       "with_x265": False}
+                       "with_x265": False,
+                       "with_dav1d": False,
+                       "with_aom": False}
 
     _cmake = None
 
@@ -26,6 +30,9 @@ class Libheif(ConanFile):
     def config_options(self):
         if self.settings.os == 'Windows':
             del self.options.fPIC
+        if tools.Version(self.version) < "1.11.0":
+            del self.options.with_aom
+            del self.options.with_dav1d
 
     def configure(self):
         if self.options.shared:
@@ -42,6 +49,10 @@ class Libheif(ConanFile):
         self.requires("libde265/1.0.8")
         if self.options.with_x265:
             self.requires("libx265/3.4")
+        if self.options.with_aom:
+            self.requires("aom/2.0.1")
+        if self.options.with_dav1d:
+            self.requires("dav1d/0.8.1")
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -52,8 +63,15 @@ class Libheif(ConanFile):
             return self._cmake
         self._cmake = CMake(self)
         self._cmake.definitions["WITH_EXAMPLES"] = False
+        self._cmake.definitions['WITH_RAV1E'] = False
+        # x265
         self._cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_X265'] = not self.options.with_x265
-        self._cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_LibAOM'] = True
+        self._cmake.definitions['WITH_X265'] = self.options.with_x265
+        # aom
+        self._cmake.definitions['CMAKE_DISABLE_FIND_PACKAGE_LibAOM'] = not self.options.get_safe('with_aom', False)
+        self._cmake.definitions['WITH_AOM'] = self.options.get_safe('with_aom', False)
+        # dav1d
+        self._cmake.definitions['WITH_DAV1D'] = self.options.get_safe('with_dav1d', False)
         self._cmake.configure()
         return self._cmake
 
@@ -80,6 +98,10 @@ class Libheif(ConanFile):
         self.cpp_info.components["heif"].requires = ["libde265::libde265"]
         if self.options.with_x265:
             self.cpp_info.components["heif"].requires.append("libx265::libx265")
+        if self.options.with_aom:
+            self.cpp_info.components["heif"].requires.append("aom::aom")
+        if self.options.with_dav1d:
+            self.cpp_info.components["heif"].requires.append("dav1d::dav1d")
 
         self.cpp_info.components["heif"].libs = ["heif"]
 

--- a/recipes/libheif/all/patches/0001-cmake_1.11.0.patch
+++ b/recipes/libheif/all/patches/0001-cmake_1.11.0.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fabf381..6379d09 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -38,8 +38,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
+ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+ set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+ 
+-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+-
+ # Create the compile command database for clang by default
+ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+ 
+@@ -165,4 +163,3 @@ if(WITH_EXAMPLES)
+     add_subdirectory (examples)
+ endif()
+ add_subdirectory (libheif)
+-add_subdirectory (gdk-pixbuf)

--- a/recipes/libheif/config.yml
+++ b/recipes/libheif/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.9.1":
     folder: all
+  "1.11.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libheif/1.11.0**

What's new:
- The new upstream version now includes some of our patches.
- Added libaom-av1 and dav1d integration for AV1 codec

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
