### PR TITLE
gstreamer: add version 1.18.3

### DIFF
--- a/recipes/gstreamer/all/conandata.yml
+++ b/recipes/gstreamer/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "1.18.0":
     sha256: "f072da67b6dad9b4aecf2cb594aaaa66f86c22af9ba80503b90f957d47015ef8"
     url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.18.0/gstreamer-1.18.0.tar.bz2"
+  "1.18.3":
+    url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.18.3/gstreamer-1.18.3.tar.gz"
+    sha256: "d7e3917b5d3d9c3bd9bb70b7500314a5725377cff39bcd818df13c1fda0f60ba"

--- a/recipes/gstreamer/config.yml
+++ b/recipes/gstreamer/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "1.18.0":
     folder: all
+  "1.18.3":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **gstreamer/1.18.3**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
