### PR TITLE
sentry-native: add version 0.4.7

### DIFF
--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.4.7":
+    url: "https://github.com/getsentry/sentry-native/archive/0.4.7.tar.gz"
+    sha256: "84f3a1dbfea1245870a7e36eef06ea78e21c173457c543eaa27904d2d017e50c"
   "0.4.1":
     url: "https://github.com/getsentry/sentry-native/archive/0.4.1.tar.gz"
     sha256: "a7d04fe9b9175c30a58ce20ae23b510595045a66884a447dd21ff2d0c749751b"

--- a/recipes/sentry-native/config.yml
+++ b/recipes/sentry-native/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.4.7":
+    folder: all
   "0.4.1":
     folder: all
   "0.2.6":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **sentry-native/4.7**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
