### PR TITLE
(#4530) Include the mysqld_error.h header in mariadb-connector-c

### DIFF
--- a/recipes/mariadb-connector-c/all/conandata.yml
+++ b/recipes/mariadb-connector-c/all/conandata.yml
@@ -10,3 +10,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0003-include-order-windows-winsock2.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0004-include-mysqld_error-header.patch"
+      base_path: "source_subfolder"

--- a/recipes/mariadb-connector-c/all/patches/0004-include-mysqld_error-header.patch
+++ b/recipes/mariadb-connector-c/all/patches/0004-include-mysqld_error-header.patch
@@ -1,0 +1,11 @@
+--- a/include/CMakeLists.txt
++++ b/include/CMakeLists.txt
+@@ -10,7 +10,7 @@ SET(MARIADB_CLIENT_INCLUDES ${CC_SOURCE_DIR}/include/mariadb_com.h
+                             ${CC_SOURCE_DIR}/include/mariadb_ctype.h
+                             ${CC_SOURCE_DIR}/include/mariadb_rpl.h
+                             )
+-IF(NOT IS_SUBPROJECT)
++IF(TRUE)
+   SET(MARIADB_CLIENT_INCLUDES ${MARIADB_CLIENT_INCLUDES}
+                               ${CC_SOURCE_DIR}/include/mysqld_error.h
+                               )

--- a/recipes/mariadb-connector-c/all/test_package/test_package.c
+++ b/recipes/mariadb-connector-c/all/test_package/test_package.c
@@ -1,6 +1,9 @@
 #include <mysql.h>
 #include <stdio.h>
 
+// See #4530
+#include <mysqld_error.h>
+
 int main(int argc, char **argv)
 {
   printf("MySQL client version: %s\n", mysql_get_client_info());


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
