### PR TITLE
[tesseract] Don't affect global locale with build_type=Debug

### DIFF
--- a/recipes/tesseract/all/conandata.yml
+++ b/recipes/tesseract/all/conandata.yml
@@ -8,3 +8,5 @@ patches:
        base_path: "source_subfolder"
      - patch_file: "patches/0002-Link-with-targets.patch"
        base_path: "source_subfolder"
+     - patch_file: "patches/0003-Dont-change-locale.patch"
+       base_path: "source_subfolder"

--- a/recipes/tesseract/all/patches/0003-Dont-change-locale.patch
+++ b/recipes/tesseract/all/patches/0003-Dont-change-locale.patch
@@ -1,0 +1,11 @@
+--- a/src/api/baseapi.cpp
++++ b/src/api/baseapi.cpp
+@@ -219,7 +219,7 @@ TessBaseAPI::TessBaseAPI()
+   // problems caused by the locale settings.
+ 
+   // Use the current locale if building debug code.
+-  std::locale::global(std::locale(""));
++  // std::locale::global(std::locale(""));
+ #endif
+ }
+ 


### PR DESCRIPTION
Tesseract was setting the global locale when built for Debug. This was affecting
consumers of this library. Comment out the line that set the global locale.

Since it's not possible to build a consumer of Tesseract with `build_type=Debug` while Tesseract is `build_type=Release`, I suggest that Tesseract should operate the same in either case with respect to the locale. I believe this will reduce confusion for projects that consume Tesseract via Conan.

This is also reported to the Tesseract OCR project: https://github.com/tesseract-ocr/tesseract/issues/3290

Specify library name and version:  **tesseract/4.1.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
