### PR TITLE
swig: have a complete example of python module in test_package

### DIFF
--- a/recipes/swig/all/cmake/conan-official-swig-targets.cmake
+++ b/recipes/swig/all/cmake/conan-official-swig-targets.cmake
@@ -1,0 +1,7 @@
+find_program(SWIG_EXECUTABLE swig PATHS ${CONAN_BIN_DIRS_SWIG} NO_DEFAULT_PATH)
+if(NOT SWIG_DIR)
+    execute_process(COMMAND ${SWIG_EXECUTABLE} -swiglib
+        OUTPUT_VARIABLE SWIG_lib_output OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(SWIG_DIR ${SWIG_lib_output} CACHE STRING "Location of SWIG library" FORCE)
+endif()
+mark_as_advanced(SWIG_DIR SWIG_EXECUTABLE)

--- a/recipes/swig/all/test_package/CMakeLists.txt
+++ b/recipes/swig/all/test_package/CMakeLists.txt
@@ -1,16 +1,24 @@
 cmake_minimum_required(VERSION 3.1)
 project(PackageTest C)
+enable_testing()
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(NO_OUTPUT_DIRS)
+
+find_program(PYTHON_EXECUTABLE NAMES python3 python REQUIRED)
+find_package(PythonLibs 3 REQUIRED)
 
 find_package(SWIG REQUIRED)
 include(UseSWIG)
 
 swig_add_library(${PROJECT_NAME}
-    TYPE MODULE
     LANGUAGE python
     SOURCES
         test.i
         test_package.c
 )
+target_include_directories(_${PROJECT_NAME} PRIVATE ${PYTHON_INCLUDE_DIRS})
+target_link_libraries(_${PROJECT_NAME} PRIVATE ${PYTHON_LIBRARIES})
+
+add_test(gcd_test ${PYTHON_EXECUTABLE} -c "import PackageTest; assert PackageTest.gcd(12, 16) == 4")
+add_test(foo_test ${PYTHON_EXECUTABLE} -c "import PackageTest; assert PackageTest.cvar.foo == 3.14159265359")

--- a/recipes/swig/all/test_package/conanfile.py
+++ b/recipes/swig/all/test_package/conanfile.py
@@ -1,31 +1,17 @@
 from conans import CMake, ConanFile, tools
-from conans.errors import ConanException
-import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
-    # # FIXME: cpython is not available on CCI (yet)
-    # def build(self):
-    #     cmake = CMake(self)
-    #     cmake.configure(args=["--trace", "--trace-expand"])
-    #     cmake.build()
-    #
-    # def build_requirements(self):
-    #     self.build_requires("cpython/3.8.3")
-    #
-    # def requirements(self):
-    #     self.requires("cpython/3.8.3")
+    def build(self):
+        if self.settings.compiler != "Visual Studio":
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
+            cmake.test(output_on_failure=True)
 
     def test(self):
         if not tools.cross_building(self.settings):
-            # # FIXME: cpython is not available on CCI (yet)
-            # with tools.chdir("lib"):
-            #     self.run("python -c \"import sys; import _PackageTest; gcd = _PackageTest.gcd(12, 16); print('gcd =', gcd); sys.exit(0 if gcd == 4 else 1)\"", run_environment=True)
-            #     self.run("python -c \"import sys; import _PackageTest; foo = _PackageTest.cvar.foo; print('foo =', foo); sys.exit(0 if foo == 3.14159265359 else 1)\"", run_environment=True)
-            testdir = os.path.dirname(os.path.realpath(__file__))
-            self.run("swig -python -outcurrentdir %s" % os.path.join(testdir, "test.i"))
-            if not os.path.isfile("example.py"):
-                raise ConanException("example.py is not created by swig")
+            self.run("swig -version")

--- a/recipes/swig/all/test_package/conanfile.py
+++ b/recipes/swig/all/test_package/conanfile.py
@@ -18,9 +18,7 @@ class TestPackageConan(ConanFile):
         # FIXEM: Fix SWIG Python build with Visual Studio
         # Have a problem linking final module with Visual Studio. CMake finds
         # correct Python library, but linker tries to use _d variant and fails.
-        if self.settings.compiler == "Visual Studio" and self.settings.build_type == "Debug":
-            return False
-        return True
+        return self.settings.compiler != "Visual Studio"
 
     def build(self):
         if self._can_build:

--- a/recipes/swig/all/test_package/conanfile.py
+++ b/recipes/swig/all/test_package/conanfile.py
@@ -5,13 +5,28 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "cmake_find_package"
 
+    __cmake = None
+
+    @property
+    def _cmake(self):
+        if not self.__cmake:
+            self.__cmake = CMake(self)
+        return self.__cmake
+
+    @property
+    def _can_build(self):
+        # FIXEM: Fix SWIG Python build with Visual Studio
+        # Have a problem linking final module with Visual Studio. CMake finds
+        # correct Python library, but linker tries to use _d variant and fails.
+        return self.settings.compiler != "Visual Studio"
+
     def build(self):
-        if self.settings.compiler != "Visual Studio":
-            cmake = CMake(self)
-            cmake.configure()
-            cmake.build()
-            cmake.test(output_on_failure=True)
+        if self._can_build:
+            self._cmake.configure()
+            self._cmake.build()
 
     def test(self):
         if not tools.cross_building(self.settings):
+            if self._can_build:
+                self._cmake.test(output_on_failure=True)
             self.run("swig -version")

--- a/recipes/swig/all/test_package/conanfile.py
+++ b/recipes/swig/all/test_package/conanfile.py
@@ -18,7 +18,9 @@ class TestPackageConan(ConanFile):
         # FIXEM: Fix SWIG Python build with Visual Studio
         # Have a problem linking final module with Visual Studio. CMake finds
         # correct Python library, but linker tries to use _d variant and fails.
-        return self.settings.compiler != "Visual Studio"
+        if self.settings.compiler == "Visual Studio" and self.settings.build_type == "Debug":
+            return False
+        return True
 
     def build(self):
         if self._can_build:

--- a/recipes/swig/all/test_package/conanfile.py
+++ b/recipes/swig/all/test_package/conanfile.py
@@ -15,9 +15,8 @@ class TestPackageConan(ConanFile):
 
     @property
     def _can_build(self):
-        # FIXEM: Fix SWIG Python build with Visual Studio
-        # Have a problem linking final module with Visual Studio. CMake finds
-        # correct Python library, but linker tries to use _d variant and fails.
+        # FIXME: SWIG Python with Visual Studio Debug - unable to find Python library at link
+        # FIXME: SWIG Python with Visual Studio - unable to load generated module in tests
         return self.settings.compiler != "Visual Studio"
 
     def build(self):

--- a/recipes/swig/all/test_package/test.i
+++ b/recipes/swig/all/test_package/test.i
@@ -1,5 +1,4 @@
-/* File : example.i */
-%module example
+%module PackageTest
 
 %inline %{
 extern int    gcd(int u, int v);

--- a/recipes/swig/all/test_package/test_package.c
+++ b/recipes/swig/all/test_package/test_package.c
@@ -11,11 +11,12 @@ int gcd(int u, int v) {
         return u;
 
     // look for factors of 2
-    if (~u & 1) // u is even
+    if (~u & 1) { // u is even
         if (v & 1) // v is odd
             return gcd(u >> 1, v);
         else // both u and v are even
             return gcd(u >> 1, v >> 1) << 1;
+    }
 
     if (~v & 1) // u is odd, v is even
         return gcd(u, v >> 1);


### PR DESCRIPTION
**swig/4.0.2**

In test_package have a working example of compiling a Python module with SWIG.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
