### PR TITLE
xkbcommon: fix pkg_config and CMake internal mechanism of conan

### DIFF
--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -107,16 +107,17 @@ class XkbcommonConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
+        self.cpp_info.names["pkg_config"] = "xkbcommon_full_package" # unofficial, but required to avoid side effects (libxkbcommon component "steals" the default global pkg_config name)
+        self.cpp_info.components["libxkbcommon"].names["pkg_config"] = "xkbcommon"
         self.cpp_info.components["libxkbcommon"].libs = ["xkbcommon"]
-        self.cpp_info.components["libxkbcommon"].name = "xkbcommon"
         self.cpp_info.components["libxkbcommon"].requires = ["xorg::xkeyboard-config"]
         if self.options.with_x11:
+            self.cpp_info.components["libxkbcommon-x11"].names["pkg_config"] = "xkbcommon-x11"
             self.cpp_info.components["libxkbcommon-x11"].libs = ["xkbcommon-x11"]
-            self.cpp_info.components["libxkbcommon-x11"].name = "xkbcommon-x11"
             self.cpp_info.components["libxkbcommon-x11"].requires = ["libxkbcommon", "xorg::xcb", "xorg::xcb-xkb"]
         if self.options.get_safe("xkbregistry"):
+            self.cpp_info.components["libxkbregistry"].names["pkg_config"] = "xkbregistry"
             self.cpp_info.components["libxkbregistry"].libs = ["xkbregistry"]
-            self.cpp_info.components["libxkbregistry"].name = "xkbregistry"
             self.cpp_info.components["libxkbregistry"].requires = ["libxml2::libxml2"]
 
         if tools.Version(self.version) >= "1.0.0":

--- a/recipes/xkbcommon/all/test_package/CMakeLists.txt
+++ b/recipes/xkbcommon/all/test_package/CMakeLists.txt
@@ -3,7 +3,6 @@ project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
-find_package(xkbcommon REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} xkbcommon::xkbcommon)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/xkbcommon/all/test_package/conanfile.py
+++ b/recipes/xkbcommon/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **xkbcommon/all**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

We must always provide a unique global pkg_config name for internal dependencies handling of conan.
Same for CMake, but not always possible. At least for xkbcommon there are no official CMake imported targets.