### PR TITLE
Fix regex.cpp test

### DIFF
--- a/recipes/boost/all/test_package/regex.cpp
+++ b/recipes/boost/all/test_package/regex.cpp
@@ -8,7 +8,7 @@ int main(int argc, const char * const argv[])
 
     std::vector<int> values;
     for (int i = 1; i < argc; ++i) {
-        const std::string word(argv[i]);
+        const std::string line(argv[i]);
         boost::smatch matches;
         if (boost::regex_match(line, matches, pat))
             std::cout << matches[2] << std::endl;


### PR DESCRIPTION
seems to have been a simple mistake, because this test isn't run by default, it was never caught. also, shouldn't compiles, somehow does.

Specify library name and version:  **boost/all**

