### PR TITLE
vulkan-headers: fix CMake names

### DIFF
--- a/recipes/vulkan-headers/all/conanfile.py
+++ b/recipes/vulkan-headers/all/conanfile.py
@@ -1,6 +1,7 @@
+from conans import ConanFile, tools
+import glob
 import os
 
-from conans import ConanFile, tools
 
 class VulkanHeadersConan(ConanFile):
     name = "vulkan-headers"
@@ -20,11 +21,7 @@ class VulkanHeadersConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        url = self.conan_data["sources"][self.version]["url"]
-        version = os.path.basename(url).replace(".tar.gz", "").replace(".zip", "")
-        if version.startswith('v'):
-            version = version[1:]
-        extracted_dir = "Vulkan-Headers-" + version
+        extracted_dir = glob.glob("Vulkan-Headers-*")[0]
         os.rename(extracted_dir, self._source_subfolder)
 
     def package(self):

--- a/recipes/vulkan-headers/all/conanfile.py
+++ b/recipes/vulkan-headers/all/conanfile.py
@@ -34,6 +34,16 @@ class VulkanHeadersConan(ConanFile):
                        src=os.path.join(self.source_folder, self._source_subfolder, "registry"))
 
     def package_info(self):
-        # TODO: CMake Target should be Vulkan::Headers
-        self.cpp_info.names["cmake_find_package"] = "VulkanHeaders"
-        self.cpp_info.names["cmake_find_package_multi"] = "VulkanHeaders"
+        self.cpp_info.filenames["cmake_find_package"] = "VulkanHeaders"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "VulkanHeaders"
+        self.cpp_info.names["cmake_find_package"] = "Vulkan"
+        self.cpp_info.names["cmake_find_package_multi"] = "Vulkan"
+        self.cpp_info.components["vulkanheaders"].names["cmake_find_package"] = "Headers"
+        self.cpp_info.components["vulkanheaders"].names["cmake_find_package_multi"] = "Headers"
+        self.cpp_info.components["vulkanheaders"].bindirs = []
+        self.cpp_info.components["vulkanheaders"].libdirs = []
+        self.cpp_info.components["vulkanregistry"].names["cmake_find_package"] = "Registry"
+        self.cpp_info.components["vulkanregistry"].names["cmake_find_package_multi"] = "Registry"
+        self.cpp_info.components["vulkanregistry"].includedirs = [os.path.join("res", "vulkan", "registry")]
+        self.cpp_info.components["vulkanregistry"].bindirs = []
+        self.cpp_info.components["vulkanregistry"].libdirs = []

--- a/recipes/vulkan-headers/all/test_package/CMakeLists.txt
+++ b/recipes/vulkan-headers/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(VulkanHeaders REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} Vulkan::Headers)

--- a/recipes/vulkan-headers/all/test_package/conanfile.py
+++ b/recipes/vulkan-headers/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **vulkan-headers/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

It will be implemented by https://github.com/KhronosGroup/Vulkan-Headers/pull/112. Before merging this PR, they need to fix several downstream libraries to avoid breaking their builds.