### PR TITLE
gmp/all: explicitly pass the "with-pic" option to GMP when fPIC=True

### DIFF
--- a/recipes/gmp/all/conanfile.py
+++ b/recipes/gmp/all/conanfile.py
@@ -69,7 +69,7 @@ class GmpConan(ConanFile):
             os.chmod(configure_file, configure_stats.st_mode | stat.S_IEXEC)
         yes_no = lambda v: "yes" if v else "no"
         configure_args = [
-            "--with-pic={}".format(yes_no(self.options.get_safe("fPIC", False))),
+            "--with-pic={}".format(yes_no(self.options.get_safe("fPIC", True))),
             "--enable-assembly={}".format(yes_no(not self.options.get_safe("disable_assembly", False))),
             "--enable-fat={}".format(yes_no(self.options.get_safe("enable_fat", False))),
             "--enable-cxx={}".format(yes_no(self.options.enable_cxx)),

--- a/recipes/gmp/all/conanfile.py
+++ b/recipes/gmp/all/conanfile.py
@@ -69,6 +69,7 @@ class GmpConan(ConanFile):
             os.chmod(configure_file, configure_stats.st_mode | stat.S_IEXEC)
         yes_no = lambda v: "yes" if v else "no"
         configure_args = [
+            "--with-pic={}".format(yes_no(self.options.get_safe("fPIC", False))),
             "--enable-assembly={}".format(yes_no(not self.options.get_safe("disable_assembly", False))),
             "--enable-fat={}".format(yes_no(self.options.get_safe("enable_fat", False))),
             "--enable-cxx={}".format(yes_no(self.options.enable_cxx)),

--- a/recipes/gmp/all/test_package/CMakeLists.txt
+++ b/recipes/gmp/all/test_package/CMakeLists.txt
@@ -7,6 +7,11 @@ conan_basic_setup()
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 
+if (TEST_PIC)
+add_library(${PROJECT_NAME}_shared SHARED test_package.c)
+target_link_libraries(${PROJECT_NAME}_shared ${CONAN_LIBS})
+endif()
+
 if (ENABLE_CXX)
     add_executable(${PROJECT_NAME}_cpp test_package.cpp)
     target_link_libraries(${PROJECT_NAME}_cpp ${CONAN_LIBS})

--- a/recipes/gmp/all/test_package/CMakeLists.txt
+++ b/recipes/gmp/all/test_package/CMakeLists.txt
@@ -8,8 +8,8 @@ add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 
 if (TEST_PIC)
-add_library(${PROJECT_NAME}_shared SHARED test_package.c)
-target_link_libraries(${PROJECT_NAME}_shared ${CONAN_LIBS})
+    add_library(${PROJECT_NAME}_shared SHARED test_package.c)
+    target_link_libraries(${PROJECT_NAME}_shared ${CONAN_LIBS})
 endif()
 
 if (ENABLE_CXX)

--- a/recipes/gmp/all/test_package/conanfile.py
+++ b/recipes/gmp/all/test_package/conanfile.py
@@ -9,6 +9,7 @@ class TestPackageConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions["ENABLE_CXX"] = self.options["gmp"].enable_cxx
+        cmake.definitions["TEST_PIC"] = "fPIC" in self.options["gmp"] and self.options["gmp"].fPIC
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  gmp/all -o gmp:disable_assembly=False

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I changed the package configuration to explicitly pass `with-pic=yes` to GMP when `fPIC=True`, which is needed whenever GMP produces assembly (e.g., when `disable_assembly=False` or `enable-fat=True`). The normal handling Conan does around `fPIC` isn't enough; GMP needs its custom option explicitly set.

I added a test case that creates a shared library showing the problem. The test will fail without the changes in this PR.