### PR TITLE
meson: add version 0.57.0

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -53,3 +53,6 @@ sources:
   "0.56.2":
     url: "https://github.com/mesonbuild/meson/archive/0.56.2.tar.gz"
     sha256: "aaae961c3413033789248ffe6762589e80b6cf487c334d0b808e31a32c48f35f"
+  "0.57.0":
+    url: "https://github.com/mesonbuild/meson/archive/0.57.0.tar.gz"
+    sha256: "fd26a27c1a509240c668ebd29d280649d9239cf8684ead51d5cb499d1e1188bd"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -35,3 +35,5 @@ versions:
     folder: all
   "0.56.2":
     folder: all
+  "0.57.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/0.57.0**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
