### PR TITLE
add qt cmake macros

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -652,7 +652,8 @@ Examples = bin/datadir/examples""")
             if not self.options.get_safe(module):
                 tools.rmdir(os.path.join(self.package_folder, "licenses", module))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        for mask in ["Find*.cmake", "*Config.cmake", "*-config.cmake"]:
+            tools.remove_files_by_mask(self.package_folder, mask)
         tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la*")
         tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.pdb*")
         tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.pdb")
@@ -696,6 +697,17 @@ Examples = bin/datadir/examples""")
                 self.cpp_info.frameworks.extend(["Security"]) # "libQt5Core.a" require "_SecRequirementCreateWithString" and more, which are in "Security" framework
 
 
+        tools.save(os.path.join("lib", "cmake", "Qt5Core", "extras.cmake"),
+                    "set(Qt5Core_QMAKE_EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/../../../bin/qmake)\n"
+                    "set(Qt5Core_MOC_EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/../../../bin/moc)\n"
+                    "set(Qt5Core_RCC_EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/../../../bin/rcc)\n"
+                    "set(Qt5Core_UIC_EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/../../../bin/uic)")
+        for gen in ["cmake", "cmake_multi", "cmake_find_package", "cmake_find_package_multi"]:
+            for m in os.listdir(os.path.join("lib", "cmake")):
+                module = os.path.join("lib", "cmake", m, "%sMacros.cmake" % m)
+                if os.path.isfile(module):
+                    self.cpp_info.build_modules[gen].append(module)
+            self.cpp_info.build_modules[gen].append(os.path.join("lib", "cmake", "Qt5Core", "extras.cmake"))
     @staticmethod
     def _remove_duplicate(l):
         seen = set()

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -696,18 +696,18 @@ Examples = bin/datadir/examples""")
                 self.cpp_info.frameworks.extend(["Cocoa"])    # "libQt5Core.a" require "_OBJC_CLASS_$_NSApplication" and more, which are in "Cocoa" framework
                 self.cpp_info.frameworks.extend(["Security"]) # "libQt5Core.a" require "_SecRequirementCreateWithString" and more, which are in "Security" framework
 
-
         tools.save(os.path.join("lib", "cmake", "Qt5Core", "extras.cmake"),
                     "set(Qt5Core_QMAKE_EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/../../../bin/qmake)\n"
                     "set(Qt5Core_MOC_EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/../../../bin/moc)\n"
                     "set(Qt5Core_RCC_EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/../../../bin/rcc)\n"
                     "set(Qt5Core_UIC_EXECUTABLE ${CMAKE_CURRENT_LIST_DIR}/../../../bin/uic)")
-        for gen in ["cmake", "cmake_multi", "cmake_find_package", "cmake_find_package_multi"]:
-            for m in os.listdir(os.path.join("lib", "cmake")):
-                module = os.path.join("lib", "cmake", m, "%sMacros.cmake" % m)
-                if os.path.isfile(module):
-                    self.cpp_info.build_modules[gen].append(module)
-            self.cpp_info.build_modules[gen].append(os.path.join("lib", "cmake", "Qt5Core", "extras.cmake"))
+        for m in os.listdir(os.path.join("lib", "cmake")):
+            module = os.path.join("lib", "cmake", m, "%sMacros.cmake" % m)
+            if os.path.isfile(module):
+                self.cpp_info.build_modules.append(module)
+        self.cpp_info.build_modules.append(os.path.join("lib", "cmake", "Qt5Core", "extras.cmake"))
+
+
     @staticmethod
     def _remove_duplicate(l):
         seen = set()

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -705,6 +705,9 @@ Examples = bin/datadir/examples""")
             module = os.path.join("lib", "cmake", m, "%sMacros.cmake" % m)
             if os.path.isfile(module):
                 self.cpp_info.build_modules.append(module)
+                self.cpp_info.builddirs.append(os.path.join("lib", "cmake", m))
+            else:
+                tools.rmdir(os.path.join("lib", "cmake", m))
         self.cpp_info.build_modules.append(os.path.join("lib", "cmake", "Qt5Core", "extras.cmake"))
 
 

--- a/recipes/qt/5.x.x/test_package/CMakeLists.txt
+++ b/recipes/qt/5.x.x/test_package/CMakeLists.txt
@@ -11,7 +11,13 @@ conan_output_dirs_setup()
 
 find_package(qt REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cpp greeter.h moc_greeter.cpp)
+
+set(SOURCES test_package.cpp)
+qt5_wrap_cpp(SOURCES greeter.h)
+
+qt5_add_resources(SOURCES example.qrc)
+
+add_executable(${PROJECT_NAME} ${SOURCES})
 # Must compile with "-fPIC" since Qt was built with -reduce-relocations.
 target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
 

--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -81,7 +81,6 @@ class TestPackageConan(ConanFile):
             if self.settings.os == "Macos":
                 cmake.definitions['CMAKE_OSX_DEPLOYMENT_TARGET'] = '10.14'
 
-            self.run("moc %s -o moc_greeter.cpp" % os.path.join(self.source_folder, "greeter.h"), run_environment=True)
             cmake.configure()
             cmake.build()
 

--- a/recipes/qt/5.x.x/test_package/example.qrc
+++ b/recipes/qt/5.x.x/test_package/example.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource>
+        <file>resource.txt</file>
+    </qresource>
+</RCC>

--- a/recipes/qt/5.x.x/test_package/meson.build
+++ b/recipes/qt/5.x.x/test_package/meson.build
@@ -1,6 +1,6 @@
 project('test_package', 'cpp')
 qt5 = import('qt5')
 qt5_dep = dependency('qt5', modules: ['Core'])
-moc_files = qt5.preprocess(moc_headers : 'greeter.h')
+moc_files = qt5.preprocess(moc_headers : 'greeter.h', qresources : 'example.qrc')
 executable('test_package', 'test_package.cpp', moc_files,
            dependencies : qt5_dep)

--- a/recipes/qt/5.x.x/test_package/resource.txt
+++ b/recipes/qt/5.x.x/test_package/resource.txt
@@ -1,0 +1,1 @@
+Hello World From Resource

--- a/recipes/qt/5.x.x/test_package/test_package.cpp
+++ b/recipes/qt/5.x.x/test_package/test_package.cpp
@@ -3,6 +3,7 @@
 #include <QString>
 #include <QTimer>
 #include "greeter.h"
+#include <QFile>
 
 int main(int argc, char *argv[]){
     QCoreApplication app(argc, argv);
@@ -17,6 +18,12 @@ int main(int argc, char *argv[]){
     Greeter* greeter = new Greeter(name, &app);
     QObject::connect(greeter, SIGNAL(finished()), &app, SLOT(quit()));
     QTimer::singleShot(0, greeter, SLOT(run()));
+
+    QFile f(":/resource.txt");
+    if(!f.open(QIODevice::ReadOnly))
+        qFatal("Could not open resource file");
+    qDebug() << "Resource content:" << f.readAll();
+    f.close();
 
     return app.exec();
 }

--- a/recipes/qt/5.x.x/test_package/test_package.pro
+++ b/recipes/qt/5.x.x/test_package/test_package.pro
@@ -2,6 +2,8 @@ SOURCES += test_package.cpp
 
 HEADERS += greeter.h
 
+RESOURCES = example.qrc
+
 QT -= gui
 
 CONFIG += console


### PR DESCRIPTION
fixes conan-io/conan-center-index#4574

Specify library name and version:  **qt/5.15.2**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
