### PR TITLE
libcheck: fix conanexception when subunit is disabled

### DIFF
--- a/recipes/libcheck/all/conanfile.py
+++ b/recipes/libcheck/all/conanfile.py
@@ -97,7 +97,8 @@ class LibCheckConan(ConanFile):
                 libsuffix = "Dynamic"
 
         self.cpp_info.components["liblibcheck"].libs = ["check" + libsuffix]
-        self.cpp_info.components["liblibcheck"].requires.append("subunit::libsubunit")
+        if self.options.with_subunit:
+            self.cpp_info.components["liblibcheck"].requires.append("subunit::libsubunit")
         if not self.options.shared:
             if self.settings.os == "Linux":
                 self.cpp_info.components["liblibcheck"].system_libs = ["m", "pthread", "rt"]


### PR DESCRIPTION
When configuring libcheck with option: with_subunit=False I'm getting the following ConanException:

   Package require 'subunit' declared in components requires but not defined as a recipe requirement

Specify library name and version:  **libcheck/0.15.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
