### PR TITLE
packio: add version 2.2.0

### DIFF
--- a/recipes/packio/all/conandata.yml
+++ b/recipes/packio/all/conandata.yml
@@ -29,3 +29,6 @@ sources:
   2.1.0:
     sha256: d13be083cd5a133b02fdd1da0d89fb75988c16109ccdcd631d53f9ca2457ad42
     url: https://github.com/qchateau/packio/archive/2.1.0.tar.gz
+  "2.2.0":
+    url: "https://github.com/qchateau/packio/archive/2.2.0.tar.gz"
+    sha256: "ac9f33d5e8dd92bd3cdec106e10453424060bae9c4cd97281aa5d20fb20476f7"

--- a/recipes/packio/config.yml
+++ b/recipes/packio/config.yml
@@ -19,3 +19,5 @@ versions:
     folder: all
   2.1.0:
     folder: all
+  "2.2.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **packio/2.2.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
