### PR TITLE
glib: add version 2.67.4

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -32,3 +32,6 @@ sources:
   "2.67.3":
     url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.3/glib-2.67.3.tar.gz"
     sha256: "aa29c0472fbce6ebce5700c0e927d313bf9a7b061339a4899a8ffcf1c1bf7575"
+  "2.67.4":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.4/glib-2.67.4.tar.gz"
+    sha256: "ec82bcb30d696e3b4679b3134db1f418dabc034f3b6180ebbb40b1815d09e3d7"

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -21,3 +21,5 @@ versions:
     folder: all
   "2.67.3":
     folder: all
+  "2.67.4":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **glib/2.67.4**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.