### PR TITLE
[tomplusplus] The different packing option should have unique package_ids to avoid problems

### DIFF
--- a/recipes/tomlplusplus/all/conanfile.py
+++ b/recipes/tomlplusplus/all/conanfile.py
@@ -58,12 +58,10 @@ class TomlPlusPlusConan(ConanFile):
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         if self.options.multiple_headers:
-            header_dir = os.path.join(
-                self._source_subfolder, "include", "toml++")
+            header_dir = os.path.join(self._source_subfolder, "include", "toml++")
             self.copy(pattern="*.h", dst="include", src=header_dir)
         else:
-            self.copy(pattern="toml.hpp", dst="include",
-                      src=self._source_subfolder)
+            self.copy(pattern="toml.hpp", dst="include", src=self._source_subfolder)
 
     def package_id(self):
-        self.info.header_only()
+        self.info.settings.clear()


### PR DESCRIPTION
Specify library name and version:  **tomlplusplus/all**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

closes https://github.com/marzer/tomlplusplus/issues/86

The different packing option should have unique `package_id`s to avoid problems. Stole this from the `nlohman_json` recipe.