### PR TITLE
Patching libiconv sources in source() step, not in build()

### DIFF
--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -48,6 +48,7 @@ class LibiconvConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         archive_name = "{0}-{1}".format(self.name, self.version)
         os.rename(archive_name, self._source_subfolder)
+        self._patch_sources()
 
     @contextmanager
     def _build_context(self):
@@ -115,7 +116,6 @@ class LibiconvConan(ConanFile):
             tools.patch(**patch)
 
     def build(self):
-        self._patch_sources()
         with self._build_context():
             autotools = self._configure_autotools()
             autotools.make()


### PR DESCRIPTION
Specify library name and version:  **libiconv/1.16**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I had problems reusing uploaded packages, due to the patch file missing.