### PR TITLE
yaml-cpp: fix cpp_info.libs

### DIFF
--- a/recipes/yaml-cpp/all/conanfile.py
+++ b/recipes/yaml-cpp/all/conanfile.py
@@ -64,6 +64,6 @@ class YamlCppConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
-            self.cpp_info.libs.append('m')
+            self.cpp_info.system_libs.append('m')
         if self.settings.compiler == 'Visual Studio':
             self.cpp_info.defines.append('_NOEXCEPT=noexcept')


### PR DESCRIPTION
flagged by conan-io/hooks#273

Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
