### PR TITLE
openvr: fix cpp_info.libs

### DIFF
--- a/recipes/openvr/all/conanfile.py
+++ b/recipes/openvr/all/conanfile.py
@@ -74,7 +74,7 @@ class OpenvrConan(ConanFile):
             self.cpp_info.defines.append('OPENVR_BUILD_STATIC')
 
         if self.settings.os != "Windows":
-            self.cpp_info.libs.append("dl")
+            self.cpp_info.system_libs.append("dl")
 
         if self.settings.os == "Macos":
             self.cpp_info.frameworks.append("Foundation")


### PR DESCRIPTION
flagged by conan-io/hooks#273

Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
