### PR TITLE
r8brain-free-src: fix cpp_info.libs

### DIFF
--- a/recipes/r8brain-free-src/all/conanfile.py
+++ b/recipes/r8brain-free-src/all/conanfile.py
@@ -58,4 +58,4 @@ class R8brainFreeSrcConan(ConanFile):
         self.cpp_info.libs = ["r8brain"]
         
         if self.settings.os == "Linux":
-            self.cpp_info.libs.append("pthread")
+            self.cpp_info.system_libs.append("pthread")


### PR DESCRIPTION
flagged by conan-io/hooks#273

Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
