### PR TITLE
gflags: fix cpp_info.libs

### DIFF
--- a/recipes/gflags/all/conanfile.py
+++ b/recipes/gflags/all/conanfile.py
@@ -63,6 +63,6 @@ class GflagsConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Windows":
-            self.cpp_info.libs.extend(['shlwapi'])
+            self.cpp_info.system_libs.extend(['shlwapi'])
         elif self.settings.os == "Linux":
             self.cpp_info.system_libs.extend(["pthread", "m"])


### PR DESCRIPTION
flagged by conan-io/hooks#273

Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
