### PR TITLE
cassandra-cpp-driver: fix cpp_info.libs

### DIFF
--- a/recipes/cassandra-cpp-driver/all/conanfile.py
+++ b/recipes/cassandra-cpp-driver/all/conanfile.py
@@ -111,7 +111,7 @@ class CassandraCppDriverConan(ConanFile):
         self.requires("rapidjson/cci.20200410")
 
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1h")
+            self.requires("openssl/1.1.1i")
 
         if self.options.with_zlib:
             self.requires("minizip/1.2.11")

--- a/recipes/cassandra-cpp-driver/all/conanfile.py
+++ b/recipes/cassandra-cpp-driver/all/conanfile.py
@@ -139,7 +139,7 @@ class CassandraCppDriverConan(ConanFile):
         self.cpp_info.libs = tools.collect_libs(self)
 
         if self.settings.os == "Windows":
-            self.cpp_info.libs.extend(["iphlpapi", "psapi", "wsock32",
+            self.cpp_info.system_libs.extend(["iphlpapi", "psapi", "wsock32",
                 "crypt32", "ws2_32", "userenv", "version"])
             if not self.options.shared:
                 self.cpp_info.defines = ["CASS_STATIC"]

--- a/recipes/cassandra-cpp-driver/all/conanfile.py
+++ b/recipes/cassandra-cpp-driver/all/conanfile.py
@@ -106,8 +106,8 @@ class CassandraCppDriverConan(ConanFile):
                 "Kerberos is not supported at the moment")
 
     def requirements(self):
-        self.requires("libuv/1.34.2")
-        self.requires("http_parser/2.9.2")
+        self.requires("libuv/1.40.0")
+        self.requires("http_parser/2.9.4")
         self.requires("rapidjson/cci.20200410")
 
         if self.options.with_openssl:
@@ -118,7 +118,7 @@ class CassandraCppDriverConan(ConanFile):
             self.requires("zlib/1.2.11")
 
         if self.options.use_atomic == "boost":
-            self.requires("boost/1.74.0")
+            self.requires("boost/1.75.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
flagged by conan-io/hooks#273

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
