### PR TITLE
libpq: add missing versions

### DIFF
--- a/recipes/libpq/all/conandata.yml
+++ b/recipes/libpq/all/conandata.yml
@@ -1,10 +1,16 @@
 sources:
+  "13.2":
+    url: "https://ftp.postgresql.org/pub/source/v13.2/postgresql-13.2.tar.gz"
+    sha256: "3386a40736332aceb055c7c9012ecc665188536d874d967fcc5a33e7992f8080"
   "13.1":
     url: "https://ftp.postgresql.org/pub/source/v13.1/postgresql-13.1.tar.gz"
     sha256: "c474a70fdacb49e5841e989b47f116080c2c21ff743312f73f4d2ca32ff1d7dd"
   "13.0":
     url: "https://ftp.postgresql.org/pub/source/v13.0/postgresql-13.0.tar.gz"
     sha256: "67b09fca40a35360aef82fee43546271e6a04c33276e0093c5fb48653b2f5afa"
+  "12.6":
+    url: "https://ftp.postgresql.org/pub/source/v12.6/postgresql-12.6.tar.gz"
+    sha256: "c22039cb91a61b46c2df26b4ff64c64b95d6cf3d8e25c22a430bd8fe8eb78e7d"
   "12.4":
     url: "https://ftp.postgresql.org/pub/source/v12.4/postgresql-12.4.tar.gz"
     sha256: "9749b891b9d8f984312fe510a7a3613035134cee1e634793dac5568d1e1a5852"
@@ -14,6 +20,9 @@ sources:
   "12.2":
     url: "https://ftp.postgresql.org/pub/source/v12.2/postgresql-12.2.tar.gz"
     sha256: "8808449444ee9b086054a6dcfbfb98029e4f8022372c2edf3de5b6d8f417c8e4"
+  "11.11":
+    url: "https://ftp.postgresql.org/pub/source/v11.11/postgresql-11.11.tar.gz"
+    sha256: "53af5d8c8c314d31d382e3be670f32f0e21197434b90845560519b373a8ea409"
   "11.9":
     url: "https://ftp.postgresql.org/pub/source/v11.9/postgresql-11.9.tar.gz"
     sha256: "e98a8649814e2fa632a5d86bfb91f1ad570d47b108bc5c0d0d854803282abb03"

--- a/recipes/libpq/config.yml
+++ b/recipes/libpq/config.yml
@@ -1,13 +1,19 @@
 versions:
+  "13.2":
+    folder: all
   "13.1":
     folder: all
   "13.0":
+    folder: all
+  "12.6":
     folder: all
   "12.4":
     folder: all
   "12.3":
     folder: all
   "12.2":
+    folder: all
+  "11.11":
     folder: all
   "11.9":
     folder: all


### PR DESCRIPTION
Update .yml files to build latest versions.

Closes #4546

Specify library name and version:  **libpq/13.2**, **libpq/12.6**,  **libpq/11.11**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
