### PR TITLE
Add so5extra/1.4.1

### DIFF
--- a/recipes/so5extra/all/conandata.yml
+++ b/recipes/so5extra/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.4.1":
+    url: "https://github.com/Stiffstream/so5extra/archive/v.1.4.1.tar.gz"
+    sha256: "d500967b4c444e4f548349b6fd28ea877471e45bcf43606b6ff7d2a9f4cfd733"

--- a/recipes/so5extra/all/conanfile.py
+++ b/recipes/so5extra/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 

--- a/recipes/so5extra/all/conanfile.py
+++ b/recipes/so5extra/all/conanfile.py
@@ -9,11 +9,8 @@ class So5extraConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     description = "A collection of various SObjectizer's extensions."
     topics = ("concurrency", "actor-framework", "actors", "agents", "sobjectizer")
-    generators = "cmake"
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "compiler"
     no_copy_source = True
-
-    _cmake = None
 
     @property
     def _source_subfolder(self):

--- a/recipes/so5extra/all/conanfile.py
+++ b/recipes/so5extra/all/conanfile.py
@@ -1,0 +1,82 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+class So5extraConan(ConanFile):
+    name = "so5extra"
+    license = "BSD-3-Clause"
+    homepage = "https://github.com/Stiffstream/so5extra"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "A collection of various SObjectizer's extensions."
+    topics = ("concurrency", "actor-framework", "actors", "agents", "sobjectizer")
+    generators = "cmake"
+    settings = "os", "compiler", "build_type", "arch"
+    no_copy_source = True
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def requirements(self):
+        self.requires("sobjectizer/5.7.2.2")
+
+    def configure(self):
+        minimal_cpp_standard = "17"
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, minimal_cpp_standard)
+        minimal_version = {
+            "gcc": "7",
+            "clang": "6",
+            "apple-clang": "10",
+            "Visual Studio": "15"
+        }
+        compiler = str(self.settings.compiler)
+        if compiler not in minimal_version:
+            self.output.warn(
+                "%s recipe lacks information about the %s compiler standard version support" % (self.name, compiler))
+            self.output.warn(
+                "%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
+            return
+
+        version = tools.Version(self.settings.compiler.version)
+        if version < minimal_version[compiler]:
+            raise ConanInvalidConfiguration("%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+
+        self._cmake = CMake(self)
+        self._cmake.definitions["SO5EXTRA_INSTALL"] = True
+
+        self._cmake.configure(source_folder=os.path.join(self._source_subfolder, "dev", "so_5_extra"))
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-v." + self.version
+        os.rename(extracted_dir, self._source_subfolder )
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib"))
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "so5extra"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "so5extra"
+        self.cpp_info.names["cmake_find_package"] = "sobjectizer"
+        self.cpp_info.names["cmake_find_package_multi"] = "sobjectizer"
+        self.cpp_info.components["so_5_extra"].name = "so5extra"
+        self.cpp_info.components["so_5_extra"].requires = ["sobjectizer::sobjectizer"]
+

--- a/recipes/so5extra/all/conanfile.py
+++ b/recipes/so5extra/all/conanfile.py
@@ -77,6 +77,6 @@ class So5extraConan(ConanFile):
         self.cpp_info.filenames["cmake_find_package_multi"] = "so5extra"
         self.cpp_info.names["cmake_find_package"] = "sobjectizer"
         self.cpp_info.names["cmake_find_package_multi"] = "sobjectizer"
-        self.cpp_info.components["so_5_extra"].name = "so5extra"
+        self.cpp_info.components["so_5_extra"].names["cmake_find_package"] = "so5extra"
+        self.cpp_info.components["so_5_extra"].names["cmake_find_package_multi"] = "so5extra"
         self.cpp_info.components["so_5_extra"].requires = ["sobjectizer::sobjectizer"]
-

--- a/recipes/so5extra/all/conanfile.py
+++ b/recipes/so5extra/all/conanfile.py
@@ -44,30 +44,14 @@ class So5extraConan(ConanFile):
         if version < minimal_version[compiler]:
             raise ConanInvalidConfiguration("%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-
-        self._cmake = CMake(self)
-        self._cmake.definitions["SO5EXTRA_INSTALL"] = True
-
-        self._cmake.configure(source_folder=os.path.join(self._source_subfolder, "dev", "so_5_extra"))
-        return self._cmake
-
-    def build(self):
-        cmake = self._configure_cmake()
-        cmake.build()
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-v." + self.version
         os.rename(extracted_dir, self._source_subfolder )
 
     def package(self):
-        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        cmake = self._configure_cmake()
-        cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib"))
+        self.copy("*.hpp", dst="include/so_5_extra", src=os.path.join(self._source_subfolder, "dev", "so_5_extra"))
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/so5extra/all/test_package/CMakeLists.txt
+++ b/recipes/so5extra/all/test_package/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.8)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(so5extra REQUIRED)
+
+add_executable(example example.cpp)
+target_link_libraries(example sobjectizer::so5extra)

--- a/recipes/so5extra/all/test_package/conanfile.py
+++ b/recipes/so5extra/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class SobjectizerTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/so5extra/all/test_package/example.cpp
+++ b/recipes/so5extra/all/test_package/example.cpp
@@ -1,0 +1,69 @@
+/*
+ * Usage of select() with send_case() for calculation of Fibonacci numbers.
+ */
+
+#include <so_5_extra/mchains/fixed_size.hpp>
+
+#include <so_5/all.hpp>
+
+#include <chrono>
+
+using namespace std;
+using namespace std::chrono_literals;
+using namespace so_5;
+
+struct quit {};
+
+void fibonacci( mchain_t values_ch, mchain_t quit_ch )
+{
+  int x = 0, y = 1;
+  mchain_select_result_t r;
+  do
+  {
+    r = select(
+      from_all().handle_n(1),
+      // Sends a new message of type 'int' with value 'x' inside
+      // when values_ch is ready for a new outgoing message.
+      send_case( values_ch, message_holder_t<int>::make(x),
+          [&x, &y] { // This block of code will be called after the send().
+            auto old_x = x;
+            x = y; y = old_x + y;
+          } ),
+      // Receive a 'quit' message from quit_ch if it is here.
+      receive_case( quit_ch, [](quit){} ) );
+  }
+  // Continue the loop while we send something and receive nothing.
+  while( r.was_sent() && !r.was_handled() );
+}
+
+int main()
+{
+  wrapped_env_t sobj;
+
+  thread fibonacci_thr;
+  auto thr_joiner = auto_join( fibonacci_thr );
+
+  // The chain for Fibonacci number will have limited capacity.
+  auto values_ch = extra::mchains::fixed_size::create_mchain<2>(
+      sobj.environment(),
+      1s, // Wait no more than 1s on overflow.
+      mchain_props::overflow_reaction_t::abort_app );
+
+  // The chain for `quit` signal should contant no more than one message.
+  auto quit_ch = extra::mchains::fixed_size::create_mchain<1>(
+      sobj.environment(),
+      mchain_props::overflow_reaction_t::drop_newest );
+
+  auto ch_closer = auto_close_drop_content( values_ch, quit_ch );
+
+  fibonacci_thr = thread{ fibonacci, values_ch, quit_ch };
+
+  // Read the first 10 numbers from values_ch.
+  receive( from( values_ch ).handle_n( 10 ),
+      // And show every number to the standard output.
+      []( int v ) { cout << v << ' '; } );
+
+  send< quit >( quit_ch );
+
+  cout << std::endl;
+}

--- a/recipes/so5extra/config.yml
+++ b/recipes/so5extra/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.4.1":
+    folder: all


### PR DESCRIPTION
This is header-only extensions to SObjectizer library (https://github.com/Stiffstream/so5extra).

Specify library name and version:  **so5extra/1.4.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
