### PR TITLE
Add andreasbuhr-cppcoro/cci.20210113

### DIFF
--- a/recipes/andreasbuhr-cppcoro/all/CMakeLists.txt
+++ b/recipes/andreasbuhr-cppcoro/all/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(cppcoro CXX)
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(cmake_wrapper CXX)
 
 include(conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/andreasbuhr-cppcoro/all/CMakeLists.txt
+++ b/recipes/andreasbuhr-cppcoro/all/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.0)
+project(cppcoro CXX)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")
+

--- a/recipes/andreasbuhr-cppcoro/all/CMakeLists.txt
+++ b/recipes/andreasbuhr-cppcoro/all/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.0)
 project(cppcoro CXX)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_subdirectory("source_subfolder")
-

--- a/recipes/andreasbuhr-cppcoro/all/conandata.yml
+++ b/recipes/andreasbuhr-cppcoro/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20210113":
+    url: "https://github.com/andreasbuhr/cppcoro/archive/7cc9433436fe8f2482138019cfaafce8e1d7a896.zip"
+    sha256: "5edc72bb19616ae5b794c7d83f9a5d4973f32c966f1966ab81779d3a38b36a2c"

--- a/recipes/andreasbuhr-cppcoro/all/conanfile.py
+++ b/recipes/andreasbuhr-cppcoro/all/conanfile.py
@@ -11,6 +11,7 @@ class AndreasbuhrCppCoroConan(ConanFile):
     homepage = "https://github.com/andreasbuhr/cppcoro"
     license = "MIT"
     settings = "os", "compiler", "build_type", "arch"
+    provides = "cppcoro"
 
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
@@ -43,7 +44,7 @@ class AndreasbuhrCppCoroConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
-    def configure(self):
+    def validate(self):
         # We can't simply check for C++20, because clang and MSVC support the coroutine TS despite not having labeled (__cplusplus macro) C++20 support
         min_version = self._minimum_compilers_version.get(str(self.settings.compiler))
         if not min_version:
@@ -65,6 +66,7 @@ class AndreasbuhrCppCoroConan(ConanFile):
         if self.settings.compiler == "clang" and self.settings.compiler.version == "11":
             raise ConanInvalidConfiguration("WIP: {} currently doesn't build on clang 11".format(self.name))
 
+    def configure(self):
         if self.options.shared:
             del self.options.fPIC
 

--- a/recipes/andreasbuhr-cppcoro/all/conanfile.py
+++ b/recipes/andreasbuhr-cppcoro/all/conanfile.py
@@ -91,9 +91,18 @@ class AndreasbuhrCppCoroConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "cppcoro"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "cppcoro"
+        self.cpp_info.names["cmake_find_package"] = "cppcoro"
+        self.cpp_info.names["cmake_find_package_multi"] = "cppcoro"
+
+        comp = self.cpp_info.components["cppcoro"]
+        comp.names["cmake_find_package"] = "cppcoro"
+        comp.names["cmake_find_package_multi"] = "cppcoro"
+
         if self.settings.compiler == "Visual Studio":
-            self.cpp_info.cxxflags.append("/await")
+            comp.cxxflags.append("/await")
         elif self.settings.compiler == "gcc":
-            self.cpp_info.cxxflags.append("-fcoroutines")
+            comp.cxxflags.append("-fcoroutines")
         elif self.settings.compiler == "clang" or self.settings.compiler == "apple-clang":
-            self.cpp_info.cxxflags.append("-fcoroutines-ts")
+            comp.cxxflags.append("-fcoroutines-ts")

--- a/recipes/andreasbuhr-cppcoro/all/conanfile.py
+++ b/recipes/andreasbuhr-cppcoro/all/conanfile.py
@@ -1,7 +1,8 @@
 import os
-import glob
 from conans import ConanFile, tools, CMake
 from conans.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.33.0"
 
 class AndreasbuhrCppCoroConan(ConanFile):
     name = "andreasbuhr-cppcoro"
@@ -71,9 +72,7 @@ class AndreasbuhrCppCoroConan(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = glob.glob("cppcoro-*/")[0]
-        os.rename(extracted_dir, self._source_subfolder)
+       tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if not self._cmake:

--- a/recipes/andreasbuhr-cppcoro/all/conanfile.py
+++ b/recipes/andreasbuhr-cppcoro/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 import glob
 from conans import ConanFile, tools, CMake
+from conans.errors import ConanInvalidConfiguration
 
 class AndreasbuhrCppCoroConan(ConanFile):
     name = "andreasbuhr-cppcoro"

--- a/recipes/andreasbuhr-cppcoro/all/conanfile.py
+++ b/recipes/andreasbuhr-cppcoro/all/conanfile.py
@@ -51,8 +51,8 @@ class AndreasbuhrCppCoroConan(ConanFile):
                 self.name, self.settings.compiler))
         else:
             if tools.Version(self.settings.compiler.version) < min_version:
-                raise ConanInvalidConfiguration("{} requires C++{} support. The current compiler {} {} does not support it.".format(
-                    self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
+                raise ConanInvalidConfiguration("{} requires coroutine TS support. The current compiler {} {} does not support it.".format(
+                    self.name, self.settings.compiler, self.settings.compiler.version))
 
         if self.options.shared:
             del self.options.fPIC

--- a/recipes/andreasbuhr-cppcoro/all/conanfile.py
+++ b/recipes/andreasbuhr-cppcoro/all/conanfile.py
@@ -35,7 +35,7 @@ class AndreasbuhrCppCoroConan(ConanFile):
         return {
             "Visual Studio": "15",
             "gcc": "10",
-            "clang": "5.0",
+            "clang": "8",
             "apple-clang": "10",
         }
 

--- a/recipes/andreasbuhr-cppcoro/all/conanfile.py
+++ b/recipes/andreasbuhr-cppcoro/all/conanfile.py
@@ -10,7 +10,7 @@ class AndreasbuhrCppCoroConan(ConanFile):
     homepage = "https://github.com/andreasbuhr/cppcoro"
     license = "MIT"
     settings = "os", "compiler", "build_type", "arch"
-    
+
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
 
@@ -56,3 +56,4 @@ class AndreasbuhrCppCoroConan(ConanFile):
         self.copy("LICENSE.txt", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))

--- a/recipes/andreasbuhr-cppcoro/all/conanfile.py
+++ b/recipes/andreasbuhr-cppcoro/all/conanfile.py
@@ -1,0 +1,58 @@
+import os
+import glob
+from conans import ConanFile, tools, CMake
+
+class AndreasbuhrCppCoroConan(ConanFile):
+    name = "andreasbuhr-cppcoro"
+    description = "A library of C++ coroutine abstractions for the coroutines TS"
+    topics = ("conan", "cpp", "async", "coroutines")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/andreasbuhr/cppcoro"
+    license = "MIT"
+    settings = "os", "compiler", "build_type", "arch"
+    
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake"
+
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = glob.glob("cppcoro-*/")[0]
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def _configure_cmake(self):
+        if not self._cmake:
+            self._cmake = CMake(self)
+            self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE.txt", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()

--- a/recipes/andreasbuhr-cppcoro/all/conanfile.py
+++ b/recipes/andreasbuhr-cppcoro/all/conanfile.py
@@ -53,12 +53,17 @@ class AndreasbuhrCppCoroConan(ConanFile):
             if tools.Version(self.settings.compiler.version) < min_version:
                 raise ConanInvalidConfiguration("{} requires coroutine TS support. The current compiler {} {} does not support it.".format(
                     self.name, self.settings.compiler, self.settings.compiler.version))
-        
+
         # Currently clang expects coroutine to be implemented in a certain way (under std::experiemental::), while libstdc++ puts them under std::
         # There are also other inconsistencies, see https://bugs.llvm.org/show_bug.cgi?id=48172
         # This should be removed after both gcc and clang implements the final coroutine TS
         if self.settings.compiler == "clang" and self.settings.compiler.get_safe("libcxx") == "libstdc++":
             raise ConanInvalidConfiguration("{} does not support clang with libstdc++. Use libc++ instead.".format(self.name))
+
+        # TODO remove once figured out why clang 11/libc++ doesn't build on CCI
+        # (due to unable to find std::experiemental::noop_coroutine, author is unable to reproduce on local machine)
+        if self.settings.compiler == "clang" and self.settings.compiler.version == "11":
+            raise ConanInvalidConfiguration("WIP: {} currently doesn't build on clang 11".format(self.name))
 
         if self.options.shared:
             del self.options.fPIC

--- a/recipes/andreasbuhr-cppcoro/all/test_package/CMakeLists.txt
+++ b/recipes/andreasbuhr-cppcoro/all/test_package/CMakeLists.txt
@@ -4,14 +4,8 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(cppcoro CONFIG REQUIRED)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  target_compile_options(${PROJECT_NAME} PRIVATE -fcoroutines)
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang") # Both regular clang and apple clang
-  target_compile_options(${PROJECT_NAME} PRIVATE -fcoroutines-ts)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  # Lower version MSVC/Visual Studio still requires /await to support coroutines, despite having /std:c++latest
-  target_compile_options(${PROJECT_NAME} PRIVATE /await)
-endif()
+target_link_libraries(${PROJECT_NAME} cppcoro::cppcoro)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 20)

--- a/recipes/andreasbuhr-cppcoro/all/test_package/CMakeLists.txt
+++ b/recipes/andreasbuhr-cppcoro/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(${PROJECT_NAME} PRIVATE -fcoroutines)
+endif()
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 20)

--- a/recipes/andreasbuhr-cppcoro/all/test_package/CMakeLists.txt
+++ b/recipes/andreasbuhr-cppcoro/all/test_package/CMakeLists.txt
@@ -8,8 +8,8 @@ add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(${PROJECT_NAME} PRIVATE -fcoroutines)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  target_compile_options(${PROJECT_NAME}, PRIVATE -fcoroutines-ts)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang") # Both regular clang and apple clang
+  target_compile_options(${PROJECT_NAME} PRIVATE -fcoroutines-ts)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # Lower version MSVC/Visual Studio still requires /await to support coroutines, despite having /std:c++latest
   target_compile_options(${PROJECT_NAME} PRIVATE /await)

--- a/recipes/andreasbuhr-cppcoro/all/test_package/CMakeLists.txt
+++ b/recipes/andreasbuhr-cppcoro/all/test_package/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(${PROJECT_NAME} PRIVATE -fcoroutines)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(${PROJECT_NAME}, PRIVATE -fcoroutines-ts)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # Lower version MSVC/Visual Studio still requires /await to support coroutines, despite having /std:c++latest
   target_compile_options(${PROJECT_NAME} PRIVATE /await)

--- a/recipes/andreasbuhr-cppcoro/all/test_package/CMakeLists.txt
+++ b/recipes/andreasbuhr-cppcoro/all/test_package/CMakeLists.txt
@@ -8,5 +8,8 @@ add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(${PROJECT_NAME} PRIVATE -fcoroutines)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  # Lower version MSVC/Visual Studio still requires /await to support coroutines, despite having /std:c++latest
+  target_compile_options(${PROJECT_NAME} PRIVATE /await)
 endif()
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 20)

--- a/recipes/andreasbuhr-cppcoro/all/test_package/conanfile.py
+++ b/recipes/andreasbuhr-cppcoro/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/andreasbuhr-cppcoro/all/test_package/conanfile.py
+++ b/recipes/andreasbuhr-cppcoro/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/andreasbuhr-cppcoro/all/test_package/test_package.cpp
+++ b/recipes/andreasbuhr-cppcoro/all/test_package/test_package.cpp
@@ -1,5 +1,6 @@
-#include <cppcoro/generator.hpp>
+#include <vector>
 #include <iostream>
+#include <cppcoro/generator.hpp>
 
 cppcoro::generator<int> intYielder() {
 	co_yield 0;

--- a/recipes/andreasbuhr-cppcoro/all/test_package/test_package.cpp
+++ b/recipes/andreasbuhr-cppcoro/all/test_package/test_package.cpp
@@ -1,0 +1,23 @@
+#include <cppcoro/generator.hpp>
+#include <iostream>
+
+cppcoro::generator<int> intYielder() {
+	co_yield 0;
+	co_yield 1;
+}
+
+int main() {
+	std::vector<int> v;
+	for (int n : intYielder()) {
+        std::cout << "yielded " << n << '\n';
+		v.push_back(n);
+	}
+
+	bool success = v[0] == 0 && v[1] == 1;
+    if (success) {
+        std::cout << "success";
+        return 0;
+    } else {
+        return 1;
+    }
+}

--- a/recipes/andreasbuhr-cppcoro/config.yml
+++ b/recipes/andreasbuhr-cppcoro/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20210113":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **andreasbuhr-cppcoro/cci.20210113**

Closes #3293
This PR packages https://github.com/andreasbuhr/cppcoro instead of https://github.com/lewissbaker/cppcoro because the latter (original version) seems unmaintained and lacks a CMake buildscript. See https://github.com/lewissbaker/cppcoro/issues/170

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
