### PR TITLE
libuv: add version 1.41.0

### DIFF
--- a/recipes/libuv/all/conandata.yml
+++ b/recipes/libuv/all/conandata.yml
@@ -11,6 +11,9 @@ sources:
   "1.40.0":
     url: "https://github.com/libuv/libuv/archive/v1.40.0.zip"
     sha256: "61366e30d8484197dc9e4a94dbd98a0ba52fb55cb6c6d991af1f3701b10f322b"
+  "1.41.0":
+    url: "https://dist.libuv.org/dist/v1.41.0/libuv-v1.41.0.tar.gz"
+    sha256: "1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e"
 patches:
   "1.34.2":
     - base_path: "source_subfolder"
@@ -24,3 +27,6 @@ patches:
   "1.40.0":
     - base_path: "source_subfolder"
       patch_file: "patches/1.40.0/fix-cmake.patch"
+  "1.41.0":
+    - base_path: "source_subfolder"
+      patch_file: "patches/1.41.0/fix-cmake.patch"

--- a/recipes/libuv/all/conandata.yml
+++ b/recipes/libuv/all/conandata.yml
@@ -12,8 +12,8 @@ sources:
     url: "https://github.com/libuv/libuv/archive/v1.40.0.zip"
     sha256: "61366e30d8484197dc9e4a94dbd98a0ba52fb55cb6c6d991af1f3701b10f322b"
   "1.41.0":
-    url: "https://dist.libuv.org/dist/v1.41.0/libuv-v1.41.0.tar.gz"
-    sha256: "1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e"
+    url: "https://github.com/libuv/libuv/archive/v1.41.0.zip"
+    sha256: "cb89a8b9f686c5ccf7ed09a9e0ece151a73ebebc17af3813159c335b02181794"
 patches:
   "1.34.2":
     - base_path: "source_subfolder"

--- a/recipes/libuv/all/conanfile.py
+++ b/recipes/libuv/all/conanfile.py
@@ -1,6 +1,7 @@
+import glob
+import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
-import os
 
 
 class libuvConan(ConanFile):
@@ -48,7 +49,8 @@ class libuvConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        os.rename("libuv-{}".format(self.version), self._source_subfolder)
+        extracted_dir = glob.glob("libuv-*/")[0]
+        os.rename(extracted_dir, self._source_subfolder)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/libuv/all/conanfile.py
+++ b/recipes/libuv/all/conanfile.py
@@ -49,8 +49,7 @@ class libuvConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = glob.glob("libuv-*/")[0]
-        os.rename(extracted_dir, self._source_subfolder)
+        os.rename("libuv-{}".format(self.version), self._source_subfolder)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/libuv/all/patches/1.41.0/fix-cmake.patch
+++ b/recipes/libuv/all/patches/1.41.0/fix-cmake.patch
@@ -1,0 +1,77 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c8e881d1..82daa0d2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -335,13 +335,19 @@ if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "DragonFly|FreeBSD|Linux|NetBSD|OpenBSD")
+   list(APPEND uv_test_libraries util)
+ endif()
+ 
+-add_library(uv SHARED ${uv_sources})
+-target_compile_definitions(uv
+-  INTERFACE
+-    USING_UV_SHARED=1
+-  PRIVATE
+-    BUILDING_UV_SHARED=1
+-    ${uv_defines})
++add_library(uv ${uv_sources})
++get_target_property(target_type uv TYPE)
++if (target_type STREQUAL "SHARED_LIBRARY")
++  target_compile_definitions(uv
++    INTERFACE
++      USING_UV_SHARED=1
++    PRIVATE
++      BUILDING_UV_SHARED=1
++  )
++else()
++  set_property(TARGET uv PROPERTY OUTPUT_NAME "uv_a")
++endif()
++target_compile_definitions(uv PRIVATE ${uv_defines})
+ target_compile_options(uv PRIVATE ${uv_cflags})
+ target_include_directories(uv
+   PUBLIC
+@@ -351,17 +357,6 @@ target_include_directories(uv
+     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+ target_link_libraries(uv ${uv_libraries})
+ 
+-add_library(uv_a STATIC ${uv_sources})
+-target_compile_definitions(uv_a PRIVATE ${uv_defines})
+-target_compile_options(uv_a PRIVATE ${uv_cflags})
+-target_include_directories(uv_a
+-  PUBLIC
+-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+-  PRIVATE
+-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+-target_link_libraries(uv_a ${uv_libraries})
+-
+ if(LIBUV_BUILD_TESTS)
+   # Small hack: use ${uv_test_sources} now to get the runner skeleton,
+   # before the actual tests are added.
+@@ -605,19 +600,18 @@ if(UNIX OR MINGW)
+   configure_file(libuv-static.pc.in libuv-static.pc @ONLY)
+ 
+   install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+-  install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
+-  install(FILES ${PROJECT_BINARY_DIR}/libuv.pc ${PROJECT_BINARY_DIR}/libuv-static.pc
+-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+-  install(TARGETS uv LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  install(TARGETS uv_a ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
++  install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses)
++  install(TARGETS uv
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ endif()
+ 
+ if(MSVC)
+   install(DIRECTORY include/ DESTINATION include)
+-  install(FILES LICENSE DESTINATION .)
+-  install(TARGETS uv uv_a
+-          RUNTIME DESTINATION lib/$<CONFIG>
+-          ARCHIVE DESTINATION lib/$<CONFIG>)
++  install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX}/licenses)
++  install(TARGETS uv
++    RUNTIME DESTINATION bin
++    ARCHIVE DESTINATION lib)
+ endif()
+ 
+ message(STATUS "summary of build options:

--- a/recipes/libuv/config.yml
+++ b/recipes/libuv/config.yml
@@ -7,3 +7,5 @@ versions:
         folder: all
     "1.40.0":
         folder: all
+    "1.41.0":
+        folder: all


### PR DESCRIPTION
Specify library name and version:  **libuv/1.41.0**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.  **Tested with Conan 1.33.1.**
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated. **Tested on gcc 10; no hook errors reported using conan-center hooks @ https://github.com/conan-io/hooks/commit/20e51f130421d0ac60b70df2798ce82cffc773e9.

---

Some topics for discussion:

## v1.41.0 is pulled from dist.libuv.org

In this PR, I am using tarballs from dist.libuv.org.  This is a response to https://github.com/conan-io/conan-center-index/issues/4518; although that is a different project, I think it would be good to use tarballs from projects' official distribution sites.  The SHA-256 was run on a tarball that passed `gpg --verify` on https://dist.libuv.org/dist/v1.41.0/libuv-v1.41.0.tar.gz.sign.

The tarballs from dist.libuv.org expand to `libuv-v1.41.0`; the tarballs from Github expand to `libuv-1.41.0` (no `v`).  I think we should modify all previous versions to _also_ use dist.libuv.org, but until that PR comes we need to handle both directory schemes.  The `glob.glob` bit was added to handle this.

## Possibly adding `-fno-strict-aliasing` to CFLAGS/CXXFLAGS

libuv 1.41's build process adds `-fno-strict-aliasing` to its build options on compilers that support it (e.g. gcc, clang).  This was done as a response to https://github.com/libuv/libuv/issues/1230 and is [now recommended for using libuv 1.x](https://github.com/libuv/libuv#-fno-strict-aliasing).  (A future 2.x version may change this.)
 
This option should be propagated to code that uses libuv or exposes libuv objects, so I'm thinking that the `libuv` recipe should also add `-fno-strict-aliasing` into `cpp_info.{cflags, cxxflags}` for compilers that support the flag.  This PR does not add this flag, but I think we should do this -- if we don't, we're planting unpleasant surprises to be dug up by newer compilers or improvements in compilation techniques (i.e. more aggressive LTO analysis). 

What do you think?