### PR TITLE
add moltenvk/1.1.1

### DIFF
--- a/recipes/moltenvk/all/CMakeLists.txt
+++ b/recipes/moltenvk/all/CMakeLists.txt
@@ -10,6 +10,7 @@ if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
     message(FATAL_ERROR "MoltenVK only supports MacOS, iOS and tvOS")
 endif()
 
+option(MVK_WITH_SPIRV_TOOLS "Build MoltenVK without the MVK_EXCLUDE_SPIRV_TOOLS build setting" ON)
 option(MVK_BUILD_SHADERCONVERTER_TOOL "Build MoltenVKShaderConverter" ON)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -73,7 +74,7 @@ add_library(MoltenVKCommon OBJECT ${MVK_COMMON_SOURCES})
 
 # MoltenVKShaderConverter
 # * direct dependencies:
-#   - external: spirv-cross, spirv-tools and glslang
+#   - external: spirv-cross, glslang, and spirv-tools (optional)
 #   - internal: MoltenVKCommon
 #   - frameworks: Foundation
 file(GLOB MVK_SC_SOURCES
@@ -86,6 +87,9 @@ target_include_directories(MoltenVKShaderConverter PUBLIC
     ${PROJECT_DIR}/common
     ${PROJECT_DIR}/MoltenVKShaderConverter/common
 )
+if(NOT MVK_WITH_SPIRV_TOOLS)
+    target_compile_definitions(MoltenVKShaderConverter PRIVATE MVK_EXCLUDE_SPIRV_TOOLS)
+endif()
 
 # MoltenVKShaderConverterTool
 # * direct dependencies:

--- a/recipes/moltenvk/all/CMakeLists.txt
+++ b/recipes/moltenvk/all/CMakeLists.txt
@@ -10,6 +10,8 @@ if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
     message(FATAL_ERROR "MoltenVK only supports MacOS, iOS and tvOS")
 endif()
 
+option(MVK_BUILD_SHADERCONVERTER_TOOL "Build MoltenVKShaderConverter" ON)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
@@ -59,6 +61,7 @@ else()
 endif()
 
 set(PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder)
+set(MVK_INSTALL_TARGETS "")
 
 # MoltenVKCommon
 # * direct dependencies:
@@ -89,22 +92,25 @@ target_include_directories(MoltenVKShaderConverter PUBLIC
 #   - external: None
 #   - internal: MoltenVKShaderConverter and MoltenVKCommon
 #   - frameworks: Metal and Foundation
-file(GLOB MVK_SCT_SOURCES
-    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverterTool/*.cpp
-    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverterTool/*.mm
-)
-add_executable(MoltenVKShaderConverterTool ${MVK_SCT_SOURCES})
-set_property(TARGET MoltenVKShaderConverterTool PROPERTY OUTPUT_NAME "MoltenVKShaderConverter")
-target_include_directories(MoltenVKShaderConverterTool PRIVATE
-    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter
-)
-target_link_libraries(MoltenVKShaderConverterTool PRIVATE
-    MoltenVKCommon
-    MoltenVKShaderConverter
-    ${CONAN_LIBS}
-    ${METAL_FRAMEWORK}
-    ${FOUNDATION_FRAMEWORK}
-)
+if(MVK_BUILD_SHADERCONVERTER_TOOL)
+    file(GLOB MVK_SCT_SOURCES
+        ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverterTool/*.cpp
+        ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverterTool/*.mm
+    )
+    add_executable(MoltenVKShaderConverterTool ${MVK_SCT_SOURCES})
+    set_property(TARGET MoltenVKShaderConverterTool PROPERTY OUTPUT_NAME "MoltenVKShaderConverter")
+    target_include_directories(MoltenVKShaderConverterTool PRIVATE
+        ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter
+    )
+    target_link_libraries(MoltenVKShaderConverterTool PRIVATE
+        MoltenVKCommon
+        MoltenVKShaderConverter
+        ${CONAN_LIBS}
+        ${METAL_FRAMEWORK}
+        ${FOUNDATION_FRAMEWORK}
+    )
+    list(APPEND MVK_INSTALL_TARGETS MoltenVKShaderConverterTool)
+endif()
 
 # MoltenVK
 # * direct dependencies:
@@ -139,9 +145,10 @@ target_link_libraries(MoltenVK PRIVATE
     ${IOSURFACE_FRAMEWORK}
     ${IO_OR_UI_KIT_FRAMEWORK}
 )
+list(APPEND MVK_INSTALL_TARGETS MoltenVK)
 
 install(
-    TARGETS MoltenVK MoltenVKShaderConverterTool
+    TARGETS ${MVK_INSTALL_TARGETS}
     BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/recipes/moltenvk/all/CMakeLists.txt
+++ b/recipes/moltenvk/all/CMakeLists.txt
@@ -69,6 +69,7 @@ file(GLOB MVK_SCT_SOURCES
     ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverterTool/*.mm
 )
 add_executable(MoltenVKShaderConverterTool ${MVK_SCT_SOURCES})
+set_property(TARGET MoltenVKShaderConverterTool PROPERTY OUTPUT_NAME "MoltenVKShaderConverter")
 target_include_directories(MoltenVKShaderConverterTool PRIVATE
     ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter
 )

--- a/recipes/moltenvk/all/CMakeLists.txt
+++ b/recipes/moltenvk/all/CMakeLists.txt
@@ -71,6 +71,7 @@ set(MVK_INSTALL_TARGETS "")
 #   - frameworks: Foundation
 file(GLOB MVK_COMMON_SOURCES ${PROJECT_DIR}/common/*.mm)
 add_library(MoltenVKCommon OBJECT ${MVK_COMMON_SOURCES})
+target_compile_definitions(MoltenVKCommon PRIVATE $<$<CONFIG:Debug>:DEBUG=1>)
 
 # MoltenVKShaderConverter
 # * direct dependencies:

--- a/recipes/moltenvk/all/CMakeLists.txt
+++ b/recipes/moltenvk/all/CMakeLists.txt
@@ -189,6 +189,42 @@ target_compile_options(MoltenVK PRIVATE
 )
 list(APPEND MVK_INSTALL_TARGETS MoltenVK)
 
+# Custom Target to generate internal header file required by MoltenVK target.
+# This header should contain:
+#  - if moltenvk < 1.44 : spirv-cross commit hash in spirvCrossRevisionString variable
+#  - if moltenvk >= 1.44: moltenvk commit hash in mvkRevString variable (but we still
+#    use spirv-cross commit hash, since MoltenVK hash is not available in this context,
+#    and hash value is no really important)
+set(MVK_REVISION_FILE ${MVK_DIR}/ExternalRevisions/SPIRV-Cross_repo_revision)
+set(MVK_REVISION_HEADER_DIR ${CMAKE_CURRENT_BINARY_DIR}/mvk_hash_generated)
+if(MVK_VERSION VERSION_LESS "1.0.44")
+    set(MVK_REVISION_HEADER ${MVK_REVISION_HEADER_DIR}/SPIRV-Cross/mvkSpirvCrossRevisionDerived.h)
+    set(MVK_REV_VAR_NAME "spirvCrossRevisionString")
+else()
+    set(MVK_REVISION_HEADER ${MVK_REVISION_HEADER_DIR}/mvkGitRevDerived.h)
+    set(MVK_REV_VAR_NAME "mvkRevString")
+endif()
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/mvk_git_hash_generator.in
+    "file(READ @MVK_REVISION_FILE@ MVK_SPIRV_CROSS_GIT_REV)\n"
+    "string(REPLACE \"\\n\" \"\" MVK_SPIRV_CROSS_GIT_REV \${MVK_SPIRV_CROSS_GIT_REV})\n"
+    "file(WRITE @MVK_REVISION_HEADER@ \"static const char* @MVK_REV_VAR_NAME@ = \\\"\${MVK_SPIRV_CROSS_GIT_REV}\\\";\")\n"
+)
+configure_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/mvk_git_hash_generator.in
+    ${CMAKE_CURRENT_BINARY_DIR}/mvk_git_hash_generator.cmake
+    @ONLY
+)
+add_custom_target(mvk-commit-hash-header DEPENDS ${MVK_REVISION_FILE} ${MVK_REVISION_HEADER})
+add_custom_command(
+  COMMENT "Create ${MVK_REVISION_HEADER}"
+  OUTPUT ${MVK_REVISION_HEADER}
+  DEPENDS ${MVK_REVISION_FILE}
+  COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/mvk_git_hash_generator.cmake"
+)
+add_dependencies(MoltenVK mvk-commit-hash-header)
+target_include_directories(MoltenVK PRIVATE ${MVK_REVISION_HEADER_DIR})
+
+# Installation
 install(
     TARGETS ${MVK_INSTALL_TARGETS}
     BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/recipes/moltenvk/all/CMakeLists.txt
+++ b/recipes/moltenvk/all/CMakeLists.txt
@@ -14,6 +14,12 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 
+add_compile_options(
+    -Wno-unguarded-availability-new
+    -Wno-deprecated-declarations
+    -Wno-nonportable-include-path
+)
+
 # PIC required for objects targets linked into shared MoltenVK
 if(BUILD_SHARED_LIBS)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/recipes/moltenvk/all/CMakeLists.txt
+++ b/recipes/moltenvk/all/CMakeLists.txt
@@ -21,17 +21,36 @@ endif()
 
 # Required Apple Frameworks
 find_library(METAL_FRAMEWORK Metal)
-find_library(FOUNDATION_FRAMEWORK Foundation)
-find_library(QUARTZ_CORE_FRAMEWORK QuartzCore)
-find_library(APPKIT_FRAMEWORK AppKit)
-find_library(IOSURFACE_FRAMEWORK IOSurface)
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    find_library(IOKIT_FRAMEWORK IOKit)
-else()
-    find_library(IOKIT_FRAMEWORK UIKit)
+if(NOT METAL_FRAMEWORK)
+    message(FATAL_ERROR "Metal framework not found")
 endif()
-
+find_library(FOUNDATION_FRAMEWORK Foundation)
+if(NOT FOUNDATION_FRAMEWORK)
+    message(FATAL_ERROR "Foundation framework not found")
+endif()
+find_library(QUARTZ_CORE_FRAMEWORK QuartzCore)
+if(NOT QUARTZ_CORE_FRAMEWORK)
+    message(FATAL_ERROR "QuartzCore framework not found")
+endif()
+find_library(APPKIT_FRAMEWORK AppKit)
+if(NOT APPKIT_FRAMEWORK)
+    message(FATAL_ERROR "AppKit framework not found")
+endif()
+find_library(IOSURFACE_FRAMEWORK IOSurface)
+if(NOT IOSURFACE_FRAMEWORK)
+    message(FATAL_ERROR "IOSurface framework not found")
+endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    find_library(IO_OR_UI_KIT_FRAMEWORK IOKit)
+    if(NOT IO_OR_UI_KIT_FRAMEWORK)
+        message(FATAL_ERROR "IOKit framework not found")
+    endif()
+else()
+    find_library(IO_OR_UI_KIT_FRAMEWORK UIKit)
+    if(NOT IO_OR_UI_KIT_FRAMEWORK)
+        message(FATAL_ERROR "UIKit framework not found")
+    endif()
+endif()
 
 set(PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder)
 
@@ -112,7 +131,7 @@ target_link_libraries(MoltenVK PRIVATE
     ${QUARTZ_CORE_FRAMEWORK}
     ${APPKIT_FRAMEWORK}
     ${IOSURFACE_FRAMEWORK}
-    ${IOKIT_FRAMEWORK}
+    ${IO_OR_UI_KIT_FRAMEWORK}
 )
 
 install(

--- a/recipes/moltenvk/all/CMakeLists.txt
+++ b/recipes/moltenvk/all/CMakeLists.txt
@@ -1,0 +1,145 @@
+cmake_minimum_required(VERSION 3.1)
+project(MoltenVK)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
+        CMAKE_SYSTEM_NAME STREQUAL "iOS" OR
+        CMAKE_SYSTEM_NAME STREQUAL "tvOS"))
+    message(FATAL_ERROR "MoltenVK only supports MacOS, iOS and tvOS")
+endif()
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS ON)
+
+# PIC required for objects targets linked into shared MoltenVK
+if(BUILD_SHARED_LIBS)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
+
+# Required Apple Frameworks
+find_library(METAL_FRAMEWORK Metal)
+find_library(FOUNDATION_FRAMEWORK Foundation)
+find_library(QUARTZ_CORE_FRAMEWORK QuartzCore)
+find_library(APPKIT_FRAMEWORK AppKit)
+find_library(IOSURFACE_FRAMEWORK IOSurface)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    find_library(IOKIT_FRAMEWORK IOKit)
+else()
+    find_library(IOKIT_FRAMEWORK UIKit)
+endif()
+
+
+set(PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder)
+
+# MoltenVKCommon
+# * direct dependencies:
+#   - external: None
+#   - internal: None
+#   - frameworks: Foundation
+file(GLOB MVK_COMMON_SOURCES ${PROJECT_DIR}/common/*.mm)
+add_library(MoltenVKCommon OBJECT ${MVK_COMMON_SOURCES})
+
+# MoltenVKShaderConverter
+# * direct dependencies:
+#   - external: spirv-cross, spirv-tools and glslang
+#   - internal: MoltenVKCommon
+#   - frameworks: Foundation
+file(GLOB MVK_SC_SOURCES
+    ${PROJECT_DIR}/MoltenVKShaderConverter/common/*.cpp
+    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*.cpp
+    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*.mm
+)
+add_library(MoltenVKShaderConverter OBJECT ${MVK_SC_SOURCES})
+target_include_directories(MoltenVKShaderConverter PUBLIC
+    ${PROJECT_DIR}/common
+    ${PROJECT_DIR}/MoltenVKShaderConverter/common
+)
+
+# MoltenVKShaderConverterTool
+# * direct dependencies:
+#   - external: None
+#   - internal: MoltenVKShaderConverter and MoltenVKCommon
+#   - frameworks: Metal and Foundation
+file(GLOB MVK_SCT_SOURCES
+    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverterTool/*.cpp
+    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverterTool/*.mm
+)
+add_executable(MoltenVKShaderConverterTool ${MVK_SCT_SOURCES})
+target_include_directories(MoltenVKShaderConverterTool PRIVATE
+    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter
+)
+target_link_libraries(MoltenVKShaderConverterTool PRIVATE
+    MoltenVKCommon
+    MoltenVKShaderConverter
+    ${CONAN_LIBS}
+    ${METAL_FRAMEWORK}
+    ${FOUNDATION_FRAMEWORK}
+)
+
+# MoltenVK
+# * direct dependencies:
+#   - external: cereal, spirv-cross and vulkan-headers
+#   - internal: MoltenVKShaderConverter and MoltenVKCommon
+#   - frameworks: Foundation, Metal, QuartzCore, AppKit, IOSurface + IOKit (Macos) or UIKit (iOS/tvOS)
+file(GLOB_RECURSE MVK_SOURCES
+    ${PROJECT_DIR}/MoltenVK/*.m
+    ${PROJECT_DIR}/MoltenVK/*.mm
+    ${PROJECT_DIR}/MoltenVK/*.cpp
+)
+add_library(MoltenVK ${MVK_SOURCES})
+target_include_directories(MoltenVK PRIVATE
+    ${PROJECT_DIR}/Common
+    ${PROJECT_DIR}/MoltenVKShaderConverter
+    ${PROJECT_DIR}/MoltenVK/MoltenVK/API
+    ${PROJECT_DIR}/MoltenVK/MoltenVK/Commands
+    ${PROJECT_DIR}/MoltenVK/MoltenVK/GPUObjects
+    ${PROJECT_DIR}/MoltenVK/MoltenVK/Layers
+    ${PROJECT_DIR}/MoltenVK/MoltenVK/OS
+    ${PROJECT_DIR}/MoltenVK/MoltenVK/Utility
+    ${PROJECT_DIR}/MoltenVK/MoltenVK/Vulkan
+)
+target_link_libraries(MoltenVK PRIVATE
+    MoltenVKCommon
+    MoltenVKShaderConverter
+    ${CONAN_LIBS}
+    ${METAL_FRAMEWORK}
+    ${FOUNDATION_FRAMEWORK}
+    ${QUARTZ_CORE_FRAMEWORK}
+    ${APPKIT_FRAMEWORK}
+    ${IOSURFACE_FRAMEWORK}
+    ${IOKIT_FRAMEWORK}
+)
+
+install(
+    TARGETS MoltenVK MoltenVKShaderConverterTool
+    BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+if(BUILD_SHARED_LIBS)
+    install(
+        FILES ${PROJECT_DIR}/MoltenVK/icd/MoltenVK_icd.json
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+endif()
+
+file(GLOB MVK_PUBLIC_HEADERS ${PROJECT_DIR}/MoltenVK/MoltenVK/API/*.h)
+install(
+    FILES ${MVK_PUBLIC_HEADERS}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/MoltenVK
+)
+
+file(GLOB MVK_SC_PUBLIC_HEADERS
+    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*Conversion.h
+    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*Converter.h
+)
+install(
+    FILES ${MVK_SC_PUBLIC_HEADERS}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/MoltenVKShaderConverter
+)

--- a/recipes/moltenvk/all/CMakeLists.txt
+++ b/recipes/moltenvk/all/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 project(MoltenVK)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 if(NOT (CMAKE_SYSTEM_NAME STREQUAL "Darwin" OR
         CMAKE_SYSTEM_NAME STREQUAL "iOS" OR
@@ -15,7 +15,6 @@ option(MVK_BUILD_SHADERCONVERTER_TOOL "Build MoltenVKShaderConverter" ON)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS ON)
 
 # PIC required for objects targets linked into shared MoltenVK
 if(BUILD_SHARED_LIBS)
@@ -55,7 +54,7 @@ else()
     endif()
 endif()
 
-set(PROJECT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder)
+set(MVK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder)
 set(MVK_INSTALL_TARGETS "")
 
 # MoltenVKCommon
@@ -63,27 +62,52 @@ set(MVK_INSTALL_TARGETS "")
 #   - external: None
 #   - internal: None
 #   - frameworks: Foundation
-file(GLOB MVK_COMMON_SOURCES ${PROJECT_DIR}/common/*.mm)
+file(GLOB MVK_COMMON_SOURCES ${MVK_DIR}/common/*.mm)
 add_library(MoltenVKCommon OBJECT ${MVK_COMMON_SOURCES})
+target_include_directories(MoltenVKCommon PUBLIC ${MVK_DIR}/common)
 target_compile_definitions(MoltenVKCommon PRIVATE $<$<CONFIG:Debug>:DEBUG=1>)
+target_link_libraries(MoltenVKCommon PRIVATE ${FOUNDATION_FRAMEWORK})
 
 # MoltenVKShaderConverter
 # * direct dependencies:
 #   - external: spirv-cross, glslang, and spirv-tools (optional)
 #   - internal: MoltenVKCommon
 #   - frameworks: Foundation
-file(GLOB MVK_SC_SOURCES
-    ${PROJECT_DIR}/MoltenVKShaderConverter/common/*.cpp
-    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*.cpp
-    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*.mm
+file(GLOB MVK_SC_COMMON_SOURCES ${MVK_DIR}/MoltenVKShaderConverter/common/*.cpp)
+if(MVK_VERSION VERSION_LESS "1.1.0")
+    file(GLOB MVK_SC_CONVERTERS_SOURCES
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/*.cpp
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/*.mm
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/*.cpp
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/*.mm
+    )
+else()
+    file(GLOB MVK_SC_CONVERTERS_SOURCES
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*.cpp
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*.mm
+    )
+endif()
+add_library(MoltenVKShaderConverter OBJECT ${MVK_SC_COMMON_SOURCES} ${MVK_SC_CONVERTERS_SOURCES})
+target_include_directories(MoltenVKShaderConverter
+    PRIVATE ${MVK_DIR}/MoltenVKShaderConverter/common
+    INTERFACE ${MVK_DIR}/MoltenVKShaderConverter
 )
-add_library(MoltenVKShaderConverter OBJECT ${MVK_SC_SOURCES})
-target_include_directories(MoltenVKShaderConverter PUBLIC
-    ${PROJECT_DIR}/common
-    ${PROJECT_DIR}/MoltenVKShaderConverter/common
+if(MVK_VERSION VERSION_LESS "1.1.0")
+    target_include_directories(MoltenVKShaderConverter PRIVATE
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter
+    )
+endif()
+target_link_libraries(MoltenVKShaderConverter
+    PRIVATE
+        CONAN_PKG::glslang
+        MoltenVKCommon
+        ${FOUNDATION_FRAMEWORK}
+    PUBLIC
+        CONAN_PKG::spirv-cross
 )
 if(NOT MVK_WITH_SPIRV_TOOLS)
     target_compile_definitions(MoltenVKShaderConverter PRIVATE MVK_EXCLUDE_SPIRV_TOOLS)
+    target_link_libraries(MoltenVKShaderConverter PRIVATE CONAN_PKG::spirv-tools)
 endif()
 
 # MoltenVKShaderConverterTool
@@ -93,18 +117,27 @@ endif()
 #   - frameworks: Metal and Foundation
 if(MVK_BUILD_SHADERCONVERTER_TOOL)
     file(GLOB MVK_SCT_SOURCES
-        ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverterTool/*.cpp
-        ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverterTool/*.mm
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverterTool/*.cpp
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverterTool/*.mm
     )
     add_executable(MoltenVKShaderConverterTool ${MVK_SCT_SOURCES})
     set_property(TARGET MoltenVKShaderConverterTool PROPERTY OUTPUT_NAME "MoltenVKShaderConverter")
     target_include_directories(MoltenVKShaderConverterTool PRIVATE
-        ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter
+        ${MVK_DIR}/MoltenVKShaderConverter/common
     )
+    if(MVK_VERSION VERSION_LESS "1.1.0")
+        target_include_directories(MoltenVKShaderConverterTool PRIVATE
+            ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter
+            ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter
+        )
+    else()
+        target_include_directories(MoltenVKShaderConverterTool PRIVATE
+            ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter
+        )
+    endif()
     target_link_libraries(MoltenVKShaderConverterTool PRIVATE
         MoltenVKCommon
         MoltenVKShaderConverter
-        ${CONAN_LIBS}
         ${METAL_FRAMEWORK}
         ${FOUNDATION_FRAMEWORK}
     )
@@ -113,37 +146,42 @@ endif()
 
 # MoltenVK
 # * direct dependencies:
-#   - external: cereal, spirv-cross and vulkan-headers
+#   - external: cereal, spirv-cross and vulkan-headers (+ vulkan-portability if moltenvk < 1.1.0)
 #   - internal: MoltenVKShaderConverter and MoltenVKCommon
 #   - frameworks: Foundation, Metal, QuartzCore, AppKit, IOSurface + IOKit (Macos) or UIKit (iOS/tvOS)
 file(GLOB_RECURSE MVK_SOURCES
-    ${PROJECT_DIR}/MoltenVK/*.m
-    ${PROJECT_DIR}/MoltenVK/*.mm
-    ${PROJECT_DIR}/MoltenVK/*.cpp
+    ${MVK_DIR}/MoltenVK/*.m
+    ${MVK_DIR}/MoltenVK/*.mm
+    ${MVK_DIR}/MoltenVK/*.cpp
 )
 add_library(MoltenVK ${MVK_SOURCES})
 target_include_directories(MoltenVK PRIVATE
-    ${PROJECT_DIR}/Common
-    ${PROJECT_DIR}/MoltenVKShaderConverter
-    ${PROJECT_DIR}/MoltenVK/MoltenVK/API
-    ${PROJECT_DIR}/MoltenVK/MoltenVK/Commands
-    ${PROJECT_DIR}/MoltenVK/MoltenVK/GPUObjects
-    ${PROJECT_DIR}/MoltenVK/MoltenVK/Layers
-    ${PROJECT_DIR}/MoltenVK/MoltenVK/OS
-    ${PROJECT_DIR}/MoltenVK/MoltenVK/Utility
-    ${PROJECT_DIR}/MoltenVK/MoltenVK/Vulkan
+    ${MVK_DIR}/MoltenVK/MoltenVK/API
+    ${MVK_DIR}/MoltenVK/MoltenVK/Commands
+    ${MVK_DIR}/MoltenVK/MoltenVK/GPUObjects
+    ${MVK_DIR}/MoltenVK/MoltenVK/Layers
+    ${MVK_DIR}/MoltenVK/MoltenVK/OS
+    ${MVK_DIR}/MoltenVK/MoltenVK/Utility
+    ${MVK_DIR}/MoltenVK/MoltenVK/Vulkan
 )
-target_link_libraries(MoltenVK PRIVATE
-    MoltenVKCommon
-    MoltenVKShaderConverter
-    ${CONAN_LIBS}
-    ${METAL_FRAMEWORK}
-    ${FOUNDATION_FRAMEWORK}
-    ${QUARTZ_CORE_FRAMEWORK}
-    ${APPKIT_FRAMEWORK}
-    ${IOSURFACE_FRAMEWORK}
-    ${IO_OR_UI_KIT_FRAMEWORK}
+target_link_libraries(MoltenVK
+    PRIVATE
+        CONAN_PKG::cereal
+        CONAN_PKG::spirv-cross
+        MoltenVKCommon
+        MoltenVKShaderConverter
+        ${FOUNDATION_FRAMEWORK}
+        ${QUARTZ_CORE_FRAMEWORK}
+        ${APPKIT_FRAMEWORK}
+        ${IO_OR_UI_KIT_FRAMEWORK}
+    PUBLIC
+        CONAN_PKG::vulkan-headers
+        ${METAL_FRAMEWORK}
+        ${IOSURFACE_FRAMEWORK}
 )
+if(MVK_VERSION VERSION_LESS "1.1.0")
+    target_link_libraries(MoltenVK PUBLIC CONAN_PKG::vulkan-portability)
+endif()
 target_compile_options(MoltenVK PRIVATE
     -Wno-unguarded-availability-new
     -Wno-deprecated-declarations
@@ -161,21 +199,30 @@ install(
 
 if(BUILD_SHARED_LIBS)
     install(
-        FILES ${PROJECT_DIR}/MoltenVK/icd/MoltenVK_icd.json
+        FILES ${MVK_DIR}/MoltenVK/icd/MoltenVK_icd.json
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 endif()
 
-file(GLOB MVK_PUBLIC_HEADERS ${PROJECT_DIR}/MoltenVK/MoltenVK/API/*.h)
+file(GLOB MVK_PUBLIC_HEADERS ${MVK_DIR}/MoltenVK/MoltenVK/API/*.h)
 install(
     FILES ${MVK_PUBLIC_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/MoltenVK
 )
 
-file(GLOB MVK_SC_PUBLIC_HEADERS
-    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*Conversion.h
-    ${PROJECT_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*Converter.h
-)
+if(MVK_VERSION VERSION_LESS "1.1.0")
+    file(GLOB MVK_SC_PUBLIC_HEADERS
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/*Conversion.h
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/*Converter.h
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/*Conversion.h
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/*Converter.h
+    )
+else()
+    file(GLOB MVK_SC_PUBLIC_HEADERS
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*Conversion.h
+        ${MVK_DIR}/MoltenVKShaderConverter/MoltenVKShaderConverter/*Converter.h
+    )
+endif()
 install(
     FILES ${MVK_SC_PUBLIC_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/MoltenVKShaderConverter

--- a/recipes/moltenvk/all/CMakeLists.txt
+++ b/recipes/moltenvk/all/CMakeLists.txt
@@ -17,12 +17,6 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 
-add_compile_options(
-    -Wno-unguarded-availability-new
-    -Wno-deprecated-declarations
-    -Wno-nonportable-include-path
-)
-
 # PIC required for objects targets linked into shared MoltenVK
 if(BUILD_SHARED_LIBS)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -149,6 +143,11 @@ target_link_libraries(MoltenVK PRIVATE
     ${APPKIT_FRAMEWORK}
     ${IOSURFACE_FRAMEWORK}
     ${IO_OR_UI_KIT_FRAMEWORK}
+)
+target_compile_options(MoltenVK PRIVATE
+    -Wno-unguarded-availability-new
+    -Wno-deprecated-declarations
+    -Wno-nonportable-include-path
 )
 list(APPEND MVK_INSTALL_TARGETS MoltenVK)
 

--- a/recipes/moltenvk/all/conandata.yml
+++ b/recipes/moltenvk/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.1.1":
+    url: "https://github.com/KhronosGroup/MoltenVK/archive/v1.1.1.tar.gz"
+    sha256: "cd1712c571d4155f4143c435c8551a5cb8cbb311ad7fff03595322ab971682c0"

--- a/recipes/moltenvk/all/conandata.yml
+++ b/recipes/moltenvk/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "1.1.1":
     url: "https://github.com/KhronosGroup/MoltenVK/archive/v1.1.1.tar.gz"
     sha256: "cd1712c571d4155f4143c435c8551a5cb8cbb311ad7fff03595322ab971682c0"
+patches:
+  "1.1.1":
+    - patch_file: "patches/0001-fix-spirv-cross-includes-1.1.x.patch"
+      base_path: "source_subfolder"

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -19,11 +19,13 @@ class MoltenVKConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_spirv_tools": [True, False],
         "tools": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_spirv_tools": True,
         "tools": True
     }
 
@@ -50,8 +52,9 @@ class MoltenVKConan(ConanFile):
         self.requires("cereal/1.3.0")
         self.requires("glslang/8.13.3559")
         self.requires("spirv-cross/20210115")
-        self.requires("spirv-tools/v2020.5")
         self.requires("vulkan-headers/1.2.162.0")
+        if self.options.with_spirv_tools:
+            self.requires("spirv-tools/v2020.5")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -77,6 +80,7 @@ class MoltenVKConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        self._cmake.definitions["MVK_WITH_SPIRV_TOOLS"] = self.options.with_spirv_tools
         self._cmake.definitions["MVK_BUILD_SHADERCONVERTER_TOOL"] = self.options.tools
         self._cmake.configure()
         return self._cmake

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -86,3 +86,7 @@ class MoltenVKConan(ConanFile):
             self.cpp_info.frameworks.append("IOKit")
         elif self.settings.os in ["iOS", "tvOS"]:
             self.cpp_info.frameworks.append("UIKit")
+
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -16,8 +16,16 @@ class MoltenVKConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
 
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "tools": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "tools": True
+    }
 
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
@@ -69,6 +77,7 @@ class MoltenVKConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        self._cmake.definitions["MVK_BUILD_SHADERCONVERTER_TOOL"] = self.options.tools
         self._cmake.configure()
         return self._cmake
 
@@ -90,6 +99,7 @@ class MoltenVKConan(ConanFile):
         elif self.settings.os in ["iOS", "tvOS"]:
             self.cpp_info.frameworks.append("UIKit")
 
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable: {}".format(bin_path))
-        self.env_info.PATH.append(bin_path)
+        if self.options.tools:
+            bin_path = os.path.join(self.package_folder, "bin")
+            self.output.info("Appending PATH environment variable: {}".format(bin_path))
+            self.env_info.PATH.append(bin_path)

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -46,6 +46,8 @@ class MoltenVKConan(ConanFile):
             tools.check_min_cppstd(self, 11)
         if self.settings.os not in ["Macos", "iOS", "tvOS"]:
             raise ConanInvalidConfiguration("MoltenVK only supported on MacOS, iOS and tvOS")
+        if self.settings.compiler != "apple-clang":
+            raise ConanInvalidConfiguration("MoltenVK requires apple-clang")
 
     def requirements(self):
         self.requires("cereal/1.3.0")

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -29,7 +29,7 @@ class MoltenVKConan(ConanFile):
         "tools": True
     }
 
-    exports_sources = "CMakeLists.txt"
+    exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake"
     _cmake = None
 
@@ -48,47 +48,90 @@ class MoltenVKConan(ConanFile):
     def requirements(self):
         self.requires("cereal/1.3.0")
         self.requires("glslang/8.13.3559")
-        self.requires("spirv-cross/20210115")
-        self.requires("vulkan-headers/1.2.162.0")
+        self.requires("spirv-cross/{}".format(self._spirv_cross_version))
+        self.requires("vulkan-headers/{}".format(self._vulkan_headers_version))
         if self.options.with_spirv_tools:
             self.requires("spirv-tools/v2020.5")
+        if tools.Version(self.version) < "1.1.0":
+            raise ConanInvalidConfiguration("MoltenVK < 1.1.0 requires vulkan-portability")
+
+    @property
+    def _spirv_cross_version(self):
+        return {
+            "1.1.1": "20210115", # can't compile with spirv-cross < 20210115
+            "1.1.0": "20200917", # works with spirv-cross 20200917 only
+        }.get(self.version)
+
+    @property
+    def _vulkan_headers_version(self):
+        return {
+            "1.1.1": "1.2.162.0",
+            "1.1.0": "1.2.154.0",
+            "1.0.44": "1.2.148.0",
+            "1.0.43": "1.2.141.0",
+            "1.0.42": "1.2.141.0",
+            "1.0.41": "1.2.135.0",
+            "1.0.40": "1.2.131.1",
+            "1.0.39": "1.1.130.0",
+            "1.0.38": "1.1.126.0",
+            "1.0.37": "1.1.121.0",
+            "1.0.36": "1.1.114.0",
+            "1.0.35": "1.1.108.0",
+            "1.0.34": "1.1.106.0",
+            "1.0.33": "1.1.101.0",
+            "1.0.32": "1.1.97.0",
+            "1.0.31": "1.1.97.0",
+            "1.0.30": "1.1.92.0",
+            "1.0.29": "1.1.92.0",
+            "1.0.28": "1.1.92.0",
+            "1.0.27": "1.1.92.0",
+            "1.0.26": "1.1.85.0",
+            "1.0.25": "1.1.85.0",
+            "1.0.24": "1.1.85.0",
+            "1.0.23": "1.1.85.0",
+            "1.0.22": "1.1.82.0",
+            "1.0.21": "1.1.82.0",
+            "1.0.20": "1.1.82.0",
+            "1.0.19": "1.1.82.0",
+            "1.0.18": "1.1.82.0",
+            "1.0.17": "1.1.82.0",
+        }.get(self.version)
+
+    def package_id(self):
+        del self.info.settings.compiler.version
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("MoltenVK-" + self.version, self._source_subfolder)
 
-    def package_id(self):
-        del self.info.settings.compiler.version
-
     def _patch_sources(self):
-        # Note: All these fixes might be very specific to 1.1.1
-        # Properly include external spirv-cross headers
-        files_to_patch = [
-            os.path.join(self._source_subfolder, "MoltenVK", "MoltenVK", "GPUObjects", "MVKPixelFormats.h"),
-            os.path.join(self._source_subfolder, "MoltenVKShaderConverter", "Common", "SPIRVSupport.cpp"),
-            os.path.join(self._source_subfolder, "MoltenVKShaderConverter", "MoltenVKShaderConverter", "SPIRVReflection.h"),
-            os.path.join(self._source_subfolder, "MoltenVKShaderConverter", "MoltenVKShaderConverter", "SPIRVToMSLConverter.h")
-        ]
-        for file_to_patch in files_to_patch:
-            tools.replace_in_file(file_to_patch, "SPIRV-Cross", "spirv_cross")
-        # Provide a random spirv-cross hash
-        tools.replace_in_file(os.path.join(self._source_subfolder, "MoltenVK", "MoltenVK", "GPUObjects", "MVKDevice.mm"),
-                              "#include \"mvkGitRevDerived.h\"",
-                              "static const char* mvkRevString = \"fc0750d67cfe825b887dd2cf25a42e9d9a013eb2\";")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        if tools.Version(self.version) >= "1.1.0":
+            tools.replace_in_file(os.path.join(self._source_subfolder, "MoltenVK", "MoltenVK", "GPUObjects", "MVKDevice.mm"),
+                                  "#include \"mvkGitRevDerived.h\"",
+                                  "static const char* mvkRevString = \"{}\";".format(self._mvk_commit_hash))
+
+    @property
+    def _mvk_commit_hash(self):
+        return {
+            "1.1.1": "49de6604b0395057e7d3b7ce7001ed29b25708f7",
+            "1.1.0": "b9b78def172074872bfbb1015ccf75eeec554ae2",
+        }.get(self.version)
 
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        self._cmake.definitions["MVK_VERSION"] = self.version
         self._cmake.definitions["MVK_WITH_SPIRV_TOOLS"] = self.options.with_spirv_tools
         self._cmake.definitions["MVK_BUILD_SHADERCONVERTER_TOOL"] = self.options.tools
         self._cmake.configure()
         return self._cmake
 
     def build(self):
-        # Might depend on MoltenVK version
-        if tools.Version(self.settings.compiler.version) < 12:
-            raise ConanInvalidConfiguration("MoltenVK {} requires XCode 12+ at build time".format(self.version))
+        if tools.Version(self.version) >= "1.0.42" and tools.Version(self.settings.compiler.version) < "12":
+            raise ConanInvalidConfiguration("MoltenVK {} requires XCode 12 or higher at build time".format(self.version))
         self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -1,0 +1,88 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class MoltenVKConan(ConanFile):
+    name = "moltenvk"
+    description = "MoltenVK is a Vulkan Portability implementation. It " \
+                  "layers a subset of the high-performance, industry-standard " \
+                  "Vulkan graphics and compute API over Apple's Metal " \
+                  "graphics framework, enabling Vulkan applications to run " \
+                  "on iOS and macOS. "
+    license = "Apache-2.0"
+    topics = ("conan", "moltenvk", "khronos", "vulkan", "metal")
+    homepage = "https://github.com/KhronosGroup/MoltenVK"
+    url = "https://github.com/conan-io/conan-center-index"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake"
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+        if self.settings.os not in ["Macos", "iOS", "tvOS"]:
+            raise ConanInvalidConfiguration("MoltenVK only supported on MacOS, iOS and tvOS")
+
+    def requirements(self):
+        self.requires("cereal/1.3.0")
+        self.requires("glslang/8.13.3559")
+        self.requires("spirv-cross/20210115")
+        self.requires("spirv-tools/v2020.5")
+        self.requires("vulkan-headers/1.2.162.0")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("MoltenVK-" + self.version, self._source_subfolder)
+
+    def _patch_sources(self):
+        # Note: All these fixes might be very specific to 1.1.1
+        # Properly include external spirv-cross headers
+        files_to_patch = [
+            os.path.join(self._source_subfolder, "MoltenVK", "MoltenVK", "GPUObjects", "MVKPixelFormats.h"),
+            os.path.join(self._source_subfolder, "MoltenVKShaderConverter", "Common", "SPIRVSupport.cpp"),
+            os.path.join(self._source_subfolder, "MoltenVKShaderConverter", "MoltenVKShaderConverter", "SPIRVReflection.h"),
+            os.path.join(self._source_subfolder, "MoltenVKShaderConverter", "MoltenVKShaderConverter", "SPIRVToMSLConverter.h")
+        ]
+        for file_to_patch in files_to_patch:
+            tools.replace_in_file(file_to_patch, "SPIRV-Cross", "spirv_cross")
+        # Provide a random spirv-cross hash
+        tools.replace_in_file(os.path.join(self._source_subfolder, "MoltenVK", "MoltenVK", "GPUObjects", "MVKDevice.mm"),
+                              "#include \"mvkGitRevDerived.h\"",
+                              "static const char* mvkRevString = \"fc0750d67cfe825b887dd2cf25a42e9d9a013eb2\";")
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        self._patch_sources()
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["MoltenVK"]
+        self.cpp_info.frameworks = ["Metal", "Foundation", "QuartzCore", "AppKit", "IOSurface"]
+        if self.settings.os == "Macos":
+            self.cpp_info.frameworks.append("IOKit")
+        elif self.settings.os in ["iOS", "tvOS"]:
+            self.cpp_info.frameworks.append("UIKit")

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -34,6 +34,9 @@ class MoltenVKConan(ConanFile):
             tools.check_min_cppstd(self, 11)
         if self.settings.os not in ["Macos", "iOS", "tvOS"]:
             raise ConanInvalidConfiguration("MoltenVK only supported on MacOS, iOS and tvOS")
+        # Might depend on MoltenVK version
+        if tools.Version(self.settings.compiler.version) < 11:
+            raise ConanInvalidConfiguration("MoltenVK {} requires macos-sdk 10.15+ (XCode 11 or higher)".format(self.version))
 
     def requirements(self):
         self.requires("cereal/1.3.0")

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -11,7 +11,7 @@ class MoltenVKConan(ConanFile):
                   "layers a subset of the high-performance, industry-standard " \
                   "Vulkan graphics and compute API over Apple's Metal " \
                   "graphics framework, enabling Vulkan applications to run " \
-                  "on iOS and macOS. "
+                  "on iOS and macOS."
     license = "Apache-2.0"
     topics = ("conan", "moltenvk", "khronos", "vulkan", "metal")
     homepage = "https://github.com/KhronosGroup/MoltenVK"

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -44,9 +44,6 @@ class MoltenVKConan(ConanFile):
             tools.check_min_cppstd(self, 11)
         if self.settings.os not in ["Macos", "iOS", "tvOS"]:
             raise ConanInvalidConfiguration("MoltenVK only supported on MacOS, iOS and tvOS")
-        # Might depend on MoltenVK version
-        if tools.Version(self.settings.compiler.version) < 11:
-            raise ConanInvalidConfiguration("MoltenVK {} requires macos-sdk 10.15+ (XCode 11 or higher)".format(self.version))
 
     def requirements(self):
         self.requires("cereal/1.3.0")
@@ -59,6 +56,9 @@ class MoltenVKConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("MoltenVK-" + self.version, self._source_subfolder)
+
+    def package_id(self):
+        del self.info.settings.compiler.version
 
     def _patch_sources(self):
         # Note: All these fixes might be very specific to 1.1.1
@@ -86,6 +86,9 @@ class MoltenVKConan(ConanFile):
         return self._cmake
 
     def build(self):
+        # Might depend on MoltenVK version
+        if tools.Version(self.settings.compiler.version) < 12:
+            raise ConanInvalidConfiguration("MoltenVK {} requires XCode 12+ at build time".format(self.version))
         self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -55,7 +55,8 @@ class MoltenVKConan(ConanFile):
         if self.options.with_spirv_tools:
             self.requires("spirv-tools/v2020.5")
         if tools.Version(self.version) < "1.1.0":
-            raise ConanInvalidConfiguration("MoltenVK < 1.1.0 requires vulkan-portability")
+            raise ConanInvalidConfiguration("MoltenVK < 1.1.0 requires vulkan-portability, not yet available in CCI")
+            self.requires("vulkan-portability/0.2")
 
     @property
     def _spirv_cross_version(self):

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.32.0"
+
 
 class MoltenVKConan(ConanFile):
     name = "moltenvk"
@@ -106,6 +108,11 @@ class MoltenVKConan(ConanFile):
                 compatible_pkg.settings.compiler.version = "12.0"
                 self.compatible_packages.append(compatible_pkg)
 
+    def validate(self):
+        if tools.Version(self.version) >= "1.0.42":
+            if tools.Version(self.settings.compiler.version) < "12.0":
+                raise ConanInvalidConfiguration("MoltenVK {} requires XCode 12.0 or higher at build time".format(self.version))
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("MoltenVK-" + self.version, self._source_subfolder)
@@ -136,9 +143,6 @@ class MoltenVKConan(ConanFile):
         return self._cmake
 
     def build(self):
-        if tools.Version(self.version) >= "1.0.42":
-            if tools.Version(self.settings.compiler.version) < "12.0":
-                raise ConanInvalidConfiguration("MoltenVK {} requires XCode 12.0 or higher at build time".format(self.version))
         self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -107,7 +107,7 @@ class MoltenVKConan(ConanFile):
         }[self.version]
 
     def package_id(self):
-        # MoltenVK >=1.42 requires at least XCode 12.0 (11.4 actually) at build
+        # MoltenVK >=1.O.42 requires at least XCode 12.0 (11.4 actually) at build
         # time but can be consumed by older compiler versions
         if tools.Version(self.version) >= "1.0.42":
             if tools.Version(self.settings.compiler.version) < "12.0":

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -61,8 +61,14 @@ class MoltenVKConan(ConanFile):
     def _spirv_cross_version(self):
         return {
             "1.1.1": "20210115", # can't compile with spirv-cross < 20210115
-            "1.1.0": "20200917", # works with spirv-cross 20200917 only
-        }.get(self.version)
+            "1.1.0": "20200917", # compiles only with spirv-cross 20200917
+            "1.0.44": "20200917", # compiles only with spirv-cross 20200917
+            "1.0.43": "20200519", # compiles only with spirv-cross 20200519
+            "1.0.42": "20200519", # compiles only with spirv-cross 20200519
+            "1.0.41": "20200519", # compiles only with spirv-cross 20200403 or 20200519
+            "1.0.40": "20200519", # compiles only with spirv-cross 20200403 or 20200519
+            "1.0.39": "20200519", # compiles only with spirv-cross 20200403 or 20200519
+        }[self.version]
 
     @property
     def _vulkan_headers_version(self):
@@ -97,7 +103,7 @@ class MoltenVKConan(ConanFile):
             "1.0.19": "1.1.82.0",
             "1.0.18": "1.1.82.0",
             "1.0.17": "1.1.82.0",
-        }.get(self.version)
+        }[self.version]
 
     def package_id(self):
         # MoltenVK >=1.42 requires at least XCode 12.0 (11.4 actually) at build

--- a/recipes/moltenvk/all/patches/0001-fix-spirv-cross-includes-1.1.x.patch
+++ b/recipes/moltenvk/all/patches/0001-fix-spirv-cross-includes-1.1.x.patch
@@ -1,0 +1,52 @@
+--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
++++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+@@ -22,7 +22,7 @@
+ #include "MVKEnvironment.h"
+ #include "MVKOSExtensions.h"
+ #include "MVKBaseObject.h"
+-#include <SPIRV-Cross/spirv_msl.hpp>
++#include <spirv_cross/spirv_msl.hpp>
+ #include <unordered_map>
+ 
+ #import <Metal/Metal.h>
+--- a/MoltenVKShaderConverter/Common/SPIRVSupport.cpp
++++ b/MoltenVKShaderConverter/Common/SPIRVSupport.cpp
+@@ -18,7 +18,7 @@
+ 
+ #include "SPIRVSupport.h"
+ #include "MVKStrings.h"
+-#include <SPIRV-Cross/spirv.hpp>
++#include <spirv_cross/spirv.hpp>
+ #include <ostream>
+ 
+ #import <CoreFoundation/CFByteOrder.h>
+--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVReflection.h
++++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVReflection.h
+@@ -19,10 +19,10 @@
+ #ifndef __SPIRVReflection_h_
+ #define __SPIRVReflection_h_ 1
+ 
+-#include <SPIRV-Cross/spirv.hpp>
+-#include <SPIRV-Cross/spirv_common.hpp>
+-#include <SPIRV-Cross/spirv_parser.hpp>
+-#include <SPIRV-Cross/spirv_reflect.hpp>
++#include <spirv_cross/spirv.hpp>
++#include <spirv_cross/spirv_common.hpp>
++#include <spirv_cross/spirv_parser.hpp>
++#include <spirv_cross/spirv_reflect.hpp>
+ #include <string>
+ #include <vector>
+ 
+--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.h
++++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.h
+@@ -19,8 +19,8 @@
+ #ifndef __SPIRVToMSLConverter_h_
+ #define __SPIRVToMSLConverter_h_ 1
+ 
+-#include <SPIRV-Cross/spirv.hpp>
+-#include <SPIRV-Cross/spirv_msl.hpp>
++#include <spirv_cross/spirv.hpp>
++#include <spirv_cross/spirv_msl.hpp>
+ #include <string>
+ #include <vector>
+ #include <unordered_map>

--- a/recipes/moltenvk/all/test_package/CMakeLists.txt
+++ b/recipes/moltenvk/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/moltenvk/all/test_package/conanfile.py
+++ b/recipes/moltenvk/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/moltenvk/all/test_package/test_package.cpp
+++ b/recipes/moltenvk/all/test_package/test_package.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+
+#include <vulkan/vulkan.hpp>
+
+int main()
+{
+    vk::ApplicationInfo appInfo;
+    appInfo.pApplicationName = "ConanTestApp";
+    appInfo.pEngineName = "ConanTestEngine";
+    appInfo.apiVersion = VK_API_VERSION_1_0;
+
+    vk::InstanceCreateInfo instanceCreateInfo;
+    instanceCreateInfo.pApplicationInfo = &appInfo;
+
+    try
+    {
+        vk::Instance instance = vk::createInstance(instanceCreateInfo);
+
+        auto physicalDevices = instance.enumeratePhysicalDevices();
+        auto physicalDevice = physicalDevices[0];
+        auto deviceProperties = physicalDevice.getProperties();
+        auto deviceMemoryProperties = physicalDevice.getMemoryProperties();
+
+        std::cout << "Vulkan device created" << std::endl;
+        std::cout << "API Version:    " << deviceProperties.apiVersion << std::endl;
+        std::cout << "Driver Version: " << deviceProperties.driverVersion << std::endl;
+        std::cout << "Device Name:    " << deviceProperties.deviceName << std::endl;
+        std::cout << "Device Type:    " << vk::to_string(deviceProperties.deviceType) << std::endl;
+        std::cout << "Memory Heaps:   " << deviceMemoryProperties.memoryHeapCount << std::endl;
+    }
+    catch(const vk::SystemError& e)
+    {
+        std::cerr << e.what() << '\n';
+    }
+
+    return 0;
+}

--- a/recipes/moltenvk/config.yml
+++ b/recipes/moltenvk/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **moltenvk/1.1.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

closes https://github.com/conan-io/conan-center-index/issues/4353

I gave up with upstream xcode build files (mainly due to upstream mechanism for dependencies handling) and decided to write a CMakeLists from scratch. Usage of GLOB and GLOB_RECURSE should allow some portability across versions.
If someone is able to provide a recipe relying on upstream XCode build files, with the guarantee to honor conan profile, and not relying on vendored dependencies, feel free to contribute.

I still don't know how to avoid that consumers have vulkan-loader in their dependency graph if they link to MoltenVK (you can have vulkan-loader and MoltenVK in the dependency graph if MoltenVK is used as an ICD).