### PR TITLE
enable usage of new FindPython modules

### DIFF
--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -69,5 +69,4 @@ class PyBind11Conan(ConanFile):
 
         def get_path(filename):
             return os.path.join(cmake_base_path, filename)
-        self.cpp_info.build_modules = [get_path("FindPythonLibsNew.cmake"),
-                                       get_path("pybind11Install.cmake")]
+        self.cpp_info.build_modules = [get_path("pybind11Install.cmake")]


### PR DESCRIPTION
Specify library name and version:  **pybind11/2.6.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This minor change enables the use of the new `FindPython` modes in CMake as per the [pybind11 documentation](https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode).

The `FindPythonLibsNew.cmake` file is included by `pybind11Install` indirectly depending on whether the new mode is used.