### PR TITLE
[picojson] bump to master + update recipe

### DIFF
--- a/recipes/picojson/all/conandata.yml
+++ b/recipes/picojson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+    "cci.20210117":
+        url: "https://github.com/kazuho/picojson/archive/111c9be5188f7350c2eac9ddaedd8cca3d7bf394.zip"
+        sha256: 9937fc918d32a2e802a32e1565f48b04850ece0389ce22e8e3acba54aee13c99
     "1.3.0":
         url: "https://github.com/kazuho/picojson/archive/v1.3.0.zip"
-        sha256: "58fff34589d93b0cef208a456788b9de6c7d04cfa9a7be576328ca7b48f10069"
+        sha256: 58fff34589d93b0cef208a456788b9de6c7d04cfa9a7be576328ca7b48f10069

--- a/recipes/picojson/all/conanfile.py
+++ b/recipes/picojson/all/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, tools
+import os, glob
 
-import os
 
 class PicoJSONConan(ConanFile):
     name = "picojson"
@@ -9,17 +9,17 @@ class PicoJSONConan(ConanFile):
     homepage = "https://github.com/kazuho/picojson"
     description = "A C++ JSON parser/serializer"
     topics = ("picojson", "json", "header-only", "conan-recipe")
-
     no_copy_source = True
-    _source_subdir_name = "source_subdir"
+
+    _source_subfolder = "source_subfolder"
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        os.rename("picojson-{}".format(self.version), self._source_subdir_name)
+        os.rename(glob.glob("picojson-*")[0], self._source_subfolder)
 
     def package(self):
-        self.copy("{}.h".format(self.name), dst="include", src=self._source_subdir_name)
-        self.copy("LICENSE", dst="licenses", src=self._source_subdir_name)
+        self.copy("{}.h".format(self.name), dst="include", src=self._source_subfolder)
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
 
     def package_info(self):
         self.info.header_only()

--- a/recipes/picojson/config.yml
+++ b/recipes/picojson/config.yml
@@ -1,3 +1,5 @@
 versions:
+    "cci.20210117":
+        folder: all
     "1.3.0":
         folder: all


### PR DESCRIPTION
There's a security fix that I would like... Almost 6 years since the last release

Specify library name and version:  **picojson/cci.20210117**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
