### PR TITLE
b2/4.2.0: fix building failure on FreeBSD

### DIFF
--- a/recipes/b2/standard/conanfile.py
+++ b/recipes/b2/standard/conanfile.py
@@ -77,9 +77,8 @@ class B2Conan(ConanFile):
         os.chdir(build_dir)
         command = os.path.join(
             engine_dir, "b2.exe" if use_windows_commands else "b2")
-        full_command = \
-            "{0} --ignore-site-config --prefix=../output --abbreviate-paths install".format(
-                command)
+        full_command = "{0} --ignore-site-config --prefix=../output --abbreviate-paths" \
+                       " toolset={1} install".format(command, self.options.toolset)
         self.run(full_command)
 
     def package(self):


### PR DESCRIPTION
Specify library name and version:  **b2/4.2.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

The reason causing to building failure is that the `toolset` option is not correctly passed to `b2` command, even user explicitly specified. That means `conan` always invokes `b2` command with `toolset=auto`, which is the default option. The base system of FreeBSD doesn't contain gcc while `toolset=auto` would imply to take gcc as the default toolset on FreeBSD. So, `conan` complains "g++ not found" error while building b2/4.2.0. To reproduce this error on other systems, we could install a new C++ compiler and remove the default one. Then the error occurs when `conan install -b b2 -o b2:toolset="new one" b2/4.2.0`.
