### PR TITLE
[benchmark] Fix broken armv8 builds by not inferring 32-bit build option

### DIFF
--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -18,9 +18,10 @@ class BenchmarkConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "enable_lto": [True, False],
-        "enable_exceptions": [True, False]
+        "enable_exceptions": [True, False],
+        "build_32_bits": [True, False]
     }
-    default_options = {"shared": False, "fPIC": True, "enable_lto": False, "enable_exceptions": True}
+    default_options = {"shared": False, "fPIC": True, "enable_lto": False, "enable_exceptions": True, "build_32_bits": False}
 
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
@@ -51,6 +52,7 @@ class BenchmarkConan(ConanFile):
         self._cmake.definitions["BENCHMARK_ENABLE_GTEST_TESTS"] = "OFF"
         self._cmake.definitions["BENCHMARK_ENABLE_LTO"] = "ON" if self.options.enable_lto else "OFF"
         self._cmake.definitions["BENCHMARK_ENABLE_EXCEPTIONS"] = "ON" if self.options.enable_exceptions else "OFF"
+        self._cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "ON" if self.options.build_32_bits else "OFF"
 
         # See https://github.com/google/benchmark/pull/638 for Windows 32 build explanation
         if self.settings.os != "Windows":
@@ -58,8 +60,6 @@ class BenchmarkConan(ConanFile):
                 self._cmake.definitions["HAVE_STD_REGEX"] = False
                 self._cmake.definitions["HAVE_POSIX_REGEX"] = False
                 self._cmake.definitions["HAVE_STEADY_CLOCK"] = False
-            else:
-                self._cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "ON" if "64" not in str(self.settings.arch) else "OFF"
             self._cmake.definitions["BENCHMARK_USE_LIBCXX"] = "ON" if (str(self.settings.compiler.libcxx) == "libc++") else "OFF"
         else:
             self._cmake.definitions["BENCHMARK_USE_LIBCXX"] = "OFF"

--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -60,7 +60,6 @@ class BenchmarkConan(ConanFile):
         self._cmake.definitions["BENCHMARK_ENABLE_EXCEPTIONS"] = "ON" if self.options.enable_exceptions else "OFF"
         self._cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "ON" if self.options.build_32_bits else "OFF"
 
-        # See https://github.com/google/benchmark/pull/638 for Windows 32 build explanation
         if self.settings.os != "Windows":
             if tools.cross_building(self.settings):
                 self._cmake.definitions["HAVE_STD_REGEX"] = False

--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -19,14 +19,12 @@ class BenchmarkConan(ConanFile):
         "fPIC": [True, False],
         "enable_lto": [True, False],
         "enable_exceptions": [True, False],
-        "build_32_bits": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "enable_lto": False,
         "enable_exceptions": True,
-        "build_32_bits": False
     }
 
     _source_subfolder = "source_subfolder"
@@ -58,7 +56,6 @@ class BenchmarkConan(ConanFile):
         self._cmake.definitions["BENCHMARK_ENABLE_GTEST_TESTS"] = "OFF"
         self._cmake.definitions["BENCHMARK_ENABLE_LTO"] = "ON" if self.options.enable_lto else "OFF"
         self._cmake.definitions["BENCHMARK_ENABLE_EXCEPTIONS"] = "ON" if self.options.enable_exceptions else "OFF"
-        self._cmake.definitions["BENCHMARK_BUILD_32_BITS"] = "ON" if self.options.build_32_bits else "OFF"
 
         if self.settings.os != "Windows":
             if tools.cross_building(self.settings):

--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -21,7 +21,13 @@ class BenchmarkConan(ConanFile):
         "enable_exceptions": [True, False],
         "build_32_bits": [True, False]
     }
-    default_options = {"shared": False, "fPIC": True, "enable_lto": False, "enable_exceptions": True, "build_32_bits": False}
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "enable_lto": False,
+        "enable_exceptions": True,
+        "build_32_bits": False
+    }
 
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

# Reason for change
Currently, all builds for armv8 (like Raspberry PI 4, NVIDIA Jetson) fail because of a check that makes no sense for armv8 platforms. The CMake option BENCHMARK_BUILD_32_BITS is automatically set to ON if the settings.arch string doesn't contain the number "64". This can never be the case if settings.arch == "armv8" (which is a 64-bit platform). Hence, on armv8 platforms, BENCHMARK_BUILD_32_BITS is always on, which during compilation leads to the use of the '-m32' compiler switch. This switch is not supported by gcc, so the building with gcc on armv8 is not possible. This is a BIG BIG BIG problem!

# Change
After the fix, the CMake BENCHMARK_BUILD_32_BITS option is not derived from the value of the settings.arch string. If a user wants a 32-bit build, they have to manually set the option "build_32_bits" to set the corresponding CMake option "BENCHMARK_BUILD_32_BITS".