### PR TITLE
Fixes conan-io#4674.  Adds --sysconfdir=/etc to configuration settings.

### DIFF
--- a/recipes/odbc/all/conanfile.py
+++ b/recipes/odbc/all/conanfile.py
@@ -57,7 +57,8 @@ class OdbcConan(ConanFile):
         args = ["--enable-static=%s" % static_flag,
                 "--enable-shared=%s" % shared_flag,
                 "--enable-ltdl-install",
-                "--enable-iconv=%s" % libiconv_flag]
+                "--enable-iconv=%s" % libiconv_flag,
+                "--sysconfdir=/etc"]
         if self.options.with_libiconv:
             libiconv_prefix = self.deps_cpp_info["libiconv"].rootpath
             args.append("--with-libiconv-prefix=%s" % libiconv_prefix)


### PR DESCRIPTION
Specify library name and version:  **odbc/2.3.7**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
