### PR TITLE
gtsam/4.0.3 disable -march=native fix

### DIFF
--- a/recipes/gtsam/all/conanfile.py
+++ b/recipes/gtsam/all/conanfile.py
@@ -17,6 +17,7 @@ class gtsamConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False],
                "fPIC": [True, False],
+               "with_march_native": [True, False],
                "use_quaternions": [True, False],
                "pose3_expmap": [True, False],
                "rot3_expmap": [True, False],
@@ -41,6 +42,7 @@ class gtsamConan(ConanFile):
 
     default_options = {"shared": False,
                        "fPIC": True,
+                        "with_march_native": True,
                         "use_quaternions": False,
                         "pose3_expmap": False,
                         "rot3_expmap": False,
@@ -95,6 +97,7 @@ class gtsamConan(ConanFile):
             self._cmake.definitions["GTSAM_BUILD_DOC_HTML"] = False
             self._cmake.definitions["GTSAM_BUILD_EXAMPLES_ALWAYS"] = False
             self._cmake.definitions["GTSAM_BUILD_WRAP"] = self.options.build_wrap
+            self._cmake.definitions["GTSAM_BUILD_WITH_MARCH_NATIVE"] = self.options.with_march_native
             self._cmake.definitions["GTSAM_WRAP_SERIALIZATION"] = self.options.wrap_serialization
             self._cmake.definitions["GTSAM_INSTALL_MATLAB_TOOLBOX"] = self.options.install_matlab_toolbox
             self._cmake.definitions["GTSAM_INSTALL_CYTHON_TOOLBOX"] = self.options.install_cython_toolbox

--- a/recipes/gtsam/all/conanfile.py
+++ b/recipes/gtsam/all/conanfile.py
@@ -17,7 +17,6 @@ class gtsamConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False],
                "fPIC": [True, False],
-               "with_march_native": [True, False],
                "use_quaternions": [True, False],
                "pose3_expmap": [True, False],
                "rot3_expmap": [True, False],
@@ -42,7 +41,6 @@ class gtsamConan(ConanFile):
 
     default_options = {"shared": False,
                        "fPIC": True,
-                        "with_march_native": False,
                         "use_quaternions": False,
                         "pose3_expmap": False,
                         "rot3_expmap": False,
@@ -97,7 +95,7 @@ class gtsamConan(ConanFile):
             self._cmake.definitions["GTSAM_BUILD_DOC_HTML"] = False
             self._cmake.definitions["GTSAM_BUILD_EXAMPLES_ALWAYS"] = False
             self._cmake.definitions["GTSAM_BUILD_WRAP"] = self.options.build_wrap
-            self._cmake.definitions["GTSAM_BUILD_WITH_MARCH_NATIVE"] = self.options.with_march_native
+            self._cmake.definitions["GTSAM_BUILD_WITH_MARCH_NATIVE"] = False
             self._cmake.definitions["GTSAM_WRAP_SERIALIZATION"] = self.options.wrap_serialization
             self._cmake.definitions["GTSAM_INSTALL_MATLAB_TOOLBOX"] = self.options.install_matlab_toolbox
             self._cmake.definitions["GTSAM_INSTALL_CYTHON_TOOLBOX"] = self.options.install_cython_toolbox

--- a/recipes/gtsam/all/conanfile.py
+++ b/recipes/gtsam/all/conanfile.py
@@ -42,7 +42,7 @@ class gtsamConan(ConanFile):
 
     default_options = {"shared": False,
                        "fPIC": True,
-                        "with_march_native": True,
+                        "with_march_native": False,
                         "use_quaternions": False,
                         "pose3_expmap": False,
                         "rot3_expmap": False,


### PR DESCRIPTION
Specify library name and version:  **gtsam/4.0.3**

adding a new option `with_march_native` that makes it possible to disable passing `-march=native`.

Default behavior is now changed to `GTSAM_BUILD_WITH_MARCH_NATIVE=OFF`.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
