### PR TITLE
Remove docs option for xkbcommon

### DIFF
--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -17,6 +17,7 @@ class XkbcommonConan(ConanFile):
         "with_x11": [True, False],
         "with_wayland": [True, False],
         "xkbregistry": [True, False],
+        "docs": [True, False, "deprecated"]
     }
     default_options = {
         "shared": False,
@@ -24,6 +25,7 @@ class XkbcommonConan(ConanFile):
         "with_x11": True,
         "with_wayland": False,
         "xkbregistry": True,
+        "docs": "deprecated"
     }
 
     generators = "pkg_config"
@@ -49,6 +51,8 @@ class XkbcommonConan(ConanFile):
     def configure(self):
         if self.settings.os not in ["Linux", "FreeBSD"]:
             raise ConanInvalidConfiguration("This library is only compatible with Linux or FreeBSD")
+        if self.options.docs != "deprecated":
+            self.output.warn("'docs' option is deprecated. Do not use.")
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
@@ -103,6 +107,9 @@ class XkbcommonConan(ConanFile):
         meson.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_id(self):
+        del self.info.options.docs
 
     def package_info(self):
         self.cpp_info.names["pkg_config"] = "xkbcommon_full_package" # unofficial, but required to avoid side effects (libxkbcommon component "steals" the default global pkg_config name)

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -17,7 +17,6 @@ class XkbcommonConan(ConanFile):
         "with_x11": [True, False],
         "with_wayland": [True, False],
         "xkbregistry": [True, False],
-        "docs": [True, False]
     }
     default_options = {
         "shared": False,
@@ -25,7 +24,6 @@ class XkbcommonConan(ConanFile):
         "with_x11": True,
         "with_wayland": False,
         "xkbregistry": True,
-        "docs": False
     }
 
     generators = "pkg_config"
@@ -73,7 +71,6 @@ class XkbcommonConan(ConanFile):
             return self._meson
         defs={
             "enable-wayland": self.options.with_wayland,
-            "enable-docs": self.options.docs,
             "enable-x11": self.options.with_x11,
             "libdir": os.path.join(self.package_folder, "lib"),
             "default_library": ("shared" if self.options.shared else "static")}

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -71,6 +71,7 @@ class XkbcommonConan(ConanFile):
             return self._meson
         defs={
             "enable-wayland": self.options.with_wayland,
+            "enable-docs": False,
             "enable-x11": self.options.with_x11,
             "libdir": os.path.join(self.package_folder, "lib"),
             "default_library": ("shared" if self.options.shared else "static")}


### PR DESCRIPTION
Specify library name and version:  **xkbcommon/1.0.3**

Usually I would say, removing any option is not allowed, because you may break some user.

However, `docs` is totally broken, it requires Doxygen (it's not installed by default in Conan Docker images) and all documentation is installed in share/ folder, which is excluded during package method.

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
