### PR TITLE
openssl: fix rt dependency for SUSE11

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -781,7 +781,7 @@ class OpenSSLConan(ConanFile):
         if self.settings.os == "Windows":
             self.cpp_info.components["crypto"].system_libs.extend(["crypt32", "ws2_32", "advapi32", "user32"])
         elif self.settings.os == "Linux":
-            self.cpp_info.components["crypto"].system_libs.append("dl")
+            self.cpp_info.components["crypto"].system_libs.extend(["dl", "rt"])
             self.cpp_info.components["ssl"].system_libs.append("dl")
             if not self.options.no_threads:
                 self.cpp_info.components["crypto"].system_libs.append("pthread")


### PR DESCRIPTION
openssl::crypto uses clock_gettime() that requires `-lrt` on SUSE.

Specify library name and version:  **openssl/1.1.1i**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
