### PR TITLE
Bump odbc to 2.3.9

### DIFF
--- a/recipes/odbc/all/conandata.yml
+++ b/recipes/odbc/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "2.3.7":
     url: "http://www.unixodbc.org/unixODBC-2.3.7.tar.gz"
     sha256: "45f169ba1f454a72b8fcbb82abd832630a3bf93baa84731cf2949f449e1e3e77"
+  "2.3.9":
+    url: "http://www.unixodbc.org/unixODBC-2.3.9.tar.gz"
+    sha256: "52833eac3d681c8b0c9a5a65f2ebd745b3a964f208fc748f977e44015a31b207"
 patches:
   "2.3.7":
     - patch_file: "patches/missing-declarations.patch"

--- a/recipes/odbc/config.yml
+++ b/recipes/odbc/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.3.7":
     folder: all
+  "2.3.9":
+    folder: all


### PR DESCRIPTION
Fixes #4702

Specify library name and version:  **odbc/2.3.9**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

The existing patch for 2.3.7 didn't apply and it looks like the fix may have been made upstream but I'm not 100% clear on the intention of the patch.  

@SpaceIm, could you take a look?  The upstream fix is https://github.com/lurcher/unixODBC/commit/ca226e2e94f68ef7eee5ed9b6368f6550e3ecd56#diff-1bf1faa7ca7b442fc9abf362144fb1848e66b29b8849ca9a8e86b85085db93d1R187.  If not could you let me know what the intention is and how to validate a patch for it? (perhaps in the `test_package`).   Thanks!
