### PR TITLE
oatpp: add version 1.2.5

### DIFF
--- a/recipes/oatpp/all/conandata.yml
+++ b/recipes/oatpp/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "1.2.0":
     url: "https://github.com/oatpp/oatpp/archive/1.2.0.tar.gz"
     sha256: "7f55669827ece429b6d85f4403b76da717d3fdf0e92721e9a0229cf8168e8e37"
+  "1.2.5":
+    url: "https://github.com/oatpp/oatpp/archive/1.2.5.tar.gz"
+    sha256: "36276e8b23e68ece1e6093c3f06fc80e3d42a5f4e47cdeef5e7e63f36eeddaad"

--- a/recipes/oatpp/config.yml
+++ b/recipes/oatpp/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "1.2.0":
     folder: all
+  "1.2.5":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
