### PR TITLE
Repoint b2 to new bfgroup home.

### DIFF
--- a/recipes/b2/config.yml
+++ b/recipes/b2/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: portable
   "4.4.1":
     folder: portable
+  "4.4.2":
+    folder: portable

--- a/recipes/b2/portable/conandata.yml
+++ b/recipes/b2/portable/conandata.yml
@@ -1,10 +1,13 @@
 sources:
   "4.3.0":
-    sha256: 97eb98343da636c314edccb08173e25cea13b155233ebb4d74e065d55f791364
-    url: https://github.com/boostorg/build/archive/4.3.0.tar.gz
+    sha256: 138c90b66edb0a28e225705a2cbf897a8cef5f87e68befc748f8e6808e21628a
+    url: https://github.com/bfgroup/b2/archive/4.3.0.tar.gz
   "4.4.0":
-    sha256: b414592b25679ec356b96d50940d5f458fb1c6799dd10a39ac6f2e3974cc5431
-    url: https://github.com/boostorg/build/archive/4.4.0.tar.gz
+    sha256: fa4079370644110604895ff08057fe2eff3289bcffdaec55fcdf43ea33ff25a8
+    url: https://github.com/bfgroup/b2/archive/4.4.0.tar.gz
   "4.4.1":
-    sha256: 31a243b1eb26638500977a8386e56d44f86c18db70cf0a5dcdd2d7391afc1a61
-    url: https://github.com/boostorg/build/archive/4.4.1.tar.gz
+    sha256: 4fb15abd994968a24868c13502f080c4a28b20f59831acf9eabd64a3b257554f
+    url: https://github.com/bfgroup/b2/archive/4.4.1.tar.gz
+  "4.4.2":
+    sha256: 575e59b89191a6a6780d7165cae3222b8a7a1e7d5e8165b3524eefe32fc3de46
+    url: https://github.com/bfgroup/b2/archive/4.4.2.tar.gz

--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -5,9 +5,9 @@ import os
 
 class B2Conan(ConanFile):
     name = "b2"
-    homepage = "https://boostorg.github.io/build/"
+    homepage = "https://www.bfgroup.xyz/b2/"
     description = "B2 makes it easy to build C++ projects, everywhere."
-    topics = ("conan", "installer", "boost", "builder")
+    topics = ("conan", "installer", "builder")
     license = "BSL-1.0"
     settings = "os", "arch"
     url = "https://github.com/conan-io/conan-center-index"
@@ -53,7 +53,7 @@ class B2Conan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "build-" + \
+        extracted_dir = "b2-" + \
             os.path.basename(self.conan_data["sources"][self.version]['url']).replace(
                 ".tar.gz", "")
         os.rename(extracted_dir, "source")


### PR DESCRIPTION
Specify library name and version:  **b2/4.4.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

These are change to adjust b2 for it's new official home in the Build Frameworks Group github organization. In additional to repointing the existing versions it adds a 4.4.2 BFG specific re-release of 4.4.1.
