### PR TITLE
(#3476) OpenSSL: change default openssldir value on Linux

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -436,9 +436,14 @@ class OpenSSLConan(ConanFile):
             self._env_build = AutoToolsBuildEnvironment(self)
         return self._env_build
 
+    def _get_default_openssl_dir(self):
+        if self.settings.os == "Linux" and self._full_version >= "1.1.0":
+            return "/etc/ssl"
+        return os.path.join(self.package_folder, "res")
+
     @property
     def _configure_args(self):
-        openssldir = self.options.openssldir if self.options.openssldir else os.path.join(self.package_folder, "res")
+        openssldir = self.options.openssldir or self._get_default_openssl_dir()
         prefix = tools.unix_path(self.package_folder) if self._win_bash else self.package_folder
         openssldir = tools.unix_path(openssldir) if self._win_bash else openssldir
         args = [


### PR DESCRIPTION
Specify library name and version:  **openssl/1.x.x**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

This patch modifies the default value of the "openssldir" option on Linux to "/etc/ssl" to solve issue #3476

resolves #3476