### PR TITLE
glib: add version 2.67.5

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -35,3 +35,6 @@ sources:
   "2.67.4":
     url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.4/glib-2.67.4.tar.gz"
     sha256: "ec82bcb30d696e3b4679b3134db1f418dabc034f3b6180ebbb40b1815d09e3d7"
+  "2.67.5":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.5/glib-2.67.5.tar.gz"
+    sha256: "410966db712638dc749054c0a3c3087545d5106643139c25806399a51a8d4ab1"

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -23,3 +23,5 @@ versions:
     folder: all
   "2.67.4":
     folder: all
+  "2.67.5":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **glib/2.67.5**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
