### PR TITLE
boost: use clang-win toolset when compiler=Visual Studio and compiler.toolset=ClangCL

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1052,7 +1052,7 @@ class BoostConan(ConanFile):
     @property
     def _toolset(self):
         if self._is_msvc:
-            return "msvc"
+            return "clang-win" if self.settings.compiler.toolset == "ClangCL" else "msvc"
         elif self.settings.os == "Windows" and self.settings.compiler == "clang":
             return "clang-win"
         elif self.settings.os == "Emscripten" and self.settings.compiler == "clang":


### PR DESCRIPTION
Specify library name and version:  **boost/1.75.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

fixes #4727