### PR TITLE
add vulkan-loader/1.2.154.0

### DIFF
--- a/recipes/vulkan-loader/all/conandata.yml
+++ b/recipes/vulkan-loader/all/conandata.yml
@@ -5,3 +5,10 @@ sources:
   "1.2.162.0":
     url: "https://github.com/KhronosGroup/Vulkan-Loader/archive/sdk-1.2.162.0.tar.gz"
     sha256: "f8f5ec2485e7fdba3f58c1cde5a25145ece1c6a686c91ba4016b28c0af3f21dd"
+  "1.2.154.0":
+    url: "https://github.com/KhronosGroup/Vulkan-Loader/archive/sdk-1.2.154.0.tar.gz"
+    sha256: "418017d7bab907e72291476df231dd0e7dc7fe20b97e55389c975bcfc48d6433"
+patches:
+  "1.2.154.0":
+    - patch_file: "patches/fix-mingw.patch"
+      base_path: "source_subfolder"

--- a/recipes/vulkan-loader/all/conanfile.py
+++ b/recipes/vulkan-loader/all/conanfile.py
@@ -30,7 +30,7 @@ class VulkanLoaderConan(ConanFile):
         "with_wsi_directfb": False,
     }
 
-    exports_sources = "CMakeLists.txt"
+    exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake", "pkg_config"
     _cmake = None
 
@@ -87,6 +87,8 @@ class VulkanLoaderConan(ConanFile):
         os.rename(glob.glob("Vulkan-Loader-*")[0], self._source_subfolder)
 
     def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         tools.replace_in_file(os.path.join(self._source_subfolder, "cmake", "FindVulkanHeaders.cmake"),
                               "HINTS ${VULKAN_HEADERS_INSTALL_DIR}/share/vulkan/registry",
                               "HINTS ${VULKAN_HEADERS_INSTALL_DIR}/res/vulkan/registry")

--- a/recipes/vulkan-loader/all/patches/fix-mingw.patch
+++ b/recipes/vulkan-loader/all/patches/fix-mingw.patch
@@ -1,0 +1,82 @@
+Fixes for MinGW:
+https://github.com/KhronosGroup/Vulkan-Loader/pull/475
+https://github.com/KhronosGroup/Vulkan-Loader/pull/495
+https://github.com/KhronosGroup/Vulkan-Loader/pull/523
+
+--- a/loader/CMakeLists.txt
++++ b/loader/CMakeLists.txt
+@@ -133,9 +133,28 @@ set(ASM_FAILURE_MSG "${ASM_FAILURE_MSG}Note that this may be unsafe, as the C co
+ set(ASM_FAILURE_MSG "${ASM_FAILURE_MSG} the stack frame for certain calls. If the compiler does not do this, then unknown device")
+ set(ASM_FAILURE_MSG "${ASM_FAILURE_MSG} extensions will suffer from a corrupted stack.")
+ if(WIN32)
+-    enable_language(ASM_MASM)
+-    if(CMAKE_ASM_MASM_COMPILER_WORKS)
+-        if(NOT CMAKE_CL_64)
++   if(MINGW)
++        find_program(JWASM_FOUND jwasm)
++        if (JWASM_FOUND)
++            set(CMAKE_ASM_MASM_COMPILER ${JWASM_FOUND})
++            execute_process(COMMAND ${CMAKE_C_COMPILER} --version OUTPUT_VARIABLE COMPILER_VERSION_OUTPUT)
++            if (COMPILER_VERSION_OUTPUT)
++                if (COMPILER_VERSION_OUTPUT MATCHES "x86_64")
++                    set(JWASM_FLAGS -win64)
++                else()
++                    set(JWASM_FLAGS -coff)
++                endif()
++            endif()
++        endif()
++    endif()
++    option(USE_MASM "Use MASM" ON)
++    if (USE_MASM)
++      enable_language(ASM_MASM)
++    endif ()
++    if(CMAKE_ASM_MASM_COMPILER_WORKS OR JWASM_FOUND)
++        if(MINGW)
++            set(CMAKE_ASM_MASM_FLAGS ${CMAKE_ASM_MASM_FLAGS} ${JWASM_FLAGS})
++        elseif(NOT CMAKE_CL_64 AND NOT JWASM_FOUND)
+             set(CMAKE_ASM_MASM_FLAGS ${CMAKE_ASM_MASM_FLAGS} /safeseh)
+         endif()
+ 
+@@ -205,14 +224,16 @@ if(WIN32)
+                           PROPERTIES LINK_FLAGS_DEBUG
+                                      "/ignore:4098"
+                                      OUTPUT_NAME
+-                                     vulkan-1)
++                                     vulkan-1
++                                     PREFIX
++                                     "")
+     target_link_libraries(vulkan Vulkan::Headers)
+ 
+     if(ENABLE_WIN10_ONECORE)
+         target_link_libraries(vulkan OneCoreUAP.lib LIBCMT.LIB LIBCMTD.LIB LIBVCRUNTIME.LIB LIBUCRT.LIB)
+         set_target_properties(vulkan PROPERTIES LINK_FLAGS "/NODEFAULTLIB")
+     else()
+-        target_link_libraries(vulkan Cfgmgr32)
++        target_link_libraries(vulkan cfgmgr32)
+     endif()
+ 
+     add_dependencies(vulkan loader_asm_gen_files)
+--- a/loader/loader.c
++++ b/loader/loader.c
+@@ -71,6 +71,9 @@
+ #include <devpkey.h>
+ #include <winternl.h>
+ #include <strsafe.h>
++#ifdef __MINGW32__
++#undef strcpy  // fix error with redfined strcpy when building with MinGW-w64
++#endif
+ #include <dxgi1_6.h>
+ #include "adapters.h"
+ 
+@@ -695,7 +698,11 @@ VkResult loaderGetDeviceRegistryFiles(const struct loader_instance *inst, char *
+                                       LPCSTR value_name) {
+     static const wchar_t *softwareComponentGUID = L"{5c4c3332-344d-483c-8739-259e934c9cc8}";
+     static const wchar_t *displayGUID = L"{4d36e968-e325-11ce-bfc1-08002be10318}";
++#ifdef CM_GETIDLIST_FILTER_PRESENT
+     const ULONG flags = CM_GETIDLIST_FILTER_CLASS | CM_GETIDLIST_FILTER_PRESENT;
++#else
++    const ULONG flags = 0x300;
++#endif
+ 
+     wchar_t childGuid[MAX_GUID_STRING_LEN + 2];  // +2 for brackets {}
+     ULONG childGuidSize = sizeof(childGuid);

--- a/recipes/vulkan-loader/config.yml
+++ b/recipes/vulkan-loader/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "1.2.162.0":
     folder: all
+  "1.2.154.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **vulkan-loader/1.2.154.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

I know that there are already versions 1.2.162.0 and 1.2.170.0 in CCI, but I would like to provide a coherent set of Vulkan components in CCI, which means the same version for `vulkan-headers`, `vulkan-loader` and `vulkan-validationlayers` (and also `moltenvk`). Indeed `vulkan-validationlayers` and `vulkan-loader` can't build with non-compliant `vulkan-headers` version, so all these recipes must be coherent, at least for the build.

Problem: the latest version we have in CCI for vulkan-validationlayers is 1.2.154.0, and we can't add latest versions because they require spirv features not yet in a release of `spirv-headers` and `spirv-tools` (maybe in a release of spirv-tools already, but not in spirv-headers, and spirv-tools depend on spirv-headers).

Therefore the latest coherent "SDK" CCI can provide is 1.2.154.0

I will probably also submit MoltenVK 1.1.0 (SDK 1.2.154.0)