### PR TITLE
nspr: fix apple silicon cross compilation

### DIFF
--- a/recipes/nspr/all/conanfile.py
+++ b/recipes/nspr/all/conanfile.py
@@ -91,7 +91,15 @@ class NsprConan(ConanFile):
         elif self.settings.os == "Windows":
             conf_args.append("--enable-win32-target={}".format(self.options.win32_target))
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        self._autotools.configure(args=conf_args)
+
+        env = self._autotools.vars
+        if self.settings.os == "Macos":
+            if self.settings.arch == "armv8":
+                # conan adds `-arch`, which conflicts with nspr's apple silicon support
+                env["CFLAGS"] = env["CFLAGS"].replace("-arch arm64", "")
+                env["CXXFLAGS"] = env["CXXFLAGS"].replace("-arch arm64", "")
+
+        self._autotools.configure(args=conf_args, vars=env)
         return self._autotools
 
     def build(self):


### PR DESCRIPTION
conan-1.33 adds `-arch arm64` to the cflags. this breaks the compilation
of nspr, which correctly adds the `-arch` flags

fixes: #4692

Specify library name and version:  **nspr**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
