### PR TITLE
openssl: fix builddirs and add vars module file to cmake_find_package only

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -5,6 +5,8 @@ from functools import total_ordering
 from conans.errors import ConanInvalidConfiguration
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
 
+required_conan_version = ">=1.33.0"
+
 
 @total_ordering
 class OpenSSLVersion(object):
@@ -760,12 +762,12 @@ class OpenSSLConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
         self._create_cmake_module_variables(
-            os.path.join(self.package_folder, self._module_subfolder, self._module_file)
+            os.path.join(self.package_folder, self._module_file_rel_path)
         )
 
     @staticmethod
     def _create_cmake_module_variables(module_file):
-        content = """\
+        content = textwrap.dedent("""\
             if(DEFINED OpenSSL_FOUND)
                 set(OPENSSL_FOUND ${OpenSSL_FOUND})
             endif()
@@ -792,8 +794,7 @@ class OpenSSLConan(ConanFile):
             if(DEFINED OpenSSL_VERSION)
                 set(OPENSSL_VERSION ${OpenSSL_VERSION})
             endif()
-        """
-        content = textwrap.dedent(content)
+        """)
         tools.save(module_file, content)
 
     @property
@@ -801,16 +802,17 @@ class OpenSSLConan(ConanFile):
         return os.path.join("lib", "cmake")
 
     @property
-    def _module_file(self):
-        return "conan-official-{}-variables.cmake".format(self.name)
+    def _module_file_rel_path(self):
+        return os.path.join(self._module_subfolder,
+                            "conan-official-{}-variables.cmake".format(self.name))
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "OpenSSL"
         self.cpp_info.names["cmake_find_package_multi"] = "OpenSSL"
-        self.cpp_info.components["ssl"].builddirs = [self._module_subfolder]
-        self.cpp_info.components["ssl"].build_modules = [os.path.join(self._module_subfolder, self._module_file)]
-        self.cpp_info.components["crypto"].builddirs = [self._module_subfolder]
-        self.cpp_info.components["crypto"].build_modules = [os.path.join(self._module_subfolder, self._module_file)]
+        self.cpp_info.components["ssl"].builddirs.append(self._module_subfolder)
+        self.cpp_info.components["ssl"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.components["crypto"].builddirs.append(self._module_subfolder)
+        self.cpp_info.components["crypto"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
         if self._use_nmake:
             libsuffix = "d" if self.settings.build_type == "Debug" else ""
             if self._full_version < "1.1.0":


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
