### PR TITLE
ios-cmake: add 4.1.1 and support new platforms

### DIFF
--- a/recipes/ios-cmake/all/conandata.yml
+++ b/recipes/ios-cmake/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "4.0.0":
     url: "https://github.com/leetal/ios-cmake/archive/4.0.0.zip"
     sha256: "2e0dcf00cd46ae808d85666ce4ce38ecd8875925588647295d41e97c874ad0b3"
+  "4.1.1":
+    url: "https://github.com/leetal/ios-cmake/archive/4.1.1.zip"
+    sha256: "4011d4b363f5905041c424d11b185e99eb516c9d1c5f6d193b1d9a4b6907500e"

--- a/recipes/ios-cmake/all/conanfile.py
+++ b/recipes/ios-cmake/all/conanfile.py
@@ -16,10 +16,11 @@ class IosCMakeConan(ConanFile):
         "enable_visibility": [True, False],
         "enable_strict_try_compile": [True, False],
         "toolchain_target": ["auto", "OS", "OS64", "OS64COMBINED",
-                       "SIMULATOR", "SIMULATOR64",
+                       "SIMULATOR", "SIMULATOR64", "SIMULATORARM64",
                        "TVOS", "TVOSCOMBINED",
                        "SIMULATOR_TVOS", "WATCHOS",
-                       "WATCHOSCOMBINED", "SIMULATOR_WATCHOS"]
+                       "WATCHOSCOMBINED", "SIMULATOR_WATCHOS",
+                       "MAC", "MAC_ARM64", "MAC_CATALYST", "MAC_CATALYST_ARM64"]
     }
     default_options = {
         "enable_bitcode": True,

--- a/recipes/ios-cmake/config.yml
+++ b/recipes/ios-cmake/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "4.0.0":
     folder: all
+  "4.1.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **ios-cmake/4.1.1**

Note: This also adds ios-cmake 4.1.0; version 4.1.1 was released while this PR was in review.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.