### PR TITLE
xkbcommon: add version 1.1.0

### DIFF
--- a/recipes/xkbcommon/all/conandata.yml
+++ b/recipes/xkbcommon/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/xkbcommon/libxkbcommon/archive/xkbcommon-1.1.0.tar.gz"
+    sha256: "3f93ebcbc5823dc61aacee2aa65c8cb8a13401a9f76fb8b7695922fbfc6689ab"
   "1.0.3":
     url: "https://github.com/xkbcommon/libxkbcommon/archive/xkbcommon-1.0.3.tar.gz"
     sha256: "5d10a57ab65daad7d975926166770eca1d2c899131ab96c23845df1c42da5c31"

--- a/recipes/xkbcommon/config.yml
+++ b/recipes/xkbcommon/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.0":
+    folder: all
   "1.0.3":
     folder: all
   "1.0.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **xkbcommon/1.1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
