### PR TITLE
aruco: regenerate binaries

### DIFF
--- a/recipes/aruco/3.x.x/conanfile.py
+++ b/recipes/aruco/3.x.x/conanfile.py
@@ -35,7 +35,7 @@ class LibnameConan(ConanFile):
 
     def requirements(self):
         self.requires("opencv/4.5.1")
-        self.requires("eigen/3.3.8")
+        self.requires("eigen/3.3.9")
         self.requires("zlib/1.2.11")
 
         self.options[

--- a/recipes/aruco/3.x.x/conanfile.py
+++ b/recipes/aruco/3.x.x/conanfile.py
@@ -38,12 +38,6 @@ class LibnameConan(ConanFile):
         self.requires("eigen/3.3.9")
         self.requires("zlib/1.2.11")
 
-        self.options[
-            "opencv"
-        ].shared = (
-            self.options.shared
-        )  # For some reason, this is not automagically inherited from self.options.shared
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version

--- a/recipes/aruco/3.x.x/conanfile.py
+++ b/recipes/aruco/3.x.x/conanfile.py
@@ -34,7 +34,7 @@ class LibnameConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("opencv/4.5.0")
+        self.requires("opencv/4.5.1")
         self.requires("eigen/3.3.8")
         self.requires("zlib/1.2.11")
 


### PR DESCRIPTION
Specify library name and version:  **aruco/***

Binaries are missing, as can be seen on https://github.com/ericLemanissier/hooks/runs/2038918245?check_suite_focus=true#step:7:3050 and https://conan.io/center/aruco

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
