### PR TITLE
[service] Reduce the number of days until stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 30
+daysUntilStale: 15
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.


### PR DESCRIPTION
This will only affect 22 PRs which have not been touched. Only 4 are less than 20 days.

**Motivation**: This will hopefully make it easier to spot PRs that could use help where the OP got stuck.

There is currently ~60 PRs that are 'inactive', or at least, with have no _Human_ events.

- Recipes like boost that received lots of PRs are being kept alive by the bots. 
- There's a section of PRs that had comments hidden which also refreshed their life span.

Labeling them sooner will make it easier to filter PRs.