### PR TITLE
opencv: add more contrib options and CUDA support

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -231,9 +231,7 @@ class OpenCVConan(ConanFile):
         self._cmake.definitions["WITH_ADE"] = False
         self._cmake.definitions["WITH_ARAVIS"] = False
         self._cmake.definitions["WITH_CLP"] = False
-        self._cmake.definitions["WITH_CUDA"] = False
         self._cmake.definitions["WITH_CUFFT"] = False
-        self._cmake.definitions["WITH_CUBLAS"] = False
         self._cmake.definitions["WITH_NVCUVID"] = False
         self._cmake.definitions["WITH_FFMPEG"] = False
         self._cmake.definitions["WITH_GSTREAMER"] = False
@@ -254,7 +252,6 @@ class OpenCVConan(ConanFile):
         self._cmake.definitions["WITH_OPENCLAMDFFT"] = False
         self._cmake.definitions["WITH_OPENCL_SVM"] = False
         self._cmake.definitions["WITH_OPENGL"] = False
-        self._cmake.definitions["WITH_OPENJPEG"] = False
         self._cmake.definitions["WITH_OPENMP"] = False
         self._cmake.definitions["WITH_OPENNI"] = False
         self._cmake.definitions["WITH_OPENNI2"] = False


### PR DESCRIPTION
Specify library name and version: opencv/4.x

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.


Currently, if CUDA is enabled, it will build for all possible archs. I don't know if it is possible to pass a list of selected archs as an option.
