### PR TITLE
Disable TCL Whole Program Optimization

### DIFF
--- a/recipes/tcl/8.6.10/conanfile.py
+++ b/recipes/tcl/8.6.10/conanfile.py
@@ -85,8 +85,15 @@ class TclConan(ConanFile):
         win_makefile_vc = os.path.join(win_config_dir, "makefile.vc")
         tools.replace_in_file(win_makefile_vc, "@type << >$@", "type <<temp.tmp >$@")
 
+        win_rules_vc = os.path.join(self._source_subfolder, "win", "rules.vc")
         # do not treat nmake build warnings as errors
-        tools.replace_in_file(os.path.join(self._source_subfolder, "win", "rules.vc"), "cwarn = $(cwarn) -WX", "")
+        tools.replace_in_file(win_rules_vc, "cwarn = $(cwarn) -WX", "")
+        # disable whole program optimization
+        # to be portable across different MSVC versions.
+        tools.replace_in_file(
+            win_rules_vc,
+            "OPTIMIZATIONS  = $(OPTIMIZATIONS) -GL",
+            "")
 
     def _build_nmake(self, targets):
         opts = []

--- a/recipes/tcl/8.6.10/conanfile.py
+++ b/recipes/tcl/8.6.10/conanfile.py
@@ -88,8 +88,8 @@ class TclConan(ConanFile):
         win_rules_vc = os.path.join(self._source_subfolder, "win", "rules.vc")
         # do not treat nmake build warnings as errors
         tools.replace_in_file(win_rules_vc, "cwarn = $(cwarn) -WX", "")
-        # disable whole program optimization
-        # to be portable across different MSVC versions.
+        # disable whole program optimization to be portable across different MSVC versions.
+        # See conan-io/conan-center-index#4811 conan-io/conan-center-index#4094
         tools.replace_in_file(
             win_rules_vc,
             "OPTIMIZATIONS  = $(OPTIMIZATIONS) -GL",


### PR DESCRIPTION
Specify library name and version:  **tcl/8.6.10**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

According to [/GL (whole program optimization)](https://docs.microsoft.com/en-us/cpp/build/reference/gl-whole-program-optimization?view=msvc-160), enabling this flag will make the produced objects only usable with the exact same version of MSVC. 

> The format of files produced with /GL in the current version often isn't readable by later versions of Visual Studio and the MSVC toolset. Unless you're willing to ship copies of the .lib file for all versions of Visual Studio you expect your users to use, now and in the future, don't ship a .lib file made up of .obj files produced by /GL . For more information, see Restrictions on binary compatibility.

While Conan does not check the minor version of Visual Studio, most users who use a different version of MSVC will not be able to use the Conan prebuilt binaries. Further more, it stops the CI of other packages because of different versions of MSVC between CI nodes.

This PR disables the /GL flag when using MSVC.
