### PR TITLE
libsodium: allow cross-compilation via host argument

### DIFF
--- a/recipes/libsodium/1.0.18/conanfile.py
+++ b/recipes/libsodium/1.0.18/conanfile.py
@@ -14,6 +14,7 @@ class LibsodiumConan(ConanFile):
     topics = ("sodium", "libsodium", "encryption", "signature", "hashing")
     generators  = "cmake"
     _source_subfolder = "source_subfolder"
+    short_paths = True
 
     options = {
         "shared" : [True, False],


### PR DESCRIPTION

Specify library name and version:  **libsodium/1.0.18**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Fixes https://github.com/conan-io/conan-center-index/issues/4815 

This allows the `host` argument to pass to `autotools.configure` while keeping the custom cross-compilation logic in the recipe. As mentioned in the bug, I'm not sure if any of that manual host setting logic is still relevant, but I both don't know how Conan handles those platforms and I'm not setup to test them, so this PR errs on the side of caution an keeps all the logic while also allowing the default of `host=None` to take place if none of that logic gets invoked.

Looping in @prince-chrismc for thoughts since you seemed to be recently looking at this recipe in https://github.com/conan-io/conan-center-index/pull/4780

