### PR TITLE
[freetype/x] Adds find_package generator to freetype

### DIFF
--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -16,7 +16,7 @@ class FreetypeConan(ConanFile):
     license = "FTL"
     topics = ("conan", "freetype", "fonts")
     exports_sources = ["CMakeLists.txt"]
-    generators = "cmake"
+    generators = ["cmake", "cmake_find_package"]
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],


### PR DESCRIPTION
Free uses find_package to find packages. Currently it uses the cmake provide findXXX, this changes that to have conan generate it. Using the official one doesn't work with msys2 for example

fixes #4829

Specify library name and version:  **freetype/x**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
