### PR TITLE
Bump openssl version

### DIFF
--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -60,7 +60,7 @@ class CMakeConan(ConanFile):
 
     def requirements(self):
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1i")
+            self.requires("openssl/1.1.1j")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **cmake/3.x**

On my `QArchive` PR (https://github.com/conan-io/conan-center-index/pull/4774) I'm getting

```
ERROR: Conflict in cmake/3.19.6:
    'cmake/3.19.6' requires 'openssl/1.1.1i' while 'libmysqlclient/8.0.17' requires 'openssl/1.1.1j'.
    To fix this conflict you need to override the package 'openssl' in your root package.
```