### PR TITLE
ixwebsocket: add version 11.0.9

### DIFF
--- a/recipes/ixwebsocket/all/conandata.yml
+++ b/recipes/ixwebsocket/all/conandata.yml
@@ -17,3 +17,6 @@ sources:
   "11.0.4":
     url: "https://github.com/machinezone/IXWebSocket/archive/v11.0.4.tar.gz"
     sha256: "deebfa04bd6bd930b2f7c0daba8674c8e8bc273a3d735b1877b1f4bb2c0e8596"
+  "11.0.8":
+    url: "https://github.com/machinezone/IXWebSocket/archive/v11.0.8.tar.gz"
+    sha256: "5d02fa5a23427e07326b4bbd285479aabb18fa2e1d47c05a676523ae4d6a4dca"

--- a/recipes/ixwebsocket/all/conandata.yml
+++ b/recipes/ixwebsocket/all/conandata.yml
@@ -20,3 +20,6 @@ sources:
   "11.0.8":
     url: "https://github.com/machinezone/IXWebSocket/archive/v11.0.8.tar.gz"
     sha256: "5d02fa5a23427e07326b4bbd285479aabb18fa2e1d47c05a676523ae4d6a4dca"
+  "11.0.9":
+    url: "https://github.com/machinezone/IXWebSocket/archive/v11.0.9.tar.gz"
+    sha256: "bb355b54add3de14fa645ac9c16c49d1cd8324fdeea959a64071ca9aec64da7e"

--- a/recipes/ixwebsocket/all/conandata.yml
+++ b/recipes/ixwebsocket/all/conandata.yml
@@ -17,9 +17,6 @@ sources:
   "11.0.4":
     url: "https://github.com/machinezone/IXWebSocket/archive/v11.0.4.tar.gz"
     sha256: "deebfa04bd6bd930b2f7c0daba8674c8e8bc273a3d735b1877b1f4bb2c0e8596"
-  "11.0.8":
-    url: "https://github.com/machinezone/IXWebSocket/archive/v11.0.8.tar.gz"
-    sha256: "5d02fa5a23427e07326b4bbd285479aabb18fa2e1d47c05a676523ae4d6a4dca"
   "11.0.9":
     url: "https://github.com/machinezone/IXWebSocket/archive/v11.0.9.tar.gz"
     sha256: "bb355b54add3de14fa645ac9c16c49d1cd8324fdeea959a64071ca9aec64da7e"

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -49,7 +49,10 @@ class IXWebSocketConan(ConanFile):
 
     def configure(self):
         if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 14)
+            # After version 11.0.8, IXWebSocket is fully compatible with C++ 11. Keep previous configuration for versions beforem 11.0.8 to prevent potential issues.
+            tools.check_min_cppstd(self, 14 if tools.Version(self.version) < "11.0.8" else 11)
+
+            
         if self.options.tls == "applessl" and not tools.is_apple_os(self.settings.os):
             raise ConanInvalidConfiguration("Can only use Apple SSL on Apple.")
         elif not self._can_use_openssl() and self.options.tls == "openssl":

--- a/recipes/ixwebsocket/all/conanfile.py
+++ b/recipes/ixwebsocket/all/conanfile.py
@@ -59,7 +59,7 @@ class IXWebSocketConan(ConanFile):
         if self.options.get_safe("with_zlib", True):
             self.requires("zlib/1.2.11")
         if self.options.tls == "openssl":
-            self.requires("openssl/1.1.1g")
+            self.requires("openssl/1.1.1j")
         elif self.options.tls == "mbedtls":
             self.requires("mbedtls/2.16.3-apache")
 

--- a/recipes/ixwebsocket/config.yml
+++ b/recipes/ixwebsocket/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: all
   "11.0.4":
     folder: all
+  "11.0.8":
+    folder: all

--- a/recipes/ixwebsocket/config.yml
+++ b/recipes/ixwebsocket/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "11.0.8":
     folder: all
+  "11.0.9":
+    folder: all

--- a/recipes/ixwebsocket/config.yml
+++ b/recipes/ixwebsocket/config.yml
@@ -11,7 +11,5 @@ versions:
     folder: all
   "11.0.4":
     folder: all
-  "11.0.8":
-    folder: all
   "11.0.9":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **ixwebsocket/11.0.8** and **ixwebsocket/11.0.9**

@prince-chrismc  I updated the OpenSSL, now you can close https://github.com/conan-io/conan-center-index/pull/4828 and merge this pr. The 11.0.8 is a "major" release according to the author, so I added it too. Thanks!

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
