### PR TITLE
Disable Whole Program Optimization in Tk

### DIFF
--- a/recipes/tk/all/conanfile.py
+++ b/recipes/tk/all/conanfile.py
@@ -86,9 +86,16 @@ class TkConan(ConanFile):
         win_makefile_in = os.path.join(self._get_configure_folder("win"), "Makefile.in")
         tools.replace_in_file(win_makefile_in, "\nTCL_GENERIC_DIR", "\n#TCL_GENERIC_DIR")
 
-        tools.replace_in_file(os.path.join(self.source_folder, self._source_subfolder, "win", "rules.vc"),
+        win_rules_vc = os.path.join(self._source_subfolder, "win", "rules.vc")
+        tools.replace_in_file(win_rules_vc,
                               "\ncwarn = $(cwarn) -WX",
                               "\n# cwarn = $(cwarn) -WX")
+        # disable whole program optimization to be portable across different MSVC versions.
+        # See conan-io/conan-center-index#4811 conan-io/conan-center-index#4094
+        tools.replace_in_file(
+            win_rules_vc,
+            "OPTIMIZATIONS  = $(OPTIMIZATIONS) -GL",
+            "# OPTIMIZATIONS  = $(OPTIMIZATIONS) -GL")
 
     def _get_default_build_system(self):
         if tools.is_apple_os(self.settings.os):

--- a/recipes/tk/all/conanfile.py
+++ b/recipes/tk/all/conanfile.py
@@ -2,6 +2,7 @@ from conans import ConanFile, AutoToolsBuildEnvironment, tools
 from conans.errors import ConanException, ConanInvalidConfiguration, ConanExceptionInUserConanfileMethod
 import os
 
+required_conan_version = ">=1.32.0"
 
 class TkConan(ConanFile):
     name = "tk"

--- a/recipes/tk/all/conanfile.py
+++ b/recipes/tk/all/conanfile.py
@@ -47,6 +47,10 @@ class TkConan(ConanFile):
             if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
                 self.build_requires("msys2/20200517")
 
+    def validate(self):
+        if self.options["tcl"].shared != self.options.shared:
+            raise ConanInvalidConfiguration("The shared option of tcl and tk must have the same value")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("tk{}".format(self.version), self._source_subfolder)
@@ -185,8 +189,6 @@ class TkConan(ConanFile):
     def build(self):
         self._patch_sources()
 
-        if self.options["tcl"].shared != self.options.shared:
-            raise ConanInvalidConfiguration("The shared option of tcl and tk must have the same value")
         if self.settings.compiler == "Visual Studio":
             self._build_nmake()
         else:


### PR DESCRIPTION
Specify library name and version:  **tk/8.6.10**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Similar to the TCL PR (#4811), this PR disables "/GL" flag (whole program optimization) to avoid problems when working across different versions of MSVC.