### PR TITLE
docopt.cpp: fix build with boost_regex

### DIFF
--- a/recipes/docopt.cpp/all/conanfile.py
+++ b/recipes/docopt.cpp/all/conanfile.py
@@ -12,7 +12,7 @@ class DocoptCppConan(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False], "boost_regex": [True, False]}
     default_options = {"shared": False, "fPIC": True, "boost_regex": False}
     topics = ("CLI", "getopt", "options", "argparser")
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
     exports_sources = ["patches/**", "CMakeLists.txt"]
 
     _cmake = None

--- a/recipes/docopt.cpp/all/patches/cmake-library-0.6.3.patch
+++ b/recipes/docopt.cpp/all/patches/cmake-library-0.6.3.patch
@@ -35,12 +35,8 @@
  endif()
  
  if(USE_BOOST_REGEX)
-@@ -79,12 +72,9 @@ if(USE_BOOST_REGEX)
- 	# This is needed on Linux, where linking a static library into docopt.so
- 	# fails because boost static libs are not compiled with -fPIC
- 	set(Boost_USE_STATIC_LIBS OFF)
--    find_package(Boost 1.53 REQUIRED COMPONENTS regex)
-+    find_package(boost 1.53 REQUIRED COMPONENTS regex)
+@@ -82,9 +75,6 @@ if(USE_BOOST_REGEX)
+     find_package(Boost 1.53 REQUIRED COMPONENTS regex)
      include_directories(${Boost_INCLUDE_DIRS})
      target_link_libraries(docopt ${Boost_LIBRARIES})
 -	if(WITH_STATIC)

--- a/recipes/docopt.cpp/all/patches/cmake-library-0.6.3.patch
+++ b/recipes/docopt.cpp/all/patches/cmake-library-0.6.3.patch
@@ -35,8 +35,12 @@
  endif()
  
  if(USE_BOOST_REGEX)
-@@ -82,9 +75,6 @@ if(USE_BOOST_REGEX)
-     find_package(Boost 1.53 REQUIRED COMPONENTS regex)
+@@ -79,12 +72,9 @@ if(USE_BOOST_REGEX)
+ 	# This is needed on Linux, where linking a static library into docopt.so
+ 	# fails because boost static libs are not compiled with -fPIC
+ 	set(Boost_USE_STATIC_LIBS OFF)
+-    find_package(Boost 1.53 REQUIRED COMPONENTS regex)
++    find_package(boost 1.53 REQUIRED COMPONENTS regex)
      include_directories(${Boost_INCLUDE_DIRS})
      target_link_libraries(docopt ${Boost_LIBRARIES})
 -	if(WITH_STATIC)


### PR DESCRIPTION
This change fixes an issue in the docopt.cpp recipe that prevents compilation with the `boost_regex` option. 

The issue is that the CMakeLists.txt of Docopt uses a `find_package(Boost ...)` statement. To make it work, I add "cmake_find_package" to the generators and replace the statement with `find_package(boost ...)`

Specify library name and version:  **docopt.cpp/0.6.3**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
