### PR TITLE
glib: add version 2.67.6

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -38,3 +38,6 @@ sources:
   "2.67.5":
     url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.5/glib-2.67.5.tar.gz"
     sha256: "410966db712638dc749054c0a3c3087545d5106643139c25806399a51a8d4ab1"
+  "2.67.6":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.6/glib-2.67.6.tar.gz"
+    sha256: "2698198b349021bae45a899e21c42bdc8cdf6e508f38a35d8c2bb474964c1240"

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -25,3 +25,5 @@ versions:
     folder: all
   "2.67.5":
     folder: all
+  "2.67.6":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **glib/2.67.6**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
