### PR TITLE
pango: add version 1.48.3

### DIFF
--- a/recipes/pango/all/conandata.yml
+++ b/recipes/pango/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "1.48.2":
     url: "https://github.com/GNOME/pango/archive/1.48.2.tar.gz"
     sha256: "19ea06742d9b8da590fed3c2bea018258609c18718a6deedd46cab957d3be9cf"
+  "1.48.3":
+    url: "https://github.com/GNOME/pango/archive/1.48.3.tar.gz"
+    sha256: "63318b75bdd510b11fc960dbcdff9bc8b744fb3e45583acbb3410ef36bacc054"

--- a/recipes/pango/config.yml
+++ b/recipes/pango/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "1.48.2":
     folder: all
+  "1.48.3":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **pango/1.48.3**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
