### PR TITLE
[docs] Add a link to conan-io/conan-docker-tools

### DIFF
--- a/docs/supported_platforms_and_configurations.md
+++ b/docs/supported_platforms_and_configurations.md
@@ -29,6 +29,9 @@ Currently, given the following supported platforms and configurations we
 are generating **136 different binary packages for a C++ library**
 and **88 for a C library**.
 
+### Build Images
+
+For more information see [conan-io/conan-docker-tools](https://github.com/conan-io/conan-docker-tools)
 
 ## Windows
 


### PR DESCRIPTION
Docs!

Follow up from #4630, there's no documentation about where the build images comes from. On rare occasion it's needed when tools are incorrectly installed.