### PR TITLE
Add libpact_mock_server_ffi/0.0.16

### DIFF
--- a/recipes/libpact_mock_server_ffi/0.0.16/conandata.yml
+++ b/recipes/libpact_mock_server_ffi/0.0.16/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.16":
+    url: "https://github.com/pact-foundation/pact-reference/archive/libpact_mock_server_ffi-v0.0.16.zip"
+    sha256: "6ded4e300787eda247cbe86bbb658c462f06cbe4a8a181759aaa471b85c5a9fa"

--- a/recipes/libpact_mock_server_ffi/0.0.16/conanfile.py
+++ b/recipes/libpact_mock_server_ffi/0.0.16/conanfile.py
@@ -1,0 +1,44 @@
+from conans import ConanFile, VisualStudioBuildEnvironment, CMake, tools
+
+class CbindgenTestConan(ConanFile):
+    name = "pact_mock_server_ffi"
+    version = "0.0.17"
+    description = "Pact/Rust FFI bindings"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/pact-foundation/pact-reference"
+    license = "MIT"
+    settings = "os", "compiler", "build_type", "arch"
+    no_copy_source = True
+    requires = "openssl/1.1.1d"
+    topics = ("pact", "consumer-driven-contracts", "contract-testing", "mock-server")
+
+    def build(self):
+        if self.settings.os == "Windows":
+            url = ("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/libpact_mock_server_ffi-windows-x86_64.lib.gz"
+                   % (str(self.version)))
+            tools.download(url, "pact_mock_server_ffi.lib.gz")
+            tools.unzip("pact_mock_server_ffi.lib.gz")
+        elif self.settings.os == "Linux":
+            url = ("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/libpact_mock_server_ffi-linux-x86_64.a.gz"
+                % (str(self.version)))
+            tools.download(url, "libpact_mock_server_ffi.a.gz")
+            tools.unzip("libpact_mock_server_ffi.a.gz")
+        elif self.settings.os == "Macos":
+            url = ("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/libpact_mock_server_ffi-osx-x86_64.a.gz"
+                   % (str(self.version)))
+            tools.download(url, "libpact_mock_server_ffi.a.gz")
+            tools.unzip("libpact_mock_server_ffi.a.gz")
+        else:
+            raise Exception("Binary does not exist for these settings")
+        tools.download(("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/pact_mock_server_ffi.h"
+                % (str(self.version))), "include/pact_mock_server_ffi.h")
+        tools.download(("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/pact_mock_server_ffi-c.h"
+                % (str(self.version))), "include/pact_mock_server_ffi-c.h")
+
+    def package(self):
+        self.copy("libpact_mock_server_ffi*.a", "lib", "")
+        self.copy("pact_mock_server_ffi*.lib", "lib", "")
+        self.copy("*.h", "", "")
+
+    def package_info(self):  # still very useful for package consumers
+        self.cpp_info.libs = ["pact_mock_server_ffi"]

--- a/recipes/libpact_mock_server_ffi/0.0.16/conanfile.py
+++ b/recipes/libpact_mock_server_ffi/0.0.16/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, VisualStudioBuildEnvironment, CMake, tools
 
-class CbindgenTestConan(ConanFile):
+class PactMockServerFfiConan(ConanFile):
     name = "pact_mock_server_ffi"
     version = "0.0.16"
     description = "Pact/Rust FFI bindings"

--- a/recipes/libpact_mock_server_ffi/0.0.16/conanfile.py
+++ b/recipes/libpact_mock_server_ffi/0.0.16/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, VisualStudioBuildEnvironment, CMake, tools
 
 class CbindgenTestConan(ConanFile):
     name = "pact_mock_server_ffi"
-    version = "0.0.17"
+    version = "0.0.16"
     description = "Pact/Rust FFI bindings"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/pact-foundation/pact-reference"
@@ -34,11 +34,13 @@ class CbindgenTestConan(ConanFile):
                 % (str(self.version))), "include/pact_mock_server_ffi.h")
         tools.download(("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/pact_mock_server_ffi-c.h"
                 % (str(self.version))), "include/pact_mock_server_ffi-c.h")
+        tools.download("https://raw.githubusercontent.com/pact-foundation/pact-reference/master/LICENSE", "MIT")
 
     def package(self):
         self.copy("libpact_mock_server_ffi*.a", "lib", "")
         self.copy("pact_mock_server_ffi*.lib", "lib", "")
         self.copy("*.h", "", "")
+        self.copy("MIT", "licenses", "")
 
     def package_info(self):  # still very useful for package consumers
         self.cpp_info.libs = ["pact_mock_server_ffi"]

--- a/recipes/libpact_mock_server_ffi/0.0.16/test_package/CMakeLists.txt
+++ b/recipes/libpact_mock_server_ffi/0.0.16/test_package/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+set( CMAKE_CXX_FLAGS " -pthread " )
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS} dl)
+include_directories(${CONAN_INCLUDE_DIRS})
+
+enable_testing()
+add_test(NAME example
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+         COMMAND example)

--- a/recipes/libpact_mock_server_ffi/0.0.16/test_package/conanfile.py
+++ b/recipes/libpact_mock_server_ffi/0.0.16/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+class CbindgentestTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+    requires = "openssl/1.1.1d"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def imports(self):
+        self.copy(pattern="*.dll", dst="bin",
+                  src="bin")
+        self.copy(pattern="*.dylib", dst="bin",
+                  src="lib")
+        self.copy(pattern="*.so*", dst="bin",
+                  src="lib")
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            with tools.run_environment(self):
+                cmake = CMake(self)
+                cmake.test()

--- a/recipes/libpact_mock_server_ffi/0.0.16/test_package/conanfile.py
+++ b/recipes/libpact_mock_server_ffi/0.0.16/test_package/conanfile.py
@@ -12,14 +12,6 @@ class CbindgentestTestConan(ConanFile):
         cmake.configure()
         cmake.build()
 
-    def imports(self):
-        self.copy(pattern="*.dll", dst="bin",
-                  src="bin")
-        self.copy(pattern="*.dylib", dst="bin",
-                  src="lib")
-        self.copy(pattern="*.so*", dst="bin",
-                  src="lib")
-
     def test(self):
         if not tools.cross_building(self.settings):
             with tools.run_environment(self):

--- a/recipes/libpact_mock_server_ffi/0.0.16/test_package/conanfile.py
+++ b/recipes/libpact_mock_server_ffi/0.0.16/test_package/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conans import ConanFile, CMake, tools
 
-class CbindgentestTestConan(ConanFile):
+class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     requires = "openssl/1.1.1d"

--- a/recipes/libpact_mock_server_ffi/0.0.16/test_package/example.cpp
+++ b/recipes/libpact_mock_server_ffi/0.0.16/test_package/example.cpp
@@ -1,0 +1,7 @@
+#include "pact_mock_server_ffi.h"
+
+int main(int argc, char *argv[]) {
+    int port = pact_mock_server_ffi::create_mock_server("{}", "127.0.0.1:0", false);
+    pact_mock_server_ffi::mock_server_matched(port);
+    return 0;
+}

--- a/recipes/libpact_mock_server_ffi_dll/0.0.16/conandata.yml
+++ b/recipes/libpact_mock_server_ffi_dll/0.0.16/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.16":
+    url: "https://github.com/pact-foundation/pact-reference/archive/libpact_mock_server_ffi-v0.0.16.zip"
+    sha256: "6ded4e300787eda247cbe86bbb658c462f06cbe4a8a181759aaa471b85c5a9fa"

--- a/recipes/libpact_mock_server_ffi_dll/0.0.16/conanfile.py
+++ b/recipes/libpact_mock_server_ffi_dll/0.0.16/conanfile.py
@@ -1,0 +1,50 @@
+from conans import ConanFile, VisualStudioBuildEnvironment, CMake, tools
+
+class CbindgenTestConan(ConanFile):
+    name = "pact_mock_server_ffi_dll"
+    version = "0.0.17"
+    description = "Pact/Rust FFI bindings (DLL/Shared Lib)"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/pact-foundation/pact-reference"
+    license = "MIT"
+    settings = "os", "compiler", "build_type", "arch"
+    no_copy_source = True
+    requires = "openssl/1.1.1d"
+    topics = ("pact", "consumer-driven-contracts", "contract-testing", "mock-server")
+
+    def build(self):
+        if self.settings.os == "Windows":
+            url = ("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/libpact_mock_server_ffi-windows-x86_64.dll.gz"
+                   % (str(self.version)))
+            tools.download(url, "pact_mock_server_ffi.dll.gz")
+            tools.unzip("pact_mock_server_ffi.dll.gz")
+            url = ("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/libpact_mock_server_ffi-windows-x86_64.dll.lib.gz"
+                   % (str(self.version)))
+            tools.download(url, "pact_mock_server_ffi.dll.lib.gz")
+            tools.unzip("pact_mock_server_ffi.dll.lib.gz")
+        elif self.settings.os == "Linux":
+            url = ("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/libpact_mock_server_ffi-linux-x86_64.so.gz"
+                % (str(self.version)))
+            tools.download(url, "libpact_mock_server_ffi.so.gz")
+            tools.unzip("libpact_mock_server_ffi.so.gz")
+        elif self.settings.os == "Macos":
+            url = ("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/libpact_mock_server_ffi-osx-x86_64.dylib.gz"
+                   % (str(self.version)))
+            tools.download(url, "libpact_mock_server_ffi.dylib.gz")
+            tools.unzip("libpact_mock_server_ffi.dylib.gz")
+        else:
+            raise Exception("Binary does not exist for these settings")
+        tools.download(("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/pact_mock_server_ffi.h"
+                % (str(self.version))), "include/pact_mock_server_ffi.h")
+        tools.download(("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/pact_mock_server_ffi-c.h"
+                % (str(self.version))), "include/pact_mock_server_ffi-c.h")
+
+    def package(self):
+        self.copy("libpact_mock_server_ffi*.so", "lib", "")
+        self.copy("libpact_mock_server_ffi*.dylib", "lib", "")
+        self.copy("pact_mock_server_ffi*.lib", "lib", "")
+        self.copy("pact_mock_server_ffi*.dll", "bin", "")
+        self.copy("*.h", "", "")
+
+    def package_info(self):  # still very useful for package consumers
+        self.cpp_info.libs = ["pact_mock_server_ffi"]

--- a/recipes/libpact_mock_server_ffi_dll/0.0.16/conanfile.py
+++ b/recipes/libpact_mock_server_ffi_dll/0.0.16/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, VisualStudioBuildEnvironment, CMake, tools
 
 class CbindgenTestConan(ConanFile):
     name = "pact_mock_server_ffi_dll"
-    version = "0.0.17"
+    version = "0.0.16"
     description = "Pact/Rust FFI bindings (DLL/Shared Lib)"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/pact-foundation/pact-reference"
@@ -38,6 +38,7 @@ class CbindgenTestConan(ConanFile):
                 % (str(self.version))), "include/pact_mock_server_ffi.h")
         tools.download(("https://github.com/pact-foundation/pact-reference/releases/download/libpact_mock_server_ffi-v%s/pact_mock_server_ffi-c.h"
                 % (str(self.version))), "include/pact_mock_server_ffi-c.h")
+        tools.download("https://raw.githubusercontent.com/pact-foundation/pact-reference/master/LICENSE", "MIT")
 
     def package(self):
         self.copy("libpact_mock_server_ffi*.so", "lib", "")
@@ -45,6 +46,7 @@ class CbindgenTestConan(ConanFile):
         self.copy("pact_mock_server_ffi*.lib", "lib", "")
         self.copy("pact_mock_server_ffi*.dll", "bin", "")
         self.copy("*.h", "", "")
+        self.copy("MIT", "licenses", "")
 
     def package_info(self):  # still very useful for package consumers
         self.cpp_info.libs = ["pact_mock_server_ffi"]

--- a/recipes/libpact_mock_server_ffi_dll/0.0.16/conanfile.py
+++ b/recipes/libpact_mock_server_ffi_dll/0.0.16/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, VisualStudioBuildEnvironment, CMake, tools
 
-class CbindgenTestConan(ConanFile):
+class PactMockServerFfiConan(ConanFile):
     name = "pact_mock_server_ffi_dll"
     version = "0.0.16"
     description = "Pact/Rust FFI bindings (DLL/Shared Lib)"

--- a/recipes/libpact_mock_server_ffi_dll/0.0.16/test_package/CMakeLists.txt
+++ b/recipes/libpact_mock_server_ffi_dll/0.0.16/test_package/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+set( CMAKE_CXX_FLAGS " -pthread " )
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS} dl)
+include_directories(${CONAN_INCLUDE_DIRS})
+
+enable_testing()
+add_test(NAME example
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+         COMMAND example)

--- a/recipes/libpact_mock_server_ffi_dll/0.0.16/test_package/conanfile.py
+++ b/recipes/libpact_mock_server_ffi_dll/0.0.16/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conans import ConanFile, CMake, tools
+
+class CbindgentestTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+    requires = "openssl/1.1.1d"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def imports(self):
+        self.copy(pattern="*.dll", dst="bin",
+                  src="bin")
+        self.copy(pattern="*.dylib", dst="bin",
+                  src="lib")
+        self.copy(pattern="*.so*", dst="bin",
+                  src="lib")
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            with tools.run_environment(self):
+                cmake = CMake(self)
+                cmake.test()

--- a/recipes/libpact_mock_server_ffi_dll/0.0.16/test_package/conanfile.py
+++ b/recipes/libpact_mock_server_ffi_dll/0.0.16/test_package/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, CMake, tools
 
-class CbindgentestTestConan(ConanFile):
+class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     requires = "openssl/1.1.1d"

--- a/recipes/libpact_mock_server_ffi_dll/0.0.16/test_package/conanfile.py
+++ b/recipes/libpact_mock_server_ffi_dll/0.0.16/test_package/conanfile.py
@@ -10,14 +10,6 @@ class CbindgentestTestConan(ConanFile):
         cmake.configure()
         cmake.build()
 
-    def imports(self):
-        self.copy(pattern="*.dll", dst="bin",
-                  src="bin")
-        self.copy(pattern="*.dylib", dst="bin",
-                  src="lib")
-        self.copy(pattern="*.so*", dst="bin",
-                  src="lib")
-
     def test(self):
         if not tools.cross_building(self.settings):
             with tools.run_environment(self):

--- a/recipes/libpact_mock_server_ffi_dll/0.0.16/test_package/example.cpp
+++ b/recipes/libpact_mock_server_ffi_dll/0.0.16/test_package/example.cpp
@@ -1,0 +1,7 @@
+#include "pact_mock_server_ffi.h"
+
+int main(int argc, char *argv[]) {
+    int port = pact_mock_server_ffi::create_mock_server("{}", "127.0.0.1:0", false);
+    pact_mock_server_ffi::mock_server_matched(port);
+    return 0;
+}


### PR DESCRIPTION
Specify library name and version:  **libpact_mock_server_ffi/0.0.16** and  **libpact_mock_server_ffi_dll/0.0.16**

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
