### PR TITLE
Add support for OpenSSL version 1.1.0g

### DIFF
--- a/recipes/openssl/1.x.x/conandata.yml
+++ b/recipes/openssl/1.x.x/conandata.yml
@@ -17,6 +17,12 @@ sources:
       "https://www.openssl.org/source/openssl-1.0.2u.tar.gz",
       "https://www.openssl.org/source/old/openssl-1.0.2u.tar.gz"
     ]
+  1.1.0g:
+    sha256: de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af
+    url: [
+      "https://www.openssl.org/source/openssl-1.1.0g.tar.gz",
+      "https://www.openssl.org/source/old/openssl-1.1.0g.tar.gz"
+    ]
   1.1.0k:
     sha256: efa4965f4f773574d6cbda1cf874dbbe455ab1c0d4f906115f867d30444470b1
     url: [

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -5,6 +5,8 @@ versions:
     folder: "1.x.x"
   1.0.2u:
     folder: "1.x.x"
+  1.1.0g:
+    folder: "1.x.x"
   1.1.0k:
     folder: "1.x.x"
   1.1.0l:


### PR DESCRIPTION
Fixes conan-io/conan-center-index#4881


Specify library name and version:  **openssl/1.1.0g**

- [v] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [V] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
