### PR TITLE
freetype: improve build robustness and reproducibility

### DIFF
--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -15,8 +15,7 @@ class FreetypeConan(ConanFile):
     homepage = "https://www.freetype.org"
     license = "FTL"
     topics = ("conan", "freetype", "fonts")
-    exports_sources = ["CMakeLists.txt"]
-    generators = "cmake"
+
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -35,6 +34,8 @@ class FreetypeConan(ConanFile):
         "with_brotli": True
     }
 
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake", "cmake_find_package"
     _cmake = None
 
     @property
@@ -45,10 +46,14 @@ class FreetypeConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    @property
+    def _has_with_brotli_option(self):
+        return tools.Version(self.version) >= "2.10.2"
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if tools.Version(self.version) < "2.10.2":
+        if not self._has_with_brotli_option:
             del self.options.with_brotli
 
     def configure(self):
@@ -71,27 +76,48 @@ class FreetypeConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("{0}-{1}".format(self.name, self.version), self._source_subfolder)
 
+    def _patch_sources(self):
+        # Do not accidentally enable dependencies we have disabled
+        cmakelists = os.path.join(self._source_subfolder, "CMakeLists.txt")
+        find_harfbuzz = "find_package(HarfBuzz {})".format("1.3.0" if tools.Version(self.version) < "2.10.2" else "${HARFBUZZ_MIN_VERSION}")
+        tools.replace_in_file(cmakelists, find_harfbuzz, "")
+        if not self.options.with_png:
+            tools.replace_in_file(cmakelists, "find_package(PNG)", "")
+            tools.replace_in_file(cmakelists, "if (PNG_FOUND)", "if(0)")
+        if not self.options.with_zlib:
+            tools.replace_in_file(cmakelists, "find_package(ZLIB)", "")
+            tools.replace_in_file(cmakelists, "if (ZLIB_FOUND)", "if(0)")
+        if not self.options.with_bzip2:
+            tools.replace_in_file(cmakelists, "find_package(BZip2)", "")
+            tools.replace_in_file(cmakelists, "if (BZIP2_FOUND)", "if(0)")
+        if self._has_with_brotli_option:
+            # the custom FindBrotliDec of upstream is too fragile
+            tools.replace_in_file(cmakelists,
+                                  "find_package(BrotliDec REQUIRED)",
+                                  "find_package(Brotli REQUIRED)\n"
+                                  "set(BROTLIDEC_FOUND 1)\n"
+                                  "set(BROTLIDEC_LIBRARIES \"Brotli::Brotli\")")
+            if not self.options.with_brotli:
+                tools.replace_in_file(cmakelists, "find_package(BrotliDec)", "")
+                tools.replace_in_file(cmakelists, "if (BROTLIDEC_FOUND)", "if(0)")
+
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
         self._cmake.definitions["PROJECT_VERSION"] = self._libtool_version
         self._cmake.definitions["FT_WITH_ZLIB"] = self.options.with_zlib
-        self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_ZLIB"] = not self.options.with_zlib
         self._cmake.definitions["FT_WITH_PNG"] = self.options.with_png
-        self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_PNG"] = not self.options.with_png
         self._cmake.definitions["FT_WITH_BZIP2"] = self.options.with_bzip2
-        self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_BZip2"] = not self.options.with_bzip2
         # TODO: Harfbuzz can be added as an option as soon as it is available.
         self._cmake.definitions["FT_WITH_HARFBUZZ"] = False
-        self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_HarfBuzz"] = True
-        if "with_brotli" in self.options:
+        if self._has_with_brotli_option:
             self._cmake.definitions["FT_WITH_BROTLI"] = self.options.with_brotli
-            self._cmake.definitions["CMAKE_DISABLE_FIND_PACKAGE_BrotliDec"] = not self.options.with_brotli
         self._cmake.configure(build_dir=self._build_subfolder)
         return self._cmake
 
     def build(self):
+        self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -130,7 +156,7 @@ conan_staticlibs="{staticlibs}"
         self.copy("LICENSE.TXT", dst="licenses", src=os.path.join(self._source_subfolder, "docs"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-            
+
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),
             {

--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -81,6 +81,7 @@ class FreetypeConan(ConanFile):
         cmakelists = os.path.join(self._source_subfolder, "CMakeLists.txt")
         find_harfbuzz = "find_package(HarfBuzz {})".format("1.3.0" if tools.Version(self.version) < "2.10.2" else "${HARFBUZZ_MIN_VERSION}")
         tools.replace_in_file(cmakelists, find_harfbuzz, "")
+        tools.replace_in_file(cmakelists, "if (HARFBUZZ_FOUND)", "if(0)")
         if not self.options.with_png:
             tools.replace_in_file(cmakelists, "find_package(PNG)", "")
             tools.replace_in_file(cmakelists, "if (PNG_FOUND)", "if(0)")


### PR DESCRIPTION
Specify library name and version:  **freetype/all**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Modifications:
- rely on `cmake_find_package`
- do not use `CMAKE_DISABLE_FIND_PACKAGE_<LIB>`, it breaks with `freetype:with_zlib=False` because `zlib` is also a dependency of `libpng`
- fix `brotli` discovery and link

closes https://github.com/conan-io/conan-center-index/issues/4829