### PR TITLE
vulkan-headers 1.2.170

### DIFF
--- a/recipes/vulkan-headers/all/conandata.yml
+++ b/recipes/vulkan-headers/all/conandata.yml
@@ -71,3 +71,6 @@ sources:
   "1.2.170.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/sdk-1.2.170.0.tar.gz"
     sha256: "d8e6050230ca678bcb0e7dc68d5984290da6eb655e8da9d08b5eaab1e84a7da9"
+  "1.2.170":
+    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.170.tar.gz"
+    sha256: "6fa84897197bd72cf4b1a686c903df67fc0fe108e4ed02e6adb3d72c468f1c1f"

--- a/recipes/vulkan-headers/config.yml
+++ b/recipes/vulkan-headers/config.yml
@@ -47,3 +47,5 @@ versions:
     folder: all
   "1.2.170.0":
     folder: all
+  "1.2.170":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **vulkan-headers/1.2.170**

the content should be exactly identical to vulkan-headers/1.2.170.0 but we need it for consistency with `volk` recipe

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
