### PR TITLE
miniaudio 0.10.32: Add recipe for miniaud.io. Closes #4796

### DIFF
--- a/recipes/miniaudio/all/conandata.yml
+++ b/recipes/miniaudio/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.10.32":
+    url: https://github.com/mackron/miniaudio/archive/d06d4983d3ff512690eb37f5edd25bf96f8f3764.tar.gz
+    sha256: 1FB7784AA6BC1C8138376C966BBDB444FF51CE04EF4289067BC59FB163CF38EA

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -25,12 +25,10 @@ class MiniaudioConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(
-            pattern="miniaudio.h", dst="include/miniaudio", src=self._source_subfolder
-        )
+        self.copy(pattern="miniaudio.h", dst="include", src=self._source_subfolder)
         self.copy(
             pattern="stb_vorbis.c",
-            dst="include/miniaudio/extras",
+            dst="include/extras",
             src=os.path.join(self._source_subfolder, "extras"),
         )
         self.copy(
@@ -40,12 +38,12 @@ class MiniaudioConan(ConanFile):
         )
         self.copy(
             pattern="ma_speex_resampler.h",
-            dst="include/miniaudio/extras/speex_resampler/",
+            dst="include/extras/speex_resampler/",
             src=os.path.join(self._source_subfolder, "extras/speex_resampler/"),
         )
         self.copy(
             pattern="*.*",
-            dst="include/miniaudio/extras/speex_resampler/thirdparty",
+            dst="include/extras/speex_resampler/thirdparty",
             src=os.path.join(
                 self._source_subfolder, "extras/speex_resampler/thirdparty"
             ),

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -28,10 +28,10 @@ class MiniaudioConan(ConanFile):
         self.copy(pattern="miniaudio.h", dst="include", src=self._source_subfolder)
 
     def package_info(self):
-        if self.settings.os == "Linux":
-            self.cpp_info.system_libs.extend(["m", "pthread", "dl"])
-        elif self.settings.os == "Macos":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["m", "pthread"])
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.append("dl")
         self.cpp_info.names["cmake_find_package"] = "Miniaudio"
         self.cpp_info.names["cmake_find_package_multi"] = "Miniaudio"
         self.cpp_info.components["miniaudiolib"].names[

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -25,7 +25,31 @@ class MiniaudioConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="miniaudio.h", dst="include", src=self._source_subfolder)
+        self.copy(
+            pattern="miniaudio.h", dst="include/miniaudio", src=self._source_subfolder
+        )
+        self.copy(
+            pattern="stb_vorbis.c",
+            dst="include/miniaudio/extras",
+            src=os.path.join(self._source_subfolder, "extras"),
+        )
+        self.copy(
+            pattern="README.md",
+            dst="licenses",
+            src=os.path.join(self._source_subfolder, "extras/speex_resampler/"),
+        )
+        self.copy(
+            pattern="ma_speex_resampler.h",
+            dst="include/miniaudio/extras/speex_resampler/",
+            src=os.path.join(self._source_subfolder, "extras/speex_resampler/"),
+        )
+        self.copy(
+            pattern="*.*",
+            dst="include/miniaudio/extras/speex_resampler/thirdparty",
+            src=os.path.join(
+                self._source_subfolder, "extras/speex_resampler/thirdparty"
+            ),
+        )
 
     def package_info(self):
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -32,6 +32,11 @@ class MiniaudioConan(ConanFile):
             src=os.path.join(self._source_subfolder, "extras"),
         )
         self.copy(
+            pattern="dr_*.h",
+            dst="include/extras",
+            src=os.path.join(self._source_subfolder, "extras"),
+        )
+        self.copy(
             pattern="ma_speex_resampler.h",
             dst="include/extras/speex_resampler/",
             src=os.path.join(self._source_subfolder, "extras/speex_resampler/"),

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -9,7 +9,7 @@ class MiniaudioConan(ConanFile):
     topics = ("conan", "miniaudio", "header-only", "sound")
     homepage = "https://github.com/mackron/miniaudio"
     url = "https://github.com/conan-io/conan-center-index"
-    license = "Unlicense"
+    license = ["Unlicense", "MIT-0"]
     settings = "os", "compiler", "build_type", "arch"
 
     no_copy_source = True

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -48,6 +48,11 @@ class MiniaudioConan(ConanFile):
                 self._source_subfolder, "extras/speex_resampler/thirdparty"
             ),
         )
+        self.copy(
+            pattern="miniaudio.*",
+            dst="include/extras/miniaudio_split",
+            src=os.path.join(self._source_subfolder, "extras/miniaudio_split"),
+        )
 
     def package_info(self):
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -32,6 +32,11 @@ class MiniaudioConan(ConanFile):
             self.cpp_info.system_libs.extend(["m", "pthread"])
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("dl")
+        if self.settings.os == "Macos":
+            self.cpp_info.frameworks.extend(
+                ["CoreFoundation", "CoreAudio", "AudioUnit"]
+            )
+            self.cpp_info.defines.append("MA_NO_RUNTIME_LINKING=1")
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -32,11 +32,6 @@ class MiniaudioConan(ConanFile):
             src=os.path.join(self._source_subfolder, "extras"),
         )
         self.copy(
-            pattern="README.md",
-            dst="licenses",
-            src=os.path.join(self._source_subfolder, "extras/speex_resampler/"),
-        )
-        self.copy(
             pattern="ma_speex_resampler.h",
             dst="include/extras/speex_resampler/",
             src=os.path.join(self._source_subfolder, "extras/speex_resampler/"),

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -27,5 +27,11 @@ class MiniaudioConan(ConanFile):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
         self.copy(pattern="miniaudio.h", dst="include", src=self._source_subfolder)
 
+    def package_info(self):
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.extend(["m", "pthread", "dl"])
+        elif self.settings.os == "Macos":
+            self.cpp_info.system_libs.extend(["m", "pthread"])
+
     def package_id(self):
         self.info.header_only()

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -1,0 +1,31 @@
+from conans import ConanFile, tools
+import os
+import glob
+
+
+class MiniaudioConan(ConanFile):
+    name = "miniaudio"
+    description = "A single file audio playback and capture library."
+    topics = ("conan", "miniaudio", "header-only", "sound")
+    homepage = "https://github.com/mackron/miniaudio"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "Unlicense"
+    settings = "os", "compiler", "build_type", "arch"
+
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = glob.glob(self.name + "-*/")[0]
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="miniaudio.h", dst="include", src=self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -32,6 +32,14 @@ class MiniaudioConan(ConanFile):
             self.cpp_info.system_libs.extend(["m", "pthread", "dl"])
         elif self.settings.os == "Macos":
             self.cpp_info.system_libs.extend(["m", "pthread"])
+        self.cpp_info.names["cmake_find_package"] = "Miniaudio"
+        self.cpp_info.names["cmake_find_package_multi"] = "Miniaudio"
+        self.cpp_info.components["miniaudiolib"].names[
+            "cmake_find_package"
+        ] = "miniaudio"
+        self.cpp_info.components["miniaudiolib"].names[
+            "cmake_find_package_multi"
+        ] = "miniaudio"
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -32,14 +32,6 @@ class MiniaudioConan(ConanFile):
             self.cpp_info.system_libs.extend(["m", "pthread"])
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("dl")
-        self.cpp_info.names["cmake_find_package"] = "Miniaudio"
-        self.cpp_info.names["cmake_find_package_multi"] = "Miniaudio"
-        self.cpp_info.components["miniaudiolib"].names[
-            "cmake_find_package"
-        ] = "miniaudio"
-        self.cpp_info.components["miniaudiolib"].names[
-            "cmake_find_package_multi"
-        ] = "miniaudio"
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/miniaudio/all/test_package/CMakeLists.txt
+++ b/recipes/miniaudio/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+find_package(miniaudio REQUIRED)
+
+add_executable(test_package example.c)
+target_link_libraries(test_package miniaudio::miniaudio)

--- a/recipes/miniaudio/all/test_package/CMakeLists.txt
+++ b/recipes/miniaudio/all/test_package/CMakeLists.txt
@@ -5,3 +5,13 @@ find_package(miniaudio REQUIRED)
 
 add_executable(test_package example.c)
 target_link_libraries(test_package miniaudio::miniaudio)
+
+if(UNIX AND NOT APPLE)
+  set(LINUX TRUE)
+endif()
+
+if(LINUX)
+  target_link_libraries(test_package m pthread dl)
+elseif(UNIX)
+  target_link_libraries(test_package m pthread)
+endif()

--- a/recipes/miniaudio/all/test_package/CMakeLists.txt
+++ b/recipes/miniaudio/all/test_package/CMakeLists.txt
@@ -4,4 +4,4 @@ project(test_package C)
 find_package(miniaudio REQUIRED)
 
 add_executable(test_package example.c)
-target_link_libraries(test_package Miniaudio::miniaudio)
+target_link_libraries(test_package miniaudio::miniaudio)

--- a/recipes/miniaudio/all/test_package/CMakeLists.txt
+++ b/recipes/miniaudio/all/test_package/CMakeLists.txt
@@ -5,13 +5,3 @@ find_package(miniaudio REQUIRED)
 
 add_executable(test_package example.c)
 target_link_libraries(test_package miniaudio::miniaudio)
-
-if(UNIX AND NOT APPLE)
-  set(LINUX TRUE)
-endif()
-
-if(LINUX)
-  target_link_libraries(test_package m pthread dl)
-elseif(UNIX)
-  target_link_libraries(test_package m pthread)
-endif()

--- a/recipes/miniaudio/all/test_package/CMakeLists.txt
+++ b/recipes/miniaudio/all/test_package/CMakeLists.txt
@@ -4,4 +4,4 @@ project(test_package C)
 find_package(miniaudio REQUIRED)
 
 add_executable(test_package example.c)
-target_link_libraries(test_package miniaudio::miniaudio)
+target_link_libraries(test_package Miniaudio::miniaudio)

--- a/recipes/miniaudio/all/test_package/conanfile.py
+++ b/recipes/miniaudio/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.run("test_package", run_environment=True)

--- a/recipes/miniaudio/all/test_package/example.c
+++ b/recipes/miniaudio/all/test_package/example.c
@@ -7,7 +7,7 @@ explicitly specify the same context you used for enumeration in the call to
 `ma_device_init()` when you initialize your devices.
 */
 #define MINIAUDIO_IMPLEMENTATION
-#include <miniaudio.h>
+#include <miniaudio/miniaudio.h>
 
 #include <stdio.h>
 

--- a/recipes/miniaudio/all/test_package/example.c
+++ b/recipes/miniaudio/all/test_package/example.c
@@ -7,7 +7,7 @@ explicitly specify the same context you used for enumeration in the call to
 `ma_device_init()` when you initialize your devices.
 */
 #define MINIAUDIO_IMPLEMENTATION
-#include <miniaudio/miniaudio.h>
+#include <miniaudio.h>
 
 #include <stdio.h>
 

--- a/recipes/miniaudio/all/test_package/example.c
+++ b/recipes/miniaudio/all/test_package/example.c
@@ -1,0 +1,53 @@
+/*
+Demonstrates how to enumerate over devices.
+Device enumaration requires a `ma_context` object which is initialized with
+`ma_context_init()`. Conceptually, the context sits above a device. You can have
+many devices to one context. If you use device enumeration, you should
+explicitly specify the same context you used for enumeration in the call to
+`ma_device_init()` when you initialize your devices.
+*/
+#define MINIAUDIO_IMPLEMENTATION
+#include <miniaudio.h>
+
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+  ma_result result;
+  ma_context context;
+  ma_device_info *pPlaybackDeviceInfos;
+  ma_uint32 playbackDeviceCount;
+  ma_device_info *pCaptureDeviceInfos;
+  ma_uint32 captureDeviceCount;
+  ma_uint32 iDevice;
+
+  if (ma_context_init(NULL, 0, NULL, &context) != MA_SUCCESS) {
+    printf("Failed to initialize context.\n");
+    return -2;
+  }
+
+  result = ma_context_get_devices(&context, &pPlaybackDeviceInfos,
+                                  &playbackDeviceCount, &pCaptureDeviceInfos,
+                                  &captureDeviceCount);
+  if (result != MA_SUCCESS) {
+    printf("Failed to retrieve device information.\n");
+    return -3;
+  }
+
+  printf("Playback Devices\n");
+  for (iDevice = 0; iDevice < playbackDeviceCount; ++iDevice) {
+    printf("    %u: %s\n", iDevice, pPlaybackDeviceInfos[iDevice].name);
+  }
+
+  printf("\n");
+
+  printf("Capture Devices\n");
+  for (iDevice = 0; iDevice < captureDeviceCount; ++iDevice) {
+    printf("    %u: %s\n", iDevice, pCaptureDeviceInfos[iDevice].name);
+  }
+
+  ma_context_uninit(&context);
+
+  (void)argc;
+  (void)argv;
+  return 0;
+}

--- a/recipes/miniaudio/all/test_package/example.c
+++ b/recipes/miniaudio/all/test_package/example.c
@@ -47,7 +47,5 @@ int main(int argc, char **argv) {
 
   ma_context_uninit(&context);
 
-  (void)argc;
-  (void)argv;
   return 0;
 }

--- a/recipes/miniaudio/config.yml
+++ b/recipes/miniaudio/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.10.32":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **miniaudio /0.10.32**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Notes: CMake used the visual studio generator to build the test .exe so it failed to run it because it was on a weird subfolder (msvc things). But the CI should work fine, let's see. 

Questions: Shouldn't I make so that the link library is Miniaudio::miniaudio isntead of miniaudio::miniaudio? If yes, how?
