### PR TITLE
libcurl: do not run test_package on crosscompilation under any circumstance 

### DIFF
--- a/recipes/libcurl/all/test_package/conanfile.py
+++ b/recipes/libcurl/all/test_package/conanfile.py
@@ -23,9 +23,7 @@ class TestPackageConan(ConanFile):
             self.test_arm()
         elif tools.cross_building(self.settings) and self.settings.os == "Windows":
             self.test_mingw_cross()
-        elif tools.cross_building(self.settings):
-            return
-        else:
+        elif not tools.cross_building(self.settings):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)
 

--- a/recipes/libcurl/all/test_package/conanfile.py
+++ b/recipes/libcurl/all/test_package/conanfile.py
@@ -23,6 +23,8 @@ class TestPackageConan(ConanFile):
             self.test_arm()
         elif tools.cross_building(self.settings) and self.settings.os == "Windows":
             self.test_mingw_cross()
+        elif tools.cross_building(self.settings):
+            return
         else:
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **libcurl/x**

`libcurl` current code doesn't consider all possible crosscompilation scenarios leading to the test being runned when it shouldn't. This is even worst if you're using custom 'arch's in conan.

To play it safe I added one more entry to the if-else chain that catches any crosscompilation that wasn't handled before.


- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
