### PR TITLE
Add latest senty-native version

### DIFF
--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.4.8":
+    url: "https://github.com/getsentry/sentry-native/archive/0.4.8.tar.gz"
+    sha256: "8100cee919b42c68699bd013c7b52e8ef7c4ee5ac7122886ffa51e972c34e2f2"
   "0.4.7":
     url: "https://github.com/getsentry/sentry-native/archive/0.4.7.tar.gz"
     sha256: "84f3a1dbfea1245870a7e36eef06ea78e21c173457c543eaa27904d2d017e50c"

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -54,7 +54,7 @@ class SentryNativeConan(ConanFile):
 
     def requirements(self):
         if self.options.transport == "curl":
-            self.requires("libcurl/7.74.0")
+            self.requires("libcurl/7.75.0")
         if self.options.backend == "crashpad":
             raise ConanInvalidConfiguration("crashpad not available yet in CCI")
         elif self.options.backend == "breakpad":

--- a/recipes/sentry-native/config.yml
+++ b/recipes/sentry-native/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.4.8":
+    folder: all
   "0.4.7":
     folder: all
   "0.4.1":


### PR DESCRIPTION
Specify library name and version:  **sentry-native/0.X**

- Add new sentry-native version, 0.4.8.
- Bump libcurl dependency to latest version available.


- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
