### PR TITLE
mariadb-connector-c: remove openssl fixes

### DIFF
--- a/recipes/mariadb-connector-c/all/conanfile.py
+++ b/recipes/mariadb-connector-c/all/conanfile.py
@@ -58,9 +58,9 @@ class MariadbConnectorcConan(ConanFile):
         if self.options.get_safe("with_iconv"):
             self.requires("libiconv/1.16")
         if self.options.with_curl:
-            self.requires("libcurl/7.73.0")
+            self.requires("libcurl/7.75.0")
         if self.options.with_ssl == "openssl":
-            self.requires("openssl/1.1.1h")
+            self.requires("openssl/1.1.1j")
         elif self.options.with_ssl == "gnutls":
             raise ConanInvalidConfiguration("gnutls not yet available in CCI")
 
@@ -76,15 +76,6 @@ class MariadbConnectorcConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "${ZLIB_LIBRARY}",
                               "${ZLIB_LIBRARIES}")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              "IF(OPENSSL_FOUND)",
-                              "IF(OpenSSL_FOUND)")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              "SET(SSL_LIBRARIES ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})",
-                              "SET(SSL_LIBRARIES ${OpenSSL_LIBRARIES})")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              "${OPENSSL_INCLUDE_DIR}",
-                              "${OpenSSL_INCLUDE_DIR}")
 
     def _configure_cmake(self):
         if self._cmake:


### PR DESCRIPTION
also, bump libcurl and openssl

Specify library name and version:  **mariadb-connector-c/***

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
