### PR TITLE
leptonica: fix all dependencies shared on Linux & Macos

### DIFF
--- a/recipes/leptonica/all/CMakeLists.txt
+++ b/recipes/leptonica/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 add_subdirectory(source_subfolder)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Even with `tools.run_environment(self)` `conan create leptonica/x.xx@ -o "*":shared=True` silently ignores `openjpeg` on Macos due to SIP (pkgconf shared lib image not found), so pkgconf is removed and we inject CONAN_PKG targets for openjpeg & libwebp.

All these issues with build requirements which might depend on shared libs (in the same package or worse in an other package) are tedious. Basically, `conan install ... -o *:shared=True -b` is fragile in CCI.

Or maybe we could inject something like `set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")` in pkgconf recipe (meson based).