### PR TITLE
volk: add version 1.2.170

### DIFF
--- a/recipes/volk/all/conandata.yml
+++ b/recipes/volk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.170":
+    url: "https://github.com/zeux/volk/archive/1.2.170.tar.gz"
+    sha256: "01f37fc0c904afd2eb8060cada73f903ab1cdae87c7c24e77585ca7fb9bafae4"
   "1.2.162":
     url: "https://github.com/zeux/volk/archive/1.2.162.tar.gz"
     sha256: "ac4d9d6e88dee5a83ad176e2da57f1989ca2c6df155a0aeb5e18e9471aa4d777"

--- a/recipes/volk/config.yml
+++ b/recipes/volk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.170":
+    folder: "all"
   "1.2.162":
     folder: "all"
   "1.2.140":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **volk/1.2.170**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
