### PR TITLE
quazip: remove unneeded patch

### DIFF
--- a/recipes/quazip/all/conanfile.py
+++ b/recipes/quazip/all/conanfile.py
@@ -47,10 +47,6 @@ class QuaZIPConan(ConanFile):
     def build(self):
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
-        tools.replace_in_file(os.path.join(self._source_subfolder, "quazip", "CMakeLists.txt"),
-            "add_library(${QUAZIP_LIB_TARGET_NAME} ${QUAZIP_SOURCES})",
-            "qt5_wrap_cpp(QUAZIP_SOURCES ${QUAZIP_HEADERS})\n"
-            "add_library(${QUAZIP_LIB_TARGET_NAME} ${QUAZIP_SOURCES})")
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/quazip/all/test_package/test_package.cpp
+++ b/recipes/quazip/all/test_package/test_package.cpp
@@ -6,7 +6,9 @@ int main(int argc, char* argv[]) {
 
     std::cout << "Quazip test_package" << std::endl;
 
-    QuaZip zip(argv[1]);
+    const QString path = QString::fromLatin1(argv[1]);
+
+    QuaZip zip(path);
 
     if (zip.open(QuaZip::mdUnzip)) {
 


### PR DESCRIPTION
unneeded after https://github.com/conan-io/conan-center-index/pull/4888 is merged

Specify library name and version:  **quazip/***

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
