### PR TITLE
Try to improve README visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-<img src="assets/JFrogConanCenter.png" width="600"/>
+<p align="center">
+    <img src="assets/JFrogConanCenter.png" width="600"/>
+</p>
 
-This is the source index of recipes of the [ConanCenter](https://conan.io/center) package repository.
+Conan Center Index is the source index of recipes of the [ConanCenter](https://conan.io/center) package repository for [Conan](https://conan.io).
 
 This repository includes a Continuous Integration system that will build automatically the Conan packages for the recipes submitted via
 [Pull Request](https://github.com/conan-io/conan-center-index/pulls).
@@ -12,27 +14,34 @@ All the documentation is available in this same repository in the [`docs/` subfo
 
 This is a list of shortcuts to some interesting topics:
 
-* If you want to learn how to **contribute new recipes**, please read [docs/how_to_add_packages.md](docs/how_to_add_packages.md).
-* **FAQ**: most common questions are listed in [docs/faqs.md](docs/faqs.md).
-* The conan-center **hook errors** reported by CCI Bot can be found in the [docs/error_knowledge_base.md](docs/error_knowledge_base.md).
-* The internal changes related to infrastructure can be checked in [docs/changelog.md](docs/changelog.md).
-* There are various community lead innitiatives which are outlined in [docs/community_resources.md](docs/community_resources.md).
+* :rocket: If you want to learn how to **contribute new recipes**, please read [docs/how_to_add_packages.md](docs/how_to_add_packages.md).
+* :speech_balloon: **FAQ**: most common questions are listed in [docs/faqs.md](docs/faqs.md).
+* :warning: The conan-center **hook errors** reported by CCI Bot can be found in the [docs/error_knowledge_base.md](docs/error_knowledge_base.md).
+* :hammer_and_wrench: The internal changes related to infrastructure can be checked in [docs/changelog.md](docs/changelog.md).
+* :world_map: There are various community lead initiatives which are outlined in [docs/community_resources.md](docs/community_resources.md).
 
 ### Reporting Issues
 
 You can open issues in the [issue tracker](https://github.com/conan-io/conan-center-index/issues) to:
 
-- Report **bugs/issues** in a package:
+* :bug: Report **bugs/issues** in a package:
     - Use the `[package]` tag in the title of the issue to help identifying them.
     - If you detect any issue or missing feature in a package, for example, a build failure or a recipe that not support a specific configuration.
     - Specify the name and version (`zlib/1.2.11`) and any relevant details about the fail configuration: Applied profile, building machine...
-- Request a **new library** to be added:
+
+* :bulb: Request a **new library** to be added:
     - Use the `[request]` label to search the library in the issue tracker in case the it was already requested.
     - If not, use the same `[request]` tag in the title of the issue to help identifying them.
     - Indicate the name and the version of the library you would like to have in the repository. Also links to the project's website,
       source download/repository and in general any relevant information that helps creating a recipe for it.
-- Report **a failure** in the CI system:
+
+*  :robot: Report **a failure** in the CI system:
     - If you open a Pull Request and get an unexpected error you might comment in the failing PR.
     - If the service or repository is down or failing, use the `[service]` tag in the title of a new issue to help identifying them.
 
 If your issue is not appropriate for a public discussion, please contact us via e-mail at `info@conan.io`. Thanks!
+
+
+### License
+
+[MIT](LICENSE)


### PR DESCRIPTION
After reading [Awesome README](https://github.com/matiassingers/awesome-readme), I think our README is not bad, all main information there. Maybe just need something to get more attention.

I added emojis because I think they are good for visual memorization and make CCI README more flashy.

You can check the preview directly on my fork: https://github.com/uilianries/conan-center-index/blob/feature/awesome-readme/README.md

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
