### PR TITLE
glib: add version 2.68.0

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -41,3 +41,6 @@ sources:
   "2.67.6":
     url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.6/glib-2.67.6.tar.gz"
     sha256: "2698198b349021bae45a899e21c42bdc8cdf6e508f38a35d8c2bb474964c1240"
+  "2.68.0":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.68.0/glib-2.68.0.tar.gz"
+    sha256: "9d99ba95ee2e5271e0246cb6faf411d00d815fefc6aab921191f2918c0dffbbc"

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -27,3 +27,5 @@ versions:
     folder: all
   "2.67.6":
     folder: all
+  "2.68.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **glib/2.68.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
