### PR TITLE
Add rpath to libgeotiff

### DIFF
--- a/recipes/libgeotiff/all/conanfile.py
+++ b/recipes/libgeotiff/all/conanfile.py
@@ -16,8 +16,8 @@ class LibgeotiffConan(ConanFile):
     exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "rpath": "ANY"}
+    default_options = {"shared": False, "fPIC": True, "rpath": None}
 
     _cmake = None
 
@@ -59,6 +59,9 @@ class LibgeotiffConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["WITH_UTILITIES"] = False
         self._cmake.definitions["WITH_TOWGS84"] = True
+        if self.options.rpath is not None:
+            self._cmake.definitions["CMAKE_BUILD_WITH_INSTALL_RPATH"] = True
+            self._cmake.definitions["CMAKE_INSTALL_RPATH"] = self.options.rpath
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **libgeotiff/1.6.0**, **libgeotiff/1.5.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

If the option "shared" is True, the requirements cannot be found. We should use the "rpath".
```
  	libtiff.so.5 => not found
	libproj.so.9 => not found
```
