### PR TITLE
[libcurl] Remove build requirements and fix test_package on arm

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -171,9 +171,6 @@ class LibcurlConan(ConanFile):
             self.build_requires("msys2/20200517")
         elif self._is_win_x_android:
             self.build_requires("ninja/1.10.2")
-        elif not tools.os_info.is_windows:
-            self.build_requires("libtool/2.4.6")
-            self.build_requires("pkgconf/1.7.3")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -171,6 +171,9 @@ class LibcurlConan(ConanFile):
             self.build_requires("msys2/20200517")
         elif self._is_win_x_android:
             self.build_requires("ninja/1.10.2")
+        elif not tools.os_info.is_windows and not tools.cross_building(self.settings):
+            self.build_requires("libtool/2.4.6")
+            self.build_requires("pkgconf/1.7.3")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/libcurl/all/test_package/conanfile.py
+++ b/recipes/libcurl/all/test_package/conanfile.py
@@ -34,7 +34,7 @@ class TestPackageConan(ConanFile):
 
     def test_arm(self):
         file_ext = "so" if self.options["libcurl"].shared else "a"
-        lib_path = os.path.join(self.deps_cpp_info["libcurl"].libdirs[0], "libcurl.%s" % file_ext)
+        lib_path = os.path.join(self.deps_cpp_info["libcurl"].lib_paths[0], "libcurl.%s" % file_ext)
         output = subprocess.check_output(["readelf", "-h", lib_path]).decode()
 
         if "armv8" in self.settings.arch:


### PR DESCRIPTION
* libtool and pkgconf (build) requirements do not work when cross building (host vs target)
* error in test_package for arm platform (did not find libcurl.a)

Specify library name and version:  **libcurl/***

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
