### PR TITLE
at-spi2-core: add version 2.40.0

### DIFF
--- a/recipes/at-spi2-core/all/conandata.yml
+++ b/recipes/at-spi2-core/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "2.39.1":
     url: "http://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.39/at-spi2-core-2.39.1.tar.xz"
     sha256: "44d2b042e47d25571581efff673af0a8cd79531babbad2b043784879e15e4228"
+  "2.40.0":
+    url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.40/at-spi2-core-2.40.0.tar.xz"
+    sha256: "4196a7d30a0051e52a67b8ce4283fe79ae5e4e14a725719934565adf1d333429"

--- a/recipes/at-spi2-core/config.yml
+++ b/recipes/at-spi2-core/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "2.39.1":
     folder: all
+  "2.40.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **at-spi2-core/2.40.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
