### PR TITLE
Add a recipe for Hedley

### DIFF
--- a/recipes/hedley/all/conandata.yml
+++ b/recipes/hedley/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "15":
+    url: "https://github.com/nemequ/hedley/archive/refs/tags/v15.tar.gz"
+    sha256: "e91c71b58f59d08c7b8289be8f687866863d934dfaa528e4be30b178139ae863"

--- a/recipes/hedley/all/conanfile.py
+++ b/recipes/hedley/all/conanfile.py
@@ -24,6 +24,7 @@ class HedleyConan(ConanFile):
     def package(self):
         include_folder = self._source_subfolder
         self.copy(pattern="*.h", dst="include", src=include_folder)
+        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/hedley/all/conanfile.py
+++ b/recipes/hedley/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, tools
 import os
 import glob
 

--- a/recipes/hedley/all/conanfile.py
+++ b/recipes/hedley/all/conanfile.py
@@ -1,0 +1,33 @@
+from conans import ConanFile, CMake, tools
+import os
+import glob
+
+
+class HedleyConan(ConanFile):
+    name = "hedley"
+    license = "CC0-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://nemequ.github.io/hedley/"
+    description = "A C/C++ header to help move #ifdefs out of your code"
+    topics = ("header", 'header-only', 'preprocessor', "#ifdef", "cross-platform")
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = glob.glob(self.name + "-*/")[0]
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        include_folder = self._source_subfolder
+        self.copy(pattern="*.h", dst="include", src=include_folder)
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "hedley"
+        self.cpp_info.names["cmake_find_package_multi"] = "hedley"

--- a/recipes/hedley/all/conanfile.py
+++ b/recipes/hedley/all/conanfile.py
@@ -28,7 +28,3 @@ class HedleyConan(ConanFile):
 
     def package_id(self):
         self.info.header_only()
-
-    def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "hedley"
-        self.cpp_info.names["cmake_find_package_multi"] = "hedley"

--- a/recipes/hedley/all/test_package/CMakeLists.txt
+++ b/recipes/hedley/all/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})
+
+# CTest is a testing tool that can be used to test your project.
+# enable_testing()
+# add_test(NAME example
+#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+#          COMMAND example)

--- a/recipes/hedley/all/test_package/CMakeLists.txt
+++ b/recipes/hedley/all/test_package/CMakeLists.txt
@@ -6,9 +6,3 @@ conan_basic_setup()
 
 add_executable(example example.cpp)
 target_link_libraries(example ${CONAN_LIBS})
-
-# CTest is a testing tool that can be used to test your project.
-# enable_testing()
-# add_test(NAME example
-#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-#          COMMAND example)

--- a/recipes/hedley/all/test_package/conanfile.py
+++ b/recipes/hedley/all/test_package/conanfile.py
@@ -1,20 +1,17 @@
 import os
-
 from conans import ConanFile, CMake, tools
 
 
-class HedleyTestConan(ConanFile):
+class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 
     def build(self):
         cmake = CMake(self)
-        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
-        # in "test_package"
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            os.chdir("bin")
-            self.run(".%sexample" % os.sep)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/hedley/all/test_package/conanfile.py
+++ b/recipes/hedley/all/test_package/conanfile.py
@@ -14,11 +14,6 @@ class HedleyTestConan(ConanFile):
         cmake.configure()
         cmake.build()
 
-    def imports(self):
-        self.copy("*.dll", dst="bin", src="bin")
-        self.copy("*.dylib*", dst="bin", src="lib")
-        self.copy('*.so*', dst='bin', src='lib')
-
     def test(self):
         if not tools.cross_building(self):
             os.chdir("bin")

--- a/recipes/hedley/all/test_package/conanfile.py
+++ b/recipes/hedley/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class HedleyTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
+        # in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def imports(self):
+        self.copy("*.dll", dst="bin", src="bin")
+        self.copy("*.dylib*", dst="bin", src="lib")
+        self.copy('*.so*', dst='bin', src='lib')
+
+    def test(self):
+        if not tools.cross_building(self):
+            os.chdir("bin")
+            self.run(".%sexample" % os.sep)

--- a/recipes/hedley/all/test_package/example.cpp
+++ b/recipes/hedley/all/test_package/example.cpp
@@ -1,5 +1,7 @@
 #include "hedley.h"
+#include <iostream>
 
 int main() {
-    return !(HEDLEY_VERSION==15);
+    std::cout << "HEDLEY_VERSION: " << HEDLEY_VERSION << std::endl;
+    return 0;
 }

--- a/recipes/hedley/all/test_package/example.cpp
+++ b/recipes/hedley/all/test_package/example.cpp
@@ -1,0 +1,5 @@
+#include "hedley.h"
+
+int main() {
+    return !(HEDLEY_VERSION==15);
+}

--- a/recipes/hedley/config.yml
+++ b/recipes/hedley/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "15":
+    folder: all


### PR DESCRIPTION
Hedley is "A C/C++ header to help move #ifdefs out of your code." It can
be found at https://github.com/nemequ/hedley. It contains cross platform
versions of common macros, like `HEDLEY_LIKELY`, version checks, and macros to
allow code to be compiled under C or C++ such as `HEDLEY_STATIC_CAST`.

As of now, the recipe pulls down Hedley version 15 and copies it into
the include directory (as far as I know).

Specify library name and version:  **hedley/15**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
