### PR TITLE
gdk-pixbuf: add version 2.42.4

### DIFF
--- a/recipes/gdk-pixbuf/all/conandata.yml
+++ b/recipes/gdk-pixbuf/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "2.42.2":
     url: "http://ftp.gnome.org/pub/gnome/sources/gdk-pixbuf/2.42/gdk-pixbuf-2.42.2.tar.xz"
     sha256: "83c66a1cfd591d7680c144d2922c5955d38b4db336d7cd3ee109f7bcf9afef15"
+  "2.42.4":
+    url: "https://ftp.gnome.org/pub/gnome/sources/gdk-pixbuf/2.42/gdk-pixbuf-2.42.4.tar.xz"
+    sha256: "fe9c5dd88f486194ea2bc09b8814c1ed895bb6c530f37cbbf259757c4e482e4d"

--- a/recipes/gdk-pixbuf/config.yml
+++ b/recipes/gdk-pixbuf/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "2.42.2":
     folder: all
+  "2.42.4":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **gdk-pixbuf/2.42.4**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
