### PR TITLE
gobject-introspection: add version 1.68.0

### DIFF
--- a/recipes/gobject-introspection/all/conandata.yml
+++ b/recipes/gobject-introspection/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.68.0":
+    url: "https://download.gnome.org/sources/gobject-introspection/1.68/gobject-introspection-1.68.0.tar.xz"
+    sha256: "d229242481a201b84a0c66716de1752bca41db4133672cfcfb37c93eb6e54a27"
   "1.67.1":
     url: "https://download.gnome.org/sources/gobject-introspection/1.67/gobject-introspection-1.67.1.tar.xz"
     sha256: "9635184d668794609f9fe661c5bde11c106385d26c3babe291c24e3655987e47"

--- a/recipes/gobject-introspection/config.yml
+++ b/recipes/gobject-introspection/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.68.0":
+    folder: all
   "1.67.1":
     folder: all
   "1.66.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **gobject-introspection/1.68.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
