### PR TITLE
gdk-pixbuf: add version 2.42.4

### DIFF
--- a/recipes/gdk-pixbuf/all/conandata.yml
+++ b/recipes/gdk-pixbuf/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "2.42.2":
     url: "http://ftp.gnome.org/pub/gnome/sources/gdk-pixbuf/2.42/gdk-pixbuf-2.42.2.tar.xz"
     sha256: "83c66a1cfd591d7680c144d2922c5955d38b4db336d7cd3ee109f7bcf9afef15"
+  "2.42.4":
+    url: "https://ftp.gnome.org/pub/gnome/sources/gdk-pixbuf/2.42/gdk-pixbuf-2.42.4.tar.xz"
+    sha256: "fe9c5dd88f486194ea2bc09b8814c1ed895bb6c530f37cbbf259757c4e482e4d"

--- a/recipes/gdk-pixbuf/all/conanfile.py
+++ b/recipes/gdk-pixbuf/all/conanfile.py
@@ -53,21 +53,21 @@ class LibnameConan(ConanFile):
             raise ConanInvalidConfiguration('This package does not support Macos currently')
     
     def build_requirements(self):
-        self.build_requires('meson/0.56.0')
+        self.build_requires('meson/0.57.1')
         self.build_requires('pkgconf/1.7.3')
     
     def requirements(self):
-        self.requires('glib/2.67.0')
+        self.requires('glib/2.68.0')
         if self.options.with_libpng:
             self.requires('libpng/1.6.37')
         if self.options.with_libtiff:
-            self.requires('libtiff/4.0.9')
+            self.requires('libtiff/4.2.0')
         if self.options.with_libjpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/2.0.5")
+            self.requires("libjpeg-turbo/2.0.6")
         elif self.options.with_libjpeg == "libjpeg":
             self.requires("libjpeg/9d")
         if self.options.with_jasper:
-            self.requires('jasper/2.0.19')
+            self.requires('jasper/2.0.27')
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/gdk-pixbuf/config.yml
+++ b/recipes/gdk-pixbuf/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "2.42.2":
     folder: all
+  "2.42.4":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **gdk-pixbuf/2.42.4**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
