### PR TITLE
Add elsid/resource_pool

### DIFF
--- a/recipes/resource_pool/all/conandata.yml
+++ b/recipes/resource_pool/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20210322":
+    url: "https://github.com/elsid/resource_pool/archive/3ea1f95fecc9ce28e66bbbc2a36c1e0142551ab6.zip"
+    sha256: 37fa3807648b66f3903d1edf03022185acc6f1626ae8bb9174894a1f29012a0c

--- a/recipes/resource_pool/all/conanfile.py
+++ b/recipes/resource_pool/all/conanfile.py
@@ -1,0 +1,65 @@
+from conans import ConanFile, tools
+from conans.tools import check_min_cppstd
+import os
+import glob
+
+
+class ResourcePool(ConanFile):
+    name = "resource_pool"
+    description = "C++ header only library purposed to create pool of some resources like keepalive connections"
+    topics = ("conan", "resource pool", "resource_pool", "asio", "elsid", "c++17", "cpp17")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://github.com/elsid/resource_pool"
+    license = "MIT"
+
+    settings = "os", "arch", "compiler", "build_type"
+    requires = (
+        "boost/1.75.0"
+    )
+    generators = "cmake_find_package"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def _validate_compiler_settings(self):
+        compiler = self.settings.compiler
+        if compiler.get_safe("cppstd"):
+            check_min_cppstd(self, "17")
+
+    def configure(self):
+        self._validate_compiler_settings()
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = glob.glob(self.name + "-*/")[0]
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        self.copy(pattern="*", dst=os.path.join("include", "yamail"), src=os.path.join(self._source_subfolder, "include", "yamail"))
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        main_comp = self.cpp_info.components["_resource_pool"]
+        main_comp.includedirs = ["include"]
+        main_comp.requires = ["boost::boost", "boost::system", "boost::thread"]
+        main_comp.defines = ["BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT"]
+        main_comp.names["cmake_find_package"] = "resource_pool"
+        main_comp.names["cmake_find_package_multi"] = "resource_pool"
+
+        if self.settings.os == "Windows":
+            main_comp.system_libs.append("ws2_32")
+
+        # Set up for compatibility with existing cmake configuration
+        self.cpp_info.filenames["cmake_find_package"] = "resource_pool"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "resource_pool"
+        self.cpp_info.names["cmake_find_package"] = "elsid"
+        self.cpp_info.names["cmake_find_package_multi"] = "elsid"

--- a/recipes/resource_pool/all/conanfile.py
+++ b/recipes/resource_pool/all/conanfile.py
@@ -48,7 +48,7 @@ class ResourcePool(ConanFile):
         elif tools.Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("resource_pool requires a compiler that supports at least C++17")
 
-    def configure(self):
+    def validate(self):
         self._validate_compiler_settings()
 
     def source(self):

--- a/recipes/resource_pool/all/conanfile.py
+++ b/recipes/resource_pool/all/conanfile.py
@@ -65,7 +65,6 @@ class ResourcePool(ConanFile):
 
     def package_info(self):
         main_comp = self.cpp_info.components["_resource_pool"]
-        main_comp.includedirs = ["include"]
         main_comp.requires = ["boost::boost", "boost::system", "boost::thread"]
         main_comp.defines = ["BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT"]
         main_comp.names["cmake_find_package"] = "resource_pool"

--- a/recipes/resource_pool/all/test_package/CMakeLists.txt
+++ b/recipes/resource_pool/all/test_package/CMakeLists.txt
@@ -3,6 +3,9 @@ project(PackageTest CXX)
 
 find_package(resource_pool REQUIRED)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 add_executable(example coro.cc)
 target_compile_features(example PRIVATE cxx_std_17)
 target_link_libraries(example PRIVATE elsid::resource_pool)

--- a/recipes/resource_pool/all/test_package/CMakeLists.txt
+++ b/recipes/resource_pool/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+project(PackageTest CXX)
+
+find_package(resource_pool REQUIRED)
+
+add_executable(example coro.cc)
+target_compile_features(example PRIVATE cxx_std_17)
+target_link_libraries(example PRIVATE elsid::resource_pool)

--- a/recipes/resource_pool/all/test_package/conanfile.py
+++ b/recipes/resource_pool/all/test_package/conanfile.py
@@ -1,9 +1,10 @@
-from conans import ConanFile, CMake
+import os
+from conans import ConanFile, CMake, tools
 
 
 class ResourcePoolTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake_find_package"
+    generators = "cmake_find_package", "cmake"
 
     def build(self):
         cmake = CMake(self)
@@ -11,4 +12,6 @@ class ResourcePoolTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        pass # Building alone is sufficient
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/resource_pool/all/test_package/conanfile.py
+++ b/recipes/resource_pool/all/test_package/conanfile.py
@@ -1,0 +1,14 @@
+from conans import ConanFile, CMake
+
+
+class ResourcePoolTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        pass # Building alone is sufficient

--- a/recipes/resource_pool/all/test_package/coro.cc
+++ b/recipes/resource_pool/all/test_package/coro.cc
@@ -1,0 +1,37 @@
+#include <yamail/resource_pool/async/pool.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <thread>
+#include <memory>
+
+using ofstream_pool = yamail::resource_pool::async::pool<std::unique_ptr<std::ofstream>>;
+using time_traits = yamail::resource_pool::time_traits;
+
+int main() {
+    boost::asio::io_context service;
+    ofstream_pool pool(1, 10);
+    boost::asio::spawn(service, [&](boost::asio::yield_context yield){
+        boost::system::error_code ec;
+        auto handle = pool.get_auto_waste(service, yield[ec], time_traits::duration::max());
+        if (ec) {
+            std::cout << "handle error: " << ec.message() << std::endl;
+            return;
+        }
+        std::cout << "got resource handle" << std::endl;
+        if (handle.empty()) {
+            auto file = std::make_unique<std::ofstream>("pool.log", std::ios::app);
+            if (!file->good()) {
+                std::cout << "open file pool.log error: " << file->rdstate() << std::endl;
+                return;
+            }
+            handle.reset(std::move(file));
+        }
+        *(handle.get()) << (time_traits::time_point::min() - time_traits::now()).count() << std::endl;
+        if (handle.get()->good()) {
+            handle.recycle();
+        }
+    });
+    service.run();
+    return 0;
+}

--- a/recipes/resource_pool/config.yml
+++ b/recipes/resource_pool/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20210322":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **resource_pool/cci.20210322**

Note: The upstream project's `CMakeLists.txt` lists `0.1.0` as a dummy version, but the library is used in a rolling release manner so far and a proper release strategy (elsid/resource_pool#27) has not been established yet.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
