### PR TITLE
Bump ECM version

### DIFF
--- a/recipes/extra-cmake-modules/all/conandata.yml
+++ b/recipes/extra-cmake-modules/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "5.75.0":
     url: "https://download.kde.org/stable/frameworks/5.75/extra-cmake-modules-5.75.0.zip"
     sha256: "dc937fd2018eb8285c1b07d4b5de104c60959404c4979883f6bdb0a4d40cf98e"
+  "5.80.0":
+    url: "https://download.kde.org/stable/frameworks/5.80/extra-cmake-modules-5.80.0.tar.xz"
+    sha256: "2370FD80F685533D0B96EFA6FA443CEEA68E0CEBA4E8A9D7C151D297B1C96F64"

--- a/recipes/extra-cmake-modules/all/conandata.yml
+++ b/recipes/extra-cmake-modules/all/conandata.yml
@@ -4,4 +4,4 @@ sources:
     sha256: "dc937fd2018eb8285c1b07d4b5de104c60959404c4979883f6bdb0a4d40cf98e"
   "5.80.0":
     url: "https://download.kde.org/stable/frameworks/5.80/extra-cmake-modules-5.80.0.tar.xz"
-    sha256: "2370FD80F685533D0B96EFA6FA443CEEA68E0CEBA4E8A9D7C151D297B1C96F64"
+    sha256: "2370fd80f685533d0b96efa6fa443ceea68e0ceba4e8a9d7c151d297b1c96f64"

--- a/recipes/extra-cmake-modules/config.yml
+++ b/recipes/extra-cmake-modules/config.yml
@@ -1,3 +1,5 @@
 versions:
   "5.75.0":
     folder: "all"
+  "5.80.0":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **extra-cmake-modules/5.80.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Question: In line 28 of conanfile.py it says `# KB-H016: do not install Find*.cmake`, but this is kinda a big point of this hole package... Comments?