### PR TITLE
[service] spdlog don't throw if no c++11 compatible compiler is used...

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -41,6 +41,8 @@ class SpdlogConan(ConanFile):
         if self.options.header_only:
             del self.options.shared
             del self.options.fPIC
+        elif self.settings.compiler.libcxx != "libstdc++11":
+            raise ConanInvalidConfiguration("libstdc++11 required")
         elif self.settings.os == "Windows" and self.options.shared and Version(self.version) < "1.6.0":
             raise ConanInvalidConfiguration("spdlog shared lib is not yet supported under windows")
         if self.settings.os != "Windows" and \


### PR DESCRIPTION
, but generates an error during linking. This can be avoided if an error is already thrown during initialization.
The [README](https://github.com/gabime/spdlog/blob/c1af0a3f21eff41b0f8ab37d4aa821fdea712cb3/README.md) says that a c++11 capable compiler is required.

Specify library name and version:  **spdlog/1.8.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
