### PR TITLE
How to deprecate a recipe option

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -122,3 +122,27 @@ There are some recipes in `conan-center-index` that provide packages that contai
 We decided that these packages (as long as they match the premises) should list all the settings needed to build, so building from sources will generate the expected binary, but they will **remove `compiler` setting inside the `package_id()` method**. As a consequence, the CI will generate packages only for one compiler reducing the workload in the pipeline and the number of possible package IDs.
 
 Note about `build_type`.- We retain the `build_type` setting to make it possible for the users to _debug_ these installer packages. We considered removing this settings and it would be possible to compile these packages in _debug_ mode, but if we remove it from the packageID, the compiled package would override the existing _release_ binary, and it'd be quite inconvenient for the users to compile the binary every time they need to switch from _debug_ to _release_.
+
+## Can I remove a deprecated option from recipe
+
+No. Changing any option will result in a different package ID and may result a different behavior, the result can break users.
+Instead, you should deprecate the option:
+
+* Add "deprecated" as option value
+* Set "deprecated" as default option
+* Check the option value, if the value is different from "deprecated", raise a warning
+* Remove the option from Package ID
+
+```python
+options = {"foobar": [True, False, "deprecated"]}
+default_options = {"foobar": "deprecated"}
+
+def configure(self):
+    if self.options.foobar != "deprecated":
+        self.out.warn("foobar option is deprecated, do not use anymore.")
+
+def package_id(self):
+    del self.info.options.foobar
+```
+
+This is the safest way, users will be warned of deprecation and their projects will not risk breaking.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -146,3 +146,5 @@ def package_id(self):
 ```
 
 This is the safest way, users will be warned of deprecation and their projects will not risk breaking.
+As aditional examples, take a look on follow recipes: [dcmtk](https://github.com/conan-io/conan-center-index/blob/5e6089005f0bb66cd16db7b0e5f37f5081c7820c/recipes/dcmtk/all/conanfile.py#L24), [gtsam](https://github.com/conan-io/conan-center-index/blob/f7f18ab050e5d97fac70932b0ba4c115a930958c/recipes/gtsam/all/conanfile.py#L40)
+and [libcurl](https://github.com/conan-io/conan-center-index/blob/f834ee1c82564199fdd9ca2f95231693c1a7136a/recipes/libcurl/all/conanfile.py#L24).

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -125,7 +125,7 @@ Note about `build_type`.- We retain the `build_type` setting to make it possible
 
 ## Can I remove an option from recipe
 
-It's preferable don't doing it, because it may break other packages which require those deleted options.
+It's preferable to don't doing it, because it may break other packages which require those deleted options.
 Prefer the deprecation path with a mapping from old options to new ones:
 
 * Add "deprecated" as option value

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -125,7 +125,7 @@ Note about `build_type`.- We retain the `build_type` setting to make it possible
 
 ## Can I remove an option from recipe
 
-It's preferable don't doing it, because it may break other packages requires those deleted options.
+It's preferable don't doing it, because it may break other packages which require those deleted options.
 Prefer the deprecation path with a mapping from old options to new ones:
 
 * Add "deprecated" as option value

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -125,8 +125,8 @@ Note about `build_type`.- We retain the `build_type` setting to make it possible
 
 ## Can I remove a deprecated option from recipe
 
-No. Changing any option will result in a different package ID and may result a different behavior, the result can break users.
-Instead, you should deprecate the option:
+It's preferable don't doing it, because it may break other packages requires those deleted options.
+Prefer the deprecation path with a mapping from old options to new ones:
 
 * Add "deprecated" as option value
 * Set "deprecated" as default option
@@ -148,3 +148,7 @@ def package_id(self):
 This is the safest way, users will be warned of deprecation and their projects will not risk breaking.
 As aditional examples, take a look on follow recipes: [dcmtk](https://github.com/conan-io/conan-center-index/blob/5e6089005f0bb66cd16db7b0e5f37f5081c7820c/recipes/dcmtk/all/conanfile.py#L24), [gtsam](https://github.com/conan-io/conan-center-index/blob/f7f18ab050e5d97fac70932b0ba4c115a930958c/recipes/gtsam/all/conanfile.py#L40)
 and [libcurl](https://github.com/conan-io/conan-center-index/blob/f834ee1c82564199fdd9ca2f95231693c1a7136a/recipes/libcurl/all/conanfile.py#L24).
+
+However, if logic is too complex (this is subjective and depends on the Conan review team) then just remove the option.
+After one month, we will welcome a PR removing the option that was deprecated.
+

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -125,7 +125,7 @@ Note about `build_type`.- We retain the `build_type` setting to make it possible
 
 ## Can I remove an option from recipe
 
-It's preferable to don't doing it, because it may break other packages which require those deleted options.
+It's preferable to leave all options (ie. not removing them) because it may break other packages which require those deleted options.
 Prefer the deprecation path with a mapping from old options to new ones:
 
 * Add "deprecated" as option value
@@ -151,4 +151,3 @@ and [libcurl](https://github.com/conan-io/conan-center-index/blob/f834ee1c825641
 
 However, if logic is too complex (this is subjective and depends on the Conan review team) then just remove the option.
 After one month, we will welcome a PR removing the option that was deprecated.
-


### PR DESCRIPTION
Sometimes we need to change recipes options, one of most intuitive action is removing deprecated options, but it could cause a break change if you are using that option in your project. Instead, on CCI we follow an undocumented protocol. Let's add it on FAQ.

/cc  @SpaceIm @ericLemanissier 

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
