### PR TITLE
mysql-connector-c: fix usage with static libc++

### DIFF
--- a/recipes/mysql-connector-c/all/conanfile.py
+++ b/recipes/mysql-connector-c/all/conanfile.py
@@ -86,20 +86,11 @@ class MysqlConnectorCConan(ConanFile):
             os.remove(f)
         tools.rmdir(os.path.join(self.package_folder, "docs"))
 
-    @property
-    def _stdcpp_library(self):
-        libcxx = self.settings.get_safe("compiler.libcxx")
-        if libcxx in ("libstdc++", "libstdc++11"):
-            return "stdc++"
-        elif libcxx in ("libc++",):
-            return "c++"
-        else:
-            return False
-
     def package_info(self):
         self.cpp_info.libs = ["libmysql" if self.options.shared and self.settings.os == "Windows" else "mysqlclient"]
         if not self.options.shared:
-            if self._stdcpp_library:
-                self.cpp_info.system_libs.append(self._stdcpp_library)
+            stdcpp_library = tools.stdcpp_library(self)
+            if stdcpp_library:
+                self.cpp_info.system_libs.append(stdcpp_library)
             if self.settings.os == "Linux":
                 self.cpp_info.system_libs.append('m')

--- a/recipes/mysql-connector-c/all/conanfile.py
+++ b/recipes/mysql-connector-c/all/conanfile.py
@@ -42,7 +42,7 @@ class MysqlConnectorCConan(ConanFile):
         self._cmake.definitions["DISABLE_SHARED"] = not self.options.shared
         self._cmake.definitions["DISABLE_STATIC"] = self.options.shared
         self._cmake.definitions["STACK_DIRECTION"] = "-1"  # stack grows downwards, on very few platforms stack grows upwards
-        self._cmake.definitions["REQUIRE_STDCPP"] = self._stdcpp_library
+        self._cmake.definitions["REQUIRE_STDCPP"] = tools.stdcpp_library(self)
 
         if self.settings.compiler == "Visual Studio":
             if self.settings.compiler.runtime == "MD" or self.settings.compiler.runtime == "MDd":


### PR DESCRIPTION
Specify library name and version:  **mysql-connector-c/***

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
