### PR TITLE
libcap: delete fPIC option if shared

### DIFF
--- a/recipes/libcap/all/conanfile.py
+++ b/recipes/libcap/all/conanfile.py
@@ -33,6 +33,8 @@ class LibcapConan(ConanFile):
     def configure(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("Only Linux supported")
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 

--- a/recipes/libcap/all/conanfile.py
+++ b/recipes/libcap/all/conanfile.py
@@ -47,6 +47,7 @@ class LibcapConan(ConanFile):
         if self._autotools:
             return self._autotools, self._autotools_env
         self._autotools = AutoToolsBuildEnvironment(self)
+        self._autotools.fpic = self.options.get_safe("fPIC", True)
         self._autotools_env = self._autotools.vars
         self._autotools_env["SHARED"] = \
             "yes" if self.options.shared else "no"


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

actually I need missing packages for https://github.com/conan-io/conan-center-index/pull/5045 which is required for https://github.com/conan-io/conan-center-index/pull/4401 🤯 