### PR TITLE
Add data for expat 2.3.0

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -11,3 +11,11 @@ sources:
   "2.2.10":
     sha256: bf42d1f52371d23684de36cc6d2f0f1acd02de264d1105bdc17792bbeb7e7ceb
     url: https://github.com/libexpat/libexpat/releases/download/R_2_2_10/expat-2.2.10.tar.gz
+  "2.3.0":
+    sha256: 89df123c62f2c2e2b235692d9fe76def6a9ab03dbe95835345bf412726eb1987
+    url: https://github.com/libexpat/libexpat/releases/download/R_2_3_0/expat-2.3.0.tar.gz
+patches:
+  "2.3.0":
+    - patch_file: "patches/relax-vs-restriction.patch"
+      base_path: "source_subfolder"
+

--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -18,4 +18,3 @@ patches:
   "2.3.0":
     - patch_file: "patches/relax-vs-restriction.patch"
       base_path: "source_subfolder"
-

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -13,8 +13,7 @@ class ExpatConan(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
     generators = "cmake"
-    exports_sources = ["CMakeLists.txt"]
-
+    exports_sources = ["CMakeLists.txt", "patches/*"]
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
 
@@ -34,6 +33,7 @@ class ExpatConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
+
 
     def _configure_cmake(self):
         if self._cmake:
@@ -57,6 +57,8 @@ class ExpatConan(ConanFile):
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -34,7 +34,6 @@ class ExpatConan(ConanFile):
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
-
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake

--- a/recipes/expat/all/patches/relax-vs-restriction.patch
+++ b/recipes/expat/all/patches/relax-vs-restriction.patch
@@ -1,0 +1,13 @@
+diff --git a/expat/CMakeLists.txt b/expat/CMakeLists.txt
+index e3564691..0dc5cf80 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -133,7 +133,7 @@ if(MSVC)
+     # Minimum supported MSVC version is 1910 = Visual Studio 15.0/2017
+     # See also https://cmake.org/cmake/help/latest/variable/MSVC_VERSION.html
+     if(MSVC_VERSION VERSION_LESS 1910)
+-        message(SEND_ERROR "MSVC_VERSION ${MSVC_VERSION} is not a supported Visual Studio compiler version. Please use Visual Studio 15.0/2017 or any later version.")
++        message(WARNING "MSVC_VERSION ${MSVC_VERSION} is not a supported Visual Studio compiler version. Please use Visual Studio 15.0/2017 or any later version.")
+     endif()
+ endif()
+ 

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "2.2.10":
     folder: all
+  "2.3.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **expat/2.3.0**

Patch support is now needed to work around expat-2.3 explicitly rejecting VS 2015 and earlier.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
