### PR TITLE
uvw: add version 2.9.0

### DIFF
--- a/recipes/uvw/all/conandata.yml
+++ b/recipes/uvw/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "2.8.0":
     url: "https://github.com/skypjack/uvw/archive/v2.8.0_libuv_v1.40.tar.gz"
     sha256: "aa5769f5b9ba50de72ab02a8f8acf298b4aa9ceaef07992418a13a0fa119ce7d"
+  "2.9.0":
+    url: "https://github.com/skypjack/uvw/archive/v2.9.0_libuv_v1.41.tar.gz"
+    sha256: "dd610cb1626b8a7779ed251584bcc0362fb98fcee13e699680f61828a1ba55de"

--- a/recipes/uvw/config.yml
+++ b/recipes/uvw/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: "all"
   "2.8.0":
     folder: "all"
+  "2.9.0":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **uvw/2.9.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.  **Tested with Conan 1.34.1.**
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated. **Successfully built on Ubuntu Linux 20.04 x86-64 with `CONAN_HOOK_ERROR_LEVEL=40` set.**
