### PR TITLE
boostdep: CMake finds wrong Boost

### DIFF
--- a/recipes/boostdep/all/CMakeLists.txt
+++ b/recipes/boostdep/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 2.8)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/boostdep/all/conanfile.py
+++ b/recipes/boostdep/all/conanfile.py
@@ -11,7 +11,7 @@ class BoostDepConan(ConanFile):
     license = "BSL-1.0"
     topics = ("conan", "boostdep", "dependency", "tree")
     exports_sources = "CMakeLists.txt"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     _cmake = None
 

--- a/recipes/boostdep/all/test_package/conanfile.py
+++ b/recipes/boostdep/all/test_package/conanfile.py
@@ -5,6 +5,9 @@ import os
 class DefaultNameConan(ConanFile):
     settings = "os", "compiler", "arch", "build_type"
 
+    def build(self):
+        pass
+
     def test(self):
         if tools.cross_building(self.settings):
             return


### PR DESCRIPTION
Upstream boostdep uses `find_package(Boost)`, but the recipe uses "global variables" approach with "cmake" generator. This causes issues if system has another Boost installation. In my case, `find_boost` finds Boost 1.73.0 instead of the boost/1.75.0 from the recipe requirements.

Adding `cmake_find_package` generator fixes the issue.

Specify library name and version:  **boostdep/1.75.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
