### PR TITLE
Add djinni generator

### DIFF
--- a/recipes/djinni-generator/all/conandata.yml
+++ b/recipes/djinni-generator/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.3.1":
+    url: https://github.com/cross-language-cpp/djinni-generator/releases/download/v0.3.1/djinni
+    sha256: "052925e2590b40982a64d5386f79078cf61718d660b876e0a26670df4fc36838"

--- a/recipes/djinni-generator/all/conanfile.py
+++ b/recipes/djinni-generator/all/conanfile.py
@@ -1,0 +1,34 @@
+import os
+
+from conans import ConanFile, tools
+
+
+class Djinni(ConanFile):
+    name = "djinni-generator"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://djinni.xlcpp.dev"
+    description = "Djinni is a tool for generating cross-language type declarations and interface bindings."
+    topics = ("java", "Objective-C", "ios", "Android")
+    license = "Apache-2.0"
+    settings = "os", "arch"
+
+
+    def source(self):
+        filename = os.path.basename(self.conan_data["sources"][self.version]["url"])
+        tools.download(filename=filename, **self.conan_data["sources"][self.version])
+
+    def build(self):
+        pass # avoid warning for missing build steps
+
+    def package(self):
+        if tools.detected_os() == "Windows":
+            os.rename('djinni','djinni.bat')
+            self.copy("djinni.bat", dst="bin", keep_path=False)
+        else:
+            self.copy("djinni", dst="bin", keep_path=False)
+            executable = os.path.join(self.package_folder, "bin", "djinni")
+            os.chmod(executable, os.stat(executable).st_mode | 0o111)
+
+    def package_info(self):
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+

--- a/recipes/djinni-generator/all/conanfile.py
+++ b/recipes/djinni-generator/all/conanfile.py
@@ -16,6 +16,7 @@ class Djinni(ConanFile):
     def source(self):
         filename = os.path.basename(self.conan_data["sources"][self.version]["url"])
         tools.download(filename=filename, **self.conan_data["sources"][self.version])
+        tools.download(filename="LICENSE", url="https://raw.githubusercontent.com/cross-language-cpp/djinni-generator/main/LICENSE")
 
     def build(self):
         pass # avoid warning for missing build steps
@@ -28,6 +29,7 @@ class Djinni(ConanFile):
             self.copy("djinni", dst="bin", keep_path=False)
             executable = os.path.join(self.package_folder, "bin", "djinni")
             os.chmod(executable, os.stat(executable).st_mode | 0o111)
+        self.copy("LICENSE", dst="licenses", keep_path=False)
 
     def package_info(self):
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/recipes/djinni-generator/all/test_package/conanfile.py
+++ b/recipes/djinni-generator/all/test_package/conanfile.py
@@ -1,0 +1,21 @@
+
+from io import StringIO
+from conans import ConanFile, tools
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch"
+
+    def build(self):
+        pass # please no warning that we build nothing
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            output = StringIO()
+            self.run("djinni --help", output=output, run_environment=True)
+            output.seek(0, 0)
+            found_usage = False
+            for line in output:
+                if "Usage: djinni [options]" in line:
+                    found_usage = True
+                    break
+            assert(found_usage)

--- a/recipes/djinni-generator/config.yml
+++ b/recipes/djinni-generator/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.3.1":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **djinni-generator/0.3.1**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

To be useful, or run the tests, java needs to be on the system.
But I do not want to make a hard dependency to the conan jdk, because that is huge and might be unwanted... if there are any suggestions in how to express that nicely ...
