### PR TITLE
libpq: deprecate useless option "with_zlib"

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -15,14 +15,14 @@ class LibpqConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "with_zlib": [True, False],
+        "with_zlib": [True, False, "deprecated"],
         "with_openssl": [True, False],
         "disable_rpath": [True, False]
     }
     default_options = {
         'shared': False,
         'fPIC': True,
-        'with_zlib': True,
+        'with_zlib': "deprecated",
         'with_openssl': False,
         'disable_rpath': False
     }
@@ -56,10 +56,11 @@ class LibpqConan(ConanFile):
         if self.settings.compiler != "Visual Studio" and self.settings.os == "Windows":
             if self.options.shared:
                 raise ConanInvalidConfiguration("static mingw build is not possible")
+        # Looking into source code, it appears that zlib is not used in libpq
+        if self.options.with_zlib != "deprecated":
+            self.output.warn("with_zlib option is deprecated, do not use anymore")
 
     def requirements(self):
-        if self.options.with_zlib:
-            self.requires("zlib/1.2.11")
         if self.options.with_openssl:
             self.requires("openssl/1.1.1h")
 
@@ -72,7 +73,7 @@ class LibpqConan(ConanFile):
         if not self._autotools:
             self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
             args = ['--without-readline']
-            args.append('--with-zlib' if self.options.with_zlib else '--without-zlib')
+            args.append('--without-zlib')
             args.append('--with-openssl' if self.options.with_openssl else '--without-openssl')
             if tools.cross_building(self.settings) and not self.options.with_openssl:
                 args.append("--disable-strong-random")
@@ -116,12 +117,6 @@ class LibpqConan(ConanFile):
             tools.replace_in_file(msbuild_project_pm, "'MultiThreadedDLL'", "'%s'" % runtime)
             config_default_pl = os.path.join(self._source_subfolder, "src", "tools", "msvc", "config_default.pl")
             solution_pm = os.path.join(self._source_subfolder, "src", "tools", "msvc", "Solution.pm")
-            if self.options.with_zlib:
-                tools.replace_in_file(solution_pm,
-                                      "zdll.lib", "%s.lib" % self.deps_cpp_info["zlib"].libs[0])
-                tools.replace_in_file(config_default_pl,
-                                      "zlib      => undef",
-                                      "zlib      => '%s'" % self.deps_cpp_info["zlib"].rootpath.replace("\\", "/"))
             if self.options.with_openssl:
                 for ssl in ["VC\libssl32", "VC\libssl64", "libssl"]:
                     tools.replace_in_file(solution_pm,
@@ -225,9 +220,6 @@ class LibpqConan(ConanFile):
         self.env_info.PostgreSQL_ROOT = self.package_folder
 
         self.cpp_info.components["pq"].libs = [self._construct_library_name("pq")]
-
-        if self.options.with_zlib:
-            self.cpp_info.components["pq"].requires.append("zlib::zlib")
 
         if self.options.with_openssl:
             self.cpp_info.components["pq"].requires.append("openssl::openssl")

--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -59,6 +59,7 @@ class LibpqConan(ConanFile):
         # Looking into source code, it appears that zlib is not used in libpq
         if self.options.with_zlib != "deprecated":
             self.output.warn("with_zlib option is deprecated, do not use anymore")
+        del self.options.with_zlib
 
     def requirements(self):
         if self.options.with_openssl:

--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -53,6 +53,10 @@ class LibpqConan(ConanFile):
     def configure(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+
+        if self.options.shared:
+            del self.options.fPIC
+
         if self.settings.compiler != "Visual Studio" and self.settings.os == "Windows":
             if self.options.shared:
                 raise ConanInvalidConfiguration("static mingw build is not possible")


### PR DESCRIPTION
zlib is not used anywhere insinde libpq, thus it is just an unnecessary
dependency.

fixes #5055

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
