### PR TITLE
caf: add version 0.18.2

### DIFF
--- a/recipes/caf/all/conandata.yml
+++ b/recipes/caf/all/conandata.yml
@@ -5,6 +5,9 @@ sources:
   "0.18.0":
     url: "https://github.com/actor-framework/actor-framework/archive/0.18.0.tar.gz"
     sha256: "df765fa78861e67d44e2587c0ac0c1c662d8c93fe5ffc8757f552fc7ac15941f"
+  "0.18.2":
+    url: "https://github.com/actor-framework/actor-framework/archive/0.18.2.tar.gz"
+    sha256: "03837dbef73a13c3e4cac76c009d018f48d1d97b182277230f204984c9542ccc"
 patches:
   "0.17.6":
     - patch_file: "patches/win_install.patch"

--- a/recipes/caf/config.yml
+++ b/recipes/caf/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "0.18.0":
     folder: all
+  "0.18.2":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **caf/0.18.2**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
