### PR TITLE
pango: add version 1.48.4

### DIFF
--- a/recipes/pango/all/conandata.yml
+++ b/recipes/pango/all/conandata.yml
@@ -11,3 +11,6 @@ sources:
   "1.48.3":
     url: "https://github.com/GNOME/pango/archive/1.48.3.tar.gz"
     sha256: "63318b75bdd510b11fc960dbcdff9bc8b744fb3e45583acbb3410ef36bacc054"
+  "1.48.4":
+    url: "https://github.com/GNOME/pango/archive/1.48.4.tar.gz"
+    sha256: "2c7e92f2430ae2ab91d6156488f41dfb0fd1ea787fbfb807dfe53a4f361a9d1a"

--- a/recipes/pango/config.yml
+++ b/recipes/pango/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "1.48.3":
     folder: all
+  "1.48.4":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **pango/1.48.4**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
