### PR TITLE
cppcheck: add version 2.4.1

### DIFF
--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.4.1":
+    url: "https://github.com/danmar/cppcheck/archive/2.4.1.tar.gz"
+    sha256: "11a9d9fe5305a105561655c45d2cd83cb30fbc87b41d0569de1b00a1a314867f"
   "2.4":
     url: "https://github.com/danmar/cppcheck/archive/2.4.tar.gz"
     sha256: "d1ac6a1eaf24f2f54df5a164c7e37d1e0624cc094a4622e226a73b53ede1eeb8"
@@ -9,6 +12,9 @@ sources:
     url: "https://github.com/danmar/cppcheck/archive/2.2.tar.gz"
     sha256: "ad96290a1842c5934bf9c4268cb270953f3078d4ce33a9a53922d6cb6daf61aa"
 patches:
+  "2.4.1":
+    - patch_file: "patches/0001-cmake-source-dir.patch"
+      base_path: "source_subfolder"
   "2.4":
     - patch_file: "patches/0001-cmake-source-dir.patch"
       base_path: "source_subfolder"

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.4.1":
+    folder: all
   "2.4":
     folder: all
   "2.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cppcheck/2.4.1**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
