### PR TITLE
onnx: bump protobuf

### DIFF
--- a/recipes/onnx/all/conanfile.py
+++ b/recipes/onnx/all/conanfile.py
@@ -49,7 +49,7 @@ class OnnxConan(ConanFile):
             raise ConanInvalidConfiguration("onnx shared is broken with Visual Studio")
 
     def requirements(self):
-        self.requires("protobuf/3.13.0")
+        self.requires("protobuf/3.15.5")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Safer to have the same protobuf version in `libtorch` and `onnx`.
Moreover, previous revision of onnx recipe was built with `protobuf:zlib=False`, and this default value was changed in https://github.com/conan-io/conan-center-index/pull/4776, so packages of onnx must be created again.