### PR TITLE
Fix redundant linkage with boost in mfast

### DIFF
--- a/recipes/mfast/all/conanfile.py
+++ b/recipes/mfast/all/conanfile.py
@@ -176,25 +176,25 @@ class mFASTConan(ConanFile):
                 "comp": "mfast",
                 "target": "mfast" + target_suffix,
                 "lib": "mfast" + lib_suffix,
-                "requires": ["boost::boost"]
+                "requires": ["boost::headers"]
             },
             "mfast_coder": {
                 "comp": "mfast_coder",
                 "target": "mfast_coder" + target_suffix,
                 "lib": "mfast_coder" + lib_suffix,
-                "requires": ["libmfast", "boost::boost"]
+                "requires": ["libmfast", "boost::headers"]
             },
             "mfast_xml_parser": {
                 "comp": "mfast_xml_parser",
                 "target": "mfast_xml_parser" + target_suffix,
                 "lib": "mfast_xml_parser" + lib_suffix,
-                "requires": ["libmfast", "boost::boost", "tinyxml2::tinyxml2"]
+                "requires": ["libmfast", "boost::headers", "tinyxml2::tinyxml2"]
             },
             "mfast_json": {
                 "comp": "mfast_json",
                 "target": "mfast_json" + target_suffix,
                 "lib": "mfast_json" + lib_suffix,
-                "requires": ["libmfast", "boost::boost"]
+                "requires": ["libmfast", "boost::headers"]
             }
         }
 


### PR DESCRIPTION
Specify library name and version:  **mfast/cci.20200824**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
