### PR TITLE
trompeloeil: add version 40

### DIFF
--- a/recipes/trompeloeil/all/conandata.yml
+++ b/recipes/trompeloeil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "40":
+    url: "https://github.com/rollbear/trompeloeil/archive/v40.tar.gz"
+    sha256: "e13e3649223a358a5a72fa5a8a1c36325b48e4f3d9d2f2277b17d746797e1734"
   "39":
     url: https://github.com/rollbear/trompeloeil/archive/v39.tar.gz
     sha256: 10506E48ABD605740BC9ED43E34059F5068BC80AF14476BD129A3ED3B54D522F

--- a/recipes/trompeloeil/config.yml
+++ b/recipes/trompeloeil/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "40":
+    folder: all
   "39":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **trompeloeil/40**

closes #5093

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
