### PR TITLE
poco: use https github URLs

### DIFF
--- a/recipes/poco/all/conandata.yml
+++ b/recipes/poco/all/conandata.yml
@@ -1,19 +1,19 @@
 sources:
   1.8.1:
     sha256: 43cc469c01d1f799efc51e2bfde6ffdf467b98a8a0901e6b33db86958619b3af
-    url: http://github.com/pocoproject/poco/archive/poco-1.8.1-release.tar.gz
+    url: https://github.com/pocoproject/poco/archive/poco-1.8.1-release.tar.gz
   1.9.3:
     sha256: 73b9dfd1f57106eefb9b451d223579281acfb50b031424e9d0c6486ebb824d01
-    url: http://github.com/pocoproject/poco/archive/poco-1.9.3-release.tar.gz
+    url: https://github.com/pocoproject/poco/archive/poco-1.9.3-release.tar.gz
   1.9.4:
     sha256: 367014cdbcfe9df8f1d746239902149d2398af9b49ba2c1aaaa88616fd538f61
-    url: http://github.com/pocoproject/poco/archive/poco-1.9.4-release.tar.gz
+    url: https://github.com/pocoproject/poco/archive/poco-1.9.4-release.tar.gz
   1.10.0:
     sha256: 8047800d5a965d3177e614b4a4a162381e2638220b24d1d15ff5d6cac1738be8
-    url: http://github.com/pocoproject/poco/archive/poco-1.10.0-release.tar.gz
+    url: https://github.com/pocoproject/poco/archive/poco-1.10.0-release.tar.gz
   1.10.1:
     sha256: 44592a488d2830c0b4f3bfe4ae41f0c46abbfad49828d938714444e858a00818
-    url: http://github.com/pocoproject/poco/archive/poco-1.10.1-release.tar.gz
+    url: https://github.com/pocoproject/poco/archive/poco-1.10.1-release.tar.gz
 patches:
   1.8.1:
     - patch_file: patches/1.8.1.patch

--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -108,6 +108,10 @@ class PocoConan(ConanFile):
             del self.options.enable_data_postgresql
             del self.options.enable_jwt
 
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
     def validate(self):
         if self.options.enable_apacheconnector:
             raise ConanInvalidConfiguration("Apache connector not supported: https://github.com/pocoproject/poco/issues/1764")


### PR DESCRIPTION
Specify library name and version:  **poco/all**

The poco recipe uses http github links for the source downloads -- github redirects those to https anyway,
and as far as I can tell all other recipes that download from github use https URLs.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
