### PR TITLE
ICU bugfix: on Linux systems that use lib64 as library dir, ICU conan…

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -170,6 +170,9 @@ class ICUBase(ConanFile):
         bindir = os.path.join(self.package_folder, "bin")
         bindir = bindir.replace("\\", "/") if tools.os_info.is_windows else bindir
         args.append("--sbindir=%s" % bindir)
+        libdir = os.path.join(self.package_folder, "lib")
+        libdir = libdir.replace("\\", "/") if tools.os_info.is_windows else libdir
+        args.append("--libdir=%s" % libdir)
 
         if self._is_mingw:
             mingw_chost = "i686-w64-mingw32" if self.settings.arch == "x86" else "x86_64-w64-mingw32"


### PR DESCRIPTION
… recipe installs icu libraries in subdir lib64 inside package folder (i.s.o. subdir lib)

Specify library name and version:  **ICU/68.2**

Fixes #5105 

Build of Conan Qt package failed because of a icu library problem. It turned out the build was using my system icu libraries because the Conan icu package installed the libraries in <package_dir>/lib64 and creating an empty <package_dir>/lib. See conan-center-index issue #5105.
Note that I use OpenSuse and Suse SLES. Both use subdirectory lib64 to install 64bit libraries.

This patch let the conan recipe install the icu libraries always in <package_dir/lib.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
