### PR TITLE
Add cpp-sort/1.10.0

### DIFF
--- a/recipes/cpp-sort/all/conandata.yml
+++ b/recipes/cpp-sort/all/conandata.yml
@@ -17,3 +17,6 @@ sources:
   "1.9.0":
     sha256: e83f3daad30bd91fed668bdb56ad379c4aeea39d7dc640484fdcc55149b6d0e4
     url: https://github.com/Morwenn/cpp-sort/archive/1.9.0.tar.gz
+  "1.10.0":
+    sha256: 48951cac0051d48fee286c3bc02804975f9d83269d80c10dfc5589e76a542765
+    url: https://github.com/Morwenn/cpp-sort/archive/1.10.0.tar.gz

--- a/recipes/cpp-sort/all/conanfile.py
+++ b/recipes/cpp-sort/all/conanfile.py
@@ -27,7 +27,8 @@ class CppSortConan(ConanFile):
         return {
             "apple-clang": "9.4",
             "clang": "3.8",
-            "gcc": "5.5"
+            "gcc": "5.5",
+            "Visual Studio": "16"
         }
 
     def validate(self):
@@ -71,6 +72,10 @@ class CppSortConan(ConanFile):
 
         # Remove CMake config files (only files in lib)
         tools.rmdir(os.path.join(self.package_folder, "lib"))
+
+    def package_info(self):
+        if self.settings.compiler == "Visual Studio":
+            self.cpp_info.cxxflags = ["/permissive-"]
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/cpp-sort/config.yml
+++ b/recipes/cpp-sort/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: all
   "1.9.0":
     folder: all
+  "1.10.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **cpp-sort/1.10.0**

Theoretically a simple update, but it adds support for the latest MSVC (as opposed to no support for MSVC at all) with `/permissive-` being a hard requirement.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
