### PR TITLE
Add fake function framework (fff)

### DIFF
--- a/recipes/fff/all/conandata.yml
+++ b/recipes/fff/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.1":
+    url: https://github.com/meekrosoft/fff/archive/refs/tags/v1.1.zip
+    sha256: 5a8329878f59bd1ea19b734573d63c228f742384b8c78d00e4d005909b90ee83

--- a/recipes/fff/all/conanfile.py
+++ b/recipes/fff/all/conanfile.py
@@ -1,0 +1,26 @@
+from conans import ConanFile, tools
+import os
+
+class TypeSafe(ConanFile):
+    name = 'fff'
+    description = 'A testing micro framework for creating function test doubles'
+    url = 'https://github.com/conan-io/conan-center-index'
+    homepage = 'https://github.com/meekrosoft/fff'
+    license = 'MIT'
+    topics = 'conan', 'c', 'c++', 'embedded', 'tdd', 'micro-framework', 'fake-functions'
+
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def package(self):
+        self.copy("LICENSE*", dst="licenses", src=self._source_subfolder)
+        self.copy("fff.h", dst="include", src=self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/fff/all/test_package/CMakeLists.txt
+++ b/recipes/fff/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/fff/all/test_package/conanfile.py
+++ b/recipes/fff/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/fff/all/test_package/test_package.cpp
+++ b/recipes/fff/all/test_package/test_package.cpp
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include "fff.h"
+
+DEFINE_FFF_GLOBALS;
+
+FAKE_VOID_FUNC(TestFunction, uint32_t, uint8_t);
+
+int main()
+{
+   RESET_FAKE(TestFunction);
+   FFF_RESET_HISTORY();
+   
+   TestFunction(8, 16);
+   
+   return 0;
+}

--- a/recipes/fff/config.yml
+++ b/recipes/fff/config.yml
@@ -1,0 +1,3 @@
+versions:
+  '1.1':
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **fff/1.1.0**

This library is a header-only library and is a micro-framework for creating fake C functions for tests.
This library do not have dependencies to other libraries.
I am NOT the author of this library.

Closes #5113 
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
