### PR TITLE
[ginkgo] prefix components names with package

### DIFF
--- a/recipes/ginkgo/all/conanfile.py
+++ b/recipes/ginkgo/all/conanfile.py
@@ -95,27 +95,34 @@ class GinkgoConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        debug_suffix = "d" if self.settings.build_type == "Debug" else ""
-
-        self.cpp_info.components["ginkgo_reference"].libs = [
-            "ginkgo_reference" + debug_suffix]
-        self.cpp_info.components["ginkgo_cuda"].libs = [
-            "ginkgo_cuda" + debug_suffix]
-        self.cpp_info.components["ginkgo_hip"].libs = [
-            "ginkgo_hip" + debug_suffix]
-
-        self.cpp_info.components["ginkgo_omp"].libs = [
-            "ginkgo_omp" + debug_suffix]
-        self.cpp_info.components["ginkgo_omp"].requires = [
-            "ginkgo_cuda", "ginkgo_hip"]
-
-        self.cpp_info.components["core"].libs = [
-            "ginkgo" + debug_suffix]
-        self.cpp_info.components["core"].requires = [
-            "ginkgo_reference", "ginkgo_omp", "ginkgo_cuda", "ginkgo_hip"]
-        self.cpp_info.components["core"].names["cmake_find_package"] = "ginkgo"
-        self.cpp_info.components["core"].names["cmake_find_package_multi"] = "ginkgo"
-
         self.cpp_info.names["cmake_find_package"] = "Ginkgo"
         self.cpp_info.names["cmake_find_package_multi"] = "Ginkgo"
         self.cpp_info.names["pkg_config"] = "ginkgo"
+
+        debug_suffix = "d" if self.settings.build_type == "Debug" else ""
+
+        self.cpp_info.components["ginkgo_core"].names["cmake_find_package"] = "ginkgo"
+        self.cpp_info.components["ginkgo_core"].names["cmake_find_package_multi"] = "ginkgo"
+        self.cpp_info.components["ginkgo_core"].names["pkg_config"] = "ginkgo"
+        self.cpp_info.components["ginkgo_core"].libs = ["ginkgo" + debug_suffix]
+        self.cpp_info.components["ginkgo_core"].requires = [
+            "ginkgo_omp", "ginkgo_cuda", "ginkgo_reference", "ginkgo_hip"
+        ]
+
+        self.cpp_info.components["ginkgo_cuda"].names["cmake_find_package"] = "ginkgo_cuda"
+        self.cpp_info.components["ginkgo_cuda"].names["cmake_find_package_multi"] = "ginkgo_cuda"
+        self.cpp_info.components["ginkgo_cuda"].libs = ["ginkgo_cuda" + debug_suffix]
+        self.cpp_info.components["ginkgo_cuda"].requires = ["ginkgo_hip"]
+
+        self.cpp_info.components["ginkgo_omp"].names["cmake_find_package"] = "ginkgo_omp"
+        self.cpp_info.components["ginkgo_omp"].names["cmake_find_package_multi"] = "ginkgo_omp"
+        self.cpp_info.components["ginkgo_omp"].libs = ["ginkgo_omp" + debug_suffix]
+        self.cpp_info.components["ginkgo_omp"].requires = ["ginkgo_cuda", "ginkgo_hip"]
+
+        self.cpp_info.components["ginkgo_hip"].names["cmake_find_package"] = "ginkgo_hip"
+        self.cpp_info.components["ginkgo_hip"].names["cmake_find_package_multi"] = "ginkgo_hip"
+        self.cpp_info.components["ginkgo_hip"].libs = ["ginkgo_hip" + debug_suffix]
+
+        self.cpp_info.components["ginkgo_reference"].names["cmake_find_package"] = "ginkgo_reference"
+        self.cpp_info.components["ginkgo_reference"].names["cmake_find_package_multi"] = "ginkgo_reference"
+        self.cpp_info.components["ginkgo_reference"].libs = ["ginkgo_reference" + debug_suffix]

--- a/recipes/ginkgo/all/conanfile.py
+++ b/recipes/ginkgo/all/conanfile.py
@@ -97,17 +97,22 @@ class GinkgoConan(ConanFile):
     def package_info(self):
         debug_suffix = "d" if self.settings.build_type == "Debug" else ""
 
-        self.cpp_info.components["reference"].libs = [
+        self.cpp_info.components["ginkgo_reference"].libs = [
             "ginkgo_reference" + debug_suffix]
-        self.cpp_info.components["cuda"].libs = ["ginkgo_cuda" + debug_suffix]
-        self.cpp_info.components["hip"].libs = ["ginkgo_hip" + debug_suffix]
+        self.cpp_info.components["ginkgo_cuda"].libs = [
+            "ginkgo_cuda" + debug_suffix]
+        self.cpp_info.components["ginkgo_hip"].libs = [
+            "ginkgo_hip" + debug_suffix]
 
-        self.cpp_info.components["omp"].libs = ["ginkgo_omp" + debug_suffix]
-        self.cpp_info.components["omp"].requires = ["cuda", "hip"]
+        self.cpp_info.components["ginkgo_omp"].libs = [
+            "ginkgo_omp" + debug_suffix]
+        self.cpp_info.components["ginkgo_omp"].requires = [
+            "ginkgo_cuda", "ginkgo_hip"]
 
-        self.cpp_info.components["core"].libs = ["ginkgo" + debug_suffix]
-        self.cpp_info.components["core"].requires = [
-            "reference", "omp", "cuda", "hip"]
+        self.cpp_info.components["ginkgo_core"].libs = [
+            "ginkgo" + debug_suffix]
+        self.cpp_info.components["ginkgo_core"].requires = [
+            "ginkgo_reference", "ginkgo_omp", "ginkgo_cuda", "ginkgo_hip"]
 
         self.cpp_info.names["cmake_find_package"] = "Ginkgo"
         self.cpp_info.names["cmake_find_package_multi"] = "Ginkgo"

--- a/recipes/ginkgo/all/conanfile.py
+++ b/recipes/ginkgo/all/conanfile.py
@@ -109,10 +109,12 @@ class GinkgoConan(ConanFile):
         self.cpp_info.components["ginkgo_omp"].requires = [
             "ginkgo_cuda", "ginkgo_hip"]
 
-        self.cpp_info.components["ginkgo_core"].libs = [
+        self.cpp_info.components["core"].libs = [
             "ginkgo" + debug_suffix]
-        self.cpp_info.components["ginkgo_core"].requires = [
+        self.cpp_info.components["core"].requires = [
             "ginkgo_reference", "ginkgo_omp", "ginkgo_cuda", "ginkgo_hip"]
+        self.cpp_info.components["core"].names["cmake_find_package"] = "ginkgo"
+        self.cpp_info.components["core"].names["cmake_find_package_multi"] = "ginkgo"
 
         self.cpp_info.names["cmake_find_package"] = "Ginkgo"
         self.cpp_info.names["cmake_find_package_multi"] = "Ginkgo"

--- a/recipes/ginkgo/all/test_package/CMakeLists.txt
+++ b/recipes/ginkgo/all/test_package/CMakeLists.txt
@@ -7,5 +7,5 @@ conan_basic_setup()
 find_package(Ginkgo REQUIRED)
 
 add_executable(test_install test_install.cpp)
-target_link_libraries(test_install Ginkgo::Ginkgo)
+target_link_libraries(test_install Ginkgo::ginkgo)
 set_target_properties(test_install PROPERTIES CXX_STANDARD 14)

--- a/recipes/ginkgo/all/test_package/CMakeLists.txt
+++ b/recipes/ginkgo/all/test_package/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_install)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-find_package(Ginkgo REQUIRED)
+find_package(Ginkgo REQUIRED CONFIG)
 
 add_executable(test_install test_install.cpp)
 target_link_libraries(test_install Ginkgo::ginkgo)

--- a/recipes/ginkgo/all/test_package/conanfile.py
+++ b/recipes/ginkgo/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Following up on a review suggestion by @SpaceIm in #4916 that unfortunately came after the PR was already merged

This PR adds a `ginkgo_` prefix to all components in the package to avoid issues with non-namespaced generators (I think?)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
