### PR TITLE
[boost] For Visual Studio, pass some values of settings.compiler.toolset to B2

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -6,6 +6,7 @@ from conans.errors import ConanException
 from conans.errors import ConanInvalidConfiguration
 import glob
 import os
+import re
 import sys
 import shlex
 import shutil
@@ -1190,8 +1191,19 @@ class BoostConan(ConanFile):
         tools.save(filename,  contents)
 
     @property
+    def _msvc_toolset(self):
+        if self._is_msvc:
+            toolset = self.settings.compiler.get_safe("toolset", default="")
+            match = re.match(r'v(\d+)(\d)$', toolset)
+            if match:
+                return "%s.%s" % (match.group(1), match.group(2))
+
+    @property
     def _toolset_version(self):
         if self._is_msvc:
+            toolset_from_setting = self._msvc_toolset
+            if toolset_from_setting:
+                return toolset_from_setting
             compiler_version = str(self.settings.compiler.version)
             if Version(compiler_version) >= "16":
                 return "14.2"

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -795,7 +795,10 @@ class BoostConan(ConanFile):
         full_command += ' --debug-configuration --build-dir="%s"' % self.build_folder
         self.output.warn(full_command)
 
-        with tools.vcvars(self.settings) if self._is_msvc else tools.no_op():
+        # If sending a toolset to B2, setting the vcvars interferes with the compiler
+        # selection.
+        use_vcvars = self._is_msvc and not self._msvc_toolset
+        with tools.vcvars(self.settings) if use_vcvars else tools.no_op():
             with tools.chdir(sources):
                 # To show the libraries *1
                 # self.run("%s --show-libraries" % b2_exe)


### PR DESCRIPTION
Specify library name and version:  **conan/1.75.0**

This fixes a problem we had where `compiler.version=16` and `compiler.toolset=v141`, but B2 was still using the `v142` compiler.

- If `compiler.toolset` is set, use that rather than inferring the toolset from the `compiler.version`.
- If the toolset is specified, don't also use `tools.vcvars()`. Doing so seems to cause B2 to build Boost with the wrong toolset, even though it says it chose the desired compiler.

I implemented this for `compiler.toolset` that is in the form `vNNN`. I'm unsure of how the other values from `settings.yml' work. I would expect that people that use those toolsets could extend this work.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
