### PR TITLE
add kaitai_struct_cpp_stl_runtime/0.9

### DIFF
--- a/recipes/kaitai_struct_cpp_stl_runtime/all/CMakeLists.txt
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.4)
+project(cmake_wrapper)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(source_subfolder)

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/conandata.yml
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.9":
+    url: "https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/archive/refs/tags/0.9.tar.gz"
+    sha256: "6a8b435da649882a6942f04be5a0fde40ca4173dae7acc6f1f75e51a385dee9e"

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/conanfile.py
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/conanfile.py
@@ -1,0 +1,59 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class KaitaiStructCppStlRuntimeConan(ConanFile):
+    name = "kaitai_struct_cpp_stl_runtime"
+    version = "0.9"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://kaitai.io/"
+    description = "kaitai struct c++ runtime library"
+    topics = ("parsers", "streams", "dsl")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+    generators = "cmake"
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"        
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename(self.name + "-" + self.version, self._source_subfolder)
+       
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure(build_folder=self._build_subfolder, source_folder=self._source_subfolder)
+        return self._cmake
+
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+
+

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/test_package/CMakeLists.txt
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(test_kaitai test_kaitai.cpp)
+target_link_libraries(test_kaitai ${CONAN_LIBS})
+
+# CTest is a testing tool that can be used to test your project.
+# enable_testing()
+# add_test(NAME example
+#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+#          COMMAND example)

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/test_package/conanfile.py
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/test_package/conanfile.py
@@ -1,0 +1,20 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class KaitaiStructCppStlTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
+        # in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            os.chdir("bin")
+            self.run(".%stest_kaitai" % os.sep)

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/test_package/test_kaitai.cpp
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/test_package/test_kaitai.cpp
@@ -1,0 +1,7 @@
+#include <kaitai/kaitaistream.h>
+
+int main() {
+    std::string buf;
+    std::istringstream is(buf);
+    kaitai::kstream ks(&is);
+}

--- a/recipes/kaitai_struct_cpp_stl_runtime/config.yml
+++ b/recipes/kaitai_struct_cpp_stl_runtime/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.9":
+    folder: all


### PR DESCRIPTION
**kaitai_struct_cpp_stl_runtime/0.9**

I am not the author of the library, and the library has no special dependencies. This is the runtime C++ parser dependency for kaitai structs https://kaitai.io/. It does not include other tools for other languages or the code generator stages for kaitai (which generates parsers for domain specific language type markup). Its a reasonably well used tool by other open source projects like Kismet (wireless packet sniffer tool https://www.kismetwireless.net/) and I believe it would be useful as a library for Conan center. I have included only the most recent version 0.9.

This is my first conan-center contribution so any feedback is greatly appreciated.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
