### PR TITLE
[m4] Remove build-related settings from package id for executable tool

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -102,6 +102,7 @@ class M4Conan(ConanFile):
 
     def package_id(self):
         self.info.include_build_settings()
+        del self.info.settings.compiler
 
     def package_info(self):
         bin_path = os.path.join(self.package_folder, "bin")


### PR DESCRIPTION
Specify library name and version:  **m4/1.4.18**

Recipe update only
Delete build-specific information in package_id for m4 as it is an executable tool per issue #3157
The m4 package only needs to execute on the build machine, so remove compiler and arch from `package_id`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
