### PR TITLE
harbuzz: keep cppstd & libcxx in settings + add with_directwrite option + cleanup

### DIFF
--- a/recipes/harfbuzz/all/conandata.yml
+++ b/recipes/harfbuzz/all/conandata.yml
@@ -19,20 +19,20 @@ sources:
     url: "https://github.com/harfbuzz/harfbuzz/archive/2.8.0.tar.gz"
 patches:
   "2.6.8":
-    - patch_file: "patches/source_subfolder.patch"
-      base_path: "."
+    - patch_file: "patches/icu.patch"
+      base_path: "source_subfolder"
   "2.7.0":
-    - patch_file: "patches/source_subfolder.patch"
-      base_path: "."
+    - patch_file: "patches/icu.patch"
+      base_path: "source_subfolder"
   "2.7.1":
-    - patch_file: "patches/source_subfolder.patch"
-      base_path: "."
+    - patch_file: "patches/icu.patch"
+      base_path: "source_subfolder"
   "2.7.2":
-    - patch_file: "patches/source_subfolder.patch"
-      base_path: "."
+    - patch_file: "patches/icu.patch"
+      base_path: "source_subfolder"
   "2.7.4":
-    - patch_file: "patches/source_subfolder.patch"
-      base_path: "."
+    - patch_file: "patches/icu.patch"
+      base_path: "source_subfolder"
   "2.8.0":
-    - patch_file: "patches/source_subfolder_2.8.X.patch"
-      base_path: "."
+    - patch_file: "patches/icu-2.8.x.patch"
+      base_path: "source_subfolder"

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -75,17 +75,11 @@ class HarfbuzzConan(ConanFile):
 
         return cmake
 
-    def _configure_cmake_macos(self, cmake):
-        if tools.is_apple_os(self.settings.os):
-            cmake.definitions["CMAKE_MACOSX_RPATH"] = True
-        return cmake
-
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
         self._cmake = self._configure_cmake_compiler_flags(self._cmake)
-        self._cmake = self._configure_cmake_macos(self._cmake)
         self._cmake.definitions["HB_HAVE_FREETYPE"] = self.options.with_freetype
         self._cmake.definitions["HB_BUILD_TESTS"] = False
         self._cmake.definitions["HB_HAVE_ICU"] = self.options.with_icu

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -32,6 +32,8 @@ class HarfbuzzConan(ConanFile):
         "with_directwrite": True,
     }
 
+    short_paths = True
+
     exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake"
     _cmake = None

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -113,7 +113,9 @@ class HarfbuzzConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "harfbuzz"
         self.cpp_info.names["cmake_find_package_multi"] = "harfbuzz"
-        self.cpp_info.libs = tools.collect_libs(self)
+        if self.options.with_icu:
+            self.cpp_info.libs.append("harfbuzz-icu")
+        self.cpp_info.libs.append("harfbuzz")
         self.cpp_info.includedirs.append(os.path.join("include", "harfbuzz"))
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("m")

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -84,7 +84,6 @@ class HarfbuzzConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake = self._configure_cmake_compiler_flags(self._cmake)
         self._cmake.definitions["HB_HAVE_FREETYPE"] = self.options.with_freetype
-        self._cmake.definitions["HB_BUILD_TESTS"] = False
         self._cmake.definitions["HB_HAVE_ICU"] = self.options.with_icu
         self._cmake.definitions["HB_HAVE_GLIB"] = self.options.with_glib
 

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -87,14 +87,19 @@ class HarfbuzzConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake = self._configure_cmake_compiler_flags(self._cmake)
         self._cmake.definitions["HB_HAVE_FREETYPE"] = self.options.with_freetype
-        self._cmake.definitions["HB_HAVE_ICU"] = self.options.with_icu
+        self._cmake.definitions["HB_HAVE_GRAPHITE2"] = False
         self._cmake.definitions["HB_HAVE_GLIB"] = self.options.with_glib
-
-        if self.settings.os == "Windows":
+        self._cmake.definitions["HB_HAVE_ICU"] = self.options.with_icu
+        if tools.is_apple_os(self.settings.os):
+            self._cmake.definitions["HB_HAVE_CORETEXT"] = True
+        elif self.settings.os == "Windows":
             self._cmake.definitions["HB_HAVE_GDI"] = self.options.with_gdi
             self._cmake.definitions["HB_HAVE_UNISCRIBE"] = self.options.with_uniscribe
             self._cmake.definitions["HB_HAVE_DIRECTWRITE"] = self.options.with_directwrite
-
+        self._cmake.definitions["HB_BUILD_UTILS"] = False
+        self._cmake.definitions["HB_BUILD_SUBSET"] = False
+        self._cmake.definitions["HB_HAVE_GOBJECT"] = False
+        self._cmake.definitions["HB_HAVE_INTROSPECTION"] = False
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -57,7 +57,6 @@ class HarfbuzzConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        del self.settings.compiler.libcxx
 
     def requirements(self):
         if self.options.with_freetype:
@@ -130,3 +129,7 @@ class HarfbuzzConan(ConanFile):
                 self.cpp_info.system_libs.append("dwrite")
         if self.settings.os == "Macos":
             self.cpp_info.frameworks.extend(["CoreFoundation", "CoreGraphics", "CoreText"])
+        if not self.options.shared:
+            libcxx = tools.stdcpp_library(self)
+            if libcxx:
+                self.cpp_info.system_libs.append(libcxx)

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -9,11 +9,8 @@ class HarfbuzzConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://harfbuzz.org"
     license = "MIT"
-    exports_sources = ["CMakeLists.txt", "patches/*.patch"]
-    generators = "cmake"
 
     settings = "os", "arch", "compiler", "build_type"
-
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -33,10 +30,30 @@ class HarfbuzzConan(ConanFile):
         "with_uniscribe": True
     }
 
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
-
+    exports_sources = ["CMakeLists.txt", "patches/**"]
+    generators = "cmake"
     _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+        else:
+            del self.options.with_gdi
+            del self.options.with_uniscribe
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
 
     def requirements(self):
         if self.options.with_freetype:
@@ -45,19 +62,6 @@ class HarfbuzzConan(ConanFile):
             self.requires("icu/68.2")
         if self.options.with_glib:
             self.requires("glib/2.68.0")
-
-    def configure(self):
-        if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-        else:
-            del self.options.with_gdi
-            del self.options.with_uniscribe
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -93,8 +93,8 @@ class HarfbuzzConan(ConanFile):
         return self._cmake
 
     def build(self):
-        for p in self.conan_data["patches"][self.version]:
-            tools.patch(**p)
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -53,7 +53,6 @@ class HarfbuzzConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
 
     def requirements(self):
         if self.options.with_freetype:

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -44,7 +44,7 @@ class HarfbuzzConan(ConanFile):
         if self.options.with_icu:
             self.requires("icu/68.2")
         if self.options.with_glib:
-            self.requires("glib/2.67.6")
+            self.requires("glib/2.68.0")
 
     def configure(self):
         if self.options.shared:

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -18,7 +18,8 @@ class HarfbuzzConan(ConanFile):
         "with_icu": [True, False],
         "with_glib": [True, False],
         "with_gdi": [True, False],
-        "with_uniscribe": [True, False]
+        "with_uniscribe": [True, False],
+        "with_directwrite": [True, False],
     }
     default_options = {
         "shared": False,
@@ -27,7 +28,8 @@ class HarfbuzzConan(ConanFile):
         "with_icu": False,
         "with_glib": True,
         "with_gdi": True,
-        "with_uniscribe": True
+        "with_uniscribe": True,
+        "with_directwrite": True,
     }
 
     exports_sources = ["CMakeLists.txt", "patches/**"]
@@ -48,6 +50,7 @@ class HarfbuzzConan(ConanFile):
         else:
             del self.options.with_gdi
             del self.options.with_uniscribe
+            del self.options.with_directwrite
 
     def configure(self):
         if self.options.shared:
@@ -90,6 +93,7 @@ class HarfbuzzConan(ConanFile):
         if self.settings.os == "Windows":
             self._cmake.definitions["HB_HAVE_GDI"] = self.options.with_gdi
             self._cmake.definitions["HB_HAVE_UNISCRIBE"] = self.options.with_uniscribe
+            self._cmake.definitions["HB_HAVE_DIRECTWRITE"] = self.options.with_directwrite
 
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
@@ -116,6 +120,14 @@ class HarfbuzzConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("m")
         if self.settings.os == "Windows" and not self.options.shared:
-            self.cpp_info.system_libs.extend(["dwrite", "rpcrt4", "usp10", "gdi32", "user32"])
+            self.cpp_info.system_libs.append("user32")
+            if self.options.with_gdi or self.options.with_uniscribe:
+                self.cpp_info.system_libs.append("gdi32")
+            if self.options.with_uniscribe or self.options.with_directwrite:
+                self.cpp_info.system_libs.append("rpcrt4")
+            if self.options.with_uniscribe:
+                self.cpp_info.system_libs.append("usp10")
+            if self.options.with_directwrite:
+                self.cpp_info.system_libs.append("dwrite")
         if self.settings.os == "Macos":
             self.cpp_info.frameworks.extend(["CoreFoundation", "CoreGraphics", "CoreText"])

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -110,8 +110,9 @@ class HarfbuzzConan(ConanFile):
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
-
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "harfbuzz"
+        self.cpp_info.names["cmake_find_package_multi"] = "harfbuzz"
         self.cpp_info.libs = tools.collect_libs(self)
         self.cpp_info.includedirs.append(os.path.join("include", "harfbuzz"))
         if self.settings.os == "Linux":

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -11,10 +11,9 @@ class HarfbuzzConan(ConanFile):
     license = "MIT"
     exports_sources = ["CMakeLists.txt", "patches/*.patch"]
     generators = "cmake"
-    short_paths = True
 
     settings = "os", "arch", "compiler", "build_type"
-    
+
     options = {
         "shared": [True, False],
         "fPIC": [True, False],

--- a/recipes/harfbuzz/all/patches/icu-2.8.x.patch
+++ b/recipes/harfbuzz/all/patches/icu-2.8.x.patch
@@ -1,28 +1,26 @@
-diff --git a/source_subfolder/CMakeLists.txt b/source_subfolder_patched/CMakeLists.txt
-index 2a8fd8b..2b7056c 100644
---- a/source_subfolder/CMakeLists.txt
-+++ b/source_subfolder_patched/CMakeLists.txt
-@@ -237,16 +237,16 @@ if (HB_HAVE_ICU)
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -241,16 +241,16 @@ if (HB_HAVE_ICU)
 -  find_package(PkgConfig)
 -  pkg_check_modules(PC_ICU QUIET icu-uc)
 +  # find_package(PkgConfig)
 +  # pkg_check_modules(PC_ICU QUIET icu-uc)
- 
+
 -  find_path(ICU_INCLUDE_DIR NAMES unicode/utypes.h HINTS ${PC_ICU_INCLUDE_DIRS} ${PC_ICU_INCLUDEDIR})
 -  find_library(ICU_LIBRARY NAMES libicuuc cygicuuc cygicuuc32 icuuc HINTS ${PC_ICU_LIBRARY_DIRS} ${PC_ICU_LIBDIR})
 +  # find_path(ICU_INCLUDE_DIR NAMES unicode/utypes.h HINTS ${PC_ICU_INCLUDE_DIRS} ${PC_ICU_INCLUDEDIR})
 +  # find_library(ICU_LIBRARY NAMES libicuuc cygicuuc cygicuuc32 icuuc HINTS ${PC_ICU_LIBRARY_DIRS} ${PC_ICU_LIBDIR})
- 
+
 -  include_directories(${ICU_INCLUDE_DIR})
 +  # include_directories(${ICU_INCLUDE_DIR})
- 
+
    list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-icu.h)
- 
+
 -  list(APPEND THIRD_PARTY_LIBS ${ICU_LIBRARY})
 +  # list(APPEND THIRD_PARTY_LIBS ${ICU_LIBRARY})
- 
+
 -  mark_as_advanced(ICU_INCLUDE_DIR ICU_LIBRARY)
 +  # mark_as_advanced(ICU_INCLUDE_DIR ICU_LIBRARY)
  endif ()
- 
+
  if (APPLE AND HB_HAVE_CORETEXT)

--- a/recipes/harfbuzz/all/patches/icu.patch
+++ b/recipes/harfbuzz/all/patches/icu.patch
@@ -1,28 +1,26 @@
-diff --git a/source_subfolder/CMakeLists.txt b/source_subfolder_patched/CMakeLists.txt
-index 2a8fd8b..2b7056c 100644
---- a/source_subfolder/CMakeLists.txt
-+++ b/source_subfolder_patched/CMakeLists.txt
-@@ -241,16 +241,16 @@ if (HB_HAVE_ICU)
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -237,16 +237,16 @@ if (HB_HAVE_ICU)
 -  find_package(PkgConfig)
 -  pkg_check_modules(PC_ICU QUIET icu-uc)
 +  # find_package(PkgConfig)
 +  # pkg_check_modules(PC_ICU QUIET icu-uc)
-
+ 
 -  find_path(ICU_INCLUDE_DIR NAMES unicode/utypes.h HINTS ${PC_ICU_INCLUDE_DIRS} ${PC_ICU_INCLUDEDIR})
 -  find_library(ICU_LIBRARY NAMES libicuuc cygicuuc cygicuuc32 icuuc HINTS ${PC_ICU_LIBRARY_DIRS} ${PC_ICU_LIBDIR})
 +  # find_path(ICU_INCLUDE_DIR NAMES unicode/utypes.h HINTS ${PC_ICU_INCLUDE_DIRS} ${PC_ICU_INCLUDEDIR})
 +  # find_library(ICU_LIBRARY NAMES libicuuc cygicuuc cygicuuc32 icuuc HINTS ${PC_ICU_LIBRARY_DIRS} ${PC_ICU_LIBDIR})
-
+ 
 -  include_directories(${ICU_INCLUDE_DIR})
 +  # include_directories(${ICU_INCLUDE_DIR})
-
+ 
    list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-icu.h)
-
+ 
 -  list(APPEND THIRD_PARTY_LIBS ${ICU_LIBRARY})
 +  # list(APPEND THIRD_PARTY_LIBS ${ICU_LIBRARY})
-
+ 
 -  mark_as_advanced(ICU_INCLUDE_DIR ICU_LIBRARY)
 +  # mark_as_advanced(ICU_INCLUDE_DIR ICU_LIBRARY)
  endif ()
-
+ 
  if (APPLE AND HB_HAVE_CORETEXT)

--- a/recipes/harfbuzz/all/test_package/CMakeLists.txt
+++ b/recipes/harfbuzz/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/example.ttf
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/recipes/harfbuzz/all/test_package/CMakeLists.txt
+++ b/recipes/harfbuzz/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
@@ -7,6 +7,8 @@ conan_basic_setup()
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/example.ttf
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-add_executable(${CMAKE_PROJECT_NAME} example.c)
-target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})
-set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY C_STANDARD 99)
+find_package(harfbuzz REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} example.c)
+target_link_libraries(${PROJECT_NAME} harfbuzz::harfbuzz)
+set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)

--- a/recipes/harfbuzz/all/test_package/conanfile.py
+++ b/recipes/harfbuzz/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

HarfBuzz is a C++ library with C API (C99), but without dependency to C++ standard library.
This PR also tries to cleanup this recipe, which is a port of bincrafters recipe, with its history (some old dirty fixes).

`HB_BUILD_SUBSET` is set to OFF, it builds a lib which is useless when `HB_BUILD_UTILS` is OFF.

I don't trust at all the way dependencies are discovered (CMake based project, with dependencies, but without usage of conan targets or cmake_find_package[_multi] is always suspicious or fragile), but it's not addressed in this PR.

closes https://github.com/conan-io/conan-center-index/issues/5110

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
