### PR TITLE
[qt][6.x] Provide all relocation information in qt.conf

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -16,7 +16,19 @@ class qt(Generator):
 
     @property
     def content(self):
-        return "[Paths]\nPrefix = %s\n" % self.conanfile.deps_cpp_info["qt"].rootpath.replace("\\", "/")
+        return """[Paths]
+Prefix = %s
+ArchData = bin/archdatadir
+HostData = bin/archdatadir
+Data = bin/datadir
+Sysconf = bin/sysconfdir
+LibraryExecutables = bin/archdatadir/bin
+Plugins = bin/archdatadir/plugins
+Imports = bin/archdatadir/imports
+Qml2Imports = bin/archdatadir/qml
+Translations = bin/datadir/translations
+Documentation = bin/datadir/doc
+Examples = bin/datadir/examples""" % self.conanfile.deps_cpp_info["qt"].rootpath.replace("\\", "/")
 
 
 class QtConan(ConanFile):

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -18,17 +18,17 @@ class qt(Generator):
     def content(self):
         return """[Paths]
 Prefix = %s
-ArchData = bin/archdatadir
-HostData = bin/archdatadir
-Data = bin/datadir
-Sysconf = bin/sysconfdir
-LibraryExecutables = bin/archdatadir/bin
-Plugins = bin/archdatadir/plugins
-Imports = bin/archdatadir/imports
-Qml2Imports = bin/archdatadir/qml
-Translations = bin/datadir/translations
-Documentation = bin/datadir/doc
-Examples = bin/datadir/examples""" % self.conanfile.deps_cpp_info["qt"].rootpath.replace("\\", "/")
+ArchData = res/archdatadir
+HostData = res/archdatadir
+Data = res/datadir
+Sysconf = res/sysconfdir
+LibraryExecutables = res/archdatadir/bin
+Plugins = res/archdatadir/plugins
+Imports = res/archdatadir/imports
+Qml2Imports = res/archdatadir/qml
+Translations = res/datadir/translations
+Documentation = res/datadir/doc
+Examples = res/datadir/examples""" % self.conanfile.deps_cpp_info["qt"].rootpath.replace("\\", "/")
 
 
 class QtConan(ConanFile):

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -10,25 +10,31 @@ from conans.model import Generator
 
 
 class qt(Generator):
+    @staticmethod
+    def content_template(path, folder):
+        return textwrap.dedent("""[Paths]
+            Prefix = {0}
+            ArchData = {1}/archdatadir
+            HostData = {1}/archdatadir
+            Data = {1}/datadir
+            Sysconf = {1}/sysconfdir
+            LibraryExecutables = {1}/archdatadir/bin
+            Plugins = {1}/archdatadir/plugins
+            Imports = {1}/archdatadir/imports
+            Qml2Imports = {1}/archdatadir/qml
+            Translations = {1}/datadir/translations
+            Documentation = {1}/datadir/doc
+            Examples = {1}/datadir/examples""").format(path, folder)
+
     @property
     def filename(self):
         return "qt.conf"
 
     @property
     def content(self):
-        return """[Paths]
-Prefix = %s
-ArchData = res/archdatadir
-HostData = res/archdatadir
-Data = res/datadir
-Sysconf = res/sysconfdir
-LibraryExecutables = res/archdatadir/bin
-Plugins = res/archdatadir/plugins
-Imports = res/archdatadir/imports
-Qml2Imports = res/archdatadir/qml
-Translations = res/datadir/translations
-Documentation = res/datadir/doc
-Examples = res/datadir/examples""" % self.conanfile.deps_cpp_info["qt"].rootpath.replace("\\", "/")
+        return qt.content_template(
+            self.conanfile.deps_cpp_info["qt"].rootpath.replace("\\", "/"),
+            "res")
 
 
 class QtConan(ConanFile):
@@ -515,19 +521,7 @@ class QtConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         with open(os.path.join(self.package_folder, "bin", "qt.conf"), "w") as f:
-            f.write(textwrap.dedent("""[Paths]
-                Prefix = ..
-                ArchData = res/archdatadir
-                HostData = res/archdatadir
-                Data = res/datadir
-                Sysconf = res/sysconfdir
-                LibraryExecutables = res/archdatadir/bin
-                Plugins = res/archdatadir/plugins
-                Imports = res/archdatadir/imports
-                Qml2Imports = res/archdatadir/qml
-                Translations = res/datadir/translations
-                Documentation = res/datadir/doc
-                Examples = res/datadir/examples"""))
+            f.write(qt.content_template("..", "res"))
         self.copy("*LICENSE*", src="qt6/", dst="licenses")
         for module in self._submodules:
             if not self.options.get_safe(module):

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -12,7 +12,8 @@ from conans.model import Generator
 class qt(Generator):
     @staticmethod
     def content_template(path, folder):
-        return textwrap.dedent("""[Paths]
+        return textwrap.dedent("""\
+            [Paths]
             Prefix = {0}
             ArchData = {1}/archdatadir
             HostData = {1}/archdatadir


### PR DESCRIPTION
Specify library name and version:  **qt/6.x**

> Since plugins and such are relocated inside the current qt.conf is insufficient. Possibly should resolve #4839, needs more information.

For 5.x: https://github.com/conan-io/conan-center-index/pull/5129

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
