### PR TITLE
spirv-tools: switch to versions without v prefix

### DIFF
--- a/recipes/spirv-tools/all/conandata.yml
+++ b/recipes/spirv-tools/all/conandata.yml
@@ -1,14 +1,26 @@
 sources:
-  "v2019.2":
-    sha256: 1fde9d2a0df920a401441cd77253fc7b3b9ab0578eabda8caaaceaa6c7638440
-    url: https://github.com/KhronosGroup/SPIRV-Tools/archive/v2019.2.tar.gz
-  "v2020.3":
-    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.3.tar.gz"
-    sha256: "8b538a1cb2a4275ef9617abcb047d54e8292f975ac1d93323d5dd1e19c85280b"
+  "2020.5":
+    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.5.tar.gz"
+    sha256: "947ee994ba416380bd7ccc1c6377ac28a4802a55ca81ccc06796c28e84c00b71"
   "v2020.5":
     url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.5.tar.gz"
     sha256: "947ee994ba416380bd7ccc1c6377ac28a4802a55ca81ccc06796c28e84c00b71"
+  "2020.3":
+    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.3.tar.gz"
+    sha256: "8b538a1cb2a4275ef9617abcb047d54e8292f975ac1d93323d5dd1e19c85280b"
+  "v2020.3":
+    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.3.tar.gz"
+    sha256: "8b538a1cb2a4275ef9617abcb047d54e8292f975ac1d93323d5dd1e19c85280b"
+  "2019.2":
+    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2019.2.tar.gz"
+    sha256: "1fde9d2a0df920a401441cd77253fc7b3b9ab0578eabda8caaaceaa6c7638440"
+  "v2019.2":
+    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2019.2.tar.gz"
+    sha256: "1fde9d2a0df920a401441cd77253fc7b3b9ab0578eabda8caaaceaa6c7638440"
 patches:
+  "2020.5":
+    - patch_file: "patches/support-SPV_KHR_fragment_shading_rate.patch"
+      base_path: "source_subfolder"
   "v2020.5":
     - patch_file: "patches/support-SPV_KHR_fragment_shading_rate.patch"
       base_path: "source_subfolder"

--- a/recipes/spirv-tools/config.yml
+++ b/recipes/spirv-tools/config.yml
@@ -1,7 +1,13 @@
 versions:
-  "v2019.2":
+  "2020.5":
+    folder: all
+  "v2020.5":
+    folder: all
+  "2020.3":
     folder: all
   "v2020.3":
     folder: all
-  "v2020.5":
+  "2019.2":
+    folder: all
+  "v2019.2":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

this v suffix leads to all sort of issues in dependency graph of `glslang`, `shaderc`, `vulkan-validationlayers` and `moltenvk`. For example I'm not even able to have `shaderc` in my build requirements and `vulkan-validationlayers` in my requirements, because they don't use the same version of spirv-tools in their conanfile

see this discussion in original PR of spirv-tools https://github.com/conan-io/conan-center-index/pull/1349#issuecomment-627818533
/cc @jgsogo

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
