### PR TITLE
[xapian-core] Add data for new version of xapian-core 1.4.18

### DIFF
--- a/recipes/xapian-core/all/conandata.yml
+++ b/recipes/xapian-core/all/conandata.yml
@@ -2,7 +2,15 @@ sources:
   "1.4.16":
     url: "https://oligarchy.co.uk/xapian/1.4.16/xapian-core-1.4.16.tar.xz"
     sha256: "4937f2f49ff27e39a42150e928c8b45877b0bf456510f0785f50159a5cb6bf70"
+  "1.4.18":
+    url: "https://oligarchy.co.uk/xapian/1.4.18/xapian-core-1.4.18.tar.xz"
+    sha256: "196ddbb4ad10450100f0991a599e4ed944cbad92e4a6fe813be6dce160244b77"
 patches:
   "1.4.16":
     - base_path: ""
       patch_file: "patches/0001-add-msvc-cl-sh.patch"
+  "1.4.18":
+    - base_path: ""
+      patch_file: "patches/0001-add-msvc-cl-sh.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0002-add-cerrno.patch"

--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -131,6 +131,8 @@ class XapianCoreConan(ConanFile):
         if not self.options.shared:
             if self.settings.os == "Linux":
                 self.cpp_info.system_libs = ["rt"]
+            if self.settings.os == "SunOS":
+                self.cpp_info.system_libs = ["socket", "nsl"]
 
         self.cpp_info.names["cmake_find_package"] = "xapian"
         self.cpp_info.names["cmake_find_package_multi"] = "xapian"

--- a/recipes/xapian-core/all/patches/0002-add-cerrno.patch
+++ b/recipes/xapian-core/all/patches/0002-add-cerrno.patch
@@ -1,0 +1,12 @@
+diff --git a/xapian-core/common/errno_to_string.cc b/xapian-core/common/errno_to_string.cc
+index 00c214b..0064304 100644
+--- common/errno_to_string.cc
++++ common/errno_to_string.cc
+@@ -28,6 +28,7 @@
+ 
+ // <cstring> doesn't give us strerror_r() with Sun C++ 5.9.
+ #include <string.h>
++#include <cerrno>
+ #if defined HAVE__SYS_ERRLIST_AND__SYS_NERR || \
+     defined HAVE_SYS_ERRLIST_AND_SYS_NERR
+ # include <stdio.h>

--- a/recipes/xapian-core/config.yml
+++ b/recipes/xapian-core/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.4.16":
+    folder: "all" 
+  "1.4.18":
     folder: "all"


### PR DESCRIPTION
Add a patch to work around problems building on AIX 7.1.
Supply depencent runtime libraries for Solaris similar to Linux.

Specify library name and version:  **xapian-core/1.4.18**

This patch was required to get xapian-core to build on AIX, and for users of a static xapian-core library to link on Solaris.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
