### PR TITLE
Add hidapi recipe

### DIFF
--- a/recipes/hidapi/all/conandata.yml
+++ b/recipes/hidapi/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.10.1":
+    url: "https://codeload.github.com/libusb/hidapi/zip/refs/tags/hidapi-0.10.1"
+    sha256: "7278906e2026343bf3926762fd48534b49a43c334c07f7da0bb51a383ad2ca5c"

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -1,0 +1,93 @@
+# Known Issues
+#
+# * Not support x64 for Windows
+#
+#     [libusb/hidapi](https://github.com/libusb/hidapi) provides a `sln` file to build for Windows, which lack support x64.
+#
+# If you get an idea to solve one of this issues, please report here or fork.
+import os
+from conans import ConanFile, AutoToolsBuildEnvironment, MSBuild, tools
+
+
+class HidapiConan(ConanFile):
+    name = "hidapi"
+    description = "HIDAPI is a multi-platform library which allows an application to interface with USB and Bluetooth HID-Class devices on Windows, Linux, FreeBSD, and macOS."
+    topics = ("conan", "hidapi", "libusb")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/libusb/hidapi"
+    license = "BSD-Style"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "minosx": ['10.7', '10.8', '10.9', '10.10', '10.11', '10.12', '10.13', '10.14', '10.15', '11'],
+        "fPIC": [True, False],
+        "with_libusb": [True, False]
+    }
+    default_options = {
+        "minosx": 10.7, "fPIC": True, "with_libusb": False
+    }
+    generators = "pkg_config"
+
+    @property
+    def _source_dir(self):
+        return "hidapi-hidapi-" + self.version
+
+    def config_options(self):
+        if self.settings.os != "Macos":
+            del self.options.minosx
+        if self.settings.os != "Linux":
+            del self.options.with_libusb
+        if self.settings.os == "Windows":
+            self.settings.arch.remove("x86_64")
+
+    def requirements(self):
+        if self.settings.os == "Linux" or self.settings.os == "FreeBSD":
+            self.requires("libusb/[~=1.0]")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        if self.settings.os != "Windows":
+            self.run("chmod +x ./%s/bootstrap" % self._source_dir)
+
+    def build(self):
+        if self.settings.os == "Windows":
+            if self.settings.compiler == "Visual Studio":
+                self.build_msvc()
+        else:
+            self.build_unix()
+
+    def build_msvc(self):
+        msbuild = MSBuild(self)
+        msbuild.build("%s/windows/hidapi.sln" % self._source_dir,
+                      platforms={"x86": "Win32"})
+
+    def build_unix(self):
+        self.run(os.path.join(".", "bootstrap"), cwd=self._source_dir)
+        if self.settings.os == "Macos":
+            configure = os.path.join(self._source_dir, "configure")
+            tools.replace_in_file(configure, r"-install_name \$rpath/",
+                                  "-install_name ")
+        autotools = AutoToolsBuildEnvironment(self)
+        if self.settings.os == "Macos":
+            autotools.flags.append('-mmacosx-version-min=%s' %
+                                   self.options.minosx)
+
+        autotools.configure(self._source_dir)
+        autotools.make()
+
+    def package(self):
+        self.copy("LICENSE*.txt", src=self._source_dir, dst="licenses")
+        self.copy(os.path.join("hidapi", "*.h"), dst="include", src=self._source_dir)
+        self.copy("*hidapi.lib", dst="lib", keep_path=False)
+        self.copy("*.dll", dst="bin", keep_path=False)
+        self.copy("*.so", dst="lib", keep_path=False)
+        self.copy("*.dylib", dst="lib", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
+
+    def package_info(self):
+        if self.settings.os == "Linux":
+            if self.options.with_libusb:
+                self.cpp_info.libs = ["hidapi-libusb"]
+            else:
+                self.cpp_info.libs = ["hidapi-hidraw"]
+        else:
+            self.cpp_info.libs = ["hidapi"]

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -44,7 +44,7 @@ class HidapiConan(ConanFile):
 
     def requirements(self):
         if self.settings.os == "Linux" or self.settings.os == "FreeBSD":
-            self.requires("libusb/[~=1.0]")
+            self.requires("libusb/1.0.24")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -30,8 +30,12 @@ class HidapiConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self.settings.compiler == "Visual Studio":
+            self.options.shared = True
 
     def configure(self):
+        if self.settings.compiler == "Visual Studio" and not self.options.shared:
+            raise ConanInvalidConfiguration("Static libraries for Visual Studio are currently not available")
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -56,7 +56,6 @@ class HidapiConan(ConanFile):
         if self._autotools:
             return self._autotools
         with tools.chdir(self._source_subfolder):
-            os.chmod("configure.ac", os.stat("configure.ac").st_mode | 0o111)
             self.run("./bootstrap")
         if self.settings.os == "Macos":
             tools.replace_in_file(os.path.join(self._source_subfolder, "configure"),

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -90,7 +90,7 @@ class HidapiConan(ConanFile):
         else:
             autotools = self._configure_autotools()
             autotools.install()
-            # tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+            tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
             tools.rmdir(os.path.join(self.package_folder, "share"))
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
 

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -93,7 +93,7 @@ class HidapiConan(ConanFile):
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
 
     def package_info(self):
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libusb"].names["pkg_config"] = "hidapi-libusb"
             self.cpp_info.components["libusb"].libs = ["hidapi-libusb"]
             self.cpp_info.components["libusb"].requires = ["libusb::libusb"]

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -7,6 +7,7 @@
 # If you get an idea to solve one of this issues, please report here or fork.
 import os
 import shutil
+import glob
 from conans import ConanFile, AutoToolsBuildEnvironment, MSBuild, tools
 from conans.errors import ConanInvalidConfiguration
 
@@ -92,6 +93,8 @@ class HidapiConan(ConanFile):
             autotools.install()
             shutil.rmtree(os.path.join(self.package_folder, "lib", "pkgconfig"))
             shutil.rmtree(os.path.join(self.package_folder, "share"))
+            for path in glob.glob(os.path.join(self.package_folder, "lib", "*.la")):
+                os.unlink(path)
 
     def package_info(self):
         if self.settings.os == "Linux":

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -43,6 +43,9 @@ class HidapiConan(ConanFile):
         if self.settings.os == "Windows" and self.settings.arch == "x86_64":
             raise ConanInvalidConfiguration("There's no support for x86_64 on Windows yet, please use x86")
 
+    def build_requirements(self):
+        self.build_requires("libtool/2.4.6")
+
     def requirements(self):
         if self.settings.os == "Linux" or self.settings.os == "FreeBSD":
             self.requires("libusb/1.0.24")

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -7,6 +7,7 @@
 # If you get an idea to solve one of this issues, please report here or fork.
 import os
 from conans import ConanFile, AutoToolsBuildEnvironment, MSBuild, tools
+from conans.errors import ConanInvalidConfiguration
 
 
 class HidapiConan(ConanFile):
@@ -36,8 +37,10 @@ class HidapiConan(ConanFile):
             del self.options.minosx
         if self.settings.os != "Linux":
             del self.options.with_libusb
-        if self.settings.os == "Windows":
-            self.settings.arch.remove("x86_64")
+
+    def configure(self):
+        if self.settings.os == "Windows" and self.settings.arch == "x86_64":
+            raise ConanInvalidConfiguration("There's no support for x86_64 on Windows yet, please use x86")
 
     def requirements(self):
         if self.settings.os == "Linux" or self.settings.os == "FreeBSD":

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -41,7 +41,8 @@ class HidapiConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def build_requirements(self):
-        self.build_requires("libtool/2.4.6")
+        if self.settings.compiler != "Visual Studio":
+            self.build_requires("libtool/2.4.6")
 
     def requirements(self):
         if self.settings.os == "Linux" or self.settings.os == "FreeBSD":

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -32,8 +32,6 @@ class HidapiConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if self.settings.os == "Windows" and self.settings.arch == "x86_64":
-            raise ConanInvalidConfiguration("There's no support for x86_64 on Windows yet, please use x86")
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -45,7 +45,7 @@ class HidapiConan(ConanFile):
             self.build_requires("libtool/2.4.6")
 
     def requirements(self):
-        if self.settings.os == "Linux" or self.settings.os == "FreeBSD":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("libusb/1.0.24")
 
     def _patch_sources(self):

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -6,6 +6,7 @@
 #
 # If you get an idea to solve one of this issues, please report here or fork.
 import os
+import shutil
 from conans import ConanFile, AutoToolsBuildEnvironment, MSBuild, tools
 from conans.errors import ConanInvalidConfiguration
 
@@ -79,12 +80,15 @@ class HidapiConan(ConanFile):
 
     def package(self):
         self.copy("LICENSE*.txt", src=self._source_dir, dst="licenses")
-        self.copy(os.path.join("hidapi", "*.h"), dst="include", src=self._source_dir)
-        self.copy("*hidapi.lib", dst="lib", keep_path=False)
-        self.copy("*.dll", dst="bin", keep_path=False)
-        self.copy("*.so", dst="lib", keep_path=False)
-        self.copy("*.dylib", dst="lib", keep_path=False)
-        self.copy("*.a", dst="lib", keep_path=False)
+        if self.settings.os == "Windows":
+            self.copy(os.path.join("hidapi", "*.h"), dst="include", src=self._source_dir)
+            self.copy("*hidapi.lib", dst="lib", keep_path=False)
+            self.copy("*.dll", dst="bin", keep_path=False)
+        else:
+            autotools = AutoToolsBuildEnvironment(self)
+            autotools.install()
+            shutil.rmtree(os.path.join(self.package_folder, "lib", "pkgconfig"))
+            shutil.rmtree(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         if self.settings.os == "Linux":

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -52,9 +52,6 @@ class HidapiConan(ConanFile):
     def _patch_sources(self):
         tools.replace_in_file(os.path.join(self._source_subfolder, "configure.ac"),
                               "AC_CONFIG_MACRO_DIR", "dnl AC_CONFIG_MACRO_DIR")
-        if self.settings.os == "Macos":
-            tools.replace_in_file(os.path.join(self._source_subfolder, "configure"),
-                                  r"-install_name \$rpath/", "-install_name ")
 
     def _configure_autotools(self):
         if self._autotools:
@@ -62,6 +59,9 @@ class HidapiConan(ConanFile):
         with tools.chdir(self._source_subfolder):
             os.chmod("configure.ac", os.stat("configure.ac").st_mode | 0o111)
             self.run("./bootstrap")
+        if self.settings.os == "Macos":
+            tools.replace_in_file(os.path.join(self._source_subfolder, "configure"),
+                                  r"-install_name \$rpath/", "-install_name ")
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         args = ["--enable-shared" if self.options.shared else "--disable-shared",
                 "--enable-static" if not self.options.shared else "--disable-static"]

--- a/recipes/hidapi/all/test_package/CMakeLists.txt
+++ b/recipes/hidapi/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/hidapi/all/test_package/conanfile.py
+++ b/recipes/hidapi/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class HidapiTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.run(os.path.join("bin", "test_package"), run_environment=True)

--- a/recipes/hidapi/all/test_package/test_package.cpp
+++ b/recipes/hidapi/all/test_package/test_package.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+#include "hidapi/hidapi.h"
+
+int main() {
+    hid_init();
+}

--- a/recipes/hidapi/config.yml
+++ b/recipes/hidapi/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.10.1":
+    folder: all

--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -8,7 +8,7 @@ class SociConan(ConanFile):
     homepage = "https://github.com/SOCI/soci"
     url = "https://github.com/conan-io/conan-center-index"
     description = "The C++ Database Access Library "
-    topics = ("cpp", "database-library", "oracle", "postgresql", "mysql", "odbc", "db2", "firebird", "sqlite3", "boost" )
+    topics = ("mysql", "odbc", "postgresql", "sqlite3")
     license = "BSL-1.0"
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"


### PR DESCRIPTION
This recipe is port from https://github.com/canmor-conan/conan-hidapi, special thanks @Psy-Kai.

Specify library name and version:  **hidapi/0.10.1**

It's a library for communicating with USB HID device, I packaged it to Bintray 3 years ago, now Bintray is closing, thanks report from  @Jihadist at https://github.com/canmor-conan/conan-hidapi/issues/2, I think ConanCenter is good place to go.

I'm not author of the library, author goes to https://github.com/libusb/hidapi.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
