### PR TITLE
openvr: add 1.16.8 + fix cpp_info.includedirs + propagate libcxx for C API

### DIFF
--- a/recipes/openvr/all/conandata.yml
+++ b/recipes/openvr/all/conandata.yml
@@ -5,3 +5,10 @@ sources:
   "1.14.15":
     url: https://github.com/ValveSoftware/openvr/archive/v1.14.15.tar.gz
     sha256: 40644e569f057e86c733d818a22d821c640307e5058d95958414422134d79584
+  "1.16.8":
+    url: https://github.com/ValveSoftware/openvr/archive/refs/tags/v1.16.8.tar.gz
+    sha256: 387c98c0540f66595c4594e5f3340a1095dd90e954ff14fd5d89cc849ba32d1b
+patches:
+  "1.16.8":
+    - patch_file: "patches/fix-includes-and-assert-1.16.8.patch"
+      base_path: "source_subfolder"

--- a/recipes/openvr/all/conanfile.py
+++ b/recipes/openvr/all/conanfile.py
@@ -80,7 +80,7 @@ class OpenvrConan(ConanFile):
             if libcxx:
                 self.cpp_info.system_libs.append(libcxx)
 
-        if self.settings.os != "Windows":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("dl")
 
         if self.settings.os == "Macos":

--- a/recipes/openvr/all/conanfile.py
+++ b/recipes/openvr/all/conanfile.py
@@ -9,8 +9,6 @@ class OpenvrConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/ValveSoftware/openvr"
     license = "BSD-3-Clause"
-    exports_sources = ["CMakeLists.txt"]
-    generators = "cmake"
 
     settings = "os", "compiler", "build_type", "arch"
     options = {
@@ -22,6 +20,8 @@ class OpenvrConan(ConanFile):
         "fPIC": True,
     }
 
+    exports_sources = ["CMakeLists.txt", "patches/**"]
+    generators = "cmake"
     _cmake = None
 
     @property
@@ -59,6 +59,8 @@ class OpenvrConan(ConanFile):
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/openvr/all/conanfile.py
+++ b/recipes/openvr/all/conanfile.py
@@ -29,10 +29,12 @@ class OpenvrConan(ConanFile):
         return "source_subfolder"
 
     def config_options(self):
-        if self.settings.os == "Windows" or self.options.shared:
+        if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "11")
 

--- a/recipes/openvr/all/conanfile.py
+++ b/recipes/openvr/all/conanfile.py
@@ -72,6 +72,7 @@ class OpenvrConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["pkg_config"] = "openvr"
         self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.includedirs.append(os.path.join("include", "openvr"))
 
         if not self.options.shared:
             self.cpp_info.defines.append('OPENVR_BUILD_STATIC')

--- a/recipes/openvr/all/conanfile.py
+++ b/recipes/openvr/all/conanfile.py
@@ -75,7 +75,7 @@ class OpenvrConan(ConanFile):
         self.cpp_info.includedirs.append(os.path.join("include", "openvr"))
 
         if not self.options.shared:
-            self.cpp_info.defines.append('OPENVR_BUILD_STATIC')
+            self.cpp_info.defines.append("OPENVR_BUILD_STATIC")
 
         if self.settings.os != "Windows":
             self.cpp_info.system_libs.append("dl")

--- a/recipes/openvr/all/conanfile.py
+++ b/recipes/openvr/all/conanfile.py
@@ -83,5 +83,5 @@ class OpenvrConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("dl")
 
-        if self.settings.os == "Macos":
+        if tools.is_apple_os(self.settings.os):
             self.cpp_info.frameworks.append("Foundation")

--- a/recipes/openvr/all/conanfile.py
+++ b/recipes/openvr/all/conanfile.py
@@ -70,6 +70,7 @@ class OpenvrConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
+        self.cpp_info.names["pkg_config"] = "openvr"
         self.cpp_info.libs = tools.collect_libs(self)
 
         if not self.options.shared:

--- a/recipes/openvr/all/conanfile.py
+++ b/recipes/openvr/all/conanfile.py
@@ -76,6 +76,9 @@ class OpenvrConan(ConanFile):
 
         if not self.options.shared:
             self.cpp_info.defines.append("OPENVR_BUILD_STATIC")
+            libcxx = tools.stdcpp_library(self)
+            if libcxx:
+                self.cpp_info.system_libs.append(libcxx)
 
         if self.settings.os != "Windows":
             self.cpp_info.system_libs.append("dl")

--- a/recipes/openvr/all/patches/fix-includes-and-assert-1.16.8.patch
+++ b/recipes/openvr/all/patches/fix-includes-and-assert-1.16.8.patch
@@ -1,0 +1,122 @@
+Fix compilaton errors due to wrong headers folder and usage of missing assert.h:
+https://github.com/ValveSoftware/openvr/pull/1524
+https://github.com/ValveSoftware/openvr/pull/1542
+
+--- a/src/openvr_api_public.cpp
++++ b/src/openvr_api_public.cpp
+@@ -2,12 +2,12 @@
+ #define VR_API_EXPORT 1
+ #include "openvr.h"
+ #include "ivrclientcore.h"
+-#include <vrcore/pathtools_public.h>
+-#include <vrcore/sharedlibtools_public.h>
+-#include <vrcore/envvartools_public.h>
++#include <vrcommon/pathtools_public.h>
++#include <vrcommon/sharedlibtools_public.h>
++#include <vrcommon/envvartools_public.h>
+ #include "hmderrors_public.h"
+-#include <vrcore/strtools_public.h>
+-#include <vrcore/vrpathregistry_public.h>
++#include <vrcommon/strtools_public.h>
++#include <vrcommon/vrpathregistry_public.h>
+ #include <mutex>
+ 
+ using vr::EVRInitError;
+--- a/src/vrcommon/dirtools_public.cpp
++++ b/src/vrcommon/dirtools_public.cpp
+@@ -1,7 +1,7 @@
+ //========= Copyright Valve Corporation ============//
+-#include <vrcore/dirtools_public.h>
+-#include <vrcore/strtools_public.h>
+-#include <vrcore/pathtools_public.h>
++#include <vrcommon/dirtools_public.h>
++#include <vrcommon/strtools_public.h>
++#include <vrcommon/pathtools_public.h>
+ 
+ #include <errno.h>
+ #include <string.h>
+--- a/src/vrcommon/envvartools_public.cpp
++++ b/src/vrcommon/envvartools_public.cpp
+@@ -1,6 +1,6 @@
+ //========= Copyright Valve Corporation ============//
+-#include <vrcore/envvartools_public.h>
+-#include <vrcore/strtools_public.h>
++#include <vrcommon/envvartools_public.h>
++#include <vrcommon/strtools_public.h>
+ #include <stdlib.h>
+ #include <string>
+ #include <cctype>
+--- a/src/vrcommon/pathtools_public.cpp
++++ b/src/vrcommon/pathtools_public.cpp
+@@ -1,6 +1,6 @@
+ //========= Copyright Valve Corporation ============//
+-#include <vrcore/strtools_public.h>
+-#include <vrcore/pathtools_public.h>
++#include <vrcommon/strtools_public.h>
++#include <vrcommon/pathtools_public.h>
+ 
+ #if defined( _WIN32)
+ #include <windows.h>
+--- a/src/vrcommon/sharedlibtools_public.cpp
++++ b/src/vrcommon/sharedlibtools_public.cpp
+@@ -1,5 +1,5 @@
+ //========= Copyright Valve Corporation ============//
+-#include <vrcore/sharedlibtools_public.h>
++#include <vrcommon/sharedlibtools_public.h>
+ #include <string.h>
+ 
+ #if defined(_WIN32)
+--- a/src/vrcommon/strtools_public.cpp
++++ b/src/vrcommon/strtools_public.cpp
+@@ -1,6 +1,7 @@
+ //========= Copyright Valve Corporation ============//
+-#include <vrcore/strtools_public.h>
++#include <vrcommon/strtools_public.h>
+ #include <string.h>
++#include <stdarg.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <sstream>
+@@ -9,7 +10,6 @@
+ #include <functional>
+ #include <locale>
+ #include <codecvt>
+-#include <vrcore/assert.h>
+ 
+ #if defined( _WIN32 )
+ #include <windows.h>
+@@ -128,7 +128,6 @@ std::string Format( const char *pchFormat, ... )
+ 	// Something went fairly wrong
+ 	if ( unSize < 0 )
+ 	{
+-		AssertMsg( false, "Format string parse failure" );
+ 		return "";
+ 	}
+ 
+@@ -149,7 +148,6 @@ std::string Format( const char *pchFormat, ... )
+ 	// Double check, just in case
+ 	if ( unSize < 0 )
+ 	{
+-		AssertMsg( false, "Format string parse failure" );
+ 		return "";
+ 	}
+ 
+--- a/src/vrcommon/vrpathregistry_public.cpp
++++ b/src/vrcommon/vrpathregistry_public.cpp
+@@ -1,11 +1,11 @@
+ //========= Copyright Valve Corporation ============//
+ 
+-#include <vrcore/vrpathregistry_public.h>
++#include <vrcommon/vrpathregistry_public.h>
+ #include <json/json.h>
+-#include <vrcore/pathtools_public.h>
+-#include <vrcore/envvartools_public.h>
+-#include <vrcore/strtools_public.h>
+-#include <vrcore/dirtools_public.h>
++#include <vrcommon/pathtools_public.h>
++#include <vrcommon/envvartools_public.h>
++#include <vrcommon/strtools_public.h>
++#include <vrcommon/dirtools_public.h>
+ 
+ #if defined( WIN32 )
+ #include <windows.h>

--- a/recipes/openvr/all/test_package/test_package.cpp
+++ b/recipes/openvr/all/test_package/test_package.cpp
@@ -1,5 +1,6 @@
+#include <openvr.h>
+
 #include <cstdlib>
-#include <openvr/openvr.h>
 
 int main()
 {

--- a/recipes/openvr/config.yml
+++ b/recipes/openvr/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: "all"
   "1.14.15":
     folder: "all"
+  "1.16.8":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

- `cpp_info.includedirs` was wrong: https://github.com/ValveSoftware/openvr/blob/4c85abcb7f7f1f02adaf3812018c99fc593bc341/src/openvr.pc.in#L4
  I've kept the previous one to not break consumers.
- openvr (C++ library) provides a C API, and we need to propagate libcxx if static

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
