### PR TITLE
Fix LGPL/BSD3 mismatch

### DIFF
--- a/recipes/ceres-solver/all/conanfile.py
+++ b/recipes/ceres-solver/all/conanfile.py
@@ -27,7 +27,7 @@ class ceressolverConan(ConanFile):
                        "use_glog": False,
                        "use_gflags": False,
                        "use_custom_blas": True,
-                       "use_eigen_sparse": True,
+                       "use_eigen_sparse": False,
                        "use_TBB": False,
                        "use_CXX11_threads": False,
                        "use_CXX11": False,


### PR DESCRIPTION
The conan package advertises its license as BSD-3-Clause but with default settings it is in fact LGPL. Fix this by disabling use_eigen_sparse by default. Here is the corresponding issue that I raised with Ceres: https://ceres-solver-review.googlesource.com/c/ceres-solver/+/18580

I noticed this by using Eigen with the MPL2_only option -- which made ceres-solver's build break due to the LGPL included in it by default. Fixed by unsetting use_eigen_sparse.

Another possible approach is to flag ceres-solver as LGPL and not change the default.

Specify library name and version:  ceres-solver/2.0.0

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
