### PR TITLE
meson: add version 0.57.2

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -59,3 +59,6 @@ sources:
   "0.57.1":
     url: "https://github.com/mesonbuild/meson/archive/0.57.1.tar.gz"
     sha256: "0c043c9b5350e9087cd4f6becf6c0d10b1d618ca3f919e0dcca2cdf342360d5d"
+  "0.57.2":
+    url: "https://github.com/mesonbuild/meson/archive/0.57.2.tar.gz"
+    sha256: "cd3773625253df4fd1c380faf03ffae3d02198d6301e7c8bc7bba6c66af66096"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -39,3 +39,5 @@ versions:
     folder: all
   "0.57.1":
     folder: all
+  "0.57.2":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/0.57.2**

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
