### PR TITLE
nlohmann_json : multiple headers by default

### DIFF
--- a/recipes/nlohmann_json/all/conanfile.py
+++ b/recipes/nlohmann_json/all/conanfile.py
@@ -17,7 +17,7 @@ class NlohmannJsonConan(ConanFile):
         "implicit_conversions": [True, False],
     }
     default_options = {
-        "multiple_headers": False,
+        "multiple_headers": True,
         "implicit_conversions": True,
     }
 

--- a/recipes/nlohmann_json/all/conanfile.py
+++ b/recipes/nlohmann_json/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, tools, CMake
+from conans import ConanFile, tools
 import os
 
 
@@ -11,64 +11,24 @@ class NlohmannJsonConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     no_copy_source = True
     license = "MIT"
-    settings = "os", "compiler", "build_type", "arch"
-    options = {
-        "multiple_headers": [True, False],
-        "implicit_conversions": [True, False],
-    }
-    default_options = {
-        "multiple_headers": True,
-        "implicit_conversions": True,
-    }
-
-    _cmake = None
-
-    @property
-    def _can_disable_implicit_conversions(self):
-        return tools.Version(self.version) >= "3.9.0"
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
-    def config_options(self):
-        if not self._can_disable_implicit_conversions:
-            del self.options.implicit_conversions
+    def package_id(self):
+        self.info.header_only()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = "json-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["JSON_BuildTests"] = False
-        self._cmake.definitions["JSON_MultipleHeaders"] = self.options.multiple_headers
-        if self._can_disable_implicit_conversions:
-            self._cmake.definitions["JSON_ImplicitConversions"] = self.options.implicit_conversions
-
-        self._cmake.configure(source_folder=self._source_subfolder)
-        return self._cmake
-
-    def build(self):
-        cmake = self._configure_cmake()
-        cmake.build()
-
     def package(self):
         self.copy(pattern="LICENSE*", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
-        cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib"))
-        try:
-            os.remove(os.path.join(self.package_folder, "nlohmann_json.natvis"))
-        except FileNotFoundError:
-            pass
-
-    def package_id(self):
-        self.info.settings.clear()
+        self.copy("*", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
     def package_info(self):
-        if self._can_disable_implicit_conversions:
-            self.cpp_info.defines = ["JSON_USE_IMPLICIT_CONVERSIONS=%s" % int(bool(self.options.implicit_conversions))]
+        self.cpp_info.names["cmake_find_package"] = "nlohmann_json"
+        self.cpp_info.names["cmake_find_package_multi"] = "nlohmann_json"
+        self.cpp_info.names["pkg_config"] = "nlohmann_json"

--- a/recipes/nlohmann_json/all/test_package/CMakeLists.txt
+++ b/recipes/nlohmann_json/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(nlohmann_json REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} nlohmann_json::nlohmann_json)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)

--- a/recipes/nlohmann_json/all/test_package/conanfile.py
+++ b/recipes/nlohmann_json/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/nlohmann_json/config.yml
+++ b/recipes/nlohmann_json/config.yml
@@ -1,4 +1,3 @@
----
 versions:
   "3.1.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

It's not the default value in upstream CMakeLists, but allows more compatibility with downstream recipes. It allows to include `<nlohmann/json_fwd.hpp>`, not available in single include. vcpkg always forces this value (https://github.com/microsoft/vcpkg/pull/12117).
I believe that all options should be removed in this recipe, and we should just copy `include` folder without calling CMakeLists.
For example the option `implicit_conversions` is useless, it has no other logic than adding a definition in `package_info()`. This feature is enabled by default when definition is missing, and consumers would likely expect to define it themselves if they want to disable implicit conversion, and potentially not globally.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
