### PR TITLE
Fix LGPL/BSD3 mismatch

### DIFF
--- a/recipes/ceres-solver/all/conanfile.py
+++ b/recipes/ceres-solver/all/conanfile.py
@@ -27,7 +27,7 @@ class ceressolverConan(ConanFile):
                        "use_glog": False,
                        "use_gflags": False,
                        "use_custom_blas": True,
-                       "use_eigen_sparse": True,
+                       "use_eigen_sparse": False,
                        "use_TBB": False,
                        "use_CXX11_threads": False,
                        "use_CXX11": False,


### PR DESCRIPTION
The conan package advertises its license as BSD-3-Clause but with default settings it is in fact LGPL. Fix this by disabling use_eigen_sparse by default. I will see about updating the Ceres documentation which isn't very clear about this.

Specify library name and version:  ceres-solver/2.0.0

I ran into this because the ceres-solver package doesn't compile if Eigen is configured with the MPL2_only option. I've submitted a patch to ceres to clarify the deocumentation with respect to the licensing issues. You can find it here https://ceres-solver-review.googlesource.com/c/ceres-solver/+/18580

I don't think it is desirable nor wise to advertise ceres as BSD-3 if the default build isn't. The other way out would be to update the license information but being more permissive is probably more useful on balance because, as I understand it, eigen_sparse is not used by default even if enabled, so the current default settings pull in LGPL code for no gain.

(I updated the pull request to make the author's email match my github account in order for it to understand that I signed the contributor agreement. In the process I've also rebased it on the current trunk.)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
