### PR TITLE
Doxygen 1 9 1

### DIFF
--- a/recipes/doxygen/all/conandata.yml
+++ b/recipes/doxygen/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.9.1":
+    url: "https://sourceforge.net/projects/doxygen/files/doxygen-1.9.1.src.tar.gz"
+    sha256: "67aeae1be4e1565519898f46f1f7092f1973cce8a767e93101ee0111717091d1"
   "1.8.20":
     url: "https://sourceforge.net/projects/doxygen/files/doxygen-1.8.20.src.tar.gz"
     sha256: "e0db6979286fd7ccd3a99af9f97397f2bae50532e4ecb312aa18862f8401ddec"
@@ -9,6 +12,9 @@ sources:
     url: "https://sourceforge.net/projects/doxygen/files/doxygen-1.8.17.src.tar.gz"
     sha256: "2cba988af2d495541cbbe5541b3bee0ee11144dcb23a81eada19f5501fd8b599"
 patches:
+  "1.9.1":
+    - patch_file: "patches/1.9.1-0001-imported-target.patch"
+      base_path: "source_subfolder"
   "1.8.20":
     - patch_file: "patches/1.8.20-0001-relocatable-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -78,7 +78,6 @@ class DoxygenConan(ConanFile):
         cmake.install()
 
     def package_id(self):
-        self.info.include_build_settings()
         del self.info.settings.compiler
 
     def package_info(self):

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -37,7 +37,7 @@ class DoxygenConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def requirements(self):
-        self.requires("xapian-core/1.4.16")
+        self.requires("xapian-core/1.4.18")
         self.requires("zlib/1.2.11")
 
     def build_requirements(self):

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -34,6 +34,11 @@ class DoxygenConan(ConanFile):
         if minimum_compiler_version is not None:
             if tools.Version(self.settings.compiler.version) < minimum_compiler_version:
                 raise ConanInvalidConfiguration("Compiler version too old. At least {} is required.".format(minimum_compiler_version))
+        if (self.settings.compiler == "Visual Studio" and
+            tools.Version(self.settings.compiler.version.value) <= 14 and
+                tools.Version(self.version) == "1.8.18"):
+            raise ConanInvalidConfiguration("Doxygen version {} broken with VS {}.".format(self.version,
+                                                                                           self.settings.compiler.version))
         del self.settings.compiler.cppstd
 
     def requirements(self):

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -77,6 +77,10 @@ class DoxygenConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
 
+    def package_id(self):
+        self.info.include_build_settings()
+        del self.info.settings.compiler
+
     def package_info(self):
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bin_path))

--- a/recipes/doxygen/all/patches/1.9.1-0001-imported-target.patch
+++ b/recipes/doxygen/all/patches/1.9.1-0001-imported-target.patch
@@ -20,3 +20,73 @@ index d0c8724..ac66577 100644
                        ${ZLIB_LIBRARIES}
                        ${WIN_EXTRA_LIBS}
  )
+diff --git a/libmscgen/mscgen_bool.h b/libmscgen/mscgen_bool.h
+index e982d80..d16ef98 100644
+--- libmscgen/mscgen_bool.h
++++ libmscgen/mscgen_bool.h
+@@ -23,6 +23,14 @@
+ #ifndef MSCGEN_BOOL_H
+ #define MSCGEN_BOOL_H
+ 
++/* Some system headers define TRUE and FALSE so undefine them first */
++#ifdef TRUE
++#undef TRUE
++#endif
++#ifdef FALSE
++#undef FALSE
++#endif
++
+ typedef enum
+ {
+     FALSE = 0,
+diff --git a/qtools/qglobal.h b/qtools/qglobal.h
+index 0deef5d..86846f8 100644
+--- qtools/qglobal.h
++++ qtools/qglobal.h
+@@ -357,6 +356,7 @@ typedef const char     *pcchar;
+ typedef __int64            int64;
+ typedef unsigned __int64   uint64;
+ #else
++#include <cinttypes>
+ #if !defined(_OS_AIX_) || !defined(_H_INTTYPES)
+ typedef long long          int64;
+ #endif
+diff --git a/src/doxygen.cpp b/src/doxygen.cpp
+index 3fdde9bc..1b32e273 100644
+--- src/doxygen.cpp
++++ src/doxygen.cpp
+@@ -12,6 +12,7 @@
+  * input used in their production; they are not affected by this license.
+  *
+  */
++#include <cinttypes>
+ 
+ #include <locale.h>
+ 
+@@ -32,7 +33,6 @@
+ #include <algorithm>
+ #include <unordered_map>
+ #include <memory>
+-#include <cinttypes>
+ 
+ #include "version.h"
+ #include "doxygen.h"
+diff --git a/src/util.cpp b/src/util.cpp
+index 7fcd5ed..399e7a2 100644
+--- src/util.cpp
++++ src/util.cpp
+@@ -13,13 +13,13 @@
+  * input used in their production; they are not affected by this license.
+  *
+  */
++#include <cinttypes>
+ 
+ #include <stdlib.h>
+ #include <ctype.h>
+ #include <errno.h>
+ #include <math.h>
+ #include <limits.h>
+-#include <cinttypes>
+ #include <string.h>
+ 
+ #include <mutex>

--- a/recipes/doxygen/all/patches/1.9.1-0001-imported-target.patch
+++ b/recipes/doxygen/all/patches/1.9.1-0001-imported-target.patch
@@ -1,0 +1,22 @@
+diff --git a/addon/doxysearch/CMakeLists.txt b/addon/doxysearch/CMakeLists.txt
+index d0c8724..ac66577 100644
+--- addon/doxysearch/CMakeLists.txt
++++ addon/doxysearch/CMakeLists.txt
+@@ -15,7 +15,7 @@ add_executable(doxyindexer
+                doxyindexer.cpp
+ )
+ target_link_libraries(doxyindexer
+-                      ${XAPIAN_LIBRARIES}
++                      CONAN_PKG::xapian-core
+                       ${ZLIB_LIBRARIES}
+                       ${WIN_EXTRA_LIBS}
+                       ${COVERAGE_LINKER_FLAGS}
+@@ -28,7 +28,7 @@ add_executable(doxysearch.cgi
+ )
+ target_link_libraries(doxysearch.cgi
+                       doxygen_version
+-                      ${XAPIAN_LIBRARIES}
++                      CONAN_PKG::xapian-core
+                       ${ZLIB_LIBRARIES}
+                       ${WIN_EXTRA_LIBS}
+ )

--- a/recipes/doxygen/config.yml
+++ b/recipes/doxygen/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.1":
+    folder: "all"
   "1.8.20":
     folder: "all"
   "1.8.18":


### PR DESCRIPTION
Specify library name and version: **doxygen/1.9.1**

Doxygen needs a bit of patching to build on AIX, primarily because the OS headers seem to be a little sloppier than we're used to.
This PR will require the changes in PR#5151 (recently merged) to get the dependency xapian-core, that also requires modifications to build on AIX.
The patch moves some include statements, as the ordering broke things on AIX, specifically the definition of the PRIu64 format specifier.
AIX also seemed to have definitions for TRUE and FALSE in system headers that conflicted with the use in Doxygen.
Doxygen 1.9.1 did NOT require the CMake file patching performed on the 1.8 release series, so that was not applied to 1.9.1

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
