### PR TITLE
uwebsockets: add version 19.1.0

### DIFF
--- a/recipes/uwebsockets/all/conandata.yml
+++ b/recipes/uwebsockets/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "18.3.0":
     url: "https://github.com/uNetworking/uWebSockets/archive/v18.3.0.tar.gz"
     sha256: "f51317e2a8cd743e6ff9dfd215569824eaca489c24f7d8fd94eaca44443a9728"
+  "19.1.0":
+    url: "https://github.com/uNetworking/uWebSockets/archive/v19.1.0.tar.gz"
+    sha256: "65afa329b0c768a7443ea2621f3f371bc5ce0e1c3518d59bb11b9a2c7adb65dd"
+

--- a/recipes/uwebsockets/all/conanfile.py
+++ b/recipes/uwebsockets/all/conanfile.py
@@ -46,10 +46,10 @@ class UwebsocketsConan(ConanFile):
     def requirements(self):
         self.requires("zlib/1.2.11")
 
-        if self.version == "18.3.0":
-            self.requires("usockets/0.4.0")
-        else:
+        if tools.Version(self.version) >= "19.0.0":
             self.requires("usockets/0.7.1")
+        else:
+            self.requires("usockets/0.4.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/uwebsockets/all/conanfile.py
+++ b/recipes/uwebsockets/all/conanfile.py
@@ -14,7 +14,7 @@ class UwebsocketsConan(ConanFile):
     settings = "compiler"
     no_copy_source = True
 
-    requires = ("usockets/0.4.0",
+    requires = ("usockets/0.7.1",
                 "zlib/1.2.11")
 
     @property

--- a/recipes/uwebsockets/all/conanfile.py
+++ b/recipes/uwebsockets/all/conanfile.py
@@ -14,9 +14,6 @@ class UwebsocketsConan(ConanFile):
     settings = "compiler"
     no_copy_source = True
 
-    requires = ("usockets/0.7.1",
-                "zlib/1.2.11")
-
     @property
     def _source_subfolder(self):
         return "source_subfolder"
@@ -45,6 +42,14 @@ class UwebsocketsConan(ConanFile):
         if version < minimal_version[compiler]:
             raise ConanInvalidConfiguration(
                 "%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
+
+    def requirements(self):
+        self.requires("zlib/1.2.11")
+
+        if self.version == "18.3.0":
+            self.requires("usockets/0.4.0")
+        else:
+            self.requires("usockets/0.7.1")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/uwebsockets/config.yml
+++ b/recipes/uwebsockets/config.yml
@@ -1,3 +1,5 @@
 versions:
   "18.3.0":
     folder: all
+  "19.1.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **uwebsockets/19.1.0**

This PR provides an updated version of the uwebsockets library (to version **19.1.0**). This newest version depends on `usockets/0.7.1`, which is provided in PR #5202

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
