### PR TITLE
jsoncpp: fix CMake imported target

### DIFF
--- a/recipes/jsoncpp/all/conandata.yml
+++ b/recipes/jsoncpp/all/conandata.yml
@@ -15,7 +15,12 @@ sources:
     url: https://github.com/open-source-parsers/jsoncpp/archive/1.9.4.tar.gz
     sha256: e34a628a8142643b976c7233ef381457efad79468c67cb1ae0b83a33d7493999
 patches:
+  "1.8.3":
+     - patch_file: "patches/implicit-conversion-1.8.3.patch"
+       base_path: "source_subfolder"
   "1.9.1":
+     - patch_file: "patches/implicit-conversion-1.9.1.patch"
+       base_path: "source_subfolder"
      - patch_file: "patches/dont-force-pic-1.9.1.patch"
        base_path: "source_subfolder"
   "1.9.2":

--- a/recipes/jsoncpp/all/conanfile.py
+++ b/recipes/jsoncpp/all/conanfile.py
@@ -82,8 +82,9 @@ class JsoncppConan(ConanFile):
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),
             {
-                "jsoncpp_lib": "jsoncpp::jsoncpp",
-                "jsoncpp_static": "jsoncpp::jsoncpp"
+                "jsoncpp_lib": "jsoncpp::jsoncpp",        # imported target for shared lib, but also static between 1.9.0 & 1.9.3
+                "jsoncpp_static": "jsoncpp::jsoncpp",     # imported target for static lib if >= 1.9.4
+                "jsoncpp_lib_static": "jsoncpp::jsoncpp", # imported target for static lib if < 1.9.0
             }
         )
 

--- a/recipes/jsoncpp/all/conanfile.py
+++ b/recipes/jsoncpp/all/conanfile.py
@@ -115,3 +115,5 @@ class JsoncppConan(ConanFile):
         self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
         self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
         self.cpp_info.libs = tools.collect_libs(self)
+        if self.settings.os == "Windows" and self.options.shared:
+            self.cpp_info.defines.append("JSON_DLL")

--- a/recipes/jsoncpp/all/conanfile.py
+++ b/recipes/jsoncpp/all/conanfile.py
@@ -78,13 +78,40 @@ class JsoncppConan(ConanFile):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
         cmake = self._configure_cmake()
         cmake.install()
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {
+                "jsoncpp_lib": "jsoncpp::jsoncpp",
+                "jsoncpp_static": "jsoncpp::jsoncpp"
+            }
+        )
+
+    @staticmethod
+    def _create_cmake_module_alias_targets(module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent("""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """.format(alias=alias, aliased=aliased))
+        tools.save(module_file, content)
+
+    @property
+    def _module_subfolder(self):
+        return os.path.join("lib", "cmake")
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join(self._module_subfolder,
+                            "conan-official-{}-targets.cmake".format(self.name))
 
     def package_info(self):
-        # TODO: CMake imported target shouldn't be namespaced (waiting https://github.com/conan-io/conan/issues/7615 to be implemented)
         self.cpp_info.names["cmake_find_package"] = "jsoncpp"
         self.cpp_info.names["cmake_find_package_multi"] = "jsoncpp"
         self.cpp_info.names["pkg_config"] = "jsoncpp"
-        self.cpp_info.components["libjsoncpp"].names["cmake_find_package"] = "jsoncpp_lib"
-        self.cpp_info.components["libjsoncpp"].names["cmake_find_package_multi"] = "jsoncpp_lib"
-        self.cpp_info.components["libjsoncpp"].names["pkg_config"] = "jsoncpp"
-        self.cpp_info.components["libjsoncpp"].libs = tools.collect_libs(self)
+        self.cpp_info.builddirs.append(self._module_subfolder)
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+        self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/jsoncpp/all/conanfile.py
+++ b/recipes/jsoncpp/all/conanfile.py
@@ -57,6 +57,7 @@ class JsoncppConan(ConanFile):
             return self._cmake
         self._cmake = CMake(self)
         self._cmake.definitions["JSONCPP_WITH_TESTS"] = False
+        self._cmake.definitions["JSONCPP_WITH_WARNING_AS_ERROR"] = False
         self._cmake.definitions["JSONCPP_WITH_CMAKE_PACKAGE"] = False
         self._cmake.definitions["JSONCPP_WITH_STRICT_ISO"] = False
         self._cmake.definitions["JSONCPP_WITH_PKGCONFIG_SUPPORT"] = False

--- a/recipes/jsoncpp/all/conanfile.py
+++ b/recipes/jsoncpp/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 import os
+import textwrap
 
 
 class JsoncppConan(ConanFile):

--- a/recipes/jsoncpp/all/patches/implicit-conversion-1.8.3.patch
+++ b/recipes/jsoncpp/all/patches/implicit-conversion-1.8.3.patch
@@ -1,0 +1,13 @@
+fixed in 1.9.2 by https://github.com/open-source-parsers/jsoncpp/pull/1023
+
+--- a/src/lib_json/json_value.cpp
++++ b/src/lib_json/json_value.cpp
+@@ -70,7 +70,7 @@ static inline bool InRange(double d, T min, U max) {
+   // The casts can lose precision, but we are looking only for
+   // an approximate range. Might fail on edge cases though. ~cdunn
+   //return d >= static_cast<double>(min) && d <= static_cast<double>(max);
+-  return d >= min && d <= max;
++  return d >= static_cast<double>(min) && d <= static_cast<double>(max);
+ }
+ #else  // if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
+ static inline double integerToDouble(Json::UInt64 value) {

--- a/recipes/jsoncpp/all/patches/implicit-conversion-1.9.1.patch
+++ b/recipes/jsoncpp/all/patches/implicit-conversion-1.9.1.patch
@@ -1,0 +1,13 @@
+fixed in 1.9.2 by https://github.com/open-source-parsers/jsoncpp/pull/1023
+
+--- a/src/lib_json/json_value.cpp
++++ b/src/lib_json/json_value.cpp
+@@ -112,7 +112,7 @@ static inline bool InRange(double d, T min, U max) {
+   // The casts can lose precision, but we are looking only for
+   // an approximate range. Might fail on edge cases though. ~cdunn
+   // return d >= static_cast<double>(min) && d <= static_cast<double>(max);
+-  return d >= min && d <= max;
++  return d >= static_cast<double>(min) && d <= static_cast<double>(max);
+ }
+ #else  // if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
+ static inline double integerToDouble(Json::UInt64 value) {

--- a/recipes/jsoncpp/all/test_package/CMakeLists.txt
+++ b/recipes/jsoncpp/all/test_package/CMakeLists.txt
@@ -2,10 +2,14 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(jsoncpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} jsoncpp::jsoncpp_lib) # TODO: remove jsoncpp:: namespace when fixed in conanfile.py of jsoncpp
+if(JSONCPP_SHARED)
+    target_link_libraries(${PROJECT_NAME} jsoncpp_lib)
+else()
+    target_link_libraries(${PROJECT_NAME} jsoncpp_static)
+endif()
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/jsoncpp/all/test_package/conanfile.py
+++ b/recipes/jsoncpp/all/test_package/conanfile.py
@@ -8,6 +8,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["JSONCPP_SHARED"] = self.options["jsoncpp"].shared
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

jsoncpp CMake imported target is:
- `jsoncpp_lib` if shared
- `jsoncpp_static` if static (but not in all versions, before 1.9.4 it was also `jsoncpp_lib`, I tried to prevent this modification few months ago, without success https://github.com/open-source-parsers/jsoncpp/pull/1197#issuecomment-679201647).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
