### PR TITLE
Fix ceres-solver on ARM architecture

### DIFF
--- a/recipes/ceres-solver/all/conandata.yml
+++ b/recipes/ceres-solver/all/conandata.yml
@@ -12,6 +12,8 @@ patches:
   "2.0.0":
     - patch_file: "patches/2.0.0-0001-find-libraries-conan.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/2.0.0-0002-fix-eigen-version.patch"
+      base_path: "source_subfolder"
   "1.14.0":
     - patch_file: "patches/1.14.0-0001-find-libraries-conan.patch"
       base_path: "source_subfolder"

--- a/recipes/ceres-solver/all/patches/2.0.0-0002-fix-eigen-version.patch
+++ b/recipes/ceres-solver/all/patches/2.0.0-0002-fix-eigen-version.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ea7e9b8..203c5d2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -240,13 +240,13 @@ message("-- Building with C++${CMAKE_CXX_STANDARD}")
+ # Eigen delivers Eigen3Config.cmake since v3.3.3
+ find_package(Eigen3 3.3 REQUIRED)
+ if (EIGEN3_FOUND)
+-  message("-- Found Eigen version ${EIGEN3_VERSION_STRING}: ${EIGEN3_INCLUDE_DIRS}")
++  message("-- Found Eigen version ${Eigen3_VERSION}: ${EIGEN3_INCLUDE_DIRS}")
+   if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*)" AND
+-      EIGEN3_VERSION_STRING VERSION_LESS 3.3.4)
++      Eigen3_VERSION VERSION_LESS 3.3.4)
+     # As per issue #289: https://github.com/ceres-solver/ceres-solver/issues/289
+     # the bundle_adjustment_test will fail for Eigen < 3.3.4 on aarch64.
+     message(FATAL_ERROR "-- Ceres requires Eigen version >= 3.3.4 on aarch64. "
+-      "Detected version of Eigen is: ${EIGEN3_VERSION_STRING}.")
++      "Detected version of Eigen is: ${Eigen3_VERSION}.")
+   endif()
+ 
+   if (EIGENSPARSE)


### PR DESCRIPTION
**ceres-solver/2.0.0**

This PR fixes a problem that occurs when compiling ceres-solver for the ARM architecture.
This problem has been fixed upstream in https://github.com/ceres-solver/ceres-solver/commit/323c350a66c503fe2815286f48da391b6ce01bc6, but it is not released yet.

To bypass the problem, and while waiting for a new ceres release, this PR patches ceres CMakeLists.txt, making it possible to build on ARM again.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
