### PR TITLE
tinyobjloader: add double option + del fPIC if shared + fix CMake imported target

### DIFF
--- a/recipes/tinyobjloader/all/CMakeLists.txt
+++ b/recipes/tinyobjloader/all/CMakeLists.txt
@@ -1,7 +1,9 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.4)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-CONAN_BASIC_SETUP()
+conan_basic_setup()
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_subdirectory(source_subfolder)

--- a/recipes/tinyobjloader/all/conandata.yml
+++ b/recipes/tinyobjloader/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  1.0.6:
+  "1.0.6":
     url: https://github.com/syoyo/tinyobjloader/archive/v1.0.6.zip
     sha256: ba549b59eafcdcd3d6a0ce367c9655affbc8e6f85053ea793a7333fe276879a2

--- a/recipes/tinyobjloader/all/conanfile.py
+++ b/recipes/tinyobjloader/all/conanfile.py
@@ -21,6 +21,10 @@ class TinyObjLoaderConan(ConanFile):
         if self.settings.os == 'Windows':
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_folder = self.name + '-' + self.version

--- a/recipes/tinyobjloader/all/conanfile.py
+++ b/recipes/tinyobjloader/all/conanfile.py
@@ -28,8 +28,6 @@ class TinyObjLoaderConan(ConanFile):
 
     def _configure_cmake(self):
         cmake = CMake(self)
-        if self.settings.os == "Windows" and self.options.shared:
-            cmake.definitions["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
         cmake.definitions["TINYOBJLOADER_COMPILATION_SHARED"] = self.options.shared
         cmake.definitions["CMAKE_INSTALL_DOCDIR"] = "licenses"
         cmake.configure(build_dir=self._build_subfolder)

--- a/recipes/tinyobjloader/all/conanfile.py
+++ b/recipes/tinyobjloader/all/conanfile.py
@@ -7,7 +7,7 @@ class TinyObjLoaderConan(ConanFile):
     description = "Tiny but powerful single file wavefront obj loader"
     settings = "os", "arch", "build_type", "compiler"
     options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {'shared': False, "fPIC": True}
+    default_options = {"shared": False, "fPIC": True}
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/syoyo/tinyobjloader"
@@ -26,7 +26,7 @@ class TinyObjLoaderConan(ConanFile):
         return "build_subfolder"
 
     def config_options(self):
-        if self.settings.os == 'Windows':
+        if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
@@ -35,7 +35,7 @@ class TinyObjLoaderConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        extracted_folder = self.name + '-' + self.version
+        extracted_folder = self.name + "-" + self.version
         os.rename(extracted_folder, self._source_subfolder)
 
     def _configure_cmake(self):

--- a/recipes/tinyobjloader/all/conanfile.py
+++ b/recipes/tinyobjloader/all/conanfile.py
@@ -12,10 +12,18 @@ class TinyObjLoaderConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/syoyo/tinyobjloader"
     topics = ("conan", "tinyobjloader", "wavefront", "geometry")
+
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
 
     def config_options(self):
         if self.settings.os == 'Windows':
@@ -31,11 +39,16 @@ class TinyObjLoaderConan(ConanFile):
         os.rename(extracted_folder, self._source_subfolder)
 
     def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["TINYOBJLOADER_COMPILATION_SHARED"] = self.options.shared
-        cmake.definitions["CMAKE_INSTALL_DOCDIR"] = "licenses"
-        cmake.configure(build_dir=self._build_subfolder)
-        return cmake
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["TINYOBJLOADER_USE_DOUBLE"] = False
+        self._cmake.definitions["TINYOBJLOADER_BUILD_TEST_LOADER"] = False
+        self._cmake.definitions["TINYOBJLOADER_COMPILATION_SHARED"] = self.options.shared
+        self._cmake.definitions["TINYOBJLOADER_BUILD_OBJ_STICHER"] = False
+        self._cmake.definitions["CMAKE_INSTALL_DOCDIR"] = "licenses"
+        self._cmake.configure(build_dir=self._build_subfolder)
+        return self._cmake
 
     def build(self):
         cmake = self._configure_cmake()

--- a/recipes/tinyobjloader/all/conanfile.py
+++ b/recipes/tinyobjloader/all/conanfile.py
@@ -5,13 +5,22 @@ from conans import ConanFile, CMake, tools
 class TinyObjLoaderConan(ConanFile):
     name = "tinyobjloader"
     description = "Tiny but powerful single file wavefront obj loader"
-    settings = "os", "arch", "build_type", "compiler"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/syoyo/tinyobjloader"
     topics = ("conan", "tinyobjloader", "wavefront", "geometry")
+
+    settings = "os", "arch", "build_type", "compiler"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "double": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "double": False,
+    }
 
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
@@ -42,7 +51,7 @@ class TinyObjLoaderConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-        self._cmake.definitions["TINYOBJLOADER_USE_DOUBLE"] = False
+        self._cmake.definitions["TINYOBJLOADER_USE_DOUBLE"] = self.options.double
         self._cmake.definitions["TINYOBJLOADER_BUILD_TEST_LOADER"] = False
         self._cmake.definitions["TINYOBJLOADER_COMPILATION_SHARED"] = self.options.shared
         self._cmake.definitions["TINYOBJLOADER_BUILD_OBJ_STICHER"] = False
@@ -61,4 +70,7 @@ class TinyObjLoaderConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "tinyobjloader"))
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        suffix = "_double" if self.options.double else ""
+        self.cpp_info.libs = ["tinyobjloader" + suffix]
+        if self.options.double:
+            self.cpp_info.defines.append("TINYOBJLOADER_USE_DOUBLE")

--- a/recipes/tinyobjloader/all/test_package/CMakeLists.txt
+++ b/recipes/tinyobjloader/all/test_package/CMakeLists.txt
@@ -2,10 +2,12 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 configure_file(cube.obj cube.obj COPYONLY)
 configure_file(cube.mtl cube.mtl COPYONLY)
+
+find_package(tinyobjloader REQUIRED CONFIG)
 
 string(FIND "${CONAN_TINYOBJLOADER_ROOT}" "2." IS_2x)
 if ("${IS_2x}" EQUAL "-1")
@@ -14,4 +16,8 @@ else()
     add_executable(${PROJECT_NAME} test_package_2.cpp)
 endif()
 
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+if(TARGET tinyobjloader_double)
+    target_link_libraries(${PROJECT_NAME} tinyobjloader_double)
+else()
+    target_link_libraries(${PROJECT_NAME} tinyobjloader)
+endif()

--- a/recipes/tinyobjloader/all/test_package/conanfile.py
+++ b/recipes/tinyobjloader/all/test_package/conanfile.py
@@ -1,10 +1,10 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,5 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

In 1.0.6 the config file is tinyobjloader_double if double else tinyobjloader, but it has been changed in master to be tinyobjloader unconditionally. So for the moment, I've kept tinyobjloader.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
