### PR TITLE
msys2: do not the library directory propagate through

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -81,6 +81,8 @@ class MSYS2Conan(ConanFile):
                         os.path.join(self.package_folder, "licenses"))
 
     def package_info(self):
+        self.cpp_info.libdirs = []
+
         msys_root = os.path.join(self.package_folder, "bin")
         msys_bin = os.path.join(msys_root, "usr", "bin")
 


### PR DESCRIPTION
Specify library name and version:  **msys2/all**

When https://github.com/conan-io/conan/issues/8816 gets fixed, this should hide the msys2 library folder.
This is useful to avoid accidentally linking to a msys2 library instead of one from a conan dependency.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
