### PR TITLE
strawberryperl: do not let library directories propagate through

### DIFF
--- a/recipes/strawberryperl/all/conanfile.py
+++ b/recipes/strawberryperl/all/conanfile.py
@@ -34,6 +34,8 @@ class StrawberryperlConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
+        self.cpp_info.libdirs = []
+
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: %s" % bin_path)
         self.env_info.PATH.append(bin_path)


### PR DESCRIPTION
Specify library name and version:  **strawberryperl/all**

When https://github.com/conan-io/conan/issues/8816 gets fixed, this should hide the strawberryperl library folder.
This is useful to avoid accidentally linking to a strawberryperl library instead of one from a conan dependency.
There are less libraries in strawberryperl then in msys2, but they are potentially _dangerous_ nonetheless.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
