### PR TITLE
added hippomocks recipe

### DIFF
--- a/recipes/hippomocks/all/conandata.yml
+++ b/recipes/hippomocks/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20190311":
+    url: https://github.com/dascandy/hippomocks/archive/10960d0.zip
+    sha256: a4efc07eacdc35107039bd3b7b491b9fc5f95d4dabb37de83a2b0642c7231fe8

--- a/recipes/hippomocks/all/conanfile.py
+++ b/recipes/hippomocks/all/conanfile.py
@@ -1,16 +1,15 @@
-from conans import CMake, ConanFile, ConanFile, tools
+from conans import ConanFile, ConanFile, tools
 import os, glob
 
 class HippomocksConan(ConanFile):
     name = 'hippomocks'
-    libname = 'HippoMocks'
+    _libname = 'HippoMocks'
     description = 'Single-header mocking framework.'
     topics = ("conan", "hippomocks", "mock", "framework")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = 'https://github.com/dascandy/hippomocks.git'
     license = 'LGPL-2.1'
     no_copy_source = True
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -21,20 +20,9 @@ class HippomocksConan(ConanFile):
         extracted_dir = glob.glob("%s-*" % (self.name))[0]
         os.rename(extracted_dir, self._source_subfolder)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.configure(source_folder=self._source_subfolder)
-        return self._cmake
-
-    def build(self):
-        cmake = self._configure_cmake()
-        cmake.build()
-
     def package(self):
         self.copy('LICENSE', dst='licenses', src=self._source_subfolder)
-        self.copy('*.h', dst=os.path.join('include', self.name), src=os.path.join(self._source_subfolder, self.libname))
+        self.copy('*.h', dst=os.path.join('include', self.name), src=os.path.join(self._source_subfolder, self._libname))
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/hippomocks/all/conanfile.py
+++ b/recipes/hippomocks/all/conanfile.py
@@ -7,7 +7,7 @@ class HippomocksConan(ConanFile):
     description = 'Single-header mocking framework.'
     topics = ("conan", "hippomocks", "mock", "framework")
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = 'https://github.com/dascandy/hippomocks.git'
+    homepage = "https://github.com/dascandy/hippomocks"
     license = 'LGPL-2.1'
     no_copy_source = True
 

--- a/recipes/hippomocks/all/conanfile.py
+++ b/recipes/hippomocks/all/conanfile.py
@@ -31,7 +31,6 @@ class HippomocksConan(ConanFile):
     def build(self):
         cmake = self._configure_cmake()
         cmake.build()
-        cmake.install()
         cmake.test()
 
     def package(self):

--- a/recipes/hippomocks/all/conanfile.py
+++ b/recipes/hippomocks/all/conanfile.py
@@ -1,0 +1,42 @@
+from conans import CMake, ConanFile, ConanFile, tools
+import os, glob
+
+class HippomocksConan(ConanFile):
+    name = 'hippomocks'
+    libname = 'HippoMocks'
+    description = 'Single-header mocking framework.'
+    topics = ("conan", "hippomocks", "mock", "framework")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = 'https://github.com/dascandy/hippomocks.git'
+    license = 'LGPL-2.1'
+    no_copy_source = True
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = glob.glob("%s-*" % (self.name))[0]
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure(source_folder=self._source_subfolder)
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+        cmake.install()
+        cmake.test()
+
+    def package(self):
+        self.copy('LICENSE', dst='licenses', src=self._source_subfolder)
+        self.copy('*.h', dst=os.path.join('include', self.name), src=os.path.join(self._source_subfolder, self.libname))
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/hippomocks/all/conanfile.py
+++ b/recipes/hippomocks/all/conanfile.py
@@ -31,7 +31,6 @@ class HippomocksConan(ConanFile):
     def build(self):
         cmake = self._configure_cmake()
         cmake.build()
-        cmake.test()
 
     def package(self):
         self.copy('LICENSE', dst='licenses', src=self._source_subfolder)

--- a/recipes/hippomocks/all/conanfile.py
+++ b/recipes/hippomocks/all/conanfile.py
@@ -22,7 +22,7 @@ class HippomocksConan(ConanFile):
 
     def package(self):
         self.copy('LICENSE', dst='licenses', src=self._source_subfolder)
-        self.copy('*.h', dst=os.path.join('include', self.name), src=os.path.join(self._source_subfolder, self._libname))
+        self.copy('*.h', dst=os.path.join('include', self._libname), src=os.path.join(self._source_subfolder, self._libname))
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/hippomocks/all/test_package/CMakeLists.txt
+++ b/recipes/hippomocks/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(hippomocks REQUIRED)
+
+add_executable(${PROJECT_NAME} main.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE hippomocks::hippomocks)

--- a/recipes/hippomocks/all/test_package/conanfile.py
+++ b/recipes/hippomocks/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools, RunEnvironment
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build() 
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/hippomocks/all/test_package/main.cpp
+++ b/recipes/hippomocks/all/test_package/main.cpp
@@ -1,4 +1,4 @@
-#include <hippomocks/hippomocks.h>
+#include <HippoMocks/hippomocks.h>
 
 struct Foo {
 public:

--- a/recipes/hippomocks/all/test_package/main.cpp
+++ b/recipes/hippomocks/all/test_package/main.cpp
@@ -1,0 +1,20 @@
+#include <hippomocks/hippomocks.h>
+
+struct Foo {
+public:
+	virtual ~Foo() {}
+	virtual void f() {}
+	virtual void g() = 0;
+};
+
+int main()
+{
+    MockRepository mocks;
+    Foo *iamock = mocks.Mock<Foo>();
+    mocks.ExpectCall(iamock, Foo::f);
+    mocks.ExpectCall(iamock, Foo::g);
+    mocks.ExpectCall(iamock, Foo::f);
+    iamock->f();
+    iamock->g();
+    iamock->f();
+}

--- a/recipes/hippomocks/config.yml
+++ b/recipes/hippomocks/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20190311":
+    folder: "all"


### PR DESCRIPTION
Signed-off-by: tkrupa <tomas@krupa.hu>

Specify library name and version:  **hippomocks/cci.20190311**

Hippomocks is a single-header mocking framework.
Homepage: https://github.com/dascandy/hippomocks
Author: https://github.com/dascandy

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
