### PR TITLE
fontconfig/2.13.93: remove dependency on libgettext

### DIFF
--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -13,16 +13,8 @@ class FontconfigConan(ConanFile):
     homepage = "https://gitlab.freedesktop.org/fontconfig/fontconfig"
     topics = ("conan", "fontconfig", "fonts", "freedesktop")
     settings = "os", "compiler", "build_type", "arch"
-    options = {
-        "shared": [True, False],
-        "fPIC": [True, False],
-        "with_nls": [True, False],
-    }
-    default_options = {
-        "shared": False,
-        "fPIC": True,
-        "with_nls": True,
-    }
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
     generators = "pkg_config"
 
     _autotools = None
@@ -48,8 +40,6 @@ class FontconfigConan(ConanFile):
         self.requires("expat/2.2.10")
         if self.settings.os == "Linux":
             self.requires("libuuid/1.0.3")
-        elif self.settings.os == "Macos" and self.options.with_nls:
-            self.requires("libgettext/0.20.1")
 
     def build_requirements(self):
         self.build_requires("gperf/3.1")
@@ -66,9 +56,9 @@ class FontconfigConan(ConanFile):
         if not self._autotools:
             args = ["--enable-static=%s" % ("no" if self.options.shared else "yes"),
                     "--enable-shared=%s" % ("yes" if self.options.shared else "no"),
-                    "--disable-docs"]
-            if not self.options.with_nls:
-                args.append("--disable-nls")
+                    "--disable-docs",
+                    "--disable-nls",
+                   ]
             args.append("--sysconfdir=%s" % tools.unix_path(os.path.join(self.package_folder, "bin", "etc")))
             args.append("--datadir=%s" % tools.unix_path(os.path.join(self.package_folder, "bin", "share")))
             args.append("--datarootdir=%s" % tools.unix_path(os.path.join(self.package_folder, "bin", "share")))

--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -13,8 +13,16 @@ class FontconfigConan(ConanFile):
     homepage = "https://gitlab.freedesktop.org/fontconfig/fontconfig"
     topics = ("conan", "fontconfig", "fonts", "freedesktop")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_nls": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_nls": True,
+    }
     generators = "pkg_config"
 
     _autotools = None
@@ -40,7 +48,7 @@ class FontconfigConan(ConanFile):
         self.requires("expat/2.2.10")
         if self.settings.os == "Linux":
             self.requires("libuuid/1.0.3")
-        elif self.settings.os == "Macos":
+        elif self.settings.os == "Macos" and self.options.with_nls:
             self.requires("libgettext/0.20.1")
 
     def build_requirements(self):
@@ -59,6 +67,8 @@ class FontconfigConan(ConanFile):
             args = ["--enable-static=%s" % ("no" if self.options.shared else "yes"),
                     "--enable-shared=%s" % ("yes" if self.options.shared else "no"),
                     "--disable-docs"]
+            if not self.options.with_nls:
+                args.append("--disable-nls")
             args.append("--sysconfdir=%s" % tools.unix_path(os.path.join(self.package_folder, "bin", "etc")))
             args.append("--datadir=%s" % tools.unix_path(os.path.join(self.package_folder, "bin", "share")))
             args.append("--datarootdir=%s" % tools.unix_path(os.path.join(self.package_folder, "bin", "share")))


### PR DESCRIPTION
Specify library name and version:  **fontconfig/2.13.93**

Fixes #5255

Gettext is nominally used for i18n of some strings. An inspection of the po files makes it clear that the status of translations could be improved. Also, the gettext library is under GPL3 license, thus it restricts where fontconfig can be used. The change initially made gettext optional but was later changed to simply remove the dependency with a --disable-nls argument to autotools' configure 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
