### PR TITLE
[protobuf] Only find protoc when cross compiling

### DIFF
--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -123,7 +123,9 @@ class ProtobufConan(ConanFile):
         protoc_rel_path = "{}bin/{}".format("".join(["../"] * module_folder_depth), protoc_filename)
         protoc_target = textwrap.dedent("""\
             if(NOT TARGET protobuf::protoc)
-                find_program(PROTOC_PROGRAM protoc PATHS ENV PATH NO_DEFAULT_PATH)
+                if(CMAKE_CROSSCOMPILING)
+                    find_program(PROTOC_PROGRAM protoc PATHS ENV PATH NO_DEFAULT_PATH)
+                endif()
                 if(NOT PROTOC_PROGRAM)
                     set(PROTOC_PROGRAM \"${{CMAKE_CURRENT_LIST_DIR}}/{protoc_rel_path}\")
                 endif()


### PR DESCRIPTION
Only use find_program to search for protoc if cross compiling.
This is to make sure a system installed protoc is never used in
a normal situation while still allowing a build profile (or system)
protoc to be used when cross compiling.

This fixes an issue introduced in https://github.com/conan-io/conan-center-index/pull/4556 that would cause a system installed protoc to have a higher priority when a project is built using cmake-conan (https://github.com/conan-io/cmake-conan).

I created a minimal project and a few scripts to try to make sure it works in the situation I could imagine, see:
https://github.com/anton-danielsson/test-conan-protobuf

Specify library name and version:  **protobuf**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
