### PR TITLE
Add lapack recipe

### DIFF
--- a/recipes/lapack/all/CMakeLists.txt
+++ b/recipes/lapack/all/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+  include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+else()
+  include(conanbuildinfo.cmake)
+endif()
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/lapack/all/CMakeLists.txt
+++ b/recipes/lapack/all/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
-if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-  include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-else()
-  include(conanbuildinfo.cmake)
-endif()
+include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_subdirectory("source_subfolder")

--- a/recipes/lapack/all/conandata.yml
+++ b/recipes/lapack/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.9.1":
+    sha256: dbd3966b272020ca38b328c01df78f23f727b8839ba191895b788a8b986c3955
+    url: https://github.com/Reference-LAPACK/lapack/archive/v3.9.1.zip

--- a/recipes/lapack/all/conanfile.py
+++ b/recipes/lapack/all/conanfile.py
@@ -102,16 +102,10 @@ class LapackConan(ConanFile):
 
     def package_info(self):
         # the order is important for static builds
-        self.cpp_info.libs = ["lapacke", "lapack", "blas", "cblas"]
-        self.cpp_info.system_libs.extend(["gfortran", "m"])
-        if self.options.visual_studio and self.options.shared:
-            self.cpp_info.libs = ["lapacke.dll.lib", "lapack.dll.lib", "blas.dll.lib", "cblas.dll.lib"]
-        self.cpp_info.libdirs = ["lib"]
-        if tools.os_info.is_macos:
-            brewout = StringIO()
-            try:
-                self.run("gfortran --print-file-name libgfortran.dylib", output=brewout)
-            except Exception as error:
-                raise ConanException("Failed to run command: {}. Output: {}".format(error, brewout.getvalue()))
-            lib = os.path.dirname(os.path.normpath(brewout.getvalue().strip()))
-            self.cpp_info.libdirs.append(lib)
+        libs = ["lapacke", "lapack", "blas", "cblas"]
+        if self.settings.os == "Windows" and self.options.shared:
+            libs = [l + ".dll.lib" for l in libs]
+        self.cpp_info.libs = libs
+
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs.extend(["gfortran", "m"])

--- a/recipes/lapack/all/conanfile.py
+++ b/recipes/lapack/all/conanfile.py
@@ -40,7 +40,7 @@ class LapackConan(ConanFile):
             raise ConanInvalidConfiguration("This library needs option 'visual_studio=True' to be consumed")
 
     def config_options(self):
-        if self.options.shared or self.settings.os == "Windows":
+        if self.settings.os == "Windows":
             del self.options.fPIC
 
     def source(self):

--- a/recipes/lapack/all/conanfile.py
+++ b/recipes/lapack/all/conanfile.py
@@ -1,0 +1,111 @@
+import glob
+import os
+import shutil
+from io import StringIO
+
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanException
+from conans.errors import ConanInvalidConfiguration
+from conans.tools import Version
+
+
+class LapackConan(ConanFile):
+    name = "lapack"
+    license = "BSD-3-Clause"
+    homepage = "https://github.com/Reference-LAPACK/lapack"
+    description = "Fortran subroutines for solving problems in numerical linear algebra"
+    topics = (
+        "lapack"
+    )
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"shared": [True, False], "fPIC": [True, False], "visual_studio": [True, False]}
+    default_options = {"shared": False, "visual_studio": False, "fPIC": True}
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake"
+    requires = "zlib/1.2.11"
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+        if self.settings.os == "Macos" and \
+            self.settings.compiler == "apple-clang" and \
+            Version(self.settings.compiler.version.value) < "8.0":
+            raise ConanInvalidConfiguration("lapack requires apple-clang >=8.0")
+        if self.options.visual_studio and not self.options.shared:
+            raise ConanInvalidConfiguration("only shared builds are supported for Visual Studio")
+        if self.settings.compiler == "Visual Studio" and not self.options.visual_studio:
+            raise ConanInvalidConfiguration("This library needs option 'visual_studio=True' to be consumed")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["CMAKE_GNUtoMS"] = self.options.visual_studio
+        cmake.definitions["BUILD_TESTING"] = False
+        cmake.definitions["LAPACKE"] = True
+        cmake.definitions["CBLAS"] = True
+        cmake.configure(build_dir=self._build_subfolder)
+        return cmake
+
+    def build(self):
+        if self.settings.compiler == "Visual Studio":
+            raise ConanInvalidConfiguration("This library cannot be built with Visual Studio. Please use MinGW to "
+                            "build it and option 'visual_studio=True' to build and consume.")
+        cmake = self._configure_cmake()
+        for target in ["blas", "cblas", "lapack", "lapacke"]:
+            cmake.build(target=target)
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+
+        if self.options.visual_studio:
+            for bin_path in self.deps_cpp_info.bin_paths:  # Copy MinGW dlls for Visual Studio consumers
+                self.copy(pattern="*seh*.dll", dst="bin", src=bin_path, keep_path=False)
+                self.copy(pattern="*sjlj*.dll", dst="bin", src=bin_path, keep_path=False)
+                self.copy(pattern="*dwarf2*.dll", dst="bin", src=bin_path, keep_path=False)
+                self.copy(pattern="*quadmath*.dll", dst="bin", src=bin_path, keep_path=False)
+                self.copy(pattern="*winpthread*.dll", dst="bin", src=bin_path, keep_path=False)
+                self.copy(pattern="*gfortran*.dll", dst="bin", src=bin_path, keep_path=False)
+
+            with tools.chdir(os.path.join(self.package_folder, "lib")):
+                libs = glob.glob("lib*.a")
+                for lib in libs:
+                    vslib = lib[3:-2] + ".lib"
+                    self.output.info('renaming %s into %s' % (lib, vslib))
+                    shutil.move(lib, vslib)
+
+    def package_id(self):
+        if self.options.visual_studio:
+            self.info.settings.compiler = "Visual Studio"
+            del self.info.settings.compiler.version
+            del self.info.settings.compiler.runtime
+            del self.info.settings.compiler.toolset
+
+    def package_info(self):
+        # the order is important for static builds
+        self.cpp_info.libs = ["lapacke", "lapack", "blas", "cblas"]
+        self.cpp_info.system_libs.extend(["gfortran", "m"])
+        if self.options.visual_studio and self.options.shared:
+            self.cpp_info.libs = ["lapacke.dll.lib", "lapack.dll.lib", "blas.dll.lib", "cblas.dll.lib"]
+        self.cpp_info.libdirs = ["lib"]
+        if tools.os_info.is_macos:
+            brewout = StringIO()
+            try:
+                self.run("gfortran --print-file-name libgfortran.dylib", output=brewout)
+            except Exception as error:
+                raise ConanException("Failed to run command: {}. Output: {}".format(error, brewout.getvalue()))
+            lib = os.path.dirname(os.path.normpath(brewout.getvalue().strip()))
+            self.cpp_info.libdirs.append(lib)

--- a/recipes/lapack/all/conanfile.py
+++ b/recipes/lapack/all/conanfile.py
@@ -28,6 +28,8 @@ class LapackConan(ConanFile):
     _build_subfolder = "build_subfolder"
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
         if self.settings.os == "Macos" and \

--- a/recipes/lapack/all/conanfile.py
+++ b/recipes/lapack/all/conanfile.py
@@ -40,7 +40,7 @@ class LapackConan(ConanFile):
             raise ConanInvalidConfiguration("This library needs option 'visual_studio=True' to be consumed")
 
     def config_options(self):
-        if self.settings.os == "Windows":
+        if self.options.shared or self.settings.os == "Windows":
             del self.options.fPIC
 
     def source(self):

--- a/recipes/lapack/all/conanfile.py
+++ b/recipes/lapack/all/conanfile.py
@@ -92,10 +92,10 @@ class LapackConan(ConanFile):
                     shutil.move(lib, vslib)
 
     def package_id(self):
-        if self.settings.os == "Windows":
+        if self.settings.compiler == "Visual Studio":
             compatible_pkg = self.info.clone() 
 
-            compatible_pkg.settings.compiler = "Visual Studio"
+            compatible_pkg.settings.compiler = "gcc"
             del compatible_pkg.settings.compiler.version
             del compatible_pkg.settings.compiler.runtime
             del compatible_pkg.settings.compiler.toolset

--- a/recipes/lapack/all/test_package/CMakeLists.txt
+++ b/recipes/lapack/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99)

--- a/recipes/lapack/all/test_package/conanfile.py
+++ b/recipes/lapack/all/test_package/conanfile.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)

--- a/recipes/lapack/all/test_package/conanfile.py
+++ b/recipes/lapack/all/test_package/conanfile.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -15,5 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/lapack/all/test_package/test_package.c
+++ b/recipes/lapack/all/test_package/test_package.c
@@ -1,0 +1,79 @@
+/*
+   LAPACKE Example : Calling DGELS using col-major layout
+   =====================================================
+
+   The program computes the solution to the system of linear
+   equations with a square matrix A and multiple
+   right-hand sides B, where A is the coefficient matrix
+   and b is the right-hand side matrix:
+
+   Description
+   ===========
+
+   In this example, we wish solve the least squares problem min_x || B - Ax ||
+   for two right-hand sides using the LAPACK routine DGELS. For input we will
+   use the 5-by-3 matrix
+
+         ( 1  1  1 )
+         ( 2  3  4 )
+     A = ( 3  5  2 )
+         ( 4  2  5 )
+         ( 5  4  3 )
+    and the 5-by-2 matrix
+
+         ( -10 -3 )
+         (  12 14 )
+     B = (  14 12 )
+         (  16 16 )
+         (  18 16 )
+    We will first store the input matrix as a static C two-dimensional array,
+    which is stored in col-major layout, and let LAPACKE handle the work space
+    array allocation. The LAPACK base name for this function is gels, and we
+    will use double precision (d), so the LAPACKE function name is LAPACKE_dgels.
+
+    lda=5 and ldb=5. The output for each right hand side is stored in b as
+    consecutive vectors of length 3. The correct answer for this problem is
+    the 3-by-2 matrix
+
+         ( 2 1 )
+         ( 1 1 )
+         ( 1 2 )
+
+    A complete C program for this example is given below. Note that when the arrays
+     are passed to the LAPACK routine, they must be dereferenced, since LAPACK is
+      expecting arrays of type double *, not double **.
+
+
+   LAPACKE Interface
+   =================
+
+   LAPACKE_dgels (col-major, high-level) Example Program Results
+
+  -- LAPACKE Example routine (version 3.7.0) --
+  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
+     December 2016
+
+*/
+/* Calling DGELS using col-major layout */
+
+/* Includes */
+#include <stdio.h>
+#include <lapacke.h>
+
+ int main() {
+   double A[5][3] = {{1,2,3},{4,5,1},{3,5,2},{4,1,4},{2,5,3}};
+   double b[5][2] = {{-10,12},{14,16},{18,-3},{14,12},{16,16}};
+
+   const lapack_int m = 5;
+   const lapack_int n = 3;
+   const lapack_int lda = 5;
+   const lapack_int ldb = 5;
+   const lapack_int nrhs = 2;
+
+   printf("LAPACKE_dgels (col-major, high-level) Example Program Results\n" );
+   const lapack_int info = LAPACKE_dgels(LAPACK_COL_MAJOR,'N',m, n, nrhs, *A, lda, *b, ldb);
+   printf( "Solution: %d %d %lf %d\n", n, nrhs, b[0][0], ldb);
+
+   return info;
+}

--- a/recipes/lapack/config.yml
+++ b/recipes/lapack/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.9.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **lapack/3.9.1**

Closes #4509.

We have adapted the deprecated recipe in https://github.com/conan-community/conan-lapack to the rules of conan center.

We did some testing with Linux (Ubuntu 18 and 20). We have no way to test properly windows and mac.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
