### PR TITLE
fix(stlab): Fix the version check for MSVC compilers

### DIFF
--- a/recipes/stlab/all/conanfile.py
+++ b/recipes/stlab/all/conanfile.py
@@ -130,6 +130,10 @@ class Stlab(ConanFile):
         if self.settings.compiler == "Visual Studio" and Version(self.settings.compiler.version) < "15.8":
             raise ConanInvalidConfiguration("Need Visual Studio >= 2017 15.8 (MSVC 19.15)")
 
+        # Actually, we want *at least* 15.8 (MSVC 19.15), but we cannot check this for now with Conan.
+        if self.settings.compiler == "msvc" and Version(self.settings.compiler.version) < "19.15":
+            raise ConanInvalidConfiguration("Need msvc >= 19.15")
+
         self._validate_task_system()
         self._validate_boost_components()
 


### PR DESCRIPTION
Specify library name and version:  **stlab**

We need this change because the recipe is otherwise broken for Visual Studio 2017 (see https://github.com/conan-io/conan/issues/8827)

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
