### PR TITLE
fontconfig/2.13.93: fix build on macos with dynamically linked dependencies

### DIFF
--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -53,6 +53,12 @@ class FontconfigConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         extrated_dir = self.name + "-" + self.version
         os.rename(extrated_dir, self._source_subfolder)
+        # disable fc-cache test to enable cross compilation but also builds with shared libraries on MacOS
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, 'Makefile.in'),
+            '@CROSS_COMPILING_TRUE@RUN_FC_CACHE_TEST = false',
+            'RUN_FC_CACHE_TEST=false'
+        )
 
     def _configure_autotools(self):
         if not self._autotools:

--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -53,12 +53,6 @@ class FontconfigConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         extrated_dir = self.name + "-" + self.version
         os.rename(extrated_dir, self._source_subfolder)
-        # disable fc-cache test to enable cross compilation but also builds with shared libraries on MacOS
-        tools.replace_in_file(
-            os.path.join(self._source_subfolder, 'Makefile.in'),
-            '@CROSS_COMPILING_TRUE@RUN_FC_CACHE_TEST = false',
-            'RUN_FC_CACHE_TEST=false'
-        )
 
     def _configure_autotools(self):
         if not self._autotools:
@@ -78,6 +72,12 @@ class FontconfigConan(ConanFile):
     def _patch_files(self):
         #  - fontconfig requires libtool version number, change it for the corresponding freetype one
         tools.replace_in_file(os.path.join(self._source_subfolder, 'configure'), '21.0.15', '2.8.1')
+        # disable fc-cache test to enable cross compilation but also builds with shared libraries on MacOS
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, 'Makefile.in'),
+            '@CROSS_COMPILING_TRUE@RUN_FC_CACHE_TEST = false',
+            'RUN_FC_CACHE_TEST=false'
+        )
 
     def build(self):
         # Patch files from dependencies


### PR DESCRIPTION
Disables running fc-cache test during make install that fails due to libraries not being found.

Fixes #5273 

Specify library name and version:  **fontconfig/2.13.93**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
