### PR TITLE
glew: add with_egl option for headless rendering

### DIFF
--- a/recipes/glew/all/conanfile.py
+++ b/recipes/glew/all/conanfile.py
@@ -17,10 +17,12 @@ class GlewConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_egl": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_egl": True
     }
 
     _cmake = None
@@ -36,6 +38,7 @@ class GlewConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+            del self.options.with_egl
 
     def configure(self):
         if self.options.shared:
@@ -55,6 +58,9 @@ class GlewConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+
+        if self.options.with_egl:
+            self._cmake.definitions["GLEW_EGL"] = True
         self._cmake.definitions["BUILD_UTILS"] = "OFF"
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake

--- a/recipes/glew/all/conanfile.py
+++ b/recipes/glew/all/conanfile.py
@@ -22,7 +22,7 @@ class GlewConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_egl": True
+        "with_egl": False
     }
 
     _cmake = None
@@ -58,10 +58,8 @@ class GlewConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-
-        if self.options.with_egl:
-            self._cmake.definitions["GLEW_EGL"] = True
-        self._cmake.definitions["BUILD_UTILS"] = "OFF"
+        self._cmake.definitions["BUILD_UTILS"] = False
+        self._cmake.definitions["GLEW_EGL"] = self.options.get_safe("with_egl", False)
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **lglew/2.1.0**

turning off GLEW_EGL flag allows rendering in a headless mode (without x-server)

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
