### PR TITLE
Fix Public Domain license for jpeg-compressor

### DIFF
--- a/recipes/jpeg-compressor/all/conanfile.py
+++ b/recipes/jpeg-compressor/all/conanfile.py
@@ -10,7 +10,7 @@ class JpegCompressorConan(ConanFile):
     homepage = "https://github.com/richgel999/jpeg-compressor"
     topics = ("conan", "jpeg", "image", "compression", "decompression")
     url = "https://github.com/conan-io/conan-center-index"
-    license = "Public Domain", "Apache-2.0"
+    license = "Unlicense", "Apache-2.0"
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
     exports_sources = ["CMakeLists.txt", "patches/*"]

--- a/recipes/jpeg-compressor/all/conanfile.py
+++ b/recipes/jpeg-compressor/all/conanfile.py
@@ -10,7 +10,7 @@ class JpegCompressorConan(ConanFile):
     homepage = "https://github.com/richgel999/jpeg-compressor"
     topics = ("conan", "jpeg", "image", "compression", "decompression")
     url = "https://github.com/conan-io/conan-center-index"
-    license = "Unlicense", "Apache-2.0"
+    license = "Unlicense", "Apache-2.0", "MIT"
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
     exports_sources = ["CMakeLists.txt", "patches/*"]


### PR DESCRIPTION
Public Domain is not allowed: https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-license-should-i-use-for-public-domain

Related to https://github.com/conan-io/hooks/pull/292

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
