### PR TITLE
Fix Public Domain license for lemon

### DIFF
--- a/recipes/lemon/all/conanfile.py
+++ b/recipes/lemon/all/conanfile.py
@@ -8,7 +8,7 @@ class LemonConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://sqlite.org/lemon.html"
     topics = ("conan", "lemon", "grammar", "lexer", "lalr", "parser", "generator", "sqlite")
-    license = "Public Domain"
+    license = "Unlicense"
     exports_sources = "CMakeLists.txt", "patches/**"
     settings = "os", "compiler", "arch", "build_type"
     generators = "cmake"


### PR DESCRIPTION
Public Domain is not allowed: https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-license-should-i-use-for-public-domain

Related to https://github.com/conan-io/hooks/pull/292

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
