### PR TITLE
Fix Public Domain license for lpdcurses

### DIFF
--- a/recipes/pdcurses/all/conanfile.py
+++ b/recipes/pdcurses/all/conanfile.py
@@ -10,7 +10,7 @@ class PDCursesConan(ConanFile):
     topics = ("conan", "pdcurses", "curses", "ncurses")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://pdcurses.org/"
-    license = "Public Domain", "MITX"
+    license = "Unlicense", "MITX"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {

--- a/recipes/pdcurses/all/conanfile.py
+++ b/recipes/pdcurses/all/conanfile.py
@@ -10,7 +10,7 @@ class PDCursesConan(ConanFile):
     topics = ("conan", "pdcurses", "curses", "ncurses")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://pdcurses.org/"
-    license = "Unlicense", "MITX"
+    license = "Unlicense", "MITX", "CC-BY-4.0", "GPL", "FSFUL"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {


### PR DESCRIPTION
Public Domain is not allowed: https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-license-should-i-use-for-public-domain

Related to https://github.com/conan-io/hooks/pull/292

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
