### PR TITLE
Fix Public Domain license for  re2c

### DIFF
--- a/recipes/re2c/all/conanfile.py
+++ b/recipes/re2c/all/conanfile.py
@@ -9,7 +9,7 @@ class Re2CConan(ConanFile):
     topics = ("conan", "re2c", "lexer", "language", "tokenizer", "flex")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://re2c.org/"
-    license = "Public domain"
+    license = "Unlicense"
     settings = "os", "arch", "build_type", "compiler"
     exports_sources = "patches/**"
 


### PR DESCRIPTION
Public Domain is not allowed: https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-license-should-i-use-for-public-domain

Related to https://github.com/conan-io/hooks/pull/292

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
