### PR TITLE
Fix Public Domain license for  stb

### DIFF
--- a/recipes/stb/all/conanfile.py
+++ b/recipes/stb/all/conanfile.py
@@ -7,7 +7,7 @@ class StbConan(ConanFile):
     topics = ("conan", "stb", "single-file")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/nothings/stb"
-    license = ("Public domain", "MIT")
+    license = ("Unlicense", "MIT")
     no_copy_source = True
     _source_subfolder = "source_subfolder"
 


### PR DESCRIPTION
Public Domain is not allowed: https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-license-should-i-use-for-public-domain

Related to https://github.com/conan-io/hooks/pull/292

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
