### PR TITLE
Fix Public Domain license for  tweetnacl

### DIFF
--- a/recipes/tweetnacl/all/conanfile.py
+++ b/recipes/tweetnacl/all/conanfile.py
@@ -5,7 +5,7 @@ import os
 
 class TweetnaclConan(ConanFile):
     name = "tweetnacl"
-    license = "Public Domain"
+    license = "Unlicense"
     homepage = "https://tweetnacl.cr.yp.to"
     url = "https://github.com/conan-io/conan-center-index"
     description = "TweetNaCl is the world's first auditable high-security cryptographic library"


### PR DESCRIPTION
Public Domain is not allowed: https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-license-should-i-use-for-public-domain

Related to https://github.com/conan-io/hooks/pull/292

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
