### PR TITLE
Fix Public Domain license for  xz_utils

### DIFF
--- a/recipes/xz_utils/all/conanfile.py
+++ b/recipes/xz_utils/all/conanfile.py
@@ -14,7 +14,7 @@ class XZUtils(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://tukaani.org/xz"
     topics = ("conan", "lzma", "xz", "compression")
-    license = "Public Domain, GNU LGPLv2.1, GNU GPLv2, or GNU GPLv3"
+    license = "Unlicense", "LGPL-2.1-or-later",  "GPL-2.0-or-later", "GPL-3.0-or-later"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}


### PR DESCRIPTION
Public Domain is not allowed: https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-license-should-i-use-for-public-domain

Related to https://github.com/conan-io/hooks/pull/292

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
