### PR TITLE
added build for libdb 4.8.30

### DIFF
--- a/recipes/libdb/all/conandata.yml
+++ b/recipes/libdb/all/conandata.yml
@@ -2,6 +2,10 @@ sources:
   "5.3.28":
     url: "https://download.oracle.com/berkeley-db/db-5.3.28.tar.gz"
     sha256: "e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628"
+  "4.8.30":
+    url: "https://download.oracle.com/berkeley-db/db-4.8.30.tar.gz"
+    sha256: "e0491a07cdb21fb9aa82773bbbedaeb7639cbd0e7f96147ab46141e0045db72a"
+
 patches:
   "5.3.28":
     - patch_file: "patches/0001-rename_atomic_compare_exchange.patch"
@@ -11,4 +15,7 @@ patches:
     - patch_file: "patches/0003-msvc-db_tcl-add-static-configuration.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0004-msvc-tcl-include-conanbuildinfo-props.patch"
+      base_path: "source_subfolder"
+  "4.8.30":
+    - patch_file: "patches/0001-rename_atomic_compare_exchange_4.28.patch"
       base_path: "source_subfolder"

--- a/recipes/libdb/all/patches/0001-rename_atomic_compare_exchange_4.28.patch
+++ b/recipes/libdb/all/patches/0001-rename_atomic_compare_exchange_4.28.patch
@@ -1,0 +1,20 @@
+--- dbinc/atomic.h
++++ dbinc/atomic.h
+@@ -144,7 +144,7 @@
+ #define	atomic_inc(env, p)	__atomic_inc(p)
+ #define	atomic_dec(env, p)	__atomic_dec(p)
+ #define	atomic_compare_exchange(env, p, o, n)	\
+-	__atomic_compare_exchange((p), (o), (n))
++	__atomic_compare_exchange_db((p), (o), (n))
+ static inline int __atomic_inc(db_atomic_t *p)
+ {
+ 	int	temp;
+@@ -176,7 +176,7 @@
+  * http://gcc.gnu.org/onlinedocs/gcc-4.1.0/gcc/Atomic-Builtins.html
+  * which configure could be changed to use.
+  */
+-static inline int __atomic_compare_exchange(
++static inline int __atomic_compare_exchange_db(
+ 	db_atomic_t *p, atomic_value_t oldval, atomic_value_t newval)
+ {
+ 	atomic_value_t was;


### PR DESCRIPTION
Signed-off-by: tkrupa <tomas@krupa.hu>

Specify library name and version:  **libdb/4.8.30**

resiprocate conan build with enabled repro depends on berkeley db 4.8 

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
