### PR TITLE
Add earcut/0.12.4

### DIFF
--- a/recipes/earcut/all/conandata.yml
+++ b/recipes/earcut/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.12.4":
+    sha256: "d935feac891fd39b4872074d968b1ddfe4b9128c5db1604e15447b87f7c70970"
+    url: "https://github.com/mapbox/earcut.hpp/archive/refs/tags/v0.12.4.zip"

--- a/recipes/earcut/all/conanfile.py
+++ b/recipes/earcut/all/conanfile.py
@@ -49,7 +49,7 @@ class EarcutConan(ConanFile):
             self.output.warn("{} recipe lacks information about the {} compiler support.".format(
                 self.name, self.settings.compiler))
         else:
-            if tools.Version(self.settings.compiler.version) < min_version:
+            if lazy_lt_semver(str(self.settings.compiler.version), min_version):
                 raise ConanInvalidConfiguration("{} requires C++{} support. The current compiler {} {} does not support it.".format(
                     self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
 

--- a/recipes/earcut/all/conanfile.py
+++ b/recipes/earcut/all/conanfile.py
@@ -36,6 +36,13 @@ class EarcutConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, self._minimum_cpp_standard)
+
+        def lazy_lt_semver(v1, v2):
+            lv1 = [int(v) for v in v1.split(".")]
+            lv2 = [int(v) for v in v2.split(".")]
+            min_length = min(len(lv1), len(lv2))
+            return lv1[:min_length] < lv2[:min_length]
+
         min_version = self._minimum_compilers_version.get(
             str(self.settings.compiler))
         if not min_version:

--- a/recipes/earcut/all/conanfile.py
+++ b/recipes/earcut/all/conanfile.py
@@ -33,7 +33,7 @@ class EarcutConan(ConanFile):
     def _minimum_cpp_standard(self):
         return 11
 
-    def configure(self):
+    def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, self._minimum_cpp_standard)
         min_version = self._minimum_compilers_version.get(

--- a/recipes/earcut/all/conanfile.py
+++ b/recipes/earcut/all/conanfile.py
@@ -1,0 +1,63 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class EarcutConan(ConanFile):
+    name = "earcut"
+    description = "A C++ port of earcut.js, a fast, header-only polygon triangulation library."
+    homepage = "https://github.com/mapbox/earcut.hpp"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "ISC"
+    topics = ("algorithm", "cpp", "geometry", "rendering", "triangulation",
+              "polygon", "header-only", "tessellation", "earcut")
+    settings = "compiler"
+    no_copy_source = True
+
+    @property
+    def _minimum_compilers_version(self):
+        # References:
+        # * https://github.com/mapbox/earcut.hpp#dependencies
+        # * https://en.cppreference.com/w/cpp/compiler_support/11
+        # * https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
+        return {
+            "apple-clang": "5.1",
+            "clang": "3.4",
+            "gcc": "4.9",
+            "intel": "15",
+            "sun-cc": "5.14",
+            "Visual Studio": "12"
+        }
+
+    @property
+    def _minimum_cpp_standard(self):
+        return 11
+
+    def configure(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, self._minimum_cpp_standard)
+        min_version = self._minimum_compilers_version.get(
+            str(self.settings.compiler))
+        if not min_version:
+            self.output.warn("{} recipe lacks information about the {} compiler support.".format(
+                self.name, self.settings.compiler))
+        else:
+            if tools.Version(self.settings.compiler.version) < min_version:
+                raise ConanInvalidConfiguration("{} requires C++{} support. The current compiler {} {} does not support it.".format(
+                    self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy("*", "include",
+                  src=os.path.join(self._source_subfolder, "include"))
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/earcut/all/test_package/CMakeLists.txt
+++ b/recipes/earcut/all/test_package/CMakeLists.txt
@@ -7,8 +7,3 @@ conan_basic_setup()
 add_executable(example example.cpp)
 target_link_libraries(example ${CONAN_LIBS})
 set_property(TARGET example PROPERTY CXX_STANDARD 11)
-
-enable_testing()
-add_test(NAME example
-         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-         COMMAND example)

--- a/recipes/earcut/all/test_package/CMakeLists.txt
+++ b/recipes/earcut/all/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})
+set_property(TARGET example PROPERTY CXX_STANDARD 11)
+
+enable_testing()
+add_test(NAME example
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+         COMMAND example)

--- a/recipes/earcut/all/test_package/conanfile.py
+++ b/recipes/earcut/all/test_package/conanfile.py
@@ -1,0 +1,21 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class EarcutTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def _configure_cmake(self):
+        if not hasattr(self, "_cmake"):
+            self._cmake = CMake(self)
+            self._cmake.configure()
+        
+        return self._cmake
+
+    def build(self):
+        self._configure_cmake().build()
+
+    def test(self):
+        self._configure_cmake().test()

--- a/recipes/earcut/all/test_package/conanfile.py
+++ b/recipes/earcut/all/test_package/conanfile.py
@@ -7,15 +7,12 @@ class EarcutTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 
-    def _configure_cmake(self):
-        if not hasattr(self, "_cmake"):
-            self._cmake = CMake(self)
-            self._cmake.configure()
-        
-        return self._cmake
-
     def build(self):
-        self._configure_cmake().build()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
-        self._configure_cmake().test()
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/earcut/all/test_package/example.cpp
+++ b/recipes/earcut/all/test_package/example.cpp
@@ -1,0 +1,33 @@
+#include <mapbox/earcut.hpp>
+
+#include <array>
+#include <vector>
+
+/// The example below is taken directly from https://github.com/mapbox/earcut.hpp#usage.
+int main(int, char **)
+{
+    // The number type to use for tessellation
+    using Coord = double;
+
+    // The index type. Defaults to uint32_t, but you can also pass uint16_t if you know that your
+    // data won't have more than 65536 vertices.
+    using N = uint32_t;
+
+    // Create array
+    using Point = std::array<Coord, 2>;
+    std::vector<std::vector<Point>> polygon;
+
+    // Fill polygon structure with actual data. Any winding order works.
+    // The first polyline defines the main polygon.
+    polygon.push_back({{100, 0}, {100, 100}, {0, 100}, {0, 0}});
+    // Following polylines define holes.
+    polygon.push_back({{75, 25}, {75, 75}, {25, 75}, {25, 25}});
+
+    // Run tessellation
+    // Returns array of indices that refer to the vertices of the input polygon.
+    // e.g: the index 6 would refer to {25, 75} in this example.
+    // Three subsequent indices form a triangle. Output triangles are clockwise.
+    std::vector<N> indices = mapbox::earcut<N>(polygon);
+
+    return indices.empty();
+}

--- a/recipes/earcut/config.yml
+++ b/recipes/earcut/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.12.4":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **earcut/0.12.4**

Excerpt from the library's README.md:
"A C++ port of earcut.js, a fast, header-only polygon triangulation library."

More information on the library itself can be found [here](https://github.com/mapbox/earcut.hpp).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
