### PR TITLE
msys2: uninstall pkgconf

### DIFF
--- a/recipes/msys2/all/conandata.yml
+++ b/recipes/msys2/all/conandata.yml
@@ -1,8 +1,7 @@
 sources:
   "cci.latest":
-    "x86_64":
-          url: [
-                 "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20210105.tar.xz",
-                 "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20210105.tar.xz",
-          ]
-          sha256: "982e54de087d53adfc6a8caf7614d4a7add36dd02dcb0b7838060dd893e9f596"
+    url: [
+            "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20210105.tar.xz",
+            "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20210105.tar.xz",
+    ]
+    sha256: "982e54de087d53adfc6a8caf7614d4a7add36dd02dcb0b7838060dd893e9f596"

--- a/recipes/msys2/all/conandata.yml
+++ b/recipes/msys2/all/conandata.yml
@@ -1,31 +1,5 @@
 sources:
-  "20190524":
-    "x86_64":
-          url: [
-                 "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz",
-                 "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20190524.tar.xz",
-          ]
-          sha256: "168e156fa9f00d90a8445676c023c63be6e82f71487f4e2688ab5cb13b345383"
-    "x86":
-          url: [
-                 "http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz",
-                 "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20190524.tar.xz",
-          ]
-          sha256: "7a463afae8bf6ce8262f010a9a1648d056ad5cefc66d6eb69fe948c57d4ccb53"
-  "20200517":
-    "x86_64":
-          url: [
-                 "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20200517.tar.xz",
-                 "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20200517.tar.xz",
-          ]
-          sha256: "c4443113497acb2d2e285d40b929fc55f33f8f669902595ecdf66a655b63dc60"
-    "x86":
-          url: [
-                 "http://repo.msys2.org/distrib/i686/msys2-base-i686-20200517.tar.xz",
-                 "https://sourceforge.net/projects/msys2/files/Base/i686/msys2-base-i686-20200517.tar.xz",
-          ]
-          sha256: "4dbdde708a4bcf3c056e8f4f28b1b0e7a3210ffacc6296a7d11fdaf076fd431e"
-  "20210105":
+  "cci.latest":
     "x86_64":
           url: [
                  "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20210105.tar.xz",

--- a/recipes/msys2/all/conandata.yml
+++ b/recipes/msys2/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "cci.latest":
     url: [
-            "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20210105.tar.xz",
-            "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20210105.tar.xz",
+            "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20210419.tar.xz",
+            "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20210419.tar.xz",
     ]
-    sha256: "982e54de087d53adfc6a8caf7614d4a7add36dd02dcb0b7838060dd893e9f596"
+    sha256: "3d014d6f5ae519ea5de5b586bff505309c1f42fd8148996d63ba132b24146c85"

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -68,9 +68,6 @@ class MSYS2Conan(ConanFile):
         with tools.chdir(os.path.join(self._msys_dir, "usr", "bin")):
             try:
                 self._kill_pacman()
-                # https://www.msys2.org/news/   see  2020-05-31 - Update may fail with "could not open file"
-                # update pacman separately first
-                self.run('bash -l -c "pacman --debug --noconfirm -Sydd pacman"')
 
                 # https://www.msys2.org/docs/ci/
                 self.run('bash -l -c "pacman --debug --noconfirm --ask 20 -Syuu"')  # Core update (in case any core packages are outdated)

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -80,6 +80,7 @@ class MSYS2Conan(ConanFile):
                 self.run('bash -l -c "pacman --debug -Rc dash --noconfirm"')
             except ConanException:
                 self.run('bash -l -c "cat /var/log/pacman.log || echo nolog"')
+                self._kill_pacman()
                 raise
 
     # https://github.com/msys2/MSYS2-packages/issues/1966

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -63,13 +63,7 @@ class MSYS2Conan(ConanFile):
         if tools.Version(self.version) >= "20210105" and self.settings.arch != "x86_64":
             raise ConanInvalidConfiguration("Only Windows x64 supported")
         if tools.Version(self.version) <= "20161025":
-            raise ConanInvalidConfiguration("msys2 v.20161025 is no longer supported")    
-
-    def _download(self, url, sha256):
-        from six.moves.urllib.parse import urlparse
-        filename = os.path.basename(urlparse(url[0]).path)
-        tools.download(url=url, filename=filename, sha256=sha256)
-        return filename
+            raise ConanInvalidConfiguration("msys2 v.20161025 is no longer supported")
 
     @property
     def _keyring_subfolder(self):
@@ -182,8 +176,7 @@ class MSYS2Conan(ConanFile):
         pass
 
     def _do_source(self):
-        filename = self._download(**self.conan_data["sources"][self.version][str(self.settings.arch)])
-        tools.unzip(filename)
+        tools.get(**self.conan_data["sources"][self.version][str(self.settings.arch)])
         self._download_keyring()
 
     def build(self):

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -118,9 +118,8 @@ class MSYS2Conan(ConanFile):
         pass
 
     def build(self):
-        os.makedirs(os.path.join(self.package_folder, "bin"))
-        with tools.chdir(os.path.join(self.package_folder, "bin")):
-            tools.get(**self.conan_data["sources"][self.version][str(self.settings.arch)])
+        tools.get(**self.conan_data["sources"][self.version],
+                    destination=os.path.join(self.package_folder, "bin"))
         with lock():
             self._do_build()
 

--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -208,6 +208,8 @@ class MSYS2Conan(ConanFile):
         with tools.chdir(os.path.join(self._msys_dir, "usr", "bin")):
             for package in packages:
                 self.run('bash -l -c "pacman -S %s --noconfirm"' % package)
+            for package in ['pkgconf']:
+                self.run('bash -l -c "pacman -Rs $(pacman -Qsq %s) --noconfirm"' % package)
 
         self._kill_pacman()
 

--- a/recipes/msys2/config.yml
+++ b/recipes/msys2/config.yml
@@ -1,8 +1,4 @@
 versions:
-    "20190524":
-      folder: "all"
-    "20200517":
-      folder: "all"
-    "20210105":
+    "cci.latest":
       folder: "all"
   


### PR DESCRIPTION
pkgconf  should be provided by conan
also, hide the msys2 library folder. This is useful to avoid accidentally linking to a msys2 library instead of one from a conan dependency.
also also, make it clear that msys2 uses rolling releases

Specify library name and version:  **msys2/***

this would also solve #5322 failure

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

