### PR TITLE
add recipe protobuf/3.5.2@

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.5.2":
+    sha256: 4ffd420f39f226e96aebc3554f9c66a912f6cad6261f39f194f16af8a1f6dab2
+    url: https://github.com/protocolbuffers/protobuf/archive/v3.5.2.tar.gz
   "3.9.1":
     sha256: 98e615d592d237f94db8bf033fba78cd404d979b0b70351a9e5aaff725398357
     url: https://github.com/protocolbuffers/protobuf/archive/v3.9.1.tar.gz

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.5.2":
+    folder: all
   "3.9.1":
     folder: all
   "3.11.3":


### PR DESCRIPTION
Specify library name and version:  **protobuf/3.5.2@**

add recipe protobuf/3.5.2@ needed by opencv dnn module

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
