### PR TITLE
libtool: always use colon separator in AUTOMAKE_CONAN_INCLUDES

### DIFF
--- a/recipes/libtool/all/conanfile.py
+++ b/recipes/libtool/all/conanfile.py
@@ -205,4 +205,10 @@ class LibtoolConan(ConanFile):
 
         automake_extra_include = tools.unix_path(os.path.join(self.package_folder, "bin", "share", "aclocal"))
         self.output.info("Appending AUTOMAKE_CONAN_INCLUDES environment variable: {}".format(automake_extra_include))
-        self.env_info.AUTOMAKE_CONAN_INCLUDES.append(automake_extra_include)
+        # force colon separator in AUTOMAKE_CONAN_INCLUDES between paths, even on Windows
+        automake_conan_includes = tools.get_env("AUTOMAKE_CONAN_INCLUDES")
+        if automake_conan_includes:
+            automake_conan_includes = automake_conan_includes + ":" + automake_extra_include
+        else:
+            automake_conan_includes = automake_extra_include
+        self.env_info.AUTOMAKE_CONAN_INCLUDES = automake_conan_includes


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

I'm trying to fix MinGW build failures in several recipes (libcurl for the moment) relying on `libtool` & `pkgconf`. When `libtool` & `pkgconf` are both in build requirements, `aclocal.exe` fails because it doesn't understand semi colon separator on Windows:

Here is an error with libcurl after some modifications in build_requirements (msys2 recipe required if subsystem is msys2 because it fails otherwise, and add `libtool` & `pkgconf` to not rely on msys2 ones):

```
autoreconf.exe: running: /c/users/spaceim/.conan/data/automake/1.16.3/_/_/package/3e48e69237f7f2196164383ef9dedf0f93cbf249/bin/aclocal.exe --force -I m4
aclocal.exe: error: couldn't open directory '/c/users/spaceim/.conan/data/libtool/2.4.6/_/_/package/c4ea6c05ba7ed11a856dbbe447d88240dd15ac92/bin/share/aclocal;/c/users/spaceim/.conan/data/pkgconf/1.7.3/_/_/package/48882e2c31b13947b68f156127a94913f34be744/bin/aclocal': No such file or directory
```

But it works if paths in `AUTOMAKE_CONAN_INCLUDES` are separated with a colon on Windows.

Here is how `xmlsec` recipe manages this issue: https://github.com/conan-io/conan-center-index/blob/ef9b1198c90a40a6caec1b53652f1271b1a3afd9/recipes/xmlsec/all/conanfile.py#L162
But it's quite unfortunate to propagate this fix in all downstream recipes.

/cc @madebr 

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
