### PR TITLE
pkgconf: always use colon separator in AUTOMAKE_CONAN_INCLUDES

### DIFF
--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -108,6 +108,12 @@ class PkgConfConan(ConanFile):
         self.output.info("Setting PKG_CONFIG env var: {}".format(pkg_config))
         self.env_info.PKG_CONFIG = pkg_config
 
-        automake_extra_includes = tools.unix_path(os.path.join(self.package_folder , "bin", "aclocal").replace("\\", "/"))
-        self.output.info("Appending AUTOMAKE_CONAN_INCLUDES env var: {}".format(automake_extra_includes))
-        self.env_info.AUTOMAKE_CONAN_INCLUDES.append(automake_extra_includes)
+        automake_extra_include = tools.unix_path(os.path.join(self.package_folder , "bin", "aclocal"))
+        self.output.info("Appending AUTOMAKE_CONAN_INCLUDES env var: {}".format(automake_extra_include))
+        # force colon separator in AUTOMAKE_CONAN_INCLUDES between paths, even on Windows
+        automake_conan_includes = tools.get_env("AUTOMAKE_CONAN_INCLUDES")
+        if automake_conan_includes:
+            automake_conan_includes = automake_conan_includes + ":" + automake_extra_include
+        else:
+            automake_conan_includes = automake_extra_include
+        self.env_info.AUTOMAKE_CONAN_INCLUDES = automake_conan_includes


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

same reason than https://github.com/conan-io/conan-center-index/pull/5326

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
