### PR TITLE
automake: properly split AUTOMAKE_CONAN_INCLUDES on Windows

### DIFF
--- a/recipes/automake/all/patches/0003-remove-embedded-datadirs-introduce-automake-conan-includes-0.16.1.patch
+++ b/recipes/automake/all/patches/0003-remove-embedded-datadirs-introduce-automake-conan-includes-0.16.1.patch
@@ -8,7 +8,7 @@
 -my @system_includes = ('@datadir@/aclocal');
 +my @automake_includes = ($ENV{"AUTOMAKE_DATADIR"} . '/aclocal-' . $APIVERSION);
 +my @system_includes = ($ENV{"AUTOMAKE_DATADIR"} . '/aclocal');
-+my @conan_includes = uniq(split(/:/, $ENV{'AUTOMAKE_CONAN_INCLUDES'} || ""));
++my @conan_includes = uniq(split(/[:;]/, $ENV{'AUTOMAKE_CONAN_INCLUDES'} || ""));
 -
  # Whether we should copy M4 file in $user_includes[0].
  my $install = 0;

--- a/recipes/automake/all/patches/0003-remove-embedded-datadirs-introduce-automake-conan-includes-0.16.2.patch
+++ b/recipes/automake/all/patches/0003-remove-embedded-datadirs-introduce-automake-conan-includes-0.16.2.patch
@@ -8,7 +8,7 @@
 -my @system_includes = ('@datadir@/aclocal');
 +my @automake_includes = ($ENV{"AUTOMAKE_DATADIR"} . '/aclocal-' . $APIVERSION);
 +my @system_includes = ($ENV{"AUTOMAKE_DATADIR"} . '/aclocal');
-+my @conan_includes = uniq(split(/:/, $ENV{'AUTOMAKE_CONAN_INCLUDES'} || ""));
++my @conan_includes = uniq(split(/[:;]/, $ENV{'AUTOMAKE_CONAN_INCLUDES'} || ""));
 -
  # Whether we should copy M4 file in $user_includes[0].
  my $install = 0;

--- a/recipes/automake/all/patches/0003-remove-embedded-datadirs-introduce-automake-conan-includes-0.16.3.patch
+++ b/recipes/automake/all/patches/0003-remove-embedded-datadirs-introduce-automake-conan-includes-0.16.3.patch
@@ -8,7 +8,7 @@
 -my @system_includes = ('@datadir@/aclocal');
 +my @automake_includes = ($ENV{"AUTOMAKE_DATADIR"} . '/aclocal-' . $APIVERSION);
 +my @system_includes = ($ENV{"AUTOMAKE_DATADIR"} . '/aclocal');
-+my @conan_includes = uniq(split(/:/, $ENV{'AUTOMAKE_CONAN_INCLUDES'} || ""));
++my @conan_includes = uniq(split(/[:;]/, $ENV{'AUTOMAKE_CONAN_INCLUDES'} || ""));
 -
  # Whether we should copy M4 file in $user_includes[0].
  my $install = 0;

--- a/recipes/automake/all/test_package/conanfile.py
+++ b/recipes/automake/all/test_package/conanfile.py
@@ -10,9 +10,8 @@ class TestPackageConan(ConanFile):
     # DON'T COPY extra.m4 TO BUILD FOLDER!!!
 
     def build_requirements(self):
-        if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ \
-                and tools.os_info.detect_windows_subsystem() != "msys2":
-            self.build_requires("msys2/20190524")
+        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/20200517")
 
     @contextmanager
     def _build_context(self):


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

see https://github.com/conan-io/conan-center-index/pull/5326#issue-623326628

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
