### PR TITLE
Fixed issue #5268.

### DIFF
--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -16,12 +16,14 @@ class PahoMqttcConan(ConanFile):
                "fPIC": [True, False],
                "ssl": [True, False],
                "samples": [True, False],
-               "asynchronous": [True, False]}
+               "asynchronous": [True, False],
+               "high_performance": [True, False]}
     default_options = {"shared": False,
                        "fPIC": True,
                        "ssl": True,
                        "asynchronous" : True,
-                       "samples": False}
+                       "samples": False,
+                       "high_performance": False}
 
     _cmake = None
 
@@ -65,6 +67,7 @@ class PahoMqttcConan(ConanFile):
         self._cmake.definitions["PAHO_BUILD_SHARED"] = self.options.shared
         self._cmake.definitions["PAHO_BUILD_SAMPLES"] = self.options.samples
         self._cmake.definitions["PAHO_WITH_SSL"] = self.options.ssl
+        self._cmake.definitions["PAHO_HIGH_PERFORMANCE"] = self.options.high_performance
         if self.options.ssl:
             self._cmake.definitions["OPENSSL_SEARCH_PATH"] = self.deps_cpp_info["openssl"].rootpath
             self._cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath


### PR DESCRIPTION
Added support for -DPAHO_HIGH_PERFORMANCE recipe flag for paho-mqtt-c
library.

Specify library name and version:  **paho-mqtt-c/all**

Fixing issue #5268
---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
