### PR TITLE
Add support for  -DPAHO_HIGH_PERFORMANCE recipe in paho-mqtt-c recipe - issue #5268.

### DIFF
--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -20,14 +20,16 @@ class PahoMqttcConan(ConanFile):
         "fPIC": [True, False],
         "ssl": [True, False],
         "asynchronous": [True, False],
-        "samples": [True, False, "deprecated"]
+        "samples": [True, False, "deprecated"],
+        "high_performance": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "ssl": True,
         "asynchronous": True,
-        "samples": "deprecated"
+        "samples": "deprecated",
+        "high_performance": False
     }
 
     _cmake = None
@@ -36,9 +38,16 @@ class PahoMqttcConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _has_high_performance_option(self):
+        return tools.Version(self.version) >= "1.3.2"
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+        if not self._has_high_performance_option:
+            del self.options.high_performance
 
     def configure(self):
         if self.options.shared:
@@ -77,6 +86,8 @@ class PahoMqttcConan(ConanFile):
         if self.options.ssl:
             self._cmake.definitions["OPENSSL_SEARCH_PATH"] = self.deps_cpp_info["openssl"].rootpath.replace("\\", "/")
             self._cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath.replace("\\", "/")
+        if self._has_high_performance_option:
+            self._cmake.definitions["PAHO_HIGH_PERFORMANCE"] = self.options.high_performance
         self._cmake.configure()
         return self._cmake
 


### PR DESCRIPTION
Added support for -DPAHO_HIGH_PERFORMANCE recipe flag for paho-mqtt-c
library.

Specify library name and version:  **paho-mqtt-c/all**

Fixing issue #5268 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
