### PR TITLE
libcurl: fix darwinssl option

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -230,7 +230,7 @@ class LibcurlConan(ConanFile):
             "--with-libmetalink={}".format(yes_no(self.options.with_libmetalink)),
             "--with-libpsl={}".format(yes_no(self.options.with_libpsl)),
             "--with-schannel={}".format(yes_no(self.options.with_ssl == "schannel")),
-            "--with-darwinssl={}".format(yes_no(self.options.with_ssl == "darwinssl")),
+            "--with-secure-transport={}".format(yes_no(self.options.with_ssl == "darwinssl")),
             "--with-brotli={}".format(yes_no(self.options.with_brotli)),
             "--enable-shared={}".format(yes_no(self.options.shared)),
             "--enable-static={}".format(yes_no(not self.options.shared)),


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

closes https://github.com/conan-io/conan-center-index/issues/441

Perhaps, we should also change darwinssl value to secure-transport in `with_ssl` recipe option, but it might break consumers.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
