### PR TITLE
Add argh 1.3.1

### DIFF
--- a/recipes/argh/all/conandata.yml
+++ b/recipes/argh/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.3.1":
+    url: "https://github.com/adishavit/argh/archive/refs/tags/v1.3.1.tar.gz"
+    sha256: "48e09999f2768afbe90ef98864980933cf0ed5323dce3593c3f2f44b0ffda3de"

--- a/recipes/argh/all/conanfile.py
+++ b/recipes/argh/all/conanfile.py
@@ -1,0 +1,36 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class ArgparseConan(ConanFile):
+    name = "argh"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/adishavit/argh"
+    topics = ("conan", "argh", "argument", "parsing")
+    license = "BSD-3"
+    description = "Frustration-free command line processing"
+    settings = "compiler"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return os.path.join(self.source_folder, "source_subfolder")
+
+    def configure(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 11)
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("argh-{}".format(self.version), self._source_subfolder)
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        self.copy("argh.h", src=os.path.join(self._source_subfolder), dst=os.path.join("include", "argh"))
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.includedirs.append(os.path.join("include", "argh"))

--- a/recipes/argh/all/conanfile.py
+++ b/recipes/argh/all/conanfile.py
@@ -26,7 +26,7 @@ class ArgparseConan(ConanFile):
 
     def package(self):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        self.copy("argh.h", src=os.path.join(self._source_subfolder), dst=os.path.join("include", "argh"))
+        self.copy("argh.h", src=self._source_subfolder, dst=os.path.join("include", "argh"))
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/argh/all/conanfile.py
+++ b/recipes/argh/all/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
 import os
 
 

--- a/recipes/argh/all/conanfile.py
+++ b/recipes/argh/all/conanfile.py
@@ -16,7 +16,7 @@ class ArgparseConan(ConanFile):
     def _source_subfolder(self):
         return os.path.join(self.source_folder, "source_subfolder")
 
-    def configure(self):
+    def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
 

--- a/recipes/argh/all/test_package/CMakeLists.txt
+++ b/recipes/argh/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/argh/all/test_package/conanfile.py
+++ b/recipes/argh/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+from io import StringIO
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.run(os.path.join("bin", "test_package"))

--- a/recipes/argh/all/test_package/conanfile.py
+++ b/recipes/argh/all/test_package/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, CMake, tools
-from io import StringIO
 import os
 
 

--- a/recipes/argh/all/test_package/test_package.cpp
+++ b/recipes/argh/all/test_package/test_package.cpp
@@ -1,0 +1,13 @@
+#include <argh.h>
+#include <iostream>
+#include <cstdlib>
+
+int main(int, char* argv[])
+{   // if this works, the package works
+    argh::parser cmdl(argv);
+
+    if (cmdl[{ "-v", "--verbose" }])
+        std::cout << "Working.\n";
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/argh/config.yml
+++ b/recipes/argh/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.3.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **argh/1.3.1**

This library already existed at some point of time, but is deprecated since some time
https://conan.io/center/argh?os=&tab=configuration

So here the latest version, to get it back, since users request it, see https://github.com/adishavit/argh/issues/59

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.


