### PR TITLE
libgeotiff: bump proj + no os.rename in source()

### DIFF
--- a/recipes/libgeotiff/all/conanfile.py
+++ b/recipes/libgeotiff/all/conanfile.py
@@ -44,8 +44,8 @@ class LibgeotiffConan(ConanFile):
         self.requires("proj/8.0.0")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def build(self):
         for patch in self.conan_data["patches"][self.version]:

--- a/recipes/libgeotiff/all/conanfile.py
+++ b/recipes/libgeotiff/all/conanfile.py
@@ -41,7 +41,7 @@ class LibgeotiffConan(ConanFile):
 
     def requirements(self):
         self.requires("libtiff/4.2.0")
-        self.requires("proj/7.2.1")
+        self.requires("proj/8.0.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

I need to submit a PR for `gdal` (mainly for MinGW build), and I will bump several dependencies, including `proj` (because each PR of `gdal` is a nightmare for CI of CCI, I don't want to submit several PR). `libgeotiff` is also a dependency of `gdal`, so `proj` version must be updated first in this recipe since major version is changed (7 => 8), and major version contributes to package id of downstreams.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
