### PR TITLE
libtool: fix ltdl extension on Windows

### DIFF
--- a/recipes/libtool/all/conanfile.py
+++ b/recipes/libtool/all/conanfile.py
@@ -162,6 +162,10 @@ class LibtoolConan(ConanFile):
             os.rename(os.path.join(binpath, "libtool"),
                       os.path.join(binpath, "libtool.exe"))
 
+        if self.settings.compiler == "Visual Studio" and self.options.shared:
+            os.rename(os.path.join(self.package_folder, "lib", "ltdl.dll.lib"),
+                      os.path.join(self.package_folder, "lib", "ltdl.lib"))
+
     @property
     def _libtool_relocatable_env(self):
         return {
@@ -173,10 +177,7 @@ class LibtoolConan(ConanFile):
         }
 
     def package_info(self):
-        lib = "ltdl"
-        if self.settings.os == "Windows" and self.options.shared:
-            lib += ".dll" + ".lib" if self.settings.compiler == "Visual Studio" else ".a"
-        self.cpp_info.libs = [lib]
+        self.cpp_info.libs = ["ltdl"]
 
         if self.options.shared:
             if self.settings.os == "Windows":


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Fixes for shared on Windows:

- msvc: rename .dll.lib to .lib extension
- mingw: for import lib with `.dll.a` extension, `.dll.a` suffix **must not** be added to the name in `self.cpp_info.libs`. You can add `.dll` if you want (useless usually), but not the full extension.
  Others recipes with this issue I believe: `libdisasm` & `ncurses`

I'v seen this issue while trying to compile gdal recipe with all shared (including build requirements) and MinGW.
I was surprised to see that libtool lib was propagated into `LIBS` (it's a build requirement 😮 ), but well it should be harmless for native build, but also very surprised to see that it failed at configure time while testing the compiler.

config.log:

```
configure:3961: c/mingw64/bin/gcc.exe -pthread -m64 -O3 -s -I/c/users/spaceim/.conan/data/libtool/2.4.6/_/_/package/6ed756b5c4c6595a67aaf3080ad44742d17c6855/include -I/c/users/spaceim/.conan/data/pkgconf/1.7.3/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include -I/c/users/spaceim/.conan/data/pkgconf/1.7.3/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include/libpkgconf -I/c/users/spaceim/.conan/data/json-c/0.15/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include -I/c/users/spaceim/.conan/data/libgeotiff/1.6.0/_/_/package/dd3498f918b720d2c4fe42074ef5f0c9b543690f/include -I/c/users/spaceim/.conan/data/flatbuffers/1.12.0/_/_/package/a5c799107dfb025c5f6ba6c4de7c4777289b9cfc/include -I/c/users/spaceim/.conan/data/libiconv/1.16/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include -I/c/users/spaceim/.conan/data/libpng/1.6.37/_/_/package/c5964d2abbfc2b4d0222455155600df3a88a1eeb/include -I/c/users/spaceim/.conan/data/giflib/5.2.1/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include -I/c/users/spaceim/.conan/data/geos/3.9.1/_/_/package/4db7ebae6aa4f675076260c9f4cd7bbb21de70d0/include -I/c/users/spaceim/.conan/data/qhull/8.0.1/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include -I/c/users/spaceim/.conan/data/proj/8.0.0/_/_/package/08d1464a92521f5bb1572c2bc47dc0fdfb2fee18/include -I/c/users/spaceim/.conan/data/libtiff/4.2.0/_/_/package/86e60160c8864fef055a710ea6a89597d0be1ec4/include -I/c/users/spaceim/.conan/data/sqlite3/3.35.5/_/_/package/988c4f294f61014a6e87e62fc0cdb9c6deac7fc5/include -I/c/users/spaceim/.conan/data/libcurl/7.75.0/_/_/package/19bf39221c1cbb3854ffd2c5a0fa73945e13669f/include -I/c/users/spaceim/.conan/data/zlib/1.2.11/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include -I/c/users/spaceim/.conan/data/libdeflate/1.7/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include -I/c/users/spaceim/.conan/data/xz_utils/5.2.5/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include -I/c/users/spaceim/.conan/data/libjpeg/9d/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include -I/c/users/spaceim/.conan/data/jbig/20160605/_/_/package/3ce8f2bc8c30ae20c031c2d57dd71fc3f331ca52/include -I/c/users/spaceim/.conan/data/zstd/1.4.8/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include -I/c/users/spaceim/.conan/data/libwebp/1.1.0/_/_/package/88bc9c35d8c46a858605dacc7c891c6df84e178a/include -I/c/users/spaceim/.conan/data/openssl/1.1.1j/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/include -DLIBDEFLATE_DLL -DUSE_UNSTABLE_GEOS_CPP_API -DGEOS_INLINE -DTTMATH_NOASM -DLIBLTDL_DLL_IMPORT -DNDEBUG -D_GLIBCXX_USE_CXX11_ABI=1 -pthread -pthread -m64 -L/c/users/spaceim/.conan/data/libtool/2.4.6/_/_/package/6ed756b5c4c6595a67aaf3080ad44742d17c6855/lib -L/c/users/spaceim/.conan/data/pkgconf/1.7.3/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/lib -L/c/users/spaceim/.conan/data/json-c/0.15/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/lib -L/c/users/spaceim/.conan/data/libgeotiff/1.6.0/_/_/package/dd3498f918b720d2c4fe42074ef5f0c9b543690f/lib -L/c/users/spaceim/.conan/data/flatbuffers/1.12.0/_/_/package/a5c799107dfb025c5f6ba6c4de7c4777289b9cfc/lib -L/c/users/spaceim/.conan/data/libiconv/1.16/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/lib -L/c/users/spaceim/.conan/data/libpng/1.6.37/_/_/package/c5964d2abbfc2b4d0222455155600df3a88a1eeb/lib -L/c/users/spaceim/.conan/data/giflib/5.2.1/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/lib -L/c/users/spaceim/.conan/data/geos/3.9.1/_/_/package/4db7ebae6aa4f675076260c9f4cd7bbb21de70d0/lib -L/c/users/spaceim/.conan/data/qhull/8.0.1/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/lib -L/c/users/spaceim/.conan/data/proj/8.0.0/_/_/package/08d1464a92521f5bb1572c2bc47dc0fdfb2fee18/lib -L/c/users/spaceim/.conan/data/libtiff/4.2.0/_/_/package/86e60160c8864fef055a710ea6a89597d0be1ec4/lib -L/c/users/spaceim/.conan/data/sqlite3/3.35.5/_/_/package/988c4f294f61014a6e87e62fc0cdb9c6deac7fc5/lib -L/c/users/spaceim/.conan/data/libcurl/7.75.0/_/_/package/19bf39221c1cbb3854ffd2c5a0fa73945e13669f/lib -L/c/users/spaceim/.conan/data/zlib/1.2.11/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/lib -L/c/users/spaceim/.conan/data/libdeflate/1.7/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/lib -L/c/users/spaceim/.conan/data/xz_utils/5.2.5/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/lib -L/c/users/spaceim/.conan/data/libjpeg/9d/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/lib -L/c/users/spaceim/.conan/data/jbig/20160605/_/_/package/3ce8f2bc8c30ae20c031c2d57dd71fc3f331ca52/lib -L/c/users/spaceim/.conan/data/zstd/1.4.8/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/lib -L/c/users/spaceim/.conan/data/libwebp/1.1.0/_/_/package/88bc9c35d8c46a858605dacc7c891c6df84e178a/lib -L/c/users/spaceim/.conan/data/openssl/1.1.1j/_/_/package/6d6a09992dfc5981848046ddfdfcb54e8e2ee05f/lib conftest.c -lltdl.a -lpkgconf -ljson-c.dll -lgeotiff.dll -lflatbuffers.dll -liconv -lcharset -lpng -lgif.dll -lgeos_c -lgeos -lqhull -lproj.dll -ltiffxx.dll -ltiff.dll -lsqlite3.dll -lcurl -lzlib -llibdeflate -llzma.dll -ljpeg -ljbig -lzstd.dll -lwebpdecoder.dll -lwebpdemux.dll -lwebpmux.dll -lwebp.dll -lssl -lcrypto -lshell32 -lOle32 -lcrypt32 -lws2_32 -ladvapi32 -luser32 >&5
c:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.3.0/../../../../x86_64-w64-mingw32/bin/ld.exe: cannot find -lltdl.a
```

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
