### PR TITLE
gdal: better mingw support + sqlite3 by default + bump dependencies

### DIFF
--- a/recipes/gdal/all/conandata.yml
+++ b/recipes/gdal/all/conandata.yml
@@ -64,3 +64,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/3.2.x/fix-include-xerces.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/3.2.x/fix-ogrelasticlayer-gcc-less-5.patch"
+      base_path: "source_subfolder"

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -122,7 +122,7 @@ class GdalConan(ConanFile):
         "with_curl": False,
         "with_xml2": False,
         # "with_spatialite": False,
-        "with_sqlite3": False,
+        "with_sqlite3": True,
         # "with_rasterlite2": False,
         "with_pcre": False,
         # "with_epsilon": False,

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -217,7 +217,7 @@ class GdalConan(ConanFile):
         self.requires("libgeotiff/1.6.0")
         # self.requires("libopencad/0.0.2") # TODO: use conan recipe when available instead of internal one
         self.requires("libtiff/4.2.0")
-        self.requires("proj/7.2.1")
+        self.requires("proj/8.0.0")
         if tools.Version(self.version) >= "3.1.0":
             self.requires("flatbuffers/1.12.0")
         if self.options.get_safe("with_zlib", True):
@@ -227,9 +227,9 @@ class GdalConan(ConanFile):
         if self.options.get_safe("with_libiconv", True):
             self.requires("libiconv/1.16")
         if self.options.get_safe("with_zstd"):
-            self.requires("zstd/1.4.8")
+            self.requires("zstd/1.4.9")
         if self.options.with_pg:
-            self.requires("libpq/13.1")
+            self.requires("libpq/13.2")
         # if self.options.with_libgrass:
         #     self.requires("libgrass/x.x.x")
         if self.options.with_cfitsio:
@@ -247,7 +247,7 @@ class GdalConan(ConanFile):
         if self.options.with_jpeg == "libjpeg":
             self.requires("libjpeg/9d")
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/2.0.6")
+            self.requires("libjpeg-turbo/2.1.0")
         if self.options.with_charls:
             self.requires("charls/2.1.0")
         if self.options.with_gif:
@@ -267,7 +267,7 @@ class GdalConan(ConanFile):
         if self.options.with_netcdf:
             self.requires("netcdf/4.7.4")
         if self.options.with_jasper:
-            self.requires("jasper/2.0.25")
+            self.requires("jasper/2.0.32")
         if self.options.with_openjpeg:
             self.requires("openjpeg/2.4.0")
         # if self.options.with_fgdb:
@@ -275,11 +275,11 @@ class GdalConan(ConanFile):
         if self.options.with_mysql == "libmysqlclient":
             self.requires("libmysqlclient/8.0.17")
         elif self.options.with_mysql == "mariadb-connector-c":
-            self.requires("mariadb-connector-c/3.1.11")
+            self.requires("mariadb-connector-c/3.1.12")
         if self.options.with_xerces:
             self.requires("xerces-c/3.2.3")
         if self.options.with_expat:
-            self.requires("expat/2.2.10")
+            self.requires("expat/2.3.0")
         if self.options.with_libkml:
             self.requires("libkml/1.3.0")
         if self.options.with_odbc and self.settings.os != "Windows":
@@ -287,13 +287,13 @@ class GdalConan(ConanFile):
         # if self.options.with_dods_root:
         #     self.requires("libdap/3.20.6")
         if self.options.with_curl:
-            self.requires("libcurl/7.74.0")
+            self.requires("libcurl/7.75.0")
         if self.options.with_xml2:
             self.requires("libxml2/2.9.10")
         # if self.options.with_spatialite:
         #     self.requires("libspatialite/4.3.0a")
         if self.options.get_safe("with_sqlite3"):
-            self.requires("sqlite3/3.34.1")
+            self.requires("sqlite3/3.35.5")
         # if self.options.with_rasterlite2:
         #     self.requires("rasterlite2/x.x.x")
         if self.options.get_safe("with_pcre"):
@@ -301,9 +301,9 @@ class GdalConan(ConanFile):
         # if self.options.with_epsilon:
         #     self.requires("epsilon/0.9.2")
         if self.options.with_webp:
-            self.requires("libwebp/1.1.0")
+            self.requires("libwebp/1.2.0")
         if self.options.with_geos:
-            self.requires("geos/3.9.0")
+            self.requires("geos/3.9.1")
         # if self.options.with_sfcgal:
         #     self.requires("sfcgal/1.3.7")
         if self.options.with_qhull:
@@ -316,7 +316,7 @@ class GdalConan(ConanFile):
         if self.options.with_poppler:
             self.requires("poppler/20.09.0")
         if self.options.with_podofo:
-            self.requires("podofo/0.9.6")
+            self.requires("podofo/0.9.7")
         # if self.options.with_pdfium:
         #     self.requires("pdfium/x.x.x")
         # if self.options.get_safe("with_tiledb"):
@@ -326,13 +326,13 @@ class GdalConan(ConanFile):
         # if self.options.with_armadillo:
         #     self.requires("armadillo/9.880.1")
         if self.options.with_cryptopp:
-            self.requires("cryptopp/8.4.0")
+            self.requires("cryptopp/8.5.0")
         if self.options.with_crypto:
-            self.requires("openssl/1.1.1i")
+            self.requires("openssl/1.1.1k")
         # if not self.options.without_lerc:
         #     self.requires("lerc/2.1") # TODO: use conan recipe (not possible yet because lerc API is broken for GDAL)
         if self.options.get_safe("with_exr"):
-            self.requires("openexr/2.5.4")
+            self.requires("openexr/2.5.5")
         if self.options.get_safe("with_heif"):
             self.requires("libheif/1.11.0")
 

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -341,6 +341,8 @@ class GdalConan(ConanFile):
             raise ConanInvalidConfiguration("gdal depends on non-reentrant qhull.")
 
     def _validate_dependency_graph(self):
+        if tools.Version(self.deps_cpp_info["libtiff"].version) < "4.0.0":
+            raise ConanInvalidConfiguration("gdal {} requires libtiff >= 4.0.0".format(self.version))
         if self.options.with_mongocxx:
             mongocxx_version = tools.Version(self.deps_cpp_info["mongo-cxx-driver"].version)
             if mongocxx_version < "3.0.0":

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -4,7 +4,7 @@ import os
 from conans import ConanFile, AutoToolsBuildEnvironment, VisualStudioBuildEnvironment, tools
 from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.32.0"
+required_conan_version = ">=1.33.0"
 
 
 class GdalConan(ConanFile):
@@ -359,8 +359,8 @@ class GdalConan(ConanFile):
                 self.build_requires("msys2/20200517")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -217,7 +217,7 @@ class GdalConan(ConanFile):
         self.requires("libgeotiff/1.6.0")
         # self.requires("libopencad/0.0.2") # TODO: use conan recipe when available instead of internal one
         self.requires("libtiff/4.2.0")
-        self.requires("proj/8.0.0")
+        self.requires("proj/8.0.1")
         if tools.Version(self.version) >= "3.1.0":
             self.requires("flatbuffers/1.12.0")
         if self.options.get_safe("with_zlib", True):
@@ -334,7 +334,7 @@ class GdalConan(ConanFile):
         if self.options.get_safe("with_exr"):
             self.requires("openexr/2.5.5")
         if self.options.get_safe("with_heif"):
-            self.requires("libheif/1.11.0")
+            self.requires("libheif/1.12.0")
 
     def validate(self):
         if self.options.with_qhull and self.options["qhull"].reentrant:

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -354,9 +354,9 @@ class GdalConan(ConanFile):
     def build_requirements(self):
         if self.settings.compiler != "Visual Studio":
             self.build_requires("libtool/2.4.6")
-            self.build_requires("pkgconf/1.7.3")
+            self.build_requires("pkgconf/1.7.4")
             if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
-                self.build_requires("msys2/20200517")
+                self.build_requires("msys2/cci.latest")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/gdal/all/patches/3.2.x/fix-ogrelasticlayer-gcc-less-5.patch
+++ b/recipes/gdal/all/patches/3.2.x/fix-ogrelasticlayer-gcc-less-5.patch
@@ -1,0 +1,43 @@
+Fix compilation failure in elastic driver with gcc < 5 in GDAL 3.2.1
+patch from https://github.com/OSGeo/gdal/pull/3440
+
+--- a/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
++++ b/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+@@ -3507,21 +3507,16 @@ OGRErr OGRElasticLayer::GetExtent(int iGeomField, OGREnvelope *psExtent, int bFo
+         return OGRERR_FAILURE;
+     }
+ 
+-    const auto DefaultGetExtent = [this, iGeomField, psExtent, bForce]()
+-    {
+-        m_bUseSingleQueryParams = true;
+-        const auto eRet = OGRLayer::GetExtentInternal(iGeomField, psExtent, bForce);
+-        m_bUseSingleQueryParams = false;
+-        return eRet;
+-    };
+-
+     // geo_shape aggregation is only available since ES 7.8, but only with XPack
+     // for now
+     if( !m_abIsGeoPoint[iGeomField] &&
+         !(m_poDS->m_nMajorVersion > 7 ||
+             (m_poDS->m_nMajorVersion == 7 && m_poDS->m_nMinorVersion >= 8)) )
+     {
+-        return DefaultGetExtent();
++        m_bUseSingleQueryParams = true;
++        const auto eRet = OGRLayer::GetExtentInternal(iGeomField, psExtent, bForce);
++        m_bUseSingleQueryParams = false;
++        return eRet;
+     }
+ 
+     CPLString osFilter = CPLSPrintf("{ \"size\": 0, \"aggs\" : { \"bbox\" : { \"geo_bounds\" : { \"field\" : \"%s\" } } } }",
+@@ -3564,7 +3559,10 @@ OGRErr OGRElasticLayer::GetExtent(int iGeomField, OGREnvelope *psExtent, int bFo
+     if( poTopLeftLon == nullptr || poTopLeftLat == nullptr ||
+         poBottomRightLon == nullptr || poBottomRightLat == nullptr )
+     {
+-        eErr = DefaultGetExtent();
++        m_bUseSingleQueryParams = true;
++        const auto eRet = OGRLayer::GetExtentInternal(iGeomField, psExtent, bForce);
++        m_bUseSingleQueryParams = false;
++        return eRet;
+     }
+     else
+     {


### PR DESCRIPTION
Specify library name and version:  **gdal/all**

Several fixes are addressed in one PR, since GDAL is always hard to build in CI of CCI:

- fix build issues with MinGW:
  - `zlib` can be silently disabled because upstream `configure` use AC_CHECK_LIB  with -lz, but libz is not the name of zlib in conan recipe for MinGW.
  - surprisingly, `pkgconf` fails to find .pc files on Windows only, so `PKG_CONFIG_PATH` is forced with unix path of build folder (unix path is important, I tried without and it fails).
  - ~when we ask for shared GDAL, libtool fallbacks to an ill-formed static lib, because it wants all dependencies of GDAL to be shared. This expectation of libtool is so wrong, I don't know why it works like this.
  Anyway, generated libtool -after configure step- can be fixed to not perform these checks, and link static lib into the shared lib (we just need to change the value of `deplibs_check_method` variable to be `pass_all`).~ Maybe we could fix `libtool.m4` in `libtool` recipe instead (but GDAL has also its own copy of `libtool.m4`, so I don't know if it would be sufficient => EDIT: yes it works) => EDIT: fix is delegated to libtool recipe https://github.com/conan-io/conan-center-index/pull/5381
- inject environment variables in autotools build (for LD_LIBRARY_PATH & PATH): useful when build requirements executables could have be linked with shared libs, like `pkgconf` for example.
- add a verification of `libtiff` version, gdal needs libtiff >= 4.0.0, otherwise it fallbacks to vendored libtiff (and fails because we remove those files).
- enable `with_sqlite3` option by default, it's the default value in upstream `ax_lib_sqlite3.m4` actually.
- tiny fix for elastic driver compilation in 3.2.1 with gcc < 5 (upstream PR: https://github.com/OSGeo/gdal/pull/3440)
- bump dependencies (the most important being `proj`, major version is updated to latest).
- ~try to build gdal 3.1.2 with Visual Studio < 2019. At least I can tell that it works in github action for Visual Studio 2017: https://github.com/SpaceIm/conan-gdal/runs/2474046858?check_suite_focus=true.~ It should work if Visual Studio 2015 & 2017 agents have ATL installed now (needs https://github.com/conan-io/conan-center-index/issues/4195) => well not yet fixed in CI of CCI

Since this PR rebuild all versions, it should fix these PR:
closes https://github.com/conan-io/conan-center-index/issues/5017
closes https://github.com/conan-io/conan-center-index/issues/4902


---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
