### PR TITLE
Add BehaviorTree.CPP 3.5.6

### DIFF
--- a/recipes/behaviortree.cpp/all/CMakeLists.txt
+++ b/recipes/behaviortree.cpp/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/behaviortree.cpp/all/conandata.yml
+++ b/recipes/behaviortree.cpp/all/conandata.yml
@@ -10,3 +10,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0003-no-werror.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0004-win-sigaction.patch"
+      base_path: "source_subfolder"

--- a/recipes/behaviortree.cpp/all/conandata.yml
+++ b/recipes/behaviortree.cpp/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
-  3.5.6:
-    sha256: 543c428602b5acb7c5666aee34feb532e18ce7200870a79b23ff9aed17ee84c4
-    url: https://github.com/BehaviorTree/BehaviorTree.CPP/archive/refs/tags/3.5.6.tar.gz
+  "3.5.6":
+    sha256: "543c428602b5acb7c5666aee34feb532e18ce7200870a79b23ff9aed17ee84c4"
+    url: "https://github.com/BehaviorTree/BehaviorTree.CPP/archive/refs/tags/3.5.6.tar.gz"
+patches:
+  "3.5.6":
+    - patch_file: "patches/0001-remove-fpic.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-find-zmq.patch"
+      base_path: "source_subfolder"

--- a/recipes/behaviortree.cpp/all/conandata.yml
+++ b/recipes/behaviortree.cpp/all/conandata.yml
@@ -8,3 +8,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0002-find-zmq.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0003-no-werror.patch"
+      base_path: "source_subfolder"

--- a/recipes/behaviortree.cpp/all/conandata.yml
+++ b/recipes/behaviortree.cpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  3.5.6:
+    sha256: 543c428602b5acb7c5666aee34feb532e18ce7200870a79b23ff9aed17ee84c4
+    url: https://github.com/BehaviorTree/BehaviorTree.CPP/archive/refs/tags/3.5.6.tar.gz

--- a/recipes/behaviortree.cpp/all/conanfile.py
+++ b/recipes/behaviortree.cpp/all/conanfile.py
@@ -68,7 +68,8 @@ class BehaviorTreeCPPConan(ConanFile):
             check_min_cppstd(self, self._minimum_cppstd_required)
         minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
         if not minimum_version:
-            self.output.warn("BehaviorTree.CPP requires C++14. Your compiler is unknown. Assuming it supports C++14.")
+            self.output.warn("BehaviorTree.CPP requires C++{}. Your compiler is unknown. Assuming it supports C++14."
+                             .format(self._minimum_cppstd_required))
         elif tools.Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("BehaviorTree.CPP requires C++{}, which your compiler does not support."
                                             .format(self._minimum_cppstd_required))
@@ -106,5 +107,5 @@ class BehaviorTreeCPPConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "BT"
         self.cpp_info.components["behaviortree_cpp_v3"].libs = ["behaviortree_cpp_v3" + postfix]
         self.cpp_info.components["behaviortree_cpp_v3"].requires = ["zeromq::zeromq", "cppzmq::cppzmq", "boost::coroutine", "ncurses::ncurses"]
-        if self.settings.os == "Linux":
+        if self.settings.os in ("Linux", "FreeBSD"):
             self.cpp_info.components["behaviortree_cpp_v3"].system_libs.append("pthread")

--- a/recipes/behaviortree.cpp/all/conanfile.py
+++ b/recipes/behaviortree.cpp/all/conanfile.py
@@ -62,6 +62,8 @@ class BehaviorTreeCPPConan(ConanFile):
     def validate(self):
         if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration("BehaviorTree.CPP can not be built as shared on Windows.")
+        elif self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) < "12":
+            raise ConanInvalidConfiguration("Requires Apple Clang 12 or higher.")
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._minimum_cppstd_required)
         minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)

--- a/recipes/behaviortree.cpp/all/conanfile.py
+++ b/recipes/behaviortree.cpp/all/conanfile.py
@@ -17,7 +17,7 @@ class BehaviorTreeCPPConan(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
     generators = "cmake", "cmake_find_package"
-    exports_sources = "CMakeLists.txt"
+    exports_sources = ["CMakeLists.txt", "patches/*"]
     _cmake = None
 
     @property
@@ -80,16 +80,9 @@ class BehaviorTreeCPPConan(ConanFile):
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
-    def _patch_sources(self):
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              "set(CMAKE_POSITION_INDEPENDENT_CODE ON)", "")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              "ZMQ", "ZeroMQ")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "tools", "CMakeLists.txt"),
-                              "ZMQ", "ZeroMQ")
-
     def build(self):
-        self._patch_sources()
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/behaviortree.cpp/all/conanfile.py
+++ b/recipes/behaviortree.cpp/all/conanfile.py
@@ -38,7 +38,7 @@ class BehaviorTreeCPPConan(ConanFile):
             "Visual Studio": "15",
             "gcc": "5",
             "clang": "5",
-            "apple-clang": "5.1",
+            "apple-clang": "12",
         }
 
     def source(self):

--- a/recipes/behaviortree.cpp/all/conanfile.py
+++ b/recipes/behaviortree.cpp/all/conanfile.py
@@ -62,8 +62,6 @@ class BehaviorTreeCPPConan(ConanFile):
     def validate(self):
         if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration("BehaviorTree.CPP can not be built as shared on Windows.")
-        elif self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) < "12":
-            raise ConanInvalidConfiguration("Requires Apple Clang 12 or higher.")
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._minimum_cppstd_required)
         minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)

--- a/recipes/behaviortree.cpp/all/conanfile.py
+++ b/recipes/behaviortree.cpp/all/conanfile.py
@@ -85,7 +85,7 @@ class BehaviorTreeCPPConan(ConanFile):
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses")
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "BehaviorTreeV3"))

--- a/recipes/behaviortree.cpp/all/conanfile.py
+++ b/recipes/behaviortree.cpp/all/conanfile.py
@@ -1,0 +1,106 @@
+import os
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+
+
+conan_minimum_required = ">=1.33.0"
+
+
+class BehaviorTreeCPPConan(ConanFile):
+    name = "behaviortree.cpp"
+    license = "MIT"
+    homepage = "https://github.com/BehaviorTree/BehaviorTree.CPP"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("ai", "robotics", "games", "coordination")
+    description = "This C++ library provides a framework to create BehaviorTrees"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+    generators = "cmake", "cmake_find_package"
+    exports_sources = "CMakeLists.txt"
+    requires = "cppzmq/4.7.1", "boost/1.76.0", "ncurses/6.2"
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    @property
+    def _minimum_compilers_version(self):
+        return {
+            "Visual Studio": "15",
+            "gcc": "5",
+            "clang": "5",
+            "apple-clang": "5.1",
+        }
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True,
+                  destination=self._source_subfolder)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def validate(self):
+        if self.settings.os == "Windows" and self.options.shared:
+            raise ConanInvalidConfiguration("BehaviorTree.CPP can not be built as shared on Windows.")
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, "14")
+        minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
+        if not minimum_version:
+            self.output.warn("BehaviorTree.CPP requires C++14. Your compiler is unknown. Assuming it supports C++14.")
+        elif tools.Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration("BehaviorTree.CPP requires C++14, which your compiler does not support.")
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["BUILD_EXAMPLES"] = False
+        self._cmake.definitions["BUILD_UNIT_TESTS"] = False
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def _patch_sources(self):
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              "set(CMAKE_POSITION_INDEPENDENT_CODE ON)", "")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              "ZMQ", "ZeroMQ")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "tools", "CMakeLists.txt"),
+                              "ZMQ", "ZeroMQ")
+
+    def build(self):
+        self._patch_sources()
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "BehaviorTreeV3"))
+
+    def package_info(self):
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH env var with : {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)
+
+        postfix = "d" if self.settings.os == "Windows" and self.settings.build_type == "Debug" else ""
+        self.cpp_info.filenames["cmake_find_package"] = "BehaviorTreeV3"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "BehaviorTreeV3"
+        self.cpp_info.names["cmake_find_package"] = "BT"
+        self.cpp_info.names["cmake_find_package_multi"] = "BT"
+        self.cpp_info.components["behaviortree_cpp_v3"].libs = ["behaviortree_cpp_v3" + postfix]
+        self.cpp_info.components["behaviortree_cpp_v3"].requires = ["cppzmq::cppzmq", "boost::coroutine", "ncurses::ncurses"]
+        if self.settings.os == "Linux":
+            self.cpp_info.components["behaviortree_cpp_v3"].system_libs.append("pthread")

--- a/recipes/behaviortree.cpp/all/patches/0001-remove-fpic.patch
+++ b/recipes/behaviortree.cpp/all/patches/0001-remove-fpic.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a390aed..aff91ec 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,7 +36,6 @@ if(NOT DEFINED BT_COROUTINES)
+     add_definitions(-DBT_NO_COROUTINES)
+ endif()
+ 
+-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ 
+ #---- project configuration ----
+ option(BUILD_EXAMPLES   "Build tutorials and examples" ON)

--- a/recipes/behaviortree.cpp/all/patches/0002-find-zmq.patch
+++ b/recipes/behaviortree.cpp/all/patches/0002-find-zmq.patch
@@ -1,0 +1,68 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index aff91ec..242c214 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,14 +45,14 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+ 
+ #---- Find other packages ----
+ find_package(Threads)
+-find_package(ZMQ)
++find_package(ZeroMQ)
+ 
+ list(APPEND BEHAVIOR_TREE_PUBLIC_LIBRARIES
+     ${CMAKE_THREAD_LIBS_INIT}
+     ${CMAKE_DL_LIBS}
+ )
+ 
+-if( ZMQ_FOUND )
++if( ZeroMQ_FOUND )
+     message(STATUS "ZeroMQ found.")
+     add_definitions( -DZMQ_FOUND )
+     list(APPEND BT_SOURCE src/loggers/bt_zmq_publisher.cpp)
+@@ -202,8 +202,8 @@ if (WIN32)
+     add_library(${BEHAVIOR_TREE_LIBRARY} STATIC ${BT_SOURCE} )
+ endif()
+ 
+-if( ZMQ_FOUND )
+-    list(APPEND BUILD_TOOL_INCLUDE_DIRS ${ZMQ_INCLUDE_DIRS})
++if( ZeroMQ_FOUND )
++    list(APPEND BUILD_TOOL_INCLUDE_DIRS ${ZeroMQ_INCLUDE_DIRS})
+ endif()
+ 
+ target_link_libraries(${BEHAVIOR_TREE_LIBRARY} PUBLIC
+@@ -211,7 +211,7 @@ target_link_libraries(${BEHAVIOR_TREE_LIBRARY} PUBLIC
+ 
+ target_link_libraries(${BEHAVIOR_TREE_LIBRARY} PRIVATE
+     ${Boost_LIBRARIES}
+-    ${ZMQ_LIBRARIES})
++    ${ZeroMQ_LIBRARIES})
+ 
+ #get_target_property(my_libs ${BEHAVIOR_TREE_LIBRARY} INTERFACE_LINK_LIBRARIES)
+ #list(REMOVE_ITEM _libs X)
+@@ -227,8 +227,8 @@ target_include_directories(${BEHAVIOR_TREE_LIBRARY} PUBLIC
+     $<INSTALL_INTERFACE:include>
+     ${BUILD_TOOL_INCLUDE_DIRS})
+ 
+-if( ZMQ_FOUND )
+-    target_compile_definitions(${BEHAVIOR_TREE_LIBRARY} PUBLIC ZMQ_FOUND)
++if( ZeroMQ_FOUND )
++    target_compile_definitions(${BEHAVIOR_TREE_LIBRARY} PUBLIC ZeroMQ_FOUND)
+ endif()
+ 
+ if(MSVC)
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index 0801850..153b447 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -6,9 +6,9 @@ target_link_libraries(bt3_log_cat  ${BEHAVIOR_TREE_LIBRARY} )
+ install(TARGETS bt3_log_cat
+         DESTINATION ${BEHAVIOR_TREE_BIN_DESTINATION} )
+ 
+-if( ZMQ_FOUND )
++if( ZeroMQ_FOUND )
+     add_executable(bt3_recorder         bt_recorder.cpp )
+-    target_link_libraries(bt3_recorder  ${BEHAVIOR_TREE_LIBRARY} ${ZMQ_LIBRARIES})
++    target_link_libraries(bt3_recorder  ${BEHAVIOR_TREE_LIBRARY} ${ZeroMQ_LIBRARIES})
+     install(TARGETS bt3_recorder
+             DESTINATION ${BEHAVIOR_TREE_BIN_DESTINATION} )
+ endif()

--- a/recipes/behaviortree.cpp/all/patches/0003-no-werror.patch
+++ b/recipes/behaviortree.cpp/all/patches/0003-no-werror.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 242c214..cb8d77a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -232,10 +232,10 @@ if( ZeroMQ_FOUND )
+ endif()
+ 
+ if(MSVC)
+-    target_compile_options(${BEHAVIOR_TREE_LIBRARY} PRIVATE /W3 /WX)
++    target_compile_options(${BEHAVIOR_TREE_LIBRARY} PRIVATE /W3)
+ else()
+     target_compile_options(${BEHAVIOR_TREE_LIBRARY} PRIVATE
+-        -Wall -Wextra -Werror=return-type)
++        -Wall -Wextra)
+ endif()
+ 
+ ######################################################

--- a/recipes/behaviortree.cpp/all/patches/0004-win-sigaction.patch
+++ b/recipes/behaviortree.cpp/all/patches/0004-win-sigaction.patch
@@ -1,5 +1,5 @@
 diff --git a/tools/bt_recorder.cpp b/tools/bt_recorder.cpp
-index 29511e49..e5015286 100644
+index 3aa6740..4b36414 100644
 --- a/tools/bt_recorder.cpp
 +++ b/tools/bt_recorder.cpp
 @@ -16,12 +16,17 @@ static void s_signal_handler(int)
@@ -14,8 +14,8 @@ index 29511e49..e5015286 100644
      action.sa_handler = s_signal_handler;
      action.sa_flags = 0;
      sigemptyset(&action.sa_mask);
-     sigaction(SIGINT, &action, nullptr);
-     sigaction(SIGTERM, &action, nullptr);
+     sigaction(SIGINT, &action, NULL);
+     sigaction(SIGTERM, &action, NULL);
 +#endif
  }
  

--- a/recipes/behaviortree.cpp/all/patches/0004-win-sigaction.patch
+++ b/recipes/behaviortree.cpp/all/patches/0004-win-sigaction.patch
@@ -1,0 +1,22 @@
+diff --git a/tools/bt_recorder.cpp b/tools/bt_recorder.cpp
+index 29511e49..e5015286 100644
+--- a/tools/bt_recorder.cpp
++++ b/tools/bt_recorder.cpp
+@@ -16,12 +16,17 @@ static void s_signal_handler(int)
+ 
+ static void CatchSignals(void)
+ {
++#ifdef _WIN32
++    signal(SIGINT, s_signal_handler);
++    signal(SIGTERM, s_signal_handler);
++#else
+     struct sigaction action;
+     action.sa_handler = s_signal_handler;
+     action.sa_flags = 0;
+     sigemptyset(&action.sa_mask);
+     sigaction(SIGINT, &action, nullptr);
+     sigaction(SIGTERM, &action, nullptr);
++#endif
+ }
+ 
+ int main(int argc, char* argv[])

--- a/recipes/behaviortree.cpp/all/test_package/CMakeLists.txt
+++ b/recipes/behaviortree.cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(BehaviorTreeV3 CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} BT::behaviortree_cpp_v3)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)

--- a/recipes/behaviortree.cpp/all/test_package/conanfile.py
+++ b/recipes/behaviortree.cpp/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/behaviortree.cpp/all/test_package/conanfile.py
+++ b/recipes/behaviortree.cpp/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import CMake, ConanFile, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/behaviortree.cpp/all/test_package/test_package.cpp
+++ b/recipes/behaviortree.cpp/all/test_package/test_package.cpp
@@ -2,70 +2,51 @@
 
 using namespace BT;
 
-/* This tutorial will teach you how to deal with ports when its
- *  type is not std::string.
-*/
-
-
-// We want to be able to use this custom type
 struct Position2D { double x,y; };
 
-// It is recommended (or, in some cases, mandatory) to define a template
-// specialization of convertFromString that converts a string to Position2D.
-namespace BT
-{
-template <> inline Position2D convertFromString(StringView str)
-{
-    printf("Converting string: \"%s\"\n", str.data() );
+namespace BT{
+    template <> inline Position2D convertFromString(StringView str) {
+        printf("Converting string: \"%s\"\n", str.data() );
 
-    // real numbers separated by semicolons
-    auto parts = splitString(str, ';');
-    if (parts.size() != 2)
-    {
-        throw RuntimeError("invalid input)");
-    }
-    else{
-        Position2D output;
-        output.x     = convertFromString<double>(parts[0]);
-        output.y     = convertFromString<double>(parts[1]);
-        return output;
+        // real numbers separated by semicolons
+        auto parts = splitString(str, ';');
+        if (parts.size() != 2)
+        {
+            throw RuntimeError("invalid input)");
+        }
+        else{
+            Position2D output;
+            output.x     = convertFromString<double>(parts[0]);
+            output.y     = convertFromString<double>(parts[1]);
+            return output;
+        }
     }
 }
-} // end namespace BT
 
-
-class CalculateGoal: public SyncActionNode
-{
+class CalculateGoal: public SyncActionNode{
 public:
     CalculateGoal(const std::string& name, const NodeConfiguration& config):
-        SyncActionNode(name,config)
-    {}
+        SyncActionNode(name,config) {}
 
-    NodeStatus tick() override
-    {
+    NodeStatus tick() override{
         Position2D mygoal = {1.1, 2.3};
         setOutput("goal", mygoal);
         return NodeStatus::SUCCESS;
     }
-    static PortsList providedPorts()
-    {
+    static PortsList providedPorts(){
         return { OutputPort<Position2D>("goal") };
     }
 };
 
 
-class PrintTarget: public SyncActionNode
-{
+class PrintTarget: public SyncActionNode {
 public:
     PrintTarget(const std::string& name, const NodeConfiguration& config):
-        SyncActionNode(name,config)
-    {}
+        SyncActionNode(name,config) {}
 
-    NodeStatus tick() override
-    {
+    NodeStatus tick() override {
         auto res = getInput<Position2D>("target");
-        if( !res )
-        {
+        if( !res ){
             throw RuntimeError("error reading port [target]:", res.error() );
         }
         Position2D goal = res.value();
@@ -73,31 +54,13 @@ public:
         return NodeStatus::SUCCESS;
     }
 
-    static PortsList providedPorts()
-    {
+    static PortsList providedPorts() {
         // Optionally, a port can have a human readable description
         const char*  description = "Simply print the target on console...";
         return { InputPort<Position2D>("target", description) };
     }
 };
 
-//----------------------------------------------------------------
-
-/** The tree is a Sequence of 4 actions
-*  1) Store a value of Position2D in the entry "GoalPosition"
-*     using the action CalculateGoal.
-*
-*  2) Call PrintTarget. The input "target" will be read from the Blackboard
-*     entry "GoalPosition".
-*
-*  3) Use the built-in action SetBlackboard to write the key "OtherGoal".
-*     A conversion from string to Position2D will be done under the hood.
-*
-*  4) Call PrintTarget. The input "goal" will be read from the Blackboard
-*     entry "OtherGoal".
-*/
-
-// clang-format off
 static const char* xml_text = R"(
  <root main_tree_to_execute = "MainTree" >
      <BehaviorTree ID="MainTree">
@@ -111,10 +74,8 @@ static const char* xml_text = R"(
  </root>
  )";
 
-// clang-format on
 
-int main()
-{
+int main() {
     using namespace BT;
 
     BehaviorTreeFactory factory;
@@ -123,12 +84,5 @@ int main()
 
     auto tree = factory.createTreeFromText(xml_text);
     tree.tickRoot();
-
-/* Expected output:
- *
-    Target positions: [ 1.1, 2.3 ]
-    Converting string: "-1;3"
-    Target positions: [ -1.0, 3.0 ]
-*/
     return 0;
 }

--- a/recipes/behaviortree.cpp/all/test_package/test_package.cpp
+++ b/recipes/behaviortree.cpp/all/test_package/test_package.cpp
@@ -1,0 +1,134 @@
+#include "behaviortree_cpp_v3/bt_factory.h"
+
+using namespace BT;
+
+/* This tutorial will teach you how to deal with ports when its
+ *  type is not std::string.
+*/
+
+
+// We want to be able to use this custom type
+struct Position2D { double x,y; };
+
+// It is recommended (or, in some cases, mandatory) to define a template
+// specialization of convertFromString that converts a string to Position2D.
+namespace BT
+{
+template <> inline Position2D convertFromString(StringView str)
+{
+    printf("Converting string: \"%s\"\n", str.data() );
+
+    // real numbers separated by semicolons
+    auto parts = splitString(str, ';');
+    if (parts.size() != 2)
+    {
+        throw RuntimeError("invalid input)");
+    }
+    else{
+        Position2D output;
+        output.x     = convertFromString<double>(parts[0]);
+        output.y     = convertFromString<double>(parts[1]);
+        return output;
+    }
+}
+} // end namespace BT
+
+
+class CalculateGoal: public SyncActionNode
+{
+public:
+    CalculateGoal(const std::string& name, const NodeConfiguration& config):
+        SyncActionNode(name,config)
+    {}
+
+    NodeStatus tick() override
+    {
+        Position2D mygoal = {1.1, 2.3};
+        setOutput("goal", mygoal);
+        return NodeStatus::SUCCESS;
+    }
+    static PortsList providedPorts()
+    {
+        return { OutputPort<Position2D>("goal") };
+    }
+};
+
+
+class PrintTarget: public SyncActionNode
+{
+public:
+    PrintTarget(const std::string& name, const NodeConfiguration& config):
+        SyncActionNode(name,config)
+    {}
+
+    NodeStatus tick() override
+    {
+        auto res = getInput<Position2D>("target");
+        if( !res )
+        {
+            throw RuntimeError("error reading port [target]:", res.error() );
+        }
+        Position2D goal = res.value();
+        printf("Target positions: [ %.1f, %.1f ]\n", goal.x, goal.y );
+        return NodeStatus::SUCCESS;
+    }
+
+    static PortsList providedPorts()
+    {
+        // Optionally, a port can have a human readable description
+        const char*  description = "Simply print the target on console...";
+        return { InputPort<Position2D>("target", description) };
+    }
+};
+
+//----------------------------------------------------------------
+
+/** The tree is a Sequence of 4 actions
+*  1) Store a value of Position2D in the entry "GoalPosition"
+*     using the action CalculateGoal.
+*
+*  2) Call PrintTarget. The input "target" will be read from the Blackboard
+*     entry "GoalPosition".
+*
+*  3) Use the built-in action SetBlackboard to write the key "OtherGoal".
+*     A conversion from string to Position2D will be done under the hood.
+*
+*  4) Call PrintTarget. The input "goal" will be read from the Blackboard
+*     entry "OtherGoal".
+*/
+
+// clang-format off
+static const char* xml_text = R"(
+ <root main_tree_to_execute = "MainTree" >
+     <BehaviorTree ID="MainTree">
+        <Sequence name="root">
+            <CalculateGoal   goal="{GoalPosition}" />
+            <PrintTarget     target="{GoalPosition}" />
+            <SetBlackboard   output_key="OtherGoal" value="-1;3" />
+            <PrintTarget     target="{OtherGoal}" />
+        </Sequence>
+     </BehaviorTree>
+ </root>
+ )";
+
+// clang-format on
+
+int main()
+{
+    using namespace BT;
+
+    BehaviorTreeFactory factory;
+    factory.registerNodeType<CalculateGoal>("CalculateGoal");
+    factory.registerNodeType<PrintTarget>("PrintTarget");
+
+    auto tree = factory.createTreeFromText(xml_text);
+    tree.tickRoot();
+
+/* Expected output:
+ *
+    Target positions: [ 1.1, 2.3 ]
+    Converting string: "-1;3"
+    Target positions: [ -1.0, 3.0 ]
+*/
+    return 0;
+}

--- a/recipes/behaviortree.cpp/config.yml
+++ b/recipes/behaviortree.cpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  3.5.6:
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **behaviortree.cpp/3.5.6**

As Bintray is close to be sunset, some projects should be migrated to CCI ASAP. The BehaviorTree.CPP is one of them.

The upstream no longer need a Conan recipe there. I opened a PR removing: https://github.com/BehaviorTree/BehaviorTree.CPP/pull/280

/cc @facontidavide

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
