### PR TITLE
libepoxy: add version 1.5.7

### DIFF
--- a/recipes/libepoxy/all/conandata.yml
+++ b/recipes/libepoxy/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.7":
+    url: "https://github.com/anholt/libepoxy/archive/1.5.7.tar.gz"
+    sha256: "b9e22ba707d0e723e9665c67a2b2974a86f4c4c27e3009dde24a988d1aadf643"
   "1.5.5":
     url: "https://github.com/anholt/libepoxy/archive/1.5.5.tar.gz"
     sha256: "5d80a43a6524a1ebdd0c9c5d5105295546a0794681853c636a0c70f8f9c658ce"

--- a/recipes/libepoxy/config.yml
+++ b/recipes/libepoxy/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.7":
+    folder: all
   "1.5.5":
     folder: all
   "1.5.4":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libepoxy/1.5.7**

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
