### PR TITLE
mpdecimal: autoreconf needs automake (due to aclocal)

### DIFF
--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -48,7 +48,7 @@ class MpdecimalConan(ConanFile):
 
     def build_requirements(self):
         if self.settings.compiler != "Visual Studio":
-            self.build_requires("autoconf/2.69")
+            self.build_requires("automake/1.16.3")
             if tools.os_info.is_windows:
                 self.build_requires("msys2/20200517")
 


### PR DESCRIPTION
Specify library name and version:  **mpdecimal/all**

`autoreconf` calls `aclocal` internally, which is provided by `automake`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
