### PR TITLE
Add hexdump/1.0.0

### DIFF
--- a/recipes/fernandovelcic-hexdump/all/conandata.yml
+++ b/recipes/fernandovelcic-hexdump/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0":
+    url: "https://github.com/FernandoVelcic/hexdump/archive/1.0.0.tar.gz"
+    sha256: "6745f9a528c0932d99ff7c400109784688e9948f298c3cc26c4cb5bd7ec002c5"

--- a/recipes/fernandovelcic-hexdump/all/conanfile.py
+++ b/recipes/fernandovelcic-hexdump/all/conanfile.py
@@ -1,0 +1,24 @@
+from conans import ConanFile, tools
+
+class FernandoVelcicHexdumpConan(ConanFile):
+    name = "fernandovelcic-hexdump"
+    description = "A header-only hexdump library."
+    license = ["BSD-3-Clause"]
+    topics = ("hexadecimal", "hexdump", "inspection", "debug")
+    homepage = "https://github.com/FernandoVelcic/hexdump"
+    url = "https://github.com/conan-io/conan-center-index"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="hexdump.hpp", dst="include", src=self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/fernandovelcic-hexdump/all/test_package/CMakeLists.txt
+++ b/recipes/fernandovelcic-hexdump/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(fernandovelcic-hexdump CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} fernandovelcic-hexdump::fernandovelcic-hexdump)

--- a/recipes/fernandovelcic-hexdump/all/test_package/conanfile.py
+++ b/recipes/fernandovelcic-hexdump/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/fernandovelcic-hexdump/all/test_package/test_package.cpp
+++ b/recipes/fernandovelcic-hexdump/all/test_package/test_package.cpp
@@ -1,0 +1,34 @@
+#include "hexdump.hpp"
+#include <stdint.h>
+#include <iostream>
+
+template <typename T, T RowSize, T bufSize, bool showFlag>
+void testCustomHexdumpBase()
+{
+    unsigned char data[bufSize];
+    for (int i = 0; i < bufSize; ++i)
+    {
+      data[i] = i;
+    }
+    std::cout << CustomHexdumpBase<T, RowSize, showFlag>(data, bufSize) << std::endl;
+}
+
+int main(int argc, char **argv)
+{
+  unsigned char data[150];
+  for (int i = 0; i < 150; ++i)
+  {
+    data[i] = i;
+  }
+
+  std::cout << Hexdump(data, sizeof(data)) << std::endl;
+  std::cout << CustomHexdump<8, true>(data, sizeof(data)) << std::endl;
+  std::cout << CustomHexdump<32, false>(data, sizeof(data)) << std::endl;
+
+  testCustomHexdumpBase<uint8_t, 8, 16, true>();
+  testCustomHexdumpBase<int8_t, 8, 16, true>();
+  testCustomHexdumpBase<uint16_t, 16, 32, true>();
+  testCustomHexdumpBase<int16_t, 16, 32, true>();
+  
+  return 0;
+}

--- a/recipes/fernandovelcic-hexdump/config.yml
+++ b/recipes/fernandovelcic-hexdump/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **hexdump/1.0.0**

This library is a dependency of my project and I think it could be very useful for other projects because conan-center-index doesn't have a recipe with an hexdump library

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
