### PR TITLE
meson: add version 0.58.0

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -62,3 +62,6 @@ sources:
   "0.57.2":
     url: "https://github.com/mesonbuild/meson/archive/0.57.2.tar.gz"
     sha256: "cd3773625253df4fd1c380faf03ffae3d02198d6301e7c8bc7bba6c66af66096"
+  "0.58.0":
+    url: "https://github.com/mesonbuild/meson/archive/0.58.0.tar.gz"
+    sha256: "991b882bfe4d37acc23c064a29ca209458764a580d52f044f3d50055a132bed4"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -41,3 +41,5 @@ versions:
     folder: all
   "0.57.2":
     folder: all
+  "0.58.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/0.58.0**

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
