### PR TITLE
zulu-openjdk: replace os.rename with tools.rename

### DIFF
--- a/recipes/zulu-openjdk/all/conandata.yml
+++ b/recipes/zulu-openjdk/all/conandata.yml
@@ -1,12 +1,14 @@
 sources:
   "11.0.8":
-    url: {
-      "Windows": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-win_x64.zip",
-      "Linux": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-linux_x64.tar.gz",
-      "Macos": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-macosx_x64.tar.gz",
+    Windows: {
+      url: "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-win_x64.zip",
+      sha256: "3602ed7bae52898c540c2d3ae3230c081cf061b219d14fb9ac15a47f4226d307",
     }
-    sha256: {
-      "Windows": "3602ed7bae52898c540c2d3ae3230c081cf061b219d14fb9ac15a47f4226d307",
-      "Linux": "f8aee4ab30ca11ab3c8f401477df0e455a9d6b06f2710b2d1b1ddcf06067bc79",
-      "Macos": "1ed070ea9a27030bcca4d7c074dec1d205d3f3506166d36faf4d1b9e083ab365",
+    Linux: {
+      url: "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-linux_x64.tar.gz",
+      sha256: "f8aee4ab30ca11ab3c8f401477df0e455a9d6b06f2710b2d1b1ddcf06067bc79",
+    }
+    Macos: {
+      url: "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-macosx_x64.tar.gz",
+      sha256: "1ed070ea9a27030bcca4d7c074dec1d205d3f3506166d36faf4d1b9e083ab365",
     }

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -28,10 +28,8 @@ class ZuluOpenJDK(ConanFile):
             raise ConanInvalidConfiguration("Unsupported os. This package currently only support Linux/Macos/Windows")
 
     def source(self):
-        url = self.conan_data["sources"][self.version]["url"][str(self.settings.os)]
-        checksum = self.conan_data["sources"][self.version]["sha256"][str(self.settings.os)]
-        tools.get(url, sha256=checksum)
-        os.rename(glob.glob("zulu*")[0], self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version][str(self.settings.os)],
+                  destination=self._source_subfolder, strip_root=True)
 
     def build(self):
         pass # nothing to do, but this shall trigger no warnings ;-)


### PR DESCRIPTION
Fixes #5359 for zulu-openjdk.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
