### PR TITLE
Add crashpad [Draft] [Help Needed]

### DIFF
--- a/recipes/crashpad/all/conandata.yml
+++ b/recipes/crashpad/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20210429":
+    url: "https://github.com/chromium/crashpad/archive/b10f07e52e56cc7463fbdd57940607ecb8118e8e.tar.gz"
+    sha256: "4cb46b2d5569fd5925c7f7d88febe236c2fe686a1e29afbdb5b53dd0d7fbf6cb"

--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -239,6 +239,7 @@ class CrashpadConan(ConanFile):
         self._copy_headers("crashpad/client", "client")
         self._copy_headers("crashpad/util",   "util")
         self._copy_headers("mini_chromium",   "third_party/mini_chromium/mini_chromium")
+        self._copy_headers("mini_chromium/build",   "out/Conan/gen/build") # for chromeos_buildflags.h
         self._copy_lib("obj/client")
         self._copy_lib("obj/util")
         self._copy_lib("obj/third_party/mini_chromium")

--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -203,7 +203,10 @@ class CrashpadConan(ConanFile):
         self.cpp_info.libs = ['client', 'util', 'base']
 
         if self._glibc_version_pre_2_27():
-            self.cpp_info.libs += ['compat', 'dl', 'pthread']
+            self.cpp_info.libs += ['compat']
+
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs = ['dl', 'pthread']
 
         if self.settings.os == "Macos":
             self.cpp_info.libs.append('machutil')  # see _export_mach_utils

--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -20,7 +20,7 @@ class CrashpadConan(ConanFile):
     default_options = {
         "linktime_optimization": False,
         "force_embedded_zlib": False}
-    exports = [ "patches/*", "LICENSE.md" ]
+    exports = [ "patches/*"]
     short_paths = True
     generators = "compiler_args"
 

--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -1,0 +1,200 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+from conans.tools import Version
+from io import StringIO
+import os
+import json
+import re
+
+class CrashpadConan(ConanFile):
+    name = "crashpad"
+    description = "Crashpad is a crash-reporting system."
+    license = "Apache-2.0"
+    homepage = "https://chromium.googlesource.com/crashpad/crashpad"
+    url = "https://github.com/bincrafters/conan-crashpad"
+    topics = ("crash-reporting", "logging", "minidump", "crash")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "linktime_optimization": [True, False],
+        "force_embedded_zlib": [True, False]}
+    default_options = {
+        "linktime_optimization": False,
+        "force_embedded_zlib": False}
+    exports = [ "patches/*", "LICENSE.md" ]
+    short_paths = True
+    generators = "compiler_args"
+
+    _commit_id = "c7d1d2a1dd7cf2442cbb8aa8da7348fa01d54182"
+    _source_dir = "crashpad"
+    _build_name = "out/Conan"
+    _build_dir = os.path.join(_source_dir, _build_name)
+    _patch_base = os.path.join(_source_dir, "third_party/mini_chromium/mini_chromium")
+
+    def build_requirements(self):
+        self.build_requires("depot_tools_installer/20200515@bincrafters/stable")
+        self.build_requires("ninja/1.10.2")
+
+    def _mangle_spec_for_gclient(self, solutions):
+        return json.dumps(solutions)          \
+                   .replace("\"", "\\\"")     \
+                   .replace("false", "False") \
+                   .replace("true", "True")
+
+    def _make_spec(self):
+        solutions = [{
+            "url": "%s@%s" % (self.homepage, self._commit_id),
+            "managed": False,
+            "name": "%s" % (self.name),
+        }]
+        return "solutions=%s" % self._mangle_spec_for_gclient(solutions)
+
+    def configure(self):
+        if self.settings.compiler == "gcc" and Version(self.settings.compiler.version.value) < "5.0":
+            raise ConanInvalidConfiguration("gcc >= 5 is required")
+
+    def source(self):
+        self.run("gclient config --spec=\"%s\"" % self._make_spec(), run_environment=True)
+        self.run("gclient sync --no-history", run_environment=True)
+
+        tools.patch(base_path=self._patch_base,
+                    patch_file="patches/buildsystem-adaptions.patch")
+
+    def _get_target_cpu(self):
+        arch = str(self.settings.arch)
+
+        if arch == "x86":
+            return "x86"
+        elif arch == "x86_64":
+            return "x64"
+
+        # best effort... please contribute, if you actually tested those platforms
+        elif arch.startswith("arm"):
+            match = re.match('^armv([0-9]+)', arch)
+            if int(match.group(1)) >= 8 and not "32" in arch:
+                return "arm64"
+            else:
+                return "arm"
+        elif arch.startswith("mips"):
+            return "mipsel"
+
+        raise ConanInvalidConfiguration("your architecture (%s) is not supported" % arch)
+
+    def _set_env_arg(self, args, envvar, gnvar):
+        val = os.getenv(envvar)
+        if val:
+            args += [ "%s=\\\"%s\\\"" % (gnvar, val) ]
+
+    def _setup_args_gn(self):
+        args = ["is_debug=%s" % ("true" if self.settings.build_type == "Debug" else "false"),
+                "target_cpu=\\\"%s\\\"" % self._get_target_cpu()]
+
+        if self.settings.os == "Macos" and self.settings.get_safe("os.version"):
+            args += [ "mac_deployment_target=\\\"%s\\\"" % self.settings.os.version ]
+        if self.settings.os == "Windows":
+            args += [ "linktime_optimization=%s" % str(self.options.linktime_optimization).lower()]
+        if self.settings.os == "Windows" and self.settings.get_safe("compiler.runtime"):
+            crt = str(self.settings.compiler.runtime)
+            args += [ "dynamic_crt=%s" % ("true" if crt.startswith("MD") else "false") ]
+
+        self._set_env_arg(args, "CC",       "custom_cc")
+        self._set_env_arg(args, "CXX",      "custom_cxx")
+        self._set_env_arg(args, "CFLAGS",   "extra_cflags_c")
+        self._set_env_arg(args, "CFLAGS",   "extra_cflags_objc")
+        self._set_env_arg(args, "CXXFLAGS", "extra_cflags_cc")
+        self._set_env_arg(args, "CXXFLAGS", "extra_cflags_objcc")
+        self._set_env_arg(args, "LDFLAGS",  "extra_ldflags")
+
+        args += [ "custom_conan_compiler_args_file=\\\"@%s\\\"" % os.path.join(self.install_folder, "conanbuildinfo.args") ]
+
+        if self.settings.compiler == "gcc":
+            args += [ "custom_cxx_is_gcc=true" ]
+        else:
+            args += [ "custom_cxx_is_gcc=false" ]
+
+        return " ".join(args)
+
+    # This is a workaround for macOS builds where certain linker errors started
+    # occuring. Apparently the crashpad build system does not package a few *.o
+    # files properly. That leads to missing symbols when linking with 3rd party
+    # projects. More details here:
+    #
+    #  * https://groups.google.com/a/chromium.org/forum/#!topic/crashpad-dev/XVggc7kvlNs
+    def _export_mach_utils(self):
+        mactools = tools.XCRun(self.settings)
+        self.run("%s cr %s %s" %                                      \
+            (mactools.ar,                                             \
+             os.path.join(self._build_dir, "obj/util/libmachutil.a"), \
+             os.path.join(self._build_dir, "obj", self._build_name, "gen/util/mach/*.o")))
+
+    def build(self):
+
+        if self.options.force_embedded_zlib:
+            tools.patch(base_path=self._patch_base,
+                        patch_file="patches/force-embedded-zlib.patch")
+
+        targets = "crashpad_handler"
+        if self._glibc_version_pre_2_27():
+            targets += " compat"
+
+        with tools.chdir(self._source_dir):
+            self.run('gn gen %s --args="%s"' % (self._build_name, self._setup_args_gn()), run_environment=True)
+            self.run("ninja -j%d -C %s %s" % (tools.cpu_count(), self._build_name, targets), run_environment=True)
+
+        if self.settings.os == "Macos":
+            self._export_mach_utils()
+
+    def _copy_lib(self, src_dir):
+        self.copy("*.a", dst="lib",
+                  src=os.path.join(self._build_dir, src_dir), keep_path=False)
+        self.copy("*.lib", dst="lib",
+                  src=os.path.join(self._build_dir, src_dir), keep_path=False)
+
+    def _copy_headers(self, dst_dir, src_dir):
+        self.copy("*.h", dst=os.path.join("include", dst_dir),
+                         src=os.path.join(self._source_dir, src_dir))
+
+    def _copy_bin(self, src_bin):
+        self.copy(src_bin, src=self._build_dir, dst="bin")
+        self.copy("%s.exe" % src_bin, src=self._build_dir, dst="bin")
+
+    def _glibc_version_pre_2_27(self):
+        if self.settings.os != "Linux":
+            return False
+
+        buf = StringIO()
+        self.run('ldd --version | head -1 | grep -o -E "[0-9]\.[0-9]+" | tail -1', output=buf)
+        return buf.getvalue().rstrip() < "2.27"
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_dir,
+                             ignore_case=True, keep_path=False)
+
+        self._copy_headers("crashpad/client", "client")
+        self._copy_headers("crashpad/util",   "util")
+        self._copy_headers("mini_chromium",   "third_party/mini_chromium/mini_chromium")
+        self._copy_lib("obj/client")
+        self._copy_lib("obj/util")
+        self._copy_lib("obj/third_party/mini_chromium")
+        self._copy_bin("crashpad_handler")
+
+        if self._glibc_version_pre_2_27():
+            self._copy_lib("obj/compat")
+
+    def package_info(self):
+        self.cpp_info.includedirs = [ "include/crashpad", "include/mini_chromium" ]
+        self.cpp_info.libdirs = [ "lib" ]
+        self.cpp_info.libs = ['client', 'util', 'base']
+
+        if self._glibc_version_pre_2_27():
+            self.cpp_info.libs += ['compat', 'dl', 'pthread']
+
+        if self.settings.os == "Macos":
+            self.cpp_info.libs.append('machutil')  # see _export_mach_utils
+            self.cpp_info.exelinkflags.append("-framework CoreFoundation")
+            self.cpp_info.exelinkflags.append("-framework CoreGraphics")
+            self.cpp_info.exelinkflags.append("-framework CoreText")
+            self.cpp_info.exelinkflags.append("-framework Foundation")
+            self.cpp_info.exelinkflags.append("-framework IOKit")
+            self.cpp_info.exelinkflags.append("-framework Security")
+            self.cpp_info.exelinkflags.append("-lbsm")
+            self.cpp_info.sharedlinkflags = self.cpp_info.exelinkflags

--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -45,7 +45,7 @@ class CrashpadConan(ConanFile):
 
 
     def build_requirements(self):
-        self.build_requires("depot_tools/cci.20201009")
+        self.build_requires("gn/cci.20210429")
         self.build_requires("ninja/1.10.2")
 
     def _mangle_spec_for_gclient(self, solutions):

--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -31,7 +31,7 @@ class CrashpadConan(ConanFile):
     _patch_base = os.path.join(_source_dir, "third_party/mini_chromium/mini_chromium")
 
     def build_requirements(self):
-        self.build_requires("depot_tools_installer/20200515@bincrafters/stable")
+        self.build_requires("depot_tools/cci.20201009")
         self.build_requires("ninja/1.10.2")
 
     def _mangle_spec_for_gclient(self, solutions):

--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -56,9 +56,6 @@ class CrashpadConan(ConanFile):
         self.run("gclient config --spec=\"%s\"" % self._make_spec(), run_environment=True)
         self.run("gclient sync --no-history", run_environment=True)
 
-        tools.patch(base_path=self._patch_base,
-                    patch_file="patches/buildsystem-adaptions.patch")
-
     def _get_target_cpu(self):
         arch = str(self.settings.arch)
 
@@ -127,6 +124,8 @@ class CrashpadConan(ConanFile):
              os.path.join(self._build_dir, "obj", self._build_name, "gen/util/mach/*.o")))
 
     def build(self):
+        tools.patch(base_path=self._patch_base,
+                    patch_file="patches/buildsystem-adaptions.patch")
 
         if self.options.force_embedded_zlib:
             tools.patch(base_path=self._patch_base,

--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -11,7 +11,7 @@ class CrashpadConan(ConanFile):
     description = "Crashpad is a crash-reporting system."
     license = "Apache-2.0"
     homepage = "https://chromium.googlesource.com/crashpad/crashpad"
-    url = "https://github.com/bincrafters/conan-crashpad"
+    url = "https://github.com/conan-io/conan-center-index"
     topics = ("crash-reporting", "logging", "minidump", "crash")
     settings = "os", "compiler", "build_type", "arch"
     options = {

--- a/recipes/crashpad/all/patches/buildsystem-adaptions.patch
+++ b/recipes/crashpad/all/patches/buildsystem-adaptions.patch
@@ -1,0 +1,194 @@
+diff --git a/build/BUILD.gn b/build/BUILD.gn
+index 8a1949c..031e819 100644
+--- a/build/BUILD.gn
++++ b/build/BUILD.gn
+@@ -39,10 +39,21 @@ if (mini_chromium_is_mac) {
+     # win_sdk\bin\SetEnv.cmd inside this path will be used to configure the
+     # Windows toolchain.
+     win_toolchain_path = "<autodetect>"
++
++    # linktime optimization (enables compiler flag /GL and linker flag /LTCG)
++    linktime_optimization = true
++
++    # Link CRT dynamically or statically
++    dynamic_crt = false
+   }
+ }
+ 
+ declare_args() {
++  custom_cc = ""
++  custom_cxx = ""
++  custom_cxx_is_gcc = false
++  custom_conan_compiler_args_file = ""
++
+   # Extra flags passed to the C compiler.
+   # Space-separated string of flags.
+   # "cflags" are passed to all invocations of the C, C++, Objective-C, and
+@@ -81,6 +92,12 @@ declare_args() {
+ config("debug") {
+   if (!mini_chromium_is_win) {
+     cflags = [ "-g" ]
++  } else {
++    if (dynamic_crt) {
++      cflags = [ "/MDd" ]
++    } else {
++      cflags = [ "/MTd" ]
++    }
+   }
+ }
+ 
+@@ -103,7 +120,6 @@ config("release") {
+     }
+   } else if (mini_chromium_is_win) {
+     cflags = [
+-      "/GL",  # LTCG.
+       "/O2",
+       "/Ob2",  # Both explicit and auto inlining.
+       "/Oy-",  # Disable omitting frame pointers, must be after /O2.
+@@ -111,11 +127,20 @@ config("release") {
+       "/d2Zi+",  # Improve debugging of optimized code.
+     ]
+     ldflags = [
+-      "/OPT:ICF",
+       "/OPT:REF",
+-      "/LTCG",
+     ]
+-    arflags = [ "/LTCG" ]
++
++    if (linktime_optimization) {
++      cflags += [ "/GL" ] # LTCG
++      ldflags += [ "/LTCG" ]
++      arflags = [ "/LTCG" ]
++    }
++
++    if (dynamic_crt) {
++      cflags += [ "/MD" ]
++    } else {
++      cflags += [ "/MT" ]
++    }
+   }
+ }
+ 
+@@ -128,32 +153,39 @@ config("default") {
+     cflags = [
+       "-Wall",
+       "-Wendif-labels",
+-      "-Werror",
+-      "-Wextra",
+-      "-Wextra-semi",
+       "-Wno-missing-field-initializers",
+       "-Wno-unused-parameter",
+       "-Wsign-compare",
+       "-fno-exceptions",
+       "-fno-rtti",
+       "-fno-strict-aliasing",  # See https://crbug.com/32204
+-      "-fobjc-call-cxx-cdtors",
+       "-fstack-protector-all",  # Implies -fstack-protector
+       "-fvisibility-inlines-hidden",
+       "-fvisibility=hidden",
+     ]
+ 
++    if (custom_cxx_is_gcc) {
++      cflags += [
++        "-Wno-multichar",
++        "-Wno-dangling-else",
++        "-Wno-empty-body"
++      ]
++    } else {
++      cflags += [
++        "-Wextra",
++        "-Wextra-semi",
++        "-Wheader-hygiene",
++        "-Wnewline-eof",
++        "-Wstring-conversion",
++        "-fobjc-call-cxx-cdtors",
++      ]
++    }
++
+     cflags_c = [ "-std=c11" ]
+     cflags_cc = [ "-std=c++14" ]
+     cflags_objc = cflags_c
+     cflags_objcc = cflags_cc
+ 
+-    cflags += [
+-      "-Wheader-hygiene",
+-      "-Wnewline-eof",
+-      "-Wstring-conversion",
+-    ]
+-
+     if (sysroot != "") {
+       if (sysroot == rebase_path(sysroot)) {
+         # If it’s already system-absolute, leave it alone.
+@@ -335,13 +367,13 @@ config("ios_enable_arc") {
+ }
+ 
+ config("Wexit_time_destructors") {
+-  if (mini_chromium_is_clang) {
++  if (mini_chromium_is_clang && !custom_cxx_is_gcc) {
+     cflags = [ "-Wexit-time-destructors" ]
+   }
+ }
+ 
+ config("Wimplicit_fallthrough") {
+-  if (mini_chromium_is_clang) {
++  if (mini_chromium_is_clang && !custom_cxx_is_gcc) {
+     cflags = [ "-Wimplicit-fallthrough" ]
+   }
+ }
+@@ -366,6 +398,14 @@ toolchain("gcc_like_toolchain") {
+   lib_switch = "-l"
+   lib_dir_switch = "-L"
+ 
++  if (defined(custom_cc) && custom_cc != "") {
++    cc = custom_cc
++  }
++
++  if (defined(custom_cxx) && custom_cxx != "") {
++    cxx = custom_cxx
++  }
++
+   if ((mini_chromium_is_linux || mini_chromium_is_fuchsia) && clang_path != "") {
+     cc = rebase_path(clang_path, root_build_dir) + "/bin/clang"
+     cxx = rebase_path(clang_path, root_build_dir) + "/bin/clang++"
+@@ -373,8 +413,12 @@ toolchain("gcc_like_toolchain") {
+     ar = rebase_path(clang_path, root_build_dir) + "/bin/llvm-ar"
+     ld = cxx
+   } else {
+-    cc = "clang"
+-    cxx = "clang++"
++    if (custom_cc == "") {
++      cc = "clang"
++    }
++    if (custom_cxx == "") {
++      cxx = "clang++"
++    }
+     asm = cxx
+     ld = cxx
+ 
+@@ -412,7 +456,7 @@ toolchain("gcc_like_toolchain") {
+ 
+   tool("cc") {
+     depfile = "{{output}}.d"
+-    command = "$cc -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_c}}${extra_cflags}${extra_cflags_c} -c {{source}} -o {{output}}"
++    command = "$cc -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} ${custom_conan_compiler_args_file} {{cflags_c}}${extra_cflags}${extra_cflags_c} -c {{source}} -o {{output}}"
+     depsformat = "gcc"
+     description = "CC {{output}}"
+     outputs = [
+@@ -422,7 +466,7 @@ toolchain("gcc_like_toolchain") {
+ 
+   tool("cxx") {
+     depfile = "{{output}}.d"
+-    command = "$cxx -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}}${extra_cflags}${extra_cflags_cc} -c {{source}} -o {{output}}"
++    command = "$cxx -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} ${custom_conan_compiler_args_file} {{cflags_cc}}${extra_cflags}${extra_cflags_cc} -c {{source}} -o {{output}}"
+     depsformat = "gcc"
+     description = "CXX {{output}}"
+     outputs = [
+@@ -538,7 +582,7 @@ toolchain("gcc_like_toolchain") {
+       start_group_flag = "-Wl,--start-group"
+       end_group_flag = "-Wl,--end-group"
+     }
+-    command = "$ld {{ldflags}}${extra_ldflags} -o \"$outfile\" $start_group_flag {{inputs}} {{solibs}} $end_group_flag {{libs}}"
++    command = "$ld ${custom_conan_compiler_args_file} {{ldflags}}${extra_ldflags} -o \"$outfile\" $start_group_flag {{inputs}} {{solibs}} $end_group_flag {{libs}}"
+     description = "LINK $outfile"
+ 
+     default_output_dir = "{{root_out_dir}}"

--- a/recipes/crashpad/all/patches/force-embedded-zlib.patch
+++ b/recipes/crashpad/all/patches/force-embedded-zlib.patch
@@ -1,0 +1,19 @@
+diff --git a/third_party/zlib/BUILD.gn b/third_party/zlib/BUILD.gn
+index e5a2ad38..ebaddd35 100644
+--- a/third_party/zlib/BUILD.gn
++++ b/third_party/zlib/BUILD.gn
+@@ -14,13 +14,7 @@
+ 
+ import("../../build/crashpad_buildconfig.gni")
+ 
+-if (crashpad_is_in_chromium || crashpad_is_in_fuchsia || crashpad_is_in_dart) {
+-  zlib_source = "external"
+-} else if (!crashpad_is_win && !crashpad_is_fuchsia) {
+-  zlib_source = "system"
+-} else {
+-  zlib_source = "embedded"
+-}
++zlib_source = "embedded"
+ 
+ config("zlib_config") {
+   if (zlib_source == "external") {

--- a/recipes/crashpad/all/test_package/CMakeLists.txt
+++ b/recipes/crashpad/all/test_package/CMakeLists.txt
@@ -1,8 +1,7 @@
-set (CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
-
-project(test_package)
 cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
+set (CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/crashpad/all/test_package/CMakeLists.txt
+++ b/recipes/crashpad/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+set (CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
+
+project(test_package)
+cmake_minimum_required(VERSION 3.1)
+
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/crashpad/all/test_package/conanfile.py
+++ b/recipes/crashpad/all/test_package/conanfile.py
@@ -1,0 +1,20 @@
+from conans import ConanFile, CMake, tools, RunEnvironment
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        test_env_dir = "test_env"
+        tools.mkdir(test_env_dir)
+        bin_path = os.path.join("bin", "test_package")
+        handler_exe = "crashpad_handler.exe" if self.settings.os == "Windows" else "crashpad_handler"
+        handler_bin_path = os.path.join(self.deps_cpp_info['crashpad'].rootpath, "bin", handler_exe)
+        self.run("%s %s/db %s" % (bin_path, test_env_dir, handler_bin_path), run_environment=True)

--- a/recipes/crashpad/all/test_package/conanfile.py
+++ b/recipes/crashpad/all/test_package/conanfile.py
@@ -12,9 +12,10 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        test_env_dir = "test_env"
-        tools.mkdir(test_env_dir)
-        bin_path = os.path.join("bin", "test_package")
-        handler_exe = "crashpad_handler.exe" if self.settings.os == "Windows" else "crashpad_handler"
-        handler_bin_path = os.path.join(self.deps_cpp_info['crashpad'].rootpath, "bin", handler_exe)
-        self.run("%s %s/db %s" % (bin_path, test_env_dir, handler_bin_path), run_environment=True)
+        if not tools.cross_building(self.settings):
+            test_env_dir = "test_env"
+            tools.mkdir(test_env_dir)
+            bin_path = os.path.join("bin", "test_package")
+            handler_exe = "crashpad_handler.exe" if self.settings.os == "Windows" else "crashpad_handler"
+            handler_bin_path = os.path.join(self.deps_cpp_info['crashpad'].rootpath, "bin", handler_exe)
+            self.run("%s %s/db %s" % (bin_path, test_env_dir, handler_bin_path), run_environment=True)

--- a/recipes/crashpad/all/test_package/test_package.cpp
+++ b/recipes/crashpad/all/test_package/test_package.cpp
@@ -1,0 +1,48 @@
+#include <map>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <cwchar>
+#endif
+
+#include "client/crashpad_client.h"
+#include "client/settings.h"
+
+bool startCrashpad(const base::FilePath &db,
+                   const base::FilePath &handler) {
+    std::string              url("http://localhost");
+    std::map<std::string, std::string> annotations;
+    std::vector<std::string>      arguments;
+
+    crashpad::CrashpadClient client;
+    return client.StartHandler(
+        handler,
+        db,
+        db,
+        url,
+        annotations,
+        arguments,
+        true,
+        false
+    );
+}
+
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        return 2;
+    }
+
+#ifdef _WIN32
+    wchar_t ws[1024];
+    swprintf(ws, 1024, L"%hs", argv[1]);
+    base::FilePath db(ws);
+    swprintf(ws, 1024, L"%hs", argv[2]);
+    base::FilePath handler(ws);
+#else
+    base::FilePath db(argv[1]);
+    base::FilePath handler(argv[2]);
+#endif
+
+    return startCrashpad(db, handler) ? 0 : 1;
+}

--- a/recipes/crashpad/config.yml
+++ b/recipes/crashpad/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "20200508":
+    folder: all

--- a/recipes/crashpad/config.yml
+++ b/recipes/crashpad/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "20200508":
+  "cci.20210429":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **crashpad/1.0**

This is a draft PR to get some help on a recipe for google crashpad. It is a missing requirement of sentry-native.
This is heavily based on https://github.com/bincrafters/community/blob/main/recipes/crashpad.

I also have a draft PR for Sentry.io's fork of crashpad, which has CMake Support. https://github.com/conan-io/conan-center-index/pull/5432
Packaging the fork is way easier, but it also has its limitations.

The challenges I'm currently facing are:

1. Getting the sources.
The official method relies on `depot-tools` using `gclient` or `sync`. This pulls the sources and also the submodules needed to build. If I understand correctly this is a conan antipattern since the submodules should be different packages, right? Even if we move forward with this approach, can the commit hash be listed in `conandata.yml` (instead of the sources link)?
There is a github mirror that would allow us to do a more traditional conan source pull, listing a github link, a sha556 and then using `tools.get()`. The problem with this is that it doesn't pull the submodules.

2. This library uses google's custom ninja files generator called `gn`. There is work being done right now to package it.

3. Passing profile configs to the build system.
The bincrafters recipe had this snippet which picks up env variables like `CXX`, `CC`, `CXXFLAGS` and translate them to what the build system understand. This only works if you have this configured in the `[env]` section of the profile, otherwise they get completely ignored.
```
    def _set_env_arg(self, args, envvar, gnvar):
        val = os.getenv(envvar)
        if val:
            args += [ "%s=\\\"%s\\\"" % (gnvar, val) ]
 ...
 
    self._set_env_arg(args, "CC",       "custom_cc")
    self._set_env_arg(args, "CXX",      "custom_cxx")
    self._set_env_arg(args, "CFLAGS",   "extra_cflags_c")
    self._set_env_arg(args, "CFLAGS",   "extra_cflags_objc")
    self._set_env_arg(args, "CXXFLAGS", "extra_cflags_cc")
    self._set_env_arg(args, "CXXFLAGS", "extra_cflags_objcc")
    self._set_env_arg(args, "LDFLAGS",  "extra_ldflags")
```

For example I build with a profile that sets compiler=gcc, compiler.version=8, compiler.libcxx=libstdc++11, but during build clang gets used instead.

What would be the best way to parse all this configurations?

4. No 32 bits arm support on mini_crhomium
5. Consuming dependencies as conan packages is not straight forward.

As discused here https://github.com/conan-io/conan-center-index/issues/5417#issuecomment-831478348 there is a fork of this library which has CMake support. It would be an option to ditch this all together and use those sources for the conan package.

I know there are a lot of smaller problems on this recipe (like the version not being the latest or not starting with `cci.`), but I would rather focus on the main issues first so please don't comment on those now so we can keep it cleaner :)

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
