### PR TITLE
harfbuzz: add version 2.8.1

### DIFF
--- a/recipes/harfbuzz/all/conandata.yml
+++ b/recipes/harfbuzz/all/conandata.yml
@@ -17,6 +17,9 @@ sources:
   "2.8.0":
     sha256: "9444358d1d8c1884c3a25b02fe702bd244172c4fdd2e98f5a165bc0987ef34f6"
     url: "https://github.com/harfbuzz/harfbuzz/archive/2.8.0.tar.gz"
+  "2.8.1":
+    url: "https://github.com/harfbuzz/harfbuzz/archive/2.8.1.tar.gz"
+    sha256: "b3f17394c5bccee456172b2b30ddec0bb87e9c5df38b4559a973d14ccd04509d"
 patches:
   "2.6.8":
     - patch_file: "patches/icu.patch"
@@ -34,5 +37,8 @@ patches:
     - patch_file: "patches/icu.patch"
       base_path: "source_subfolder"
   "2.8.0":
+    - patch_file: "patches/icu-2.8.x.patch"
+      base_path: "source_subfolder"
+  "2.8.1":
     - patch_file: "patches/icu-2.8.x.patch"
       base_path: "source_subfolder"

--- a/recipes/harfbuzz/config.yml
+++ b/recipes/harfbuzz/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: all
   "2.8.0":
     folder: all
+  "2.8.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **harfbuzz/2.8.1**

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
