### PR TITLE
swig: bump dependencies

### DIFF
--- a/recipes/swig/all/conanfile.py
+++ b/recipes/swig/all/conanfile.py
@@ -29,7 +29,7 @@ class SwigConan(ConanFile):
     def build_requirements(self):
         if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH") \
                 and tools.os_info.detect_windows_subsystem() != "msys2":
-            self.build_requires("msys2/20200517")
+            self.build_requires("msys2/cci.latest")
         if self.settings.compiler == "Visual Studio":
             self.build_requires("winflexbison/2.5.24")
         else:
@@ -116,6 +116,9 @@ class SwigConan(ConanFile):
         with self._build_context():
             autotools = self._configure_autotools()
             autotools.make()
+            if self.settings.compiler in ("gcc", "clang"):
+                # FIXME: remove
+                self.run("strings {}".format(os.path.join(self.package_folder, "bin", "swig")), run_environment=True)
 
     def package(self):
         self.copy(pattern="LICENSE*", dst="licenses", src=self._source_subfolder)

--- a/recipes/swig/all/conanfile.py
+++ b/recipes/swig/all/conanfile.py
@@ -124,9 +124,6 @@ class SwigConan(ConanFile):
         with self._build_context():
             autotools = self._configure_autotools()
             autotools.install()
-            if self.settings.compiler in ("gcc", "clang"):
-                # FIXME: remove
-                self.run("strings {}".format(os.path.join(self.package_folder, "bin", "swig")), run_environment=True)
 
     @property
     def _swiglibdir(self):

--- a/recipes/swig/all/conanfile.py
+++ b/recipes/swig/all/conanfile.py
@@ -23,6 +23,9 @@ class SwigConan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
+    def package_id(self):
+        del self.info.settings.compiler
+
     def build_requirements(self):
         if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH") \
                 and tools.os_info.detect_windows_subsystem() != "msys2":

--- a/recipes/swig/all/conanfile.py
+++ b/recipes/swig/all/conanfile.py
@@ -116,9 +116,6 @@ class SwigConan(ConanFile):
         with self._build_context():
             autotools = self._configure_autotools()
             autotools.make()
-            if self.settings.compiler in ("gcc", "clang"):
-                # FIXME: remove
-                self.run("strings {}".format(os.path.join(self.package_folder, "bin", "swig")), run_environment=True)
 
     def package(self):
         self.copy(pattern="LICENSE*", dst="licenses", src=self._source_subfolder)
@@ -127,6 +124,9 @@ class SwigConan(ConanFile):
         with self._build_context():
             autotools = self._configure_autotools()
             autotools.install()
+            if self.settings.compiler in ("gcc", "clang"):
+                # FIXME: remove
+                self.run("strings {}".format(os.path.join(self.package_folder, "bin", "swig")), run_environment=True)
 
     @property
     def _swiglibdir(self):

--- a/recipes/swig/all/conanfile.py
+++ b/recipes/swig/all/conanfile.py
@@ -29,15 +29,15 @@ class SwigConan(ConanFile):
     def build_requirements(self):
         if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH") \
                 and tools.os_info.detect_windows_subsystem() != "msys2":
-            self.build_requires("msys2/20190524")
+            self.build_requires("msys2/20200517")
         if self.settings.compiler == "Visual Studio":
-            self.build_requires("winflexbison/2.5.22")
+            self.build_requires("winflexbison/2.5.24")
         else:
             self.build_requires("bison/3.7.1")
-        self.build_requires("automake/1.16.2")
+        self.build_requires("automake/1.16.3")
 
     def requirements(self):
-        self.requires("pcre/8.41")
+        self.requires("pcre/8.44")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/swig/all/patches/0001-swig-linux-library-path.patch
+++ b/recipes/swig/all/patches/0001-swig-linux-library-path.patch
@@ -4,7 +4,7 @@
    }
  }
  
-+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
++#if defined(HAVE_UNISTD_H)
 +#include <libgen.h>
 +#include <unistd.h>
 +
@@ -36,7 +36,7 @@
      }
      if (Len(SWIG_LIB_WIN_UNIX) > 0)
        SwigLibWinUnix = NewString(SWIG_LIB_WIN_UNIX); // Unix installation path using a drive letter (for msys/mingw)
-+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
++#elif defined(HAVE_UNISTD_H)
 +    SwigLib = get_exe_path();
  #else
      SwigLib = NewString(SWIG_LIB);

--- a/recipes/swig/all/patches/0001-swig-linux-library-path.patch
+++ b/recipes/swig/all/patches/0001-swig-linux-library-path.patch
@@ -4,7 +4,7 @@
    }
  }
  
-+#if defined(HAVE_UNISTD_H)
++#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 +#include <libgen.h>
 +#include <unistd.h>
 +
@@ -36,7 +36,7 @@
      }
      if (Len(SWIG_LIB_WIN_UNIX) > 0)
        SwigLibWinUnix = NewString(SWIG_LIB_WIN_UNIX); // Unix installation path using a drive letter (for msys/mingw)
-+#elif defined(HAVE_UNISTD_H)
++#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 +    SwigLib = get_exe_path();
  #else
      SwigLib = NewString(SWIG_LIB);


### PR DESCRIPTION
Specify library name and version:  **swig/all**

Fixes #5068

Don't use `HAVE_UNISTD_H` but use `/proc/self/exe` unconditionally on Linux, Macos and all BSD's.
If `/proc/self/exe` does not exist, then it will use the embedded path.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
