### PR TITLE
gn: add initial gn recipe

### DIFF
--- a/recipes/gn/all/conandata.yml
+++ b/recipes/gn/all/conandata.yml
@@ -1,0 +1,3 @@
+sources:
+  "cci.20210429":
+    url: "https://gn.googlesource.com/gn/+archive/6771ce569fb4803dad7a427aa2e2c23e960b917e.tar.gz"

--- a/recipes/gn/all/conanfile.py
+++ b/recipes/gn/all/conanfile.py
@@ -1,0 +1,99 @@
+from conans import ConanFile, tools
+from contextlib import contextmanager
+import os
+import textwrap
+
+required_conan_version = ">=1.33.0"
+
+
+class GnConan(ConanFile):
+    name = "gn"
+    description = "GN is a meta-build system that generates build files for Ninja."
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("conan", "gmp", "math")
+    license = ("LGPL-3.0", "GPL-2.0")
+    homepage = "https://gn.googlesource.com/"
+    settings = "os", "arch", "compiler", "build_type"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def package_id(self):
+        del self.info.settings.compiler
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)
+
+    def build_requirements(self):
+        self.build_requires("ninja/1.10.2")
+
+    @contextmanager
+    def _build_context(self):
+        if self.settings.compiler == "Visual Studio":
+            with tools.vcvars(self.settings):
+                yield
+        else:
+            compiler_defaults = {}
+            if self.settings.compiler == "gcc":
+                compiler_defaults = {
+                    "CC": "gcc",
+                    "CXX": "g++",
+                    "AR": "ar",
+                    "LD": "g++",
+                }
+            elif self.settings.compiler == "clang":
+                compiler_defaults = {
+                    "CC": "clang",
+                    "CXX": "clang++",
+                    "AR": "ar",
+                    "LD": "clang++",
+                }
+            env = {}
+            for k in ("CC", "CXX", "AR", "LD"):
+                v = tools.get_env(k, compiler_defaults.get(k, None))
+                if v:
+                    env[k] = v
+            with tools.environment_append(env):
+                yield
+
+    @staticmethod
+    def _to_gn_platform(os_, compiler):
+        if tools.is_apple_os(os_):
+            return "darwin"
+        if compiler == "Visual Studio":
+            return "msvc"
+        # Assume gn knows about the os
+        return str(os_).lower()
+
+    def build(self):
+        with tools.chdir(self._source_subfolder):
+            with self._build_context():
+                tools.save(os.path.join("src", "gn", "last_commit_position.h"),
+                           textwrap.dedent("""\
+                                #pragma once
+                                #define LAST_COMMIT_POSITION "1"
+                                #define LAST_COMMIT_POSITION_NUM 1
+                                """))
+                conf_args = [
+                    "--no-last-commit-position",
+                    "--host={}".format(self._to_gn_platform(self.settings.os, self.settings.compiler)),
+                ]
+                if self.settings.build_type == "Debug":
+                    conf_args.append("-d")
+                self.run("python build/gen.py {}".format(" ".join(conf_args)), run_environment=True)
+                build_args = [
+                    "-C", "out",
+                    "-j{}".format(tools.cpu_count()),
+                ]
+                self.run("ninja {}".format(" ".join(build_args)), run_environment=True)
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        self.copy("gn", src=os.path.join(self._source_subfolder, "out"), dst="bin")
+        self.copy("gn.exe", src=os.path.join(self._source_subfolder, "out"), dst="bin")
+
+    def package_info(self):
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)

--- a/recipes/gn/all/test_package/.gn
+++ b/recipes/gn/all/test_package/.gn
@@ -1,0 +1,2 @@
+# The location of the build configuration file.
+buildconfig = "//config/BUILDCONFIG.gn"

--- a/recipes/gn/all/test_package/BUILD.gn
+++ b/recipes/gn/all/test_package/BUILD.gn
@@ -1,0 +1,14 @@
+
+executable("test_package") {
+    sources = ["test_package.cpp"]
+
+    deps = [
+        ":test_static",
+    ]
+}
+
+static_library("test_static") {
+    sources = [
+        "test_static.cpp",
+    ]
+}

--- a/recipes/gn/all/test_package/conanfile.py
+++ b/recipes/gn/all/test_package/conanfile.py
@@ -1,0 +1,67 @@
+from conans import ConanFile, CMake, tools
+from contextlib import contextmanager
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+
+    def build_requirements(self):
+        self.build_requires("ninja/1.10.2")
+
+    @contextmanager
+    def _build_context(self):
+        if self.settings.compiler == "Visual Studio":
+            with tools.vcvars(self.settings):
+                yield
+        else:
+            compiler_defaults = {}
+            if self.settings.compiler == "gcc":
+                compiler_defaults = {
+                    "CC": "gcc",
+                    "CXX": "g++",
+                    "AR": "ar",
+                    "LD": "g++",
+                }
+            elif self.settings.compiler == "clang":
+                compiler_defaults = {
+                    "CC": "clang",
+                    "CXX": "clang++",
+                    "AR": "ar",
+                    "LD": "clang++",
+                }
+            env = {}
+            for k in ("CC", "CXX", "AR", "LD"):
+                v = tools.get_env(k, compiler_defaults.get(k, None))
+                if v:
+                    env[k] = v
+            with tools.environment_append(env):
+                yield
+
+    @property
+    def _target_os(self):
+        if tools.is_apple_os(self.settings.os):
+            return "darwin"
+        # Assume gn knows about the os
+        return str(self.settings.os).lower()
+
+    @property
+    def _target_cpu(self):
+        return {
+            "x86_64": "x64",
+        }.get(str(self.settings.arch), str(self.settings.arch))
+
+    def build(self):
+        if not tools.cross_building(self.settings):
+            with tools.chdir(self.source_folder):
+                gn_args = [
+                    """--args='target_os="{os_}" target_cpu="{cpu}"'""".format(os_=self._target_os, cpu=self._target_cpu),
+                    os.path.join(self.build_folder, "bin")
+                ]
+                self.run("gn gen {}".format(" ".join(gn_args)), run_environment=True)
+            with self._build_context():
+                self.run("ninja -v -j{} -C bin".format(tools.cpu_count()), run_environment=True)
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.run(os.path.join("bin", "test_package"), run_environment=True)

--- a/recipes/gn/all/test_package/config/BUILD.gn
+++ b/recipes/gn/all/test_package/config/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright 2014 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+config("compiler_defaults") {
+  if (current_os == "linux") {
+    cflags = [
+      "-fPIC",
+      "-pthread",
+    ]
+  }
+}
+config("executable_ldconfig") {
+  if (!is_mac) {
+    ldflags = [
+      "-Wl,-rpath=\$ORIGIN/",
+      "-Wl,-rpath-link=",
+    ]
+  }
+}

--- a/recipes/gn/all/test_package/config/BUILDCONFIG.gn
+++ b/recipes/gn/all/test_package/config/BUILDCONFIG.gn
@@ -1,0 +1,37 @@
+# Copyright 2014 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+if (target_os == "") {
+  target_os = host_os
+}
+if (target_cpu == "") {
+  target_cpu = host_cpu
+}
+if (current_cpu == "") {
+  current_cpu = target_cpu
+}
+if (current_os == "") {
+  current_os = target_os
+}
+is_windows = host_os == "darwin" && current_os == "darwin" && target_os == "darwin"
+is_linux = host_os == "linux" && current_os == "linux" && target_os == "linux"
+is_mac = host_os == "mac" && current_os == "mac" && target_os == "mac"
+# All binary targets will get this list of configs by default.
+_shared_binary_target_configs = [ "//config:compiler_defaults" ]
+# Apply that default list to the binary target types.
+set_defaults("executable") {
+  configs = _shared_binary_target_configs
+  # Executables get this additional configuration.
+  configs += [ "//config:executable_ldconfig" ]
+}
+set_defaults("static_library") {
+  configs = _shared_binary_target_configs
+}
+set_defaults("shared_library") {
+  configs = _shared_binary_target_configs
+}
+set_defaults("source_set") {
+  configs = _shared_binary_target_configs
+}
+set_default_toolchain("//config/toolchain:gcc")

--- a/recipes/gn/all/test_package/config/toolchain/BUILD.gn
+++ b/recipes/gn/all/test_package/config/toolchain/BUILD.gn
@@ -1,0 +1,101 @@
+# Copyright 2014 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+toolchain("gcc") {
+  tool("cc") {
+    depfile = "{{output}}.d"
+    _compiler = getenv("CC")
+    if (_compiler == "") {
+        _compiler = "gcc"
+    }
+    command = _compiler + " -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} -c {{source}} -o {{output}}"
+    depsformat = "gcc"
+    description = "CC {{output}}"
+    outputs =
+        [ "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o" ]
+  }
+  tool("cxx") {
+    depfile = "{{output}}.d"
+    _compiler = getenv("CXX")
+    if (_compiler == "") {
+        _compiler = "g++"
+    }
+    command = _compiler + " -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} -c {{source}} -o {{output}}"
+    depsformat = "gcc"
+    description = "CXX {{output}}"
+    outputs =
+        [ "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o" ]
+  }
+  tool("alink") {
+    _archiver = getenv("AR")
+    if (_archiver == "") {
+        _archiver = "ar"
+    }
+    command = "rm -f {{output}} && " + _archiver + " rcs {{output}} {{inputs}}"
+    description = "AR {{target_output_name}}{{output_extension}}"
+    outputs =
+        [ "{{target_out_dir}}/{{target_output_name}}{{output_extension}}" ]
+    default_output_extension = ".a"
+    output_prefix = "lib"
+  }
+  tool("solink") {
+    _linker = getenv("LD")
+    if (_linker == "") {
+        _linker = getenv("CXX")
+        if (_linker == "") {
+            _linker = "g++"
+        }
+    }
+    soname = "{{target_output_name}}{{output_extension}}"  # e.g. "libfoo.so".
+    sofile = "{{output_dir}}/$soname"
+    rspfile = soname + ".rsp"
+    if (is_mac) {
+      os_specific_option = "-install_name @executable_path/$sofile"
+      rspfile_content = "{{inputs}} {{solibs}} {{libs}}"
+    } else {
+      os_specific_option = "-Wl,-soname=$soname"
+      rspfile_content = "-Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive {{libs}}"
+    }
+    command = _linker + " -shared {{ldflags}} -o $sofile $os_specific_option @$rspfile"
+    description = "SOLINK $soname"
+    # Use this for {{output_extension}} expansions unless a target manually
+    # overrides it (in which case {{output_extension}} will be what the target
+    # specifies).
+    default_output_extension = ".so"
+    # Use this for {{output_dir}} expansions unless a target manually overrides
+    # it (in which case {{output_dir}} will be what the target specifies).
+    default_output_dir = "{{root_out_dir}}"
+    outputs = [ sofile ]
+    link_output = sofile
+    depend_output = sofile
+    output_prefix = "lib"
+  }
+  tool("link") {
+    _linker = getenv("LD")
+    if (_linker == "") {
+        _linker = getenv("CXX")
+        if (_linker == "") {
+            _linker = "g++"
+        }
+    }
+    outfile = "{{target_output_name}}{{output_extension}}"
+    rspfile = "$outfile.rsp"
+    if (is_mac) {
+      command = _linker + " {{ldflags}} -o $outfile @$rspfile {{solibs}} {{libs}}"
+    } else {
+      command = _linker + " {{ldflags}} -o $outfile -Wl,--start-group @$rspfile {{solibs}} -Wl,--end-group {{libs}}"
+    }
+    description = "LINK $outfile"
+    default_output_dir = "{{root_out_dir}}"
+    rspfile_content = "{{inputs}}"
+    outputs = [ outfile ]
+  }
+  tool("stamp") {
+    command = "touch {{output}}"
+    description = "STAMP {{output}}"
+  }
+  tool("copy") {
+    command = "cp -af {{source}} {{output}}"
+    description = "COPY {{source}} {{output}}"
+  }
+}

--- a/recipes/gn/all/test_package/test_package.cpp
+++ b/recipes/gn/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include "test_static.h"
+
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+    std::cout << get_test_static_text() << "\n";
+    return 0;
+}

--- a/recipes/gn/all/test_package/test_static.cpp
+++ b/recipes/gn/all/test_package/test_static.cpp
@@ -1,0 +1,5 @@
+#include "test_static.h"
+
+const char *get_test_static_text() {
+    return "hello from the static library!";
+}

--- a/recipes/gn/all/test_package/test_static.h
+++ b/recipes/gn/all/test_package/test_static.h
@@ -1,0 +1,3 @@
+#pragma once
+
+const char *get_test_static_text();

--- a/recipes/gn/config.yml
+++ b/recipes/gn/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20210429":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **gn/cci.20210429**

gn is a build system developed by google, used for google produces (chromium)

I've tested this on Linux (gcc + clang).
TODO's: Windows + Macos

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
