### PR TITLE
fcl: fix CMake imported target + del fPIC if shared + bump dependencies

### DIFF
--- a/recipes/fcl/all/conanfile.py
+++ b/recipes/fcl/all/conanfile.py
@@ -62,7 +62,7 @@ class FclConan(ConanFile):
                   destination=self._source_subfolder, strip_root=True)
 
     def build(self):
-        for patch in self.conan_data["patches"][self.version]:
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/fcl/all/conanfile.py
+++ b/recipes/fcl/all/conanfile.py
@@ -40,6 +40,8 @@ class FclConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
         if self.settings.os == "Windows" and self.options.shared:

--- a/recipes/fcl/all/conanfile.py
+++ b/recipes/fcl/all/conanfile.py
@@ -58,8 +58,8 @@ class FclConan(ConanFile):
             self.requires("octomap/1.9.6")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def build(self):
         for patch in self.conan_data["patches"][self.version]:

--- a/recipes/fcl/all/conanfile.py
+++ b/recipes/fcl/all/conanfile.py
@@ -1,7 +1,10 @@
-import os
-
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import os
+import textwrap
+
+required_conan_version = ">=1.33.0"
+
 
 class FclConan(ConanFile):
     name = "fcl"
@@ -95,6 +98,37 @@ class FclConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"fcl": "fcl::fcl"}
+        )
+
+    @staticmethod
+    def _create_cmake_module_alias_targets(module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent("""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """.format(alias=alias, aliased=aliased))
+        tools.save(module_file, content)
+
+    @property
+    def _module_subfolder(self):
+        return os.path.join("lib", "cmake")
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join(self._module_subfolder,
+                            "conan-official-{}-targets.cmake".format(self.name))
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "fcl"
+        self.cpp_info.names["cmake_find_package_multi"] = "fcl"
+        self.cpp_info.builddirs.append(self._module_subfolder)
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+        self.cpp_info.names["pkg_config"] = "fcl"
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/fcl/all/conanfile.py
+++ b/recipes/fcl/all/conanfile.py
@@ -47,10 +47,10 @@ class FclConan(ConanFile):
                                                                                                             self.version))
 
     def requirements(self):
-        self.requires("eigen/3.3.8")
+        self.requires("eigen/3.3.9")
         self.requires("libccd/2.1")
         if self.options.with_octomap:
-            self.requires("octomap/1.9.3")
+            self.requires("octomap/1.9.6")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/fcl/all/test_package/CMakeLists.txt
+++ b/recipes/fcl/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(fcl REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} fcl)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/fcl/all/test_package/conanfile.py
+++ b/recipes/fcl/all/test_package/conanfile.py
@@ -1,10 +1,10 @@
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

fcl imported target is not namespaced: https://github.com/flexible-collision-library/fcl/blob/v0.6.1/src/CMakeLists.txt#L138-L141

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
