### PR TITLE
fix lib mysql version

### DIFF
--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -50,7 +50,7 @@ class LibMysqlClientCConan(ConanFile):
         os.rename("CMakeLists.txt", sources_cmake)
         version_old = os.path.join(self._source_subfolder, "VERSION")
         version_new = os.path.join(self._source_subfolder, "MYSQL_VERSION")
-        os.rename(version_old, version_new)
+        tools.rename(version_old, version_new)
 
         if self.settings.os == "Macos":
             tools.replace_in_file(os.path.join(self._source_subfolder, "libmysql", "CMakeLists.txt"), "COMMAND $<TARGET_FILE:libmysql_api_test>", "COMMAND DYLD_LIBRARY_PATH=%s $<TARGET_FILE:libmysql_api_test>" % os.path.join(self.build_folder, "library_output_directory"))
@@ -121,4 +121,3 @@ class LibMysqlClientCConan(ConanFile):
                 self.cpp_info.system_libs.append(stdcpp_library)
             if self.settings.os == "Linux":
                 self.cpp_info.system_libs.append('m')
-

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -50,7 +50,8 @@ class LibMysqlClientCConan(ConanFile):
         os.rename("CMakeLists.txt", sources_cmake)
         version_old = os.path.join(self._source_subfolder, "VERSION")
         version_new = os.path.join(self._source_subfolder, "MYSQL_VERSION")
-        tools.rename(version_old, version_new)
+        if os.path.isfile(version_old):
+            tools.rename(version_old, version_new)
 
         if self.settings.os == "Macos":
             tools.replace_in_file(os.path.join(self._source_subfolder, "libmysql", "CMakeLists.txt"), "COMMAND $<TARGET_FILE:libmysql_api_test>", "COMMAND DYLD_LIBRARY_PATH=%s $<TARGET_FILE:libmysql_api_test>" % os.path.join(self.build_folder, "library_output_directory"))

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -48,6 +48,10 @@ class LibMysqlClientCConan(ConanFile):
         sources_cmake_orig = os.path.join(self._source_subfolder, "CMakeListsOriginal.txt")
         os.rename(sources_cmake, sources_cmake_orig)
         os.rename("CMakeLists.txt", sources_cmake)
+        version_old = os.path.join(self._source_subfolder, "VERSION")
+        version_new = os.path.join(self._source_subfolder, "MYSQL_VERSION")
+        os.rename(version_old, version_new)
+
         if self.settings.os == "Macos":
             tools.replace_in_file(os.path.join(self._source_subfolder, "libmysql", "CMakeLists.txt"), "COMMAND $<TARGET_FILE:libmysql_api_test>", "COMMAND DYLD_LIBRARY_PATH=%s $<TARGET_FILE:libmysql_api_test>" % os.path.join(self.build_folder, "library_output_directory"))
 
@@ -117,3 +121,4 @@ class LibMysqlClientCConan(ConanFile):
                 self.cpp_info.system_libs.append(stdcpp_library)
             if self.settings.os == "Linux":
                 self.cpp_info.system_libs.append('m')
+


### PR DESCRIPTION
Specify library name and version:  **libmysqlclient/8.0.17**

fix for libmysqlclient version
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
