### PR TITLE
new lmdb recipe

### DIFF
--- a/recipes/lmdb/all/CMakeLists.txt
+++ b/recipes/lmdb/all/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+# LMDB library:
+
+add_library(lmdb
+    source_subfolder/lmdb.h
+    source_subfolder/mdb.c
+    source_subfolder/midl.c
+    source_subfolder/midl.h
+)
+
+set_target_properties(lmdb PROPERTIES PUBLIC_HEADER
+    source_subfolder/lmdb.h
+)
+
+if(NOT WIN32)
+    target_link_libraries(lmdb PUBLIC pthread)
+endif()
+
+install(TARGETS lmdb)
+
+# LMDB utilities:
+
+if(NOT WIN32)
+    foreach(TOOL mdb_stat mdb_copy mdb_dump mdb_load)
+        add_executable(${TOOL} source_subfolder/${TOOL}.c)
+        target_link_libraries(${TOOL} lmdb)
+        install(TARGETS ${TOOL})
+    endforeach()
+endif()

--- a/recipes/lmdb/all/CMakeLists.txt
+++ b/recipes/lmdb/all/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.4)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/lmdb/all/CMakeLists.txt
+++ b/recipes/lmdb/all/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.8.11)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/lmdb/all/CMakeLists.txt
+++ b/recipes/lmdb/all/CMakeLists.txt
@@ -13,16 +13,13 @@ add_library(lmdb
     source_subfolder/midl.h
 )
 
-set_target_properties(lmdb PROPERTIES PUBLIC_HEADER
-    source_subfolder/lmdb.h
+set_target_properties(lmdb PROPERTIES
+    PUBLIC_HEADER source_subfolder/lmdb.h
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
 
 if(NOT WIN32)
     target_link_libraries(lmdb PUBLIC pthread)
-endif()
-
-if(WIN32 AND BUILD_SHARED_LIBS)
-  set_target_properties(maxminddb PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
 install(TARGETS lmdb)

--- a/recipes/lmdb/all/CMakeLists.txt
+++ b/recipes/lmdb/all/CMakeLists.txt
@@ -21,6 +21,10 @@ if(NOT WIN32)
     target_link_libraries(lmdb PUBLIC pthread)
 endif()
 
+if(WIN32 AND BUILD_SHARED_LIBS)
+  set_target_properties(maxminddb PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 install(TARGETS lmdb)
 
 # LMDB utilities:

--- a/recipes/lmdb/all/CMakeLists.txt
+++ b/recipes/lmdb/all/CMakeLists.txt
@@ -18,9 +18,8 @@ set_target_properties(lmdb PROPERTIES
     WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
 
-if(NOT WIN32)
-    target_link_libraries(lmdb PUBLIC pthread)
-endif()
+include(FindThreads)
+target_link_libraries(lmdb PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS lmdb)
 

--- a/recipes/lmdb/all/conandata.yml
+++ b/recipes/lmdb/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.9.29":
+    url: "https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz"
+    sha256: "d4c668167a2d703ef91db733b4069b8b74dbc374405855be6626b45e2a7e2dd3"

--- a/recipes/lmdb/all/conanfile.py
+++ b/recipes/lmdb/all/conanfile.py
@@ -59,6 +59,10 @@ class lmdbConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["lmdb"]
+        self.cpp_info.names["cmake_find_package"] = "LMDB"
+        self.cpp_info.names["cmake_find_package_multi"] = "LMDB"
+        self.cpp_info.names["pkg_config"] = "lmdb"
+
         if self.settings.os != "Windows":
             self.cpp_info.system_libs = ["pthread"]
 

--- a/recipes/lmdb/all/conanfile.py
+++ b/recipes/lmdb/all/conanfile.py
@@ -1,0 +1,68 @@
+import os
+import shutil
+from conans import ConanFile, CMake, tools
+
+
+class lmdbConan(ConanFile):
+    name = "lmdb"
+    license = "OLDAP-2.8"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://symas.com/lmdb/"
+    description = "Fast and compat memory-mapped key-value database"
+    topics = ("LMDB", "database", "key-value", "memory-mapped")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake"
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        root = "openldap-LMDB_{}".format(self.version)
+        os.rename(os.path.join(root, "libraries", "liblmdb"), self._source_subfolder)
+        shutil.rmtree(root)
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["lmdb"]
+        if self.settings.os != "Windows":
+            self.cpp_info.system_libs = ["pthread"]
+
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)

--- a/recipes/lmdb/all/conanfile.py
+++ b/recipes/lmdb/all/conanfile.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 from conans import ConanFile, CMake, tools
 
 
@@ -39,8 +38,8 @@ class lmdbConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         root = "openldap-LMDB_{}".format(self.version)
-        os.rename(os.path.join(root, "libraries", "liblmdb"), self._source_subfolder)
-        shutil.rmtree(root)
+        tools.rename(os.path.join(root, "libraries", "liblmdb"), self._source_subfolder)
+        tools.rmdir(root)
 
     def build(self):
         cmake = self._configure_cmake()

--- a/recipes/lmdb/all/test_package/CMakeLists.txt
+++ b/recipes/lmdb/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(PkgConfig)
+pkg_check_modules(LMDB REQUIRED IMPORTED_TARGET GLOBAL lmdb)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PkgConfig::LMDB)

--- a/recipes/lmdb/all/test_package/CMakeLists.txt
+++ b/recipes/lmdb/all/test_package/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.4)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/lmdb/all/test_package/CMakeLists.txt
+++ b/recipes/lmdb/all/test_package/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/lmdb/all/test_package/conanfile.py
+++ b/recipes/lmdb/all/test_package/conanfile.py
@@ -1,0 +1,21 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class LmdbTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "pkg_config"
+
+    def build_requirements(self):
+        self.build_requires("pkgconf/1.7.3")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/lmdb/all/test_package/test_package.c
+++ b/recipes/lmdb/all/test_package/test_package.c
@@ -1,0 +1,10 @@
+#include <lmdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main()
+{
+    const char *version = mdb_version(NULL, NULL, NULL);
+    printf("%s\n", version);
+    return 0;
+}

--- a/recipes/lmdb/config.yml
+++ b/recipes/lmdb/config.yml
@@ -1,0 +1,3 @@
+"versions":
+  "0.9.29":
+    "folder": "all"


### PR DESCRIPTION
Specify library name and version:  **lmdb/0.9.29**

LMDB is a quite popular memory mapped key-value database. Many projects "vendor" LMDB because it's embedable and lightweight. However, it it's possible to use it as normal library and I think it would be beneficial to have it in Conan as well.

I'm not the author but I use it.

LMDB ships simple Makefile for compilation but it hardcodes a few compiler parameters and forces dynamic linking. I found it easier to add the few source files into the CMake shipped with the recipe. Let me know if this should be done differently.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
