### PR TITLE
add doctest/2.4.5

### DIFF
--- a/recipes/doctest/2.x.x/conandata.yml
+++ b/recipes/doctest/2.x.x/conandata.yml
@@ -23,3 +23,6 @@ sources:
   "2.4.4":
     url: "https://github.com/onqtam/doctest/archive/2.4.4.tar.gz"
     sha256: "3bcb62ad316bf4230873a336fcc6eb6292116568a6e19ab8cdd37a1610773d70"
+  "2.4.5":
+    url: "https://github.com/onqtam/doctest/archive/2.4.5.tar.gz"
+    sha256: "b76ece19f0e473e3afa5c545dbdce2dd70bfef98ed0f383443b2f9fd9f86d5b4"

--- a/recipes/doctest/config.yml
+++ b/recipes/doctest/config.yml
@@ -15,3 +15,5 @@ versions:
     folder: 2.x.x
   2.4.4:
     folder: 2.x.x
+  2.4.5:
+    folder: 2.x.x


### PR DESCRIPTION
**doctest/2.4.5**

Version 2.4.6 has already been released but it has [a bug ](https://github.com/onqtam/doctest/issues/489)which breaks `doctest_discover_tests` (and `test_package`).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
