### PR TITLE
bullet3: add version 3.17

### DIFF
--- a/recipes/bullet3/all/conandata.yml
+++ b/recipes/bullet3/all/conandata.yml
@@ -14,3 +14,6 @@ sources:
   "3.09":
     url: "https://github.com/bulletphysics/bullet3/archive/3.09.tar.gz"
     sha256: "f2feef9322329c0571d9066fede2db0ede92b19f7f7fdf54def3b4651f02af03"
+  "3.17":
+    url: "https://github.com/bulletphysics/bullet3/archive/3.17.tar.gz"
+    sha256: "baa642c906576d4d98d041d0acb80d85dd6eff6e3c16a009b1abf1ccd2bc0a61"

--- a/recipes/bullet3/config.yml
+++ b/recipes/bullet3/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "3.09":
     folder: all
+  "3.17":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **bullet3/3.17**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
