### PR TITLE
xapian-core: fix missing include in 1.4.16 + bump msys2 + no os.rename + fix AUTOMAKE_CONAN_INCLUDES

### DIFF
--- a/recipes/xapian-core/all/conandata.yml
+++ b/recipes/xapian-core/all/conandata.yml
@@ -9,6 +9,8 @@ patches:
   "1.4.16":
     - base_path: ""
       patch_file: "patches/0001-add-msvc-cl-sh.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0003-missing-limits-include.patch"
   "1.4.18":
     - base_path: ""
       patch_file: "patches/0001-add-msvc-cl-sh.patch"

--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -49,7 +49,7 @@ class XapianCoreConan(ConanFile):
 
     def build_requirements(self):
         if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires("msys2/20200517")
+            self.build_requires("msys2/cci.latest")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -143,6 +143,6 @@ class XapianCoreConan(ConanFile):
         self.output.info("Appending PATH environment variable: {}".format(binpath))
         self.env_info.PATH.append(binpath)
 
-        automake_path = os.path.join(self._datarootdir, "aclocal")
-        self.output.info("Appending AUTOMAKE_CONAN_INCLUDES environment variable: {}".format(automake_path))
-        self.env_info.AUTOMAKE_CONAN_INCLUDES.append(tools.unix_path(automake_path))
+        xapian_aclocal = tools.unix_path(os.path.join(self._datarootdir, "aclocal"))
+        self.output.info("Appending AUTOMAKE_CONAN_INCLUDES environment variable: {}".format(xapian_aclocal))
+        self.env_info.AUTOMAKE_CONAN_INCLUDES.append(tools.unix_path(xapian_aclocal))

--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -138,6 +138,7 @@ class XapianCoreConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "xapian"
         self.cpp_info.names["cmake_find_package_multi"] = "xapian"
         # FIXME: must define XAPIAN_INCLUDE_DIRS and XAPIAN_LIBRARIES cmake variables
+        self.cpp_info.names["pkg_config"] = "xapian-core"
 
         binpath = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(binpath))

--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -3,6 +3,8 @@ from conans.errors import ConanInvalidConfiguration
 from contextlib import contextmanager
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class XapianCoreConan(ConanFile):
     name = "xapian-core"
@@ -50,8 +52,8 @@ class XapianCoreConan(ConanFile):
             self.build_requires("msys2/20190524")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     @contextmanager
     def _build_context(self):
@@ -116,8 +118,8 @@ class XapianCoreConan(ConanFile):
             if self.options.shared:
                 pass
             else:
-                os.rename(os.path.join(self.package_folder, "lib", "libxapian.lib"),
-                          os.path.join(self.package_folder, "lib", "xapian.lib"))
+                tools.rename(os.path.join(self.package_folder, "lib", "libxapian.lib"),
+                             os.path.join(self.package_folder, "lib", "xapian.lib"))
 
         os.unlink(os.path.join(os.path.join(self.package_folder, "bin", "xapian-config")))
         os.unlink(os.path.join(os.path.join(self.package_folder, "lib", "libxapian.la")))

--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -162,7 +162,9 @@ class XapianCoreConan(ConanFile):
         if not self.options.shared:
             if self.settings.os == "Linux":
                 self.cpp_info.system_libs = ["rt"]
-            if self.settings.os == "SunOS":
+            elif self.settings.os == "Windows":
+                self.cpp_info.system_libs = ["rpcrt4", "ws2_32"]
+            elif self.settings.os == "SunOS":
                 self.cpp_info.system_libs = ["socket", "nsl"]
 
         self.cpp_info.names["cmake_find_package"] = "xapian"

--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -47,9 +47,8 @@ class XapianCoreConan(ConanFile):
         self.requires("zlib/1.2.11")
 
     def build_requirements(self):
-        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH") and \
-                tools.os_info.detect_windows_subsystem() != "msys2":
-            self.build_requires("msys2/20190524")
+        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/20200517")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -158,7 +158,7 @@ class XapianCoreConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["xapian"]
         if not self.options.shared:
-            if self.settings.os == "Linux":
+            if self.settings.os in ("Linux", "FreeBSD"):
                 self.cpp_info.system_libs = ["rt"]
             elif self.settings.os == "Windows":
                 self.cpp_info.system_libs = ["rpcrt4", "ws2_32"]

--- a/recipes/xapian-core/all/conanfile.py
+++ b/recipes/xapian-core/all/conanfile.py
@@ -57,11 +57,10 @@ class XapianCoreConan(ConanFile):
 
     @contextmanager
     def _build_context(self):
-        env = {}
         if self.settings.compiler == "Visual Studio":
             with tools.vcvars(self.settings):
                 msvc_cl_sh =  os.path.join(self.build_folder, "msvc_cl.sh").replace("\\", "/")
-                env.update({
+                env = {
                     "AR": "lib",
                     "CC": msvc_cl_sh,
                     "CXX": msvc_cl_sh,
@@ -70,12 +69,11 @@ class XapianCoreConan(ConanFile):
                     "OBJDUMP": ":",
                     "RANLIB": ":",
                     "STRIP": ":",
-                })
+                }
                 with tools.environment_append(env):
                     yield
         else:
-            with tools.environment_append(env):
-                yield
+            yield
 
     @property
     def _datarootdir(self):

--- a/recipes/xapian-core/all/patches/0003-missing-limits-include.patch
+++ b/recipes/xapian-core/all/patches/0003-missing-limits-include.patch
@@ -1,0 +1,10 @@
+--- a/api/omdocument.cc
++++ b/api/omdocument.cc
+@@ -38,6 +38,7 @@
+ #include <xapian/valueiterator.h>
+ 
+ #include <algorithm>
++#include <limits>
+ #include <string>
+ 
+ using namespace std;

--- a/recipes/xapian-core/all/test_package/CMakeLists.txt
+++ b/recipes/xapian-core/all/test_package/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup()
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(xapian REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_include_directories(${PROJECT_NAME} PRIVATE ${XAPIAN_INCLUDE_DIR})
+target_link_libraries(${PROJECT_NAME} ${XAPIAN_LIBRARIES})

--- a/recipes/xapian-core/all/test_package/conanfile.py
+++ b/recipes/xapian-core/all/test_package/conanfile.py
@@ -3,8 +3,8 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

closes https://github.com/conan-io/conan-center-index/issues/5472

/cc @madebr 

Shared for Windows could be fixed also thanks to https://github.com/conan-io/conan-center-index/pull/5381, by adding libtool to build requirements and calling autoreconf, but there seems to be missing prebuilt packages of libtool on Windows https://github.com/conan-io/conan-center-index/issues/5476

It's worth noting that it fails to build with Visual Studio if CC & CXX are set in profile.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
