### PR TITLE
robin-hood-hashing: add version 3.11.1

### DIFF
--- a/recipes/robin-hood-hashing/all/conandata.yml
+++ b/recipes/robin-hood-hashing/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "3.9.1":
     url: "https://github.com/martinus/robin-hood-hashing/archive/3.9.1.tar.gz"
     sha256: "d6d15546a58d170717b2be5311425f80dc06f087a0885bd95de61a727bf9adef"
+  "3.11.1":
+    url: "https://github.com/martinus/robin-hood-hashing/archive/3.11.1.tar.gz"
+    sha256: "31143d316b49e29b57773e720ec9ac3f7a8223dc7710329b566c874c69e1d087"

--- a/recipes/robin-hood-hashing/config.yml
+++ b/recipes/robin-hood-hashing/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "3.9.1":
     folder: all
+  "3.11.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **robin-hood-hashing/3.11.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
