### PR TITLE
fix cross compilation error by setting cache variable

### DIFF
--- a/recipes/libarchive/all/CMakeLists.txt
+++ b/recipes/libarchive/all/CMakeLists.txt
@@ -4,4 +4,11 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
+if(CMAKE_CROSSCOMPILING)
+    if(WIN32 AND NOT CYGWIN)
+        set(ZLIB_WINAPI_EXITCODE "0")
+        set(ZLIB_WINAPI_EXITCODE__TRYRUN_OUTPUT "")
+    endif()
+endif()
+
 add_subdirectory("source_subfolder")


### PR DESCRIPTION
Specify library name and version:  **libarchive/3.5.1**

The libarchive's CMakeLists.txt uses TRY_MACRO_FOR_LIBRARY to check ZLIB_WINAPI.
TRY_MACRO_FOR_LIBRARY uses try_run.
It causes CMake configuration error in cross compilation for Windows target:

```
-- Performing Test ZLIB_WINAPI
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   ZLIB_WINAPI_EXITCODE (advanced)
   ZLIB_WINAPI_EXITCODE__TRYRUN_OUTPUT (advanced)
```

To fix it, I set ZLIB_WINAPI_EXITCODE and ZLIB_WINAPI_EXITCODE__TRYRUN_OUTPUT variables in cross compilation for Windows target.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
