### PR TITLE
libssh2: robust injection of dependencies + bump dependencies

### DIFF
--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -50,9 +50,9 @@ class Libssh2Conan(ConanFile):
         if self.options.with_zlib:
             self.requires("zlib/1.2.11")
         if self.options.crypto_backend == "openssl":
-            self.requires("openssl/1.1.1g")
+            self.requires("openssl/1.1.1k")
         elif self.options.crypto_backend == "mbedtls":
-            self.requires("mbedtls/2.16.3-gpl")
+            self.requires("mbedtls/2.25.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -1,6 +1,8 @@
 from conans import ConanFile, CMake, tools
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class Libssh2Conan(ConanFile):
     name = "libssh2"
@@ -55,8 +57,8 @@ class Libssh2Conan(ConanFile):
             self.requires("mbedtls/2.25.0")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("libssh2-%s" % (self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -94,8 +96,8 @@ class Libssh2Conan(ConanFile):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder, keep_path=False)
         if os.path.exists(os.path.join(self.package_folder, "lib64")):
             # rhel installs libraries into lib64
-            os.rename(os.path.join(self.package_folder, "lib64"),
-                      os.path.join(self.package_folder, "lib"))
+            tools.rename(os.path.join(self.package_folder, "lib64"),
+                         os.path.join(self.package_folder, "lib"))
 
         tools.rmdir(os.path.join(self.package_folder, "share"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))

--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -92,13 +92,7 @@ class Libssh2Conan(ConanFile):
     def package(self):
         cmake = self._configure_cmake()
         cmake.install()
-
-        self.copy("COPYING", dst="licenses", src=self._source_subfolder, keep_path=False)
-        if os.path.exists(os.path.join(self.package_folder, "lib64")):
-            # rhel installs libraries into lib64
-            tools.rename(os.path.join(self.package_folder, "lib64"),
-                         os.path.join(self.package_folder, "lib"))
-
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
         tools.rmdir(os.path.join(self.package_folder, "share"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))

--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -111,7 +111,7 @@ class Libssh2Conan(ConanFile):
         self.cpp_info.components["_libssh2"].names["cmake_find_package_multi"] = "libssh2"
         self.cpp_info.components["_libssh2"].names["pkg_config"] = "libssh2"
         self.cpp_info.components["_libssh2"].libs = tools.collect_libs(self)
-        if self.settings.compiler == "Visual Studio" and not self.options.shared:
+        if self.settings.os == "Windows":
             self.cpp_info.components["_libssh2"].system_libs.append("ws2_32")
         elif self.settings.os == "Linux":
             self.cpp_info.components["_libssh2"].system_libs.extend(["pthread", "dl"])

--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -104,8 +104,10 @@ class Libssh2Conan(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "Libssh2"
         self.cpp_info.names["cmake_find_package_multi"] = "Libssh2"
+        self.cpp_info.names["pkg_config"] = "libssh2"
         self.cpp_info.components["_libssh2"].names["cmake_find_package"] = "libssh2"
         self.cpp_info.components["_libssh2"].names["cmake_find_package_multi"] = "libssh2"
+        self.cpp_info.components["_libssh2"].names["pkg_config"] = "libssh2"
         self.cpp_info.components["_libssh2"].libs = tools.collect_libs(self)
         if self.settings.compiler == "Visual Studio" and not self.options.shared:
             self.cpp_info.components["_libssh2"].system_libs.append("ws2_32")

--- a/recipes/libssh2/all/test_package/CMakeLists.txt
+++ b/recipes/libssh2/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(Libssh2 REQUIRED CONFIG)
 


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

When crypto backend is mbetls, it might still be fragile, since mbetls doesn't have an official Find module or config file, and libssh2 has its own `findmbeTLS.cmake`

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
