### PR TITLE
update CPR to 1.6.2

### DIFF
--- a/recipes/cpr/all/conandata.yml
+++ b/recipes/cpr/all/conandata.yml
@@ -14,6 +14,9 @@ sources:
   "1.6.0":
     sha256: "5a20a9f014b47988f5230d008174e5db2b33f8c547df825e6beae0c78fc05a9e"
     url: https://github.com/whoshuu/cpr/archive/1.6.0.tar.gz
+  "1.6.2":
+    sha256: "c45f9c55797380c6ba44060f0c73713fbd7989eeb1147aedb8723aa14f3afaa3"
+    url: https://github.com/whoshuu/cpr/archive/1.6.2.tar.gz
 patches:
   "1.3.0":
     - patch_file: "patches/001-fix-curl-define.patch"

--- a/recipes/cpr/config.yml
+++ b/recipes/cpr/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "1.6.0":
     folder: all
+  "1.6.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  cpr/1.6.2

Updating this because I'm a user of this library and wanted to use the latest version of it with Conan in my project. I think I have done this correctly (though this is my first time messing with recipes, so please let me know if something needs to be changed!)

---

- [x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
