### PR TITLE
sqlcipher: add 4.4.3 and requires openssl/1.1.1k

### DIFF
--- a/recipes/sqlcipher/all/conandata.yml
+++ b/recipes/sqlcipher/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   4.4.2:
     sha256: 6bb5c154ef979ddd28f4668846f394ae2ccbf6cece09a9148b73fadf8adc7b55
     url: https://github.com/sqlcipher/sqlcipher/archive/v4.4.2.zip
+  4.4.3:
+    sha256: e52d0595dc1ed30eed68523fe286d38657bd905957447a3725706ff54e21edf8
+    url: https://github.com/sqlcipher/sqlcipher/archive/v4.4.3.zip
 patches:
   4.3.0:
     - patch_file: patches/Makefile.in-v4.3.0.patch
@@ -29,4 +32,11 @@ patches:
     - patch_file: patches/Makefile.msc-v4.4.2.patch
       base_path: source_subfolder
     - patch_file: patches/fix_configure-v4.4.2.patch
+      base_path: source_subfolder
+  4.4.3:
+    - patch_file: patches/Makefile.in-v4.4.3.patch
+      base_path: source_subfolder
+    - patch_file: patches/Makefile.msc-v4.4.3.patch
+      base_path: source_subfolder
+    - patch_file: patches/fix_configure-v4.4.3.patch
       base_path: source_subfolder

--- a/recipes/sqlcipher/all/conanfile.py
+++ b/recipes/sqlcipher/all/conanfile.py
@@ -39,6 +39,10 @@ class SqlcipherConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
     def build_requirements(self):
         # It is possible to have a MinGW cross-build toolchain (Linux to Windows)
         # Only require msys2 when building on an actual Windows system

--- a/recipes/sqlcipher/all/conanfile.py
+++ b/recipes/sqlcipher/all/conanfile.py
@@ -48,7 +48,7 @@ class SqlcipherConan(ConanFile):
 
     def requirements(self):
         if self.options.crypto_library == "openssl":
-            self.requires("openssl/1.1.1h")
+            self.requires("openssl/1.1.1k")
         else:
             self.requires("libressl/3.2.0")
 

--- a/recipes/sqlcipher/all/patches/Makefile.in-v4.4.3.patch
+++ b/recipes/sqlcipher/all/patches/Makefile.in-v4.4.3.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile.in b/Makefile.in
+index d365631..920ac7d 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -1472,9 +1472,8 @@ lib_install:	libsqlcipher.la
+ 	$(INSTALL) -d $(DESTDIR)$(libdir)
+ 	$(LTINSTALL) libsqlcipher.la $(DESTDIR)$(libdir)
+ 
+-install:	sqlcipher$(TEXE) lib_install sqlite3.h sqlcipher.pc ${HAVE_TCL:1=tcl_install}
++install:	lib_install sqlite3.h
+ 	$(INSTALL) -d $(DESTDIR)$(bindir)
+-	$(LTINSTALL) sqlcipher$(TEXE) $(DESTDIR)$(bindir)
+ 	$(INSTALL) -d $(DESTDIR)$(includedir)
+ 	$(INSTALL) -m 0644 sqlite3.h $(DESTDIR)$(includedir)
+ 	$(INSTALL) -m 0644 $(TOP)/src/sqlite3ext.h $(DESTDIR)$(includedir)

--- a/recipes/sqlcipher/all/patches/Makefile.msc-v4.4.3.patch
+++ b/recipes/sqlcipher/all/patches/Makefile.msc-v4.4.3.patch
@@ -1,0 +1,161 @@
+diff --git a/Makefile.msc b/Makefile.msc
+index 312b40c..fb4c3cc 100644
+--- a/Makefile.msc
++++ b/Makefile.msc
+@@ -285,9 +285,9 @@ SQLITE3H = sqlite3.h
+ #
+ !IFNDEF SQLITE3DLL
+ !IF $(FOR_WIN10)!=0
+-SQLITE3DLL = winsqlite3.dll
++SQLITE3DLL = sqlcipher.dll
+ !ELSE
+-SQLITE3DLL = sqlite3.dll
++SQLITE3DLL = sqlcipher.dll
+ !ENDIF
+ !ENDIF
+ 
+@@ -295,9 +295,9 @@ SQLITE3DLL = sqlite3.dll
+ #
+ !IFNDEF SQLITE3LIB
+ !IF $(FOR_WIN10)!=0
+-SQLITE3LIB = winsqlite3.lib
++SQLITE3LIB = sqlcipher.lib
+ !ELSE
+-SQLITE3LIB = sqlite3.lib
++SQLITE3LIB = sqlcipher.lib
+ !ENDIF
+ !ENDIF
+ 
+@@ -672,7 +672,7 @@ SHELL_CORE_SRC = $(SQLITE3C)
+ SHELL_CORE_DEP = $(SQLITE3DLL)
+ # <<mark>>
+ !ELSEIF $(USE_AMALGAMATION)==0
+-SHELL_CORE_DEP = libsqlite3.lib
++SHELL_CORE_DEP = sqlcipher.lib
+ # <</mark>>
+ !ELSE
+ SHELL_CORE_DEP =
+@@ -695,7 +695,7 @@ TESTFIXTURE_DEP = zlib $(TESTFIXTURE_DEP)
+ SHELL_CORE_LIB = $(SQLITE3LIB)
+ # <<mark>>
+ !ELSEIF $(USE_AMALGAMATION)==0
+-SHELL_CORE_LIB = libsqlite3.lib
++SHELL_CORE_LIB = sqlcipher.lib
+ # <</mark>>
+ !ELSE
+ SHELL_CORE_LIB =
+@@ -730,8 +730,9 @@ RCC = $(RCC) -DWINAPI_FAMILY=WINAPI_FAMILY_APP
+ # C compiler options for the Windows 10 platform (needs MSVC 2015).
+ #
+ !IF $(FOR_WIN10)!=0
+-TCC = $(TCC) /d2guard4 -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
+-BCC = $(BCC) /d2guard4 -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
++# /d2guard4 requires /guard:cf to be present as well, but it doesn't work with /Zi (Debug builds)
++TCC = $(TCC) -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
++BCC = $(BCC) -D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE
+ !ENDIF
+ 
+ # Also, we need to dynamically link to the correct MSVC runtime
+@@ -1008,8 +1009,10 @@ TLIBS =
+ # default to file, 2 to default to memory, and 3 to force temporary
+ # tables to always be in memory.
+ #
+-TCC = $(TCC) -DSQLITE_TEMP_STORE=1
+-RCC = $(RCC) -DSQLITE_TEMP_STORE=1
++
++# Allow overriding the value
++TCC = $(TCC) -DSQLITE_TEMP_STORE=$(SQLITE_TEMP_STORE)
++RCC = $(RCC) -DSQLITE_TEMP_STORE=$(SQLITE_TEMP_STORE)
+ 
+ # Enable/disable loadable extensions, and other optional features
+ # based on configuration. (-DSQLITE_OMIT*, -DSQLITE_ENABLE*).
+@@ -1175,14 +1178,15 @@ LTLINKOPTS = $(LTLINKOPTS) "/LIBPATH:$(WP81LIBPATH)"
+ !ENDIF
+ LTLINKOPTS = $(LTLINKOPTS) /DYNAMICBASE
+ LTLINKOPTS = $(LTLINKOPTS) WindowsPhoneCore.lib RuntimeObject.lib PhoneAppModelHost.lib
+-LTLINKOPTS = $(LTLINKOPTS) /NODEFAULTLIB:kernel32.lib /NODEFAULTLIB:ole32.lib
++# Remove /NODEFAULTLIB:kernel32.lib, required by OpenSSL
+ !ENDIF
+ 
+ # When compiling for UWP or the Windows 10 platform, some extra linker
+ # options are also required.
+ #
+ !IF $(FOR_UWP)!=0 || $(FOR_WIN10)!=0
+-LTLINKOPTS = $(LTLINKOPTS) /DYNAMICBASE /NODEFAULTLIB:kernel32.lib
++# Remove /NODEFAULTLIB:kernel32.lib, required by OpenSSL
++LTLINKOPTS = $(LTLINKOPTS) /DYNAMICBASE
+ LTLINKOPTS = $(LTLINKOPTS) mincore.lib
+ !IFDEF PSDKLIBPATH
+ LTLINKOPTS = $(LTLINKOPTS) "/LIBPATH:$(PSDKLIBPATH)"
+@@ -1237,7 +1241,7 @@ LTLIBS = $(LTLIBS) $(LIBICU)
+ #
+ LIBOBJS0 = vdbe.lo parse.lo alter.lo analyze.lo attach.lo auth.lo \
+          backup.lo bitvec.lo btmutex.lo btree.lo build.lo \
+-         callback.lo complete.lo ctime.lo \
++         callback.lo complete.lo crypto.lo crypto_impl.lo crypto_openssl.lo ctime.lo \
+          date.lo dbpage.lo dbstat.lo delete.lo \
+          expr.lo fault.lo fkey.lo \
+          fts3.lo fts3_aux.lo fts3_expr.lo fts3_hash.lo fts3_icu.lo \
+@@ -1730,7 +1734,7 @@ ALL_TCL_TARGETS =
+ # This is the default Makefile target.  The objects listed here
+ # are what get build when you type just "make" with no arguments.
+ #
+-core:	dll libsqlite3.lib shell
++core:	dll sqlcipher.lib shell
+ 
+ # Targets that require the Tcl library.
+ #
+@@ -1749,11 +1753,12 @@ dll:	$(SQLITE3DLL)
+ shell:	$(SQLITE3EXE)
+ 
+ # <<mark>>
+-libsqlite3.lib:	$(LIBOBJ)
+-	$(LTLIB) $(LTLIBOPTS) /OUT:$@ $(LIBOBJ) $(TLIBS)
++# LTLIBPATHS is required to find the openssl/libressl libs
++sqlcipher.lib:	$(LIBOBJ)
++	$(LTLIB) $(LTLIBPATHS) $(LTLIBOPTS) /OUT:$@ $(LIBOBJ) $(TLIBS)
+ 
+-libtclsqlite3.lib:	tclsqlite.lo libsqlite3.lib
+-	$(LTLIB) $(LTLIBOPTS) $(TCLLIBPATHS) $(LTLIBPATHS) /OUT:$@ tclsqlite.lo libsqlite3.lib $(LIBTCLSTUB) $(TLIBS)
++libtclsqlite3.lib:	tclsqlite.lo sqlcipher.lib
++	$(LTLIB) $(LTLIBOPTS) $(TCLLIBPATHS) $(LTLIBPATHS) /OUT:$@ tclsqlite.lo sqlcipher.lib $(LIBTCLSTUB) $(TLIBS)
+ 
+ tclsqlite3.def:	tclsqlite.lo
+ 	echo EXPORTS > tclsqlite3.def
+@@ -1775,9 +1780,9 @@ $(SQLITE3DLL):	$(LIBOBJ) $(LIBRESOBJS) $(CORE_LINK_DEP)
+ 	$(LD) $(LDFLAGS) $(LTLINKOPTS) $(LTLIBPATHS) /DLL $(CORE_LINK_OPTS) /OUT:$@ $(LIBOBJ) $(LIBRESOBJS) $(LTLIBS) $(TLIBS)
+ 
+ # <<block2>>
+-sqlite3.def:	libsqlite3.lib
++sqlite3.def:	sqlcipher.lib
+ 	echo EXPORTS > sqlite3.def
+-	dumpbin /all libsqlite3.lib \
++	dumpbin /all sqlcipher.lib \
+ 		| $(TCLSH_CMD) $(TOP)\tool\replace.tcl include "^\s+1 _?(sqlite3(?:session|changeset|changegroup|rebaser|rbu)?_[^@]*)(?:@\d+)?$$" \1 \
+ 		| sort >> sqlite3.def
+ # <</block2>>
+@@ -1957,6 +1962,15 @@ callback.lo:	$(TOP)\src\callback.c $(HDR)
+ complete.lo:	$(TOP)\src\complete.c $(HDR)
+ 	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\complete.c
+ 
++crypto.lo:	$(TOP)\src\crypto.c $(HDR)
++	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\crypto.c
++
++crypto_impl.lo:	$(TOP)\src\crypto_impl.c $(HDR)
++	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\crypto_impl.c
++
++crypto_openssl.lo:	$(TOP)\src\crypto_openssl.c $(HDR)
++	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\crypto_openssl.c
++
+ ctime.lo:	$(TOP)\src\ctime.c $(HDR)
+ 	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\ctime.c
+ 
+@@ -2382,7 +2396,7 @@ sqlite3rbu.lo:	$(TOP)\ext\rbu\sqlite3rbu.c $(HDR) $(EXTHDR)
+ # Rules to build the 'testfixture' application.
+ #
+ # If using the amalgamation, use sqlite3.c directly to build the test
+-# fixture.  Otherwise link against libsqlite3.lib.  (This distinction is
++# fixture.  Otherwise link against sqlcipher.lib.  (This distinction is
+ # necessary because the test fixture requires non-API symbols which are
+ # hidden when the library is built via the amalgamation).
+ #

--- a/recipes/sqlcipher/all/patches/fix_configure-v4.4.3.patch
+++ b/recipes/sqlcipher/all/patches/fix_configure-v4.4.3.patch
@@ -1,0 +1,20 @@
+diff --git a/configure b/configure
+index 55102b0..32f5bdd 100755
+--- a/configure
++++ b/configure
+@@ -12118,7 +12118,6 @@ if ${ac_cv_lib_crypto_HMAC_Init_ex+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+   ac_check_lib_save_LIBS=$LIBS
+-LIBS="-lcrypto  $LIBS"
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+@@ -12153,7 +12152,6 @@ if test "x$ac_cv_lib_crypto_HMAC_Init_ex" = xyes; then :
+ #define HAVE_LIBCRYPTO 1
+ _ACEOF
+ 
+-  LIBS="-lcrypto $LIBS"
+ 
+ else
+   as_fn_error $? "Library crypto not found. Install openssl!\"" "$LINENO" 5

--- a/recipes/sqlcipher/config.yml
+++ b/recipes/sqlcipher/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "4.4.2":
     folder: all
+  "4.4.3":
+    folder: all


### PR DESCRIPTION
fixed #5056 

Specify library name and version:  sqlcipher/4.4.3

sqlcipher 4.4.2 and below and openssl 1.1.1j and below are vulnerable.

- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3119
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3450

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
