### PR TITLE
autoconf: override trailer_m4 environment variable + bump msys2

### DIFF
--- a/recipes/autoconf/all/conandata.yml
+++ b/recipes/autoconf/all/conandata.yml
@@ -17,7 +17,7 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/2.71-0005-disable-man-regeneration.patch"
       base_path: "source_subfolder"
-    - patch_file: "patches/2.71-0006-autoconf-trailer_m4-from-uppercase-env.patch"
+    - patch_file: "patches/2.71-0006-autoconf-no-embedded-trailer_m4-path.patch"
       base_path: "source_subfolder"
   "2.69":
     - patch_file: "patches/2.69-0001-autom4te-relocatable.patch"

--- a/recipes/autoconf/all/conandata.yml
+++ b/recipes/autoconf/all/conandata.yml
@@ -17,6 +17,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/2.71-0005-disable-man-regeneration.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/2.71-0006-autoconf-trailer_m4-from-uppercase-env.patch"
+      base_path: "source_subfolder"
   "2.69":
     - patch_file: "patches/2.69-0001-autom4te-relocatable.patch"
       base_path: "source_subfolder"

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -118,8 +118,3 @@ class AutoconfConan(ConanFile):
         autom4te_perllibdir = self._autoconf_datarootdir
         self.output.info("Setting AUTOM4TE_PERLLIBDIR to {}".format(autom4te_perllibdir))
         self.env_info.AUTOM4TE_PERLLIBDIR = autom4te_perllibdir
-
-        if tools.Version(self.version) > "2.69":
-            trailer_m4 = tools.unix_path(os.path.join(self.package_folder, "bin", "share", "autoconf", "autoconf", "trailer.m4"))
-            self.output.info("Settings TRAILER_M4 to {}".format(trailer_m4))
-            self.env_info.TRAILER_M4 = trailer_m4

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -31,8 +31,8 @@ class AutoconfConan(ConanFile):
         self.info.requires.clear()
 
     def build_requirements(self):
-        if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:
-            self.build_requires("msys2/20190524")
+        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
 
     @property
     def _datarootdir(self):
@@ -118,3 +118,8 @@ class AutoconfConan(ConanFile):
         autom4te_perllibdir = self._autoconf_datarootdir
         self.output.info("Setting AUTOM4TE_PERLLIBDIR to {}".format(autom4te_perllibdir))
         self.env_info.AUTOM4TE_PERLLIBDIR = autom4te_perllibdir
+
+        if tools.Version(self.version) > "2.69":
+            trailer_m4 = tools.unix_path(os.path.join(self.package_folder, "bin", "share", "autoconf", "autoconf", "trailer.m4"))
+            self.output.info("Settings $TRAILER_M4 to {}".format(trailer_m4))
+            self.env_info.TRAILER_M4 = trailer_m4

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -121,5 +121,5 @@ class AutoconfConan(ConanFile):
 
         if tools.Version(self.version) > "2.69":
             trailer_m4 = tools.unix_path(os.path.join(self.package_folder, "bin", "share", "autoconf", "autoconf", "trailer.m4"))
-            self.output.info("Settings $TRAILER_M4 to {}".format(trailer_m4))
+            self.output.info("Settings TRAILER_M4 to {}".format(trailer_m4))
             self.env_info.TRAILER_M4 = trailer_m4

--- a/recipes/autoconf/all/patches/2.71-0006-autoconf-no-embedded-trailer_m4-path.patch
+++ b/recipes/autoconf/all/patches/2.71-0006-autoconf-no-embedded-trailer_m4-path.patch
@@ -11,7 +11,7 @@ Work around this problem by getting the system information from an uppercase env
  # Variables.
  : ${AUTOM4TE='@bindir@/@autom4te-name@'}
 -: ${trailer_m4='@pkgdatadir@/autoconf/trailer.m4'}
-+: ${trailer_m4="$TRAILER_M4"}
++: ${trailer_m4="$AC_MACRODIR/autoconf/trailer.m4"}
  autom4te_options=
  outfile=
  verbose=false

--- a/recipes/autoconf/all/patches/2.71-0006-autoconf-trailer_m4-from-uppercase-env.patch
+++ b/recipes/autoconf/all/patches/2.71-0006-autoconf-trailer_m4-from-uppercase-env.patch
@@ -4,9 +4,9 @@ But Windows has case insensitive environment variables.
 Python silently converts lowercase environment variables to uppercase.
 Work around this problem by getting the system information from an uppercase environment variable.
 
---- bin/autoconf.in
-+++ bin/autoconf.in
-@@ -413,7 +413,7 @@
+--- bin/autoconf.as
++++ bin/autoconf.as
+@@ -90,7 +90,7 @@
  
  # Variables.
  : ${AUTOM4TE='@bindir@/@autom4te-name@'}

--- a/recipes/autoconf/all/patches/2.71-0006-autoconf-trailer_m4-from-uppercase-env.patch
+++ b/recipes/autoconf/all/patches/2.71-0006-autoconf-trailer_m4-from-uppercase-env.patch
@@ -1,0 +1,17 @@
+The trailer_m4 environment variable contains build-environment dependent information.
+So this variable needs to be overridden by the conanfile.
+But Windows has case insensitive environment variables.
+Python silently converts lowercase environment variables to uppercase.
+Work around this problem by getting the system information from an uppercase environment variable.
+
+--- bin/autoconf.in
++++ bin/autoconf.in
+@@ -413,7 +413,7 @@
+ 
+ # Variables.
+ : ${AUTOM4TE='@bindir@/@autom4te-name@'}
+-: ${trailer_m4='@pkgdatadir@/autoconf/trailer.m4'}
++: ${trailer_m4="$TRAILER_M4"}
+ autom4te_options=
+ outfile=
+ verbose=false

--- a/recipes/autoconf/all/test_package/conanfile.py
+++ b/recipes/autoconf/all/test_package/conanfile.py
@@ -9,8 +9,8 @@ class TestPackageConan(ConanFile):
     exports_sources = "configure.ac", "config.h.in", "Makefile.in", "test_package_c.c", "test_package_cpp.cpp",
 
     def build_requirements(self):
-        if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:
-            self.build_requires("msys2/20190524")
+        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
 
     @contextmanager
     def _build_context(self):


### PR DESCRIPTION
Specify library name and version:  **autoconf/2.71**

CCI packages do not work on local machines because a build system path was still present.
Patch the source + set an environment variable to make autoconf portable.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
