### PR TITLE
sentry-native: add crashpad support

### DIFF
--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -1,16 +1,16 @@
 sources:
   "0.4.9":
-    url: "https://github.com/getsentry/sentry-native/archive/0.4.9.tar.gz"
-    sha256: "d1937a78473767493cb77639376b03f4de91d3cd49189ad9a1082010c7175d75"
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.9/sentry-native.zip"
+    sha256: "559344bad846b7868c182b22df0cd9869c31ebf46a222ac7a6588aab0211af7d"
   "0.4.8":
-    url: "https://github.com/getsentry/sentry-native/archive/0.4.8.tar.gz"
-    sha256: "8100cee919b42c68699bd013c7b52e8ef7c4ee5ac7122886ffa51e972c34e2f2"
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.8/sentry-native.zip"
+    sha256: "35afb62eecc5e719187c81f5c89b4e3d3c45c7b3c1597836202989fa40c79178"
   "0.4.7":
-    url: "https://github.com/getsentry/sentry-native/archive/0.4.7.tar.gz"
-    sha256: "84f3a1dbfea1245870a7e36eef06ea78e21c173457c543eaa27904d2d017e50c"
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.7/sentry-native.zip"
+    sha256: "fb16658b250c342ed05e4d2edeff8ec806d9db758dfa188b78070bdfaf54f598"
   "0.4.1":
-    url: "https://github.com/getsentry/sentry-native/archive/0.4.1.tar.gz"
-    sha256: "a7d04fe9b9175c30a58ce20ae23b510595045a66884a447dd21ff2d0c749751b"
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.1/sentry-native.zip"
+    sha256: "ffeec2a8aa6d2f274123cd16c62ad6d5d4c6f993e44e9e2f88210261ccb51fcc"
   "0.2.6":
-    url: "https://github.com/getsentry/sentry-native/archive/0.2.6.tar.gz"
-    sha256: "e96ed2dee226b978a2d2de552a8d4b8a578bd5990de1c41bf23add455eef597a"
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.2.6/sentry-native-0.2.6.zip"
+    sha256: "0d93bd77f70a64f3681d4928dfca6b327374218a84d33ee31489114d8e4716c0"

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -56,7 +56,7 @@ class SentryNativeConan(ConanFile):
         if self.options.transport == "curl":
             self.requires("libcurl/7.75.0")
         if self.options.backend == "crashpad":
-            raise ConanInvalidConfiguration("crashpad not available yet in CCI")
+            self.requires("crashpad/cci.20210507")
         elif self.options.backend == "breakpad":
             raise ConanInvalidConfiguration("breakpad not available yet in CCI")
 
@@ -70,6 +70,7 @@ class SentryNativeConan(ConanFile):
             return self._cmake
         self._cmake = CMake(self)
         self._cmake.definitions["SENTRY_BACKEND"] = self.options.backend
+        self._cmake.definitions["SENTRY_CRASHPAD_SYSTEM"] = True
         self._cmake.definitions["SENTRY_ENABLE_INSTALL"] = True
         self._cmake.definitions["SENTRY_TRANSPORT"] = self.options.transport
         self._cmake.definitions["SENTRY_PIC"] = self.options.get_safe("fPIC", True)
@@ -105,6 +106,6 @@ class SentryNativeConan(ConanFile):
                 self.cpp_info.system_libs.append("Version")
             if self.options.transport == "winhttp":
                 self.cpp_info.system_libs.append("winhttp")
-            
+
         if not self.options.shared:
             self.cpp_info.defines = ["SENTRY_BUILD_STATIC"]

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -37,6 +37,7 @@ class SentryNativeConan(ConanFile):
         return "source_subfolder"
 
     def config_options(self):
+        # FIXME: set default backend for each platform (missing breakpad recipe)
         if self.settings.os == "Windows":
             del self.options.fPIC
 

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -3,6 +3,8 @@ import glob
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.28.0"
+
 
 class SentryNativeConan(ConanFile):
     name = "sentry-native"
@@ -62,9 +64,7 @@ class SentryNativeConan(ConanFile):
             raise ConanInvalidConfiguration("breakpad not available yet in CCI")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)
 
     def _configure_cmake(self):
         if self._cmake:


### PR DESCRIPTION
Specify library name and version:  **sentry-native/all**

Add crashpad support to sentry-native.
Depends on #5511 when using with `-o crashpad:backend=crashpad`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
