### PR TITLE
[mp-units] typo in mp-units, bug in the CCI library

### DIFF
--- a/recipes/mp-units/config.yml
+++ b/recipes/mp-units/config.yml
@@ -1,5 +1,5 @@
 versions:
   "0.7.0":
-    folder: all
+    folder: 0.7.0
   "0.6.0":
     folder: 0.6.0


### PR DESCRIPTION
Specify library name and version:  **mp-units/0.7.0**

