### PR TITLE
Add google benchmark 1.5.3

### DIFF
--- a/recipes/benchmark/all/conandata.yml
+++ b/recipes/benchmark/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "1.5.2":
     sha256: dccbdab796baa1043f04982147e67bb6e118fe610da2c65f88912d73987e700c
     url: https://github.com/google/benchmark/archive/v1.5.2.tar.gz
+  "1.5.3":
+    sha256: e4fbb85eec69e6668ad397ec71a3a3ab165903abe98a8327db920b94508f720e
+    url: https://github.com/google/benchmark/archive/v1.5.3.tar.gz

--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class BenchmarkConan(ConanFile):
     name = "benchmark"
@@ -27,23 +29,28 @@ class BenchmarkConan(ConanFile):
         "enable_exceptions": True,
     }
 
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
     _cmake = None
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def config_options(self):
         if self.settings.os == "Windows":
-            if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version.value) <= 12:
-                raise ConanInvalidConfiguration("{} {} does not support Visual Studio <= 12".format(self.name, self.version))
             del self.options.fPIC
+        if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version.value) <= 12:
+            raise ConanInvalidConfiguration("{} {} does not support Visual Studio <= 12".format(self.name, self.version))
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration("Windows shared builds are not supported right now, see issue #639")
 
@@ -62,7 +69,7 @@ class BenchmarkConan(ConanFile):
                 self._cmake.definitions["HAVE_STD_REGEX"] = False
                 self._cmake.definitions["HAVE_POSIX_REGEX"] = False
                 self._cmake.definitions["HAVE_STEADY_CLOCK"] = False
-            self._cmake.definitions["BENCHMARK_USE_LIBCXX"] = "ON" if (str(self.settings.compiler.libcxx) == "libc++") else "OFF"
+            self._cmake.definitions["BENCHMARK_USE_LIBCXX"] = "ON" if self.settings.compiler.get_safe("libcxx") == "libc++" else "OFF"
         else:
             self._cmake.definitions["BENCHMARK_USE_LIBCXX"] = "OFF"
 
@@ -82,8 +89,8 @@ class BenchmarkConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, 'lib', 'cmake'))
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
-        if self.settings.os == "Linux":
+        self.cpp_info.libs = ["benchmark", "benchmark_main"]
+        if self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.system_libs.extend(["pthread", "rt"])
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs.append("shlwapi")

--- a/recipes/benchmark/config.yml
+++ b/recipes/benchmark/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "1.5.2":
     folder: all
+  "1.5.3":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **benchmark/1.5.3**

A minor update to an existing recipe to pull in a new version.

This fixes issues building with GCC 11, amongst other minorbug fixes.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
