### PR TITLE
catch2 main support for 2.13.5+

### DIFF
--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -46,6 +46,8 @@ class ConanRecipe(ConanFile):
         self._cmake.definitions["BUILD_TESTING"] = "OFF"
         self._cmake.definitions["CATCH_INSTALL_DOCS"] = "OFF"
         self._cmake.definitions["CATCH_INSTALL_HELPERS"] = "ON"
+        self._cmake.definitions["CATCH_BUILD_STATIC_LIBRARY"] = self.options.with_main
+
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **catch2/2.13.5**

Utilizes the [newly introduced](https://github.com/catchorg/Catch2/releases/tag/v2.13.5) `CATCH_BUILD_STATIC_LIBRARY` to build the target `Catch2WithMain` through the `with_main` option.

---

- 🥳 