### PR TITLE
sentry-crashpad: add sentry-crashpad recipe

### DIFF
--- a/recipes/sentry-crashpad/all/CMakeLists.txt
+++ b/recipes/sentry-crashpad/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup()
+
+add_subdirectory(source_subfolder/external/crashpad)

--- a/recipes/sentry-crashpad/all/conandata.yml
+++ b/recipes/sentry-crashpad/all/conandata.yml
@@ -1,0 +1,32 @@
+sources:
+  "0.4.9":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.9/sentry-native.zip"
+    sha256: "559344bad846b7868c182b22df0cd9869c31ebf46a222ac7a6588aab0211af7d"
+  "0.4.8":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.8/sentry-native.zip"
+    sha256: "35afb62eecc5e719187c81f5c89b4e3d3c45c7b3c1597836202989fa40c79178"
+  "0.4.7":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.7/sentry-native.zip"
+    sha256: "fb16658b250c342ed05e4d2edeff8ec806d9db758dfa188b78070bdfaf54f598"
+  "0.4.1":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.1/sentry-native.zip"
+    sha256: "ffeec2a8aa6d2f274123cd16c62ad6d5d4c6f993e44e9e2f88210261ccb51fcc"
+  "0.2.6":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.2.6/sentry-native-0.2.6.zip"
+    sha256: "0d93bd77f70a64f3681d4928dfca6b327374218a84d33ee31489114d8e4716c0"
+patches:
+  "0.4.9":
+    - patch_file: "patches/0.4.9-0001-missing-installed-headers.patch"
+      base_path: "source_subfolder"
+  "0.4.8":
+    - patch_file: "patches/0.4.7-0001-missing-installed-headers.patch"
+      base_path: "source_subfolder"
+  "0.4.7":
+    - patch_file: "patches/0.4.7-0001-missing-installed-headers.patch"
+      base_path: "source_subfolder"
+  "0.4.1":
+    - patch_file: "patches/0.4.1-0001-missing-installed-headers.patch"
+      base_path: "source_subfolder"
+  "0.2.6":
+    - patch_file: "patches/0.2.6-0001-missing-installed-headers.patch"
+      base_path: "source_subfolder"

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -75,7 +75,7 @@ class SentryCrashpadConan(ConanFile):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         if tools.Version(self.version) > "0.4":
-            openssl_repl  = "find_package(OpenSSL REQUIRED)" if self.options.get_safe("with_tls") else ""
+            openssl_repl = "find_package(OpenSSL REQUIRED)" if self.options.get_safe("with_tls") else ""
             tools.replace_in_file(os.path.join(self._source_subfolder, "external", "crashpad", "CMakeLists.txt"),
                                   "find_package(OpenSSL)", openssl_repl)
         cmake = self._configure_cmake()
@@ -109,7 +109,7 @@ class SentryCrashpadConan(ConanFile):
         self.cpp_info.components["util"].requires = ["compat", "mini_chromium", "zlib::zlib"]
         if self.settings.os in ("Linux", "FreeBSD"):
             self.cpp_info.components["util"].system_libs.extend(["pthread", "rt"])
-        if self.options.with_tls == "openssl":
+        if self.options.get_safe("with_tls") == "openssl":
             self.cpp_info.components["util"].requires.append("openssl::openssl")
 
         self.cpp_info.components["client"].libs = ["crashpad_client"]

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -50,8 +50,11 @@ class SentryCrashpadConan(ConanFile):
 
         if self.settings.os == "Linux":
             if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < 5:
-                # FIXME: need to test for availability of SYS_memfd_create syscall availability (Linux kernel >= 3.17)
+                # FIXME: need to test for availability of SYS_memfd_create syscall (Linux kernel >= 3.17)
                 raise ConanInvalidConfiguration("sentry-crashpad needs SYS_memfd_create syscall support.")
+
+        if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) < 15:
+            raise ConanInvalidConfiguration("Require at least Visual Studio 2017 (15)")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -1,0 +1,119 @@
+import os
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.28.0"
+
+
+class SentryCrashpadConan(ConanFile):
+    name = "sentry-crashpad"
+    description = "Crashpad is a crash-reporting system."
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/getsentry/sentry-native"
+    license = "Apache-2.0"
+    topics = ("conan", "crashpad", "error-reporting", "crash-reporting")
+    provides = "crashpad", "mini_chromium"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+        "with_tls": ["openssl", False],
+    }
+    default_options = {
+        "fPIC": True,
+        "with_tls": "openssl",
+    }
+    exports_sources = "CMakeLists.txt", "patches/*"
+    generators = "cmake"
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 11)
+
+    def requirements(self):
+        self.requires("zlib/1.2.11")
+        if self.options.with_tls:
+            self.requires("openssl/1.1.1k")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["CRASHPAD_ENABLE_INSTALL"] = True
+        self._cmake.definitions["CRASHPAD_ENABLE_INSTALL_DEV"] = True
+        self._cmake.definitions["CRASHPAD_ZLIB_SYSTEM"] = True
+        self._cmake.configure()
+        return self._cmake
+
+    def validate(self):
+        if self.settings.os == "Linux":
+            if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < 5:
+                # FIXME: need to test for availability of SYS_memfd_create syscall availability (Linux kernel >= 3.17)
+                raise ConanInvalidConfiguration("sentry-crashpad needs SYS_memfd_create syscall support.")
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.pdb")
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "crashpad"
+        self.cpp_info.names["cmake_find_package_multi"] = "crashpad"
+        self.cpp_info.filenames["cmake_find_package"] = "crashpad"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "crashpad"
+
+        self.cpp_info.components["mini_chromium"].includedirs.append(os.path.join("include", "crashpad", "mini_chromium"))
+        self.cpp_info.components["mini_chromium"].libs = ["mini_chromium"]
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.components["mini_chromium"].system_libs.append("pthread")
+
+        self.cpp_info.components["compat"].includedirs.append(os.path.join("include", "crashpad"))
+        self.cpp_info.components["compat"].libs = ["crashpad_compat"]
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.components["compat"].system_libs.append("dl")
+
+        self.cpp_info.components["util"].libs = ["crashpad_util"]
+        self.cpp_info.components["util"].requires = ["compat", "mini_chromium", "zlib::zlib"]
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.components["util"].system_libs.append("pthread")
+        if self.options.with_tls == "openssl":
+            self.cpp_info.components["util"].requires.append("openssl::openssl")
+
+        self.cpp_info.components["client"].libs = ["crashpad_client"]
+        self.cpp_info.components["client"].requires = ["util", "mini_chromium"]
+
+        self.cpp_info.components["snapshot"].libs = ["crashpad_snapshot"]
+        self.cpp_info.components["snapshot"].requires = ["client", "compat", "util", "mini_chromium"]
+
+        self.cpp_info.components["minidump"].libs = ["crashpad_minidump"]
+        self.cpp_info.components["minidump"].requires = ["compat", "snapshot", "util", "mini_chromium"]
+
+        self.cpp_info.components["handler"].libs = ["crashpad_handler_lib"]
+        self.cpp_info.components["handler"].requires = ["compat", "minidump", "snapshot", "util", "mini_chromium"]
+
+        self.cpp_info.components["tools"].libs = ["crashpad_tools"]
+
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -96,7 +96,7 @@ class SentryCrashpadConan(ConanFile):
         self.cpp_info.components["util"].libs = ["crashpad_util"]
         self.cpp_info.components["util"].requires = ["compat", "mini_chromium", "zlib::zlib"]
         if self.settings.os in ("Linux", "FreeBSD"):
-            self.cpp_info.components["util"].system_libs.append("pthread")
+            self.cpp_info.components["util"].system_libs.extend(["pthread", "rt"])
         if self.options.with_tls == "openssl":
             self.cpp_info.components["util"].requires.append("openssl::openssl")
 
@@ -109,8 +109,9 @@ class SentryCrashpadConan(ConanFile):
         self.cpp_info.components["minidump"].libs = ["crashpad_minidump"]
         self.cpp_info.components["minidump"].requires = ["compat", "snapshot", "util", "mini_chromium"]
 
-        self.cpp_info.components["handler"].libs = ["crashpad_handler_lib"]
-        self.cpp_info.components["handler"].requires = ["compat", "minidump", "snapshot", "util", "mini_chromium"]
+        if tools.Version(self.version) > "0.3":
+            self.cpp_info.components["handler"].libs = ["crashpad_handler_lib"]
+            self.cpp_info.components["handler"].requires = ["compat", "minidump", "snapshot", "util", "mini_chromium"]
 
         self.cpp_info.components["tools"].libs = ["crashpad_tools"]
 

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -76,7 +76,7 @@ class SentryCrashpadConan(ConanFile):
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy("LICENSE", dst="licenses", src=os.path.join(self._source_subfolder, "external", "crashpad"))
         cmake = self._configure_cmake()
         cmake.install()
 

--- a/recipes/sentry-crashpad/all/patches/0.2.6-0001-missing-installed-headers.patch
+++ b/recipes/sentry-crashpad/all/patches/0.2.6-0001-missing-installed-headers.patch
@@ -1,0 +1,20 @@
+--- external/crashpad/third_party/mini_chromium/CMakeLists.txt
++++ external/crashpad/third_party/mini_chromium/CMakeLists.txt
+@@ -172,3 +172,7 @@
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad"
+    FILES_MATCHING PATTERN "*.h"
+ )
++crashpad_install_dev(DIRECTORY build
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad/mini_chromium"
++    FILES_MATCHING PATTERN "*.h"
++)
+--- external/crashpad/util/CMakeLists.txt
++++ external/crashpad/util/CMakeLists.txt
+@@ -395,3 +395,7 @@
+ add_library(crashpad::util ALIAS crashpad_util)
+ 
+ crashpad_install_target(crashpad_util)
++crashpad_install_dev(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad/util"
++    FILES_MATCHING PATTERN "*.h"
++)

--- a/recipes/sentry-crashpad/all/patches/0.2.6-0001-missing-installed-headers.patch
+++ b/recipes/sentry-crashpad/all/patches/0.2.6-0001-missing-installed-headers.patch
@@ -1,8 +1,26 @@
+--- external/crashpad/compat/CMakeLists.txt
++++ external/crashpad/compat/CMakeLists.txt
+@@ -108,12 +108,13 @@
+ endif()
+ 
+ if(LINUX OR ANDROID)
+-    target_include_directories(crashpad_compat ${TI_YPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/linux>")
++    target_include_directories(crashpad_compat ${TI_TYPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/linux>")
++    target_link_libraries(crashpad_compat ${TI_TYPE} ${CMAKE_DL_LIBS})
+ endif()
+ 
+ if(ANDROID)
+-    target_include_directories(crashpad_compat ${TI_YPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/android>")
++    target_include_directories(crashpad_compat ${TI_TYPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/android>")
+ endif()
+ 
+ set_property(TARGET crashpad_compat PROPERTY EXPORT_NAME compat)
+ add_library(crashpad::compat ALIAS crashpad_compat)
 --- external/crashpad/third_party/mini_chromium/CMakeLists.txt
 +++ external/crashpad/third_party/mini_chromium/CMakeLists.txt
 @@ -172,3 +172,7 @@
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad"
-    FILES_MATCHING PATTERN "*.h"
+     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad"
+     FILES_MATCHING PATTERN "*.h"
  )
 +crashpad_install_dev(DIRECTORY build
 +    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad/mini_chromium"
@@ -10,7 +28,35 @@
 +)
 --- external/crashpad/util/CMakeLists.txt
 +++ external/crashpad/util/CMakeLists.txt
-@@ -395,3 +395,7 @@
+@@ -237,7 +237,7 @@
+         linux/thread_info.cc
+         linux/thread_info.h
+         linux/traits.h
+-        misc/capture_context_linux.S
++        misc/capture_context_linux.S misc/time_linux.cc
+         misc/paths_linux.cc
+         posix/process_info_linux.cc
+         process/process_memory_linux.cc
+@@ -353,7 +353,7 @@
+ target_include_directories(crashpad_util PRIVATE
+     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+ )
+ target_link_libraries(crashpad_util
+     PRIVATE
+         $<BUILD_INTERFACE:crashpad_interface>
+     PUBLIC
+@@ -371,6 +371,10 @@
+     )
+ endif()
+ 
++if(LINUX)
++   target_link_libraries(crashpad_util PRIVATE rt pthread)
++endif()
++
+ if(WIN32)
+     target_link_libraries(crashpad_util PRIVATE user32 version winhttp)
+     if(MSVC)
+@@ -395,3 +399,7 @@
  add_library(crashpad::util ALIAS crashpad_util)
  
  crashpad_install_target(crashpad_util)

--- a/recipes/sentry-crashpad/all/patches/0.4.1-0001-missing-installed-headers.patch
+++ b/recipes/sentry-crashpad/all/patches/0.4.1-0001-missing-installed-headers.patch
@@ -1,0 +1,20 @@
+--- external/crashpad/third_party/mini_chromium/CMakeLists.txt
++++ external/crashpad/third_party/mini_chromium/CMakeLists.txt
+@@ -204,3 +204,7 @@
+     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad"
+     FILES_MATCHING PATTERN "*.h"
+ )
++crashpad_install_dev(DIRECTORY build
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad/mini_chromium"
++    FILES_MATCHING PATTERN "*.h"
++)
+--- external/crashpad/util/CMakeLists.txt
++++ external/crashpad/util/CMakeLists.txt
+@@ -438,3 +438,7 @@
+ add_library(crashpad::util ALIAS crashpad_util)
+ 
+ crashpad_install_target(crashpad_util)
++crashpad_install_dev(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad/util"
++    FILES_MATCHING PATTERN "*.h"
++)

--- a/recipes/sentry-crashpad/all/patches/0.4.7-0001-missing-installed-headers.patch
+++ b/recipes/sentry-crashpad/all/patches/0.4.7-0001-missing-installed-headers.patch
@@ -1,0 +1,10 @@
+--- external/crashpad/third_party/mini_chromium/CMakeLists.txt
++++ external/crashpad/third_party/mini_chromium/CMakeLists.txt
+@@ -209,3 +209,7 @@
+     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad"
+     FILES_MATCHING PATTERN "*.h"
+ )
++crashpad_install_dev(DIRECTORY build
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad/mini_chromium"
++    FILES_MATCHING PATTERN "*.h"
++)

--- a/recipes/sentry-crashpad/all/patches/0.4.9-0001-missing-installed-headers.patch
+++ b/recipes/sentry-crashpad/all/patches/0.4.9-0001-missing-installed-headers.patch
@@ -1,0 +1,10 @@
+--- external/crashpad/third_party/mini_chromium/CMakeLists.txt
++++ external/crashpad/third_party/mini_chromium/CMakeLists.txt
+@@ -207,3 +207,7 @@
+     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad"
+     FILES_MATCHING PATTERN "*.h"
+ )
++crashpad_install_dev(DIRECTORY build
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad/mini_chromium"
++    FILES_MATCHING PATTERN "*.h"
++)

--- a/recipes/sentry-crashpad/all/test_package/CMakeLists.txt
+++ b/recipes/sentry-crashpad/all/test_package/CMakeLists.txt
@@ -7,5 +7,5 @@ conan_basic_setup(TARGETS)
 find_package(crashpad REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE crashpad::client crashpad::handler)
+target_link_libraries(${PROJECT_NAME} PRIVATE crashpad::client)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/sentry-crashpad/all/test_package/CMakeLists.txt
+++ b/recipes/sentry-crashpad/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(crashpad REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE crashpad::client crashpad::handler)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/sentry-crashpad/all/test_package/conanfile.py
+++ b/recipes/sentry-crashpad/all/test_package/conanfile.py
@@ -1,0 +1,21 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            test_env_dir = "test_env"
+            tools.mkdir(test_env_dir)
+            bin_path = os.path.join("bin", "test_package")
+            handler_exe = "crashpad_handler.exe" if self.settings.os == "Windows" else "crashpad_handler"
+            handler_bin_path = os.path.join(self.deps_cpp_info["sentry-crashpad"].rootpath, "bin", handler_exe)
+            self.run("%s %s/db %s" % (bin_path, test_env_dir, handler_bin_path), run_environment=True)

--- a/recipes/sentry-crashpad/all/test_package/test_package.cpp
+++ b/recipes/sentry-crashpad/all/test_package/test_package.cpp
@@ -1,0 +1,48 @@
+#include <map>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <cwchar>
+#endif
+
+#include "client/crashpad_client.h"
+#include "client/settings.h"
+
+bool startCrashpad(const base::FilePath &db,
+                   const base::FilePath &handler) {
+    std::string              url("http://localhost");
+    std::map<std::string, std::string> annotations;
+    std::vector<std::string>      arguments;
+
+    crashpad::CrashpadClient client;
+    return client.StartHandler(
+        handler,
+        db,
+        db,
+        url,
+        annotations,
+        arguments,
+        true,
+        false
+    );
+}
+
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        return 2;
+    }
+
+#ifdef _WIN32
+    wchar_t ws[1024];
+    swprintf(ws, 1024, L"%hs", argv[1]);
+    base::FilePath db(ws);
+    swprintf(ws, 1024, L"%hs", argv[2]);
+    base::FilePath handler(ws);
+#else
+    base::FilePath db(argv[1]);
+    base::FilePath handler(argv[2]);
+#endif
+
+    return startCrashpad(db, handler) ? 0 : 1;
+}

--- a/recipes/sentry-crashpad/config.yml
+++ b/recipes/sentry-crashpad/config.yml
@@ -1,0 +1,11 @@
+versions:
+  "0.4.9":
+    folder: all
+  "0.4.8":
+    folder: all
+  "0.4.7":
+    folder: all
+  "0.4.1":
+    folder: all
+  "0.2.6":
+    folder: all


### PR DESCRIPTION
The versions are the same as the one in `sentry-native`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
