### PR TITLE
ctre: add version 3.4.1

### DIFF
--- a/recipes/ctre/all/conandata.yml
+++ b/recipes/ctre/all/conandata.yml
@@ -26,3 +26,6 @@ sources:
   "3.3.4":
     url: "https://github.com/hanickadot/compile-time-regular-expressions/archive/v3.3.4.tar.gz"
     sha256: "8161f0d3100fc690590f475aa9acb70163ed7f2922e35e13136dececc52c49a9"
+  "3.4.1":
+    url: "https://github.com/hanickadot/compile-time-regular-expressions/archive/v3.4.1.tar.gz"
+    sha256: "c4a1a88b8c4a8c267507a3da3707f29a2b7c1f722e27d695296f152501a414ab"

--- a/recipes/ctre/config.yml
+++ b/recipes/ctre/config.yml
@@ -17,3 +17,5 @@ versions:
     folder: all
   "3.3.4":
     folder: all
+  "3.4.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **ctre/3.4.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
