### PR TITLE
libharu: fix libtiff conflict

### DIFF
--- a/recipes/libharu/all/conandata.yml
+++ b/recipes/libharu/all/conandata.yml
@@ -8,3 +8,5 @@ patches:
       patch_file: "patches/0001-allow-cmake-subproject.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/0002-linux-add-m-system-library.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0003-rename-tiff-symbols.patch"

--- a/recipes/libharu/all/conanfile.py
+++ b/recipes/libharu/all/conanfile.py
@@ -2,6 +2,7 @@ from conans import CMake, ConanFile, tools
 import os
 import re
 
+required_conan_version = ">=1.33.0"
 
 class LibharuConan(ConanFile):
     name = "libharu"
@@ -47,8 +48,8 @@ class LibharuConan(ConanFile):
         self.requires("libpng/1.6.37")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("libharu-RELEASE_{}".format(self.version.replace(".", "_")), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/libharu/all/patches/0003-rename-tiff-symbols.patch
+++ b/recipes/libharu/all/patches/0003-rename-tiff-symbols.patch
@@ -1,0 +1,46 @@
+--- src/hpdf_image_ccitt.c
++++ src/hpdf_image_ccitt.c
+@@ -578,11 +578,11 @@ HPDF_Fax3Encode2DRow(struct _HPDF_CCITT_Data *pData, unsigned char* bp, unsigned
+ 				a2 = finddiff2(bp, a1, bits, PIXEL(bp,a1));
+ 				putcode(pData, &horizcode);
+ 				if (a0+a1 == 0 || PIXEL(bp, a0) == 0) {
+-					putspan(pData, a1-a0, TIFFFaxWhiteCodes);
+-					putspan(pData, a2-a1, TIFFFaxBlackCodes);
++					putspan(pData, a1-a0, HPDF_TIFFFaxWhiteCodes);
++					putspan(pData, a2-a1, HPDF_TIFFFaxBlackCodes);
+ 				} else {
+-					putspan(pData, a1-a0, TIFFFaxBlackCodes);
+-					putspan(pData, a2-a1, TIFFFaxWhiteCodes);
++					putspan(pData, a1-a0, HPDF_TIFFFaxBlackCodes);
++					putspan(pData, a2-a1, HPDF_TIFFFaxWhiteCodes);
+ 				}
+ 				a0 = a2;
+ 			} else {			/* vertical mode */
+--- src/t4.h
++++ src/t4.h
+@@ -55,7 +55,7 @@ typedef struct tableentry {
+  *     during state generation (see mkg3states.c).
+  */
+ #ifdef G3CODES
+-const tableentry TIFFFaxWhiteCodes[] = {
++const tableentry HPDF_TIFFFaxWhiteCodes[] = {
+     { 8, 0x35, 0 },	/* 0011 0101 */
+     { 6, 0x7, 1 },	/* 0001 11 */
+     { 4, 0x7, 2 },	/* 0111 */
+@@ -167,7 +167,7 @@ const tableentry TIFFFaxWhiteCodes[] = {
+     { 12, 0x0, G3CODE_INVALID },	/* 0000 0000 0000 */
+ };
+ 
+-const tableentry TIFFFaxBlackCodes[] = {
++const tableentry HPDF_TIFFFaxBlackCodes[] = {
+     { 10, 0x37, 0 },	/* 0000 1101 11 */
+     { 3, 0x2, 1 },	/* 010 */
+     { 2, 0x3, 2 },	/* 11 */
+@@ -281,5 +281,7 @@ const tableentry TIFFFaxBlackCodes[] = {
+ #else
+ extern	const tableentry TIFFFaxWhiteCodes[];
+ extern	const tableentry TIFFFaxBlackCodes[];
++const tableentry *HPDF_TIFFFaxWhiteCodes = TIFFFaxWhiteCodes;
++const tableentry *HPDF_TIFFFaxBlackCodes = TIFFFaxBlackCodes;
+ #endif
+ #endif /* _T4_ */


### PR DESCRIPTION
Specify library name and version:  **libharu/2.3.0**

- get rid of os.rename
- avoid issue with libtiff duplicate symbols

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
