### PR TITLE
Add s2let/2.2.4 package

### DIFF
--- a/recipes/s2let/all/CMakeLists.txt
+++ b/recipes/s2let/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/s2let/all/conandata.yml
+++ b/recipes/s2let/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2.2.3":
-    url: "https://github.com/astro-informatics/s2let/archive/refs/tags/v2.2.3rc1.zip"
-    sha256: "fef6c3ac8c9c8413f3e8ee02f0744ebae5fb01287cb53c31e32cb79f27c90c68"
+    url: "https://github.com/astro-informatics/s2let/archive/refs/tags/v2.2.3rc1.tar.gz"
+    sha256: "73869e17b5c53536ef74fbc194e4259a9a5cc77244d6988f0197bca9465e5372"

--- a/recipes/s2let/all/conandata.yml
+++ b/recipes/s2let/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2.2.3":
-    url: "https://github.com/astro-informatics/s2let/archive/refs/tags/v2.2.3rc1.tar.gz"
-    sha256: "73869e17b5c53536ef74fbc194e4259a9a5cc77244d6988f0197bca9465e5372"
+    url: "https://github.com/astro-informatics/s2let/archive/refs/tags/v2.2.3.tar.gz"
+    sha256: "1321e1bc96ba200e4cd4056843cd4075de1c05be20e64185f065f48b9cefe3f8"

--- a/recipes/s2let/all/conandata.yml
+++ b/recipes/s2let/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.2.3":
+    url: "https://github.com/astro-informatics/s2let/archive/refs/tags/v2.2.3rc1.zip"
+    sha256: "fef6c3ac8c9c8413f3e8ee02f0744ebae5fb01287cb53c31e32cb79f27c90c68"

--- a/recipes/s2let/all/conanfile.py
+++ b/recipes/s2let/all/conanfile.py
@@ -1,0 +1,63 @@
+from conans import CMake, ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+from glob import glob
+import os
+
+
+class S2let(ConanFile):
+    name = "s2let"
+    license = "GPL-3.0-or-later"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/astro-informatics/s2let"
+    description = "Fast wavelets on the sphere"
+    settings = "os", "arch", "compiler", "build_type"
+    topics = ("physics", "astrophysics", "radio interferometry")
+    options = {"fPIC": [True, False]}
+    default_options = {"fPIC": True}
+    requires = "astro-informatics-so3/[>=1.3.4]", "cfitsio/[>=3.490]"
+    generators = "cmake", "cmake_find_package"
+    exports_sources = ["CMakeLists.txt"]
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def configure(self):
+        del self.settings.compiler.cppstd
+        del self.settings.compiler.libcxx
+
+    def config_options(self):
+        if self.settings.compiler == "Visual Studio":
+            raise ConanInvalidConfiguration(
+                "SO3 requires C99 support for complex numbers."
+            )
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = glob("s2let-*/")[0]
+        os.rename(extracted_dir, self._source_subfolder)
+
+    @property
+    def cmake(self):
+        if not hasattr(self, "_cmake"):
+            self._cmake = CMake(self)
+            self._cmake.definitions["BUILD_TESTING"] = False
+            self._cmake.definitions["cfitsio"] = True
+            self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def build(self):
+        self.cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        self.cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["s2let"]
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs = ["m"]

--- a/recipes/s2let/all/test_package/CMakeLists.txt
+++ b/recipes/s2let/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(s2let REQUIRED NO_MODULE)
 

--- a/recipes/s2let/all/test_package/CMakeLists.txt
+++ b/recipes/s2let/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(s2let REQUIRED NO_MODULE)
+
+add_executable(${PROJECT_NAME} example.c)
+target_compile_features(${PROJECT_NAME} PUBLIC c_std_99)
+target_link_libraries(${PROJECT_NAME} s2let::s2let)

--- a/recipes/s2let/all/test_package/conanfile.py
+++ b/recipes/s2let/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/s2let/all/test_package/example.c
+++ b/recipes/s2let/all/test_package/example.c
@@ -1,0 +1,9 @@
+#include <s2let/s2let.h>
+
+int main(int argc, char *argv[])
+{
+  complex double *buffer;
+  s2let_allocate_lm(&buffer, 5);
+  free(buffer);
+  return 0;
+}

--- a/recipes/s2let/config.yml
+++ b/recipes/s2let/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.2.3":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **s2let/2.2.4**

s2let is a fast wavelet  transform on the sphere. It can be used for radio-inteferometry, VR, or anywhere a signal on  the sphere is analyzed. This PR is a follow up to ssht and astro-informatics-so3 added recently.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
