### PR TITLE
Qt6: Only show error/output log files if they exist

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import glob
 import textwrap
-
+from pathlib import Path
 import configparser
 from conans import ConanFile, tools, RunEnvironment, CMake
 from conans.errors import ConanInvalidConfiguration
@@ -480,8 +480,12 @@ class QtConan(ConanFile):
         try:
             self._cmake.configure(source_folder="qt6")
         except:
-            self.output.info(tools.load(os.path.join(self.build_folder, "CMakeFiles", "CMakeError.log")))
-            self.output.info(tools.load(os.path.join(self.build_folder, "CMakeFiles", "CMakeOutput.log")))
+            cmake_err_log = os.path.join(self.build_folder, "CMakeFiles", "CMakeError.log")
+            cmake_out_log = os.path.join(self.build_folder, "CMakeFiles", "CMakeOutput.log")
+            if (Path.exists(cmake_err_log)):
+                self.output.info(tools.load(cmake_err_log))
+            if (Path.exists(cmake_out_log)):
+                self.output.info(tools.load(cmake_out_log))
             raise
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **qt/6.0.4**

When the cmake configure step fails the recipe shows the contents of the cmake error and output files. However if something fails very early in the configure those files don't exist yet. For example, if you try to build the current recipe with cmake <= 3.15 the conan create command spits out the following error:

```
CMake Error at CMakeLists.txt:7 (cmake_minimum_required):
  CMake 3.16 or higher is required.  You are running version 3.15.7


-- Configuring incomplete, errors occurred!
qt/6.0.4: 
qt/6.0.4: ERROR: Package 'bcf0c7009808cb8a0b81ee9f833913f0dcb74326' build failed
qt/6.0.4: WARN: Build folder /home/wdobbe/.conan/data/qt/6.0.4/_/_/build/bcf0c7009808cb8a0b81ee9f833913f0dcb74326
ERROR: qt/6.0.4: Error in build() method, line 524
        cmake = self._configure_cmake()
while calling '_configure_cmake', line 483
        self.output.info(tools.load(os.path.join(self.build_folder, "CMakeFiles", "CMakeError.log")))
        FileNotFoundError: [Errno 2] No such file or directory: '/home/wdobbe/.conan/data/qt/6.0.4/_/_/build/bcf0c7009808cb8a0b81ee9f833913f0dcb74326/CMakeFiles/CMakeError.log'
```
Check if the cmake error and output files exist before loading the contents.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
