### PR TITLE
boost: Improve option for i18n backend

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -56,6 +56,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/support_msvc_2019.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
+      base_path: "source_subfolder"
   1.70.0:
     - patch_file: "patches/0001-beast-fix-moved-from-executor.patch"
       base_path: "source_subfolder"
@@ -69,6 +71,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/solaris_pthread_data.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
+      base_path: "source_subfolder"
   1.71.0:
     - patch_file: "patches/bcp_namespace_issues_1_71.patch"
       base_path: "source_subfolder"
@@ -79,6 +83,8 @@ patches:
     - patch_file: "patches/python_base_prefix.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/solaris_pthread_data.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
       base_path: "source_subfolder"
   1.72.0:
     - patch_file: "patches/bcp_namespace_issues_1_72.patch"
@@ -95,18 +101,26 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/boost_log_filesystem_no_deprecated_1_72.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
+      base_path: "source_subfolder"
   1.73.0:
     - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/python_base_prefix.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
       base_path: "source_subfolder"
   1.74.0:
     - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter_since_1_74.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/python_base_prefix_since_1_74.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
+      base_path: "source_subfolder"
   1.75.0:
     - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter_since_1_74.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/python_base_prefix_since_1_74.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
       base_path: "source_subfolder"

--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -124,3 +124,6 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
       base_path: "source_subfolder"
+  1.76.0:
+    - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
+      base_path: "source_subfolder"

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -327,8 +327,8 @@ class BoostConan(ConanFile):
                 self.options.i18n_backend_iconv = "off"
                 self.options.i18n_backend_icu = False
         if self.options.without_locale:
-            self.options.i18n_backend_iconv = "off"
-            self.options.i18n_backend_icu = False
+            del self.options.i18n_backend_iconv
+            del self.options.i18n_backend_icu
         else:
             if self.options.i18n_backend_iconv == "off" and not self.options.i18n_backend_icu and not self._is_windows_platform:
                 raise ConanInvalidConfiguration("Boost.Locale library needs either iconv or ICU library to be built on non windows platforms")
@@ -445,7 +445,7 @@ class BoostConan(ConanFile):
 
     @property
     def _with_iconv(self):
-        return not self.options.header_only and self._with_dependency("iconv") and self.options.i18n_backend_iconv == "libc"
+        return not self.options.header_only and self._with_dependency("iconv") and self.options.get_safe("i18n_backend_iconv") == "libc"
 
     def requirements(self):
         if self._with_zlib:
@@ -867,7 +867,7 @@ class BoostConan(ConanFile):
         else:
             flags.append("boost.locale.icu=off")
             flags.append("--disable-icu")
-        if self.options.i18n_backend_iconv in ["libc", "libiconv"]:
+        if self.options.get_safe("i18n_backend_iconv") in ["libc", "libiconv"]:
             flags.append("boost.locale.iconv=on")
         else:
             flags.append("boost.locale.iconv=off")

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -264,6 +264,8 @@ class BoostConan(ConanFile):
         # iconv is off by default on Windows and Solaris
         if self._is_windows_platform or self.settings.os == "SunOS":
             self.options.i18n_backend_iconv = "off"
+        elif self.settings.os == "Macos":
+            self.options.i18n_backend_iconv = "libiconv"
 
         # Remove options not supported by this version of boost
         for dep_name in CONFIGURE_OPTIONS:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -441,11 +441,11 @@ class BoostConan(ConanFile):
 
     @property
     def _with_icu(self):
-        return not self.options.header_only and self._with_dependency("icu") and self.options.i18n_backend_icu
+        return not self.options.header_only and self._with_dependency("icu") and self.options.get_safe("i18n_backend_icu")
 
     @property
     def _with_iconv(self):
-        return not self.options.header_only and self._with_dependency("iconv") and self.options.get_safe("i18n_backend_iconv") == "libc"
+        return not self.options.header_only and self._with_dependency("iconv") and self.options.get_safe("i18n_backend_iconv") == "libiconv"
 
     def requirements(self):
         if self._with_zlib:
@@ -862,13 +862,17 @@ class BoostConan(ConanFile):
         flags.append("-sNO_LZMA=%s" % ("0" if self._with_lzma else "1"))
         flags.append("-sNO_ZSTD=%s" % ("0" if self._with_zstd else "1"))
 
-        if self.options.i18n_backend_icu:
+        if self.options.get_safe("i18n_backend_icu"):
             flags.append("boost.locale.icu=on")
         else:
             flags.append("boost.locale.icu=off")
             flags.append("--disable-icu")
         if self.options.get_safe("i18n_backend_iconv") in ["libc", "libiconv"]:
             flags.append("boost.locale.iconv=on")
+            if self.options.get_safe("i18n_backend_iconv") == "libc":
+                flags.append("boost.locale.iconv.lib=libc")
+            else:
+                flags.append("boost.locale.iconv.lib=libiconv")
         else:
             flags.append("boost.locale.iconv=off")
             flags.append("--disable-iconv")

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -231,9 +231,7 @@ class BoostConan(ConanFile):
 
     @property
     def _is_windows_platform(self):
-        return ((self.settings.os == "Windows") and
-                (self.settings.os.subsystem in [None, "cygwin"]) or
-                self.settings.os in ["WindowsStore", "WindowsCE"])
+        return self.settings.os in ["Windows", "WindowsStore", "WindowsCE"]
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/boost/all/patches/boost_locale_fail_on_missing_backend.patch
+++ b/recipes/boost/all/patches/boost_locale_fail_on_missing_backend.patch
@@ -1,0 +1,53 @@
+diff --git a/libs/locale/build/Jamfile.v2 b/libs/locale/build/Jamfile.v2
+index 578e722..b715f59 100644
+--- a/libs/locale/build/Jamfile.v2
++++ b/libs/locale/build/Jamfile.v2
+@@ -17,6 +17,7 @@ import feature ;
+ # Features
+ 
+ feature.feature boost.locale.iconv : on off : optional propagated ;
++feature.feature boost.locale.iconv.lib : libc libiconv : optional propagated ;
+ feature.feature boost.locale.icu : on off :  optional propagated ;
+ feature.feature boost.locale.posix : on off : optional propagated ;
+ feature.feature boost.locale.std : on off : optional propagated ;
+@@ -217,6 +218,14 @@ rule configure-full ( properties * : flags-only )
+         if [ configure.builds has_iconv : $(properties) : "iconv (libc)" ]
+         {
+             found-iconv = true ;
++            if <boost.locale.iconv.lib>libiconv in $(properties)
++            {
++                EXIT "- Boost.Locale found iconv (libc) instead of iconv (separate) library to be built." ;
++            }
++        }
++        else if <boost.locale.iconv.lib>libc in $(properties)
++        {
++            EXIT "- Boost.Locale failed to find iconv (libc) library to be built." ;
+         }
+         else 
+         {
+@@ -225,6 +234,14 @@ rule configure-full ( properties * : flags-only )
+                 found-iconv = true ;
+                 result += <library>iconv ;
+             }
++            else if <boost.locale.iconv.lib>libiconv in $(properties)
++            {
++                EXIT "- Boost.Locale failed to find iconv (separate) library to be built." ;
++            }
++        }
++        if ! $(found-iconv)
++        {
++            EXIT "- Boost.Locale failed to find iconv library to be built." ;
+         }
+     }        
+     if $(found-iconv) 
+@@ -265,6 +282,10 @@ rule configure-full ( properties * : flags-only )
+                       <library>../../thread/build//boost_thread 
+                       ;
+         }
++        else
++        {
++            EXIT "- Boost.Locale failed to find ICU library to be built." ;
++        }
+ 
+     }
+         


### PR DESCRIPTION
- Deprecate `i18n_backend` option and add separate ones for `iconv`/`icu`
  - Note that boost also a `posix`, `std` and `winapi` backend. 
- For the `iconv` backend, add the possibility to use the one included in libc instead of libiconv
  - also make that the default
  - Macos still uses libiconv as default
- On Windows, allow building without both `iconv`/`icu` backends and make it the default (#5528)
  - Something similar was added in #1704, but nether merged
  - Unsure if WindowsStore/WindowsCE OS are handled correctly (#1704 did still need on of the backends there)
- Fail build if Boost's test for the backend fails

---
Below are some original notes for this PR, which are partly outdated.

As far as I can tell boost sadly:
- has no option to distinguish between `iconv` from libc or libiconv
  - It does automatic detection, and always preferes the one from libc
- even if the `iconv`/`icu` backend is set to on, and boost fails not find it, compilation will still work

The above means that:
- `iconv` can be set True (i.e. as external lib), but boost will still use the one from libc
- `iconv` can be set to use the one from glibc, but silently use an external one, or (i.e. on windows) without it at all
- `iconv`/`icu` can be set to True, but boost may still be build without them if it fails to find them 

Note that the first one was already an issue in the current recipe. I think it would be good to get an error, or at least a warning.
Unfortunately I can't think of an nice and easy solution.
- One could try to search in the build output for e.g. `iconv (libc)             : yes`. Don't know if Conan already support that, and if that is something that recipes should do.
- Patch boost builds files to not only changes how the options normally behave, but also add a new one to be able set iconv from libc and external lib separately

Maybe this could also be address in a separate PR later on.

See also the boost documentation and build file for reference:
https://www.boost.org/doc/libs/1_76_0/libs/locale/doc/html/building_boost_locale.html
https://github.com/boostorg/locale/blob/develop/build/Jamfile.v2

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
