### PR TITLE
acado/1.2.2-beta relocatable

### DIFF
--- a/recipes/acado/all/conandata.yml
+++ b/recipes/acado/all/conandata.yml
@@ -6,3 +6,6 @@ patches:
   "1.2.2-beta":
     - base_path: "source_subfolder"
       patch_file: "patches/0001-binding-temp-object.patch"
+  "1.2.2-beta":
+    - base_path: "source_subfolder"
+      patch_file: "patches/0002-read-template-path-from-env.patch"

--- a/recipes/acado/all/conandata.yml
+++ b/recipes/acado/all/conandata.yml
@@ -6,6 +6,5 @@ patches:
   "1.2.2-beta":
     - base_path: "source_subfolder"
       patch_file: "patches/0001-binding-temp-object.patch"
-  "1.2.2-beta":
     - base_path: "source_subfolder"
       patch_file: "patches/0002-read-template-path-from-env.patch"

--- a/recipes/acado/all/conanfile.py
+++ b/recipes/acado/all/conanfile.py
@@ -93,6 +93,8 @@ class AcadoConan(ConanFile):
         tools.remove_files_by_mask(self.package_folder, "*.pdb")
 
     def package_info(self):
+        self.env_info.ACADO_TEMPLATE_PATHS = os.path.join(self.package_folder, "include", "acado", "code_generation", "templates")
+
         if self.options.shared:
             self.cpp_info.libs = ["acado_toolkit_s", "acado_casadi"]
         else:

--- a/recipes/acado/all/conanfile.py
+++ b/recipes/acado/all/conanfile.py
@@ -93,7 +93,9 @@ class AcadoConan(ConanFile):
         tools.remove_files_by_mask(self.package_folder, "*.pdb")
 
     def package_info(self):
-        self.env_info.ACADO_TEMPLATE_PATHS = os.path.join(self.package_folder, "include", "acado", "code_generation", "templates")
+        acado_template_paths = os.path.join(self.package_folder, "include", "acado", "code_generation", "templates")
+        self.output.info("Setting ACADO_TEMPLATE_PATHS environment variable: {}".format(acado_template_paths))
+        self.env_info.ACADO_TEMPLATE_PATHS = acado_template_paths
 
         if self.options.shared:
             self.cpp_info.libs = ["acado_toolkit_s", "acado_casadi"]

--- a/recipes/acado/all/patches/0002-read-template-path-from-env.patch
+++ b/recipes/acado/all/patches/0002-read-template-path-from-env.patch
@@ -1,0 +1,25 @@
+diff --git a/acado/code_generation/export_templated_file.cpp b/acado/code_generation/export_templated_file.cpp
+index 76ec47a2..937a9c7b 100644
+--- a/acado/code_generation/export_templated_file.cpp
++++ b/acado/code_generation/export_templated_file.cpp
+@@ -34,6 +34,8 @@
+ #include <acado/code_generation/export_templated_file.hpp>
+ #include <acado/code_generation/templates/templates.hpp>
+ 
++#include <cstdlib>
++
+ using namespace std;
+ 
+ BEGIN_NAMESPACE_ACADO
+@@ -66,7 +68,10 @@ returnValue ExportTemplatedFile::setup(	const std::string& _templateName,
+ {
+     ExportFile::setup( _fileName, _commonHeaderName, _realString, _intString, _precision, _commentString );
+     
+-	folders = TEMPLATE_PATHS;
++	if(const char* template_paths = std::getenv("ACADO_TEMPLATE_PATHS"))
++	{
++		folders = template_paths;
++	}
+ 	templateName = _templateName;
+     
+     return SUCCESSFUL_RETURN;

--- a/recipes/acado/all/test_package/conanfile.py
+++ b/recipes/acado/all/test_package/conanfile.py
@@ -8,6 +8,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.parallel = False # to mitigate CCI-CI build errors
         cmake.configure()
         cmake.build()
 

--- a/recipes/acado/all/test_package/conanfile.py
+++ b/recipes/acado/all/test_package/conanfile.py
@@ -8,7 +8,8 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.parallel = False # to mitigate CCI-CI build errors
+        # FIXME: CCI infrastructure should provide cpu count input to avoid errors
+        cmake.parallel = False
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **acado/1.2.2-beta**

Making acado relocateable.

Question: Is `self.env_info.ACADO_TEMPLATE_PATHS` still the correct way to have env-values set whenever this library is part of the build-tree? It is important, that all users of this library have this env-var set. I also assume this happens during execution of the generators, like `cmake_find_package`, and not during build or packaging of this library.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
