### PR TITLE
prometheus-cpp: Bump to 0.12.3 (and libcurl dependency to 7.77.0)

### DIFF
--- a/recipes/prometheus-cpp/all/conandata.yml
+++ b/recipes/prometheus-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.12.3":
+    url: "https://github.com/jupp0r/prometheus-cpp/archive/v0.12.3.tar.gz"
+    sha256: "e021e76e8e933672f1af0d223307282004f585a054354f8d894db39debddff8e"
   "0.12.1":
     url: "https://github.com/jupp0r/prometheus-cpp/archive/v0.12.1.tar.gz"
     sha256: "2102609457f812dbeaaafd55736461fd0538fc7e7568174b1cdec43399dbded4"

--- a/recipes/prometheus-cpp/all/conanfile.py
+++ b/recipes/prometheus-cpp/all/conanfile.py
@@ -49,7 +49,7 @@ class PrometheusCppConan(ConanFile):
         if self.options.with_pull:
             self.requires("civetweb/1.14")
         if self.options.with_push:
-            self.requires("libcurl/7.74.0")
+            self.requires("libcurl/7.77.0")
         if self.options.with_compression:
             self.requires("zlib/1.2.11")
 

--- a/recipes/prometheus-cpp/all/conanfile.py
+++ b/recipes/prometheus-cpp/all/conanfile.py
@@ -83,6 +83,7 @@ class PrometheusCppConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "prometheus-cpp"
@@ -90,6 +91,7 @@ class PrometheusCppConan(ConanFile):
 
         self.cpp_info.components["prometheus-cpp-core"].names["cmake_find_package"] = "core"
         self.cpp_info.components["prometheus-cpp-core"].names["cmake_find_package_multi"] = "core"
+        self.cpp_info.components["prometheus-cpp-core"].names["pkg_config"] = "prometheus-cpp-core"
         self.cpp_info.components["prometheus-cpp-core"].libs = ["prometheus-cpp-core"]
         if self.settings.os == "Linux":
             self.cpp_info.components["prometheus-cpp-core"].system_libs = ["pthread", "rt"]
@@ -97,6 +99,7 @@ class PrometheusCppConan(ConanFile):
         if self.options.with_push:
             self.cpp_info.components["prometheus-cpp-push"].names["cmake_find_package"] = "push"
             self.cpp_info.components["prometheus-cpp-push"].names["cmake_find_package_multi"] = "push"
+            self.cpp_info.components["prometheus-cpp-push"].names["pkg_config"] = "prometheus-cpp-push"
             self.cpp_info.components["prometheus-cpp-push"].libs = ["prometheus-cpp-push"]
             self.cpp_info.components["prometheus-cpp-push"].requires = [
                 "prometheus-cpp-core",
@@ -108,6 +111,7 @@ class PrometheusCppConan(ConanFile):
         if self.options.with_pull:
             self.cpp_info.components["prometheus-cpp-pull"].names["cmake_find_package"] = "pull"
             self.cpp_info.components["prometheus-cpp-pull"].names["cmake_find_package_multi"] = "pull"
+            self.cpp_info.components["prometheus-cpp-pull"].names["pkg_config"] = "prometheus-cpp-pull"
             self.cpp_info.components["prometheus-cpp-pull"].libs = ["prometheus-cpp-pull"]
             self.cpp_info.components["prometheus-cpp-pull"].requires = [
                 "prometheus-cpp-core",

--- a/recipes/prometheus-cpp/config.yml
+++ b/recipes/prometheus-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.12.3":
+    folder: all
   "0.12.1":
     folder: all
   "0.11.0":


### PR DESCRIPTION
Specify library name and version:  **prometheus-cpp/0.12.3**

Package latest upstream source

I haven't done any tests, apart from checking the checksums with `sha256sum` (for both the version that I'm bumping, and the latest version that you already had, to make sure that I was doing it correctly).  I specifically haven't tested that this commit build correctly the new version and that it is usable, because I got an error message when trying to do so:

https://github.com/conan-io/hooks/issues/157

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
