### PR TITLE
tcl: depends on CoreFoundation on mac

### DIFF
--- a/recipes/tcl/8.6.10/conanfile.py
+++ b/recipes/tcl/8.6.10/conanfile.py
@@ -206,7 +206,7 @@ class TclConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "TCL"
 
         if self.settings.os == "Macos":
-            self.cpp_info.frameworks = ["Cocoa"]
+            self.cpp_info.frameworks = ["CoreFoundation"]
             self.cpp_info.sharedlinkflags = self.cpp_info.exelinkflags
 
         tcl_library = os.path.join(self.package_folder, "lib", "{}{}".format(self.name, ".".join(self.version.split(".")[:2])))


### PR DESCRIPTION
Specify library name and version:  **tcl/8.6.10**

fix #5572

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
