### PR TITLE
openssl: add some no_options from Configure

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -117,6 +117,14 @@ class OpenSSLConan(ConanFile):
                "no_ssl": [True, False],
                "no_ts": [True, False],
                "no_whirlpool": [True, False],
+               "no_ec": [True, False],
+               "no_ecdh": [True, False],
+               "no_ecdsa": [True, False],
+               "no_rfc3779": [True, False],
+               "no_seed": [True, False],
+               "no_sock": [True, False],
+               "no_ssl3": [True, False],
+               "no_tls1": [True, False],
                "capieng_dialog": [True, False],
                "enable_capieng": [True, False],
                "openssldir": "ANY"}
@@ -144,6 +152,8 @@ class OpenSSLConan(ConanFile):
             del self.options.no_idea
             del self.options.no_md4
             del self.options.no_ocsp
+            del self.options.no_seed
+            del self.options.no_sock
             del self.options.no_srp
             del self.options.no_ts
             del self.options.no_whirlpool


### PR DESCRIPTION
Specify library name and version:  **openssl/1.1.1k**

I add some missing no_options for sqlcipher.
https://github.com/sqlcipher/android-database-sqlcipher/blob/v4.4.3/android-database-sqlcipher/build-openssl-libraries.sh#L45-L51
Also, a similar PR #3558 has been submitted before.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
