### PR TITLE
Add docgen utility for easy Doxygen documentation generation

### DIFF
--- a/recipes/docgen/all/conandata.yml
+++ b/recipes/docgen/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0":
+    url: "https://github.com/DavidZemon/docgen/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "347daa50ab481f53735d854a04c9696e7feb8f663fc7bcbba002e6632d0846d3"

--- a/recipes/docgen/all/conandata.yml
+++ b/recipes/docgen/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "1.0.0":
     url: "https://github.com/DavidZemon/docgen/archive/refs/tags/v1.0.0.tar.gz"
-    sha256: "347daa50ab481f53735d854a04c9696e7feb8f663fc7bcbba002e6632d0846d3"
+    sha256: "baf8bcd9e99a0e505b0aeca9ba4d7e49d66e36d6c78c1b7e1846a7c5b1c43aea"

--- a/recipes/docgen/all/conanfile.py
+++ b/recipes/docgen/all/conanfile.py
@@ -2,6 +2,7 @@ import os
 import shutil
 
 from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
 
 
 class DocgenConan(ConanFile):
@@ -15,6 +16,18 @@ class DocgenConan(ConanFile):
         'compiler': None
     }
     topics = ('doxygen',)
+
+    # Doxygen requires GCC 5 or newer and Doxygen is required by the test_package folder, so do not attempt to provide
+    # a package if the compiler version is older than GCC 5
+    _minimum_compiler_version = {
+        "gcc": 5,
+    }
+
+    def configure(self):
+        minimum_compiler_version = self._minimum_compiler_version.get(str(self.settings.compiler))
+        if minimum_compiler_version is not None:
+            if tools.Version(self.settings.compiler.version) < minimum_compiler_version:
+                raise ConanInvalidConfiguration("Compiler version too old. At least {} is required.".format(minimum_compiler_version))
 
     @property
     def _source_subfolder(self):

--- a/recipes/docgen/all/conanfile.py
+++ b/recipes/docgen/all/conanfile.py
@@ -6,7 +6,7 @@ from conans import ConanFile, tools
 
 class DocgenConan(ConanFile):
     name = 'docgen'
-    license = '0BSD'
+    license = 'MIT'
     homepage = 'https://github.com/DavidZemon/docgen.git'
     url = 'https://github.com/conan-io/conan-center-index'
     description = 'Doxygen documentation generation utilities'

--- a/recipes/docgen/all/conanfile.py
+++ b/recipes/docgen/all/conanfile.py
@@ -54,9 +54,6 @@ class DocgenConan(ConanFile):
         self.cpp_info.libdirs = []
         self.cpp_info.builddirs = [os.path.join('res')]
 
-        self.cpp_info.set_property('cmake_file_name', 'DocGen')
-        self.cpp_info.set_property('cmake_target_name', 'DocGen')
-        self.cpp_info.set_property(
-            'cmake_build_modules',
-            [os.path.join('res', 'DocGen-functions.cmake')]
-        )
+        self.cpp_info.filenames['cmake_find_package'] = 'DocGen'
+        self.cpp_info.filenames['cmake_find_package_multi'] = 'DocGen'
+        self.cpp_info.build_modules = [os.path.join('res', 'DocGen-functions.cmake')]

--- a/recipes/docgen/all/conanfile.py
+++ b/recipes/docgen/all/conanfile.py
@@ -1,0 +1,62 @@
+import os
+import shutil
+
+from conans import ConanFile, tools
+
+
+class DocgenConan(ConanFile):
+    name = 'docgen'
+    license = '0BSD'
+    homepage = 'https://github.com/DavidZemon/docgen.git'
+    url = 'https://github.com/conan-io/conan-center-index'
+    description = 'Doxygen documentation generation utilities'
+    settings = {
+        'os': None,
+        'compiler': None
+    }
+    topics = ('doxygen',)
+
+    @property
+    def _source_subfolder(self):
+        return f'{self.name}-{self.version}'
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+
+    def package(self):
+        os.makedirs(os.path.join(f'{self.package_folder}', 'licenses'))
+        shutil.copy2(
+            os.path.join(self._source_subfolder, 'license.txt'),
+            os.path.join(f'{self.package_folder}', 'licenses', self.name)
+        )
+
+        os.makedirs(f'{self.package_folder}/res')
+        self.copy(
+            'resources/*',
+            f'{self.package_folder}/res/resources',
+            src=self._source_subfolder,
+            keep_path=False
+        )
+        self.copy(
+            'Doxyfile.in',
+            f'{self.package_folder}/res',
+            src=self._source_subfolder,
+            keep_path=False
+        )
+        self.copy(
+            'DocGen-functions.cmake',
+            f'{self.package_folder}/res',
+            src=self._source_subfolder,
+            keep_path=False
+        )
+
+    def package_info(self):
+        self.cpp_info.libdirs = []
+        self.cpp_info.builddirs = [os.path.join('res')]
+
+        self.cpp_info.set_property('cmake_file_name', 'DocGen')
+        self.cpp_info.set_property('cmake_target_name', 'DocGen')
+        self.cpp_info.set_property(
+            'cmake_build_modules',
+            [os.path.join('res', 'DocGen-functions.cmake')]
+        )

--- a/recipes/docgen/all/test_package/CMakeLists.txt
+++ b/recipes/docgen/all/test_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.3)
+
+project(DocGenTestConan VERSION 0.0.1)
+
+find_package(Doxygen REQUIRED)
+find_package(DocGen REQUIRED)
+configure_doxygen(
+    MAINPAGE README.md
+    INPUT "src" "include"
+    STRIP_INC_PATH "include")
+
+add_executable(${PROJECT_NAME} src/${PROJECT_NAME})
+target_include_directories(${PROJECT_NAME} PRIVATE include)

--- a/recipes/docgen/all/test_package/conanfile.py
+++ b/recipes/docgen/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake
+
+
+class JumpstartedSkeletonTest(ConanFile):
+    settings = ()
+    generators = 'cmake_find_package'
+
+    build_requires = 'doxygen/[^1.8.0]'
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+
+    def test(self):
+        cmake = CMake(self)
+        cmake.build(target='docs')

--- a/recipes/docgen/all/test_package/include/DocGenTestConan.h
+++ b/recipes/docgen/all/test_package/include/DocGenTestConan.h
@@ -1,0 +1,9 @@
+/**
+ * @file DocGenTestConan.h
+ */
+
+/**
+ * @brief It does the foo
+ * @return Value of foo
+ */
+int foo();

--- a/recipes/docgen/all/test_package/src/DocGenTestConan.cpp
+++ b/recipes/docgen/all/test_package/src/DocGenTestConan.cpp
@@ -1,0 +1,17 @@
+/**
+ * @file DocGenTestConan.cpp
+ */
+
+#include "DocGenTestConan.h"
+
+/**
+ * @brief A sample function
+ * @return the exit code
+ */
+int main () {
+    return foo();
+}
+
+int foo() {
+    return 0;
+}

--- a/recipes/docgen/config.yml
+++ b/recipes/docgen/config.yml
@@ -1,3 +1,3 @@
-verisons:
+versions:
   "1.0.0":
     folder: all

--- a/recipes/docgen/config.yml
+++ b/recipes/docgen/config.yml
@@ -1,0 +1,3 @@
+verisons:
+  "1.0.0":
+    folder: all


### PR DESCRIPTION
docgen/1.0.0
=========

This is a new utility which provides an easy-to-invoke Make target named `docs` which will invoke Doxygen for the user. It also generates the `Doxyfile` on the user's behalf and sets some of its properties based on the corresponding CMake values (such as the project name and version number).

I'm the author of this package and would like it to be available for public consumption when I write part 2 of this [blog article](https://objectpartners.com/2020/08/19/modern-development-environment-for-c-part-1/).
The project is licensed under MIT.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
