### PR TITLE
ignore .devcontainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .pydevproject
 .settings/
 .ropeproject/
+.devcontainer/
 ## emacs
 *~
 


### PR DESCRIPTION
`.devcontainer` is a folder used by [VSCode](https://code.visualstudio.com/docs/remote/containers) for container development

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
