### PR TITLE
Add new version of expat 2.4.1.

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -14,6 +14,9 @@ sources:
   "2.3.0":
     sha256: 89df123c62f2c2e2b235692d9fe76def6a9ab03dbe95835345bf412726eb1987
     url: https://github.com/libexpat/libexpat/releases/download/R_2_3_0/expat-2.3.0.tar.gz
+  "2.4.1":
+    sha256: a00ae8a6b96b63a3910ddc1100b1a7ef50dc26dceb65ced18ded31ab392f132b
+    url: https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.4.1.tar.gz
 patches:
   "2.3.0":
     - patch_file: "patches/relax-vs-restriction.patch"

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "2.3.0":
     folder: all
+  "2.4.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **expat/2.4.1**

Upstream incorporated changes in the patch, so the 2.3.0 patch is not applied.

Expat 2.3.0 has identified security bugs fixed in 2.4.1  CVE-2013-0340/CWE-776

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
