### PR TITLE
expat: Add support for EXPAT_CHAR_TYPE=wchar_t

### DIFF
--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
+required_conan_version = ">=1.33.0"
 
 class ExpatConan(ConanFile):
     name = "expat"
@@ -32,9 +33,8 @@ class ExpatConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -10,8 +10,8 @@ class ExpatConan(ConanFile):
     homepage = "https://github.com/libexpat/libexpat"
     license = "MIT"
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "char_type": ["char", "wchar_t"]}
+    default_options = {"shared": False, "fPIC": True, "char_type": "char"}
     generators = "cmake"
     exports_sources = ["CMakeLists.txt", "patches/*"]
     _source_subfolder = "source_subfolder"
@@ -22,6 +22,8 @@ class ExpatConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if tools.Version(self.version) < "2.2.8":
+            del self.options.char_type
 
     def configure(self):
         if self.options.shared:
@@ -51,6 +53,8 @@ class ExpatConan(ConanFile):
             self._cmake.definitions["EXPAT_SHARED_LIBS"] = self.options.shared
             self._cmake.definitions["EXPAT_BUILD_TESTS"] = "Off"
             self._cmake.definitions["EXPAT_BUILD_TOOLS"] = "Off"
+            # EXPAT_CHAR_TYPE was added in 2.2.8
+            self._cmake.definitions["EXPAT_CHAR_TYPE"] = self.options.char_type
 
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
@@ -75,3 +79,5 @@ class ExpatConan(ConanFile):
         self.cpp_info.libs = tools.collect_libs(self)
         if not self.options.shared:
             self.cpp_info.defines = ["XML_STATIC"]
+        if self.options.char_type == "wchar_t":
+            self.cpp_info.defines.append("XML_UNICODE_WCHAR_T")

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -79,5 +79,5 @@ class ExpatConan(ConanFile):
         self.cpp_info.libs = tools.collect_libs(self)
         if not self.options.shared:
             self.cpp_info.defines = ["XML_STATIC"]
-        if self.options.char_type == "wchar_t":
+        if self.options.get_safe("char_type") == "wchar_t":
             self.cpp_info.defines.append("XML_UNICODE_WCHAR_T")

--- a/recipes/expat/all/test_package/test_package.cpp
+++ b/recipes/expat/all/test_package/test_package.cpp
@@ -8,6 +8,10 @@
 #include <stdio.h>
 #include "expat.h"
 
+#ifdef XML_UNICODE_WCHAR_T
+#include <wchar.h>
+#endif
+
 #ifdef XML_LARGE_SIZE
 #if defined(XML_USE_MSC_EXTENSIONS) && _MSC_VER < 1400
 #define XML_FMT_INT_MOD "I64"
@@ -19,7 +23,7 @@
 #endif
 
 static void XMLCALL
-startElement(void *userData, const char *name, const char **atts)
+startElement(void *userData, const XML_Char *name, const XML_Char **atts)
 {
   int i;
   int *depthPtr = (int *)userData;
@@ -27,12 +31,16 @@ startElement(void *userData, const char *name, const char **atts)
 
   for (i = 0; i < *depthPtr; i++)
     putchar('\t');
+#ifdef XML_UNICODE_WCHAR_T
+  fputws(name, stdout);
+#else
   puts(name);
+#endif
   *depthPtr += 1;
 }
 
 static void XMLCALL
-endElement(void *userData, const char *name)
+endElement(void *userData, const XML_Char *name)
 {
   int *depthPtr = (int *)userData;
   (void)name;


### PR DESCRIPTION
Specify library name and version:  **expat/2.2.8+**

"EXPAT_CHAR_TYPE=wchar_t" might be useful on Windows.
It changes XML_CHAR to wchar_t and changes encoding from UTF-8 to UTF-16.
expat also supports ushort as char type but I don't know in what cases it should be used.

wchar_t interface can also be enabled on older versions but it requires different approach.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
