### PR TITLE
djinni-support-lib: make configuration more flexible

### DIFF
--- a/recipes/djinni-support-lib/1.x.x/conanfile.py
+++ b/recipes/djinni-support-lib/1.x.x/conanfile.py
@@ -13,12 +13,20 @@ class DjinniSuppotLib(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False],
                 "fPIC": [True, False],
-                "target": ["jni", "objc", "python", "cppcli", "auto"],
+                "target": ["jni", "objc", "python", "cppcli", "auto", "deprecated"],
+                "with_jni": [True, False, "auto"],
+                "with_objc": [True, False, "auto"],
+                "with_python": [True, False, "auto"],
+                "with_cppcli": [True, False, "auto"],
                 "system_java": [True, False]
                }
     default_options = {"shared": False,
                         "fPIC": True ,
-                        "target": "auto",
+                        "target": "deprecated",
+                        "with_jni": "auto",
+                        "with_objc": "auto",
+                        "with_python": "auto",
+                        "with_cppcli": "auto",
                         "system_java": False,
                        }
     exports_sources = ["CMakeLists.txt"]
@@ -28,28 +36,28 @@ class DjinniSuppotLib(ConanFile):
 
     @property
     def _objc_support(self):
-        if self.options.target == "auto":
+        if self.options.with_objc == "auto" or self.options.target == "auto":
             return tools.is_apple_os(self.settings.os)
         else:
-            return self.options.target == "objc"
+            return self.options.with_objc == True or self.options.target == "objc"
 
     @property
     def _jni_support(self):
-        if self.options.target == "auto":
+        if self.options.with_jni == "auto" or self.options.target == "auto":
             return self.settings.os == "Android"
         else:
-            return self.options.target == "jni"
+            return self.options.with_jni == True or self.options.target == "jni"
 
     @property
     def _python_support(self):
-        return self.options.target == "python"
+        return self.options.with_python == True or self.options.target == "python"
 
     @property
     def _cppcli_support(self):
-        if self.options.target == "auto":
+        if self.options.with_cppcli == "auto" or self.options.target == "auto":
             return self.settings.os  == "Windows"
         else:
-            return self.options.target == "cppcli"
+            return self.options.with_cppcli == True or self.options.target == "cppcli"
 
     def configure(self):
         if self.settings.compiler == "Visual Studio" or self.options.shared:
@@ -79,12 +87,19 @@ class DjinniSuppotLib(ConanFile):
         }
 
     def validate(self):
+        if self.options.target != "deprecated":
+            self.output.warn("The 'target' option is deprecated and will be removed soon. Use 'with_jni', 'with_objc', 'with_python' or 'with_cppcli' options instead.")
         if not (self._objc_support or self._jni_support or self._python_support or self._cppcli_support):
-            raise ConanInvalidConfiguration("Target language could not be determined automatically. Set target explicitly to one of 'jni', 'objc', 'python' or 'cppcli'")
-        if self._cppcli_support and (self.settings.compiler.runtime == "MT" or self.settings.compiler.runtime == "MTd"):
-            raise ConanInvalidConfiguration("'/clr' and '/MT' command-line options are incompatible")
-        if self.options.shared and self._cppcli_support:
-            raise ConanInvalidConfiguration("C++/CLI does not support building as shared library")
+            raise ConanInvalidConfiguration("Target language could not be determined automatically. Set at least one of 'with_jni', 'with_objc', 'with_python' or 'with_cppcli' options to `True`.")
+        if self._cppcli_support:
+            if self.settings.os != "Windows":
+                raise ConanInvalidConfiguration("C++/CLI has been enabled on a non-Windows operating system. This is not supported.")
+            if self.options.shared:
+                raise ConanInvalidConfiguration("C++/CLI does not support building as shared library")
+            if self.settings.compiler.runtime == "MT" or self.settings.compiler.runtime == "MTd":
+                raise ConanInvalidConfiguration("'/clr' and '/MT' command-line options are incompatible")
+            if self._objc_support or self._jni_support or self._python_support:
+                raise ConanInvalidConfiguration("C++/CLI is not yet supported with other languages enabled as well. Disable 'with_jni', 'with_objc' and 'with_python' options for a valid configuration.")
         if self.settings.get_safe("compiler.cppstd"):
             tools.check_min_cppstd(self, "17")
         try:

--- a/recipes/djinni-support-lib/1.x.x/conanfile.py
+++ b/recipes/djinni-support-lib/1.x.x/conanfile.py
@@ -3,6 +3,7 @@ import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
+
 class DjinniSuppotLib(ConanFile):
     name = "djinni-support-lib"
     homepage = "https://djinni.xlcpp.dev"
@@ -12,22 +13,22 @@ class DjinniSuppotLib(ConanFile):
     license = "Apache-2.0"
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False],
-                "fPIC": [True, False],
-                "target": ["jni", "objc", "python", "cppcli", "auto", "deprecated"],
-                "with_jni": [True, False, "auto"],
-                "with_objc": [True, False, "auto"],
-                "with_python": [True, False, "auto"],
-                "with_cppcli": [True, False, "auto"],
-                "system_java": [True, False]
+               "fPIC": [True, False],
+               "target": ["jni", "objc", "python", "cppcli", "auto", "deprecated"],
+               "with_jni": [True, False, "auto"],
+               "with_objc": [True, False, "auto"],
+               "with_python": [True, False, "auto"],
+               "with_cppcli": [True, False, "auto"],
+               "system_java": [True, False]
                }
     default_options = {"shared": False,
-                        "fPIC": True ,
-                        "target": "deprecated",
-                        "with_jni": "auto",
-                        "with_objc": "auto",
-                        "with_python": "auto",
-                        "with_cppcli": "auto",
-                        "system_java": False,
+                       "fPIC": True,
+                       "target": "deprecated",
+                       "with_jni": "auto",
+                       "with_objc": "auto",
+                       "with_python": "auto",
+                       "with_cppcli": "auto",
+                       "system_java": False,
                        }
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake", "cmake_find_package"
@@ -55,7 +56,7 @@ class DjinniSuppotLib(ConanFile):
     @property
     def _cppcli_support(self):
         if self.options.with_cppcli == "auto" or self.options.target == "auto":
-            return self.settings.os  == "Windows"
+            return self.settings.os == "Windows"
         else:
             return self.options.with_cppcli == True or self.options.target == "cppcli"
 
@@ -99,7 +100,8 @@ class DjinniSuppotLib(ConanFile):
             if self.settings.compiler.runtime == "MT" or self.settings.compiler.runtime == "MTd":
                 raise ConanInvalidConfiguration("'/clr' and '/MT' command-line options are incompatible")
             if self._objc_support or self._jni_support or self._python_support:
-                raise ConanInvalidConfiguration("C++/CLI is not yet supported with other languages enabled as well. Disable 'with_jni', 'with_objc' and 'with_python' options for a valid configuration.")
+                raise ConanInvalidConfiguration(
+                    "C++/CLI is not yet supported with other languages enabled as well. Disable 'with_jni', 'with_objc' and 'with_python' options for a valid configuration.")
         if self.settings.get_safe("compiler.cppstd"):
             tools.check_min_cppstd(self, "17")
         try:

--- a/recipes/djinni-support-lib/1.x.x/conanfile.py
+++ b/recipes/djinni-support-lib/1.x.x/conanfile.py
@@ -87,6 +87,9 @@ class DjinniSuppotLib(ConanFile):
             "apple-clang": "10",
         }
 
+    def package_id(self):
+        del self.options.target
+
     def validate(self):
         if self.options.target != "deprecated":
             self.output.warn("The 'target' option is deprecated and will be removed soon. Use 'with_jni', 'with_objc', 'with_python' or 'with_cppcli' options instead.")

--- a/recipes/djinni-support-lib/1.x.x/conanfile.py
+++ b/recipes/djinni-support-lib/1.x.x/conanfile.py
@@ -87,9 +87,6 @@ class DjinniSuppotLib(ConanFile):
             "apple-clang": "10",
         }
 
-    def package_id(self):
-        del self.options.target
-
     def validate(self):
         if self.options.target != "deprecated":
             self.output.warn("The 'target' option is deprecated and will be removed soon. Use 'with_jni', 'with_objc', 'with_python' or 'with_cppcli' options instead.")


### PR DESCRIPTION
Specify library name and version:  **djinni-support-lib/1.0.0**

- deprecate `target` option because it is not flexible enough. 
- add new options `with_jni`, `with_objc`, `with_python`, `with_cppcli` that behave like the underlying cmake options & provide enabling multiple languages at once, if supported.
- apply PEP8 style guide

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
