### PR TITLE
libsndfile: fix with_sqlite option usage

### DIFF
--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -57,9 +57,11 @@ class LibsndfileConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        if self.options.get_safe("with_sqlite", "deprecated") != "deprecated":
+        if self.options.with_sqlite != "deprecated":
             self.output.warn("with_sqlite is a deprecated option. Do not use.")
-        del self.options.with_sqlite
+
+    def package_id(self):
+        del self.info.options.with_sqlite
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)

--- a/recipes/libsndfile/all/conanfile.py
+++ b/recipes/libsndfile/all/conanfile.py
@@ -57,7 +57,7 @@ class LibsndfileConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        if self.options.with_sqlite != "deprecated":
+        if self.options.get_safe("with_sqlite", "deprecated") != "deprecated":
             self.output.warn("with_sqlite is a deprecated option. Do not use.")
         del self.options.with_sqlite
 


### PR DESCRIPTION
fixes bincrafters/community#1392

Specify library name and version:  **libsndfile/***

when libsndfile is required several times in a dependency graph, libsndfile's configure method seems to be called several time, because currently it fails with 
```
ERROR: libsndfile/1.0.30: Error in configure() method, line 58
	if self.options.with_sqlite != "deprecated":
	ConanException: option 'with_sqlite' doesn't exist
Possible options are ['shared', 'fPIC', 'programs', 'experimental', 'with_alsa', 'with_external_libs']
```


---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
