### PR TITLE
cubicinterpolation: regenerate binaries

### DIFF
--- a/recipes/cubicinterpolation/all/conanfile.py
+++ b/recipes/cubicinterpolation/all/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.32.0"
+required_conan_version = ">=1.33.0"
 
 
 class CubicInterpolationConan(ConanFile):
@@ -79,9 +79,8 @@ class CubicInterpolationConan(ConanFile):
             raise ConanInvalidConfiguration("cubicinterpolation shared is not supported with Visual Studio")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "cubic_interpolation-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Due to a new dependency (libbacktrace) in the default build of boost recipe, package must be regenerated, since package id has changed (known bug in conan client, @memsharded if you know the related issue id?).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
