### PR TITLE
crashpad: 2 common libraries are built -> rename them

### DIFF
--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -214,7 +214,7 @@ class CrashpadConan(ConanFile):
         self.copy("crashpad_handler", src=os.path.join(self._source_subfolder, "out", "Default"), dst="bin", keep_path=False)
         self.copy("crashpad_handler.exe", src=os.path.join(self._source_subfolder, "out", "Default"), dst="bin", keep_path=False)
         self.copy("crashpad_handler_com.com", src=os.path.join(self._source_subfolder, "out", "Default"), dst="bin", keep_path=False)
-        if self.setings.os == "Windows":
+        if self.settings.os == "Windows":
             tools.rename(os.path.join(self.package_folder, "bin", "crashpad_handler_com.com"),
                          os.path.join(self.package_folder, "bin", "crashpad_handler.com"))
 

--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -214,6 +214,9 @@ class CrashpadConan(ConanFile):
         self.copy("crashpad_handler", src=os.path.join(self._source_subfolder, "out", "Default"), dst="bin", keep_path=False)
         self.copy("crashpad_handler.exe", src=os.path.join(self._source_subfolder, "out", "Default"), dst="bin", keep_path=False)
         self.copy("crashpad_handler_com.com", src=os.path.join(self._source_subfolder, "out", "Default"), dst="bin", keep_path=False)
+        if self.setings.os == "Windows":
+            tools.rename(os.path.join(self.package_folder, "bin", "crashpad_handler_com.com"),
+                         os.path.join(self.package_folder, "bin", "crashpad_handler.com"))
 
         # Remove accidentally copied libraries. These are used by the executables, not by the libraries.
         tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*getopt*")

--- a/recipes/crashpad/all/conanfile.py
+++ b/recipes/crashpad/all/conanfile.py
@@ -191,6 +191,14 @@ class CrashpadConan(ConanFile):
                     targets=" ".join(targets),
                     parallel=tools.cpu_count()), run_environment=True)
 
+        def lib_filename(name):
+            prefix, suffix = ("", ".lib")  if self.settings.compiler == "Visual Studio" else ("lib", ".a")
+            return "{}{}{}".format(prefix, name, suffix)
+        tools.rename(os.path.join(self._source_subfolder, "out", "Default", "obj", "client", lib_filename("common")),
+                     os.path.join(self._source_subfolder, "out", "Default", "obj", "client", lib_filename("client_common")))
+        tools.rename(os.path.join(self._source_subfolder, "out", "Default", "obj", "handler", lib_filename("common")),
+                     os.path.join(self._source_subfolder, "out", "Default", "obj", "handler", lib_filename("handler_common")))
+
     def package(self):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
 
@@ -201,6 +209,7 @@ class CrashpadConan(ConanFile):
         self.copy("*.h", src=os.path.join(self._source_subfolder, "out", "Default", "gen", "build"), dst=os.path.join("include", "build"))
 
         self.copy("*.a", src=os.path.join(self._source_subfolder, "out", "Default"), dst="lib", keep_path=False)
+
         self.copy("*.lib", src=os.path.join(self._source_subfolder, "out", "Default"), dst="lib", keep_path=False)
         self.copy("crashpad_handler", src=os.path.join(self._source_subfolder, "out", "Default"), dst="bin", keep_path=False)
         self.copy("crashpad_handler.exe", src=os.path.join(self._source_subfolder, "out", "Default"), dst="bin", keep_path=False)
@@ -243,11 +252,11 @@ class CrashpadConan(ConanFile):
             self.cpp_info.components["util"].frameworks.extend(["CoreFoundation", "Foundation", "IOKit"])
             self.cpp_info.components["util"].system_libs.append("bsm")
 
-        self.cpp_info.components["common"].libs = ["common"]
-        self.cpp_info.components["common"].requires = ["util"]
+        self.cpp_info.components["client_common"].libs = ["client_common"]
+        self.cpp_info.components["client_common"].requires = ["util", "mini_chromium_base"]
 
         self.cpp_info.components["client"].libs = ["client"]
-        self.cpp_info.components["client"].requires = ["common"]
+        self.cpp_info.components["client"].requires = ["util", "mini_chromium_base", "client_common"]
         if self.settings.os == "Windows":
             self.cpp_info.components["client"].system_libs.append("rpcrt4")
 
@@ -255,7 +264,7 @@ class CrashpadConan(ConanFile):
         self.cpp_info.components["context"].requires = ["util"]
 
         self.cpp_info.components["snapshot"].libs = ["snapshot"]
-        self.cpp_info.components["snapshot"].requires = ["common", "mini_chromium_base", "util"]
+        self.cpp_info.components["snapshot"].requires = ["client_common", "mini_chromium_base", "util"]
         if tools.is_apple_os(self.settings.os):
             self.cpp_info.components["snapshot"].frameworks.extend(["OpenCL"])
 
@@ -265,8 +274,11 @@ class CrashpadConan(ConanFile):
         self.cpp_info.components["minidump"].libs = ["minidump"]
         self.cpp_info.components["minidump"].requires = ["snapshot", "mini_chromium_base", "util"]
 
+        self.cpp_info.components["handler_common"].libs = ["handler_common"]
+        self.cpp_info.components["handler_common"].requires = ["client_common", "snapshot", "util"]
+
         self.cpp_info.components["handler"].libs = ["handler"]
-        self.cpp_info.components["handler"].requires = ["common", "minidump", "snapshot"]
+        self.cpp_info.components["handler"].requires = ["client", "util", "handler_common", "minidump", "snapshot"]
 
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bin_path))

--- a/recipes/crashpad/all/test_package/conanfile.py
+++ b/recipes/crashpad/all/test_package/conanfile.py
@@ -20,6 +20,6 @@ class TestPackageConan(ConanFile):
             handler_bin_path = os.path.join(self.deps_cpp_info["crashpad"].rootpath, "bin", handler_exe)
             self.run("%s %s/db %s" % (bin_path, test_env_dir, handler_bin_path), run_environment=True)
             if self.settings.os == "Windows":
-                handler_exe = "crashpad_handler_com.com"
+                handler_exe = "crashpad_handler.com"
                 handler_bin_path = os.path.join(self.deps_cpp_info["crashpad"].rootpath, "bin", handler_exe)
                 self.run("%s %s/db %s" % (bin_path, test_env_dir, handler_bin_path), run_environment=True)

--- a/recipes/crashpad/all/test_package/test_package.cpp
+++ b/recipes/crashpad/all/test_package/test_package.cpp
@@ -9,6 +9,8 @@
 #include "client/crashpad_client.h"
 #include "client/settings.h"
 
+#include "client/crash_report_database.h"
+
 bool startCrashpad(const base::FilePath &db,
                    const base::FilePath &handler) {
     std::string              url("http://localhost");
@@ -43,6 +45,10 @@ int main(int argc, char* argv[]) {
     base::FilePath db(argv[1]);
     base::FilePath handler(argv[2]);
 #endif
+
+    // Test availability of this function.
+    auto database = crashpad::CrashReportDatabase::Initialize(db);
+    (void) database; /* Avoid warning about unused variable */
 
     return startCrashpad(db, handler) ? 0 : 1;
 }


### PR DESCRIPTION
Specify library name and version:  **crashpad/all**

2 common libraries were copied to the `lib` folder by `self.copy`.
Avoid conflict by renaming both of them.

Fixes #5618

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
