### PR TITLE
civetweb: Bump versions

### DIFF
--- a/recipes/civetweb/all/conandata.yml
+++ b/recipes/civetweb/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.13":
     url: "https://github.com/civetweb/civetweb/archive/v1.13.tar.gz"
     sha256: "a7ccc76c2f1b5f4e8d855eb328ed542f8fe3b882a6da868781799a98f4acdedc"
+  "1.14":
+    url: "https://github.com/civetweb/civetweb/archive/v1.14.tar.gz"
+    sha256: "d02d7ab091c8b4edf21fc13a03c6db08a8a8b8605e35e0073251b9d88443c653"

--- a/recipes/civetweb/all/conanfile.py
+++ b/recipes/civetweb/all/conanfile.py
@@ -59,7 +59,7 @@ class CivetwebConan(ConanFile):
 
     def requirements(self):
         if self.options.with_ssl:
-            self.requires("openssl/1.1.1j")
+            self.requires("openssl/1.1.1k")
 
     def validate(self):
         if self.options.get_safe("ssl_dynamic_loading") and not self.options["openssl"].shared:

--- a/recipes/civetweb/config.yml
+++ b/recipes/civetweb/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.13":
     folder: all
+  "1.14":
+    folder: all


### PR DESCRIPTION
**civetweb/1.14**

prometheus-cpp 0.12.3 bumped the dependency of civetweb in their upstream source to 1.14.
To be able to package prometheus-cpp, we need to produce the civetweb/1.14 pkg.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
