### PR TITLE
Add breakpad recipe

### DIFF
--- a/recipes/breakpad/all/conandata.yml
+++ b/recipes/breakpad/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20210521":
+    url: "https://github.com/google/breakpad/archive/f7428bc.tar.gz"
+    sha256: "55a688a49ffc476d94d92c3fd73f9264c974c25af8d6371c3901bd3451081e47"

--- a/recipes/breakpad/all/conandata.yml
+++ b/recipes/breakpad/all/conandata.yml
@@ -2,3 +2,9 @@ sources:
   "cci.20210521":
     url: "https://github.com/google/breakpad/archive/f7428bc.tar.gz"
     sha256: "55a688a49ffc476d94d92c3fd73f9264c974c25af8d6371c3901bd3451081e47"
+patches:
+  "cci.20210521":
+    - patch_file: "patches/0001-Use_conans_lss.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-Remove-hardcoded-fpic.patch"
+      base_path: "source_subfolder"

--- a/recipes/breakpad/all/conanfile.py
+++ b/recipes/breakpad/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 import textwrap
 
@@ -24,6 +25,10 @@ class BreakpadConan(ConanFile):
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("Breakpad can only be built on Linux. For other OSs check sentry-breakpad")
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/breakpad/all/conanfile.py
+++ b/recipes/breakpad/all/conanfile.py
@@ -14,6 +14,7 @@ class BreakpadConan(ConanFile):
     homepage = "https://chromium.googlesource.com/breakpad/breakpad/"
     settings = "os", "compiler", "build_type", "arch"
     provides = "breakpad"
+    exports_sources = "patches/**"
     options = {
         "fPIC": [True, False]
     }
@@ -33,57 +34,6 @@ class BreakpadConan(ConanFile):
     def requirements(self):
         self.requires("linux-syscall-support/cci.20200813")
 
-    def _patch_sources(self):
-        # Use Conan's lss instead of the submodule
-        # 1. Remove from include dirs
-        # 2. Remove from list of headers to install
-        # 3. Patch all #include statements
-        tools.replace_in_file(os.path.join(self._source_subfolder, "Makefile.in"),
-                            "$(includegbc_HEADERS) $(includelss_HEADERS) ",
-                            "$(includegbc_HEADERS) "
-        )
-        tools.replace_in_file(os.path.join(self._source_subfolder, "Makefile.in"),
-                            "install-includelssHEADERS install-includepHEADERS ",
-                            "iinstall-includepHEADERS "
-        )
-        files_to_patch = [
-            "src/tools/linux/md2core/minidump-2-core.cc",
-            "src/processor/testdata/linux_test_app.cc",
-            "src/common/memory_allocator.h",
-            "src/common/linux/memory_mapped_file.cc",
-            "src/common/linux/file_id.cc",
-            "src/common/linux/safe_readlink.cc",
-            "src/client/minidump_file_writer.cc",
-            "src/client/linux/handler/exception_handler.cc",
-            "src/client/linux/handler/exception_handler_unittest.cc",
-            "src/client/linux/log/log.cc",
-            "src/client/linux/crash_generation/crash_generation_client.cc",
-            "src/client/linux/minidump_writer/linux_dumper.cc",
-            "src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc",
-            "src/client/linux/minidump_writer/proc_cpuinfo_reader.h",
-            "src/client/linux/minidump_writer/minidump_writer.cc",
-            "src/client/linux/minidump_writer/linux_ptrace_dumper.cc",
-            "src/client/linux/minidump_writer/cpu_set.h",
-            "src/client/linux/minidump_writer/directory_reader.h",
-            "src/client/linux/minidump_writer/line_reader.h"
-        ]
-
-        for file in files_to_patch:
-            tools.replace_in_file(
-                os.path.join(self._source_subfolder, file),
-                "#include \"third_party/lss/linux_syscall_support.h\"",
-                "#include <linux_syscall_support.h>"
-            )
-
-        # Let Conan handle fPIC
-        tools.replace_in_file(
-            os.path.join(self._source_subfolder, "Makefile.in"),
-            textwrap.dedent("""\
-                @LINUX_HOST_TRUE@am__append_2 = -fPIC
-                @LINUX_HOST_TRUE@am__append_3 = -fPIC"""),
-            ""
-        )
-
     def _configure_autotools(self):
         if not self._env_build:
             self._env_build = AutoToolsBuildEnvironment(self)
@@ -94,7 +44,8 @@ class BreakpadConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def build(self):
-        self._patch_sources()
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         env_build = self._configure_autotools()
         env_build.make()
 

--- a/recipes/breakpad/all/conanfile.py
+++ b/recipes/breakpad/all/conanfile.py
@@ -4,7 +4,7 @@ import textwrap
 
 required_conan_version = ">=1.33.0"
 
-class BreakpadConan( ConanFile ):
+class BreakpadConan(ConanFile):
     name = "breakpad"
     description = "A set of client and server components which implement a crash-reporting system"
     topics = ["crash", "report", "breakpad"]
@@ -108,11 +108,23 @@ class BreakpadConan( ConanFile ):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info( self ):
-        self.cpp_info.libs = ["breakpad", "breakpad_client"]
-        self.cpp_info.includedirs = [os.path.join("include", "breakpad")]
+        self.cpp_info.components["libbreakpad"].libs = ["breakpad"]
+        self.cpp_info.components["libbreakpad"].includedirs.append(os.path.join("include", "breakpad"))
+        self.cpp_info.components["libbreakpad"].names["pkg_config"] = "breakpad"
+
+        self.cpp_info.components["client"].libs = ["breakpad_client"]
+        self.cpp_info.components["client"].includedirs.append(os.path.join("include", "breakpad"))
+        self.cpp_info.components["client"].names["pkg_config"] = "breakpad-client"
+
+        if tools.is_apple_os(self.settings.os):
+            self.cpp_info.components["client"].frameworks.append("CoreFoundation")
 
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.components["libbreakpad"].system_libs.append("pthread")
+            self.cpp_info.components["libbreakpad"].requires.append("linux-syscall-support::linux-syscall-support")
+
+            self.cpp_info.components["client"].system_libs.append("pthread")
+            self.cpp_info.components["client"].requires.append("linux-syscall-support::linux-syscall-support")
 
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bindir))

--- a/recipes/breakpad/all/conanfile.py
+++ b/recipes/breakpad/all/conanfile.py
@@ -11,7 +11,8 @@ class BreakpadConan( ConanFile ):
     license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://chromium.googlesource.com/breakpad/breakpad/"
-    settings = 'os', 'compiler', 'build_type', 'arch'
+    settings = "os", "compiler", "build_type", "arch"
+    provides = "breakpad"
     options = {
         "fPIC": [True, False]
     }

--- a/recipes/breakpad/all/conanfile.py
+++ b/recipes/breakpad/all/conanfile.py
@@ -1,0 +1,118 @@
+from conans import ConanFile, AutoToolsBuildEnvironment, tools
+import os
+import textwrap
+
+required_conan_version = ">=1.33.0"
+
+class BreakpadConan( ConanFile ):
+    name = "breakpad"
+    description = "A set of client and server components which implement a crash-reporting system"
+    topics = ["crash", "report", "breakpad"]
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://chromium.googlesource.com/breakpad/breakpad/"
+    settings = 'os', 'compiler', 'build_type', 'arch'
+    options = {
+        "fPIC": [True, False]
+    }
+    default_options = {
+        "fPIC": True
+    }
+    _env_build = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def requirements(self):
+        if self.settings.os == "Linux":
+            self.requires("linux-syscall-support/cci.20200813")
+
+    def _patch_sources(self):
+        # Use Conan's lss instead of the submodule
+        # 1. Remove from include dirs
+        # 2. Remove from list of headers to install
+        # 3. Patch all #include statements
+        tools.replace_in_file(os.path.join(self._source_subfolder, "Makefile.in"),
+                            "$(includegbc_HEADERS) $(includelss_HEADERS) ",
+                            "$(includegbc_HEADERS) "
+        )
+        tools.replace_in_file(os.path.join(self._source_subfolder, "Makefile.in"),
+                            "install-includelssHEADERS install-includepHEADERS ",
+                            "iinstall-includepHEADERS "
+        )
+        files_to_patch = [
+            "src/tools/linux/md2core/minidump-2-core.cc",
+            "src/processor/testdata/linux_test_app.cc",
+            "src/common/memory_allocator.h",
+            "src/common/linux/memory_mapped_file.cc",
+            "src/common/linux/file_id.cc",
+            "src/common/linux/safe_readlink.cc",
+            "src/client/minidump_file_writer.cc",
+            "src/client/linux/handler/exception_handler.cc",
+            "src/client/linux/handler/exception_handler_unittest.cc",
+            "src/client/linux/log/log.cc",
+            "src/client/linux/crash_generation/crash_generation_client.cc",
+            "src/client/linux/minidump_writer/linux_dumper.cc",
+            "src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc",
+            "src/client/linux/minidump_writer/proc_cpuinfo_reader.h",
+            "src/client/linux/minidump_writer/minidump_writer.cc",
+            "src/client/linux/minidump_writer/linux_ptrace_dumper.cc",
+            "src/client/linux/minidump_writer/cpu_set.h",
+            "src/client/linux/minidump_writer/directory_reader.h",
+            "src/client/linux/minidump_writer/line_reader.h"
+        ]
+
+        for file in files_to_patch:
+            tools.replace_in_file(
+                os.path.join(self._source_subfolder, file),
+                "#include \"third_party/lss/linux_syscall_support.h\"",
+                "#include <linux_syscall_support.h>"
+            )
+
+        # Let Conan handle fPIC
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "Makefile.in"),
+            textwrap.dedent("""\
+                @LINUX_HOST_TRUE@am__append_2 = -fPIC
+                @LINUX_HOST_TRUE@am__append_3 = -fPIC"""),
+            ""
+        )
+
+    def _configure_autotools(self):
+        if not self._env_build:
+            self._env_build = AutoToolsBuildEnvironment(self)
+            self._env_build.configure(configure_dir=self._source_subfolder)
+        return self._env_build
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def build(self):
+        if self.settings.os == "Linux":
+            self._patch_sources()
+
+        env_build = self._configure_autotools()
+        env_build.make()
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        env_build = self._configure_autotools()
+        env_build.install()
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info( self ):
+        self.cpp_info.libs = ["breakpad", "breakpad_client"]
+        self.cpp_info.includedirs = [os.path.join("include", "breakpad")]
+
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.append("pthread")
+
+        bindir = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bindir))
+        self.env_info.PATH.append(bindir)

--- a/recipes/breakpad/all/conanfile.py
+++ b/recipes/breakpad/all/conanfile.py
@@ -30,13 +30,8 @@ class BreakpadConan(ConanFile):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("Breakpad can only be built on Linux. For other OSs check sentry-breakpad")
 
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
     def requirements(self):
-        if self.settings.os == "Linux":
-            self.requires("linux-syscall-support/cci.20200813")
+        self.requires("linux-syscall-support/cci.20200813")
 
     def _patch_sources(self):
         # Use Conan's lss instead of the submodule
@@ -99,9 +94,7 @@ class BreakpadConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def build(self):
-        if self.settings.os == "Linux":
-            self._patch_sources()
-
+        self._patch_sources()
         env_build = self._configure_autotools()
         env_build.make()
 
@@ -121,15 +114,12 @@ class BreakpadConan(ConanFile):
         self.cpp_info.components["client"].includedirs.append(os.path.join("include", "breakpad"))
         self.cpp_info.components["client"].names["pkg_config"] = "breakpad-client"
 
-        if tools.is_apple_os(self.settings.os):
-            self.cpp_info.components["client"].frameworks.append("CoreFoundation")
 
-        if self.settings.os == "Linux":
-            self.cpp_info.components["libbreakpad"].system_libs.append("pthread")
-            self.cpp_info.components["libbreakpad"].requires.append("linux-syscall-support::linux-syscall-support")
+        self.cpp_info.components["libbreakpad"].system_libs.append("pthread")
+        self.cpp_info.components["libbreakpad"].requires.append("linux-syscall-support::linux-syscall-support")
 
-            self.cpp_info.components["client"].system_libs.append("pthread")
-            self.cpp_info.components["client"].requires.append("linux-syscall-support::linux-syscall-support")
+        self.cpp_info.components["client"].system_libs.append("pthread")
+        self.cpp_info.components["client"].requires.append("linux-syscall-support::linux-syscall-support")
 
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bindir))

--- a/recipes/breakpad/all/patches/0001-Use_conans_lss.patch
+++ b/recipes/breakpad/all/patches/0001-Use_conans_lss.patch
@@ -1,0 +1,258 @@
+diff --color -ur Makefile.in Makefile.in
+--- Makefile.in	2021-05-21 15:56:41.000000000 -0300
++++ Makefile.in	2021-05-27 18:57:23.986912433 -0300
+@@ -2082,7 +2082,7 @@
+ HEADERS = $(includec_HEADERS) $(includecl_HEADERS) \
+ 	$(includeclc_HEADERS) $(includecldwc_HEADERS) \
+ 	$(includeclh_HEADERS) $(includeclm_HEADERS) \
+-	$(includegbc_HEADERS) $(includelss_HEADERS) \
++	$(includegbc_HEADERS) \
+ 	$(includep_HEADERS)
+ am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
+ # Read a list of newline-separated strings from the standard input,
+@@ -9718,7 +9718,7 @@
+ 	install-includeclHEADERS install-includeclcHEADERS \
+ 	install-includecldwcHEADERS install-includeclhHEADERS \
+ 	install-includeclmHEADERS install-includegbcHEADERS \
+-	install-includelssHEADERS install-includepHEADERS \
++	iinstall-includepHEADERS \
+ 	install-pkgconfigDATA
+ 
+ install-dvi: install-dvi-am
+@@ -10084,7 +10084,7 @@
+ 	install-includeclHEADERS install-includeclcHEADERS \
+ 	install-includecldwcHEADERS install-includeclhHEADERS \
+ 	install-includeclmHEADERS install-includegbcHEADERS \
+-	install-includelssHEADERS install-includepHEADERS install-info \
++	iinstall-includepHEADERS install-info \
+ 	install-info-am install-libLIBRARIES install-libexecPROGRAMS \
+ 	install-man install-pdf install-pdf-am install-pkgconfigDATA \
+ 	install-ps install-ps-am install-strip installcheck \
+diff --color -ur src/client/linux/crash_generation/crash_generation_client.cc src/client/linux/crash_generation/crash_generation_client.cc
+--- src/client/linux/crash_generation/crash_generation_client.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/crash_generation/crash_generation_client.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -37,7 +37,7 @@
+ 
+ #include "common/linux/eintr_wrapper.h"
+ #include "common/linux/ignore_ret.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ namespace google_breakpad {
+ 
+diff --color -ur src/client/linux/handler/exception_handler.cc src/client/linux/handler/exception_handler.cc
+--- src/client/linux/handler/exception_handler.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/handler/exception_handler.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -95,7 +95,7 @@
+ #include "client/linux/minidump_writer/linux_dumper.h"
+ #include "client/linux/minidump_writer/minidump_writer.h"
+ #include "common/linux/eintr_wrapper.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ #if defined(__ANDROID__)
+ #include "linux/sched.h"
+diff --color -ur src/client/linux/handler/exception_handler_unittest.cc src/client/linux/handler/exception_handler_unittest.cc
+--- src/client/linux/handler/exception_handler_unittest.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/handler/exception_handler_unittest.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -50,7 +50,7 @@
+ #include "common/linux/linux_libc_support.h"
+ #include "common/tests/auto_tempdir.h"
+ #include "common/using_std_string.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ #include "google_breakpad/processor/minidump.h"
+ 
+ using namespace google_breakpad;
+diff --color -ur src/client/linux/log/log.cc src/client/linux/log/log.cc
+--- src/client/linux/log/log.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/log/log.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -33,7 +33,7 @@
+ #include <android/log.h>
+ #include <dlfcn.h>
+ #else
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ #endif
+ 
+ namespace logger {
+diff --color -ur src/client/linux/minidump_writer/cpu_set.h src/client/linux/minidump_writer/cpu_set.h
+--- src/client/linux/minidump_writer/cpu_set.h	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/minidump_writer/cpu_set.h	2021-05-27 18:57:23.990912414 -0300
+@@ -35,7 +35,7 @@
+ #include <string.h>
+ 
+ #include "common/linux/linux_libc_support.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ namespace google_breakpad {
+ 
+diff --color -ur src/client/linux/minidump_writer/directory_reader.h src/client/linux/minidump_writer/directory_reader.h
+--- src/client/linux/minidump_writer/directory_reader.h	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/minidump_writer/directory_reader.h	2021-05-27 18:57:23.990912414 -0300
+@@ -38,7 +38,7 @@
+ #include <string.h>
+ 
+ #include "common/linux/linux_libc_support.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ namespace google_breakpad {
+ 
+diff --color -ur src/client/linux/minidump_writer/line_reader.h src/client/linux/minidump_writer/line_reader.h
+--- src/client/linux/minidump_writer/line_reader.h	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/minidump_writer/line_reader.h	2021-05-27 18:57:23.990912414 -0300
+@@ -35,7 +35,7 @@
+ #include <string.h>
+ 
+ #include "common/linux/linux_libc_support.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ namespace google_breakpad {
+ 
+diff --color -ur src/client/linux/minidump_writer/linux_dumper.cc src/client/linux/minidump_writer/linux_dumper.cc
+--- src/client/linux/minidump_writer/linux_dumper.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/minidump_writer/linux_dumper.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -51,7 +51,7 @@
+ #include "common/linux/memory_mapped_file.h"
+ #include "common/linux/safe_readlink.h"
+ #include "google_breakpad/common/minidump_exception_linux.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ #if defined(__ANDROID__)
+ 
+diff --color -ur src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc
+--- src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -39,7 +39,7 @@
+ #include <unistd.h>
+ 
+ #include "common/scoped_ptr.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ #if defined(__ARM_EABI__)
+ #define TID_PTR_REGISTER "r3"
+diff --color -ur src/client/linux/minidump_writer/linux_ptrace_dumper.cc src/client/linux/minidump_writer/linux_ptrace_dumper.cc
+--- src/client/linux/minidump_writer/linux_ptrace_dumper.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/minidump_writer/linux_ptrace_dumper.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -57,7 +57,7 @@
+ #include "client/linux/minidump_writer/directory_reader.h"
+ #include "client/linux/minidump_writer/line_reader.h"
+ #include "common/linux/linux_libc_support.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ // Suspends a thread by attaching to it.
+ static bool SuspendThread(pid_t pid) {
+diff --color -ur src/client/linux/minidump_writer/minidump_writer.cc src/client/linux/minidump_writer/minidump_writer.cc
+--- src/client/linux/minidump_writer/minidump_writer.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/minidump_writer/minidump_writer.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -77,7 +77,7 @@
+ #include "common/linux/linux_libc_support.h"
+ #include "common/minidump_type_helper.h"
+ #include "google_breakpad/common/minidump_format.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ namespace {
+ 
+diff --color -ur src/client/linux/minidump_writer/proc_cpuinfo_reader.h src/client/linux/minidump_writer/proc_cpuinfo_reader.h
+--- src/client/linux/minidump_writer/proc_cpuinfo_reader.h	2021-05-21 15:56:41.000000000 -0300
++++ src/client/linux/minidump_writer/proc_cpuinfo_reader.h	2021-05-27 18:57:23.990912414 -0300
+@@ -36,7 +36,7 @@
+ 
+ #include "client/linux/minidump_writer/line_reader.h"
+ #include "common/linux/linux_libc_support.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ namespace google_breakpad {
+ 
+diff --color -ur src/client/minidump_file_writer.cc src/client/minidump_file_writer.cc
+--- src/client/minidump_file_writer.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/client/minidump_file_writer.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -41,7 +41,7 @@
+ #include "common/linux/linux_libc_support.h"
+ #include "common/string_conversion.h"
+ #if defined(__linux__) && __linux__
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ #endif
+ 
+ #if defined(__ANDROID__)
+diff --color -ur src/common/linux/file_id.cc src/common/linux/file_id.cc
+--- src/common/linux/file_id.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/common/linux/file_id.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -46,7 +46,7 @@
+ #include "common/linux/linux_libc_support.h"
+ #include "common/linux/memory_mapped_file.h"
+ #include "common/using_std_string.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ namespace google_breakpad {
+ 
+diff --color -ur src/common/linux/memory_mapped_file.cc src/common/linux/memory_mapped_file.cc
+--- src/common/linux/memory_mapped_file.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/common/linux/memory_mapped_file.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -40,7 +40,7 @@
+ #include <unistd.h>
+ 
+ #include "common/memory_range.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ namespace google_breakpad {
+ 
+diff --color -ur src/common/linux/safe_readlink.cc src/common/linux/safe_readlink.cc
+--- src/common/linux/safe_readlink.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/common/linux/safe_readlink.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -32,7 +32,7 @@
+ 
+ #include <stddef.h>
+ 
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ namespace google_breakpad {
+ 
+diff --color -ur src/common/memory_allocator.h src/common/memory_allocator.h
+--- src/common/memory_allocator.h	2021-05-21 15:56:41.000000000 -0300
++++ src/common/memory_allocator.h	2021-05-27 18:57:23.990912414 -0300
+@@ -47,7 +47,7 @@
+ #define sys_munmap munmap
+ #define MAP_ANONYMOUS MAP_ANON
+ #else
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ #endif
+ 
+ namespace google_breakpad {
+diff --color -ur src/processor/testdata/linux_test_app.cc src/processor/testdata/linux_test_app.cc
+--- src/processor/testdata/linux_test_app.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/processor/testdata/linux_test_app.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -46,7 +46,7 @@
+ #include <string>
+ 
+ #include "client/linux/handler/exception_handler.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ 
+ namespace {
+ 
+diff --color -ur src/tools/linux/md2core/minidump-2-core.cc src/tools/linux/md2core/minidump-2-core.cc
+--- src/tools/linux/md2core/minidump-2-core.cc	2021-05-21 15:56:41.000000000 -0300
++++ src/tools/linux/md2core/minidump-2-core.cc	2021-05-27 18:57:23.990912414 -0300
+@@ -52,7 +52,7 @@
+ #include "common/using_std_string.h"
+ #include "google_breakpad/common/breakpad_types.h"
+ #include "google_breakpad/common/minidump_format.h"
+-#include "third_party/lss/linux_syscall_support.h"
++#include <linux_syscall_support.h>
+ #include "tools/linux/md2core/minidump_memory_range.h"
+ 
+ #if ULONG_MAX == 0xffffffffffffffff

--- a/recipes/breakpad/all/patches/0002-Remove-hardcoded-fpic.patch
+++ b/recipes/breakpad/all/patches/0002-Remove-hardcoded-fpic.patch
@@ -1,0 +1,13 @@
+diff --color -ur a/Makefile.in b/Makefile.in
+--- Makefile.in	2021-05-21 15:56:41.000000000 -0300
++++ Makefile.in	2021-05-27 19:01:06.857704652 -0300
+@@ -130,8 +130,7 @@
+ @ANDROID_HOST_TRUE@	-I$(top_srcdir)/src/common/android/testing/include
+ 
+ # Build as PIC on Linux, for linux_client_unittest_shlib
+-@LINUX_HOST_TRUE@am__append_2 = -fPIC
+-@LINUX_HOST_TRUE@am__append_3 = -fPIC
++
+ libexec_PROGRAMS = $(am__EXEEXT_10)
+ bin_PROGRAMS = $(am__EXEEXT_2) $(am__EXEEXT_3) $(am__EXEEXT_4)
+ check_PROGRAMS = $(am__EXEEXT_5) $(am__EXEEXT_6) $(am__EXEEXT_7) \

--- a/recipes/breakpad/all/test_package/CMakeLists.txt
+++ b/recipes/breakpad/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/breakpad/all/test_package/CMakeLists.txt
+++ b/recipes/breakpad/all/test_package/CMakeLists.txt
@@ -5,4 +5,5 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/breakpad/all/test_package/conanfile.py
+++ b/recipes/breakpad/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class BreakpadTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/breakpad/all/test_package/test_package.cpp
+++ b/recipes/breakpad/all/test_package/test_package.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+#include "client/linux/handler/exception_handler.h"
+
+using namespace google_breakpad;
+
+namespace {
+
+bool callback(const MinidumpDescriptor &descriptor,
+              void *context,
+              bool succeeded) {
+    // if succeeded is true, descriptor.path() contains a path
+    // to the minidump file. Context is the context passed to
+    // the exception handler's constructor.
+    return succeeded;
+}
+
+}
+
+int main(int argc, char *argv[]) {
+
+    std::cout << "Breakpad test_package" << std::endl;
+
+    MinidumpDescriptor descriptor("path/to/cache");
+    ExceptionHandler eh(
+      descriptor,
+      /* filter */ nullptr,
+      callback,
+      /* context */ nullptr,
+      /* install handler */ true,
+      /* server FD */ -1
+    );
+
+    // run your program here
+    return 0;
+}

--- a/recipes/breakpad/all/test_package/test_package.cpp
+++ b/recipes/breakpad/all/test_package/test_package.cpp
@@ -1,5 +1,6 @@
-#include <iostream>
 #include "client/linux/handler/exception_handler.h"
+
+#include <iostream>
 
 using namespace google_breakpad;
 
@@ -17,8 +18,7 @@ bool callback(const MinidumpDescriptor &descriptor,
 }
 
 int main(int argc, char *argv[]) {
-
-    std::cout << "Breakpad test_package" << std::endl;
+    std::cout << "Breakpad test_package\n";
 
     MinidumpDescriptor descriptor("path/to/cache");
     ExceptionHandler eh(

--- a/recipes/breakpad/config.yml
+++ b/recipes/breakpad/config.yml
@@ -1,3 +1,3 @@
 versions:
-    "cci.20210521":
-        folder: all
+  "cci.20210521":
+    folder: all

--- a/recipes/breakpad/config.yml
+++ b/recipes/breakpad/config.yml
@@ -1,0 +1,3 @@
+versions:
+    "cci.20210521":
+        folder: all


### PR DESCRIPTION
Specify library name and version:  **breakpad/cci.20210521**

This is the last missing requirement of `sentry-native`. https://github.com/conan-io/conan-center-index/blob/master/recipes/sentry-native/all/conanfile.py#L66

Some help is required around the `components/cpp_info` part since this library only provides `pkg config` files and I'm not familiar with it, so I'm not sure about how to model it on Conan.

CC: @madebr 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
