### PR TITLE
Boost.python requires numpy. Fix function _run_python_script().

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -10,6 +10,7 @@ import sys
 import shlex
 import shutil
 import yaml
+import re
 
 try:
     from cStringIO import StringIO
@@ -385,6 +386,13 @@ class BoostConan(ConanFile):
                     if min_compiler_version is not None:
                         if tools.Version(self.settings.compiler.version) < min_compiler_version:
                             raise ConanInvalidConfiguration("Boost.Math requires a C++11 capable compiler")
+                            
+        if not self.options.without_python:
+            #Boost python library build will fail if python package numpy is not installed
+            try:
+                import numpy
+            except ImportError as e:
+                raise ConanInvalidConfiguration("Boost.python library requires numpy but this is not installed in your python environment")
 
     def build_requirements(self):
         if not self.options.header_only:
@@ -478,6 +486,8 @@ class BoostConan(ConanFile):
         # Conan is broken when run_to_output = True
         if "\n-----------------\n" in output:
             output = output.split("\n-----------------\n", 1)[1]
+        elif re.search('\n----+$', output) != None: 
+            output = ''
         return output if output != "None" else None
 
     def _get_python_path(self, name):

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -10,7 +10,6 @@ import sys
 import shlex
 import shutil
 import yaml
-import re
 
 try:
     from cStringIO import StringIO
@@ -386,13 +385,6 @@ class BoostConan(ConanFile):
                     if min_compiler_version is not None:
                         if tools.Version(self.settings.compiler.version) < min_compiler_version:
                             raise ConanInvalidConfiguration("Boost.Math requires a C++11 capable compiler")
-                            
-        if not self.options.without_python:
-            #Boost python library build will fail if python package numpy is not installed
-            try:
-                import numpy
-            except ImportError as e:
-                raise ConanInvalidConfiguration("Boost.python library requires numpy but this is not installed in your python environment")
 
     def build_requirements(self):
         if not self.options.header_only:
@@ -482,12 +474,11 @@ class BoostConan(ConanFile):
         except ConanException:
             self.output.info("(failed)")
             return None
-        output = output.getvalue().strip()
+        output = output.getvalue()
         # Conan is broken when run_to_output = True
         if "\n-----------------\n" in output:
             output = output.split("\n-----------------\n", 1)[1]
-        elif re.search('\n----+$', output) != None: 
-            output = ''
+        output = output.strip()
         return output if output != "None" else None
 
     def _get_python_path(self, name):


### PR DESCRIPTION
Specify library name and version:  **boost/all_versions**

**First fix:**
Function `_run_python_script` was broken when provided script returns empty output.
And on Windows the script that  `_python_abiflags(self)` sends to `_run_python_script` does return no output. As a result the `_run_python_script` returned something like
```
 ----Running------
> "python" -c "from __future__ import print_function; import sys; print(getattr(sys, 'abiflags', ''))"
-----------------
```
instead of an empty string. Result was the following error message when building the boost recipe with option `without_python=False` even though python libraries were present: 

`ERROR: boost/1.76.0: Invalid configuration: couldn't locate python libraries - make sure you have installed python development files`

**Second fix:**
Build of Boost.python library will fail if python package numpy is not installed. Check for presence of numpy in validate().


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
