### PR TITLE
how_to_add_packages.md: typo fix

### DIFF
--- a/docs/how_to_add_packages.md
+++ b/docs/how_to_add_packages.md
@@ -190,7 +190,7 @@ Please be aware that ConanCenter only builds from sources and [pre-compiled bina
 Call `conan create . lib/1.0@` in the folder of the recipe using the profile you want to test. For instance:
 
     cd conan-center-index/recipes/boost/all
-    conan create . 1.74.0@
+    conan create . boost/1.74.0@
 
 ### Updating conan hooks on your machine
 


### PR DESCRIPTION
The command as it was gives an error.
Fix the typo to use the correct syntax

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
