### PR TITLE
wt: bump dependencies

### DIFF
--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 import os
 import shutil
 
-required_conan_version = ">=1.32.0"
+required_conan_version = ">=1.33.0"
 
 
 class WtConan(ConanFile):
@@ -117,9 +117,8 @@ class WtConan(ConanFile):
             raise ConanInvalidConfiguration("Wt requires these boost components: {}".format(", ".join(self._required_boost_components)))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -95,13 +95,13 @@ class WtConan(ConanFile):
         return ["program_options", "filesystem", "thread"]
 
     def requirements(self):
-        self.requires("boost/1.75.0")
+        self.requires("boost/1.76.0")
         if self.options.connector_http:
             self.requires("zlib/1.2.11")
         if self.options.with_ssl:
-            self.requires("openssl/1.1.1j")
+            self.requires("openssl/1.1.1k")
         if self.options.get_safe("with_sqlite"):
-            self.requires("sqlite3/3.34.1")
+            self.requires("sqlite3/3.35.5")
         if self.options.get_safe("with_mysql"):
             self.requires("libmysqlclient/8.0.17")
         if self.options.get_safe("with_postgres"):

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -54,7 +54,7 @@ class WtConan(ConanFile):
         "connector_http": True,
         "connector_isapi": True,
         "connector_fcgi": False
-        }
+    }
 
     _cmake = None
 


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

The idea is to generate binaries again, due to last revisions of boost recipe, leading to `ERROR: Missing prebuilt package for 'wt/4.5.0'`

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
