### PR TITLE
tgbot: bump dependencies + check mandatory boost components

### DIFF
--- a/recipes/tgbot/all/conanfile.py
+++ b/recipes/tgbot/all/conanfile.py
@@ -43,9 +43,9 @@ class TgbotConan(ConanFile):
             tools.check_min_cppstd(self, 11)
 
     def requirements(self):
-        self.requires("boost/1.75.0")
-        self.requires("libcurl/7.75.0")
-        self.requires("openssl/1.1.1j")
+        self.requires("boost/1.76.0")
+        self.requires("libcurl/7.76.0")
+        self.requires("openssl/1.1.1k")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/tgbot/all/conanfile.py
+++ b/recipes/tgbot/all/conanfile.py
@@ -45,7 +45,7 @@ class TgbotConan(ConanFile):
 
     def requirements(self):
         self.requires("boost/1.76.0")
-        self.requires("libcurl/7.76.0")
+        self.requires("libcurl/7.77.0")
         self.requires("openssl/1.1.1k")
 
     @property

--- a/recipes/tgbot/all/conanfile.py
+++ b/recipes/tgbot/all/conanfile.py
@@ -24,7 +24,7 @@ class TgbotConan(ConanFile):
     }
 
     generators = "cmake", "cmake_find_package"
-    exports_sources = ['CMakeLists.txt']
+    exports_sources = ["CMakeLists.txt"]
 
     _cmake = None
 
@@ -78,4 +78,4 @@ class TgbotConan(ConanFile):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
 
     def package_info(self):
-        self.cpp_info.libs = ['TgBot']
+        self.cpp_info.libs = ["TgBot"]

--- a/recipes/tgbot/all/conanfile.py
+++ b/recipes/tgbot/all/conanfile.py
@@ -1,5 +1,7 @@
-import os
 from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.33.0"
 
 
 class TgbotConan(ConanFile):
@@ -46,9 +48,8 @@ class TgbotConan(ConanFile):
         self.requires("openssl/1.1.1j")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-cpp-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
         # Don't force PIC

--- a/recipes/tgbot/all/conanfile.py
+++ b/recipes/tgbot/all/conanfile.py
@@ -16,12 +16,12 @@ class TgbotConan(ConanFile):
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
+        "shared": [True, False],
         "fPIC": [True, False],
-        "shared": [True, False]
     }
     default_options = {
+        "shared": False,
         "fPIC": True,
-        "shared": False
     }
 
     generators = "cmake", "cmake_find_package"

--- a/recipes/tgbot/all/test_package/conanfile.py
+++ b/recipes/tgbot/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
 import os
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 
 
 class TestPackageConan(ConanFile):
@@ -12,4 +12,5 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        self.run(os.path.join("bin", "test_package"), run_environment=True)
+        if not tools.cross_building(self.settings):
+            self.run(os.path.join("bin", "test_package"), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Same issue than https://github.com/conan-io/conan-center-index/pull/5680 and https://github.com/conan-io/conan-center-index/pull/5682, binaries must be generated again due to modifications in boost recipe.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
