### PR TITLE
Qt: add component support for Qt5

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -14,3 +14,5 @@ patches:
       base_path: "qt5/qtwebengine"
     - patch_file: "patches/fix-macdeployqt.diff"
       base_path: "qt5/qttools"
+    - patch_file: "patches/QTBUG-88625.diff"
+      base_path: "qt5/qtwebengine"

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -337,7 +337,7 @@ class QtConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/1.5.0")
         if self.options.qtwebengine and self.settings.os == "Linux":
-            self.requires("expat/2.3.0")
+            self.requires("expat/2.4.1")
             self.requires("opus/1.3.1")
 
     def source(self):

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -247,22 +247,21 @@ class QtConan(ConanFile):
 
     def validate(self):
         if self.options.widgets and not self.options.gui:
-            raise ConanInvalidConfiguration("using option qt:widgets without option qt:gui is not possible. "
-                                            "You can either disable qt:widgets or enable qt:gui")
+            raise ConanInvalidConfiguration("using option qt5:widgets without option qt5:gui is not possible. "
+                                            "You can either disable qt5:widgets or enable qt5:gui")
 
         if self.options.qtwebengine:
             if not self.options.shared:
-                raise ConanInvalidConfiguration("Static builds of Qt Webengine are not supported")
+                raise ConanInvalidConfiguration("Static builds of Qt WebEngine are not supported")
+
+            if not self.options.gui and self.options.qtdeclarative and self.options.qtlocation and self.options.qtwebchannel:
+                raise ConanInvalidConfiguration("option qt5:qtwebengine requires also qt5:gui, qt5:qtdeclarative, qt5:qtlocation and qt5:qtwebchannel")
 
             if tools.cross_building(self.settings, skip_x64_x86=True):
                 raise ConanInvalidConfiguration("Cross compiling Qt WebEngine is not supported")
 
             if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "5":
                 raise ConanInvalidConfiguration("Compiling Qt WebEngine with gcc < 5 is not supported")
-
-            if self.settings.os == "Linux":
-                #Linking of QtWebEngine shared library fails with unresolved error to freetype.
-                raise ConanInvalidConfiguration("Building QtWebEngine on Linux will currently result in a build error.")
 
         if self.settings.os == "Android" and self.options.get_safe("opengl", "no") == "desktop":
             raise ConanInvalidConfiguration("OpenGL desktop is not supported on Android. Consider using OpenGL es2")
@@ -779,7 +778,7 @@ Examples = bin/datadir/examples""")
             self.cpp_info.components[componentname].names["cmake_find_package"] = pluginname
             self.cpp_info.components[componentname].names["cmake_find_package_multi"] = pluginname
             self.cpp_info.components[componentname].libs = [libname + libsuffix]
-            self.cpp_info.components[componentname].libdirs = [os.path.join("res", "archdatadir", "plugins", type)]
+            self.cpp_info.components[componentname].libdirs = [os.path.join("bin", "archdatadir", "plugins", type)]
             self.cpp_info.components[componentname].includedirs = []
             if "Core" not in requires:
                 requires.append("Core")
@@ -839,7 +838,7 @@ Examples = bin/datadir/examples""")
         if self.options.get_safe("opengl", "no") != "no" and self.options.gui:
             _create_module("OpenGL", ["Gui"])
         if self.options.widgets and self.options.get_safe("opengl", "no") != "no":
-            _create_module("OpenGLWidgets", ["OpenGL", "Widgets"])
+            _create_module("OpenGLExtensions", ["Gui"])
         _create_module("DBus")
         _create_module("Concurrent")
         _create_module("Xml")
@@ -902,8 +901,8 @@ Examples = bin/datadir/examples""")
         if self.options.qtwebchannel:
             _create_module("WebChannel", ["Qml"])
 
-        if self.options.qtwebengine and self.options.gui:
-            _create_module("WebEngineCore", ["Gui", "Quick", "WebChannel", "Positioning", "expat::expat"])
+        if self.options.qtwebengine:
+            _create_module("WebEngineCore", ["Gui", "Quick", "WebChannel", "Positioning", "expat::expat", "opus::libopus"])
             _create_module("WebEngine", ["WebEngineCore"])
             _create_module("WebEngineWidgets", ["WebEngineCore", "Quick", "PrintSupport", "Widgets", "Gui", "Network"])
 
@@ -1016,7 +1015,7 @@ Examples = bin/datadir/examples""")
                 self.cpp_info.components["qtCore"].frameworks.append("Cocoa")     # qtcore requires "_OBJC_CLASS_$_NSApplication" and more, which are in "Cocoa" framework
                 self.cpp_info.components["qtCore"].frameworks.append("Security")  # qtcore requires "_SecRequirementCreateWithString" and more, which are in "Security" framework
 
-        self.cpp_info.components["qtCore"].builddirs.append(os.path.join("res","archdatadir","bin"))
+        self.cpp_info.components["qtCore"].builddirs.append(os.path.join("bin","archdatadir","bin"))
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package"].append(self._cmake_executables_file)
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_executables_file)
 

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -663,9 +663,6 @@ class QtConan(ConanFile):
     def _cmake_executables_file(self):
         return os.path.join("lib", "cmake", "Qt5Core", "conan_qt_executables_variables.cmake")
 
-    def _cmake_qt5_private_file(self, module):
-        return os.path.join("lib", "cmake", "Qt5{0}".format(module), "conan_qt_qt5_{0}private.cmake".format(module.lower()))
-
     def package(self):
         with tools.chdir("build_folder"):
             self.run("%s install" % self._make_program())
@@ -849,8 +846,6 @@ Examples = bin/datadir/examples""")
 
         if self.options.qtdeclarative:
             _create_module("Qml", ["Network"])
-            #self.cpp_info.components["qtQml"].build_modules["cmake_find_package"].append(self._cmake_qt5_private_file("Qml"))
-            #self.cpp_info.components["qtQml"].build_modules["cmake_find_package_multi"].append(self._cmake_qt5_private_file("Qml"))
             _create_module("QmlModels", ["Qml"])
             self.cpp_info.components["qtQmlImportScanner"].names["cmake_find_package"] = "QmlImportScanner" # this is an alias for Qml and there to integrate with existing consumers
             self.cpp_info.components["qtQmlImportScanner"].names["cmake_find_package_multi"] = "QmlImportScanner"
@@ -1024,8 +1019,6 @@ Examples = bin/datadir/examples""")
         self.cpp_info.components["qtCore"].builddirs.append(os.path.join("res","archdatadir","bin"))
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package"].append(self._cmake_executables_file)
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_executables_file)
-        #self.cpp_info.components["qtCore"].build_modules["cmake_find_package"].append(self._cmake_qt5_private_file("Core"))
-        #self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_qt5_private_file("Core"))
 
         for m in os.listdir(os.path.join("lib", "cmake")):
             module = os.path.join("lib", "cmake", m, "%sMacros.cmake" % m)

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -968,8 +968,7 @@ Examples = bin/datadir/examples""")
             if self.settings.os == "Linux":
                 _create_plugin("QEvdevGamepadBackendPlugin", "evdevgamepad", "gamepads", [])
             if self.settings.os == "Macos":
-                #TODO
-                pass
+                _create_plugin("QDarwinGamepadBackendPlugin", "darwingamepad", "gamepads", [])
             if self.settings.os =="Windows":
                 _create_plugin("QXInputGamepadBackendPlugin", "xinputgamepad", "gamepads", [])
 
@@ -990,8 +989,10 @@ Examples = bin/datadir/examples""")
                 _create_plugin("DSServicePlugin", "dsengine", "mediaservice", [])
                 _create_plugin("QWindowsAudioPlugin", "qtaudio_windows", "audio", [])
             if self.settings.os == "Macos":
-                #TODO
-                pass
+                _create_plugin("AudioCaptureServicePlugin", "qtmedia_audioengine", "mediaservice", [])
+                _create_plugin("AVFMediaPlayerServicePlugin", "qavfmediaplayer", "mediaservice", [])
+                _create_plugin("AVFServicePlugin", "qavfcamera", "mediaservice", [])
+                _create_plugin("CoreAudioPlugin", "qtaudio_coreaudio", "audio", [])
 
         if self.options.qtwebsockets:
             _create_module("WebSockets", ["Network"])
@@ -1014,7 +1015,6 @@ Examples = bin/datadir/examples""")
                 self.cpp_info.components["qtCore"].system_libs.append("userenv")  # qtcore requires "__imp_GetUserProfileDirectoryW " which is in "UserEnv.Lib" library
                 self.cpp_info.components["qtCore"].system_libs.append("ws2_32")  # qtcore requires "WSAStartup " which is in "Ws2_32.Lib" library
                 self.cpp_info.components["qtNetwork"].system_libs.append("DnsApi")  # qtnetwork from qtbase requires "DnsFree" which is in "Dnsapi.lib" library
-
 
             if self.settings.os == "Macos":
                 self.cpp_info.components["qtCore"].frameworks.append("IOKit")     # qtcore requires "_IORegistryEntryCreateCFProperty", "_IOServiceGetMatchingService" and much more which are in "IOKit" framework

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -821,7 +821,7 @@ Examples = bin/datadir/examples""")
         if self.options.with_pq:
             _create_plugin("QPSQLDriverPlugin", "qsqlpsql", "sqldrivers", ["libpq::libpq"])
         if self.options.get_safe("with_mysql", False):
-            _create_plugin("QMySQLDriverPlugin", "qsqlmysql", "sqldriver", ["libmysqlclient::libmysqlclient"])
+            _create_plugin("QMySQLDriverPlugin", "qsqlmysql", "sqldrivers", ["libmysqlclient::libmysqlclient"])
         if self.options.with_odbc:
             if self.settings.os != "Windows":
                 _create_plugin("QODBCDriverPlugin", "qsqlodbc", "sqldrivers", ["odbc::odbc"])

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -81,7 +81,7 @@ class QtConan(ConanFile):
         "cross_compile": "ANY",
         "sysroot": "ANY",
         "config": "ANY",
-        "multiconfiguration": [True, False],
+        "multiconfiguration": [True, False]
     }
     options.update({module: [True, False] for module in _submodules})
 
@@ -117,7 +117,7 @@ class QtConan(ConanFile):
         "cross_compile": None,
         "sysroot": None,
         "config": None,
-        "multiconfiguration": False,
+        "multiconfiguration": False
     }
     default_options.update({module: False for module in _submodules})
 
@@ -148,10 +148,11 @@ class QtConan(ConanFile):
                 msg = ("Python2 must be available in PATH "
                        "in order to build Qt WebEngine")
                 raise ConanInvalidConfiguration(msg)
+                    
             # In any case, check its actual version for compatibility
             from six import StringIO  # Python 2 and 3 compatible
             mybuf = StringIO()
-            cmd_v = "{} --version".format(python_exe)
+            cmd_v = "\"{}\" --version".format(python_exe)
             self.run(cmd_v, output=mybuf)
             verstr = mybuf.getvalue().strip().split("Python ")[1]
             if verstr.endswith("+"):
@@ -167,7 +168,7 @@ class QtConan(ConanFile):
             else:
                 msg = ("Found Python 2 in path, but with invalid version {}"
                        " (QtWebEngine requires >= {} & < "
-                       "{})".format(verstr, v_min, v_max))
+                       "{})\nIf you have both Python 2 and 3 installed, copy the python 2 executable to python2(.exe)".format(verstr, v_min, v_max))
                 raise ConanInvalidConfiguration(msg)
 
     def config_options(self):
@@ -796,7 +797,7 @@ Examples = bin/datadir/examples""")
                 gui_reqs.append("xorg::xorg")
                 if not tools.cross_building(self, skip_x64_x86=True):
                     gui_reqs.append("xkbcommon::xkbcommon")
-            if self.settings.os != "Windows" and self.options.get_safe("opengl", "no") != "no":
+            if self.options.get_safe("opengl", "no") != "no":
                 gui_reqs.append("opengl::opengl")
             if self.options.with_harfbuzz:
                 gui_reqs.append("harfbuzz::harfbuzz")
@@ -874,6 +875,9 @@ Examples = bin/datadir/examples""")
         if self.options.qtwayland and self.options.gui:
             _create_module("WaylandClient", ["Gui", "wayland::wayland-client"])
             _create_module("WaylandCompositor", ["Gui", "wayland::wayland-server"])
+            
+        if self.options.qtwebengine and self.options.gui:
+            _create_module("WebEngine", ["Gui", "Quick"])
 
 
         if not self.options.shared:

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -33,7 +33,7 @@ Examples = bin/datadir/examples""" % self.conanfile.deps_cpp_info["qt"].rootpath
 
 class QtConan(ConanFile):
     _submodules = ["qtsvg", "qtdeclarative", "qtactiveqt", "qtscript", "qtmultimedia", "qttools", "qtxmlpatterns",
-    "qttranslations", "qtdoc", "qtlocation", "qtsensors", "qtbluetooth", "qtwayland",
+    "qttranslations", "qtdoc", "qtlocation", "qtsensors", "qtconnectivity", "qtwayland",
     "qt3d", "qtimageformats", "qtgraphicaleffects", "qtquickcontrols", "qtserialbus", "qtserialport", "qtx11extras",
     "qtmacextras", "qtwinextras", "qtandroidextras", "qtwebsockets", "qtwebchannel", "qtwebengine", "qtwebview",
     "qtquickcontrols2", "qtpurchasing", "qtcharts", "qtdatavis3d", "qtvirtualkeyboard", "qtgamepad", "qtscxml",
@@ -908,7 +908,7 @@ Examples = bin/datadir/examples""")
             _create_module("WebChannel", ["Qml"])
 
         if self.options.qtwebengine and self.options.gui:
-            _create_module("WebEngineCore", ["Gui", "Quick", "WebChannel", "Positioning", "expat::expat"]
+            _create_module("WebEngineCore", ["Gui", "Quick", "WebChannel", "Positioning", "expat::expat"])
             _create_module("WebEngine", ["WebEngineCore"])
             _create_module("WebEngineWidgets", ["WebEngineCore", "Quick", "PrintSupport", "Widgets", "Gui", "Network"])
 
@@ -996,8 +996,9 @@ Examples = bin/datadir/examples""")
         if self.options.qtwebsockets:
             _create_module("WebSockets", ["Network"])
 
-        if self.options.qtbluetooth:
-            _create_module("Bluetooth", [])
+        if self.options.qtconnectivity:
+            _create_module("Bluetooth", ["Network"])
+            _create_module("Nfc", [])
 
 
         if not self.options.shared:

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -824,7 +824,7 @@ Examples = bin/datadir/examples""")
             _create_plugin("QSQLiteDriverPlugin", "qsqlite", "sqldrivers", ["sqlite3::sqlite3"])
         if self.options.with_pq:
             _create_plugin("QPSQLDriverPlugin", "qsqlpsql", "sqldrivers", ["libpq::libpq"])
-        if self.options.with_mysql:
+        if self.options.get_safe("with_mysql", False):
             _create_plugin("QMySQLDriverPlugin", "qsqlmysql", "sqldriver", ["libmysqlclient::libmysqlclient"])
         if self.options.with_odbc:
             if self.settings.os != "Windows":

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -33,7 +33,7 @@ Examples = bin/datadir/examples""" % self.conanfile.deps_cpp_info["qt"].rootpath
 
 class QtConan(ConanFile):
     _submodules = ["qtsvg", "qtdeclarative", "qtactiveqt", "qtscript", "qtmultimedia", "qttools", "qtxmlpatterns",
-    "qttranslations", "qtdoc", "qtlocation", "qtsensors", "qtconnectivity", "qtwayland",
+    "qttranslations", "qtdoc", "qtlocation", "qtsensors", "qtbluetooth", "qtwayland",
     "qt3d", "qtimageformats", "qtgraphicaleffects", "qtquickcontrols", "qtserialbus", "qtserialport", "qtx11extras",
     "qtmacextras", "qtwinextras", "qtandroidextras", "qtwebsockets", "qtwebchannel", "qtwebengine", "qtwebview",
     "qtquickcontrols2", "qtpurchasing", "qtcharts", "qtdatavis3d", "qtvirtualkeyboard", "qtgamepad", "qtscxml",
@@ -890,14 +890,114 @@ Examples = bin/datadir/examples""")
             _create_module("WaylandClient", ["Gui", "wayland::wayland-client"])
             _create_module("WaylandCompositor", ["Gui", "wayland::wayland-server"])
 
+        if self.options.qtlocation:
+            _create_module("Positioning")
+            _create_module("Location", ["Gui", "Quick"])
+            _create_plugin("QGeoServiceProviderFactoryMapbox", "qtgeoservices_mapbox", "geoservices", [])
+            _create_plugin("QGeoServiceProviderFactoryMapboxGL", "qtgeoservices_mapboxgl", "geoservices", [])
+            _create_plugin("GeoServiceProviderFactoryEsri", "qtgeoservices_esri", "geoservices", [])
+            _create_plugin("QGeoServiceProviderFactoryItemsOverlay", "qtgeoservices_itemsoverlay", "geoservices", [])
+            _create_plugin("QGeoServiceProviderFactoryNokia", "qtgeoservices_nokia", "geoservices", [])
+            _create_plugin("QGeoServiceProviderFactoryOsm", "qtgeoservices_osm", "geoservices", [])
+            _create_plugin("QGeoPositionInfoSourceFactoryGeoclue", "qtposition_geoclue", "position", [])
+            _create_plugin("QGeoPositionInfoSourceFactoryGeoclue2", "qtposition_geoclue2", "position", [])
+            _create_plugin("QGeoPositionInfoSourceFactoryPoll", "qtposition_positionpoll", "position", [])
+            _create_plugin("QGeoPositionInfoSourceFactorySerialNmea", "qtposition_serialnmea", "position", [])
+
+        if self.options.qtwebchannel:
+            _create_module("WebChannel", ["Qml"])
+
         if self.options.qtwebengine and self.options.gui:
-            _create_module("WebEngine", ["Gui", "Quick"])
+            _create_module("WebEngineCore", ["Gui", "Quick", "WebChannel", "Positioning", "expat::expat"]
+            _create_module("WebEngine", ["WebEngineCore"])
+            _create_module("WebEngineWidgets", ["WebEngineCore", "Quick", "PrintSupport", "Widgets", "Gui", "Network"])
 
         if self.options.qtserialport:
             _create_module("SerialPort")
 
         if self.options.qtserialbus:
-            _create_module("SerialBus")
+            _create_module("SerialBus", ["SerialPort"])
+            _create_plugin("PassThruCanBusPlugin", "qtpassthrucanbus", "canbus", [])
+            _create_plugin("PeakCanBusPlugin", "qtpeakcanbus", "canbus", [])
+            _create_plugin("SocketCanBusPlugin", "qtsocketcanbus", "canbus", [])
+            _create_plugin("TinyCanBusPlugin", "qttinycanbus", "canbus", [])
+            _create_plugin("VirtualCanBusPlugin", "qtvirtualcanbus", "canbus", [])
+
+        if self.options.qtsensors:
+            _create_module("Sensors")
+            _create_plugin("genericSensorPlugin", "qtsensors_generic", "sensors", [])
+            _create_plugin("IIOSensorProxySensorPlugin", "qtsensors_iio-sensor-proxy", "sensors", [])
+            if self.settings.os == "Linux":
+                _create_plugin("LinuxSensorPlugin", "qtsensors_linuxsys", "sensors", [])
+            _create_plugin("QtSensorGesturePlugin", "qtsensorgestures_plugin", "sensorgestures", [])
+            _create_plugin("QShakeSensorGesturePlugin", "qtsensorgestures_shakeplugin", "sensorgestures", [])
+
+        if self.options.qtscxml:
+            _create_module("Scxml", ["Qml"])
+
+        if self.options.qtpurchasing:
+            _create_module("Purchasing")
+
+        if self.options.qtcharts:
+            _create_module("Charts", ["Gui", "Widgets"])
+
+        if self.options.qt3d:
+            _create_module("3DCore", ["Gui", "Network"])
+
+            _create_module("3DRender", ["3DCore"])
+            _create_plugin("DefaultGeometryLoaderPlugin", "defaultgeometryloader", "geometryloaders", [])
+            _create_plugin("GLTFGeometryLoaderPlugin", "gltfgeometryloader", "geometryloaders", [])
+            _create_plugin("GLTFSceneExportPlugin", "gltfsceneexport", "sceneparsers", [])
+            _create_plugin("GLTFSceneImportPlugin", "gltfsceneimport", "sceneparsers", [])
+            _create_plugin("OpenGLRendererPlugin", "openglrenderer", "renderers", [])
+            _create_plugin("Scene2DPlugin", "scene2d", "renderplugins", [])
+
+            _create_module("3DAnimation", ["3DRender", "3DCore", "Gui"])
+            _create_module("3DInput", ["3DCore", "GamePad", "Gui"])
+            _create_module("3DLogic", ["3DCore", "Gui"])
+            _create_module("3DExtras", ["3DRender", "3DInput", "3DLogic", "3DCore", "Gui"])
+            _create_module("3DQuick", ["3DCore", "Quick", "Gui", "Qml"])
+            _create_module("3DQuickAnimation", ["3DAnimation", "3DRender", "3DQuick", "3DCore", "Gui", "Qml"])
+            _create_module("3DQuickExtras", ["3DExtras", "3DInput", "3DQuick", "3DRender", "3DLogic", "3DCore", "Gui", "Qml"])
+            _create_module("3DQuickInput", ["3DInput", "3DQuick", "3DCore", "Gui", "Qml"])
+            _create_module("3DQuickRender", ["3DRender", "3DQuick", "3DCore", "Gui", "Qml"])
+            _create_module("3DQuickScene2D", ["3DRender", "3DQuick", "3DCore", "Gui", "Qml"])
+
+        if self.options.qtgamepad:
+            _create_module("Gamepad", ["Gui"])
+            if self.settings.os == "Linux":
+                _create_plugin("QEvdevGamepadBackendPlugin", "evdevgamepad", "gamepads", [])
+            if self.settings.os == "Macos":
+                #TODO
+                pass
+            if self.settings.os =="Windows":
+                _create_plugin("QXInputGamepadBackendPlugin", "xinputgamepad", "gamepads", [])
+
+        if self.options.qtmultimedia:
+            _create_module("Multimedia", ["Network", "Gui"])
+            _create_module("MultimediaWidgets", ["Multimedia", "Widgets", "Gui"])
+            _create_module("MultimediaQuick", ["Multimedia", "Quick"])
+            _create_plugin("QM3uPlaylistPlugin", "qtmultimedia_m3u", "playlistformats", [])
+            if self.settings.os == "Linux":
+                _create_module("MultimediaGstTools", ["Multimedia", "MultimediaWidgets", "Gui"])
+                _create_plugin("CameraBinServicePlugin", "gstcamerabin", "mediaservice", [])
+                _create_plugin("QAlsaPlugin", "qtaudio_alsa", "audio", [])
+                _create_plugin("QGstreamerAudioDecoderServicePlugin", "gstaudiodecoder", "mediaservice", [])
+                _create_plugin("QGstreamerCaptureServicePlugin", "gstmediacapture", "mediaservice", [])
+                _create_plugin("QGstreamerPlayerServicePlugin", "gstmediaplayer", "mediaservice", [])
+            if self.settings.os == "Windows":
+                _create_plugin("AudioCaptureServicePlugin", "qtmedia_audioengine", "mediaservice", [])
+                _create_plugin("DSServicePlugin", "dsengine", "mediaservice", [])
+                _create_plugin("QWindowsAudioPlugin", "qtaudio_windows", "audio", [])
+            if self.settings.os == "Macos":
+                #TODO
+                pass
+
+        if self.options.qtwebsockets:
+            _create_module("WebSockets", ["Network"])
+
+        if self.options.qtbluetooth:
+            _create_module("Bluetooth", [])
 
 
         if not self.options.shared:

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -247,15 +247,15 @@ class QtConan(ConanFile):
 
     def validate(self):
         if self.options.widgets and not self.options.gui:
-            raise ConanInvalidConfiguration("using option qt5:widgets without option qt5:gui is not possible. "
-                                            "You can either disable qt5:widgets or enable qt5:gui")
+            raise ConanInvalidConfiguration("using option qt:widgets without option qt:gui is not possible. "
+                                            "You can either disable qt:widgets or enable qt:gui")
 
         if self.options.qtwebengine:
             if not self.options.shared:
                 raise ConanInvalidConfiguration("Static builds of Qt WebEngine are not supported")
 
-            if not self.options.gui and self.options.qtdeclarative and self.options.qtlocation and self.options.qtwebchannel:
-                raise ConanInvalidConfiguration("option qt5:qtwebengine requires also qt5:gui, qt5:qtdeclarative, qt5:qtlocation and qt5:qtwebchannel")
+            if not (self.options.gui and self.options.qtdeclarative and self.options.qtlocation and self.options.qtwebchannel):
+                raise ConanInvalidConfiguration("option qt:qtwebengine requires also qt:gui, qt:qtdeclarative, qt:qtlocation and qt:qtwebchannel")
 
             if tools.cross_building(self.settings, skip_x64_x86=True):
                 raise ConanInvalidConfiguration("Cross compiling Qt WebEngine is not supported")
@@ -777,7 +777,8 @@ Examples = bin/datadir/examples""")
             assert componentname not in self.cpp_info.components, "Plugin %s already present in self.cpp_info.components" % pluginname
             self.cpp_info.components[componentname].names["cmake_find_package"] = pluginname
             self.cpp_info.components[componentname].names["cmake_find_package_multi"] = pluginname
-            self.cpp_info.components[componentname].libs = [libname + libsuffix]
+            if not self.options.shared:
+                self.cpp_info.components[componentname].libs = [libname + libsuffix]
             self.cpp_info.components[componentname].libdirs = [os.path.join("bin", "archdatadir", "plugins", type)]
             self.cpp_info.components[componentname].includedirs = []
             if "Core" not in requires:

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1000,6 +1000,11 @@ Examples = bin/datadir/examples""")
             _create_module("Bluetooth", ["Network"])
             _create_module("Nfc", [])
 
+        if self.options.qtdatavis3d:
+            _create_module("DataVisualization", ["Gui"])
+
+        if self.options.qtnetworkauth:
+            _create_module("NetworkAuth", ["Network"])
 
         if not self.options.shared:
             if self.settings.os == "Windows":

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -893,6 +893,12 @@ Examples = bin/datadir/examples""")
         if self.options.qtwebengine and self.options.gui:
             _create_module("WebEngine", ["Gui", "Quick"])
 
+        if self.options.qtserialport:
+            _create_module("SerialPort")
+
+        if self.options.qtserialbus:
+            _create_module("SerialBus")
+
 
         if not self.options.shared:
             if self.settings.os == "Windows":

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -291,10 +291,10 @@ class QtConan(ConanFile):
         if self.options.openssl:
             self.requires("openssl/1.1.1k")
         if self.options.with_pcre2:
-            self.requires("pcre2/10.36")
+            self.requires("pcre2/10.37")
 
         if self.options.with_glib:
-            self.requires("glib/2.68.1")
+            self.requires("glib/2.68.3")
         # if self.options.with_libiconv: # QTBUG-84708
         #     self.requires("libiconv/1.16")# QTBUG-84708
         if self.options.with_doubleconversion and not self.options.multiconfiguration:
@@ -304,7 +304,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("with_fontconfig", False):
             self.requires("fontconfig/2.13.93")
         if self.options.get_safe("with_icu", False):
-            self.requires("icu/68.2")
+            self.requires("icu/69.1")
         if self.options.get_safe("with_harfbuzz", False) and not self.options.multiconfiguration:
             self.requires("harfbuzz/2.8.1")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:
@@ -318,7 +318,7 @@ class QtConan(ConanFile):
             self.requires("sqlite3/3.35.5")
             self.options["sqlite3"].enable_column_metadata = True
         if self.options.get_safe("with_mysql", False):
-            self.requires("libmysqlclient/8.0.17")
+            self.requires("libmysqlclient/8.0.25")
         if self.options.with_pq:
             self.requires("libpq/13.2")
         if self.options.with_odbc:
@@ -331,7 +331,7 @@ class QtConan(ConanFile):
         if self.options.gui and self.settings.os == "Linux":
             self.requires("xorg/system")
             if not tools.cross_building(self, skip_x64_x86=True):
-                self.requires("xkbcommon/1.2.1")
+                self.requires("xkbcommon/1.3.0")
         if self.options.get_safe("opengl", "no") != "no":
             self.requires("opengl/system")
         if self.options.with_zstd:
@@ -751,7 +751,7 @@ Examples = bin/datadir/examples""")
         if self.settings.build_type == "Debug":
             if self.settings.os == "Windows":
                 libsuffix = "d"
-            if tools.is_apple_os(self.settings.os):
+            elif tools.is_apple_os(self.settings.os):
                 libsuffix = "_debug"
 
         def _get_corrected_reqs(requires):

--- a/recipes/qt/5.x.x/patches/QTBUG-88625.diff
+++ b/recipes/qt/5.x.x/patches/QTBUG-88625.diff
@@ -1,0 +1,58 @@
+Fix compile errors in QtWebEngine when building with VS2019 >= 16.8.0 .
+See https://bugreports.qt.io/browse/QTBUG-88625 and 
+https://codereview.qt-project.org/c/qt/qtwebengine-chromium/+/321741 .
+
+diff -u -r a/src/3rdparty/chromium/third_party/angle/src/common/mathutil.cpp b/src/3rdparty/chromium/third_party/angle/src/common/mathutil.cpp
+--- a/src/3rdparty/chromium/third_party/angle/src/common/mathutil.cpp	2021-05-20 13:38:32.243947800 +0200
++++ b/src/3rdparty/chromium/third_party/angle/src/common/mathutil.cpp	2021-05-20 12:25:30.392900700 +0200
+@@ -72,11 +72,11 @@
+     const RGB9E5Data *inputData = reinterpret_cast<const RGB9E5Data *>(&input);
+ 
+     *red =
+-        inputData->R * pow(2.0f, (int)inputData->E - g_sharedexp_bias - g_sharedexp_mantissabits);
++        inputData->R * (float)pow(2.0f, (int)inputData->E - g_sharedexp_bias - g_sharedexp_mantissabits);
+     *green =
+-        inputData->G * pow(2.0f, (int)inputData->E - g_sharedexp_bias - g_sharedexp_mantissabits);
++        inputData->G * (float)pow(2.0f, (int)inputData->E - g_sharedexp_bias - g_sharedexp_mantissabits);
+     *blue =
+-        inputData->B * pow(2.0f, (int)inputData->E - g_sharedexp_bias - g_sharedexp_mantissabits);
++        inputData->B * (float)pow(2.0f, (int)inputData->E - g_sharedexp_bias - g_sharedexp_mantissabits);
+ }
+ 
+ }  // namespace gl
+diff -u -r a/src/3rdparty/chromium/third_party/blink/renderer/platform/graphics/lab_color_space.h b/src/3rdparty/chromium/third_party/blink/renderer/platform/graphics/lab_color_space.h
+--- a/src/3rdparty/chromium/third_party/blink/renderer/platform/graphics/lab_color_space.h	2020-11-07 02:22:36.000000000 +0100
++++ b/src/3rdparty/chromium/third_party/blink/renderer/platform/graphics/lab_color_space.h	2021-05-20 13:39:42.890109500 +0200
+@@ -130,7 +130,7 @@
+   // https://en.wikipedia.org/wiki/CIELAB_color_space#Forward_transformation.
+   FloatPoint3D toXYZ(const FloatPoint3D& lab) const {
+     auto invf = [](float x) {
+-      return x > kSigma ? pow(x, 3) : 3 * kSigma2 * (x - 4.0f / 29.0f);
++      return x > kSigma ? (float)pow(x, 3) : 3 * kSigma2 * (x - 4.0f / 29.0f);
+     };
+ 
+     FloatPoint3D v = {clamp(lab.X(), 0.0f, 100.0f),
+diff -u -r a/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/timestamped_trace_piece.h b/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/timestamped_trace_piece.h
+--- a/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/timestamped_trace_piece.h	2020-11-07 02:22:36.000000000 +0100
++++ b/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/timestamped_trace_piece.h	2021-05-20 13:41:08.983902900 +0200
+@@ -197,6 +197,20 @@
+     }
+     return *this;
+   }
++  
++  #if PERFETTO_BUILDFLAG(PERFETTO_COMPILER_MSVC)
++  TimestampedTracePiece& operator=(TimestampedTracePiece&& ttp) const
++  {
++    if (this != &ttp) {
++      // First invoke the destructor and then invoke the move constructor
++      // inline via placement-new to implement move-assignment.
++      this->~TimestampedTracePiece();
++      new (const_cast<TimestampedTracePiece*>(this)) TimestampedTracePiece(std::move(ttp));
++    }
++
++    return const_cast<TimestampedTracePiece&>(*this);
++  }
++#endif  // PERFETTO_BUILDFLAG(PERFETTO_COMPILER_MSVC)
+ 
+   ~TimestampedTracePiece() {
+     switch (type) {

--- a/recipes/qt/5.x.x/test_package/CMakeLists.txt
+++ b/recipes/qt/5.x.x/test_package/CMakeLists.txt
@@ -9,7 +9,7 @@ conan_set_vs_runtime()
 conan_set_libcxx()
 conan_output_dirs_setup()
 
-find_package(qt REQUIRED CONFIG)
+find_package(Qt5Core REQUIRED CONFIG)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -20,4 +20,4 @@ add_executable(${PROJECT_NAME} ${SOURCES})
 # Must compile with "-fPIC" since Qt was built with -reduce-relocations.
 target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
 
-target_link_libraries(${PROJECT_NAME} qt::qt)
+target_link_libraries(${PROJECT_NAME} Qt5::Core)

--- a/recipes/qt/5.x.x/test_package/CMakeLists.txt
+++ b/recipes/qt/5.x.x/test_package/CMakeLists.txt
@@ -9,7 +9,7 @@ conan_set_vs_runtime()
 conan_set_libcxx()
 conan_output_dirs_setup()
 
-find_package(Qt5Core REQUIRED CONFIG)
+find_package(Qt5 COMPONENTS Core REQUIRED CONFIG)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)

--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -10,7 +10,6 @@ class TestPackageConan(ConanFile):
     generators = "qt", "cmake", "cmake_find_package_multi", "qmake"
 
     def build_requirements(self):
-        self.build_requires("cmake/3.20.2")
         if tools.os_info.is_windows and self.settings.compiler == "Visual Studio":
             self.build_requires("jom/1.1.3")
         if self._meson_supported():

--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -10,6 +10,7 @@ class TestPackageConan(ConanFile):
     generators = "qt", "cmake", "cmake_find_package_multi", "qmake"
 
     def build_requirements(self):
+        self.build_requires("cmake/3.20.2")
         if tools.os_info.is_windows and self.settings.compiler == "Visual Studio":
             self.build_requires("jom/1.1.3")
         if self._meson_supported():


### PR DESCRIPTION
Specify library name and version:  **qt/5.15.2**
Resolves #4529.

This PR backports component support from the Qt6 recipe. In addition I added most of the Qt modules that are not ported to Qt6 yet.

In a cmake script you can now call `find_package` in the same way as when using the Qt libraries from the upstream Qt installer:
`
find_package(Qt5 5.15.2 COMPONENTS Core Gui Network Widgets QuickControls2 REQUIRED)`

Also added a patch to fix QtWebEngine compile errors with VS2019 (QTBUG-88625).

With the Qt5 recipe that is currently in CCI, building the QtWebEngine module on Linux fails on both my Linux machines during linking with an unresolved symbol error to a Freetype symbol. I have not been able to solve this. At first I suspected host contamination but that doesn't seem to be the case. I have marked QtWebEngine on Linux as an invalid configuration.
linking ../../lib/libQt5WebEngineCore.so.5.15.2
```
/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: /home/wdobbe/.conan/data/fontconfig/2.13.93/_/_/package/6d993acb2c48d439d3b1f7a0d34d2d4140abcfef/lib/libfontconfig.a(fcfreetype.o): in function `FcFreeTypeQueryFaceInternal':
fcfreetype.c:(.text+0x2f61): undefined reference to `FT_Get_BDF_Property'
/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: fcfreetype.c:(.text+0x2f97): undefined reference to `FT_Get_BDF_Property'
```

I tested the following components with my own Qt projects: `Core Gui Network QuickControls2 SerialPort` on Linux and Windows. The other modules added to package_info() are untested.

Note that this change is not backwards compatible for users of the Qt5 recipe that is currently in CCI.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
