### PR TITLE
double-conversion: regenerate binaries

### DIFF
--- a/recipes/double-conversion/all/conanfile.py
+++ b/recipes/double-conversion/all/conanfile.py
@@ -34,15 +34,15 @@ class DoubleConversionConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+    
+    def validate(self):
         if self.settings.os == "Windows" and \
             self.settings.compiler == "Visual Studio" and \
             Version(self.settings.compiler.version.value) < "14":
             raise ConanInvalidConfiguration("Double Convertion could not be built by MSVC <14")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def _configure_cmake(self):
         if self._cmake:


### PR DESCRIPTION
Specify library name and version:  **double-conversion/***

this is an investigation on https://github.com/conan-io/conan-center-index/pull/5691#issuecomment-851250572, to see if double-conversion.lib is actually generated or not for package hash df81ad20137149d7a51276fd3e24009b45e5964a (MSVC14 release MT)

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
