### PR TITLE
building gdal on rhel7 requires creating an empty config.rpath file

### DIFF
--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -404,6 +404,13 @@ class GdalConan(ConanFile):
                                       "-lz ",
                                       "-l{} ".format(zlib_name))
 
+        # Redhat 7 needs an existing config.rpath file
+        major_version = str(tools.os_info.os_version.major(False))
+
+        if tools.os_info.linux_distro in ["rhel", "centos"] and major_version == "7":
+            with open(os.path.join(self._source_subfolder,"config.rpath"),"w"):
+                pass
+
     def _edit_nmake_opt(self):
         simd_intrinsics = str(self.options.get_safe("simd_intrinsics", False))
         if simd_intrinsics != "avx":


### PR DESCRIPTION
Specify library name and version:  gdal/3.2.1

Fixes https://github.com/conan-io/conan-center-index/issues/5711
---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
