### PR TITLE
gRPC: bump version, update dependencies

### DIFF
--- a/recipes/grpc/all/conandata.yml
+++ b/recipes/grpc/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.38.0":
     url: "https://github.com/grpc/grpc/archive/refs/tags/v1.38.0.tar.gz"
-    sha256: "ABD9E52C69000F2C051761CFA1F12D52D8B7647B6C66828A91D462E796F2AEDE"
+    sha256: "abd9e52c69000f2c051761cfa1f12d52d8b7647b6c66828a91d462e796f2aede"
   "1.37.1":
     url: "https://github.com/grpc/grpc/archive/v1.37.1.tar.gz"
     sha256: "acf247ec3a52edaee5dee28644a4e485c5e5badf46bdb24a80ca1d76cb8f1174"

--- a/recipes/grpc/all/conandata.yml
+++ b/recipes/grpc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.38.0":
+    url: "https://github.com/grpc/grpc/archive/refs/tags/v1.38.0.tar.gz"
+    sha256: "ABD9E52C69000F2C051761CFA1F12D52D8B7647B6C66828A91D462E796F2AEDE"
   "1.37.1":
     url: "https://github.com/grpc/grpc/archive/v1.37.1.tar.gz"
     sha256: "acf247ec3a52edaee5dee28644a4e485c5e5badf46bdb24a80ca1d76cb8f1174"

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -236,7 +236,7 @@ class grpcConan(ConanFile):
         # gRPC::grpc_cpp_plugin
         if self.options.cpp_plugin:
             module_target_rel_path = os.path.join("lib", "cmake", "grpc_cpp_plugin.cmake")
-            self.cpp_info.components["execs"].builddirs = os.path.join("lib", "cmake")
+            self.cpp_info.components["execs"].builddirs.append(os.path.join("lib", "cmake"))
             self.cpp_info.components["execs"].build_modules["cmake_find_package"] = [module_target_rel_path]
             self.cpp_info.components["execs"].build_modules["cmake_find_package_multi"] = [module_target_rel_path]
         # gRPC::grpc_csharp_plugin

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -57,7 +57,7 @@ class grpcConan(ConanFile):
         self.requires('openssl/1.1.1k')
         self.requires('protobuf/3.17.1')
         self.requires('c-ares/1.17.1')
-        self.requires('abseil/20210324.0')
+        self.requires('abseil/20210324.1')
         self.requires('re2/20210401')
 
     def config_options(self):

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -55,10 +55,10 @@ class grpcConan(ConanFile):
     def requirements(self):
         self.requires('zlib/1.2.11')
         self.requires('openssl/1.1.1k')
-        self.requires('protobuf/3.15.5')
+        self.requires('protobuf/3.17.1')
         self.requires('c-ares/1.17.1')
         self.requires('abseil/20210324.0')
-        self.requires('re2/20210202')
+        self.requires('re2/20210401')
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -236,6 +236,7 @@ class grpcConan(ConanFile):
         # gRPC::grpc_cpp_plugin
         if self.options.cpp_plugin:
             module_target_rel_path = os.path.join("lib", "cmake", "grpc_cpp_plugin.cmake")
+            self.cpp_info.components["execs"].builddirs = os.path.join("lib", "cmake")
             self.cpp_info.components["execs"].build_modules["cmake_find_package"] = [module_target_rel_path]
             self.cpp_info.components["execs"].build_modules["cmake_find_package_multi"] = [module_target_rel_path]
         # gRPC::grpc_csharp_plugin

--- a/recipes/grpc/config.yml
+++ b/recipes/grpc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.38.0":
+    folder: "all"
   "1.37.1":
     folder: "all"
   "1.37.0":


### PR DESCRIPTION
Specify library name and version:  **grpc/1.38.0**

Updating dependency protobuf due to https://github.com/protocolbuffers/protobuf/commit/5d0c30934bb6a6c1d387b549f5af3a4efcebe2ef
After this commit you can use ```protobuf_generate``` cmake function with grpc_cpp_plugin 
Updating dependency re2: i have no reason, but i update one dependency so i update another too.

Update library version too.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
