### PR TITLE
gdal: workaround for autoconf 2.71 + bump dependencies

### DIFF
--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -227,7 +227,7 @@ class GdalConan(ConanFile):
         if self.options.get_safe("with_libiconv", True):
             self.requires("libiconv/1.16")
         if self.options.get_safe("with_zstd"):
-            self.requires("zstd/1.4.9")
+            self.requires("zstd/1.5.0")
         if self.options.with_pg:
             self.requires("libpq/13.2")
         # if self.options.with_libgrass:
@@ -279,15 +279,15 @@ class GdalConan(ConanFile):
         if self.options.with_xerces:
             self.requires("xerces-c/3.2.3")
         if self.options.with_expat:
-            self.requires("expat/2.3.0")
+            self.requires("expat/2.4.1")
         if self.options.with_libkml:
             self.requires("libkml/1.3.0")
         if self.options.with_odbc and self.settings.os != "Windows":
-            self.requires("odbc/2.3.7")
+            self.requires("odbc/2.3.9")
         # if self.options.with_dods_root:
         #     self.requires("libdap/3.20.6")
         if self.options.with_curl:
-            self.requires("libcurl/7.75.0")
+            self.requires("libcurl/7.77.0")
         if self.options.with_xml2:
             self.requires("libxml2/2.9.10")
         # if self.options.with_spatialite:
@@ -309,8 +309,8 @@ class GdalConan(ConanFile):
         if self.options.with_qhull:
             self.requires("qhull/8.0.1")
         if self.options.with_opencl:
-            self.requires("opencl-headers/2020.06.16")
-            self.requires("opencl-icd-loader/2020.06.16")
+            self.requires("opencl-headers/2021.04.29")
+            self.requires("opencl-icd-loader/2021.04.29")
         if self.options.with_freexl:
             self.requires("freexl/1.0.6")
         if self.options.with_poppler:

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -403,6 +403,9 @@ class GdalConan(ConanFile):
                 tools.replace_in_file(configure_ac,
                                       "-lz ",
                                       "-l{} ".format(zlib_name))
+            # Workaround for autoconf 2.71
+            with open(os.path.join(self._source_subfolder, "config.rpath"), "w"):
+                pass
 
     def _edit_nmake_opt(self):
         simd_intrinsics = str(self.options.get_safe("simd_intrinsics", False))


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

gdal build is broken (except for Visual Studio) since https://github.com/conan-io/conan-center-index/pull/5539. This is a dirty fix, but we should find a way to force specific version of autotools in build requirement (not possible right now I think because it would conflict with autotools version coming from libtool -> automake -> autoconf, it's a conan limitation).

closes https://github.com/conan-io/conan-center-index/issues/5707
closes https://github.com/conan-io/conan-center-index/issues/5711
closes https://github.com/conan-io/conan-center-index/issues/5715

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
