### PR TITLE
Qt5: allow relocation of dependencies

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -553,7 +553,6 @@ class QtConan(ConanFile):
         for package in self.deps_cpp_info.deps:
             args += ["-I \"%s\"" % s for s in self.deps_cpp_info[package].include_paths]
             args += ["-D %s" % s for s in self.deps_cpp_info[package].defines]
-            args += ["-L \"%s\"" % s for s in self.deps_cpp_info[package].lib_paths]
 
         if "libmysqlclient" in self.deps_cpp_info.deps:
             args.append("-mysql_config \"%s\"" % os.path.join(self.deps_cpp_info["libmysqlclient"].rootpath, "bin", "mysql_config"))
@@ -627,6 +626,9 @@ class QtConan(ConanFile):
                 build_env = {"MAKEFLAGS": "j%d" % tools.cpu_count(), "PKG_CONFIG_PATH": [self.build_folder]}
                 if self.settings.os == "Windows":
                     build_env["PATH"] = [os.path.join(self.source_folder, "qt5", "gnuwin32", "bin")]
+
+                build_env["LIB" if self.settings.compiler == "Visual Studio" else "LIBRARY_PATH"] = \
+                    [l for package in self.deps_cpp_info.deps for l in self.deps_cpp_info[package].lib_paths]
                 with tools.environment_append(build_env):
 
                     if tools.os_info.is_macos:

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -181,7 +181,7 @@ class QtConan(ConanFile):
         if self.settings.compiler in ["gcc", "clang"]:
             if tools.Version(self.settings.compiler.version) < "5.0":
                 raise ConanInvalidConfiguration("qt 5.15.X does not support GCC or clang before 5.0")
-        if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "5.3":
+        if self.settings.compiler in ["gcc", "clang"] and tools.Version(self.settings.compiler.version) < "5.3":
             del self.options.with_mysql
         if self.settings.os == "Windows":
             self.options.with_mysql = False

--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -13,7 +13,7 @@ class TestPackageConan(ConanFile):
         if tools.os_info.is_windows and self.settings.compiler == "Visual Studio":
             self.build_requires("jom/1.1.3")
         if self._meson_supported():
-            self.build_requires("meson/0.56.2")
+            self.build_requires("meson/0.57.1")
 
     def _is_mingw(self):
         return self.settings.os == "Windows" and self.settings.compiler == "gcc"

--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -7,7 +7,7 @@ from conans.errors import ConanException
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "qt", "cmake", "cmake_find_package_multi"
+    generators = "qt", "cmake", "cmake_find_package_multi", "qmake"
 
     def build_requirements(self):
         if tools.os_info.is_windows and self.settings.compiler == "Visual Studio":

--- a/recipes/qt/5.x.x/test_package/test_package.pro
+++ b/recipes/qt/5.x.x/test_package/test_package.pro
@@ -7,3 +7,6 @@ RESOURCES = example.qrc
 QT -= gui
 
 CONFIG += console
+
+CONFIG += conan_basic_setup
+include($$OUT_PWD/../conanbuildinfo.pri)


### PR DESCRIPTION
Specify library name and version:  **qt/5.*.***

when using configure's -L flag, qmake saves the full path to dependencies libraries,
which prevents consuming qt if the cache folder is at a different path.
The workaround mentionned in QTBUG-87054 is to stop using the -L flag, but pass
the path to libraries using environment variables

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

