### PR TITLE
sentry-breakpad: add recipe

### DIFF
--- a/recipes/sentry-breakpad/all/CMakeLists.txt
+++ b/recipes/sentry-breakpad/all/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup()
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    set(LINUX ON)
+endif()
+
+add_subdirectory(source_subfolder/external)

--- a/recipes/sentry-breakpad/all/CMakeLists.txt
+++ b/recipes/sentry-breakpad/all/CMakeLists.txt
@@ -9,4 +9,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 endif()
 
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_C_STANDARD 11)
+
 add_subdirectory(source_subfolder/external)

--- a/recipes/sentry-breakpad/all/CMakeLists.txt
+++ b/recipes/sentry-breakpad/all/CMakeLists.txt
@@ -8,4 +8,5 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     set(LINUX ON)
 endif()
 
+set(CMAKE_CXX_STANDARD 11)
 add_subdirectory(source_subfolder/external)

--- a/recipes/sentry-breakpad/all/CMakeLists.txt
+++ b/recipes/sentry-breakpad/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")

--- a/recipes/sentry-breakpad/all/conandata.yml
+++ b/recipes/sentry-breakpad/all/conandata.yml
@@ -1,0 +1,17 @@
+sources:
+  "0.4.9":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.9/sentry-native.zip"
+    sha256: "559344bad846b7868c182b22df0cd9869c31ebf46a222ac7a6588aab0211af7d"
+  "0.4.8":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.8/sentry-native.zip"
+    sha256: "35afb62eecc5e719187c81f5c89b4e3d3c45c7b3c1597836202989fa40c79178"
+  "0.4.7":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.7/sentry-native.zip"
+    sha256: "fb16658b250c342ed05e4d2edeff8ec806d9db758dfa188b78070bdfaf54f598"
+  "0.4.1":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.1/sentry-native.zip"
+    sha256: "ffeec2a8aa6d2f274123cd16c62ad6d5d4c6f993e44e9e2f88210261ccb51fcc"
+  "0.2.6":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.2.6/sentry-native-0.2.6.zip"
+    sha256: "0d93bd77f70a64f3681d4928dfca6b327374218a84d33ee31489114d8e4716c0"
+#patches:

--- a/recipes/sentry-breakpad/all/conanfile.py
+++ b/recipes/sentry-breakpad/all/conanfile.py
@@ -28,10 +28,6 @@ class SentryBreakpadConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -51,7 +47,7 @@ class SentryBreakpadConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-        self._cmake.configure(build_folder=self._build_subfolder)
+        self._cmake.configure()
         return self._cmake
 
     def _patch_sources(self):

--- a/recipes/sentry-breakpad/all/conanfile.py
+++ b/recipes/sentry-breakpad/all/conanfile.py
@@ -6,7 +6,7 @@ required_conan_version = ">=1.28.0"
 
 class SentryBreakpadConan(ConanFile):
     name = "sentry-breakpad"
-    description = "A set of client and server components which implement a crash-reporting system."
+    description = "Client component that implements a crash-reporting system."
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/getsentry/breakpad"
     license = "Apache-2.0"
@@ -28,12 +28,17 @@ class SentryBreakpadConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("linux-syscall-support/cci.20200813")
+        if self.settings.os in ("FreeBSD", "Linux"):
+            self.requires("linux-syscall-support/cci.20200813")
 
     def validate(self):
         if self.settings.compiler.cppstd:
@@ -46,7 +51,7 @@ class SentryBreakpadConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-        self._cmake.configure()
+        self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
     def _patch_sources(self):

--- a/recipes/sentry-breakpad/all/conanfile.py
+++ b/recipes/sentry-breakpad/all/conanfile.py
@@ -44,6 +44,9 @@ class SentryBreakpadConan(ConanFile):
         if tools.Version(self.version) <= "0.4.1":
             if self.settings.os == "Android" or tools.is_apple_os(self.settings.os):
                 raise ConanInvalidConfiguration("Versions <=0.4.1 do not support Apple or Android")
+        if tools.Version(self.version) <= "0.2.6":
+            if self.settings.os == "Windows":
+                raise ConanInvalidConfiguration("Versions <=0.2.6 do not support Windows")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)

--- a/recipes/sentry-breakpad/all/conanfile.py
+++ b/recipes/sentry-breakpad/all/conanfile.py
@@ -1,0 +1,143 @@
+import os
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.28.0"
+
+
+class SentryBreakpadConan(ConanFile):
+    name = "sentry-breakpad"
+    description = "A set of client and server components which implement a crash-reporting system."
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/getsentry/breakpad"
+    license = "Apache-2.0"
+    topics = ("conan", "breakpad", "error-reporting", "crash-reporting")
+    provides = "breakpad"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+    }
+    exports_sources = "CMakeLists.txt", "patches/*"
+    generators = "cmake"
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def requirements(self):
+        self.requires("linux-syscall-support/cci.20200813")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 11)
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure()
+        return self._cmake
+
+    def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+        # FIXME: convert to patches
+        import textwrap
+
+        files_to_patch = [
+            # "src/tools/linux/md2core/minidump-2-core.cc",
+            # "src/processor/testdata/linux_test_app.cc",
+            "src/common/memory_allocator.h",
+            "src/common/linux/memory_mapped_file.cc",
+            "src/common/linux/file_id.cc",
+            "src/common/linux/safe_readlink.cc",
+            "src/client/minidump_file_writer.cc",
+            "src/client/linux/handler/exception_handler.cc",
+            "src/client/linux/handler/exception_handler_unittest.cc",
+            "src/client/linux/log/log.cc",
+            "src/client/linux/crash_generation/crash_generation_client.cc",
+            "src/client/linux/minidump_writer/linux_dumper.cc",
+            "src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc",
+            "src/client/linux/minidump_writer/proc_cpuinfo_reader.h",
+            "src/client/linux/minidump_writer/minidump_writer.cc",
+            "src/client/linux/minidump_writer/linux_ptrace_dumper.cc",
+            "src/client/linux/minidump_writer/cpu_set.h",
+            "src/client/linux/minidump_writer/directory_reader.h",
+            "src/client/linux/minidump_writer/line_reader.h"
+        ]
+
+        for file in files_to_patch:
+            tools.replace_in_file(
+                os.path.join(self._source_subfolder, "external", "breakpad", file),
+                "#include \"third_party/lss/linux_syscall_support.h\"",
+                "#include <linux_syscall_support.h>"
+            )
+
+        tools.save(os.path.join(self._source_subfolder, "external", "CMakeLists.txt"),
+                   textwrap.dedent("""\
+                    install(TARGETS breakpad_client
+                        ARCHIVE DESTINATION lib
+                        LIBRARY DESTINATION lib
+                        RUNTIME DESTINATION bin
+                    )
+                    file(GLOB COMMON_FILES breakpad/src/common/*.h)
+                    install(FILES ${COMMON_FILES}
+                        DESTINATION include/breakpad/common
+                    )
+                    set(PLATFORM_FOLDER)
+                    if(IOS)
+                        set(PLATFORM_FOLDER ios)
+                    elseif(APPLE)
+                        set(PLATFORM_FOLDER mac)
+                    elseif(UNIX)
+                        set(PLATFORM_FOLDER linux)
+                    endif()
+                    if(WIN32)
+                        set(PLATFORM_FOLDER windows)
+                    endif()
+                    if(NOT PLATFORM_FOLDER)
+                        message(FATAL_ERROR "Unknown os -> don't know how to install headers")
+                    endif()
+                    file(GLOB COMMON_PLATFORM_HEADERS breakpad/src/common/${PLATFORM_FOLDER}/*.h)
+                    install(FILES ${COMMON_PLATFORM_HEADERS}
+                        DESTINATION include/breakpad/common/${PLATFORM_FOLDER})
+                    install(DIRECTORY breakpad/src/client/${PLATFORM_FOLDER}
+                        DESTINATION include/breakpad/client
+                        FILES_MATCHING PATTERN *.h
+                    )
+                    install(DIRECTORY breakpad/src/google_breakpad/common
+                        DESTINATION include/breakpad/google_breakpad
+                        FILES_MATCHING PATTERN *.h
+                    )
+                   """), append=True)
+
+    def build(self):
+        self._patch_sources()
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=os.path.join(self._source_subfolder, "external", "breakpad"))
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.names["pkg_config"] = "breakpad-client"
+        self.cpp_info.libs = ["breakpad_client"]
+        self.cpp_info.includedirs.append(os.path.join("include", "breakpad"))
+        if tools.is_apple_os(self.settings.os):
+            self.cpp_info.frameworks.append("CoreFoundation")
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/sentry-breakpad/all/conanfile.py
+++ b/recipes/sentry-breakpad/all/conanfile.py
@@ -1,5 +1,6 @@
-import os
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
 
 required_conan_version = ">=1.28.0"
 
@@ -39,6 +40,10 @@ class SentryBreakpadConan(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
+
+        if tools.Version(self.version) <= "0.4.1":
+            if self.settings.os == "Android" or tools.is_apple_os(self.settings.os):
+                raise ConanInvalidConfiguration("Versions <=0.4.1 do not support Apple or Android")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)

--- a/recipes/sentry-breakpad/all/test_package/CMakeLists.txt
+++ b/recipes/sentry-breakpad/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(BREAKPAD REQUIRED IMPORTED_TARGET breakpad-client)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::BREAKPAD)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/sentry-breakpad/all/test_package/conanfile.py
+++ b/recipes/sentry-breakpad/all/test_package/conanfile.py
@@ -1,0 +1,20 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "pkg_config"
+
+    def build_requirements(self):
+        self.build_requires("pkgconf/1.7.3")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/sentry-breakpad/all/test_package/test_package.cpp
+++ b/recipes/sentry-breakpad/all/test_package/test_package.cpp
@@ -1,0 +1,35 @@
+#include "client/linux/handler/exception_handler.h"
+
+#include <iostream>
+
+using namespace google_breakpad;
+
+namespace {
+
+bool callback(const MinidumpDescriptor &descriptor,
+              void *context,
+              bool succeeded) {
+    // if succeeded is true, descriptor.path() contains a path
+    // to the minidump file. Context is the context passed to
+    // the exception handler's constructor.
+    return succeeded;
+}
+
+}
+
+int main(int argc, char *argv[]) {
+    std::cout << "Breakpad test_package\n";
+
+    MinidumpDescriptor descriptor("path/to/cache");
+    ExceptionHandler eh(
+      descriptor,
+      /* filter */ nullptr,
+      callback,
+      /* context */ nullptr,
+      /* install handler */ true,
+      /* server FD */ -1
+    );
+
+    // run your program here
+    return 0;
+}

--- a/recipes/sentry-breakpad/all/test_package/test_package.cpp
+++ b/recipes/sentry-breakpad/all/test_package/test_package.cpp
@@ -1,4 +1,8 @@
-#include "client/linux/handler/exception_handler.h"
+#ifdef _WIN32
+# include "client/windows/handler/exception_handler.h"
+#else
+# include "client/linux/handler/exception_handler.h"
+#endif
 
 #include <iostream>
 
@@ -6,6 +10,24 @@ using namespace google_breakpad;
 
 namespace {
 
+#ifdef _WIN32
+
+bool filter_callback(void *context, EXCEPTION_POINTERS *exinfo,
+                     MDRawAssertionInfo* assertion) {
+    // If a FilterCallback returns true, Breakpad will continue processing
+    return true;
+}
+
+bool callback(const wchar_t* dump_path,
+              const wchar_t* minidump_id,
+              void* context,
+              EXCEPTION_POINTERS* exinfo,
+              MDRawAssertionInfo* assertion,
+              bool succeeded) {
+    // succeeded indicates whether a minidump file was successfully written.
+    return succeeded;
+}
+#else
 bool callback(const MinidumpDescriptor &descriptor,
               void *context,
               bool succeeded) {
@@ -14,12 +36,22 @@ bool callback(const MinidumpDescriptor &descriptor,
     // the exception handler's constructor.
     return succeeded;
 }
+#endif
 
 }
 
 int main(int argc, char *argv[]) {
     std::cout << "Breakpad test_package\n";
 
+#ifdef _WIN32
+    ExceptionHandler eh(
+      /* dump_path */ L".",
+      filter_callback,
+      callback,
+      /* context */ nullptr,
+      ExceptionHandler::HANDLER_ALL
+    );
+#else
     MinidumpDescriptor descriptor("path/to/cache");
     ExceptionHandler eh(
       descriptor,
@@ -29,6 +61,7 @@ int main(int argc, char *argv[]) {
       /* install handler */ true,
       /* server FD */ -1
     );
+#endif
 
     // run your program here
     return 0;

--- a/recipes/sentry-breakpad/all/test_package/test_package.cpp
+++ b/recipes/sentry-breakpad/all/test_package/test_package.cpp
@@ -8,8 +8,6 @@
 
 #include <iostream>
 
-using namespace google_breakpad;
-
 namespace {
 
 #ifdef _WIN32
@@ -41,7 +39,7 @@ bool callback(void* context,
 }
 
 #else
-bool callback(const MinidumpDescriptor &descriptor,
+bool callback(const google_breakpad::MinidumpDescriptor &descriptor,
               void *context,
               bool succeeded) {
     // if succeeded is true, descriptor.path() contains a path
@@ -57,22 +55,22 @@ int main(int argc, char *argv[]) {
     std::cout << "Breakpad test_package\n";
 
 #ifdef _WIN32
-    ExceptionHandler eh(
+    google_breakpad::ExceptionHandler eh(
       /* dump_path */ L".",
       filter_callback,
       callback,
       /* context */ nullptr,
-      ExceptionHandler::HANDLER_ALL
+      google_breakpad::ExceptionHandler::HANDLER_ALL
     );
 #elif defined(__APPLE__)
-    ExceptionHandler eh(
+    google_breakpad::ExceptionHandler eh(
       callback,
       /* context */ nullptr,
       /* install_handler*/ true
     );
 #else
-    MinidumpDescriptor descriptor("path/to/cache");
-    ExceptionHandler eh(
+    google_breakpad::MinidumpDescriptor descriptor("path/to/cache");
+    google_breakpad::ExceptionHandler eh(
       descriptor,
       /* filter */ nullptr,
       callback,

--- a/recipes/sentry-breakpad/all/test_package/test_package.cpp
+++ b/recipes/sentry-breakpad/all/test_package/test_package.cpp
@@ -1,5 +1,7 @@
 #ifdef _WIN32
 # include "client/windows/handler/exception_handler.h"
+#elif defined(__APPLE__)
+# include "client/mac/handler/exception_handler.h"
 #else
 # include "client/linux/handler/exception_handler.h"
 #endif
@@ -27,6 +29,17 @@ bool callback(const wchar_t* dump_path,
     // succeeded indicates whether a minidump file was successfully written.
     return succeeded;
 }
+
+#elif defined(__APPLE__)
+
+bool callback(void* context,
+              int exception_type,
+              int exception_code,
+              int exception_subcode,
+              mach_port_t thread_name) {
+    return true;
+}
+
 #else
 bool callback(const MinidumpDescriptor &descriptor,
               void *context,
@@ -50,6 +63,12 @@ int main(int argc, char *argv[]) {
       callback,
       /* context */ nullptr,
       ExceptionHandler::HANDLER_ALL
+    );
+#elif defined(__APPLE__)
+    ExceptionHandler eh(
+      callback,
+      /* context */ nullptr,
+      /* install_handler*/ true
     );
 #else
     MinidumpDescriptor descriptor("path/to/cache");

--- a/recipes/sentry-breakpad/config.yml
+++ b/recipes/sentry-breakpad/config.yml
@@ -1,0 +1,11 @@
+versions:
+  "0.4.9":
+    folder: all
+  "0.4.8":
+    folder: all
+  "0.4.7":
+    folder: all
+  "0.4.1":
+    folder: all
+  "0.2.6":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **sentry-breakpad/all**

- Add sentry's fork of breakpad
- Versions are the same as those of `sentry-native`.
- See #5067 
- After merging of this pr and #5639, sentry-native will have the possibility to switch between google's original and sentry's fork (same approach as in #5717)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
