### PR TITLE
gstreamer: add version 1.19.1

### DIFF
--- a/recipes/gstreamer/all/conandata.yml
+++ b/recipes/gstreamer/all/conandata.yml
@@ -11,3 +11,6 @@ sources:
   "1.18.4":
     url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.18.4/gstreamer-1.18.4.tar.gz"
     sha256: "f0956c2056281f5909d030945a9896810e55084f29b6bcfc401b53e91ddf1c7f"
+  "1.19.1":
+    url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.19.1/gstreamer-1.19.1.tar.gz"
+    sha256: "2e51f61e59564e48883b5f1996871b0d1c404406aadb9aa1b306de8a2a331a90"

--- a/recipes/gstreamer/config.yml
+++ b/recipes/gstreamer/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "1.18.4":
     folder: all
+  "1.19.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **gstreamer/1.19.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
