### PR TITLE
[thrift] Select build-requirements depending on build-context

### DIFF
--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -78,7 +78,7 @@ class ThriftConan(ConanFile):
             self.requires("libevent/2.1.12")
 
     def build_requirements(self):
-        build_os = self.settings_build.os if hasattr(self, 'settings_build') else self.settings.os
+        build_os = self.settings_build.os if hasattr(self, "settings_build") else self.settings.os
             
         if build_os == "Windows":
             self.build_requires("winflexbison/2.5.24")

--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -78,7 +78,9 @@ class ThriftConan(ConanFile):
             self.requires("libevent/2.1.12")
 
     def build_requirements(self):
-        if tools.os_info.is_windows:
+        is_windows_build_context = self.settings_build.os if hasattr(conanfile, 'settings_build') else self.settings.os
+            
+        if is_windows_build_context:
             self.build_requires("winflexbison/2.5.24")
         else:
             self.build_requires("flex/2.6.4")

--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -78,7 +78,7 @@ class ThriftConan(ConanFile):
             self.requires("libevent/2.1.12")
 
     def build_requirements(self):
-        build_os = self.settings_build.os if hasattr(conanfile, 'settings_build') else self.settings.os
+        build_os = self.settings_build.os if hasattr(self, 'settings_build') else self.settings.os
             
         if build_os == "Windows":
             self.build_requires("winflexbison/2.5.24")

--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -78,9 +78,9 @@ class ThriftConan(ConanFile):
             self.requires("libevent/2.1.12")
 
     def build_requirements(self):
-        is_windows_build_context = self.settings_build.os if hasattr(conanfile, 'settings_build') else self.settings.os
+        build_os = self.settings_build.os if hasattr(conanfile, 'settings_build') else self.settings.os
             
-        if is_windows_build_context:
+        if build_os == "Windows":
             self.build_requires("winflexbison/2.5.24")
         else:
             self.build_requires("flex/2.6.4")


### PR DESCRIPTION
Specify library name and version:  **thrift**

Computation of packageID is performed in a Linux machine, so the output from `os_info` cannot be used to consider the operating system where the package is going to be built. That information can be obtained only from the profiles.

Fix https://github.com/conan-io/conan-center-index/issues/5729