### PR TITLE
pkgconf: check for builtin symbol

### DIFF
--- a/recipes/pkgconf/all/patches/1.7.3-0002-clang-12-strndup-not-in-string-h.patch
+++ b/recipes/pkgconf/all/patches/1.7.3-0002-clang-12-strndup-not-in-string-h.patch
@@ -5,7 +5,7 @@
  
  foreach f : check_functions
 -  if cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') and cc.has_header_symbol(f.get(2), f.get(1))
-+  if cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') or cc.has_header_symbol(f.get(2), f.get(1))
++  if cc.has_function(f.get(1)) or (cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') and cc.has_header_symbol(f.get(2), f.get(1)))
      cdata.set(f.get(0), 1)
    endif
  endforeach

--- a/recipes/pkgconf/all/patches/1.7.4-0001-clang-12-strndup-not-in-string-h.patch
+++ b/recipes/pkgconf/all/patches/1.7.4-0001-clang-12-strndup-not-in-string-h.patch
@@ -5,7 +5,7 @@
  
  foreach f : check_functions
 -  if cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') and cc.has_header_symbol(f.get(2), f.get(1))
-+  if cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') or cc.has_header_symbol(f.get(2), f.get(1))
++  if cc.has_function(f.get(1)) or (cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') and cc.has_header_symbol(f.get(2), f.get(1)))
      cdata.set(f.get(0), 1)
    endif
  endforeach


### PR DESCRIPTION
Specify library name and version:  **pkgconf/all**

Fixes #5757

@lieser Please check on your system. I could not reproduce your error.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
