### PR TITLE
sentry-crashpad: allow build on apple os

### DIFF
--- a/recipes/sentry-crashpad/all/CMakeLists.txt
+++ b/recipes/sentry-crashpad/all/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.11)
 project(cmake_wrapper)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_subdirectory(source_subfolder/external/crashpad)

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -109,7 +109,9 @@ class SentryCrashpadConan(ConanFile):
             self.cpp_info.components["mini_chromium"].system_libs.append("pthread")
 
         self.cpp_info.components["compat"].includedirs.append(os.path.join("include", "crashpad"))
-        self.cpp_info.components["compat"].libs = ["crashpad_compat"]
+        # On Apple crashpad_compat is an interface library
+        if not tools.is_apple_os(self.settings.os):
+            self.cpp_info.components["compat"].libs = ["crashpad_compat"]
         if self.settings.os in ("Linux", "FreeBSD"):
             self.cpp_info.components["compat"].system_libs.append("dl")
 

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -66,7 +66,7 @@ class SentryCrashpadConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)
 
-    def _configure_cmake(self):
+    def _configure_common_cmake(self):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
@@ -75,6 +75,13 @@ class SentryCrashpadConan(ConanFile):
         self._cmake.definitions["CRASHPAD_ZLIB_SYSTEM"] = True
         self._cmake.configure()
         return self._cmake
+
+    def _configure_cmake(self):
+        if (tools.is_apple_os(self.settings.os)):
+            with tools.environment_append({"SDKROOT": tools.XCRun(self.settings).sdk_path}):
+                return self._configure_common_cmake();
+        else:
+            return self._configure_common_cmake();
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -24,6 +24,7 @@ class SentryCrashpadConan(ConanFile):
     }
     exports_sources = "CMakeLists.txt", "patches/*"
     generators = "cmake"
+    short_paths = True
 
     _cmake = None
 

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -67,22 +67,21 @@ class SentryCrashpadConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)
 
-    def _configure_common_cmake(self):
+    def _configure_cmake(self):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
         self._cmake.definitions["CRASHPAD_ENABLE_INSTALL"] = True
         self._cmake.definitions["CRASHPAD_ENABLE_INSTALL_DEV"] = True
         self._cmake.definitions["CRASHPAD_ZLIB_SYSTEM"] = True
+
+        if tools.is_apple_os(self.settings.os) and "CMAKE_OSX_SYSROOT" not in self._cmake.definitions:
+            sdk_path = tools.XCRun(self.settings).sdk_path
+            if sdk_path:
+                self._cmake.definitions["CMAKE_OSX_SYSROOT"] = sdk_path
+
         self._cmake.configure()
         return self._cmake
-
-    def _configure_cmake(self):
-        if (tools.is_apple_os(self.settings.os)):
-            with tools.environment_append({"SDKROOT": tools.XCRun(self.settings).sdk_path}):
-                return self._configure_common_cmake();
-        else:
-            return self._configure_common_cmake();
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -44,11 +44,8 @@ class SentryCrashpadConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 11)
-
-        if tools.is_apple_os(self.settings.os):
-            # FIXME: add Apple support
-            raise ConanInvalidConfiguration("This recipe does not support Apple.")
+            # Set as required in crashpad CMake file
+            tools.check_min_cppstd(self, 14)
 
         if self.settings.os == "Linux":
             if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < 5:

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -53,7 +53,8 @@ class SentryCrashpadConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.cppstd:
-            # Set as required in crashpad CMake file
+            # Set as required in crashpad CMake file.
+            # See https://github.com/getsentry/crashpad/blob/71bcaad4cf30294b8de1bfa02064ab629437163b/CMakeLists.txt#L67
             tools.check_min_cppstd(self, 14)
 
         minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)

--- a/recipes/sentry-crashpad/all/test_package/CMakeLists.txt
+++ b/recipes/sentry-crashpad/all/test_package/CMakeLists.txt
@@ -9,22 +9,3 @@ find_package(crashpad REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE crashpad::client)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
-
-if(APPLE)
-    find_library(COREFOUNDATION_FRAMEWORK CoreFoundation)
-    find_library(FOUNDATION_FRAMEWORK Foundation)
-    find_library(IOKIT_FRAMEWORK IOKit)
-    find_library(SECURITY_FRAMEWORK Security)
-    find_library(APPSERVICES_FRAMEWORK ApplicationServices)
-    find_library(BSM_LIBRARY bsm)
-
-    target_link_libraries(${PROJECT_NAME}
-        PRIVATE
-            ${COREFOUNDATION_FRAMEWORK}
-            ${FOUNDATION_FRAMEWORK}
-            ${IOKIT_FRAMEWORK}
-            ${SECURITY_FRAMEWORK}
-            ${APPSERVICES_FRAMEWORK}
-            ${BSM_LIBRARY}
-    )
-endif()

--- a/recipes/sentry-crashpad/all/test_package/CMakeLists.txt
+++ b/recipes/sentry-crashpad/all/test_package/CMakeLists.txt
@@ -9,3 +9,22 @@ find_package(crashpad REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE crashpad::client)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+
+if(APPLE)
+    find_library(COREFOUNDATION_FRAMEWORK CoreFoundation)
+    find_library(FOUNDATION_FRAMEWORK Foundation)
+    find_library(IOKIT_FRAMEWORK IOKit)
+    find_library(SECURITY_FRAMEWORK Security)
+    find_library(APPSERVICES_FRAMEWORK ApplicationServices)
+    find_library(BSM_LIBRARY bsm)
+
+    target_link_libraries(${PROJECT_NAME}
+        PRIVATE
+            ${COREFOUNDATION_FRAMEWORK}
+            ${FOUNDATION_FRAMEWORK}
+            ${IOKIT_FRAMEWORK}
+            ${SECURITY_FRAMEWORK}
+            ${APPSERVICES_FRAMEWORK}
+            ${BSM_LIBRARY}
+    )
+endif()


### PR DESCRIPTION
Specify library name and version: **sentry-native/all**

Allowed build for Apple os-s. Build checked for both macOS and iOS targets.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
