### PR TITLE
apr/1.7.0: Drop name change to apr when compiled as shared

### DIFF
--- a/recipes/apr/all/conanfile.py
+++ b/recipes/apr/all/conanfile.py
@@ -120,7 +120,7 @@ class AprConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.names["pkg_config"] = "apr-1"
-        self.cpp_info.libs = ["apr-1"]
+        self.cpp_info.libs = ["libapr-1" if self.settings.compiler == "Visual Studio" and self.options.shared else "apr-1"]
         if not self.options.shared:
             self.cpp_info.defines = ["APR_DECLARE_STATIC"]
             if self.settings.os == "Linux":

--- a/recipes/apr/all/patches/0001-cmake-build-only-shared-static.patch
+++ b/recipes/apr/all/patches/0001-cmake-build-only-shared-static.patch
@@ -1,6 +1,6 @@
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -258,27 +258,27 @@
+@@ -258,27 +258,26 @@
  SET(install_targets)
  SET(install_bin_pdb)
  
@@ -11,7 +11,6 @@
  SET(install_bin_pdb ${install_bin_pdb} ${PROJECT_BINARY_DIR}/libapr-1.pdb)
  TARGET_LINK_LIBRARIES(libapr-1 ${APR_SYSTEM_LIBS})
  SET_TARGET_PROPERTIES(libapr-1 PROPERTIES COMPILE_DEFINITIONS "APR_DECLARE_EXPORT;WINNT")
-+SET_TARGET_PROPERTIES(libapr-1 PROPERTIES PREFIX "" OUTPUT_NAME "apr-1")
  ADD_DEPENDENCIES(libapr-1 test_char_header)
 -
 +ELSE()


### PR DESCRIPTION
Patch 0001 changes the name of the library binary from libapr-1 to apr-1
when compiled as shared. This was done so conan only compiles one
library, either static or shared, not both as apr usually does.

This name change affects compilation of consumer packages like serf
which expects the libapr-1 name when linking the library as shared.

Making the change here prevents a need to patch any consumer package
that looks for the original name.

To allow consumers find the correct library cpp_info.libs is set to the
library binary name depending if the shared options was used or not. This is
the same approach the apr-util package took.

  Fixes #5660 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
