### PR TITLE
[icu][xbuild] Cross building (m1)

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -68,6 +68,9 @@ class ICUBase(ConanFile):
         if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/20200517")
 
+        if tools.cross_building(self.settings, skip_x64_x86=True):
+            self.build_requires("icu/{}".format(self.version)) # TODO: This is a problem if we want to introduce new versions
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("icu", self._source_subfolder)
@@ -148,7 +151,6 @@ class ICUBase(ConanFile):
         bits = "64" if self.settings.arch in arch64 else "32"
         args = [platform,
                 "--prefix={0}".format(prefix),
-                "--with-library-bits={0}".format(bits),
                 "--disable-samples",
                 "--disable-layout",
                 "--disable-layoutex",
@@ -159,12 +161,17 @@ class ICUBase(ConanFile):
 
         env_build = self._configure_autotools()
         if tools.cross_building(self.settings, skip_x64_x86=True):
-            if env_build.build:
-                args.append("--build=%s" % env_build.build)
+            #if env_build.build:
+            #    args.append("--build=%s" % env_build.build)
             if env_build.host:
                 args.append("--host=%s" % env_build.host)
-            if env_build.target:
-                args.append("--target=%s" % env_build.target)
+            #if env_build.target:
+            #    args.append("--target=%s" % env_build.target)
+            bin_path = self.deps_env_info["icu"].PATH[0]
+            base_path, _ = bin_path.rsplit('/', 1)
+            args.append("--with-cross-build={}".format(base_path))
+        else:
+            args.append("--with-library-bits={0}".format(bits),)
 
         if self.settings.os != "Windows":
             # http://userguide.icu-project.org/icudata
@@ -220,6 +227,7 @@ class ICUBase(ConanFile):
             tools.mkdir(os.path.join(self.package_folder, "res"))
             shutil.move(self._data_path, os.path.join(self.package_folder, "res"))
 
+        self.copy("*", src=os.path.join(build_dir, "config"), dst="config")  # This is required to cross-compile
         tools.rmdir(os.path.join(self.package_folder, "lib", "icu"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "man"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))

--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -227,7 +227,10 @@ class ICUBase(ConanFile):
             tools.mkdir(os.path.join(self.package_folder, "res"))
             shutil.move(self._data_path, os.path.join(self.package_folder, "res"))
 
-        self.copy("*", src=os.path.join(build_dir, "config"), dst="config")  # This is required to cross-compile
+        # Copy some files required for cross-compiling
+        self.copy("icucross.mk", src=os.path.join(build_dir, "config"), dst="config")
+        self.copy("icucross.inc", src=os.path.join(build_dir, "config"), dst="config")
+
         tools.rmdir(os.path.join(self.package_folder, "lib", "icu"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "man"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))

--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -69,7 +69,7 @@ class ICUBase(ConanFile):
             self.build_requires("msys2/20200517")
 
         if tools.cross_building(self.settings, skip_x64_x86=True) and hasattr(self, 'settings_build'):
-            self.build_requires("icu/{}".format(self.version)) # TODO: This is a problem if we want to introduce new versions
+            self.build_requires("icu/{}".format(self.version))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -161,12 +161,8 @@ class ICUBase(ConanFile):
 
         env_build = self._configure_autotools()
         if tools.cross_building(self.settings, skip_x64_x86=True):
-            #if env_build.build:
-            #    args.append("--build=%s" % env_build.build)
             if env_build.host:
                 args.append("--host=%s" % env_build.host)
-            #if env_build.target:
-            #    args.append("--target=%s" % env_build.target)
             bin_path = self.deps_env_info["icu"].PATH[0]
             base_path, _ = bin_path.rsplit('/', 1)
             args.append("--with-cross-build={}".format(base_path))

--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -68,7 +68,7 @@ class ICUBase(ConanFile):
         if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/20200517")
 
-        if tools.cross_building(self.settings, skip_x64_x86=True):
+        if tools.cross_building(self.settings, skip_x64_x86=True) and hasattr(self, 'settings_build'):
             self.build_requires("icu/{}".format(self.version)) # TODO: This is a problem if we want to introduce new versions
 
     def source(self):


### PR DESCRIPTION
Specify library name and version:  **icu**

We are starting to build M1 binaries behind the scenes in C3i... and **we are using two profiles approach (we are cross-building from regular Macos)**. As expected, some libraries are failing, and before activating these profiles for all the PRs we want to explore and fix some of them.

To cross-build ICU some changes are needed:
 * `icu` needs to package additional files in `config` folder
 * build step will use those files in a `--with-cross-build` flag while building

Some issues on the Conan side:
 * We need `icu/<version>` to cross-build `icu/<version>` 😓 . Two approaches:
    - we ensure native builds run before any cross-build scenario, that way, native packages should be available at the moment cross configurations start to run.
    - we use bug/feature in Conan: as we are creating the packages with `--build=icu`, in a cross-building scenario Conan will build first the build-requires and then the library itself. We are building twice some packages, but still it works.

