### PR TITLE
[ozz-animation] Do not run dump2ozz if cross-building

### DIFF
--- a/recipes/ozz-animation/all/conanfile.py
+++ b/recipes/ozz-animation/all/conanfile.py
@@ -46,6 +46,10 @@ class OzzAnimationConan(ConanFile):
         for before, after in [('string(REGEX REPLACE "/MT" "/MD" ${flag} "${${flag}}")', ""), ('string(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")', "")]:
             tools.replace_in_file(os.path.join(self._source_subfolder, "build-utils", "cmake", "compiler_settings.cmake"), before, after)
 
+        tools.replace_in_file(os.path.join(self._source_subfolder, "src", "animation", "offline", "tools", "CMakeLists.txt"), 
+                              "if(NOT EMSCRIPTEN)",
+                              "if(NOT CMAKE_CROSSCOMPILING)")
+
         cmake = self._configure_cmake()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **ozz-animation**

Fix for cross-building scenario (M1)

