### PR TITLE
fmt/7.1.3: Install fmt/args.h

### DIFF
--- a/recipes/fmt/all/conandata.yml
+++ b/recipes/fmt/all/conandata.yml
@@ -51,3 +51,6 @@ patches:
   "6.1.0":
     - patch_file: "patches/fix-mingw-msvc2015-export-assert-fail-6.1.0.patch"
       base_path: "source_subfolder"
+  "7.1.3":
+    - patch_file: "patches/0001-Install-fmt-args.h-2096_7.1.3.patch"
+      base_path: "source_subfolder"

--- a/recipes/fmt/all/patches/0001-Install-fmt-args.h-2096_7.1.3.patch
+++ b/recipes/fmt/all/patches/0001-Install-fmt-args.h-2096_7.1.3.patch
@@ -1,0 +1,29 @@
+From e64fa20d4f56dc5ab12593f014d033fbdbb04a65 Mon Sep 17 00:00:00 2001
+From: Victor Zverovich <victor.zverovich@gmail.com>
+Date: Sat, 16 Jan 2021 08:05:02 -0800
+Subject: [PATCH] Install fmt/args.h (#2096)
+
+Signed-off-by: Alejandro Colomar <alejandro.colomar@exfo.com>
+---
+ CMakeLists.txt | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f21cf456..8798614b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -183,8 +183,9 @@ function(add_headers VAR)
+ endfunction()
+ 
+ # Define the fmt library, its includes and the needed defines.
+-add_headers(FMT_HEADERS chrono.h color.h compile.h core.h format.h format-inl.h
+-                        locale.h os.h ostream.h posix.h printf.h ranges.h)
++add_headers(FMT_HEADERS args.h chrono.h color.h compile.h core.h format.h
++                        format-inl.h locale.h os.h ostream.h posix.h printf.h
++                        ranges.h)
+ if (FMT_OS)
+   set(FMT_SOURCES src/format.cc src/os.cc)
+ else()
+-- 
+2.32.0.rc0
+


### PR DESCRIPTION
**fmt/7.1.3**

Apply upstream unreleased patch

cppserver/1.0.1.0 depends on fmt's master branch, which has
applied this patch.  Without it, cppserver/1.0.1.0 won't build,
apparently.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
