### PR TITLE
[libffi] update msys2

### DIFF
--- a/recipes/libffi/all/conanfile.py
+++ b/recipes/libffi/all/conanfile.py
@@ -37,7 +37,7 @@ class LibffiConan(ConanFile):
 
     def build_requirements(self):
         if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:
-            self.build_requires("msys2/20200517")
+            self.build_requires("msys2/cci.latest")
         self.build_requires("gnu-config/cci.20201022")
 
     def configure(self):

--- a/recipes/libffi/all/conanfile.py
+++ b/recipes/libffi/all/conanfile.py
@@ -36,7 +36,7 @@ class LibffiConan(ConanFile):
             del self.options.fPIC
 
     def build_requirements(self):
-        if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ:
+        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
         self.build_requires("gnu-config/cci.20201022")
 


### PR DESCRIPTION
Specify library name and version:  **libffi/all**

The current msys2 version referenced is no longer built.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
