### PR TITLE
gobject-introspection: declare variables in .pc file

### DIFF
--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -37,8 +37,8 @@ class GobjectIntrospectionConan(ConanFile):
             raise ConanInvalidConfiguration("%s recipe does not support windows. Contributions are welcome!" % self.name)
 
     def build_requirements(self):
-        self.build_requires("meson/0.57.1")
-        self.build_requires("pkgconf/1.7.3")
+        self.build_requires("meson/0.58.0")
+        self.build_requires("pkgconf/1.7.4")
         if self.settings.os == "Windows":
             self.build_requires("winflexbison/2.5.24")
         else:
@@ -46,7 +46,7 @@ class GobjectIntrospectionConan(ConanFile):
             self.build_requires("bison/3.7.1")
 
     def requirements(self):
-        self.requires("glib/2.68.0")
+        self.requires("glib/2.68.2")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -48,9 +48,7 @@ class GobjectIntrospectionConan(ConanFile):
         self.requires("glib/2.68.0")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def _configure_meson(self):
         meson = Meson(self)

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -110,3 +110,17 @@ class GobjectIntrospectionConan(ConanFile):
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH env var with: {}".format(bin_path))
         self.env_info.PATH.append(bin_path)
+
+        exe_ext = ".exe" if self.settings.os == "Windows" else ""
+
+        pkgconfig_variables = [
+            'datadir=${prefix}/res',
+            'bindir=${prefix}/bin',
+            'g_ir_scanner=${bindir}/g-ir-scanner',
+            'g_ir_compiler=${bindir}/g-ir-compiler%s' % exe_ext,
+            'g_ir_generate=${bindir}/g-ir-generate%s' % exe_ext,
+            'gidatadir=${datadir}/gobject-introspection-1.0',
+            'girdir="${datadir}/gir-1.0',
+            'typelibdir=${libdir}/girepository-1.0',
+        ]
+        self.cpp_info.set_property("pkg_config_custom_content", "\n".join(pkgconfig_variables))

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -112,14 +112,16 @@ class GobjectIntrospectionConan(ConanFile):
 
         exe_ext = ".exe" if self.settings.os == "Windows" else ""
 
-        pkgconfig_variables = [
-            'datadir=${prefix}/res',
-            'bindir=${prefix}/bin',
-            'g_ir_scanner=${bindir}/g-ir-scanner',
-            'g_ir_compiler=${bindir}/g-ir-compiler%s' % exe_ext,
-            'g_ir_generate=${bindir}/g-ir-generate%s' % exe_ext,
-            'gidatadir=${datadir}/gobject-introspection-1.0',
-            'girdir="${datadir}/gir-1.0',
-            'typelibdir=${libdir}/girepository-1.0',
-        ]
-        self.cpp_info.set_property("pkg_config_custom_content", "\n".join(pkgconfig_variables))
+        pkgconfig_variables = {
+            'datadir': '${prefix}/res',
+            'bindir': '${prefix}/bin',
+            'g_ir_scanner': '${bindir}/g-ir-scanner',
+            'g_ir_compiler': '${bindir}/g-ir-compiler%s' % exe_ext,
+            'g_ir_generate': '${bindir}/g-ir-generate%s' % exe_ext,
+            'gidatadir': '${datadir}/gobject-introspection-1.0',
+            'girdir': '${datadir}/gir-1.0',
+            'typelibdir': '${libdir}/girepository-1.0',
+        }
+        self.cpp_info.set_property(
+            "pkg_config_custom_content",
+            "\n".join("%s=%s" % (key, value) for key,value in pkgconfig_variables.items()))

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import glob
 
+required_conan_version = ">=1.36.0"
 
 class GobjectIntrospectionConan(ConanFile):
     name = "gobject-introspection"

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -36,16 +36,16 @@ class GobjectIntrospectionConan(ConanFile):
             raise ConanInvalidConfiguration("%s recipe does not support windows. Contributions are welcome!" % self.name)
 
     def build_requirements(self):
-        self.build_requires("meson/0.56.2")
+        self.build_requires("meson/0.57.1")
         self.build_requires("pkgconf/1.7.3")
         if self.settings.os == "Windows":
-            self.build_requires("winflexbison/2.5.22")
+            self.build_requires("winflexbison/2.5.24")
         else:
             self.build_requires("flex/2.6.4")
             self.build_requires("bison/3.7.1")
 
     def requirements(self):
-        self.requires("glib/2.67.1")
+        self.requires("glib/2.68.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/gobject-introspection/all/test_package/conanfile.py
+++ b/recipes/gobject-introspection/all/test_package/conanfile.py
@@ -8,11 +8,12 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         if self.settings.os != 'Windows':
-            self.run('g-ir-annotation-tool --version', run_environment=True)
-            self.run('g-ir-compiler --version', run_environment=True)
-            self.run('g-ir-generate --version', run_environment=True)
-            self.run('g-ir-inspect -h', run_environment=True)
-            self.run('g-ir-scanner --version', run_environment=True)
+            with tools.environment_append({'PKG_CONFIG_PATH': "."}):
+                pkg_config = tools.PkgConfig("gobject-introspection-1.0")
+                for tool in ["g_ir_compiler", "g_ir_generate", "g_ir_scanner"]:
+                    self.run('%s --version' % pkg_config.variables[tool], run_environment=True)
+                self.run('g-ir-annotation-tool --version', run_environment=True)
+                self.run('g-ir-inspect -h', run_environment=True)
 
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
Specify library name and version:  **gobject-introspection/***

the variables are declared upstream in https://github.com/GNOME/gobject-introspection/blob/master/meson.build#L248

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
