### PR TITLE
pkgconf: allow colon and semicolon as path separator for PKG_CONFIG_PATH

### DIFF
--- a/recipes/pkgconf/all/conandata.yml
+++ b/recipes/pkgconf/all/conandata.yml
@@ -1,11 +1,18 @@
 sources:
-  "1.7.3":
-    url: "https://distfiles.dereferenced.org/pkgconf/pkgconf-1.7.3.tar.xz"
-    sha256: "b846aea51cf696c3392a0ae58bef93e2e72f8e7073ca6ad1ed8b01c85871f9c0"
   "1.7.4":
     url: "https://distfiles.dereferenced.org/pkgconf/pkgconf-1.7.4.tar.xz"
     sha256: "d73f32c248a4591139a6b17777c80d4deab6b414ec2b3d21d0a24be348c476ab"
+  "1.7.3":
+    url: "https://distfiles.dereferenced.org/pkgconf/pkgconf-1.7.3.tar.xz"
+    sha256: "b846aea51cf696c3392a0ae58bef93e2e72f8e7073ca6ad1ed8b01c85871f9c0"
 patches:
+  "1.7.4":
+    - patch_file: "patches/1.7.4-0001-clang-12-strndup-not-in-string-h.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/1.7.4-0002-fix-static-link.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/1.7.4-0003-PKG_CONF_PATH-allow-colon+semicolon-separator.patch"
+      base_path: "source_subfolder"
   "1.7.3":
     - patch_file: "patches/1.7.3-0001-meson-use-declare-dependencies.patch"
       base_path: "source_subfolder"
@@ -13,8 +20,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/1.7.3-0003-meson-use-library.patch"
       base_path: "source_subfolder"
-  "1.7.4":
-    - patch_file: "patches/1.7.4-0001-clang-12-strndup-not-in-string-h.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/1.7.4-0002-fix-static-link.patch"
+    - patch_file: "patches/1.7.3-0004-PKG_CONF_PATH-allow-colon+semicolon-separator.patch"
       base_path: "source_subfolder"

--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -46,7 +46,7 @@ class PkgConfConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def build_requirements(self):
-        self.build_requires("meson/0.57.2")
+        self.build_requires("meson/0.58.1")
 
     @property
     def _sharedstatedir(self):

--- a/recipes/pkgconf/all/patches/1.7.3-0004-PKG_CONF_PATH-allow-colon+semicolon-separator.patch
+++ b/recipes/pkgconf/all/patches/1.7.3-0004-PKG_CONF_PATH-allow-colon+semicolon-separator.patch
@@ -1,0 +1,11 @@
+--- libpkgconf/path.c
++++ libpkgconf/path.c
+@@ -146,7 +146,7 @@
+ 		return 0;
+ 
+ 	iter = workbuf = strdup(text);
+-	while ((p = strtok(iter, PKG_CONFIG_PATH_SEP_S)) != NULL)
++	while ((p = strtok(iter, ":;")) != NULL)
+ 	{
+ 		pkgconf_path_add(p, dirlist, filter);
+ 

--- a/recipes/pkgconf/all/patches/1.7.4-0003-PKG_CONF_PATH-allow-colon+semicolon-separator.patch
+++ b/recipes/pkgconf/all/patches/1.7.4-0003-PKG_CONF_PATH-allow-colon+semicolon-separator.patch
@@ -1,0 +1,11 @@
+--- libpkgconf/path.c
++++ libpkgconf/path.c
+@@ -142,7 +142,7 @@
+ 		return 0;
+ 
+ 	iter = workbuf = strdup(text);
+-	while ((p = strtok(iter, PKG_CONFIG_PATH_SEP_S)) != NULL)
++	while ((p = strtok(iter, ":;")) != NULL)
+ 	{
+ 		pkgconf_path_add(p, dirlist, filter);
+ 


### PR DESCRIPTION
Specify library name and version:  **pkgconf/all**

I am seeing an issue where the difference in path separator of `PKG_CONF_PATH` on unix and Windows systems is causing problems when running `configure`.
I could fix this by splitting the `PKG_CONF_PATH` variable with either of `:` and `;` (instead of a platform dependent choice).
The reasoning is the same as done in https://github.com/conan-io/conan-center-index/pull/5329

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
