### PR TITLE
capnproto: Fixed install issue on windows

### DIFF
--- a/recipes/capnproto/all/conandata.yml
+++ b/recipes/capnproto/all/conandata.yml
@@ -17,6 +17,8 @@ patches:
       base_path: source_subfolder
     - patch_file: patches/0005-msvc-16.7-ice-workaround.patch
       base_path: source_subfolder
+    - patch_file: patches/0009-windows-symlink-fix-0.8.0.patch
+      base_path: source_subfolder
   "0.7.0":
     - patch_file: patches/0006-symlink.patch
       base_path: source_subfolder

--- a/recipes/capnproto/all/patches/0009-windows-symlink-fix-0.8.0.patch
+++ b/recipes/capnproto/all/patches/0009-windows-symlink-fix-0.8.0.patch
@@ -1,0 +1,20 @@
+Workaround for install step on Windows where symlinks might be not supported.
+This leads to the following error:
+CMake error : failed to create symbolic link ... : operation not permitted
+--- a/c++/src/capnp/CMakeLists.txt
++++ b/c++/src/capnp/CMakeLists.txt
+@@ -188,8 +188,12 @@ if(NOT CAPNP_LITE)
+ 
+   install(TARGETS capnp_tool capnpc_cpp capnpc_capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
+ 
+-  # Symlink capnpc -> capnp
+-  install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp${CMAKE_EXECUTABLE_SUFFIX} \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
++  if(WIN32)
++    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E copy \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnp${CMAKE_EXECUTABLE_SUFFIX}\" \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
++  else()
++    # Symlink capnpc -> capnp
++    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp${CMAKE_EXECUTABLE_SUFFIX} \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc${CMAKE_EXECUTABLE_SUFFIX}\")")
++  endif()
+ endif()  # NOT CAPNP_LITE
+ 
+ # Tests ========================================================================


### PR DESCRIPTION
Specify library name and version:  **capnproto/0.8.0**

Fixed installation of capnproto binaries on Windows where symlinks not always supported.
Patch copies required file on WIndows instead of making a symlink.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
