### PR TITLE
taocpp-pegtl 3.x.x: fix compiler verifications and allow to use boost filesystem backend

### DIFF
--- a/recipes/taocpp-pegtl/3.x.x/conanfile.py
+++ b/recipes/taocpp-pegtl/3.x.x/conanfile.py
@@ -28,17 +28,21 @@ class TaoCPPPEGTLConan(ConanFile):
             "apple-clang": "10",
         }
 
-    def configure(self):
+    def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "17")
+
+        def lazy_lt_semver(v1, v2):
+            lv1 = [int(v) for v in v1.split(".")]
+            lv2 = [int(v) for v in v2.split(".")]
+            min_length = min(len(lv1), len(lv2))
+            return lv1[:min_length] < lv2[:min_length]
+
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if not minimum_version:
-            self.output.warn("TaoCPP PEGTL requires C++17. Your compiler is unknown. Assuming it supports C++17.")
-        elif tools.Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration("TaoCPP PEGTL requires C++17 or higher support standard."
-                                            " {} {} is not supported."
-                                            .format(self.settings.compiler,
-                                                    self.settings.compiler.version))
+            self.output.warn("{} {} requires C++17. Your compiler is unknown. Assuming it supports C++17.".format(self.name, self.version))
+        elif lazy_lt_semver(str(self.settings.compiler.version), minimum_version):
+            raise ConanInvalidConfiguration("{} {} requires C++17, which your compiler does not support.".format(self.name, self.version))
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/taocpp-pegtl/3.x.x/conanfile.py
+++ b/recipes/taocpp-pegtl/3.x.x/conanfile.py
@@ -33,9 +33,9 @@ class TaoCPPPEGTLConan(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            "gcc": "8",
+            "gcc": "7" if self.options.boost_filesystem else "8",
             "Visual Studio": "15.7",
-            "clang": "6",
+            "clang": "6.0",
             "apple-clang": "10",
         }
 

--- a/recipes/taocpp-pegtl/3.x.x/conanfile.py
+++ b/recipes/taocpp-pegtl/3.x.x/conanfile.py
@@ -1,8 +1,9 @@
-import os
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
+import os
 
-required_conan_version = ">=1.28.0"
+required_conan_version = ">=1.33.0"
+
 
 class TaoCPPPEGTLConan(ConanFile):
     name = "taocpp-pegtl"
@@ -48,9 +49,8 @@ class TaoCPPPEGTLConan(ConanFile):
         self.info.header_only()
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "PEGTL-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy("LICENSE*", dst="licenses", src=self._source_subfolder)

--- a/recipes/taocpp-pegtl/3.x.x/conanfile.py
+++ b/recipes/taocpp-pegtl/3.x.x/conanfile.py
@@ -15,10 +15,20 @@ class TaoCPPPEGTLConan(ConanFile):
               "parsing", "cpp17", "cpp11", "grammar")
     no_copy_source = True
     settings = "compiler"
+    options = {
+        "boost_filesystem": [True, False],
+    }
+    default_options = {
+        "boost_filesystem": False,
+    }
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def requirements(self):
+        if self.options.boost_filesystem:
+            self.requires("boost/1.76.0")
 
     @property
     def _compilers_minimum_version(self):
@@ -45,6 +55,9 @@ class TaoCPPPEGTLConan(ConanFile):
         elif lazy_lt_semver(str(self.settings.compiler.version), minimum_version):
             raise ConanInvalidConfiguration("{} {} requires C++17, which your compiler does not support.".format(self.name, self.version))
 
+        if self.options.boost_filesystem and (self.options["boost"].header_only or self.options["boost"].without_filesystem):
+            raise ConanInvalidConfiguration("{} requires non header-only boost with filesystem component".format(self.name))
+
     def package_id(self):
         self.info.header_only()
 
@@ -63,3 +76,6 @@ class TaoCPPPEGTLConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "taocpp"
         self.cpp_info.components["_taocpp-pegtl"].names["cmake_find_package"] = "pegtl"
         self.cpp_info.components["_taocpp-pegtl"].names["cmake_find_package_multi"] = "pegtl"
+        if self.options.boost_filesystem:
+            self.cpp_info.components["_taocpp-pegtl"].requires.append("boost::filesystem")
+            self.cpp_info.components["_taocpp-pegtl"].defines.append("TAO_PEGTL_BOOST_FILESYSTEM")


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Avoid to raise for Visual Studio 2017. I would like to know if it works (I'm packaging another library which depends on taocpp-pegtl).
I also think that clang with libstdc++ on Linux is not supported.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
