### PR TITLE
[tinycbor] Fix build-system (M1): pass cflags to executable

### DIFF
--- a/recipes/tinycbor/all/conandata.yml
+++ b/recipes/tinycbor/all/conandata.yml
@@ -4,6 +4,6 @@ sources:
     sha256: "956eb4b670ea4969eaee67395b5bb6437b153960385b77357d6692e979d1b12d"
 patches:
   "0.5.3":
-    - patch_file: "patches/conan.patch"
+    - patch_file: "patches/001-build-system.patch"
       base_path: "source_subfolder"
 

--- a/recipes/tinycbor/all/conanfile.py
+++ b/recipes/tinycbor/all/conanfile.py
@@ -2,6 +2,9 @@ import os
 from conans import ConanFile, tools, AutoToolsBuildEnvironment
 from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.33.0"
+
+
 class tinycborConan(ConanFile):
     name = "tinycbor"
     license = "MIT"
@@ -32,9 +35,7 @@ class tinycborConan(ConanFile):
             raise ConanInvalidConfiguration("Shared library only supported on Linux platform")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def _configure_autotools(self):
         if not self._env_build:
@@ -47,7 +48,6 @@ class tinycborConan(ConanFile):
             else:
                 self._env_vars["BUILD_SHARED"] = "1" if self.options.shared else "0"
                 self._env_vars["BUILD_STATIC"] = "1" if not self.options.shared else "0"
-                self._env_build.fpic = self.options.fPIC
         return self._env_build, self._env_vars
 
     def _build_nmake(self):

--- a/recipes/tinycbor/all/conanfile.py
+++ b/recipes/tinycbor/all/conanfile.py
@@ -23,6 +23,9 @@ class tinycborConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
         if self.settings.os != "Linux" and self.options.shared:

--- a/recipes/tinycbor/all/patches/001-build-system.patch
+++ b/recipes/tinycbor/all/patches/001-build-system.patch
@@ -1,5 +1,7 @@
---- Makefile	2019-10-22 08:11:21.000000000 -0700
-+++ Makefile_fix	2019-12-20 10:58:06.255975751 -0800
+diff --git a/Makefile b/Makefile
+index 239dde8..c43ea68 100644
+--- a/Makefile
++++ b/Makefile
 @@ -1,15 +1,15 @@
  # Variables:
 -prefix = /usr/local
@@ -20,7 +22,7 @@
  
  GIT_ARCHIVE = git archive --prefix="$(PACKAGE)/" -9
  INSTALL = install
-@@ -31,8 +31,8 @@
+@@ -31,8 +31,8 @@ TINYCBOR_FREESTANDING_SOURCES = \
  #
  CBORDUMP_SOURCES = tools/cbordump/cbordump.c
  
@@ -31,3 +33,17 @@
  
  ifneq ($(BUILD_STATIC),1)
  ifneq ($(BUILD_SHARED),1)
+@@ -151,11 +151,11 @@ lib/libtinycbor.so: $(TINYCBOR_SOURCES:.c=.pic.o)
+ 
+ bin/cbordump: $(CBORDUMP_SOURCES:.c=.o) $(BINLIBRARY)
+ 	@$(MKDIR) -p bin
+-	$(CC) -o $@ $(LDFLAGS) $^ $(LDLIBS)
++	$(CC) $(cflags) -o $@ $(LDFLAGS) $^ $(LDLIBS)
+ 
+ bin/json2cbor: $(JSON2CBOR_SOURCES:.c=.o) $(BINLIBRARY)
+ 	@$(MKDIR) -p bin
+-	$(CC) -o $@ $(LDFLAGS) $^ $(LDFLAGS_CJSON) $(LDLIBS)
++	$(CC) $(cflags) -o $@ $(LDFLAGS) $^ $(LDFLAGS_CJSON) $(LDLIBS)
+ 
+ tinycbor.pc: tinycbor.pc.in
+ 	$(SED) > $@ < $< \


### PR DESCRIPTION
Specify library name and version:  **tinycbor**

Fixes to cross-build for M1.

Thanks @lasote 