### PR TITLE
libmorton: add 0.2.7 + change include interface + remove NOMINMAX

### DIFF
--- a/recipes/libmorton/all/conandata.yml
+++ b/recipes/libmorton/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.7":
+    url: "https://github.com/Forceflow/libmorton/archive/refs/tags/v0.2.7.tar.gz"
+    sha256: "02bf640732750a5db638991b9f63049252f9656ef52a00d30d2a90df542b9ecf"
   "0.2.6":
     url: "https://github.com/Forceflow/libmorton/archive/v0.2.6.tar.gz"
     sha256: "466e31af19b49399426a860107f7fe9336ee784e46e49070959b3ac300f0d90d"

--- a/recipes/libmorton/all/conanfile.py
+++ b/recipes/libmorton/all/conanfile.py
@@ -30,8 +30,15 @@ class LibmortonConan(ConanFile):
 
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy("*.h", dst="include", src=os.path.join(self._source_subfolder, "libmorton", "include"))
+        if tools.Version(self.version) < "0.2.7":
+            src_hdrs = os.path.join(self._source_subfolder, "libmorton", "include")
+        else:
+            src_hdrs = os.path.join(self._source_subfolder, "libmorton")
+        self.copy("*.h", dst=os.path.join("include", "libmorton"), src=src_hdrs)
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "libmorton"
+        self.cpp_info.names["cmake_find_package_multi"] = "libmorton"
+        self.cpp_info.names["pkg_config"] = "libmorton"
         if self.settings.os == "Linux":
             self.cpp_info.system_libs = ["m"]

--- a/recipes/libmorton/all/conanfile.py
+++ b/recipes/libmorton/all/conanfile.py
@@ -33,7 +33,5 @@ class LibmortonConan(ConanFile):
         self.copy("*.h", dst="include", src=os.path.join(self._source_subfolder, "libmorton", "include"))
 
     def package_info(self):
-        if self.settings.compiler == "Visual Studio":
-            self.cpp_info.defines = ["NOMINMAX"]
         if self.settings.os == "Linux":
             self.cpp_info.system_libs = ["m"]

--- a/recipes/libmorton/all/conanfile.py
+++ b/recipes/libmorton/all/conanfile.py
@@ -1,6 +1,8 @@
 from conans import ConanFile, tools
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class LibmortonConan(ConanFile):
     name = "libmorton"
@@ -21,8 +23,8 @@ class LibmortonConan(ConanFile):
         self.info.header_only()
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/libmorton/all/test_package/CMakeLists.txt
+++ b/recipes/libmorton/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(libmorton REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} libmorton::libmorton)

--- a/recipes/libmorton/all/test_package/conanfile.py
+++ b/recipes/libmorton/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/libmorton/all/test_package/test_package.cpp
+++ b/recipes/libmorton/all/test_package/test_package.cpp
@@ -1,4 +1,4 @@
-#include <morton.h>
+#include <libmorton/morton.h>
 
 #include <iostream>
 

--- a/recipes/libmorton/config.yml
+++ b/recipes/libmorton/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.7":
+    folder: all
   "0.2.6":
     folder: all
   "0.2.5":


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

include interface layout is explicit since 0.2.7.
NOMINMAX definition was coming from upstream CMakeLists, but actually it was useless (needed for tests due to inclusion of windows.h, but it was useless for public headers).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
