### PR TITLE
Add rapidfuzz/cci.20210517

### DIFF
--- a/recipes/rapidfuzz/all/conandata.yml
+++ b/recipes/rapidfuzz/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20210513":
+    url: "https://github.com/maxbachmann/rapidfuzz-cpp/archive/d1e82379395cafc6d439c1c1e2cbe7512eaf2518.zip"
+    sha256: "88d6279665a7fe4473594d034c13be83b9b923db7a15755f51b43d6be5b8ba78"

--- a/recipes/rapidfuzz/all/conandata.yml
+++ b/recipes/rapidfuzz/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "cci.20210513":
     url: "https://github.com/maxbachmann/rapidfuzz-cpp/archive/d1e82379395cafc6d439c1c1e2cbe7512eaf2518.tar.gz"
-    sha256: "88d6279665a7fe4473594d034c13be83b9b923db7a15755f51b43d6be5b8ba78"
+    sha256: "e5c306aae2fb4b34a381fbffaa97399114f20de14d83914ac2c9013b0226ce57"

--- a/recipes/rapidfuzz/all/conandata.yml
+++ b/recipes/rapidfuzz/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "cci.20210513":
-    url: "https://github.com/maxbachmann/rapidfuzz-cpp/archive/d1e82379395cafc6d439c1c1e2cbe7512eaf2518.zip"
+    url: "https://github.com/maxbachmann/rapidfuzz-cpp/archive/d1e82379395cafc6d439c1c1e2cbe7512eaf2518.tar.gz"
     sha256: "88d6279665a7fe4473594d034c13be83b9b923db7a15755f51b43d6be5b8ba78"

--- a/recipes/rapidfuzz/all/conanfile.py
+++ b/recipes/rapidfuzz/all/conanfile.py
@@ -1,0 +1,28 @@
+from conans import ConanFile, tools
+import glob
+
+
+class RapidFuzzConan(ConanFile):
+    name = "rapidfuzz"
+    description = "Rapid fuzzy string matching in C++ using the Levenshtein Distance "
+    topics = ("conan", "cpp", "levenshtein", "string-matching", "string-similarity", "string-comparison")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/maxbachmann/rapidfuzz-cpp"
+    license = "MIT"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = glob.glob(self.name + "-*/")[0]
+        tools.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="rapidfuzz/*.hpp", dst="include", src=self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/rapidfuzz/all/conanfile.py
+++ b/recipes/rapidfuzz/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, tools
-import glob
+
+required_conan_version = ">=1.33.0"
 
 
 class RapidFuzzConan(ConanFile):
@@ -16,9 +17,8 @@ class RapidFuzzConan(ConanFile):
         return "source_subfolder"
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = glob.glob(self.name + "-*/")[0]
-        tools.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)

--- a/recipes/rapidfuzz/all/test_package/CMakeLists.txt
+++ b/recipes/rapidfuzz/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/rapidfuzz/all/test_package/conanfile.py
+++ b/recipes/rapidfuzz/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/rapidfuzz/all/test_package/test_package.cpp
+++ b/recipes/rapidfuzz/all/test_package/test_package.cpp
@@ -1,0 +1,13 @@
+#include <rapidfuzz/fuzz.hpp>
+#include <string>
+
+int main() {
+    std::string s1("new york mets");
+    std::string s2("new YORK mets");
+    int r = rapidfuzz::fuzz::ratio(s1, s1);
+    if (r == 100) {
+        return 0;
+    } else {
+        return -1;
+    }
+}

--- a/recipes/rapidfuzz/config.yml
+++ b/recipes/rapidfuzz/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20210513":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **rapidfuzz/cci.20210517**

https://github.com/maxbachmann/rapidfuzz-cpp
I omitted the -cpp suffix because I don't think we will be packaging the python version.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
