### PR TITLE
[cmake][m1] xbuild to host M1

### DIFF
--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -76,6 +76,9 @@ class CMakeConan(ConanFile):
                 self._cmake.definitions["CMAKE_USE_OPENSSL"] = self.options.with_openssl
                 if self.options.with_openssl:
                     self._cmake.definitions["OPENSSL_USE_STATIC_LIBS"] = not self.options["openssl"].shared
+            if tools.cross_building(self):
+                self._cmake.definitions["HAVE_POLL_FINE_EXITCODE"] = ''
+                self._cmake.definitions["HAVE_POLL_FINE_EXITCODE__TRYRUN_OUTPUT"] = ''
             self._cmake.configure(source_folder=self._source_subfolder)
         return self._cmake
 

--- a/recipes/cmake/3.x.x/test_package/conanfile.py
+++ b/recipes/cmake/3.x.x/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, tools
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "os_build"
+    settings = "os"
 
     def test(self):
         if not tools.cross_building(self.settings):


### PR DESCRIPTION
Specify library name and version:  **cmake**

M1 cross-build was failing with this error (CMake configure):

```
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAVE_POLL_FINE_EXITCODE (advanced)
   HAVE_POLL_FINE_EXITCODE__TRYRUN_OUTPUT (advanced)
```

Indeed, here (https://gitlab.kitware.com/cmake/cmake/-/blob/master/Utilities/cmcurl/CMake/OtherTests.cmake#L264) it is only skipping the test if using CMAKE_TOOLCHAIN_FILE 🤷 