### PR TITLE
[llvm-core] Fix linking problem with LLVMTableGenGlobalISel on Windows

### DIFF
--- a/recipes/llvm-core/all/conanfile.py
+++ b/recipes/llvm-core/all/conanfile.py
@@ -216,7 +216,7 @@ class LLVMCoreConan(ConanFile):
         if not self.options.shared:
             for ext in ['.a', '.lib']:
                 lib = '*LLVMTableGenGlobalISel{}'.format(ext)
-                self.copy(lib, dst='lib', src='lib')
+                self.copy(lib, dst='lib', keep_path=False)
 
             self.run('cmake --graphviz=graph/llvm.dot .')
             with tools.chdir('graph'):

--- a/recipes/llvm-core/all/conanfile.py
+++ b/recipes/llvm-core/all/conanfile.py
@@ -197,8 +197,7 @@ class LLVMCoreConan(ConanFile):
         self._supports_compiler()
 
     def source(self):
-        tools.get(**self.conan_data['sources'][self.version])
-        os.rename('llvm-{}.src'.format(self.version), self._source_subfolder)
+        tools.get(**self.conan_data['sources'][self.version], destination=self._source_subfolder, strip_root=True)
         self._patch_sources()
 
     def build(self):

--- a/recipes/llvm-core/all/test_package/CMakeLists.txt
+++ b/recipes/llvm-core/all/test_package/CMakeLists.txt
@@ -11,6 +11,7 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 
 if(TARGET llvm-core::interpreter)  # static libraries
     target_link_libraries(${PROJECT_NAME} PRIVATE
+        llvm-core::lto
         llvm-core::interpreter
         llvm-core::irreader
         llvm-core::x86codegen


### PR DESCRIPTION
Specify library name and version:  **llvm-core/11.1.0**

I've been trying the new llvm-core package (A big thanks to the author!) and came across a linking problem on Windows.

It's related to the library `LLVMTableGenGlobalISel` which couldn't be found in (static) Windows packages. This library is not
installed by CMake but copied explicitly in the recipe, but the copy-command doesn't work on Windows. So this PR is fixing
that.

The reason for the failing copy-command is the fact that on Windows the libraries aren't placed under `lib/`. They are placed in `source/${CMAKE_BUILD_TYPE}`. I assume this difference in behaviour is caused by MSBuild or some cmake misconfiguration in LLVM. Nevertheless this can be fixed by adjusting the copy command. I have also adjusted the test package such that the problem occurs there.

Additionally there is a second commit which removes the `os.rename` which is known to make problems on Windows

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
