### PR TITLE
[glib][m1] Cross-building not implemented

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -39,6 +39,9 @@ class GLibConan(ConanFile):
         return self.settings.compiler == "Visual Studio"
 
     def configure(self):
+        if tools.cross_building(self, skip_x64_x86=True):
+            raise ConanInvalidConfiguration("Cross-building not implemented")
+
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx


### PR DESCRIPTION
Specify library name and version:  **glib**

We might need to wait for toolchain/generate approach in Conan to be a bit more stable, and then implement it using those helpers.
