### PR TITLE
[xerces-c/all] Add option "char_type"

### DIFF
--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -53,11 +53,9 @@ class XercesCConan(ConanFile):
                                                  "Macos": "macosunicodeconverter",
                                                  "Linux": "gnuiconv"}.get(str(self.settings.os))
         self._cmake.definitions["message-loader"] = "inmemory"
-        
-        self._cmake.definitions["xmlch-type"] = {"Windows": self.options.char_type,
-                                                 "Macos": "uint16_t",
-                                                 "Linux": "uint16_t"}.get(str(self.settings.os))
-                                                 
+
+        self._cmake.definitions["xmlch-type"] = self.options.char_type if "char_type" in self.options else "uint16_t"
+
         self._cmake.definitions["mutex-manager"] = {"Windows": "windows",
                                                     "Macos": "posix",
                                                     "Linux": "posix"}.get(str(self.settings.os))

--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -87,3 +87,5 @@ class XercesCConan(ConanFile):
             self.cpp_info.system_libs.append("pthread")
         self.cpp_info.names["cmake_find_package"] = "XercesC"
         self.cpp_info.names["cmake_find_package_multi"] = "XercesC"
+
+        

--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -25,16 +25,21 @@ class XercesCConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+    
+    def validate(self):
+        if self.options.char_type == "wchar_t" and self.settings.os != Windows:
+            raise ConanInvalidConfiguration("Option 'char_type=wchar_t' is only supported in Windows")
+
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        else:
-            del self.options.char_type
 
     def configure(self):
         if self.settings.os not in ("Windows", "Macos", "Linux"):
             raise ConanInvalidConfiguration("OS is not supported")
+        if self.options.shared:
+            del self.options.fPIC
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -54,7 +59,7 @@ class XercesCConan(ConanFile):
                                                  "Linux": "gnuiconv"}.get(str(self.settings.os))
         self._cmake.definitions["message-loader"] = "inmemory"
 
-        self._cmake.definitions["xmlch-type"] = self.options.char_type if "char_type" in self.options else "uint16_t"
+        self._cmake.definitions["xmlch-type"] = self.options.char_type
 
         self._cmake.definitions["mutex-manager"] = {"Windows": "windows",
                                                     "Macos": "posix",
@@ -87,5 +92,3 @@ class XercesCConan(ConanFile):
             self.cpp_info.system_libs.append("pthread")
         self.cpp_info.names["cmake_find_package"] = "XercesC"
         self.cpp_info.names["cmake_find_package_multi"] = "XercesC"
-
-        

--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -13,8 +13,8 @@ class XercesCConan(ConanFile):
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "char_type": ["uint16_t", "wchar_t"]}
+    default_options = {"shared": False, "fPIC": True, "char_type": "uint16_t"}
 
     _cmake = None
 
@@ -29,6 +29,8 @@ class XercesCConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        else:
+            del self.options.char_type
 
     def configure(self):
         if self.settings.os not in ("Windows", "Macos", "Linux"):
@@ -51,7 +53,11 @@ class XercesCConan(ConanFile):
                                                  "Macos": "macosunicodeconverter",
                                                  "Linux": "gnuiconv"}.get(str(self.settings.os))
         self._cmake.definitions["message-loader"] = "inmemory"
-        self._cmake.definitions["xmlch-type"] = "uint16_t"
+        
+        self._cmake.definitions["xmlch-type"] = {"Windows": self.options.char_type,
+                                                 "Macos": "uint16_t",
+                                                 "Linux": "uint16_t"}.get(str(self.settings.os))
+                                                 
         self._cmake.definitions["mutex-manager"] = {"Windows": "windows",
                                                     "Macos": "posix",
                                                     "Linux": "posix"}.get(str(self.settings.os))


### PR DESCRIPTION
Our software uses xerces with the `wchar_t` based binary interface on Windows. However the conan package doesn't provide an option to configure the xerces build that way. We'd rather extend and use the official recipe than maintain our own copy.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
