### PR TITLE
gtest: remove obsolete defines and refactor recipe

### DIFF
--- a/recipes/gtest/all/CMakeLists.txt
+++ b/recipes/gtest/all/CMakeLists.txt
@@ -1,15 +1,13 @@
 cmake_minimum_required(VERSION 2.8.11)
 project(cmake_wrapper)
 
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+include("conanbuildinfo.cmake")
 conan_basic_setup()
 
-option(GTEST_NO_MAIN "Generate google main libraries" OFF)
-
 if(MSVC)
-  if(MSVC_VERSION AND MSVC_VERSION GREATER_EQUAL 1910)
+  if(MSVC_VERSION AND (MSVC_VERSION EQUAL 1910 OR MSVC_VERSION GREATER 1910))
     add_definitions(-DGTEST_LANG_CXX11=1 -DGTEST_HAS_TR1_TUPLE=0)
-  endif(MSVC_VERSION AND MSVC_VERSION GREATER_EQUAL 1910)
+  endif(MSVC_VERSION AND (MSVC_VERSION EQUAL 1910 OR MSVC_VERSION GREATER 1910))
 endif(MSVC)
 
 add_subdirectory("source_subfolder")

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -156,7 +156,7 @@ class GTestConan(ConanFile):
 
         if self.version == "1.8.1":
             if self.settings.compiler == "Visual Studio":
-                if tools.Version(self.settings.compiler.version.value) >= "15":
+                if tools.Version(self.settings.compiler.version) >= "15":
                     self.cpp_info.components["libgtest"].defines.append("GTEST_LANG_CXX11=1")
                     self.cpp_info.components["libgtest"].defines.append("GTEST_HAS_TR1_TUPLE=0")
 

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -1,7 +1,8 @@
-import glob
-import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
 
 
 class GTestConan(ConanFile):
@@ -10,13 +11,35 @@ class GTestConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/google/googletest"
     license = "BSD-3-Clause"
-    topics = ("conan", "gtest", "testing", "google-testing", "unit-test")
+    topics = ("gtest", "testing", "google-testing", "unit-test")
     exports_sources = ["CMakeLists.txt", "patches/*"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "build_gmock": [True, False], "fPIC": [True, False], "no_main": [True, False], "debug_postfix": "ANY", "hide_symbols": [True, False]}
-    default_options = {"shared": False, "build_gmock": True, "fPIC": True, "no_main": False, "debug_postfix": 'd', "hide_symbols": False}
-    _source_subfolder = "source_subfolder"
+    options = {
+        "shared": [True, False],
+        "build_gmock": [True, False],
+        "fPIC": [True, False],
+        "no_main": [True, False],
+        "debug_postfix": "ANY",
+        "hide_symbols": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "build_gmock": True,
+        "fPIC": True,
+        "no_main": False,
+        "debug_postfix": "d",
+        "hide_symbols": False,
+    }
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
 
     @property
     def _minimum_cpp_standard(self):
@@ -45,7 +68,7 @@ class GTestConan(ConanFile):
                 "clang": "5",
                 "apple-clang": "9.1"
             }
-        
+
     @property
     def _postfix(self):
         return self.options.debug_postfix if self.settings.build_type == "Debug" else ""
@@ -59,6 +82,8 @@ class GTestConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+
+    def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
             tools.check_min_cppstd(self, self._minimum_cpp_standard)
         min_version = self._minimum_compilers_version.get(
@@ -79,26 +104,27 @@ class GTestConan(ConanFile):
                     self.name, self.settings.compiler, min_version, self.settings.compiler.version))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
-        cmake = CMake(self)
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
         if self.settings.build_type == "Debug":
-            cmake.definitions["CUSTOM_DEBUG_POSTFIX"] = self.options.debug_postfix
+            self._cmake.definitions["CUSTOM_DEBUG_POSTFIX"] = self.options.debug_postfix
         if self.settings.os == "Windows" and self.settings.get_safe("compiler.runtime"):
-            cmake.definitions["gtest_force_shared_crt"] = "MD" in str(self.settings.compiler.runtime)
-        cmake.definitions["BUILD_GMOCK"] = self.options.build_gmock
-        cmake.definitions["GTEST_NO_MAIN"] = self.options.no_main
+            self._cmake.definitions["gtest_force_shared_crt"] = "MD" in str(self.settings.compiler.runtime)
+        self._cmake.definitions["BUILD_GMOCK"] = self.options.build_gmock
         if self.settings.os == "Windows" and self.settings.compiler == "gcc":
-            cmake.definitions["gtest_disable_pthreads"] = True
-        cmake.definitions["gtest_hide_internal_symbols"] = self.options.hide_symbols
-        cmake.configure()
-        return cmake
+            self._cmake.definitions["gtest_disable_pthreads"] = True
+        self._cmake.definitions["gtest_hide_internal_symbols"] = self.options.hide_symbols
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
 
     def build(self):
-        if "patches" in self.conan_data:
-            for patch in self.conan_data["patches"][self.version]:
-                tools.patch(**patch)
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -108,8 +134,7 @@ class GTestConan(ConanFile):
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        for pdb_file in glob.glob(os.path.join(self.package_folder, "lib", "*.pdb")):
-            os.unlink(pdb_file)
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.pdb")
 
     def package_id(self):
         del self.info.options.no_main
@@ -122,17 +147,18 @@ class GTestConan(ConanFile):
         self.cpp_info.components["libgtest"].libs = ["gtest{}".format(self._postfix)]
         if self.settings.os == "Linux":
             self.cpp_info.components["libgtest"].system_libs.append("pthread")
-        
+
         if self.settings.os == "Neutrino" and self.settings.os.version == "7.1":
             self.cpp_info.components["libgtest"].system_libs.append("regex")
 
         if self.options.shared:
             self.cpp_info.components["libgtest"].defines.append("GTEST_LINKED_AS_SHARED_LIBRARY=1")
 
-        if self.settings.compiler == "Visual Studio":
-            if tools.Version(self.settings.compiler.version.value) >= "15":
-                self.cpp_info.components["libgtest"].defines.append("GTEST_LANG_CXX11=1")
-                self.cpp_info.components["libgtest"].defines.append("GTEST_HAS_TR1_TUPLE=0")
+        if self.version == "1.8.1":
+            if self.settings.compiler == "Visual Studio":
+                if tools.Version(self.settings.compiler.version.value) >= "15":
+                    self.cpp_info.components["libgtest"].defines.append("GTEST_LANG_CXX11=1")
+                    self.cpp_info.components["libgtest"].defines.append("GTEST_HAS_TR1_TUPLE=0")
 
         if not self.options.no_main:
             self.cpp_info.components["gtest_main"].libs = ["gtest_main{}".format(self._postfix)]


### PR DESCRIPTION
I've noticed that new googletest doesn't use GTEST_LANG_CXX11 and GTEST_HAS_TR1_TUPLE so I've decided to slightly improve recipe.

Check conan version for tools.get
Use remove_files_by_mask
Refactor call to patching
Move compiler checks to validate method
Use shorter lines and other small style changes
Remove GTEST_NO_MAIN which was doing nothing
Do not use GREATER_EQUAL - it is not present in CMake 2.8
Remove "conan" from topics

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
