### PR TITLE
apr-util/all: bump dependencies

### DIFF
--- a/recipes/apr-util/all/CMakeLists.txt
+++ b/recipes/apr-util/all/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.12)
-project(cmake_wrapper)
+project(cmake_wrapper C)
 
 include(conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/apr-util/all/conanfile.py
+++ b/recipes/apr-util/all/conanfile.py
@@ -1,10 +1,9 @@
 from conans import AutoToolsBuildEnvironment, ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
-import glob
 import os
 
 
-required_conan_version = ">=1.32.0"
+required_conan_version = ">=1.33.0"
 
 
 class AprUtilConan(ConanFile):
@@ -73,7 +72,7 @@ class AprUtilConan(ConanFile):
     def requirements(self):
         self.requires("apr/1.7.0")
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1j")
+            self.requires("openssl/1.1.1k")
         if self.options.with_nss:
             # self.requires("nss/x.y.z")
             raise ConanInvalidConfiguration("CCI has no nss recipe (yet)")
@@ -96,17 +95,17 @@ class AprUtilConan(ConanFile):
             # self.requires("ldap/x.y.z")
             raise ConanInvalidConfiguration("CCI has no ldap recipe (yet)")
         if self.options.with_mysql:
-            self.requires("libmysqlclient/8.0.17")
+            self.requires("libmysqlclient/8.0.25")
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.35.1")
+            self.requires("sqlite3/3.35.5")
         if self.options.with_expat:
-            self.requires("expat/2.2.10")
+            self.requires("expat/2.4.1")
         if self.options.with_postgresql:
             self.requires("libpq/13.2")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def validate(self):
         if self.options.shared != self.options["apr"].shared:
@@ -176,8 +175,7 @@ class AprUtilConan(ConanFile):
             autotools = self._configure_autotools()
             autotools.install()
 
-            for file in glob.glob(os.path.join(self.package_folder, "lib", "apr-util-1", "*.la")):
-                os.unlink(file)
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib", "apr-util-1"), "*.la")
             os.unlink(os.path.join(self.package_folder, "lib", "libaprutil-1.la"))
             tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 


### PR DESCRIPTION
small improvements to recipe

Specify library name and version:  **apr-util/all**

While adding log4cxx, I've noticed that apr-util doesn't use latest expat.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
