### PR TITLE
[mailio/0.20.0] Fix broken link to sources

### DIFF
--- a/recipes/mailio/all/conandata.yml
+++ b/recipes/mailio/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "0.20.0":
-    url: "https://github.com/karastojko/mailio/archive/version_0-20-0.tar.gz"
-    sha256: "2ecf57ec467aa8c5d1d2c51a6cc44476c53e890466b7a240304106eeab993245"
+    url: "https://github.com/karastojko/mailio/archive/refs/tags/0.20.0.tar.gz"
+    sha256: "073d6b1ff891444b54a01c2a3f17074fd612f9e2e14d9ebd61863c70737b1882"
 patches:
   "0.20.0":
     - patch_file: "patches/adapt-cmakelists.patch"


### PR DESCRIPTION
Library name and version:  mailio/0.20.0
GitHub link: https://github.com/karastojko/mailio

I am not the author of the library, but I want to use it. It seems like previous link was broken.
You can try it: https://github.com/karastojko/mailio/archive/version_0-20-0.tar.gz

So I replaced link and `sha256` hash for sources archive.

I applied this change to my local project that uses conan and now it works.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
