### PR TITLE
[premake][m1] Raise InvalidConfig for cross-building scenarios

### DIFF
--- a/recipes/premake/5.x/conanfile.py
+++ b/recipes/premake/5.x/conanfile.py
@@ -35,7 +35,7 @@ class PremakeConan(ConanFile):
             del self.options.lto
 
     def validate(self):
-        if tools.cross_building(self, skip_x64_x86=True):
+        if hasattr(self, 'settings_build') and tools.cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building not implemented")
 
     @property

--- a/recipes/premake/5.x/conanfile.py
+++ b/recipes/premake/5.x/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
+from conans.errors import ConanInvalidConfiguration
 import glob
 import os
 import re
@@ -32,6 +33,10 @@ class PremakeConan(ConanFile):
     def config_options(self):
         if self.settings.os != "Windows" or self.settings.compiler == "Visual Studio":
             del self.options.lto
+
+    def validate(self):
+        if tools.cross_building(self, skip_x64_x86=True):
+            raise ConanInvalidConfiguration("Cross-building not implemented")
 
     @property
     def _msvc_version(self):


### PR DESCRIPTION
Specify library name and version:  **premake**

It doesn't work in cross-building scenario.