### PR TITLE
apr-util: use libiconv/1.16

### DIFF
--- a/recipes/apr-util/all/conanfile.py
+++ b/recipes/apr-util/all/conanfile.py
@@ -71,6 +71,7 @@ class AprUtilConan(ConanFile):
 
     def requirements(self):
         self.requires("apr/1.7.0")
+        self.requires("libiconv/1.16")
         if self.options.with_openssl:
             self.requires("openssl/1.1.1k")
         if self.options.with_nss:
@@ -138,6 +139,7 @@ class AprUtilConan(ConanFile):
         conf_args = [
             "--with-apr={}".format(tools.unix_path(self.deps_cpp_info["apr"].rootpath)),
             "--with-crypto" if self._with_crypto else "--without-crypto",
+            "--with-iconv={}".format(tools.unix_path(self.deps_cpp_info["libiconv"].rootpath)),
             "--with-openssl={}".format(tools.unix_path(self.deps_cpp_info["openssl"].rootpath)) if self.options.with_openssl else "--without-openssl",
             "--with-expat={}".format(tools.unix_path(self.deps_cpp_info["expat"].rootpath)) if self.options.with_expat else "--without-expat",
             "--with-mysql={}".format(tools.unix_path(self.deps_cpp_info["libmysqlclient"].rootpath)) if self.options.with_mysql else "--without-mysql",
@@ -189,8 +191,6 @@ class AprUtilConan(ConanFile):
                 self.cpp_info.system_libs = ["dl", "pthread", "rt"]
             elif self.settings.os == "Windows":
                 self.cpp_info.system_libs = ["mswsock", "rpcrt4", "ws2_32"]
-            elif self.settings.os == "Macos":
-                self.cpp_info.system_libs = ["iconv"]
 
         binpath = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH env var : {}".format(binpath))

--- a/recipes/apr-util/all/conanfile.py
+++ b/recipes/apr-util/all/conanfile.py
@@ -71,7 +71,9 @@ class AprUtilConan(ConanFile):
 
     def requirements(self):
         self.requires("apr/1.7.0")
-        self.requires("libiconv/1.16")
+        if self.settings.os != "Windows":
+            #cmake build doesn't allow injection of iconv yet
+            self.requires("libiconv/1.16")
         if self.options.with_openssl:
             self.requires("openssl/1.1.1k")
         if self.options.with_nss:


### PR DESCRIPTION
Specify library name and version:  **apr-util/all**

Before this change apr-util tried to use iconv from system for building xlate.c

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
