### PR TITLE
trompeloeil: add version 41

### DIFF
--- a/recipes/trompeloeil/all/conandata.yml
+++ b/recipes/trompeloeil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "41":
+    url: "https://github.com/rollbear/trompeloeil/archive/v41.tar.gz"
+    sha256: "48986b507497f027e4fa1144a08c2d0b6d81fb476fad024956f8104448ca9ad8"
   "40":
     url: "https://github.com/rollbear/trompeloeil/archive/v40.tar.gz"
     sha256: "e13e3649223a358a5a72fa5a8a1c36325b48e4f3d9d2f2277b17d746797e1734"

--- a/recipes/trompeloeil/config.yml
+++ b/recipes/trompeloeil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "41":
+    folder: all
   "40":
     folder: all
   "39":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **trompeloeil/41**

closes conan-io/conan-center-index#5940

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
