### PR TITLE
[sdl2] Rename from sdl (1/3)

### DIFF
--- a/recipes/sdl2/all/CMakeLists.txt
+++ b/recipes/sdl2/all/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include(${CONAN_INSTALL_FOLDER}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+if(UNIX AND NOT APPLE)
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+      add_definitions("-DGBM_BO_USE_CURSOR=2")
+    endif()
+  endif()
+endif()
+
+add_subdirectory(source_subfolder)

--- a/recipes/sdl2/all/conandata.yml
+++ b/recipes/sdl2/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.0.14":
+    url: "https://www.libsdl.org/release/SDL2-2.0.14.tar.gz"
+    sha256: d8215b571a581be1332d2106f8036fcb03d12a70bae01e20f424976d275432bc

--- a/recipes/sdl2/all/conanfile.py
+++ b/recipes/sdl2/all/conanfile.py
@@ -1,0 +1,318 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class SDLConan(ConanFile):
+    name = "sdl2"
+    description = "Access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL, Direct3D and Vulkan"
+    topics = ("sdl2", "audio", "keyboard", "graphics", "opengl")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.libsdl.org"
+    license = "Zlib"
+    exports_sources = ["CMakeLists.txt", "patches/*"]
+    generators = ["cmake", "pkg_config"]
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "directx": [True, False],
+        "alsa": [True, False],
+        "jack": [True, False],
+        "pulse": [True, False],
+        "sndio": [True, False],
+        "nas": [True, False],
+        "esd": [True, False],
+        "arts": [True, False],
+        "x11": [True, False],
+        "xcursor": [True, False],
+        "xinerama": [True, False],
+        "xinput": [True, False],
+        "xrandr": [True, False],
+        "xscrnsaver": [True, False],
+        "xshape": [True, False],
+        "xvm": [True, False],
+        "wayland": [True, False],
+        "directfb": [True, False],
+        "iconv": [True, False],
+        "video_rpi": [True, False],
+        "sdl2main": [True, False],
+        "opengl": [True, False],
+        "opengles": [True, False],
+        "vulkan": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "directx": True,
+        "alsa": True,
+        "jack": True,
+        "pulse": True,
+        "sndio": False,
+        "nas": True,
+        "esd": False,
+        "arts": False,
+        "x11": True,
+        "xcursor": True,
+        "xinerama": True,
+        "xinput": True,
+        "xrandr": True,
+        "xscrnsaver": True,
+        "xshape": True,
+        "xvm": True,
+        "wayland": False,
+        "directfb": False,
+        "iconv": True,
+        "video_rpi": False,
+        "sdl2main": True,
+        "opengl": True,
+        "opengles": True,
+        "vulkan": True
+    }
+
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
+    _cmake = None
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+            if self.settings.compiler == "Visual Studio":
+                del self.options.iconv
+        if self.settings.os != "Linux":
+            del self.options.alsa
+            del self.options.jack
+            del self.options.pulse
+            del self.options.sndio
+            del self.options.nas
+            del self.options.esd
+            del self.options.arts
+            del self.options.x11
+            del self.options.xcursor
+            del self.options.xinerama
+            del self.options.xinput
+            del self.options.xrandr
+            del self.options.xscrnsaver
+            del self.options.xshape
+            del self.options.xvm
+            del self.options.wayland
+            del self.options.directfb
+            del self.options.video_rpi
+        if self.settings.os != "Windows":
+            del self.options.directx
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+        if self.settings.os == "Macos" and not self.options.iconv:
+            raise ConanInvalidConfiguration("On macOS iconv can't be disabled")
+        if self.settings.os == "Linux":
+            raise ConanInvalidConfiguration("Linux not supported yet")
+
+    def requirements(self):
+        if self.options.get_safe("iconv", False):
+            self.requires("libiconv/1.16")
+        if self.settings.os == "Linux":
+            self.requires("xorg/system")
+            if self.options.alsa:
+                self.requires("libalsa/1.2.4")
+            if self.options.pulse:
+                self.requires("pulseaudio/13.0")
+            if self.options.opengl:
+                self.requires("opengl/system")
+
+    def package_id(self):
+        del self.info.options.sdl2main
+
+    def build_requirements(self):
+        if self.settings.os == "Linux":
+            self.build_requires("pkgconf/1.7.3")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+        # ensure sdl2-config is created for MinGW
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              "if(NOT WINDOWS OR CYGWIN)",
+                              "if(NOT WINDOWS OR CYGWIN OR MINGW)")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              "if(NOT (WINDOWS OR CYGWIN))",
+                              "if(NOT (WINDOWS OR CYGWIN OR MINGW))")
+        if self.version >= "2.0.14":
+            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                                  'check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)',
+                                  '# check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)')
+        self._build_cmake()
+
+    def _check_pkg_config(self, option, package_name):
+        if option:
+            pkg_config = tools.PkgConfig(package_name)
+            if not pkg_config.provides:
+                raise ConanInvalidConfiguration("package %s is not available" % package_name)
+
+    def _check_dependencies(self):
+        if self.settings.os == "Linux":
+            self._check_pkg_config(self.options.jack, "jack")
+            self._check_pkg_config(self.options.esd, "esound")
+            self._check_pkg_config(self.options.wayland, "wayland-client")
+            self._check_pkg_config(self.options.wayland, "wayland-protocols")
+            self._check_pkg_config(self.options.directfb, "directfb")
+
+    def validate(self):
+        self._check_dependencies()
+
+    def _configure_cmake(self):
+        if not self._cmake:
+            self._cmake = CMake(self)
+            # FIXME: self.install_folder not defined? Neccessary?
+            self._cmake.definitions["CONAN_INSTALL_FOLDER"] = self.install_folder
+            if self.settings.os != "Windows":
+                if not self.options.shared:
+                    self._cmake.definitions["SDL_STATIC_PIC"] = self.options.fPIC
+            if self.settings.compiler == "Visual Studio" and not self.options.shared:
+                self._cmake.definitions["HAVE_LIBC"] = True
+            self._cmake.definitions["SDL_SHARED"] = self.options.shared
+            self._cmake.definitions["SDL_STATIC"] = not self.options.shared
+            self._cmake.definitions["VIDEO_OPENGL"] = self.options.opengl
+            self._cmake.definitions["VIDEO_OPENGLES"] = self.options.opengles
+            self._cmake.definitions["VIDEO_VULKAN"] = self.options.vulkan
+            if self.settings.os == "Linux":
+                # See https://github.com/bincrafters/community/issues/696
+                self._cmake.definitions["SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS"] = 1
+
+                self._cmake.definitions["ALSA"] = self.options.alsa
+                if self.options.alsa:
+                    self._cmake.definitions["HAVE_ASOUNDLIB_H"] = True
+                    self._cmake.definitions["HAVE_LIBASOUND"] = True
+                self._cmake.definitions["JACK"] = self.options.jack
+                self._cmake.definitions["PULSEAUDIO"] = self.options.pulse
+                self._cmake.definitions["SNDIO"] = self.options.sndio
+                self._cmake.definitions["NAS"] = self.options.nas
+                self._cmake.definitions["VIDEO_X11"] = self.options.x11
+                if self.options.x11:
+                    self._cmake.definitions["HAVE_XEXT_H"] = True
+                self._cmake.definitions["VIDEO_X11_XCURSOR"] = self.options.xcursor
+                if self.options.xcursor:
+                    self._cmake.definitions["HAVE_XCURSOR_H"] = True
+                self._cmake.definitions["VIDEO_X11_XINERAMA"] = self.options.xinerama
+                if self.options.xinerama:
+                    self._cmake.definitions["HAVE_XINERAMA_H"] = True
+                self._cmake.definitions["VIDEO_X11_XINPUT"] = self.options.xinput
+                if self.options.xinput:
+                    self._cmake.definitions["HAVE_XINPUT_H"] = True
+                self._cmake.definitions["VIDEO_X11_XRANDR"] = self.options.xrandr
+                if self.options.xrandr:
+                    self._cmake.definitions["HAVE_XRANDR_H"] = True
+                self._cmake.definitions["VIDEO_X11_XSCRNSAVER"] = self.options.xscrnsaver
+                if self.options.xscrnsaver:
+                    self._cmake.definitions["HAVE_XSS_H"] = True
+                self._cmake.definitions["VIDEO_X11_XSHAPE"] = self.options.xshape
+                if self.options.xshape:
+                    self._cmake.definitions["HAVE_XSHAPE_H"] = True
+                self._cmake.definitions["VIDEO_X11_XVM"] = self.options.xvm
+                if self.options.xvm:
+                    self._cmake.definitions["HAVE_XF86VM_H"] = True
+                self._cmake.definitions["VIDEO_WAYLAND"] = self.options.wayland
+                self._cmake.definitions["VIDEO_DIRECTFB"] = self.options.directfb
+                self._cmake.definitions["VIDEO_RPI"] = self.options.video_rpi
+            elif self.settings.os == "Windows":
+                self._cmake.definitions["DIRECTX"] = self.options.directx
+
+            self._cmake.configure(build_dir=self._build_subfolder)
+        return self._cmake
+
+    def _build_cmake(self):
+        if self.settings.os == "Linux":
+            if self.options.pulse:
+                tools.rename("libpulse.pc", "libpulse-simple.pc")
+        lib_paths = [lib for dep in self.deps_cpp_info.deps for lib in self.deps_cpp_info[dep].lib_paths]
+        with tools.environment_append({"LIBRARY_PATH": os.pathsep.join(lib_paths)}):
+            cmake = self._configure_cmake()
+            cmake.build()
+
+    def package(self):
+        self.copy(pattern="COPYING.txt", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "sdl2-config")
+        tools.rmdir(os.path.join(self.package_folder, "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "libdata"))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def _add_libraries_from_pc(self, library, static=None):
+        if static is None:
+            static = not self.options.shared
+        pkg_config = tools.PkgConfig(library, static=static)
+        libs = [lib[2:] for lib in pkg_config.libs_only_l]  # cut -l prefix
+        lib_paths = [lib[2:] for lib in pkg_config.libs_only_L]  # cut -L prefix
+        self.cpp_info.components["libsdl2"].libs.extend(libs)
+        self.cpp_info.components["libsdl2"].libdirs.extend(lib_paths)
+        self.cpp_info.components["libsdl2"].sharedlinkflags.extend(pkg_config.libs_only_other)
+        self.cpp_info.components["libsdl2"].exelinkflags.extend(pkg_config.libs_only_other)
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "SDL2"
+        self.cpp_info.names["cmake_find_package_multi"] = "SDL2"
+
+        postfix = "d" if self.settings.build_type == "Debug" else ""
+        # SDL2
+        sdl2_cmake_target = "SDL2" if self.options.shared else "SDL2-static"
+        self.cpp_info.components["libsdl2"].names["cmake_find_package"] = sdl2_cmake_target
+        self.cpp_info.components["libsdl2"].names["cmake_find_package_multi"] = sdl2_cmake_target
+        self.cpp_info.components["libsdl2"].includedirs.append(os.path.join("include", "SDL2"))
+        self.cpp_info.components["libsdl2"].libs = ["SDL2" + postfix]
+        if self.options.get_safe("iconv", False):
+            self.cpp_info.components["libsdl2"].requires.append("libiconv::libiconv")
+        if self.settings.os == "Linux":
+            self.cpp_info.components["libsdl2"].system_libs = ["dl", "rt", "pthread"]
+            self.cpp_info.components["libsdl2"].requires.append("xorg::xorg")
+            if self.options.alsa:
+                self.cpp_info.components["libsdl2"].requires.append("libalsa::libalsa")
+            if self.options.pulse:
+                self.cpp_info.components["libsdl2"].requires.append("pulseaudio::pulseaudio")
+            if self.options.opengl:
+                self.cpp_info.components["libsdl2"].requires.append("opengl::opengl")
+            if self.options.jack:
+                self._add_libraries_from_pc("jack")
+            if self.options.sndio:
+                self._add_libraries_from_pc("sndio")
+            if self.options.nas:
+                self.cpp_info.components["libsdl2"].libs.append("audio")
+            if self.options.esd:
+                self._add_libraries_from_pc("esound")
+            if self.options.directfb:
+                self._add_libraries_from_pc("directfb")
+            if self.options.video_rpi:
+                self.cpp_info.components["libsdl2"].libs.append("bcm_host")
+                self.cpp_info.components["libsdl2"].includedirs.extend([
+                    "/opt/vc/include",
+                    "/opt/vc/include/interface/vcos/pthreads",
+                    "/opt/vc/include/interface/vmcs_host/linux"
+                ])
+                self.cpp_info.components["libsdl2"].libdirs.append("/opt/vc/lib")
+                self.cpp_info.components["libsdl2"].sharedlinkflags.append("-Wl,-rpath,/opt/vc/lib")
+                self.cpp_info.components["libsdl2"].exelinkflags.append("-Wl,-rpath,/opt/vc/lib")
+        elif self.settings.os == "Macos":
+            self.cpp_info.components["libsdl2"].frameworks = ["Cocoa", "Carbon", "IOKit", "CoreVideo", "CoreAudio", "AudioToolbox", "ForceFeedback"]
+            if tools.Version(self.version) >= "2.0.14":
+                self.cpp_info.components["libsdl2"].frameworks.append("Metal")
+        elif self.settings.os == "Windows":
+            self.cpp_info.components["libsdl2"].system_libs = ["user32", "gdi32", "winmm", "imm32", "ole32", "oleaut32", "version", "uuid", "advapi32", "setupapi", "shell32"]
+            if self.settings.compiler == "gcc":
+                self.cpp_info.components["libsdl2"].system_libs.append("mingw32")
+        # SDL2main
+        if self.options.sdl2main:
+            self.cpp_info.components["sdl2main"].names["cmake_find_package"] = "SDL2main"
+            self.cpp_info.components["sdl2main"].names["cmake_find_package_multi"] = "SDL2main"
+            self.cpp_info.components["sdl2main"].libs = ["SDL2main" + postfix]
+            self.cpp_info.components["sdl2main"].requires = ["libsdl2"]

--- a/recipes/sdl2/all/test_package/CMakeLists.txt
+++ b/recipes/sdl2/all/test_package/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(SDL2 REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+if(SDL2_SHARED)
+  target_link_libraries(${PROJECT_NAME} SDL2::SDL2main SDL2::SDL2)
+else()
+  target_link_libraries(${PROJECT_NAME} SDL2::SDL2main SDL2::SDL2-static)
+endif()
+
+function(add_option option)
+    if(${option})
+        target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE "${option}")
+    endif()
+endfunction()
+
+add_option(WITH_X11)
+add_option(WITH_ALSA)
+add_option(WITH_PULSE)
+add_option(WITH_ESD)
+add_option(WITH_ARTS)
+add_option(WITH_DIRECTFB)
+add_option(WITH_DIRECTX)

--- a/recipes/sdl2/all/test_package/conanfile.py
+++ b/recipes/sdl2/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+from conans import ConanFile, CMake, tools, RunEnvironment
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        self.build_cmake()
+
+    def build_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["SDL2_SHARED"] = self.options["sdl2"].shared
+        if self.settings.os == "Linux":
+            cmake.definitions["WITH_X11"] = self.options["sdl2"].x11
+            cmake.definitions["WITH_ALSA"] = self.options["sdl2"].alsa
+            cmake.definitions["WITH_PULSE"] = self.options["sdl2"].pulse
+            cmake.definitions["WITH_ESD"] = self.options["sdl2"].esd
+            cmake.definitions["WITH_ARTS"] = self.options["sdl2"].arts
+            cmake.definitions["WITH_DIRECTFB"] = self.options["sdl2"].directfb
+        if self.settings.os == "Windows":
+            cmake.definitions["WITH_DIRECTX"] = self.options["sdl2"].directx
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/sdl2/all/test_package/test_package.cpp
+++ b/recipes/sdl2/all/test_package/test_package.cpp
@@ -1,0 +1,81 @@
+#include <SDL.h>
+#include <stdexcept>
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <cstdlib>
+
+static void throw_exception(const char * message, const char * name)
+{
+    std::stringstream s;
+    s << message << " - " << name;
+    throw std::runtime_error(s.str().c_str());
+}
+
+static void check_audio_driver(const char * name)
+{
+    std::cout << "checking for audio driver " << name << " ... ";
+    bool found = false;
+    int count = SDL_GetNumAudioDrivers();
+    for (int i = 0; i < count; ++i) {
+        if (0 == strcmp(name, SDL_GetAudioDriver(i))) {
+            found = true;
+            break;
+        }
+    }
+    if (!found)
+        throw_exception("audio driver wasn't found", name);
+    std::cout << "OK!" << std::endl;
+}
+
+static void check_video_driver(const char * name)
+{
+    std::cout << "checking for video driver " << name << " ... ";
+    bool found = false;
+    int count = SDL_GetNumVideoDrivers();
+    for (int i = 0; i < count; ++i) {
+        if (0 == strcmp(name, SDL_GetVideoDriver(i))) {
+            found = true;
+            break;
+        }
+    }
+    if (!found)
+        throw_exception("video driver wasn't found", name);
+    std::cout << "OK!" << std::endl;
+}
+
+
+int main(int argc, char *argv[]) try
+{
+    SDL_version v;
+    SDL_GetVersion(&v);
+    std::cout << "SDL version " << int(v.major) << "." << int(v.minor) << "." << int(v.patch) << std::endl;
+#ifdef WITH_X11
+    check_video_driver("x11");
+#endif
+#ifdef WITH_ALSA
+    check_audio_driver("alsa");
+#endif
+#ifdef WITH_PULSE
+    check_audio_driver("pulseaudio");
+#endif
+#ifdef WITH_ESD
+    check_audio_driver("esd");
+#endif
+#ifdef WITH_ARTS
+    check_audio_driver("arts");
+#endif
+#ifdef WITH_DIRECTFB
+    check_video_driver("directfb");
+#endif
+#ifdef WITH_DIRECTX
+    check_audio_driver("directsound");
+#endif
+    return EXIT_SUCCESS;
+}
+catch (std::runtime_error & e)
+{
+    std::cout << "FAIL!" << std::endl;
+    std::cerr << e.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/recipes/sdl2/config.yml
+++ b/recipes/sdl2/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.0.14":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **sdl2**

We feel like we did a mistake merging https://github.com/conan-io/conan-center-index/pull/5466 using `sdl` as a name. Version 2 is known elsewhere as `sdl2` and we think this name change is needed.

Next steps as follows:
 * Add new `sdl2` recipe (this PR)
 * Deprecate existing `sdl` recipe: create new revision with the deprecation notice.
 * Remove `sdl` from repository, in the future someone could contribute `sdl` (version 1)

ping @MartinDelille 