### PR TITLE
[argtable2][m1] Include missing header (error when building M1)

### DIFF
--- a/recipes/argtable2/all/conandata.yml
+++ b/recipes/argtable2/all/conandata.yml
@@ -8,3 +8,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/2.13-0002-msvc-nmake-accept-conan-flags.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/2.13-0003-armv8-build.patch"
+      base_path: "source_subfolder"

--- a/recipes/argtable2/all/patches/2.13-0003-armv8-build.patch
+++ b/recipes/argtable2/all/patches/2.13-0003-armv8-build.patch
@@ -1,0 +1,12 @@
+diff --git a/src/arg_int.c b/src/arg_int.c
+index 29c20e5..bc10012 100644
+--- a/src/arg_int.c
++++ b/src/arg_int.c
+@@ -30,6 +30,7 @@ USA.
+ 
+ #include "argtable2.h"
+ #include <limits.h>
++#include <ctype.h>
+ 
+ /* local error codes */
+ enum {EMINCOUNT=1,EMAXCOUNT,EBADINT,EOVERFLOW};


### PR DESCRIPTION
Specify library name and version:  **argtable2**

Although it is failing only for M1 build, I think it is safe to apply the new patch to all the versions.