### PR TITLE
[qt] Fixes for Qt5::Multimedia

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -970,7 +970,8 @@ Examples = bin/datadir/examples""")
         if self.options.qtmultimedia:
             _create_module("Multimedia", ["Network", "Gui", "openal::openal"])
             _create_module("MultimediaWidgets", ["Multimedia", "Widgets", "Gui"])
-            _create_module("MultimediaQuick", ["Multimedia", "Quick"])
+            if self.options.qtdeclarative and self.options.gui:
+                _create_module("MultimediaQuick", ["Multimedia", "Quick"])
             _create_plugin("QM3uPlaylistPlugin", "qtmultimedia_m3u", "playlistformats", [])
             if self.settings.os == "Linux":
                 _create_module("MultimediaGstTools", ["Multimedia", "MultimediaWidgets", "Gui"])

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -968,7 +968,7 @@ Examples = bin/datadir/examples""")
                 _create_plugin("QXInputGamepadBackendPlugin", "xinputgamepad", "gamepads", [])
 
         if self.options.qtmultimedia:
-            _create_module("Multimedia", ["Network", "Gui"])
+            _create_module("Multimedia", ["Network", "Gui", "openal::openal"])
             _create_module("MultimediaWidgets", ["Multimedia", "Widgets", "Gui"])
             _create_module("MultimediaQuick", ["Multimedia", "Quick"])
             _create_plugin("QM3uPlaylistPlugin", "qtmultimedia_m3u", "playlistformats", [])


### PR DESCRIPTION
Specify library name and version:  **qt/5.15.2**

Building Qt5 with the multimedia submodule is currently broken.

#5931 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
