### PR TITLE
[ninja] Crossbuilding can only be detected if both profiles are available

### DIFF
--- a/recipes/ninja/1.9.x/conanfile.py
+++ b/recipes/ninja/1.9.x/conanfile.py
@@ -19,7 +19,7 @@ class NinjaConan(ConanFile):
         del self.info.settings.compiler
 
     def validate(self):
-        if tools.cross_building(self, skip_x64_x86=True):
+        if hasattr(self, 'settings_build') and tools.cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building not implemented")
 
     def _build_vs(self):


### PR DESCRIPTION
Specify library name and version:  **ninja**

fixes https://github.com/conan-io/conan-center-index/issues/5948