### PR TITLE
[glib] Crossbuilding can only be detected if both profiles are provided

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -1,44 +1,28 @@
 sources:
   "2.65.0":
-    url: 
-      - "https://download.gnome.org/sources/glib/2.65/glib-2.65.0.tar.xz"
-      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.0/glib-2.65.0.tar.gz"
-    sha256: "b041e63cd0ac1fccb486374022ade040d907aad29b278e27d9e43e9294a6e7a3"
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.0/glib-2.65.0.tar.gz"
+    sha256: "60c82c8f3e45dff15815df08375f01638df9ee12271982d431295f0ab0e7779a"
   "2.65.1":
-    url: 
-      - "https://download.gnome.org/sources/glib/2.65/glib-2.65.1.tar.xz"
-      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.1/glib-2.65.1.tar.gz"
-    sha256: "bc63bf6c32713e0ee1dddc28e03f23b4a20c78bcb9a2c5b0f4eea41e46fb9cee"
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.1/glib-2.65.1.tar.gz"
+    sha256: "9a391abc24b90305588b022770bf44e0ab7f87af2fd260a015438a124e8fc7be"
   "2.65.2":
-    url: 
-      - "https://download.gnome.org/sources/glib/2.65/glib-2.65.2.tar.xz"
-      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.2/glib-2.65.2.tar.gz"
-    sha256: "445b1951eaa82d7a8af46bdff5dcc8030406db1ceeb0f0c3a88983f70152c555"
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.2/glib-2.65.2.tar.gz"
+    sha256: "346d4b29bf05e7b129a829b52ff917a9eb0e769d7c88ca775102256f9cf109ee"
   "2.65.3":
-    url: 
-      - "https://download.gnome.org/sources/glib/2.65/glib-2.65.3.tar.xz"
-      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.3/glib-2.65.3.tar.gz"
-    sha256: "efd894e4693068bca945cb20d168b088510fa24d48a577f5edaf3d55912c60c2"
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.3/glib-2.65.3.tar.gz"
+    sha256: "0fa5004fafe377b3d299c8f1d3ed03778fc1091a3f02ef9e837df977e50f2904"
   "2.66.0":
-    url: 
-      - "https://download.gnome.org/sources/glib/2.66/glib-2.66.0.tar.xz"
-      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.66.0/glib-2.66.0.tar.gz"
-    sha256: "c5a66bf143065648c135da4c943d2ac23cce15690fc91c358013b2889111156c"
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.66.0/glib-2.66.0.tar.gz"
+    sha256: "dd720b29bea359e74c93333e4a322cee20f94d499402aa83d187989fabcf04b0"
   "2.66.1":
-    url: 
-      - "https://download.gnome.org/sources/glib/2.66/glib-2.66.1.tar.xz"
-      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.66.1/glib-2.66.1.tar.gz"
-    sha256: "a269ffe69fbcc3a21ff1acb1b6146b2a5723499d6e2de33ae16ccb6d2438ef60"
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.66.1/glib-2.66.1.tar.gz"
+    sha256: "40e127273e464b82c2bec310a77c22f5a881a7af1ad6e27b287eee5442d6dfa8"
   "2.66.2":
-    url: 
-      - "https://download.gnome.org/sources/glib/2.66/glib-2.66.2.tar.xz"
-      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.66.2/glib-2.66.2.tar.gz"
-    sha256: "ec390bed4e8dd0f89e918f385e8d4cfd7470b1ef7c1ce93ec5c4fc6e3c6a17c4"
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.66.2/glib-2.66.2.tar.gz"
+    sha256: "2a02d8f9c7403ec577b08c16145fa70b683b562a2277b53f108209dc656058b6"
   "2.67.0":
-    url: 
-      - "https://download.gnome.org/sources/glib/2.67/glib-2.67.0.tar.xz"
-      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.0/glib-2.67.0.tar.gz"
-    sha256: "0b15e57ab6c2bb90ced4e24a1b0d8d6e9a13af8a70266751aa3a45baffeed7c1"
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.0/glib-2.67.0.tar.gz"
+    sha256: "a6df47c78dc8793dac80edecd9602c53a517ec2d30e9f7832a25eb554fa5ddb6"
   "2.67.1":
     url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.1/glib-2.67.1.tar.gz"
     sha256: "99861fb444a2801c1885c63504efb4cbff4d1acc0cf276c21f2c96f6b95020ad"

--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -1,27 +1,43 @@
 sources:
   "2.65.0":
-    url: "https://download.gnome.org/sources/glib/2.65/glib-2.65.0.tar.xz"
+    url: 
+      - "https://download.gnome.org/sources/glib/2.65/glib-2.65.0.tar.xz"
+      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.0/glib-2.65.0.tar.gz"
     sha256: "b041e63cd0ac1fccb486374022ade040d907aad29b278e27d9e43e9294a6e7a3"
   "2.65.1":
-    url: "https://download.gnome.org/sources/glib/2.65/glib-2.65.1.tar.xz"
+    url: 
+      - "https://download.gnome.org/sources/glib/2.65/glib-2.65.1.tar.xz"
+      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.1/glib-2.65.1.tar.gz"
     sha256: "bc63bf6c32713e0ee1dddc28e03f23b4a20c78bcb9a2c5b0f4eea41e46fb9cee"
   "2.65.2":
-    url: "https://download.gnome.org/sources/glib/2.65/glib-2.65.2.tar.xz"
+    url: 
+      - "https://download.gnome.org/sources/glib/2.65/glib-2.65.2.tar.xz"
+      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.2/glib-2.65.2.tar.gz"
     sha256: "445b1951eaa82d7a8af46bdff5dcc8030406db1ceeb0f0c3a88983f70152c555"
   "2.65.3":
-    url: "https://download.gnome.org/sources/glib/2.65/glib-2.65.3.tar.xz"
+    url: 
+      - "https://download.gnome.org/sources/glib/2.65/glib-2.65.3.tar.xz"
+      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.65.3/glib-2.65.3.tar.gz"
     sha256: "efd894e4693068bca945cb20d168b088510fa24d48a577f5edaf3d55912c60c2"
   "2.66.0":
-    url: "https://download.gnome.org/sources/glib/2.66/glib-2.66.0.tar.xz"
+    url: 
+      - "https://download.gnome.org/sources/glib/2.66/glib-2.66.0.tar.xz"
+      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.66.0/glib-2.66.0.tar.gz"
     sha256: "c5a66bf143065648c135da4c943d2ac23cce15690fc91c358013b2889111156c"
   "2.66.1":
-    url: "https://download.gnome.org/sources/glib/2.66/glib-2.66.1.tar.xz"
+    url: 
+      - "https://download.gnome.org/sources/glib/2.66/glib-2.66.1.tar.xz"
+      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.66.1/glib-2.66.1.tar.gz"
     sha256: "a269ffe69fbcc3a21ff1acb1b6146b2a5723499d6e2de33ae16ccb6d2438ef60"
   "2.66.2":
-    url: "https://download.gnome.org/sources/glib/2.66/glib-2.66.2.tar.xz"
+    url: 
+      - "https://download.gnome.org/sources/glib/2.66/glib-2.66.2.tar.xz"
+      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.66.2/glib-2.66.2.tar.gz"
     sha256: "ec390bed4e8dd0f89e918f385e8d4cfd7470b1ef7c1ce93ec5c4fc6e3c6a17c4"
   "2.67.0":
-    url: "https://download.gnome.org/sources/glib/2.67/glib-2.67.0.tar.xz"
+    url: 
+      - "https://download.gnome.org/sources/glib/2.67/glib-2.67.0.tar.xz"
+      - "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.0/glib-2.67.0.tar.gz"
     sha256: "0b15e57ab6c2bb90ced4e24a1b0d8d6e9a13af8a70266751aa3a45baffeed7c1"
   "2.67.1":
     url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.67.1/glib-2.67.1.tar.gz"

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -39,7 +39,7 @@ class GLibConan(ConanFile):
         return self.settings.compiler == "Visual Studio"
 
     def validate(self):
-        if tools.cross_building(self, skip_x64_x86=True):
+        if hasattr(self, 'settings_build') and tools.cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building not implemented")
 
     def configure(self):


### PR DESCRIPTION
Specify library name and version:  **glib**

I've moved to sources from gitlab.gnome.org, the other mirror was responding with a timeout.

Fix https://github.com/conan-io/conan-center-index/pull/5886
