### PR TITLE
capnproto headers

### DIFF
--- a/recipes/capnproto/all/conanfile.py
+++ b/recipes/capnproto/all/conanfile.py
@@ -153,19 +153,20 @@ function(CAPNP_GENERATE_CPP SOURCES HEADERS)""")
         self.cpp_info.names["cmake_find_package_multi"] = "CapnProto"
 
         components = [
-            {"name": "capnp", "requires": ["kj"]},
-            {"name": "capnp-json", "requires": ["capnp", "kj"]},
-            {"name": "capnp-rpc", "requires": ["capnp", "kj", "kj-async"]},
-            {"name": "capnpc", "requires": ["capnp", "kj"]},
-            {"name": "kj", "requires": []},
-            {"name": "kj-async", "requires": ["kj"]},
-            {"name": "kj-http", "requires": ["kj", "kj-async"]},
-            {"name": "kj-test", "requires": ["kj"]},
+            {"name": "capnp",      "libs": ["capnp"],      "requires": ["kj"]},
+            {"name": "capnp-json", "libs": ["capnp-json"], "requires": ["capnp", "kj"]},
+            {"name": "capnp-rpc",  "libs": ["capnp-rpc"],  "requires": ["capnp", "kj", "kj-async"]},
+            {"name": "capnpc",     "libs": ["capnpc"],     "requires": ["capnp", "kj"]},
+            {"name": "kj",         "libs": ["kj"],         "requires": []},
+            {"name": "kj-async",   "libs": ["kj-async"],   "requires": ["kj"]},
+            {"name": "kj-http",    "libs": ["kj-http"],    "requires": ["kj", "kj-async"]},
+            {"name": "kj-test",    "libs": ["kj-test"],    "requires": ["kj"]},
+            {"name": "headers",    "libs": [],             "requires": []},
         ]
         if self.options.get_safe("with_zlib"):
-            components.append({"name": "kj-gzip", "requires": ["kj", "kj-async", "zlib::zlib"]})
+            components.append({"name": "kj-gzip", "libs": ["kj-gzip"], "requires": ["kj", "kj-async", "zlib::zlib"]})
         if self.options.with_openssl:
-            components.append({"name": "kj-tls", "requires": ["kj", "kj-async", "openssl::openssl"]})
+            components.append({"name": "kj-tls", "libs": ["kj-tls"], "requires": ["kj", "kj-async", "openssl::openssl"]})
 
         for component in components:
             self._register_component(component)
@@ -188,5 +189,5 @@ function(CAPNP_GENERATE_CPP SOURCES HEADERS)""")
         self.cpp_info.components[name].names["cmake_find_package"] = name
         self.cpp_info.components[name].names["cmake_find_package_multi"] = name
         self.cpp_info.components[name].names["pkg_config"] = name
-        self.cpp_info.components[name].libs = [name]
+        self.cpp_info.components[name].libs = component["libs"]
         self.cpp_info.components[name].requires = component["requires"]


### PR DESCRIPTION
Specify library name and version:  **capnproto/all**

For cross compilation, I need a target that only provides the required headerfiles.
---
usage will be:
```python
    def generate(self):
        if self.settings.os != "Windows":
            deps = CMakeDeps(self)
            deps.build_context_activated = ["capnproto"]
            deps.build_context_build_modules = ["capnproto"]
            deps.generate()
```

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
