### PR TITLE
libusb: allow enable_udev option on Android and disable it by default

### DIFF
--- a/recipes/libusb/all/conanfile.py
+++ b/recipes/libusb/all/conanfile.py
@@ -35,9 +35,11 @@ class LibUSBConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+        if self.settings.os == "Android":
+            self.options.enable_udev = False
 
     def config_options(self):
-        if self.settings.os != "Linux":
+        if self.settings.os not in  ["Linux", "Android"]:
             del self.options.enable_udev
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -90,7 +92,7 @@ class LibUSBConan(ConanFile):
             self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
             configure_args = ["--enable-shared" if self.options.shared else "--disable-shared"]
             configure_args.append("--enable-static" if not self.options.shared else "--disable-static")
-            if self.settings.os == "Linux":
+            if self.settings.os in ["Linux", "Android"]:
                 configure_args.append("--enable-udev" if self.options.enable_udev else "--disable-udev")
             elif self._is_mingw:
                 if self.settings.arch == "x86_64":
@@ -144,6 +146,7 @@ class LibUSBConan(ConanFile):
         self.cpp_info.includedirs.append(os.path.join("include", "libusb-1.0"))
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")
+        if self.settings.os in ["Linux", "Android"]:
             if self.options.enable_udev:
                 self.cpp_info.system_libs.append("udev")
         elif self.settings.os == "Macos":


### PR DESCRIPTION
On Android, we have to disable udev when build with ndk.
To do that, enable_udev option should not be deleted on Android
and disable by default.

Specify library name and version:  **libusb/1.0.24**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
