### PR TITLE
serf: quote usage of sys.executable in SConstruct file

### DIFF
--- a/recipes/serf/all/conandata.yml
+++ b/recipes/serf/all/conandata.yml
@@ -13,3 +13,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0003-1.3.9-scons-msvc.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0004-1.3.9-scons-python-spaces.patch"
+      base_path: "source_subfolder"

--- a/recipes/serf/all/patches/0004-1.3.9-scons-python-spaces.patch
+++ b/recipes/serf/all/patches/0004-1.3.9-scons-python-spaces.patch
@@ -1,0 +1,17 @@
+conan-center-index/recipes/apr/all/patches/0004-1.3.9-scons-python-spaces.patch
+
+This corrects build failure if python is in a path with spaces,
+e.g. the default system-wide C:\Program Files\Python39
+
+The patch is a cherry-pick from upstream r1809132
+--- SConstruct.orig	2021-04-21 11:31:44.866021500 -0500
++++ SConstruct	2021-04-21 11:50:22.148062300 -0500
+@@ -159,7 +159,7 @@
+ 
+ env.Append(BUILDERS = {
+     'GenDef' : 
+-      Builder(action = sys.executable + ' build/gen_def.py $SOURCES > $TARGET',
++      Builder(action = '"%s" build/gen_def.py $SOURCES > $TARGET' % (sys.executable,),
+               suffix='.def', src_suffix='.h')
+   })
+ 


### PR DESCRIPTION
# serf/1.3.9

This corrects build failure if python is in a path with spaces,
e.g. the default system-wide C:\Program Files\Python39

The patch is a cherry-pick from upstream [r1809132](http://svn.apache.org/viewvc/serf/trunk/SConstruct?r1=1809132&r2=1809131&pathrev=1809132)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
