### PR TITLE
Add xege/20.08

### DIFF
--- a/recipes/xege/all/conandata.yml
+++ b/recipes/xege/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "20.08":
+    url: "https://github.com/wysaid/xege/archive/refs/tags/20.08.tar.gz"
+    sha256: "33bc63366d093902b5bc68d3d613ebd90e449bc22800b40f2dd98e2b5c44b88a"

--- a/recipes/xege/all/conanfile.py
+++ b/recipes/xege/all/conanfile.py
@@ -2,6 +2,7 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+
 class XegeConan(ConanFile):
     name = "xege"
     version = "20.08"
@@ -17,7 +18,8 @@ class XegeConan(ConanFile):
 
     def configure(self):
         if self.settings.os != "Windows":
-            raise ConanInvalidConfiguration("This library is only compatible for Windows")
+            raise ConanInvalidConfiguration(
+                "This library is only compatible for Windows")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/xege/all/conanfile.py
+++ b/recipes/xege/all/conanfile.py
@@ -1,0 +1,67 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+class XegeConan(ConanFile):
+    name = "xege"
+    version = "20.08"
+    license = "LGPLv2.1"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://xege.org/"
+    description = "Easy Graphics Engine, a lite graphics library in Windows"
+    topics = ("ege", "graphics", "gui")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False]}
+    default_options = {"shared": False}
+    generators = "cmake"
+
+    def configure(self):
+        if self.settings.os != "Windows":
+            raise ConanInvalidConfiguration("This library is only compatible for Windows")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, "source_subfolder")
+        # This small hack might be useful to guarantee proper /MT /MD linkage
+        # in MSVC if the packaged project doesn't have variables to set it
+        # properly
+#         tools.replace_in_file("hello/CMakeLists.txt", "PROJECT(HelloWorld)",
+#                               '''PROJECT(HelloWorld)
+# include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+# conan_basic_setup()''')
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(source_folder="source_subfolder")
+        cmake.build()
+
+        # Explicit way:
+        # self.run('cmake %s/hello %s'
+        #          % (self.source_folder, cmake.command_line))
+        # self.run("cmake --build . %s" % cmake.build_config)
+
+    def package(self):
+        self.copy("*.h", dst="include", src="source_subfolder/src")
+        self.copy("*.lib", dst="lib", keep_path=False)
+        self.copy("*.dll", dst="bin", keep_path=False)
+        self.copy("*.so", dst="lib", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
+        self.copy("LICENSE", dst="licenses", src="source_subfolder")
+
+    def package_info(self):
+        if self.settings.arch == "x86_64":
+            self.cpp_info.libs = ["graphics64"]
+        else:
+            self.cpp_info.libs = ["graphics"]
+        if self.settings.compiler == "gcc":
+            self.cpp_info.system_libs = [
+                "gdiplus",
+                "uuid",
+                "msimg32",
+                "gdi32",
+                "imm32",
+                "ole32",
+                "oleaut32",
+                "winmm"
+            ]

--- a/recipes/xege/all/test_package/CMakeLists.txt
+++ b/recipes/xege/all/test_package/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})
+
+if(MSYS OR MINGW)
+    target_link_libraries(example -static-libgcc -static-libstdc++)
+endif()
+
+# CTest is a testing tool that can be used to test your project.
+# enable_testing()
+# add_test(NAME example
+#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+#          COMMAND example)

--- a/recipes/xege/all/test_package/conanfile.py
+++ b/recipes/xege/all/test_package/conanfile.py
@@ -3,6 +3,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
+
 class XegeTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"

--- a/recipes/xege/all/test_package/conanfile.py
+++ b/recipes/xege/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+# Tested under MinGW-w64 32bit / 64bit and Visual Studio 2019.
+
+from conans import ConanFile, CMake, tools
+import os
+
+class XegeTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/xege/all/test_package/example.cpp
+++ b/recipes/xege/all/test_package/example.cpp
@@ -1,0 +1,16 @@
+#include <ege.h>
+
+using namespace ege;
+
+int main() {
+    initgraph(640, 480);
+    circle(120, 120, 100);
+    int i = 0;
+    while (is_run()) {
+        key_msg msg = getkey();
+        if (msg.msg == key_msg_char) {
+            xyprintf(0, i * 20, "%d", msg.key);
+            ++i;
+        }
+    }
+}

--- a/recipes/xege/config.yml
+++ b/recipes/xege/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "20.08":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **xege/20.08**

`xege`, or Easy Graphics Engine (EGE), is a graphics library in **Windows**. It implements most of the features of [BGI](https://en.wikipedia.org/wiki/Borland_Graphics_Interface). The reason this library was created is that some areas (China, India, etc.) still widely use BGI-like graphics libraries in education, but BGI has been eliminated. This library will be helpful for them.

I'm not the author of this library (the main authors of it are @misakamm and @wysaid). But I'd like to use this library in some projects which I prefer Conan as a package manager. 

*I've tested this package under Windows with MSVC and MinGW-w64.*

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
