### PR TITLE
add libnet/1.2

### DIFF
--- a/recipes/libnet/all/conandata.yml
+++ b/recipes/libnet/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.2":
+    sha256: caa4868157d9e5f32e9c7eac9461efeff30cb28357f7f6bf07e73933fb4edaa7
+    url: https://github.com/libnet/libnet/releases/download/v1.2/libnet-1.2.tar.gz

--- a/recipes/libnet/all/conanfile.py
+++ b/recipes/libnet/all/conanfile.py
@@ -1,0 +1,86 @@
+from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class LibnetConan(ConanFile):
+    name = "libnet"
+
+    description = "Libnet is an API to help with the construction and injection of network packets."
+    topics = ("conan", "libnet", "network")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://libnet.sourceforge.net/"
+    license = ["BSD-2-Clause"]
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+        if self.options.shared:
+            del self.options.fPIC
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            raise ConanInvalidConfiguration("libnet is not supported by Visual Studio")
+        if self.settings.os == "Windows" and self.options.shared:
+            raise ConanInvalidConfiguration("libnet can't be built as shared on Windows")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  strip_root=True, destination=self._source_subfolder)
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+
+        self._autotools = AutoToolsBuildEnvironment(self)
+
+        args = []
+        if self.options.shared:
+            args.extend(["--disable-static", "--enable-shared"])
+        else:
+            args.extend(["--disable-shared", "--enable-static"])
+
+        self._autotools.configure(configure_dir=self._source_subfolder, args=args)
+
+        return self._autotools
+
+    def build(self):
+        autotools = self._configure_autotools()
+        autotools.make()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+
+        autotools = self._configure_autotools()
+        autotools.install()
+
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+        os.unlink(os.path.join(self.package_folder, "lib", "libnet.la"))
+        os.unlink(os.path.join(self.package_folder, "lib", "pkgconfig", "libnet.pc"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["net"]
+        self.cpp_info.names["pkg_config"] = "libnet"
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.append("m")
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs.append("ws2_32")

--- a/recipes/libnet/all/conanfile.py
+++ b/recipes/libnet/all/conanfile.py
@@ -58,6 +58,7 @@ class LibnetConan(ConanFile):
             args.extend(["--disable-static", "--enable-shared"])
         else:
             args.extend(["--disable-shared", "--enable-static"])
+            args.append("--disable-doxygen-doc")
 
         self._autotools.configure(configure_dir=self._source_subfolder, args=args)
 

--- a/recipes/libnet/all/conanfile.py
+++ b/recipes/libnet/all/conanfile.py
@@ -38,7 +38,7 @@ class LibnetConan(ConanFile):
         del self.settings.compiler.cppstd
         if self.options.shared:
             del self.options.fPIC
-        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+        if self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration("libnet is not supported by Visual Studio")
         if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration("libnet can't be built as shared on Windows")

--- a/recipes/libnet/all/test_package/CMakeLists.txt
+++ b/recipes/libnet/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/libnet/all/test_package/conanfile.py
+++ b/recipes/libnet/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libnet/all/test_package/test_package.c
+++ b/recipes/libnet/all/test_package/test_package.c
@@ -1,0 +1,19 @@
+#include <libnet.h>
+#include <stdio.h>
+
+int main()
+{
+    libnet_t *l = NULL;
+    unsigned char enet_dst[6] = {0x0d, 0x0e, 0x0a, 0x0d, 0x00, 0x00};
+    libnet_ptag_t t = libnet_autobuild_ethernet(
+                        enet_dst,                   /* ethernet destination */
+                        ETHERTYPE_ARP,              /* protocol type */
+                        l);                         /* libnet handle */
+    if (t != (-1)) {
+        fprintf(stderr, "[-] Failed!\n");
+        return 1;
+    }
+
+    fprintf(stderr, "[+] Passed!\n");
+    return 0;
+}

--- a/recipes/libnet/config.yml
+++ b/recipes/libnet/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libnet/1.2**

Libnet is an API to help with the construction and injection of network packets. It provides a portable framework for low-level network packet writing and handling (use libnet in conjunction with libpcap and you can write some really cool stuff). Libnet includes packet creation at the IP layer and at the link layer as well as a host of supplementary and complementary functionality.

I'm not the author of the library. The maintainer is @troglobit. I use this library in some project and I would like to use the Conan as a packager manager.

fixes #5973

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
