### PR TITLE
testing libdb

### DIFF
--- a/recipes/libdb/all/conanfile.py
+++ b/recipes/libdb/all/conanfile.py
@@ -132,6 +132,7 @@ class LibdbConan(ConanFile):
         return self._msvc_platforms[str(self.settings.arch)]
 
     def _build_msvc(self):
+        # This seems to be broken for latest VS 16 2019 (16.10), even if it built in the past (16.4.4)
         projects = ["db", "db_sql", "db_stl"]
         if self.options.with_tcl:
             projects.append("db_tcl")


### PR DESCRIPTION
Specify library name and version:  **libdb/***

This library is no longer building at least in VS 16 2019, apparently the upgrades in the toolchain broke the build. It doesn't build anymore in clang 12 apparently.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
