### PR TITLE
qt 6: fix PrintSupport system dependency on Macos

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -886,6 +886,8 @@ class QtConan(ConanFile):
                 self.cpp_info.components["qtCore"].frameworks.append("Security")  # qtcore requires "_SecRequirementCreateWithString" and more, which are in "Security" framework
                 self.cpp_info.components["qtNetwork"].frameworks.append("SystemConfiguration")
                 self.cpp_info.components["qtNetwork"].frameworks.append("GSS")
+                if self.options.gui and self.options.widgets:
+                    self.cpp_info.components["qtPrintSupport"].system_libs.append("cups")
 
         self.cpp_info.components["qtCore"].builddirs.append(os.path.join("res","archdatadir","bin"))
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package"].append(self._cmake_executables_file)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Get link errors with Qt static (but not shared) in shared `qcustomplot` on Macos, which depends on `Qt::PrintSupport`:

```
Undefined symbols for architecture x86_64:
  "_ppdClose", referenced from:
      QCocoaPrintDevice::openPpdFile() in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
      QCocoaPrintDevice::~QCocoaPrintDevice() in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
  "_ppdFindMarkedChoice", referenced from:
      QCocoaPrintDevice::defaultInputSlot() const in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
      QCocoaPrintDevice::defaultOutputBin() const in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
  "_ppdFindOption", referenced from:
      QCocoaPrintDevice::QCocoaPrintDevice(QString const&) in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
      QCocoaPrintDevice::loadInputSlots() const in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
      QCocoaPrintDevice::defaultInputSlot() const in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
      QCocoaPrintDevice::loadOutputBins() const in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
      QCocoaPrintDevice::defaultOutputBin() const in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
      QCocoaPrintDevice::loadDuplexModes() const in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
      QCocoaPrintDevice::defaultColorMode() const in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
      ...
  "_ppdOpenFile", referenced from:
      QCocoaPrintDevice::openPpdFile() in libQt6PrintSupport.a(qcocoaprintdevice.mm.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

see https://github.com/qt/qtbase/blob/v6.1.1/src/printsupport/CMakeLists.txt#L47-L73

As you may see in Qt CMakeLists, recipe is not very neat for windows also (`PrintSupport` depends on `gdi32` and `user32`, and `comdlg32` + `winspool` as public dependencies), but I didn't see link errors when qt is static.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
