### PR TITLE
[corrade][xbuild] Requires 'corrade-rc' while crossbuilding

### DIFF
--- a/recipes/corrade/all/conanfile.py
+++ b/recipes/corrade/all/conanfile.py
@@ -80,6 +80,11 @@ class CorradeConan(ConanFile):
 
         return self._cmake
 
+
+    def build_requirements(self):
+        if hasattr(self, 'settings_build') and tools.cross_building(self.settings, skip_x64_x86=True):
+            self.build_requires("corrade/{}".format(self.version))
+
     def build(self):
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/corrade/all/conanfile.py
+++ b/recipes/corrade/all/conanfile.py
@@ -49,6 +49,8 @@ class CorradeConan(ConanFile):
             raise ConanInvalidConfiguration("Corrade requires Visual Studio version 14 or greater")
         if tools.cross_building(self):
             self.output.warn("This Corrade recipe could not be prepared for cross building")
+        if self.options.shared:
+            del self.options.fPIC
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **corrade**

It requires `corrade-rc` tool to cross-build.