### PR TITLE
magic_enum: add version 0.7.3

### DIFF
--- a/recipes/magic_enum/all/conandata.yml
+++ b/recipes/magic_enum/all/conandata.yml
@@ -14,3 +14,6 @@ sources:
   "0.7.2":
     url: "https://github.com/Neargye/magic_enum/archive/v0.7.2.tar.gz"
     sha256: "a77895ebc684f7a4dd2e4e06529b22e9ae694037f6dee0753d3ce0bbcd5b3e38"
+  "0.7.3":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.7.3.tar.gz"
+    sha256: "b8d0cd848546fee136dc1fa4bb021a1e4dc8fe98e44d8c119faa3ef387636bf7"

--- a/recipes/magic_enum/config.yml
+++ b/recipes/magic_enum/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "0.7.2":
     folder: all
+  "0.7.3":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **magic_enum/0.7.3**

closes #6010 

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
