### PR TITLE
oatpp-websocket: add version 1.2.5

### DIFF
--- a/recipes/oatpp-websocket/all/conandata.yml
+++ b/recipes/oatpp-websocket/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "1.2.0":
     url: "https://github.com/oatpp/oatpp-websocket/archive/1.2.0.tar.gz"
     sha256: "0100140a4580637e0397346ac19c58a3f5cd2e8f88649b70aac6fb072cce60ef"
+  "1.2.5":
+    url: "https://github.com/oatpp/oatpp-websocket/archive/1.2.5.tar.gz"
+    sha256: "b930034aaed40715ccc9b9df094292ea6e2a44f31bf830d1e15db5255ece9184"

--- a/recipes/oatpp-websocket/config.yml
+++ b/recipes/oatpp-websocket/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "1.2.0":
     folder: all
+  "1.2.5":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **oatpp-websocket/1.2.5**

closes #5971 

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
