### PR TITLE
Update POCO CMake wrapper cmake_minimum_required

### DIFF
--- a/recipes/poco/all/CMakeLists.txt
+++ b/recipes/poco/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.0)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)


### PR DESCRIPTION
POCO 1.10.1 already requires 3.5.0.

See also https://github.com/pocoproject/poco/blob/a9a3962590d48298055bba5d0b4c8794dedf5e13/CMakeLists.txt#L1 .

At least on my environment, 3.1 is required for distinguish Clang and AppleClang.

Specify library name and version:  poco/1.10.1

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [N/A] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
