### PR TITLE
oatpp-swagger: add version 1.2.5

### DIFF
--- a/recipes/oatpp-swagger/all/conandata.yml
+++ b/recipes/oatpp-swagger/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.5":
+    url: "https://github.com/oatpp/oatpp-swagger/archive/1.2.5.tar.gz"
+    sha256: "56dd44f3b041fe432c27b52f741bb98f1ef97b3c6c4095dc8b9d76e840639ac8"
   "1.2.0":
     url: "https://github.com/oatpp/oatpp-swagger/archive/1.2.0.tar.gz"
     sha256: "8457c9d6f13165428df66f8ff648d3970d0108d572cf8c42bb87122a05e507e6"

--- a/recipes/oatpp-swagger/config.yml
+++ b/recipes/oatpp-swagger/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.2.5":
+    folder: all
   "1.2.0":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **lib/1.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
