### PR TITLE
[gainput] Fix CMake condition

### DIFF
--- a/recipes/gainput/all/conandata.yml
+++ b/recipes/gainput/all/conandata.yml
@@ -6,3 +6,5 @@ patches:
   "1.0.0":
     - patch_file: "patches/0001-fix-cmake.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0002-fix-cmake-win32-condition.patch"
+      base_path: "source_subfolder"

--- a/recipes/gainput/all/patches/0002-fix-cmake-win32-condition.patch
+++ b/recipes/gainput/all/patches/0002-fix-cmake-win32-condition.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a443b66..2c920eb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,7 +9,7 @@ option(GAINPUT_TESTS "Build Tests for Gainput" ON)
+ option(GAINPUT_BUILD_SHARED "BUILD_SHARED" ON)
+ option(GAINPUT_BUILD_STATIC "BUILD_STATIC" ON)
+ 
+-if(!WIN32)
++if(NOT WIN32)
+ 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra")
+ else()
+ 	set(XINPUT "Xinput9_1_0")


### PR DESCRIPTION
Specify library name and version:  **gainput**

CMake condition `!WIN32` choose the wrong branch when building in Macos (at least)... and in a cross-building scenario the CMAKE_SYSTEM_VERSION is not defined and CMake configuration fails.