### PR TITLE
[libde265] SSE only in x86 and x86_64

### DIFF
--- a/recipes/libde265/all/conanfile.py
+++ b/recipes/libde265/all/conanfile.py
@@ -32,7 +32,7 @@ class Libde265Conan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if self.settings.arch in ["x86", "x86_64"]:
+        if self.settings.arch not in ["x86", "x86_64"]:
             del self.options.sse
 
     def configure(self):


### PR DESCRIPTION
Specify library name and version:  **libde265**

I applied wrong the comment from this review https://github.com/conan-io/conan-center-index/pull/6003#pullrequestreview-688532559 🤦 

> sse is supported on x86 and x86_64 only. I advice to delete this option in config_options if not x86 or x86_64, then rely on get_safe("sse", False"), otherwise you prevent to build libde256 out of the box since sse option is True by default.


ping @SpaceIm 
