### PR TITLE
Add args-parser library version 6.1.0.0.

### DIFF
--- a/recipes/args-parser/6.1.0.0/conandata.yml
+++ b/recipes/args-parser/6.1.0.0/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "6.1.0.0":
+    url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.1.0.0.tar.gz"
+    sha256: "f6fadc1458e8821160a287a7dd096e94a36f968ba9719fa2a7ce8cec6bfb6969"

--- a/recipes/args-parser/6.1.0.0/conanfile.py
+++ b/recipes/args-parser/6.1.0.0/conanfile.py
@@ -1,7 +1,6 @@
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
-import textwrap
 
 
 class ArgsParserConan(ConanFile):

--- a/recipes/args-parser/6.1.0.0/conanfile.py
+++ b/recipes/args-parser/6.1.0.0/conanfile.py
@@ -1,0 +1,56 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+import textwrap
+
+
+class ArgsParserConan(ConanFile):
+    name = "args-parser"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/igormironchik/args-parser"
+    license = "MIT"
+    description = "Small C++ header-only library for parsing command line arguments."
+    topics = ("conan", "args-parser", "argument", "parsing")
+    settings = "compiler"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "15",
+            "gcc": "5",
+            "clang": "3.5",
+            "apple-clang": "10"
+        }
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, "14")
+
+        compiler = str(self.settings.compiler)
+        if compiler not in self._compilers_minimum_version:
+            self.output.warn("Unknown compiler, assuming it supports at least C++14")
+            return
+
+        version = tools.Version(self.settings.compiler.version)
+        if version < self._compilers_minimum_version[compiler]:
+            raise ConanInvalidConfiguration("args-parser requires a compiler that supports at least C++14")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def package(self):
+        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
+        self.copy("*.hpp", src=os.path.join(self._source_subfolder, "args-parser"), dst=os.path.join("include", "args-parser"))
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "args-parser"
+        self.cpp_info.names["cmake_find_package_multi"] = "args-parser"
+        self.cpp_info.includedirs.append(os.path.join("include", "args-parser"))

--- a/recipes/args-parser/6.1.0.0/test_package/CMakeLists.txt
+++ b/recipes/args-parser/6.1.0.0/test_package/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(args-parser.test)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+
+conan_basic_setup(TARGETS)
+
+find_package(args-parser REQUIRED)
+
+add_executable(${PROJECT_NAME} example.cpp)
+
+target_link_libraries(${PROJECT_NAME} args-parser::args-parser)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED ON
+)

--- a/recipes/args-parser/6.1.0.0/test_package/conanfile.py
+++ b/recipes/args-parser/6.1.0.0/test_package/conanfile.py
@@ -1,0 +1,15 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class ArgsParserTestConan(ConanFile):
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "args-parser.test")
+            self.run(bin_path, run_environment=True)

--- a/recipes/args-parser/6.1.0.0/test_package/example.cpp
+++ b/recipes/args-parser/6.1.0.0/test_package/example.cpp
@@ -1,0 +1,24 @@
+#include <args-parser/all.hpp>
+
+int main()
+{
+    static const int argc = 2;
+    static const char * argv[argc] = {"args-parser.test", "-a"};
+
+    Args::CmdLine cmd(argc, argv);
+
+    try {
+        cmd.addArgWithFlagOnly('a');
+
+        cmd.parse();
+    }
+    catch(const Args::BaseException &)
+    {
+        return 1;
+    }
+
+    if(cmd.isDefined("-a"))
+        return 0;
+    else
+        return 1;
+}


### PR DESCRIPTION
Specify library name and version:  **args-parser/6.1.0.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

I'm the author of this library.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
