### PR TITLE
tcb-span: New package

### DIFF
--- a/recipes/tcb-span/all/conandata.yml
+++ b/recipes/tcb-span/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.0":
+    url: "https://github.com/alejandro-colomar/tcb-span/archive/v0.0.0.tar.gz"
+    sha256: "5b806cb92ac56249f2280be53cf1d82bb543b24560a3d02d8986565673828d22"

--- a/recipes/tcb-span/all/conandata.yml
+++ b/recipes/tcb-span/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.0.0":
-    url: "https://github.com/alejandro-colomar/tcb-span/archive/v0.0.0.tar.gz"
-    sha256: "5b806cb92ac56249f2280be53cf1d82bb543b24560a3d02d8986565673828d22"
+  "cci.20200603":
+    url: "https://github.com/tcbrindle/span/archive/5d8d366eca918d0ed3d2d196cbeae6abfd874736.tar.gz"
+    sha256: "c294ec2314eeccbcfe12b549ca6c165fbe9f97d2d52a0ad4c9a28f73fa87861a"

--- a/recipes/tcb-span/all/conanfile.py
+++ b/recipes/tcb-span/all/conanfile.py
@@ -18,7 +18,8 @@ class TcbSpanConan(ConanFile):
         return "source_subfolder"
 
     def configure(self):
-        tools.check_min_cppstd(self, "11")
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/tcb-span/all/conanfile.py
+++ b/recipes/tcb-span/all/conanfile.py
@@ -1,0 +1,32 @@
+from conans import ConanFile, tools
+import os
+import glob
+
+
+class TcbSpanConan(ConanFile):
+    name = "tcb-span"
+    description = "Implementation of C++20's std::span for older compilers"
+    topics = ("conan", "span", "header-only", "tcb-span")
+    homepage = "https://github.com/tcbrindle/span"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "BSL-1.0"
+    settings = "os", "compiler", "build_type", "arch"
+
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = glob.glob(self.name + "-*/")[0]
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        include_folder = os.path.join(self._source_subfolder, "include")
+        self.copy(pattern="LICENSE*.txt", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="*.hpp", dst="include", src=include_folder)
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/tcb-span/all/conanfile.py
+++ b/recipes/tcb-span/all/conanfile.py
@@ -9,7 +9,7 @@ class TcbSpanConan(ConanFile):
     homepage = "https://github.com/tcbrindle/span"
     url = "https://github.com/conan-io/conan-center-index"
     license = "BSL-1.0"
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "compiler"
 
     no_copy_source = True
 

--- a/recipes/tcb-span/all/conanfile.py
+++ b/recipes/tcb-span/all/conanfile.py
@@ -1,6 +1,5 @@
 from conans import ConanFile, tools
 import os
-import glob
 
 
 class TcbSpanConan(ConanFile):

--- a/recipes/tcb-span/all/conanfile.py
+++ b/recipes/tcb-span/all/conanfile.py
@@ -19,9 +19,8 @@ class TcbSpanConan(ConanFile):
         return "source_subfolder"
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = glob.glob(self.name + "-*/")[0]
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         include_folder = os.path.join(self._source_subfolder, "include")

--- a/recipes/tcb-span/all/conanfile.py
+++ b/recipes/tcb-span/all/conanfile.py
@@ -5,7 +5,7 @@ import glob
 
 class TcbSpanConan(ConanFile):
     name = "tcb-span"
-    description = "Implementation of C++20's std::span for older compilers"
+    description = "Implementation of C++20's std::span for older C++ standards"
     topics = ("conan", "span", "header-only", "tcb-span")
     homepage = "https://github.com/tcbrindle/span"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/tcb-span/all/conanfile.py
+++ b/recipes/tcb-span/all/conanfile.py
@@ -18,6 +18,9 @@ class TcbSpanConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    def configure(self):
+        tools.check_min_cppstd(self, "11")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)

--- a/recipes/tcb-span/all/test_package/CMakeLists.txt
+++ b/recipes/tcb-span/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+find_package(tcb-span REQUIRED)
+
+add_executable(test_package test_package.cxx)
+target_link_libraries(test_package tcb-span::tcb-span)

--- a/recipes/tcb-span/all/test_package/CMakeLists.txt
+++ b/recipes/tcb-span/all/test_package/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 project(test_package)
 
 find_package(tcb-span REQUIRED)

--- a/recipes/tcb-span/all/test_package/CMakeLists.txt
+++ b/recipes/tcb-span/all/test_package/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+project(test_package)
 
 find_package(tcb-span REQUIRED)
 

--- a/recipes/tcb-span/all/test_package/CMakeLists.txt
+++ b/recipes/tcb-span/all/test_package/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required(VERSION 3.1)
-
-set(CMAKE_CXX_STANDARD 17)
-
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
 
 find_package(tcb-span REQUIRED)
 
 add_executable(test_package test_package.cxx)
 target_link_libraries(test_package tcb-span::tcb-span)
+set_property(TARGET test_package PROPERTY CXX_STANDARD 17)

--- a/recipes/tcb-span/all/test_package/CMakeLists.txt
+++ b/recipes/tcb-span/all/test_package/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(tcb-span REQUIRED)
 
 add_executable(test_package test_package.cxx)

--- a/recipes/tcb-span/all/test_package/CMakeLists.txt
+++ b/recipes/tcb-span/all/test_package/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 
+set(CMAKE_CXX_STANDARD 17)
+
 project(test_package)
 
 find_package(tcb-span REQUIRED)

--- a/recipes/tcb-span/all/test_package/conanfile.py
+++ b/recipes/tcb-span/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.run("test_package", run_environment=True)

--- a/recipes/tcb-span/all/test_package/conanfile.py
+++ b/recipes/tcb-span/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake_find_package"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/tcb-span/all/test_package/conanfile.py
+++ b/recipes/tcb-span/all/test_package/conanfile.py
@@ -13,4 +13,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self.settings):
-            self.run("test_package", run_environment=True)
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/tcb-span/all/test_package/test_package.cxx
+++ b/recipes/tcb-span/all/test_package/test_package.cxx
@@ -1,6 +1,7 @@
 #include <tcb/span.hpp>
 
 #include <array>
+#include <cstddef>
 #include <cstdio>
 #include <vector>
 

--- a/recipes/tcb-span/all/test_package/test_package.cxx
+++ b/recipes/tcb-span/all/test_package/test_package.cxx
@@ -1,0 +1,21 @@
+#include <tcb/span.hpp>
+
+#include <array>
+#include <cstdio>
+#include <vector>
+
+std::ptrdiff_t size(tcb::span<const int> s)
+{
+	return s.size();
+}
+
+int main(void)
+{
+	int                carr[3] = {1, 3, 4};
+	std::array<int, 2> cxxarr = {1, 2};
+
+	printf("C-array: %ti\n", size(carr));
+	printf("array:   %ti\n", size(cxxarr));
+
+	return 0;
+}

--- a/recipes/tcb-span/config.yml
+++ b/recipes/tcb-span/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.0.0":
+    folder: all

--- a/recipes/tcb-span/config.yml
+++ b/recipes/tcb-span/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.0.0":
+  "cci.20200603":
     folder: all


### PR DESCRIPTION
**tcb-span/cci.20200603**

I based this package on trompeloeil and hedley,
which I found to be 2 header-only packages, like this one.

I removed the test_package folder from those, though.
That's something to be added.

The weird version number is because there is no upstream version (I asked for one), and to be able to package in the meantime, I created a version from my fork (which is at the same commit as upstream's master branch), and to avoid collision with future upstream versions, I called it 0.0.0.  See https://github.com/tcbrindle/span/issues/41

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
