### PR TITLE
Update vulkan-headers to 1.2.182

### DIFF
--- a/recipes/vulkan-headers/all/conandata.yml
+++ b/recipes/vulkan-headers/all/conandata.yml
@@ -83,3 +83,9 @@ sources:
   "1.2.176.0":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/sdk-1.2.176.0.tar.gz"
     sha256: "211d8552c5cf8b0607323d69c251d9c4639f89550f8de3d51d3995b5cdd737fb"
+  "1.2.176.0":
+    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/sdk-1.2.176.0.tar.gz"
+    sha256: "211d8552c5cf8b0607323d69c251d9c4639f89550f8de3d51d3995b5cdd737fb"
+  "1.2.182":
+    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.2.182.tar.gz"
+    sha256: "38d1c953de7bb2d839556226851feeb690f0d23bc22ac46c823dcb66c97bfdc8"

--- a/recipes/vulkan-headers/config.yml
+++ b/recipes/vulkan-headers/config.yml
@@ -55,3 +55,7 @@ versions:
     folder: all
   "1.2.176.0":
     folder: all
+  "1.2.176.0":
+    folder: all
+  "1.2.182":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **vulkan-headers/1.2.182**

Added version 1.2.176.0 (sdk) and 1.2.182 to vulkan-headers
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
