### PR TITLE
MacOS ARM support  for nodejs architecture

### DIFF
--- a/recipes/nodejs/all/conandata.yml
+++ b/recipes/nodejs/all/conandata.yml
@@ -1,31 +1,43 @@
 sources:
   "12.14.1":
       Windows:
-          url: "https://nodejs.org/dist/v12.14.1/node-v12.14.1-win-x64.zip"
-          sha256: "1f96ccce3ba045ecea3f458e189500adb90b8bc1a34de5d82fc10a5bf66ce7e3"
+          "x86_64":
+              url: "https://nodejs.org/dist/v12.14.1/node-v12.14.1-win-x64.zip"
+              sha256: "1f96ccce3ba045ecea3f458e189500adb90b8bc1a34de5d82fc10a5bf66ce7e3"
       Linux:
-          url: "https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-x64.tar.xz"
-          sha256: "07cfcaa0aa9d0fcb6e99725408d9e0b07be03b844701588e3ab5dbc395b98e1b"
+          "x86_64":
+              url: "https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-x64.tar.xz"
+              sha256: "07cfcaa0aa9d0fcb6e99725408d9e0b07be03b844701588e3ab5dbc395b98e1b"
       Macos:
-          url: "https://nodejs.org/dist/v12.14.1/node-v12.14.1-darwin-x64.tar.gz"
-          sha256: "0be10a28737527a1e5e3784d3ad844d742fe8b0718acd701fd48f718fd3af78f"
+          "x86_64":
+              url: "https://nodejs.org/dist/v12.14.1/node-v12.14.1-darwin-x64.tar.gz"
+              sha256: "0be10a28737527a1e5e3784d3ad844d742fe8b0718acd701fd48f718fd3af78f"
   "13.6.0":
       Windows:
-          url: "https://nodejs.org/dist/v13.6.0/node-v13.6.0-win-x64.zip"
-          sha256: "7fe37b34a4673a071bea52fcaf913ec422cf6fd79fd025bfb22de42ccc77f386"
+         "x86_64":
+              url: "https://nodejs.org/dist/v13.6.0/node-v13.6.0-win-x64.zip"
+              sha256: "7fe37b34a4673a071bea52fcaf913ec422cf6fd79fd025bfb22de42ccc77f386"
       Linux:
-          url: "https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-x64.tar.xz"
-          sha256: "00f01315a867da16d1638f7a02966c608e344ac6c5b7d04d1fdae3138fa9d798"
+          "x86_64":
+              url: "https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-x64.tar.xz"
+              sha256: "00f01315a867da16d1638f7a02966c608e344ac6c5b7d04d1fdae3138fa9d798"
       Macos:
-          url: "https://nodejs.org/dist/v13.6.0/node-v13.6.0-darwin-x64.tar.gz"
-          sha256: "da13adb864777b322dda7af20410a9b0c63aa69de4b5574008d1e6910768bf69"
+          "x86_64":
+              url: "https://nodejs.org/dist/v13.6.0/node-v13.6.0-darwin-x64.tar.gz"
+              sha256: "da13adb864777b322dda7af20410a9b0c63aa69de4b5574008d1e6910768bf69"
   "16.3.0":
       Windows:
-          url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-win-x64.zip"
-          sha256: "3352e58d3603cf58964409d07f39f3816285317d638ddb0a0bf3af5deb2ff364"
+          "x86_64":
+              url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-win-x64.zip"
+              sha256: "3352e58d3603cf58964409d07f39f3816285317d638ddb0a0bf3af5deb2ff364"
       Linux:
-          url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-x64.tar.xz"
-          sha256: "5347ece975747e4d9768d4ed3f8b2220c955ac01f8a695347cd7f71ff5efa318"
+          "x86_64":
+              url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-x64.tar.xz"
+              sha256: "5347ece975747e4d9768d4ed3f8b2220c955ac01f8a695347cd7f71ff5efa318"
       Macos:
-          url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-x64.tar.gz"
-          sha256: "3e075bcfb6130dda84bfd04633cb228ec71e72d9a844c57efb7cfff130b4be89"
+          "x86_64":
+              url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-x64.tar.gz"
+              sha256: "3e075bcfb6130dda84bfd04633cb228ec71e72d9a844c57efb7cfff130b4be89"
+          "armv8":
+              url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-arm64.tar.gz"
+              sha256: "aeac294dbe54a4dfd222eedfbae704b185c40702254810e2c5917f6dbc80e017"

--- a/recipes/nodejs/all/conanfile.py
+++ b/recipes/nodejs/all/conanfile.py
@@ -20,11 +20,13 @@ class NodejsConan(ConanFile):
         return os.path.join(self.source_folder, "source_subfolder")
 
     def validate(self):
-        if self.settings.arch != "x86_64":
-            raise ConanInvalidConfiguration("Only x86_64 binaries are available")
+        if (not (self.version in self.conan_data["sources"]) or
+            not (str(self.settings.os) in self.conan_data["sources"][self.version]) or
+            not (str(self.settings.arch) in self.conan_data["sources"][self.version][str(self.settings.os)] ) ):
+            raise ConanInvalidConfiguration("Binaries for this combination of architecture/version/os not available")
 
     def build(self):
-        tools.get(**self.conan_data["sources"][self.version][str(self.settings.os)], destination=self._source_subfolder, strip_root=True)
+        tools.get(**self.conan_data["sources"][self.version][str(self.settings.os)][str(self.settings.arch)], destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)


### PR DESCRIPTION
Specify library name and version:  **nodejs/16.3.0**

This is also a good place to share with all of us **why you are submitting this PR** 

Adds multiple architecture support for the nodejs recipe. Needed for our use-case to support M1 Macbooks

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
