### PR TITLE
wayland: bump requirement

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -41,6 +41,8 @@ class WaylandConan(ConanFile):
         del self.settings.compiler.cppstd
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("Wayland can be built on Linux only")
+        if self.options.shared:
+            del self.options.fPIC
 
     def requirements(self):
         if self.options.enable_libraries:

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -47,15 +47,14 @@ class WaylandConan(ConanFile):
             self.requires("libffi/3.3")
         if self.options.enable_dtd_validation:
             self.requires("libxml2/2.9.10")
-        self.requires("expat/2.2.10")
+        self.requires("expat/2.4.1")
 
     def build_requirements(self):
-        self.build_requires("meson/0.57.1")
+        self.build_requires("meson/0.58.1")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "wayland-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  strip_root=True, destination=self._source_subfolder)
 
     def _patch_sources(self):
         tools.replace_in_file(os.path.join(self._source_subfolder, "meson.build"),


### PR DESCRIPTION
to fix conflict on expat with fontconfig

Specify library name and version:  **wayland/***

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
