### PR TITLE
miniz: add 2.2.0 + delete fPIC if shared + include miniz_zip.h in 2.1.0 + modernize recipe

### DIFF
--- a/recipes/miniz/all/CMakeLists.txt
+++ b/recipes/miniz/all/CMakeLists.txt
@@ -4,8 +4,4 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
-if(WIN32 AND BUILD_SHARED_LIBS)
-  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-endif(WIN32 AND BUILD_SHARED_LIBS)
-
 add_subdirectory("source_subfolder")

--- a/recipes/miniz/all/conandata.yml
+++ b/recipes/miniz/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.0":
+    url: "https://github.com/richgel999/miniz/archive/refs/tags/2.2.0.tar.gz"
+    sha256: "bd1136d0a1554520dcb527a239655777148d90fd2d51cf02c36540afc552e6ec"
   "2.1.0":
     url: "https://github.com/richgel999/miniz/archive/2.1.0.tar.gz"
     sha256: "95f9b23c92219ad2670389a23a4ed5723b7329c82c3d933b7047673ecdfc1fea"

--- a/recipes/miniz/all/conandata.yml
+++ b/recipes/miniz/all/conandata.yml
@@ -11,3 +11,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/2.1.0/002-fix-shared-windows.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/2.1.0/003-include-miniz_zip.patch"
+      base_path: "source_subfolder"

--- a/recipes/miniz/all/conandata.yml
+++ b/recipes/miniz/all/conandata.yml
@@ -2,8 +2,9 @@ sources:
   "2.1.0":
     url: "https://github.com/richgel999/miniz/archive/2.1.0.tar.gz"
     sha256: "95f9b23c92219ad2670389a23a4ed5723b7329c82c3d933b7047673ecdfc1fea"
-
 patches:
   "2.1.0":
     - patch_file: "patches/2.1.0/001-remove-examples.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/2.1.0/002-fix-shared-windows.patch"
       base_path: "source_subfolder"

--- a/recipes/miniz/all/conanfile.py
+++ b/recipes/miniz/all/conanfile.py
@@ -62,5 +62,5 @@ class MinizConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = ["miniz"]
         self.cpp_info.includedirs = ["include", os.path.join("include", "miniz")]

--- a/recipes/miniz/all/conanfile.py
+++ b/recipes/miniz/all/conanfile.py
@@ -31,6 +31,8 @@ class MinizConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 

--- a/recipes/miniz/all/conanfile.py
+++ b/recipes/miniz/all/conanfile.py
@@ -55,7 +55,6 @@ class MinizConan(ConanFile):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        self.copy(pattern="*.dll", dst="bin", src=os.path.join(self._build_subfolder, "bin"), keep_path=False)
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/miniz/all/conanfile.py
+++ b/recipes/miniz/all/conanfile.py
@@ -1,5 +1,8 @@
-import os
 from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
 
 class MinizConan(ConanFile):
     name = "miniz"
@@ -37,8 +40,8 @@ class MinizConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/miniz/all/conanfile.py
+++ b/recipes/miniz/all/conanfile.py
@@ -47,6 +47,12 @@ class MinizConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        if tools.Version(self.version) >= "2.2.0":
+            self._cmake.definitions["BUILD_EXAMPLES"] = False
+            self._cmake.definitions["BUILD_FUZZERS"] = False
+            self._cmake.definitions["AMALGAMATE_SOURCES"] = False
+            self._cmake.definitions["BUILD_HEADER_ONLY"] = False
+            self._cmake.definitions["INSTALL_PROJECT"] = True
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
@@ -60,7 +66,12 @@ class MinizConan(ConanFile):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "miniz"
+        self.cpp_info.names["cmake_find_package_multi"] = "miniz"
+        self.cpp_info.names["pkg_config"] = "miniz"
         self.cpp_info.libs = ["miniz"]
         self.cpp_info.includedirs = ["include", os.path.join("include", "miniz")]

--- a/recipes/miniz/all/patches/2.1.0/001-remove-examples.patch
+++ b/recipes/miniz/all/patches/2.1.0/001-remove-examples.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f3e453a..65ca6de 100644
+index f3e453a..4d8d385 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -15,31 +15,6 @@ set(miniz_SOURCE miniz.c miniz_zip.c miniz_tinfl.c miniz_tdef.c)
@@ -34,10 +34,3 @@ index f3e453a..65ca6de 100644
  
  # add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
  # target_link_libraries(miniz_tester miniz)
-@@ -49,4 +24,4 @@ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
-     LIBRARY DESTINATION lib
-     )
- file(GLOB INSTALL_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
--install(FILES ${INSTALL_HEADERS} DESTINATION include/${PROJECT_NAME})
-\ No newline at end of file
-+install(FILES ${INSTALL_HEADERS} DESTINATION include/${PROJECT_NAME})

--- a/recipes/miniz/all/patches/2.1.0/002-fix-shared-windows.patch
+++ b/recipes/miniz/all/patches/2.1.0/002-fix-shared-windows.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4d8d385..7db30dc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ PROJECT(miniz C)
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.4)
+ if(CMAKE_BUILD_TYPE STREQUAL "")
+   # CMake defaults to leaving CMAKE_BUILD_TYPE empty. This screws up
+   # differentiation between debug and release builds.
+@@ -14,12 +14,14 @@ set(miniz_SOURCE miniz.c miniz_zip.c miniz_tinfl.c miniz_tdef.c)
+ 
+ add_library(miniz ${miniz_SOURCE})
+ target_include_directories(miniz PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
++set_property(TARGET miniz PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ 
+ 
+ # add_executable(miniz_tester ${MINIZ_TESTER_SRC_LIST})
+ # target_link_libraries(miniz_tester miniz)
+ 
+ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Targets
++    RUNTIME DESTINATION bin
+     ARCHIVE  DESTINATION lib
+     LIBRARY DESTINATION lib
+     )

--- a/recipes/miniz/all/patches/2.1.0/003-include-miniz_zip.patch
+++ b/recipes/miniz/all/patches/2.1.0/003-include-miniz_zip.patch
@@ -1,0 +1,8 @@
+--- a/miniz.h
++++ b/miniz.h
+@@ -475,3 +475,5 @@ typedef void *const voidpc;
+ #ifdef __cplusplus
+ }
+ #endif
++
++#include "miniz_zip.h"

--- a/recipes/miniz/all/test_package/CMakeLists.txt
+++ b/recipes/miniz/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(miniz REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} miniz::miniz)

--- a/recipes/miniz/all/test_package/conanfile.py
+++ b/recipes/miniz/all/test_package/conanfile.py
@@ -3,8 +3,8 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/miniz/config.yml
+++ b/recipes/miniz/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.2.0":
+    folder: all
   "2.1.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **miniz/2.2.0**

closes https://github.com/conan-io/conan-center-index/issues/5872

I moved specific fix of 2.1.0 in a patch, to keep conanfile and CMake wrapper as generic as possible.
Since 2.2.0:
- CMake target is exported in a config file, and a pkgconfig file is created.
- several CMake options were added to avoid to build examples, tests etc

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
