### PR TITLE
sdl: sdl on Android links to system liblog library

### DIFF
--- a/recipes/sdl/all/conandata.yml
+++ b/recipes/sdl/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "2.0.14":
     url: "https://www.libsdl.org/release/SDL2-2.0.14.tar.gz"
     sha256: d8215b571a581be1332d2106f8036fcb03d12a70bae01e20f424976d275432bc
+patches:
+  "2.0.14":
+    - patch_file: "patches/2.0.14-0001-don-t-build-hidapi-as-shared.patch"
+      base_path: "source_subfolder"

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -314,6 +314,8 @@ class SDLConan(ConanFile):
             self.cpp_info.components["libsdl2"].system_libs.extend(["android", "log"])
             self.cpp_info.components["hidapi"].libs = ["hidapi"]
             self.cpp_info.components["libsdl2"].requires.append("hidapi")
+            if self.options.opengles:
+                self.cpp_info.components["libsdl2"].system_libs.extend(["GLESv1_CM", "GLESv2"])
         # SDL2main
         if self.options.sdl2main:
             self.cpp_info.components["sdl2main"].names["cmake_find_package"] = "SDL2main"

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -311,7 +311,9 @@ class SDLConan(ConanFile):
             if self.settings.compiler == "gcc":
                 self.cpp_info.components["libsdl2"].system_libs.append("mingw32")
         elif self.settings.os == "Android":
-            self.cpp_info.components["libsdl2"].system_libs.append("log")
+            self.cpp_info.components["libsdl2"].system_libs.extend(["android", "log"])
+            self.cpp_info.components["hidapi"].libs = ["hidapi"]
+            self.cpp_info.components["libsdl2"].requires.append("hidapi")
         # SDL2main
         if self.options.sdl2main:
             self.cpp_info.components["sdl2main"].names["cmake_find_package"] = "SDL2main"

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -310,6 +310,8 @@ class SDLConan(ConanFile):
             self.cpp_info.components["libsdl2"].system_libs = ["user32", "gdi32", "winmm", "imm32", "ole32", "oleaut32", "version", "uuid", "advapi32", "setupapi", "shell32"]
             if self.settings.compiler == "gcc":
                 self.cpp_info.components["libsdl2"].system_libs.append("mingw32")
+        elif self.settings.os == "Android":
+            self.cpp_info.components["libsdl2"].system_libs.append("log")
         # SDL2main
         if self.options.sdl2main:
             self.cpp_info.components["sdl2main"].names["cmake_find_package"] = "SDL2main"

--- a/recipes/sdl/all/patches/2.0.14-0001-don-t-build-hidapi-as-shared.patch
+++ b/recipes/sdl/all/patches/2.0.14-0001-don-t-build-hidapi-as-shared.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -2253,7 +2253,7 @@
+ 
+ if(ANDROID)
+   if(HAVE_HIDAPI)
+-    add_library(hidapi SHARED ${SDL2_SOURCE_DIR}/src/hidapi/android/hid.cpp)
++    add_library(hidapi ${SDL2_SOURCE_DIR}/src/hidapi/android/hid.cpp)
+   endif()
+ 
+   if(MSVC AND NOT LIBC)

--- a/recipes/sdl/all/test_package/CMakeLists.txt
+++ b/recipes/sdl/all/test_package/CMakeLists.txt
@@ -2,15 +2,15 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(SDL2 REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 if(SDL2_SHARED)
-  target_link_libraries(${PROJECT_NAME} SDL2::SDL2main SDL2::SDL2)
+    target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2)
 else()
-  target_link_libraries(${PROJECT_NAME} SDL2::SDL2main SDL2::SDL2-static)
+    target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2-static)
 endif()
 
 function(add_option option)

--- a/recipes/sdl/all/test_package/test_package.cpp
+++ b/recipes/sdl/all/test_package/test_package.cpp
@@ -1,3 +1,4 @@
+#define SDL_MAIN_HANDLED
 #include <SDL.h>
 #include <stdexcept>
 #include <string>
@@ -47,6 +48,7 @@ static void check_video_driver(const char * name)
 
 int main(int argc, char *argv[]) try
 {
+    SDL_SetMainReady();
     SDL_version v;
     SDL_GetVersion(&v);
     std::cout << "SDL version " << int(v.major) << "." << int(v.minor) << "." << int(v.patch) << std::endl;


### PR DESCRIPTION
Specify library name and version:  **sdl/all**

Fixes linking errors when using the library + fixes building the test_package.

---


Fixes this linking error when using `android-ndk`:

```
ld: error: undefined symbol: __android_log_write
>>> referenced by SDL_log.c:401 (/home/maarten/.conan/data/sdl/2.0.14/_/_/build/df4384d55b48b7b842e1f0677a652ed56d2c8b82/source_subfolder/src/SDL_log.c:401)
>>>               SDL_log.c.o:(SDL_LogOutput) in archive /home/maarten/.conan/data/sdl/2.0.14/_/_/package/df4384d55b48b7b842e1f0677a652ed56d2c8b82/lib/libSDL2.a
```

Location of API: https://developer.android.com/ndk/guides/stable_apis#logging

This type of error is also fixed:
```
ld: error: undefined symbol: ANativeWindow_fromSurface
>>> referenced by SDL_android.c:1377 (/home/maarten/.conan/data/sdl/2.0.14/_/_/build/8943b2de26e38068facb73fc7665f59fad8efc9e/source_subfolder/src/core/android/SDL_android.c:1377)
>>>               SDL_android.c.o:(Android_JNI_GetNativeWindow) in archive /home/maarten/.conan/data/sdl/2.0.14/_/_/package/8943b2de26e38068facb73fc7665f59fad8efc9e/lib/libSDL2.a
```

As is this:
```
ld: error: undefined symbol: hid_init
>>> referenced by SDL_hidapijoystick.c:598 (/home/maarten/.conan/data/sdl/2.0.14/_/_/build/8943b2de26e38068facb73fc7665f59fad8efc9e/source_subfolder/src/joystick/hidapi/SDL_hidapijoystick.c:598)
>>>               SDL_hidapijoystick.c.o:(HIDAPI_JoystickInit) in archive /home/maarten/.conan/data/sdl/2.0.14/_/_/package/8943b2de26e38068facb73fc7665f59fad8efc9e/lib/libSDL2.a
```

These type errors are fixed too:
```
ld: error: undefined symbol: glBindTexture
>>> referenced by SDL_glesfuncs.h:22 (/home/maarten/.conan/data/sdl/2.0.14/_/_/build/df4384d55b48b7b842e1f0677a652ed56d2c8b82/source_subfolder/src/render/opengles/SDL_glesfuncs.h:22)
>>>               SDL_render_gles.c.o:(GLES_CreateRenderer) in archive /home/maarten/.conan/data/sdl/2.0.14/_/_/package/df4384d55b48b7b842e1f0677a652ed56d2c8b82/lib/libSDL2.a
>>> referenced by SDL_glesfuncs.h:22 (/home/maarten/.conan/data/sdl/2.0.14/_/_/build/df4384d55b48b7b842e1f0677a652ed56d2c8b82/source_subfolder/src/render/opengles/SDL_glesfuncs.h:22)
>>>               SDL_render_gles.c.o:(GLES_CreateRenderer) in archive /home/maarten/.conan/data/sdl/2.0.14/_/_/package/df4384d55b48b7b842e1f0677a652ed56d2c8b82/lib/libSDL2.a
>>> referenced by SDL_gles2funcs.h:25 (/home/maarten/.conan/data/sdl/2.0.14/_/_/build/df4384d55b48b7b842e1f0677a652ed56d2c8b82/source_subfolder/src/render/opengles2/SDL_gles2funcs.h:25)
>>>               SDL_render_gles2.c.o:(GLES2_CreateRenderer) in archive /home/maarten/.conan/data/sdl/2.0.14/_/_/package/df4384d55b48b7b842e1f0677a652ed56d2c8b82/lib/libSDL2.a
>>> referenced 1 more times

ld: error: undefined symbol: glBlendFunc
>>> referenced by SDL_glesfuncs.h:23 (/home/maarten/.conan/data/sdl/2.0.14/_/_/build/df4384d55b48b7b842e1f0677a652ed56d2c8b82/source_subfolder/src/render/opengles/SDL_glesfuncs.h:23)
>>>               SDL_render_gles.c.o:(GLES_CreateRenderer) in archive /home/maarten/.conan/data/sdl/2.0.14/_/_/package/df4384d55b48b7b842e1f0677a652ed56d2c8b82/lib/libSDL2.a
>>> referenced by SDL_glesfuncs.h:23 (/home/maarten/.conan/data/sdl/2.0.14/_/_/build/df4384d55b48b7b842e1f0677a652ed56d2c8b82/source_subfolder/src/render/opengles/SDL_glesfuncs.h:23)
>>>               SDL_render_gles.c.o:(GLES_CreateRenderer) in archive /home/maarten/.conan/data/sdl/2.0.14/_/_/package/df4384d55b48b7b842e1f0677a652ed56d2c8b82/lib/libSDL2.a
```



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
