### PR TITLE
openssl: add option to enable weak ciphers

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -74,6 +74,7 @@ class OpenSSLConan(ConanFile):
                "shared": [True, False],
                "fPIC": [True, False],
                "no_asm": [True, False],
+               "enable_weak_ssl_ciphers": [True, False],
                "386": [True, False],
                "no_sse2": [True, False],
                "no_bf": [True, False],


### PR DESCRIPTION
Specify library name and version:  **openssl/1.x.x**

Added a missing configure option:

- **enable-weak-ssl-ciphers**  _Enable weak ciphers that are disabled by default._

This is useful when you need to interact with old client/servers.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
