### PR TITLE
hipony-enumerate: add version 2.4.0

### DIFF
--- a/recipes/hipony-enumerate/all/conandata.yml
+++ b/recipes/hipony-enumerate/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.4.0":
+    url: "https://github.com/hipony/enumerate/archive/v2.4.0.tar.gz"
+    sha256: "21ee64fc3b1fda25356df0ee0e0292b529bb9b99931ee2b388222d2f498d7a45"
   "2.2.1":
     url: "https://github.com/hipony/enumerate/archive/refs/tags/v2.2.1.zip"
     sha256: "0b6e208007fc0cdffe7f23686faddf5c2bc06f6794bacf2e612197e1e54140e7"

--- a/recipes/hipony-enumerate/config.yml
+++ b/recipes/hipony-enumerate/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.4.0":
+    folder: "all"
   "2.2.1":
     folder: "all"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **hipony-enumerate/2.4.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
