### PR TITLE
[xerces-c/all] Add missing quotes in recipe

### DIFF
--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -27,7 +27,7 @@ class XercesCConan(ConanFile):
         return "build_subfolder"
     
     def validate(self):
-        if self.options.char_type == "wchar_t" and self.settings.os != Windows:
+        if self.options.char_type == "wchar_t" and self.settings.os != "Windows":
             raise ConanInvalidConfiguration("Option 'char_type=wchar_t' is only supported in Windows")
 
 


### PR DESCRIPTION
My last PR (#5890) introduced the new option `char_type`. However setting that option to `wchar_t` results in a `NameError` because of missing quotes. This is fixed here.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
