### PR TITLE
add aws-libfabric

### DIFF
--- a/recipes/aws-libfabric/all/conandata.yml
+++ b/recipes/aws-libfabric/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.9.0amzn1.1":
+    url: https://github.com/aws/libfabric/releases/download/v1.9.0amzn1.1/libfabric-1.9.0amzn1.1.tar.gz
+    sha256: 4e3912c379ca351f5039b01cfd168750030d919f1ce3f46531b5396b6a4266e5

--- a/recipes/aws-libfabric/all/conandata.yml
+++ b/recipes/aws-libfabric/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.9.0amzn1.1":
-    url: https://github.com/aws/libfabric/releases/download/v1.9.0amzn1.1/libfabric-1.9.0amzn1.1.tar.gz
-    sha256: 4e3912c379ca351f5039b01cfd168750030d919f1ce3f46531b5396b6a4266e5
+  "1.9.1amzncdi1.0":
+    url: https://github.com/aws/libfabric/archive/refs/tags/1.9.1amzncdi1.0.tar.gz
+    sha256: 714935292fb85a6edad4f3824cc23e46d18ba0a65ba5e292b6378440e8293ce7

--- a/recipes/aws-libfabric/all/conanfile.py
+++ b/recipes/aws-libfabric/all/conanfile.py
@@ -76,14 +76,13 @@ class LibfabricConan(ConanFile):
             self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows)
 
         yes_no_dl = lambda v: {"True": "yes", "False": "no", "shared": "dl"}[str(v)]
+        yes_no = lambda v: "yes" if v else "no"
         args = [
+            "--enable-shared={}".format(yes_no(self.options.shared)),
+            "--enable-static={}".format(yes_no(not self.options.shared)),
             "--with-bgq-progress={}".format(self.options.bgq_progress),
             "--with-bgq-mr={}".format(self.options.bgq_mr),
         ]
-        if self.options.shared:
-            args.extend(['--disable-static', '--enable-shared'])
-        else:
-            args.extend(['--disable-shared', '--enable-static'])
         for p in self._providers:
             args.append("--enable-{}={}".format(p, yes_no_dl(getattr(self.options, p))))
         if self.options.with_libnl:

--- a/recipes/aws-libfabric/all/conanfile.py
+++ b/recipes/aws-libfabric/all/conanfile.py
@@ -61,8 +61,8 @@ class LibfabricConan(ConanFile):
             self.requires("libnl/3.2.25")
 
     def validate(self):
-        if self.settings.compiler == "Visual Studio":
-            raise ConanInvalidConfiguration("The libfabric package cannot be built on Visual Studio.")
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration("The libfabric package cannot be built on Windows.")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/aws-libfabric/all/conanfile.py
+++ b/recipes/aws-libfabric/all/conanfile.py
@@ -12,7 +12,7 @@ class LibfabricConan(ConanFile):
     homepage = "https://github.com/aws/libfabric"
     license = "BSD-2-Clause", "GPL-2.0-or-later"
     settings = "os", "arch", "compiler", "build_type"
-    _providers = ['gni', 'psm', 'psm2', 'sockets', 'rxm', 'tcp', 'udp', 'usnic', 'verbs', 'bgq', 'shm', 'efa', 'rxd', 'mrail', 'rstream', 'perf', 'hook_debug']
+    _providers = ["gni", "psm", "psm2", "sockets", "rxm", "tcp", "udp", "usnic", "verbs", "bgq", "shm", "efa", "rxd", "mrail", "rstream", "perf", "hook_debug"]
     options = {
         **{ p: [True, False, "shared"] for p in _providers },
         **{
@@ -24,12 +24,11 @@ class LibfabricConan(ConanFile):
         }
     }
     default_options = {
-        **{ p: False for p in _providers },
+        **{ p: False for p in _providers if p not in ["efa", ] },
         **{
             "shared": False,
             "fPIC": True,
             "tcp": True,
-            "efa": tools.os_info.is_linux,
             "with_libnl": False,
             "with_bgq_progress": "manual",
             "with_bgq_mr": "basic"
@@ -50,6 +49,8 @@ class LibfabricConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        if self.options.efa == None:
+            self.options.efa = self.settings.os in ["Linux", ]
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 

--- a/recipes/aws-libfabric/all/conanfile.py
+++ b/recipes/aws-libfabric/all/conanfile.py
@@ -45,9 +45,9 @@ class LibfabricConan(ConanFile):
         self.build_requires("libtool/2.4.6")
 
     def config_options(self):
-        if tools.os_info.is_windows:
+        if self.settings.os == "Windows":
             del self.options.fPIC
-        if tools.os_info.is_linux:
+        elif self.settings.os == "Linux":
             self.options.efa = True
 
     def configure(self):

--- a/recipes/aws-libfabric/all/conanfile.py
+++ b/recipes/aws-libfabric/all/conanfile.py
@@ -98,9 +98,16 @@ class LibfabricConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+        if self.options.shared:
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.a")
+        else:
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.so*")
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.dylib")
 
     def package_info(self):
         self.cpp_info.names["pkg_config"] = "libfabric"
         self.cpp_info.libs = self.collect_libs()
         if self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.system_libs = ["pthread", "m"]
+            if not self.options.shared:
+                self.cpp_info.system_libs.extend(["dl", "rt"])

--- a/recipes/aws-libfabric/all/conanfile.py
+++ b/recipes/aws-libfabric/all/conanfile.py
@@ -1,0 +1,99 @@
+from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.35.0"
+
+class LibfabricConan(ConanFile):
+    name = "aws-libfabric"
+    description = "AWS Libfabric"
+    topics = ("fabric", "communication", "framework", "service")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/aws/libfabric"
+    license = "BSD-2-Clause", "GPL-2.0-or-later"
+    settings = "os", "arch", "compiler", "build_type"
+    _providers = ['gni', 'psm', 'psm2', 'psm3', 'rxm', 'sockets', 'tcp', 'udp', 'usnic', 'verbs', 'bgq']
+    options = {
+        **{ p: "ANY" for p in _providers },
+        **{
+            "shared": [True, False],
+            "fPIC": [True, False],
+            "with_libnl": "ANY",
+            "with_bgq_progress": [None, "auto", "manual"],
+            "with_bgq_mr": [None, "basic", "scalable"]
+        }
+    }
+    default_options = {
+        **{ p: "auto" for p in _providers },
+        **{
+            "shared": False,
+            "fPIC": True,
+            "with_libnl": None,
+            "with_bgq_progress": None,
+            "with_bgq_mr": None
+        }
+    }
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    _autotools = None
+
+    def config_options(self):
+        if self.settings.os == 'Windows':
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def validate(self):
+        if self.settings.compiler == "Visual Studio":
+            raise ConanInvalidConfiguration("The libfabric package cannot be built on Visual Studio.")
+        for p in self._providers:
+            if self.options.get_safe(p) not in ["auto", "yes", "no", "dl"] and not os.path.isdir(str(self.options.get_safe(p))):
+                raise ConanInvalidConfiguration("Option {} can only be one of 'auto', 'yes', 'no', 'dl' or a directory path")
+        if self.options.get_safe('with_libnl') and not os.path.isdir(str(self.options.with_libnl)):
+            raise ConanInvalidConfiguration("Value of with_libnl must be an existing directory")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self)
+        args = []
+        for p in self._providers:
+            args.append('--enable-{}={}'.format(p, self.options.get_safe(p)))
+        if self.options.with_libnl:
+            args.append('--with-libnl={}'.format(self.options.with_libnl))
+        if self.options.with_bgq_progress:
+            args.append('--with-bgq-progress={}'.format(self.options.with_bgq_progress))
+        if self.options.with_bgq_mr:
+            args.append('--with-bgq-mr={}'.format(self.options.with_bgq_mr))
+        self._autotools.configure(args=args, configure_dir=self._source_subfolder)
+        return self._autotools
+
+    def build(self):
+        autotools = self._configure_autotools()
+        autotools.make()
+
+    def package(self):
+        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
+        autotools = self._configure_autotools()
+        autotools.install()
+
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+
+    def package_info(self):
+        self.cpp_info.names["pkg_config"] = "libfabric"
+        self.cpp_info.libs = self.collect_libs()
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs = ["pthread", "m"]

--- a/recipes/aws-libfabric/all/conanfile.py
+++ b/recipes/aws-libfabric/all/conanfile.py
@@ -73,7 +73,8 @@ class LibfabricConan(ConanFile):
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         with tools.chdir(self._source_subfolder):
-            self.run("./autogen.sh", win_bash=tools.os_info.is_windows)
+            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows)
+
         yes_no_dl = lambda v: {"True": "yes", "False": "no", "shared": "dl"}[str(v)]
         args = [
             "--with-bgq-progress={}".format(self.options.with_bgq_progress),

--- a/recipes/aws-libfabric/all/conanfile.py
+++ b/recipes/aws-libfabric/all/conanfile.py
@@ -14,28 +14,28 @@ class LibfabricConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     _providers = ['gni', 'psm', 'psm2', 'sockets', 'rxm', 'tcp', 'udp', 'usnic', 'verbs', 'bgq', 'shm', 'efa', 'rxd', 'mrail', 'rstream', 'perf', 'hook_debug']
     options = {
-        **{ p: "ANY" for p in _providers },
+        **{ p: [True, False, "shared"] for p in _providers },
         **{
             "shared": [True, False],
             "fPIC": [True, False],
             "with_libnl": [True, False],
-            "with_bgq_progress": [None, "auto", "manual"],
-            "with_bgq_mr": [None, "basic", "scalable"]
+            "with_bgq_progress": ["auto", "manual"],
+            "with_bgq_mr": ["basic", "scalable"]
         }
     }
     default_options = {
-        **{ p: "auto" for p in _providers if p not in ('efa', 'verbs', 'rxd') },
+        **{ p: False for p in _providers },
         **{
             "shared": False,
             "fPIC": True,
-            "efa": "yes",
-            "verbs": "no",
-            "rxd": "no",
+            "tcp": True,
+            "efa": tools.os_info.is_linux,
             "with_libnl": False,
-            "with_bgq_progress": None,
-            "with_bgq_mr": None
+            "with_bgq_progress": "manual",
+            "with_bgq_mr": "basic"
         }
     }
+    build_requires = "autoconf/2.71", "automake/1.16.3", "libtool/2.4.6"
 
     @property
     def _source_subfolder(self):
@@ -44,7 +44,7 @@ class LibfabricConan(ConanFile):
     _autotools = None
 
     def config_options(self):
-        if self.settings.os == 'Windows':
+        if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
@@ -54,15 +54,12 @@ class LibfabricConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def requirements(self):
-        if self.options.get_safe('with_libnl'):
-            self.requires('libnl/3.2.25')
+        if self.options.with_libnl:
+            self.requires("libnl/3.2.25")
 
     def validate(self):
         if self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration("The libfabric package cannot be built on Visual Studio.")
-        for p in self._providers:
-            if self.options.get_safe(p) not in ["auto", "yes", "no", "dl"] and not os.path.isdir(str(self.options.get_safe(p))):
-                raise ConanInvalidConfiguration("Option {} can only be one of 'auto', 'yes', 'no', 'dl' or a directory path")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -74,15 +71,19 @@ class LibfabricConan(ConanFile):
         self._autotools = AutoToolsBuildEnvironment(self)
         with tools.chdir(self._source_subfolder):
             self.run("./autogen.sh", win_bash=tools.os_info.is_windows)
-        args = []
+        yes_no_dl = lambda v: {"True": "yes", "False": "no", "shared": "dl"}[str(v)]
+        args = [
+            "--with-bgq-progress={}".format(self.options.with_bgq_progress),
+            "--with-bgq-mr={}".format(self.options.with_bgq_mr),
+        ]
         for p in self._providers:
-            args.append('--enable-{}={}'.format(p, self.options.get_safe(p)))
+            args.append("--enable-{}={}".format(p, yes_no_dl(getattr(self.options, p))))
         if self.options.with_libnl:
-            args.append('--with-libnl={}'.format(self.deps_cpp_info["libnl"].rootpath))
-        if self.options.with_bgq_progress:
-            args.append('--with-bgq-progress={}'.format(self.options.with_bgq_progress))
-        if self.options.with_bgq_mr:
-            args.append('--with-bgq-mr={}'.format(self.options.with_bgq_mr))
+            args.append("--with-libnl={}".format(tools.unix_path(self.deps_cpp_info["libnl"].rootpath))),
+        else:
+            args.append("--with-libnl=no")
+        if self.settings.build_type == "Debug":
+            args.append("--enable-debug")
         self._autotools.configure(args=args, configure_dir=self._source_subfolder)
         return self._autotools
 
@@ -99,10 +100,10 @@ class LibfabricConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
         if self.options.shared:
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.a")
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "libfabric.a")
         else:
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.so*")
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.dylib")
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "libfabric.so*")
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "libfabric.dylib")
 
     def package_info(self):
         self.cpp_info.names["pkg_config"] = "libfabric"

--- a/recipes/aws-libfabric/all/conanfile.py
+++ b/recipes/aws-libfabric/all/conanfile.py
@@ -19,8 +19,8 @@ class LibfabricConan(ConanFile):
             "shared": [True, False],
             "fPIC": [True, False],
             "with_libnl": [True, False],
-            "with_bgq_progress": ["auto", "manual"],
-            "with_bgq_mr": ["basic", "scalable"]
+            "bgq_progress": ["auto", "manual"],
+            "bgq_mr": ["basic", "scalable"]
         }
     }
     default_options = {
@@ -30,8 +30,8 @@ class LibfabricConan(ConanFile):
             "fPIC": True,
             "tcp": True,
             "with_libnl": False,
-            "with_bgq_progress": "manual",
-            "with_bgq_mr": "basic"
+            "bgq_progress": "manual",
+            "bgq_mr": "basic"
         }
     }
 
@@ -77,9 +77,13 @@ class LibfabricConan(ConanFile):
 
         yes_no_dl = lambda v: {"True": "yes", "False": "no", "shared": "dl"}[str(v)]
         args = [
-            "--with-bgq-progress={}".format(self.options.with_bgq_progress),
-            "--with-bgq-mr={}".format(self.options.with_bgq_mr),
+            "--with-bgq-progress={}".format(self.options.bgq_progress),
+            "--with-bgq-mr={}".format(self.options.bgq_mr),
         ]
+        if self.options.shared:
+            args.extend(['--disable-static', '--enable-shared'])
+        else:
+            args.extend(['--disable-shared', '--enable-static'])
         for p in self._providers:
             args.append("--enable-{}={}".format(p, yes_no_dl(getattr(self.options, p))))
         if self.options.with_libnl:
@@ -103,11 +107,6 @@ class LibfabricConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
-        if self.options.shared:
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "libfabric.a")
-        else:
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "libfabric.so*")
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "libfabric.dylib")
 
     def package_info(self):
         self.cpp_info.names["pkg_config"] = "libfabric"

--- a/recipes/aws-libfabric/all/test_package/CMakeLists.txt
+++ b/recipes/aws-libfabric/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/aws-libfabric/all/test_package/CMakeLists.txt
+++ b/recipes/aws-libfabric/all/test_package/CMakeLists.txt
@@ -4,5 +4,5 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/aws-libfabric/all/test_package/conanfile.py
+++ b/recipes/aws-libfabric/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/aws-libfabric/all/test_package/conanfile.py
+++ b/recipes/aws-libfabric/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/aws-libfabric/all/test_package/test_package.c
+++ b/recipes/aws-libfabric/all/test_package/test_package.c
@@ -2,8 +2,10 @@
 
 #include <rdma/fabric.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int main () {
     const uint32_t version = fi_version();
     printf("hello libfabric version %d.%d\n", FI_MAJOR(version), FI_MINOR(version));
+    return EXIT_SUCCESS;
 }

--- a/recipes/aws-libfabric/all/test_package/test_package.c
+++ b/recipes/aws-libfabric/all/test_package/test_package.c
@@ -1,9 +1,9 @@
 /* example was taken from https://www.gnu.org/ghm/2011/paris/slides/andreas-enge-mpc.pdf */
 
 #include <rdma/fabric.h>
-#include <iostream>
+#include <stdio.h>
 
 int main () {
     const uint32_t version = fi_version();
-    std::cout << "hello libfabric version " << FI_MAJOR(version) << "." << FI_MINOR(version) << "\n";
+    printf("hello libfabric version %d.%d\n", FI_MAJOR(version), FI_MINOR(version));
 }

--- a/recipes/aws-libfabric/all/test_package/test_package.cpp
+++ b/recipes/aws-libfabric/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+/* example was taken from https://www.gnu.org/ghm/2011/paris/slides/andreas-enge-mpc.pdf */
+
+#include <rdma/fabric.h>
+#include <iostream>
+
+int main () {
+    const uint32_t version = fi_version();
+    std::cout << "hello libfabric version " << FI_MAJOR(version) << "." << FI_MINOR(version) << "\n";
+}

--- a/recipes/aws-libfabric/config.yml
+++ b/recipes/aws-libfabric/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.9.0amzn1.1":
+    folder: all

--- a/recipes/aws-libfabric/config.yml
+++ b/recipes/aws-libfabric/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.9.0amzn1.1":
+  "1.9.1amzncdi1.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **aws-libfabric/1.9.0amzn1.1**

This is a fork of `libfabric` by AWS. required for [AWS CDI SDK](https://github.com/aws/aws-cdi-sdk).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
