### PR TITLE
Add sentry-crashpad/0.4.10

### DIFF
--- a/recipes/sentry-crashpad/all/conandata.yml
+++ b/recipes/sentry-crashpad/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.4.10":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.10/sentry-native.zip"
+    sha256: "8926735b5c27ad2ae0e40098c53f45a031cdc584cb4519ffc93d04de28df6a7a"
   "0.4.9":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.9/sentry-native.zip"
     sha256: "559344bad846b7868c182b22df0cd9869c31ebf46a222ac7a6588aab0211af7d"

--- a/recipes/sentry-crashpad/config.yml
+++ b/recipes/sentry-crashpad/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.4.10":
+    folder: all
   "0.4.9":
     folder: all
   "0.4.8":


### PR DESCRIPTION
Specify library name and version:  **sentry-crashpad/0.4.10**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
