### PR TITLE
add possibility to override namespace of spirv-cross

### DIFF
--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -25,7 +25,8 @@ class SpirvCrossConan(ConanFile):
         "cpp": [True, False],
         "reflect": [True, False],
         "c_api": [True, False],
-        "util": [True, False]
+        "util": [True, False],
+        "namespace": "ANY",
     }
     default_options = {
         "shared": False,
@@ -37,7 +38,8 @@ class SpirvCrossConan(ConanFile):
         "cpp": True,
         "reflect": True,
         "c_api": True,
-        "util": True
+        "util": True,
+        "namespace": "spirv_cross",
     }
 
     _cmake = None
@@ -95,6 +97,7 @@ class SpirvCrossConan(ConanFile):
         self._cmake.definitions["SPIRV_CROSS_SKIP_INSTALL"] = False
         self._cmake.definitions["SPIRV_CROSS_FORCE_PIC"] = self.options.get_safe("fPIC", True)
         self._cmake.configure(build_folder=self._build_subfolder)
+        self._cmake.definitions["SPIRV_CROSS_NAMESPACE_OVERRIDE"] = self.options.namespace
         return self._cmake
 
     @property
@@ -148,6 +151,7 @@ class SpirvCrossConan(ConanFile):
             bin_path = os.path.join(self.package_folder, "bin")
             self.output.info("Appending PATH environment variable: {}".format(bin_path))
             self.env_info.PATH.append(bin_path)
+        self.cpp_info.defines.append("SPIRV_CROSS_NAMESPACE_OVERRIDE={}".format(self.options.namespace))
 
     def _get_ordered_libs(self):
         libs = []

--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -96,8 +96,8 @@ class SpirvCrossConan(ConanFile):
         self._cmake.definitions["SPIRV_CROSS_ENABLE_UTIL"] = self.options.get_safe("util", False)
         self._cmake.definitions["SPIRV_CROSS_SKIP_INSTALL"] = False
         self._cmake.definitions["SPIRV_CROSS_FORCE_PIC"] = self.options.get_safe("fPIC", True)
-        self._cmake.configure(build_folder=self._build_subfolder)
         self._cmake.definitions["SPIRV_CROSS_NAMESPACE_OVERRIDE"] = self.options.namespace
+        self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
     @property


### PR DESCRIPTION
Specify library name and version:  **sprv-cross/any**


it is needed for creation of dirigent package
https://github.com/conan-io/conan-center-index/issues/1533#issuecomment-872322674

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
