### PR TITLE
Bump sentry-native/0.4.10

### DIFF
--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -33,3 +33,5 @@ patches:
   "0.2.6":
     - patch_file: "patches/0.2.6-0001-remove-sentry-handler-dependency.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0.2.6-0002-set-cmake-cxx-standard-11.patch"
+      base_path: "source_subfolder"

--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.4.10":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.10/sentry-native.zip"
+    sha256: "8926735b5c27ad2ae0e40098c53f45a031cdc584cb4519ffc93d04de28df6a7a"
   "0.4.9":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.9/sentry-native.zip"
     sha256: "559344bad846b7868c182b22df0cd9869c31ebf46a222ac7a6588aab0211af7d"
@@ -15,6 +18,9 @@ sources:
     url: "https://github.com/getsentry/sentry-native/releases/download/0.2.6/sentry-native-0.2.6.zip"
     sha256: "0d93bd77f70a64f3681d4928dfca6b327374218a84d33ee31489114d8e4716c0"
 patches:
+  "0.4.10":
+    - patch_file: "patches/0.4.10-0001-find-conan-qt.patch"
+      base_path: "source_subfolder"
   "0.4.9":
     - patch_file: "patches/0.4.9-0001-find-conan-qt.patch"
       base_path: "source_subfolder"

--- a/recipes/sentry-native/all/patches/0.2.6-0002-set-cmake-cxx-standard-11.patch
+++ b/recipes/sentry-native/all/patches/0.2.6-0002-set-cmake-cxx-standard-11.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c41d902..4793e9b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,6 +10,10 @@ if(NOT CMAKE_C_STANDARD)
+   set(CMAKE_C_STANDARD 11)
+ endif()
+ 
++if(NOT CMAKE_CXX_STANDARD)
++  set(CMAKE_CXX_STANDARD 11)
++endif()
++
+ include(GNUInstallDirs)
+ set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/sentry")
+ 

--- a/recipes/sentry-native/all/patches/0.4.10-0001-find-conan-qt.patch
+++ b/recipes/sentry-native/all/patches/0.4.10-0001-find-conan-qt.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 696d270..006bf68 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -462,17 +462,10 @@ endif()
+ 
+ option(SENTRY_INTEGRATION_QT "Build Qt integration")
+ if(SENTRY_INTEGRATION_QT)
+-	if(QT_DEFAULT_MAJOR_VERSION)
+-		# Let user choose major version
+-		set(Qt_VERSION_MAJOR ${QT_DEFAULT_MAJOR_VERSION})
+-	else()
+-		# Find best match, prioritizing Qt 6 if available
+-		find_package(Qt NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+-	endif()
+-	find_package(Qt${Qt_VERSION_MAJOR} COMPONENTS Core REQUIRED)
++	find_package(qt REQUIRED)
+ 	message(STATUS "Found Qt: ${Qt${Qt_VERSION_MAJOR}_DIR} "
+ 		"(found version \"${Qt${Qt_VERSION_MAJOR}_VERSION}\")")
+-	target_link_libraries(sentry PRIVATE Qt${Qt_VERSION_MAJOR}::Core)
++	target_link_libraries(sentry PRIVATE qt::qt)
+ endif()
+ 
+ include(CMakePackageConfigHelpers)

--- a/recipes/sentry-native/config.yml
+++ b/recipes/sentry-native/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.4.10":
+    folder: all
   "0.4.9":
     folder: all
   "0.4.8":


### PR DESCRIPTION
Specify library name and version:  **sentry-native/0.4.10**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

It worked locally because I have exported sentry-crashpad/0.4.10 from [here](https://github.com/conan-io/conan-center-index/pull/6129).