### PR TITLE
Bump spirv-tools to 2021.2

### DIFF
--- a/recipes/spirv-tools/all/conandata.yml
+++ b/recipes/spirv-tools/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2021.2":
+    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2021.2.tar.gz"
+    sha256: "2416a0354a0b14b8e7b671f6f99652cc8a8a83dc9acf195dafd22fbee5e92035"
   "2020.5":
     url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.5.tar.gz"
     sha256: "947ee994ba416380bd7ccc1c6377ac28a4802a55ca81ccc06796c28e84c00b71"

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -60,6 +60,7 @@ class SpirvtoolsConan(ConanFile):
     @property
     def _get_compatible_spirv_headers_version(self):
         return {
+            "2021.2": "cci.20210616",
             "2020.5": "1.5.4",
             "2020.3": "1.5.3",
             "2019.2": "1.5.1",

--- a/recipes/spirv-tools/config.yml
+++ b/recipes/spirv-tools/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2021.2":
+    folder: all
   "2020.5":
     folder: all
   "v2020.5":


### PR DESCRIPTION
Specify library name and version:  **spirv-tools/2021.2**

This pull request updates spirv-tools to 2021.2

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
