### PR TITLE
sqlite3: fix executable build when system not available

### DIFF
--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -146,6 +146,11 @@ if(SQLITE3_BUILD_EXECUTABLE)
     add_executable(sqlite3-bin source_subfolder/shell.c)
     target_link_libraries(sqlite3-bin PRIVATE ${PROJECT_NAME})
     set_target_properties(sqlite3-bin PROPERTIES OUTPUT_NAME "sqlite3")
+    include(CheckSymbolExists)
+    check_symbol_exists(system "stdlib.h" HAVE_SYSTEM)
+    if(NOT HAVE_SYSTEM)
+        target_compile_definitions(sqlite3-bin PRIVATE SQLITE_NOHAVE_SYSTEM)
+    endif()
     install(TARGETS sqlite3-bin
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

`shell.c` can't be compiled if host is iOS >= 11 and SQLITE_NOHAVE_SYSTEM not defined.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
