### PR TITLE
flac: fix cross compilation to iOS + modernize recipe

### DIFF
--- a/recipes/flac/all/conanfile.py
+++ b/recipes/flac/all/conanfile.py
@@ -1,6 +1,8 @@
 from conans import ConanFile, tools, CMake
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class FlacConan(ConanFile):
     name = "flac"
@@ -43,9 +45,8 @@ class FlacConan(ConanFile):
         self.build_requires("nasm/2.14")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "{}-{}".format(self.name, self.version)
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/flac/all/conanfile.py
+++ b/recipes/flac/all/conanfile.py
@@ -94,3 +94,7 @@ class FlacConan(ConanFile):
             self.cpp_info.components["libflac"].defines = ["FLAC__NO_DLL"]
             if self.settings.os == "Linux":
                 self.cpp_info.components["libflac"].system_libs += ["m"]
+
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)

--- a/recipes/flac/all/conanfile.py
+++ b/recipes/flac/all/conanfile.py
@@ -11,7 +11,7 @@ class FlacConan(ConanFile):
     license = ("BSD-3-Clause", "GPL-2.0-or-later", "LPGL-2.1-or-later", "GFDL-1.2")
     exports_sources = ["CMakeLists.txt", "patches/*"]
 
-    generators = "cmake",
+    generators = "cmake", "cmake_find_package"
     settings = "os", "compiler", "build_type", "arch"
     options = {
         "shared": [True, False],

--- a/recipes/flac/all/patches/fix-cmake.patch
+++ b/recipes/flac/all/patches/fix-cmake.patch
@@ -1,5 +1,14 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -13,7 +13,7 @@ option(BUILD_EXAMPLES "Build and install examples" ON)
+ option(WITH_OGG "ogg support (default: test for libogg)" ON)
+ 
+ if(WITH_OGG)
+-    find_package(OGG REQUIRED)
++    find_package(Ogg REQUIRED)
+ endif()
+ 
+ if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
 @@ -25,9 +25,6 @@ endif()
  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wcast-align -Wshadow -Wwrite-strings -Wctor-dtor-privacy -Wnon-virtual-dtor -Wreorder -Wsign-promo -Wundef")
@@ -19,6 +28,14 @@
  endif()
  
  include_directories("include")
+--- a/src/flac/CMakeLists.txt
++++ b/src/flac/CMakeLists.txt
+@@ -21,4 +21,4 @@ if(TARGET win_utf8_io)
+ endif()
+ 
+ install(TARGETS flacapp EXPORT targets
+-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
++    DESTINATION "${CMAKE_INSTALL_BINDIR}")
 --- a/src/libFLAC/CMakeLists.txt
 +++ b/src/libFLAC/CMakeLists.txt
 @@ -102,7 +102,7 @@ target_compile_definitions(FLAC
@@ -30,8 +47,20 @@
  if(TARGET Ogg::ogg)
      target_link_libraries(FLAC PUBLIC Ogg::ogg)
  endif()
+--- a/src/metaflac/CMakeLists.txt
++++ b/src/metaflac/CMakeLists.txt
+@@ -15,4 +15,4 @@ if(TARGET win_utf8_io)
+ endif()
+ 
+ install(TARGETS metaflac EXPORT targets
+-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
++    DESTINATION "${CMAKE_INSTALL_BINDIR}")
 --- a/src/share/getopt/CMakeLists.txt
 +++ b/src/share/getopt/CMakeLists.txt
-@@ -3,1 +3,1 @@ 
+@@ -1,6 +1,5 @@
+ check_include_file("string.h" HAVE_STRING_H)
+ 
 -find_package(Intl)
-+
+ 
+ add_library(getopt STATIC getopt.c getopt1.c)
+ 


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

cross compilation to iOS was broken because it can't find Ogg with the custom upstream FindOGG.cmake (and also due to install destination of executables)

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
