### PR TITLE
lcms: allow more cross-building configurations + bump msys2 + modernize

### DIFF
--- a/recipes/lcms/all/conanfile.py
+++ b/recipes/lcms/all/conanfile.py
@@ -1,7 +1,7 @@
-import os
-
 from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
 from conans.tools import Version
+import os
+import shutil
 
 
 class LcmsConan(ConanFile):
@@ -32,9 +32,10 @@ class LcmsConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def build_requirements(self):
-        if tools.os_info.is_windows and self.settings.compiler != "Visual Studio" and \
-           not tools.get_env("CONAN_BASH_PATH") and tools.os_info.detect_windows_subsystem() != "msys2":
-            self.build_requires("msys2/20200517")
+        if self.settings.compiler != "Visual Studio":
+            self.build_requires("gnu-config/cci.20201022")
+            if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+                self.build_requires("msys2/cci.latest")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -76,11 +77,23 @@ class LcmsConan(ConanFile):
         self._autotools.configure(args=args, configure_dir=self._source_subfolder)
         return self._autotools
 
+    @property
+    def _user_info_build(self):
+        # If using the experimental feature with different context for host and
+        # build, the 'user_info' attributes of the 'build_requires' packages
+        # will be located into the 'user_info_build' object. In other cases they
+        # will be located into the 'deps_user_info' object.
+        return getattr(self, "user_info_build", None) or self.deps_user_info
+
     def build(self):
         self._patch_sources()
         if self.settings.compiler == "Visual Studio":
             self._build_visual_studio()
         else:
+            shutil.copy(self._user_info_build["gnu-config"].CONFIG_SUB,
+                        os.path.join(self._source_subfolder, "config.sub"))
+            shutil.copy(self._user_info_build["gnu-config"].CONFIG_GUESS,
+                        os.path.join(self._source_subfolder, "config.guess"))
             autotools = self._configure_autotools()
             autotools.make()
 

--- a/recipes/lcms/all/conanfile.py
+++ b/recipes/lcms/all/conanfile.py
@@ -3,6 +3,8 @@ from conans.tools import Version
 import os
 import shutil
 
+required_conan_version = ">=1.33.0"
+
 
 class LcmsConan(ConanFile):
     name = "lcms"
@@ -38,11 +40,8 @@ class LcmsConan(ConanFile):
                 self.build_requires("msys2/cci.latest")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        if os.path.isdir("Little-CMS-lcms%s" % self.version):
-            os.rename("Little-CMS-lcms%s" % self.version, self._source_subfolder)
-        else:
-            os.rename("Little-CMS-%s" % self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
         if self.settings.compiler == "Visual Studio" and Version(self.settings.compiler.version) >= "14":

--- a/recipes/lcms/all/test_package/CMakeLists.txt
+++ b/recipes/lcms/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

It was broken for iOS, now it works.

I used the same tricks than libelf recipe.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
