### PR TITLE
Update glslang 11.5.0

### DIFF
--- a/recipes/glslang/all/conandata.yml
+++ b/recipes/glslang/all/conandata.yml
@@ -1,8 +1,14 @@
 sources:
+  "11.5.0":
+    url: "https://github.com/KhronosGroup/glslang/archive/11.5.0.tar.gz"
+    sha256: "fd0b5e3bda591bb08bd3049655a99a0a55f0de4059b9c8f7b397e4b19cf5d51f"
   "8.13.3559":
     url: "https://github.com/KhronosGroup/glslang/archive/8.13.3559.tar.gz"
     sha256: "c58fdcf7e00943ba10f9ae565b2725ec9d5be7dab7c8e82cac72fcaa83c652ca"
 patches:
+  "11.5.0":
+    - patch_file: "patches/conanize-cmake-11.5.0.patch"
+      base_path: "source_subfolder"
   "8.13.3559":
     - patch_file: "patches/conanize-cmake-8.13.3559.patch"
       base_path: "source_subfolder"

--- a/recipes/glslang/all/conanfile.py
+++ b/recipes/glslang/all/conanfile.py
@@ -151,15 +151,16 @@ class GlslangConan(ConanFile):
             self.cpp_info.components["glslang-core"].requires.extend(["genericcodegen", "machineindependent"])
 
         if tools.Version(self.version) >= "11.5.0":
+            # MachineIndependent
+            self.cpp_info.components["machineindependent"].names["cmake_find_package"] = "MachineIndependent"
+            self.cpp_info.components["machineindependent"].names["cmake_find_package_multi"] = "MachineIndependent"
+            self.cpp_info.components["machineindependent"].libs = ["MachineIndependent" + lib_suffix]
+
             # GenericCodeGen
             self.cpp_info.components["genericcodegen"].names["cmake_find_package"] = "GenericCodeGen"
             self.cpp_info.components["genericcodegen"].names["cmake_find_package_multi"] = "GenericCodeGen"
             self.cpp_info.components["genericcodegen"].libs = ["GenericCodeGen" + lib_suffix]
 
-            # MachineIndependent
-            self.cpp_info.components["machineindependent"].names["cmake_find_package"] = "MachineIndependent"
-            self.cpp_info.components["machineindependent"].names["cmake_find_package_multi"] = "MachineIndependent"
-            self.cpp_info.components["machineindependent"].libs = ["MachineIndependent" + lib_suffix]
 
         # OSDependent
         self.cpp_info.components["osdependent"].names["cmake_find_package"] = "OSDependent"

--- a/recipes/glslang/all/conanfile.py
+++ b/recipes/glslang/all/conanfile.py
@@ -56,9 +56,16 @@ class GlslangConan(ConanFile):
         if self.options.shared and self.settings.os in ["Windows", "Macos"]:
             raise ConanInvalidConfiguration("Current glslang shared library build is broken on Windows and Macos")
 
+    @property
+    def _get_compatible_spirv_tools_version(self):
+        return {
+            "11.5.0": "2021.2",
+            "8.13.3559": "2020.5",
+        }.get(str(self.version), False)
+
     def requirements(self):
         if self.options.enable_optimizer:
-            self.requires("spirv-tools/2020.5")
+            self.requires("spirv-tools/{}".format(self._get_compatible_spirv_tools_version))
 
     def validate(self):
         if self.options.enable_optimizer and self.options["spirv-tools"].shared:
@@ -82,11 +89,16 @@ class GlslangConan(ConanFile):
                 {"target": "OGLCompiler", "relpath": os.path.join("OGLCompilersDLL", "CMakeLists.txt")},
                 {"target": "SPIRV"      , "relpath": os.path.join("SPIRV", "CMakeLists.txt")},
                 {"target": "SPVRemapper", "relpath": os.path.join("SPIRV", "CMakeLists.txt")},
-                {"target": "glslang"    , "relpath": os.path.join("glslang", "CMakeLists.txt")},
                 {"target": "OSDependent", "relpath": os.path.join("glslang", "OSDependent", "Unix","CMakeLists.txt")},
                 {"target": "OSDependent", "relpath": os.path.join("glslang", "OSDependent", "Windows","CMakeLists.txt")},
                 {"target": "HLSL"       , "relpath": os.path.join("hlsl", "CMakeLists.txt")},
             ]
+            if tools.Version(self.version) < "11.5.0":
+                cmake_files_to_fix.append({"target": "glslang"    , "relpath": os.path.join("glslang", "CMakeLists.txt")})
+            else:
+                cmake_files_to_fix.append({"target": "glslang-default-resource-limits", "relpath": os.path.join("StandAlone" , "CMakeLists.txt")})
+                cmake_files_to_fix.append({"target": "MachineIndependent", "relpath": os.path.join("glslang", "CMakeLists.txt")})
+                cmake_files_to_fix.append({"target": "GenericCodeGen", "relpath": os.path.join("glslang", "CMakeLists.txt")})
             for cmake_file in cmake_files_to_fix:
                 tools.replace_in_file(os.path.join(self._source_subfolder, cmake_file["relpath"]),
                                       "set_property(TARGET {} PROPERTY POSITION_INDEPENDENT_CODE ON)".format(cmake_file["target"]),
@@ -138,6 +150,18 @@ class GlslangConan(ConanFile):
         self.cpp_info.components["oglcompiler"].names["cmake_find_package"] = "OGLCompiler"
         self.cpp_info.components["oglcompiler"].names["cmake_find_package_multi"] = "OGLCompiler"
         self.cpp_info.components["oglcompiler"].libs = ["OGLCompiler" + lib_suffix]
+
+        if tools.Version(self.version) >= "11.5.0":
+            # GenericCodeGen
+            self.cpp_info.components["genericcodegen"].names["cmake_find_package"] = "GenericCodeGen"
+            self.cpp_info.components["genericcodegen"].names["cmake_find_package_multi"] = "GenericCodeGen"
+            self.cpp_info.components["genericcodegen"].libs = ["GenericCodeGen" + lib_suffix]
+
+            # MachineIndependent
+            self.cpp_info.components["machineindependent"].names["cmake_find_package"] = "MachineIndependent"
+            self.cpp_info.components["machineindependent"].names["cmake_find_package_multi"] = "MachineIndependent"
+            self.cpp_info.components["machineindependent"].libs = ["MachineIndependent" + lib_suffix]
+
         # glslang
         self.cpp_info.components["glslang-core"].names["cmake_find_package"] = "glslang"
         self.cpp_info.components["glslang-core"].names["cmake_find_package_multi"] = "glslang"
@@ -145,6 +169,8 @@ class GlslangConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.components["glslang-core"].system_libs.extend(["m", "pthread"])
         self.cpp_info.components["glslang-core"].requires = ["oglcompiler", "osdependent"]
+        if tools.Version(self.version) >= "11.5.0":
+            self.cpp_info.components["glslang-core"].requires.extend(["genericcodegen", "machineindependent"])
         # SPIRV
         self.cpp_info.components["spirv"].names["cmake_find_package"] = "SPIRV"
         self.cpp_info.components["spirv"].names["cmake_find_package_multi"] = "SPIRV"

--- a/recipes/glslang/all/conanfile.py
+++ b/recipes/glslang/all/conanfile.py
@@ -150,17 +150,6 @@ class GlslangConan(ConanFile):
         if tools.Version(self.version) >= "11.5.0":
             self.cpp_info.components["glslang-core"].requires.extend(["genericcodegen", "machineindependent"])
 
-        # OSDependent
-        self.cpp_info.components["osdependent"].names["cmake_find_package"] = "OSDependent"
-        self.cpp_info.components["osdependent"].names["cmake_find_package_multi"] = "OSDependent"
-        self.cpp_info.components["osdependent"].libs = ["OSDependent" + lib_suffix]
-        if self.settings.os == "Linux":
-            self.cpp_info.components["osdependent"].system_libs.append("pthread")
-        # OGLCompiler
-        self.cpp_info.components["oglcompiler"].names["cmake_find_package"] = "OGLCompiler"
-        self.cpp_info.components["oglcompiler"].names["cmake_find_package_multi"] = "OGLCompiler"
-        self.cpp_info.components["oglcompiler"].libs = ["OGLCompiler" + lib_suffix]
-
         if tools.Version(self.version) >= "11.5.0":
             # GenericCodeGen
             self.cpp_info.components["genericcodegen"].names["cmake_find_package"] = "GenericCodeGen"
@@ -171,6 +160,17 @@ class GlslangConan(ConanFile):
             self.cpp_info.components["machineindependent"].names["cmake_find_package"] = "MachineIndependent"
             self.cpp_info.components["machineindependent"].names["cmake_find_package_multi"] = "MachineIndependent"
             self.cpp_info.components["machineindependent"].libs = ["MachineIndependent" + lib_suffix]
+
+        # OSDependent
+        self.cpp_info.components["osdependent"].names["cmake_find_package"] = "OSDependent"
+        self.cpp_info.components["osdependent"].names["cmake_find_package_multi"] = "OSDependent"
+        self.cpp_info.components["osdependent"].libs = ["OSDependent" + lib_suffix]
+        if self.settings.os == "Linux":
+            self.cpp_info.components["osdependent"].system_libs.append("pthread")
+        # OGLCompiler
+        self.cpp_info.components["oglcompiler"].names["cmake_find_package"] = "OGLCompiler"
+        self.cpp_info.components["oglcompiler"].names["cmake_find_package_multi"] = "OGLCompiler"
+        self.cpp_info.components["oglcompiler"].libs = ["OGLCompiler" + lib_suffix]
 
         # SPIRV
         self.cpp_info.components["spirv"].names["cmake_find_package"] = "SPIRV"

--- a/recipes/glslang/all/conanfile.py
+++ b/recipes/glslang/all/conanfile.py
@@ -155,12 +155,12 @@ class GlslangConan(ConanFile):
             self.cpp_info.components["machineindependent"].names["cmake_find_package"] = "MachineIndependent"
             self.cpp_info.components["machineindependent"].names["cmake_find_package_multi"] = "MachineIndependent"
             self.cpp_info.components["machineindependent"].libs = ["MachineIndependent" + lib_suffix]
+            self.cpp_info.components["machineindependent"].requires = ["oglcompiler", "osdependent", "genericcodegen"]
 
             # GenericCodeGen
             self.cpp_info.components["genericcodegen"].names["cmake_find_package"] = "GenericCodeGen"
             self.cpp_info.components["genericcodegen"].names["cmake_find_package_multi"] = "GenericCodeGen"
             self.cpp_info.components["genericcodegen"].libs = ["GenericCodeGen" + lib_suffix]
-
 
         # OSDependent
         self.cpp_info.components["osdependent"].names["cmake_find_package"] = "OSDependent"

--- a/recipes/glslang/all/conanfile.py
+++ b/recipes/glslang/all/conanfile.py
@@ -140,6 +140,16 @@ class GlslangConan(ConanFile):
     def package_info(self):
         # TODO: glslang exports non-namespaced targets but without config file...
         lib_suffix = "d" if self.settings.os == "Windows" and self.settings.build_type == "Debug" else ""
+        # glslang
+        self.cpp_info.components["glslang-core"].names["cmake_find_package"] = "glslang"
+        self.cpp_info.components["glslang-core"].names["cmake_find_package_multi"] = "glslang"
+        self.cpp_info.components["glslang-core"].libs = ["glslang" + lib_suffix]
+        if self.settings.os == "Linux":
+            self.cpp_info.components["glslang-core"].system_libs.extend(["m", "pthread"])
+        self.cpp_info.components["glslang-core"].requires = ["oglcompiler", "osdependent"]
+        if tools.Version(self.version) >= "11.5.0":
+            self.cpp_info.components["glslang-core"].requires.extend(["genericcodegen", "machineindependent"])
+
         # OSDependent
         self.cpp_info.components["osdependent"].names["cmake_find_package"] = "OSDependent"
         self.cpp_info.components["osdependent"].names["cmake_find_package_multi"] = "OSDependent"
@@ -162,15 +172,6 @@ class GlslangConan(ConanFile):
             self.cpp_info.components["machineindependent"].names["cmake_find_package_multi"] = "MachineIndependent"
             self.cpp_info.components["machineindependent"].libs = ["MachineIndependent" + lib_suffix]
 
-        # glslang
-        self.cpp_info.components["glslang-core"].names["cmake_find_package"] = "glslang"
-        self.cpp_info.components["glslang-core"].names["cmake_find_package_multi"] = "glslang"
-        self.cpp_info.components["glslang-core"].libs = ["glslang" + lib_suffix]
-        if self.settings.os == "Linux":
-            self.cpp_info.components["glslang-core"].system_libs.extend(["m", "pthread"])
-        self.cpp_info.components["glslang-core"].requires = ["oglcompiler", "osdependent"]
-        if tools.Version(self.version) >= "11.5.0":
-            self.cpp_info.components["glslang-core"].requires.extend(["genericcodegen", "machineindependent"])
         # SPIRV
         self.cpp_info.components["spirv"].names["cmake_find_package"] = "SPIRV"
         self.cpp_info.components["spirv"].names["cmake_find_package_multi"] = "SPIRV"

--- a/recipes/glslang/all/patches/conanize-cmake-11.5.0.patch
+++ b/recipes/glslang/all/patches/conanize-cmake-11.5.0.patch
@@ -1,0 +1,41 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -306,10 +306,6 @@
+     add_subdirectory(External)
+ endif()
+ 
+-if(NOT TARGET SPIRV-Tools-opt)
+-    set(ENABLE_OPT OFF)
+-endif()
+-
+ if(ENABLE_OPT)
+     message(STATUS "optimizer enabled")
+     add_definitions(-DENABLE_OPT=1)
+--- a/SPIRV/CMakeLists.txt
++++ b/SPIRV/CMakeLists.txt
+@@ -91,14 +91,7 @@
+ endif()
+ 
+ if(ENABLE_OPT)
+-    target_include_directories(SPIRV
+-        PRIVATE ${spirv-tools_SOURCE_DIR}/include
+-        PRIVATE ${spirv-tools_SOURCE_DIR}/source
+-    )
+-    target_link_libraries(SPIRV PRIVATE MachineIndependent SPIRV-Tools-opt)
+-    target_include_directories(SPIRV PUBLIC
+-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../External>
+-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/External>)
++    target_link_libraries(SPIRV glslang ${CONAN_LIBS})
+ else()
+     target_link_libraries(SPIRV PRIVATE MachineIndependent)
+ endif(ENABLE_OPT)
+--- a/glslang/CMakeLists.txt
++++ b/glslang/CMakeLists.txt
+@@ -167,7 +167,6 @@ set(GLSLANG_HEADERS
+ add_library(glslang ${LIB_TYPE} ${BISON_GLSLParser_OUTPUT_SOURCE} ${GLSLANG_SOURCES} ${GLSLANG_HEADERS})
+ set_target_properties(glslang PROPERTIES
+     FOLDER glslang
+-    POSITION_INDEPENDENT_CODE ON
+     VERSION   "${GLSLANG_VERSION}"
+     SOVERSION "${GLSLANG_VERSION_MAJOR}")
+ target_link_libraries(glslang PRIVATE OGLCompiler OSDependent MachineIndependent)

--- a/recipes/glslang/all/patches/conanize-cmake-11.5.0.patch
+++ b/recipes/glslang/all/patches/conanize-cmake-11.5.0.patch
@@ -31,7 +31,7 @@
  endif(ENABLE_OPT)
 --- a/glslang/CMakeLists.txt
 +++ b/glslang/CMakeLists.txt
-@@ -167,7 +167,6 @@ set(GLSLANG_HEADERS
+@@ -167,7 +167,6 @@
  add_library(glslang ${LIB_TYPE} ${BISON_GLSLParser_OUTPUT_SOURCE} ${GLSLANG_SOURCES} ${GLSLANG_HEADERS})
  set_target_properties(glslang PROPERTIES
      FOLDER glslang
@@ -39,3 +39,13 @@
      VERSION   "${GLSLANG_VERSION}"
      SOVERSION "${GLSLANG_VERSION_MAJOR}")
  target_link_libraries(glslang PRIVATE OGLCompiler OSDependent MachineIndependent)
+@@ -206,6 +205,9 @@
+                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++        install(TARGETS MachineIndependent GenericCodeGen
++                EXPORT  glslangTargets
++                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+     else()
+         install(TARGETS glslang MachineIndependent GenericCodeGen
+                 EXPORT  glslangTargets

--- a/recipes/glslang/config.yml
+++ b/recipes/glslang/config.yml
@@ -1,3 +1,5 @@
 versions:
   "8.13.3559":
     folder: all
+  "11.5.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **glslang/11.5.0**

This pull request update glslang to 11.5.0. Sometime between 11.5.0 and the previous conan package version, they split the glslang target into 3 targets: glslang, MachineIndependent and GenericCodeGen, so the conanfile.py has been updated to reflect that split.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
