### PR TITLE
capnproto: allow to use capnproto macros in build context

### DIFF
--- a/recipes/capnproto/all/test_package/conanfile.py
+++ b/recipes/capnproto/all/test_package/conanfile.py
@@ -6,11 +6,14 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
+    def build_requirements(self):
+        if tools.cross_building(self.settings):
+            self.build_requires(str(self.requires["capnproto"]))
+
     def build(self):
-        with tools.run_environment(self):
-            cmake = CMake(self)
-            cmake.configure()
-            cmake.build()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
         if not tools.cross_building(self.settings):


### PR DESCRIPTION
It's more or less the same trick than protobuf recipe.

And like protobuf, it might break if consumers inject environment variables of host context before calling CMake for their project (this is why I've removed `tools.run_environment(self)` in test_package, otherwise it fails when you cross compile).

I've tested cross compilation macOS x86_64 => iOS armv8

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
