### PR TITLE
harfbuzz: robust discovery of Freetype + fix frameworks on Apple OS + bump dependencies

### DIFF
--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -1,6 +1,8 @@
 from conans import ConanFile, CMake, tools
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class HarfbuzzConan(ConanFile):
     name = "harfbuzz"
@@ -67,8 +69,8 @@ class HarfbuzzConan(ConanFile):
             self.requires("glib/2.68.3")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -127,7 +127,7 @@ class HarfbuzzConan(ConanFile):
                 self.cpp_info.system_libs.append("usp10")
             if self.options.with_directwrite:
                 self.cpp_info.system_libs.append("dwrite")
-        if self.settings.os == "Macos":
+        if tools.is_apple_os(self.settings.os):
             self.cpp_info.frameworks.extend(["CoreFoundation", "CoreGraphics", "CoreText"])
         if not self.options.shared:
             libcxx = tools.stdcpp_library(self)

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -35,7 +35,7 @@ class HarfbuzzConan(ConanFile):
     short_paths = True
 
     exports_sources = ["CMakeLists.txt", "patches/**"]
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
     _cmake = None
 
     @property

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -62,9 +62,9 @@ class HarfbuzzConan(ConanFile):
         if self.options.with_freetype:
             self.requires("freetype/2.10.4")
         if self.options.with_icu:
-            self.requires("icu/68.2")
+            self.requires("icu/69.1")
         if self.options.with_glib:
-            self.requires("glib/2.68.0")
+            self.requires("glib/2.68.3")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

cross-building to iOS was broken because:
- it was not able to find Freetype (and it was probably too fragile in all cases). This PR can work thanks to https://github.com/conan-io/conan-center-index/pull/6056, because upstream CMakeLists tests `FREETYPE_FOUND` variable, and injects Freetype through `FREETYPE_INCLUDE_DIRS` and `FREETYPE_LIBRARIES`.
- frameworks were not propagated for iOS/tvOS etc (test package failed)

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
