### PR TITLE
astro-informatics-so3: do not download & call cmake-conan in upstream CMakeLists + modernize

### DIFF
--- a/recipes/astro-informatics-so3/all/conanfile.py
+++ b/recipes/astro-informatics-so3/all/conanfile.py
@@ -12,9 +12,10 @@ class AstroInformaticsSO3(ConanFile):
     description = "Fast and accurate Wigner transforms"
     settings = "os", "arch", "compiler", "build_type"
     topics = ("physics", "astrophysics", "radio interferometry")
+
     options = {"fPIC": [True, False]}
     default_options = {"fPIC": True}
-    requires = "fftw/3.3.9", "ssht/1.3.7"
+
     generators = "cmake", "cmake_find_package"
     exports_sources = ["CMakeLists.txt"]
 
@@ -33,6 +34,10 @@ class AstroInformaticsSO3(ConanFile):
     def configure(self):
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
+
+    def requirements(self):
+        self.requires("fftw/3.3.9")
+        self.requires("ssht/1.3.7")
 
     def validate(self):
         if self.settings.compiler == "Visual Studio":

--- a/recipes/astro-informatics-so3/all/conanfile.py
+++ b/recipes/astro-informatics-so3/all/conanfile.py
@@ -1,7 +1,5 @@
 from conans import CMake, ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
-from glob import glob
-import os
 
 required_conan_version = ">=1.33.0"
 

--- a/recipes/astro-informatics-so3/all/conanfile.py
+++ b/recipes/astro-informatics-so3/all/conanfile.py
@@ -67,5 +67,5 @@ class AstroInformaticsSO3(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["astro-informatics-so3"]
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["m"]

--- a/recipes/astro-informatics-so3/all/conanfile.py
+++ b/recipes/astro-informatics-so3/all/conanfile.py
@@ -42,7 +42,7 @@ class AstroInformaticsSO3(ConanFile):
     def validate(self):
         if self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration(
-                "SO3 requires C99 support for complex numbers."
+                "Visual Studio not supported, since SO3 requires C99 support for complex numbers"
             )
 
     def source(self):

--- a/recipes/astro-informatics-so3/all/conanfile.py
+++ b/recipes/astro-informatics-so3/all/conanfile.py
@@ -32,7 +32,7 @@ class AstroInformaticsSO3(ConanFile):
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
 
-    def config_options(self):
+    def validate(self):
         if self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration(
                 "SO3 requires C99 support for complex numbers."

--- a/recipes/astro-informatics-so3/all/conanfile.py
+++ b/recipes/astro-informatics-so3/all/conanfile.py
@@ -45,6 +45,7 @@ class AstroInformaticsSO3(ConanFile):
     def cmake(self):
         if not hasattr(self, "_cmake"):
             self._cmake = CMake(self)
+            self._cmake.definitions["conan_deps"] = False
             self._cmake.definitions["BUILD_TESTING"] = False
             self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake

--- a/recipes/astro-informatics-so3/all/conanfile.py
+++ b/recipes/astro-informatics-so3/all/conanfile.py
@@ -3,6 +3,8 @@ from conans.errors import ConanInvalidConfiguration
 from glob import glob
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class AstroInformaticsSO3(ConanFile):
     name = "astro-informatics-so3"
@@ -37,9 +39,8 @@ class AstroInformaticsSO3(ConanFile):
             )
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = glob("so3-*/")[0]
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     @property
     def cmake(self):

--- a/recipes/astro-informatics-so3/all/conanfile.py
+++ b/recipes/astro-informatics-so3/all/conanfile.py
@@ -28,6 +28,10 @@ class AstroInformaticsSO3(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
     def configure(self):
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Downloading something on internet after source() step is not allowed, and calling cmake-conan with a custom conanfile.txt can defeat many things in the recipe.
For example, I've tested cross compilation, and it downloads at build() time others package id of fftw and ssht than the one selected by the recipe, and obviously the correct package id can't exist in conan-center currently when you cross compile to iOS. Moreover, upstream conanfile.txt uses version range, which is not allowed in CCI.

/cc @mdavezac

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
