### PR TITLE
bdwgc: fix compilation on arm for Apple OS

### DIFF
--- a/recipes/bdwgc/all/conanfile.py
+++ b/recipes/bdwgc/all/conanfile.py
@@ -94,6 +94,7 @@ class BdwGcConan(ConanFile):
         if tools.is_apple_os(self.settings.os):
             cmake_osx_arch = {
                 "x86": "i386",
+                "armv8": "arm64",
             }.get(str(self.settings.arch), str(self.settings.arch))
             self._cmake.definitions["CMAKE_OSX_ARCHITECTURES"] = cmake_osx_arch
         self._cmake.verbose = True

--- a/recipes/bdwgc/all/conanfile.py
+++ b/recipes/bdwgc/all/conanfile.py
@@ -88,7 +88,7 @@ class BdwGcConan(ConanFile):
             return self._cmake
         self._cmake = CMake(self)
         for option, _ in self._autotools_options_defaults:
-                self._cmake.definitions["enable_{}".format(option)] = self.options.get_safe(option)
+            self._cmake.definitions["enable_{}".format(option)] = self.options.get_safe(option)
         self._cmake.definitions["disable_gc_debug"] = not self.options.gc_debug
         self._cmake.definitions["disable_handle_fork"] = not self.options.handle_fork
         self._cmake.definitions["install_headers"] = True

--- a/recipes/bdwgc/all/conanfile.py
+++ b/recipes/bdwgc/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import CMake, ConanFile, tools
 from conans.errors import ConanException
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class BdwGcConan(ConanFile):
     name = "bdwgc"
@@ -78,8 +80,8 @@ class BdwGcConan(ConanFile):
             self.requires("libatomic_ops/7.6.10")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("gc-{}".format(self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/bdwgc/all/conanfile.py
+++ b/recipes/bdwgc/all/conanfile.py
@@ -93,12 +93,6 @@ class BdwGcConan(ConanFile):
         self._cmake.definitions["disable_handle_fork"] = not self.options.handle_fork
         self._cmake.definitions["install_headers"] = True
         self._cmake.definitions["build_tests"] = False
-        if tools.is_apple_os(self.settings.os):
-            cmake_osx_arch = {
-                "x86": "i386",
-                "armv8": "arm64",
-            }.get(str(self.settings.arch), str(self.settings.arch))
-            self._cmake.definitions["CMAKE_OSX_ARCHITECTURES"] = cmake_osx_arch
         self._cmake.verbose = True
         self._cmake.parallel = False
         self._cmake.configure()


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

~If someone can propose more CMAKE_OSX_ARCHITECTURES mapping, feel free to review here. I'm wondering if this manual mapping is really useful. If I remove it, it works out of the box for arm (but fails if keep the original recipe).~

EDIT: well, this mapping is useless (maybe it was useful in old conan versions), and fragile. CMake helper handles CMAKE_OSX_ARCHITECTURES => https://docs.conan.io/en/latest/reference/build_helpers/cmake.html#definitions

/cc @madebr

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
