### PR TITLE
caf: robust discovery of OpenSSL + bump openssl + modernize

### DIFF
--- a/recipes/caf/all/conanfile.py
+++ b/recipes/caf/all/conanfile.py
@@ -3,6 +3,8 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 from conans.tools import Version
 
+required_conan_version = ">=1.33.0"
+
 
 class CAFConan(ConanFile):
     name = "caf"
@@ -32,10 +34,6 @@ class CAFConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("actor-framework-" + self.version, self._source_subfolder)
 
     def requirements(self):
         if self.options.with_openssl:
@@ -80,6 +78,10 @@ class CAFConan(ConanFile):
             raise ConanInvalidConfiguration("Shared libraries are not supported on Windows")
         if self.options.with_openssl and self.settings.os == "Windows" and self.settings.arch == "x86":
             raise ConanInvalidConfiguration("OpenSSL is not supported for Windows x86")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _cmake_configure(self):
         if not self._cmake:

--- a/recipes/caf/all/conanfile.py
+++ b/recipes/caf/all/conanfile.py
@@ -20,12 +20,24 @@ class CAFConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "log_level": ["error", "warning", "info", "debug", "trace", "quiet"],
-        "with_openssl": [True, False]
+        "with_openssl": [True, False],
     }
-    default_options = {"shared": False, "fPIC": True, "log_level": "quiet", "with_openssl": True}
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "log_level": "quiet",
+        "with_openssl": True,
+    }
+
     _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/caf/all/conanfile.py
+++ b/recipes/caf/all/conanfile.py
@@ -37,7 +37,7 @@ class CAFConan(ConanFile):
 
     def requirements(self):
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1j")
+            self.requires("openssl/1.1.1k")
 
     def _minimum_compilers_version(self, cppstd):
         standards = {

--- a/recipes/caf/all/conanfile.py
+++ b/recipes/caf/all/conanfile.py
@@ -103,6 +103,9 @@ class CAFConan(ConanFile):
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              "set(CMAKE_MODULE_PATH \"${CMAKE_CURRENT_SOURCE_DIR}/cmake\")",
+                              "list(APPEND CMAKE_MODULE_PATH \"${CMAKE_CURRENT_SOURCE_DIR}/cmake\")")
         cmake = self._cmake_configure()
         cmake.build()
 

--- a/recipes/caf/all/test_package/CMakeLists.txt
+++ b/recipes/caf/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(CAF REQUIRED)
 


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Generated FindOpenSSL.cmake was not used, because upstream CMakeLists resets CMAKE_MODULE_PATH, leading to fragile behaviour (broken on iOS).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
