### PR TITLE
OpenCV control NEON

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -34,6 +34,7 @@ class OpenCVConan(ConanFile):
         "with_cublas": [True, False],
         "with_cufft": [True, False],
         "with_v4l": [True, False],
+        "with_neon": [None, True, False],
         "dnn": [True, False],
         "detect_cpu_baseline": [True, False]
     }
@@ -57,6 +58,7 @@ class OpenCVConan(ConanFile):
         "with_cublas": False,
         "with_cufft": False,
         "with_v4l": False,
+        "with_neon": None,
         "dnn": True,
         "detect_cpu_baseline": False
     }
@@ -294,6 +296,9 @@ class OpenCVConan(ConanFile):
         
         if self.options.detect_cpu_baseline:
             self._cmake.definitions["CPU_BASELINE"] = "DETECT"
+        
+        if self.options.with_neon is not None:
+            self._cmake.definitions["ENABLE_NEON"] = self.options.with_neon
 
         self._cmake.definitions["WITH_PROTOBUF"] = self.options.dnn
         if self.options.dnn:

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -34,7 +34,7 @@ class OpenCVConan(ConanFile):
         "with_cublas": [True, False],
         "with_cufft": [True, False],
         "with_v4l": [True, False],
-        "with_neon": [True, False],
+        "neon": [True, False],
         "dnn": [True, False],
         "detect_cpu_baseline": [True, False]
     }
@@ -58,7 +58,7 @@ class OpenCVConan(ConanFile):
         "with_cublas": False,
         "with_cufft": False,
         "with_v4l": False,
-        "with_neon": True,
+        "neon": True,
         "dnn": True,
         "detect_cpu_baseline": False
     }
@@ -88,7 +88,7 @@ class OpenCVConan(ConanFile):
             del self.options.with_gtk
             del self.options.with_v4l
         if "arm" not in self.settings.arch:
-            del self.options.with_neon
+            del self.options.neon
 
     def configure(self):
         if self.settings.compiler == "Visual Studio" and \
@@ -299,8 +299,8 @@ class OpenCVConan(ConanFile):
         if self.options.detect_cpu_baseline:
             self._cmake.definitions["CPU_BASELINE"] = "DETECT"
         
-        if self.options.get_safe("with_neon") is not None:
-            self._cmake.definitions["ENABLE_NEON"] = self.options.get_safe("with_neon")
+        if self.options.get_safe("neon") is not None:
+            self._cmake.definitions["ENABLE_NEON"] = self.options.get_safe("neon")
 
         self._cmake.definitions["WITH_PROTOBUF"] = self.options.dnn
         if self.options.dnn:

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -34,7 +34,7 @@ class OpenCVConan(ConanFile):
         "with_cublas": [True, False],
         "with_cufft": [True, False],
         "with_v4l": [True, False],
-        "with_neon": [None, True, False],
+        "with_neon": [True, False],
         "dnn": [True, False],
         "detect_cpu_baseline": [True, False]
     }
@@ -58,7 +58,7 @@ class OpenCVConan(ConanFile):
         "with_cublas": False,
         "with_cufft": False,
         "with_v4l": False,
-        "with_neon": None,
+        "with_neon": True,
         "dnn": True,
         "detect_cpu_baseline": False
     }
@@ -87,6 +87,8 @@ class OpenCVConan(ConanFile):
         if self.settings.os != "Linux":
             del self.options.with_gtk
             del self.options.with_v4l
+        if "arm" not in self.settings.arch:
+            del self.options.with_neon
 
     def configure(self):
         if self.settings.compiler == "Visual Studio" and \
@@ -297,8 +299,8 @@ class OpenCVConan(ConanFile):
         if self.options.detect_cpu_baseline:
             self._cmake.definitions["CPU_BASELINE"] = "DETECT"
         
-        if self.options.with_neon is not None:
-            self._cmake.definitions["ENABLE_NEON"] = self.options.with_neon
+        if self.options.get_safe("with_neon") is not None:
+            self._cmake.definitions["ENABLE_NEON"] = self.options.get_safe("with_neon")
 
         self._cmake.definitions["WITH_PROTOBUF"] = self.options.dnn
         if self.options.dnn:


### PR DESCRIPTION
Specify library name and version:  **opencv/all**

Add an option to control `ENABLE_NEON`, also required for QNX :P

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
