### PR TITLE
cppcheck: fix cross-build iOS + bump deps + modernize

### DIFF
--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -1,5 +1,7 @@
-import os
 from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.33.0"
 
 
 class CppcheckConan(ConanFile):
@@ -39,9 +41,8 @@ class CppcheckConan(ConanFile):
             self.requires("pcre/8.45")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "cppcheck-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -36,7 +36,7 @@ class CppcheckConan(ConanFile):
         if self.options.with_z3:
             self.requires("z3/4.8.8")
         if self.options.have_rules:
-            self.requires("pcre/8.44")
+            self.requires("pcre/8.45")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -18,7 +18,7 @@ class CppcheckConan(ConanFile):
     exports_sources = ["CMakeLists.txt", "patches/**"]
 
     _cmake = None
-    
+
     @property
     def _source_subfolder(self):
         return "source_subfolder"
@@ -26,10 +26,13 @@ class CppcheckConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
-        
+
     def _patch_sources(self):
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
+        tools.replace_in_file(os.path.join(self._source_subfolder, "cli", "CMakeLists.txt"),
+                              "RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR}",
+                              "DESTINATION ${CMAKE_INSTALL_FULL_BINDIR}")
 
     def requirements(self):
         if self.options.with_z3:
@@ -64,7 +67,7 @@ class CppcheckConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "share"))
-        
+
     def package_info(self):
         bin_folder = os.path.join(self.package_folder, "bin")
         self.output.info("Append %s to environment variable PATH" % bin_folder)

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -1,5 +1,3 @@
-"""Conan recipe package for cppcheck
-"""
 import os
 from conans import ConanFile, CMake, tools
 

--- a/recipes/cppcheck/all/test_package/conanfile.py
+++ b/recipes/cppcheck/all/test_package/conanfile.py
@@ -1,7 +1,9 @@
-from conans import ConanFile
+from conans import ConanFile, tools
 
 
 class TestPackageConan(ConanFile):
+    settings = "os", "arch"
 
     def test(self):
-        self.run("cppcheck --version", run_environment=True)
+        if not tools.cross_building(self.settings):
+            self.run("cppcheck --version", run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Probably not very useful to cross-build cppcheck to iOS, but at least it won't fail now.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
