### PR TITLE
Add virtual release for gperf (fixes broken C++17 compilation)

### DIFF
--- a/recipes/gperf/all/conandata.yml
+++ b/recipes/gperf/all/conandata.yml
@@ -9,3 +9,6 @@ patches:
   "3.1":
     - patch_file: "patches/0001-remove-register-keyword.patch"
       base_path: "source_subfolder"
+  "cci.20210606":
+    - patch_file: "patches/0002-remove-docs-and-tests.patch"
+      base_path: "source_subfolder"

--- a/recipes/gperf/all/conandata.yml
+++ b/recipes/gperf/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "3.1":
     url: "https://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"
     sha256: "588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
+  "cci.20210606":
+    url: "https://git.savannah.gnu.org/gitweb/?p=gperf.git;a=snapshot;h=96ebd0b95dda2817923ef6de25cdaca1e7ee2956;sf=tgz"
+    sha256: "e9b40d8d573e67db145a726a762f2a031cd64a300f8aa5cc3d576ee8f1ea93f5"   
 patches:
   "3.1":
     - patch_file: "patches/0001-remove-register-keyword.patch"

--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -26,7 +26,7 @@ class GperfConan(ConanFile):
     def build_requirements(self):
         if self.settings.os == "Windows" and tools.os_info.is_windows:
             if "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != "msys2":
-                self.build_requires("msys2/20190524")
+                self.build_requires("msys2/cci.latest")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -57,7 +57,7 @@ class GperfConan(ConanFile):
     def _build_configure(self):
         with tools.chdir(self._source_subfolder):
             try:
-                self.run("./autogen.sh")
+                self.run("autogen.sh", run_environment=True)
             except:
                 pass
             autotools = self._configure_autotools()

--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -1,6 +1,7 @@
-from conans import ConanFile, tools, AutoToolsBuildEnvironment
-import glob
 import os
+
+from conans import ConanFile, tools, AutoToolsBuildEnvironment
+from conans.errors import ConanException
 
 class GperfConan(ConanFile):
     name = "gperf"
@@ -24,7 +25,7 @@ class GperfConan(ConanFile):
 
     def build_requirements(self):
         if self.settings.os == "Windows" and tools.os_info.is_windows:
-            if "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != 'msys2':
+            if "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != "msys2":
                 self.build_requires("msys2/20190524")
 
     def source(self):

--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -58,7 +58,7 @@ class GperfConan(ConanFile):
         with tools.chdir(self._source_subfolder):
             try:
                 self.run("autogen.sh", run_environment=True)
-            except:
+            except ConanException:
                 pass
             autotools = self._configure_autotools()
             autotools.make()

--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools, AutoToolsBuildEnvironment
+import glob
 import os
 
 class GperfConan(ConanFile):
@@ -27,9 +28,8 @@ class GperfConan(ConanFile):
                 self.build_requires("msys2/20190524")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], filename=self.name + "-" + self.version + ".tar.gz")
+        os.rename(glob.glob("gperf-*")[0], self._source_subfolder)
 
     def _configure_autotools(self):
         if not self._autotools:
@@ -56,6 +56,10 @@ class GperfConan(ConanFile):
 
     def _build_configure(self):
         with tools.chdir(self._source_subfolder):
+            try:
+                self.run("./autogen.sh")
+            except:
+                pass
             autotools = self._configure_autotools()
             autotools.make()
 

--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -28,8 +28,9 @@ class GperfConan(ConanFile):
                 self.build_requires("msys2/20190524")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], filename=self.name + "-" + self.version + ".tar.gz")
-        os.rename(glob.glob("gperf-*")[0], self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  filename="gperf.tar.gz",
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_autotools(self):
         if not self._autotools:

--- a/recipes/gperf/all/patches/0002-remove-docs-and-tests.patch
+++ b/recipes/gperf/all/patches/0002-remove-docs-and-tests.patch
@@ -1,0 +1,26 @@
+--- configure.ac
++++ configure.ac
+@@ -30,7 +30,7 @@
+ 
+ AC_CONFIG_FILES([Makefile])
+ 
+-AC_CONFIG_SUBDIRS([lib src tests doc])
++AC_CONFIG_SUBDIRS([lib src])
+ 
+ dnl This piece of sed script replaces every line containing '@subdir@'
+ dnl by several consecutive lines, each referencing one subdir.
+@@ -42,14 +42,6 @@
+ p
+ g
+ s/@subdir@/src/
+-p
+-g
+-s/@subdir@/tests/
+-p
+-g
+-s/@subdir@/doc/
+-p
+-d
+ }
+ '
+ 

--- a/recipes/gperf/config.yml
+++ b/recipes/gperf/config.yml
@@ -1,3 +1,5 @@
 versions:
   "3.1":
     folder: "all"
+  "cci.20210606":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **gperf/cci.20210606**

This PR is in response to @prince-chrismc suggestion to add a virtual release to fix broken C++17 build of gperf. I had originally proposed a PR to patch the 3.1 version to fix the compilation error but the result of the discussion was that it would be better to create a virtual release. See here:
https://github.com/conan-io/conan-center-index/pull/3876

---

- [✓] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [✓] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [✓] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [✓] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
