### PR TITLE
[opencolorio] Disable SSE for arch other from x86/64

### DIFF
--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
-import os, shutil
+import os
+import shutil
 
 required_conan_version = ">=1.33.0"
 
@@ -12,8 +13,16 @@ class OpenColorIOConan(ConanFile):
     homepage = "https://opencolorio.org/"
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "use_sse": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "use_sse": True
+    }
     generators = "cmake", "cmake_find_package"
     exports_sources = ["CMakeLists.txt", "patches/*"]
     topics = ("colors", "visual", "effects", "animation")
@@ -27,6 +36,8 @@ class OpenColorIOConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self.settings.arch not in ["x86", "x86_64"]:
+            del self.options.use_sse
 
     def configure(self):
         if self.options.shared:
@@ -40,12 +51,9 @@ class OpenColorIOConan(ConanFile):
         self.requires("lcms/2.11")
         self.requires("yaml-cpp/0.6.3")
 
-    def validate(self):
-        if self.settings.arch not in ["x86", "x86_64"]:
-            raise ConanInvalidConfiguration("Only x86/x86_64 supported")
-
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:
@@ -55,6 +63,7 @@ class OpenColorIOConan(ConanFile):
 
         self._cmake.definitions["OCIO_BUILD_SHARED"] = self.options.shared
         self._cmake.definitions["OCIO_BUILD_STATIC"] = not self.options.shared
+        self._cmake.definitions["OCIO_USE_SSE"] = self.options.get_safe("use_sse", False)
         self._cmake.definitions["OCIO_BUILD_APPS"] = True
         self._cmake.definitions["OCIO_BUILD_DOCS"] = False
         self._cmake.definitions["OCIO_BUILD_TESTS"] = False
@@ -84,7 +93,8 @@ class OpenColorIOConan(ConanFile):
         cm.install()
 
         if not self.options.shared:
-            self.copy("*", src=os.path.join(self.package_folder, "lib", "static"), dst="lib")
+            self.copy("*", src=os.path.join(self.package_folder,
+                      "lib", "static"), dst="lib")
             tools.rmdir(os.path.join(self.package_folder, "lib", "static"))
 
         tools.rmdir(os.path.join(self.package_folder, "cmake"))

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -1,7 +1,6 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
-import shutil
 
 required_conan_version = ">=1.33.0"
 


### PR DESCRIPTION
Specify library name and version:  **opencolorio**

Use option `use_sse` to enable/disable SSE.

Following comment https://github.com/conan-io/conan-center-index/pull/6207#discussion_r666013157 cc/ @SpaceIm 
