### PR TITLE
[libx265] Improve error message for non x86/64 builds

### DIFF
--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -64,7 +64,7 @@ class Libx265Conan(ConanFile):
 
     def validate(self):
         if self.settings.arch not in ["x86", "x86_64"]:
-            raise ConanInvalidConfiguration("Only x86/x86_64 supported")
+            raise ConanInvalidConfiguration("Current recipe supports only x86/x86_64 builds")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)


### PR DESCRIPTION
Specify library name and version:  **libx265**

Following good advice here: https://github.com/conan-io/conan-center-index/pull/6213#discussion_r666058366

