### PR TITLE
qt: add upstream patch for QTBUG-88309

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -16,3 +16,5 @@ patches:
       base_path: "qt5/qttools"
     - patch_file: "patches/QTBUG-88625.diff"
       base_path: "qt5/qtwebengine"
+    - patch_file: "patches/7371d3a.diff"
+      base_path: "qt5/qtbase"

--- a/recipes/qt/5.x.x/patches/7371d3a.diff
+++ b/recipes/qt/5.x.x/patches/7371d3a.diff
@@ -1,0 +1,38 @@
+Parent:     30151e20 (Fix misidentification of some shearing QTransforms as only rotating)
+Author:     Zhang Yu <zhangyub@uniontech.com>
+AuthorDate: 2020-11-17 21:05:39 +0800
+Commit:     Zhang Yu <zhangyub@uniontech.com>
+CommitDate: 2020-11-18 07:41:48 +0000
+
+Fix QGraphicsItem crash if click right button of mouse
+
+In this case, the 'parent' is QGraphicsTextItem which isn't a object
+inheriting from QWidget. Converting QGraphicsTextItem to QWidget
+by static_cast and using it as QWidget leads to crash.
+
+Fixes: QTBUG-88309
+Change-Id: I3c583f43125eb36841848434d1fa9a135b0e9f57
+Reviewed-by: Volker Hilsheimer <volker.hilsheimer@qt.io>
+(cherry picked from commit 4df5f93018344f6cdc6cd5a08a084b1c61e0c076)
+
+diff --git a/src/widgets/widgets/qwidgettextcontrol.cpp b/src/widgets/widgets/qwidgettextcontrol.cpp
+index 40b8af6..e2a07c0 100644
+--- a/src/widgets/widgets/qwidgettextcontrol.cpp
++++ b/src/widgets/widgets/qwidgettextcontrol.cpp
+@@ -1942,10 +1942,14 @@
+     if (!menu)
+         return;
+     menu->setAttribute(Qt::WA_DeleteOnClose);
+-    if (auto *window = static_cast<QWidget *>(parent)->window()->windowHandle()) {
+-        QMenuPrivate::get(menu)->topData()->initialScreenIndex =
++
++    if (auto *widget = qobject_cast<QWidget *>(parent)) {
++        if (auto *window = widget->window()->windowHandle()) {
++            QMenuPrivate::get(menu)->topData()->initialScreenIndex =
+                 QGuiApplication::screens().indexOf(window->screen());
++        }
+     }
++
+     menu->popup(screenPos);
+ #endif
+ }


### PR DESCRIPTION
Specify library name and version:  **qt/5.15.2**

When using the QGraphicsView framework (QWidgets), bug [QTBUG-88309](https://bugreports.qt.io/browse/QTBUG-88309) is particularly nasty because it may crash your application if you right click on a QGraphicsItem derived object.
This bug was introduced in qt 5.15.1.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
