### PR TITLE
gperf: fix PR #5835. Correct patch file name and apply patches

### DIFF
--- a/recipes/gperf/all/conandata.yml
+++ b/recipes/gperf/all/conandata.yml
@@ -4,5 +4,5 @@ sources:
     sha256: "588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
 patches:
   "3.1":
-    - patch_file: "all/0001-assert-exception-upstream-issue-2011.patch"
+    - patch_file: "patches/0001-remove-register-keyword.patch"
       base_path: "source_subfolder"

--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -11,7 +11,7 @@ class GperfConan(ConanFile):
     settings = "os", "arch", "compiler"
     _source_subfolder = "source_subfolder"
     _autotools = None
-    exports_sources = "patches/**"
+    exports_sources = "patches/*"
 
     @property
     def _is_msvc(self):
@@ -30,6 +30,8 @@ class GperfConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
 
     def _configure_autotools(self):
         if not self._autotools:

--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -30,8 +30,6 @@ class GperfConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
 
     def _configure_autotools(self):
         if not self._autotools:
@@ -62,6 +60,8 @@ class GperfConan(ConanFile):
             autotools.make()
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         if self._is_msvc:
             with tools.vcvars(self.settings):
                 self._build_configure()


### PR DESCRIPTION
…rce() method

Specify library name and version:  **gperf/3.1**

PR #5835 added a patch to remove a register keyword. However the patch is never applied because:

1. The name of the patch file in conandata.yml is wrong (looks like copy/paste error).
2. The patch is never applied because the code to do so is missing in the source() method of conanfile.py.

I compiled gperf 3.1 successfully with clang12 (that uses C++17 by default) with this PR.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
