### PR TITLE
autoconf: add LDFLAGS when linking executable

### DIFF
--- a/recipes/autoconf/all/test_package/Makefile.in
+++ b/recipes/autoconf/all/test_package/Makefile.in
@@ -5,7 +5,7 @@ SRCS = test_package_c.c test_package_cpp.cpp
 OBJS := $(patsubst %.c,%.@OBJEXT@,$(patsubst %.cpp,%.@OBJEXT@,$(SRCS)))
 
 test_package@EXEEXT@: $(OBJS)
-	@CXX@ $^ -o $@
+	@CXX@ $^ -o $@ @LDFLAGS@
 
 %.@OBJEXT@: %.cpp
 	@CXX@ @CXXFLAGS@ @CPPFLAGS@ -c $< @CC_MINUS_O@ $@


### PR DESCRIPTION
Specify library name and version:  **autoconf/all**

Fixes #6198


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
