### PR TITLE
[hdf5] enable parallel support via OpenMPI

### DIFF
--- a/recipes/hdf5/all/conandata.yml
+++ b/recipes/hdf5/all/conandata.yml
@@ -18,6 +18,8 @@ patches:
   "1.10.6":
     - patch_file: "patches/fix-missing-function-prototypes-1.10.5+.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-missing-function-prototypes-1.10.6.patch"
+      base_path: "source_subfolder"
     - patch_file: "patches/conanize-link-szip-1.10.5+.patch"
       base_path: "source_subfolder"
   "1.10.5":

--- a/recipes/hdf5/all/conandata.yml
+++ b/recipes/hdf5/all/conandata.yml
@@ -16,9 +16,13 @@ patches:
     - patch_file: "patches/conanize-link-szip-1.10.5+.patch"
       base_path: "source_subfolder"
   "1.10.6":
+    - patch_file: "patches/fix-missing-function-prototypes-1.10.5+.patch"
+      base_path: "source_subfolder"
     - patch_file: "patches/conanize-link-szip-1.10.5+.patch"
       base_path: "source_subfolder"
   "1.10.5":
+    - patch_file: "patches/fix-missing-function-prototypes-1.10.5+.patch"
+      base_path: "source_subfolder"
     - patch_file: "patches/conanize-link-szip-1.10.5+.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/build-either-static-or-shared-1.10.5.patch"

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -57,7 +57,6 @@ class Hdf5Conan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-
         if not self.options.enable_cxx:
             del self.settings.compiler.libcxx
             del self.settings.compiler.cppstd

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -57,7 +57,7 @@ class Hdf5Conan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-            
+
         if not self.options.enable_cxx:
             del self.settings.compiler.libcxx
             del self.settings.compiler.cppstd
@@ -72,7 +72,7 @@ class Hdf5Conan(ConanFile):
         if self.options.parallel:
             if self.options.enable_cxx:
                 raise ConanInvalidConfiguration("Parallel and C++ options are mutually exclusive")
-            if self.options.threadsafe:
+            if self.options.get_safe("threadsafe", False):
                 raise ConanInvalidConfiguration("Parallel and Threadsafe options are mutually exclusive")
 
     def validate(self):
@@ -146,10 +146,6 @@ class Hdf5Conan(ConanFile):
         self._cmake.definitions["HDF5_BUILD_CPP_LIB"] = self.options.enable_cxx
         if tools.Version(self.version) >= "1.10.0":
             self._cmake.definitions["HDF5_BUILD_JAVA"] = False
-
-        # apple-clang 12 changed defaults (now enforces C99) and it adds 'implicit-function-declaration' as error
-        if self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) >= "12" and tools.Version(self.version) < "1.11":
-            self._cmake.definitions["CMAKE_C_FLAGS"] = "-Wno-error=implicit-function-declaration"
 
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -68,16 +68,16 @@ class Hdf5Conan(ConanFile):
              self.options.szip_encoding and \
              not self.options["szip"].enable_encoding:
             raise ConanInvalidConfiguration("encoding must be enabled in szip dependency (szip:enable_encoding=True)")
-        if self.options.parallel:
-            if self.options.enable_cxx:
-                raise ConanInvalidConfiguration("Parallel and C++ options are mutually exclusive")
-            if self.options.get_safe("threadsafe", False):
-                raise ConanInvalidConfiguration("Parallel and Threadsafe options are mutually exclusive")
 
     def validate(self):
         if hasattr(self, "settings_build") and tools.cross_building(self, skip_x64_x86=True):
             # While building it runs some executables like H5detect
             raise ConanInvalidConfiguration("Current recipe doesn't support cross-building (yet)")
+        if self.options.parallel:
+            if self.options.enable_cxx:
+                raise ConanInvalidConfiguration("Parallel and C++ options are mutually exclusive")
+            if self.options.get_safe("threadsafe", False):
+                raise ConanInvalidConfiguration("Parallel and Threadsafe options are mutually exclusive")
 
     def requirements(self):
         if self.options.with_zlib:

--- a/recipes/hdf5/all/patches/fix-missing-function-prototypes-1.10.5+.patch
+++ b/recipes/hdf5/all/patches/fix-missing-function-prototypes-1.10.5+.patch
@@ -1,0 +1,48 @@
+diff --git a/src/H5Fsuper.c b/src/H5Fsuper.c
+index 4999565137..00a3dc552e 100644
+--- a/src/H5Fsuper.c
++++ b/src/H5Fsuper.c
+@@ -54,6 +54,7 @@
+ /********************/
+ static herr_t H5F__super_ext_create(H5F_t *f, H5O_loc_t *ext_ptr);
+ static herr_t H5F__update_super_ext_driver_msg(H5F_t *f);
++herr_t H5O__fsinfo_set_version(H5F_t *f, H5O_fsinfo_t *fsinfo);
+ 
+ 
+ /*********************/
+diff --git a/src/H5Odeprec.c b/src/H5Odeprec.c
+index 33ed787440..0e1290476c 100644
+--- a/src/H5Odeprec.c
++++ b/src/H5Odeprec.c
+@@ -32,6 +32,7 @@
+ /* Headers */
+ /***********/
+ #include "H5private.h"      /* Generic Functions    */
++#include "H5CXprivate.h"    /* API Contexts         */
+ #include "H5Eprivate.h"     /* Error handling       */
+ #include "H5Opkg.h"         /* Object headers       */
+ 
+diff --git a/src/H5Oint.c b/src/H5Oint.c
+index 543637c127..92809e4d5a 100644
+--- a/src/H5Oint.c
++++ b/src/H5Oint.c
+@@ -31,6 +31,7 @@
+ /* Headers */
+ /***********/
+ #include "H5private.h"          /* Generic Functions                        */
++#include "H5CXprivate.h"        /* API Contexts                             */
+ #include "H5Eprivate.h"         /* Error handling                           */
+ #include "H5Fprivate.h"         /* File access                              */
+ #include "H5FLprivate.h"        /* Free lists                               */
+diff --git a/src/H5Rint.c b/src/H5Rint.c
+index 159bccac34..6f8efb33a2 100644
+--- a/src/H5Rint.c
++++ b/src/H5Rint.c
+@@ -23,6 +23,7 @@
+ /***********/
+ #include "H5private.h"          /* Generic Functions                        */
+ #include "H5ACprivate.h"        /* Metadata cache                           */
++#include "H5CXprivate.h"        /* API Contexts                             */
+ #include "H5Dprivate.h"         /* Datasets                                 */
+ #include "H5Eprivate.h"         /* Error handling                           */
+ #include "H5Gprivate.h"         /* Groups                                   */

--- a/recipes/hdf5/all/patches/fix-missing-function-prototypes-1.10.5+.patch
+++ b/recipes/hdf5/all/patches/fix-missing-function-prototypes-1.10.5+.patch
@@ -1,5 +1,5 @@
 diff --git a/src/H5Fsuper.c b/src/H5Fsuper.c
-index 4999565137..00a3dc552e 100644
+index 9339b3df6c..052c296ac1 100644
 --- a/src/H5Fsuper.c
 +++ b/src/H5Fsuper.c
 @@ -54,6 +54,7 @@
@@ -11,38 +11,24 @@ index 4999565137..00a3dc552e 100644
  
  /*********************/
 diff --git a/src/H5Odeprec.c b/src/H5Odeprec.c
-index 33ed787440..0e1290476c 100644
+index 33ed787440..b8e1af55ce 100644
 --- a/src/H5Odeprec.c
 +++ b/src/H5Odeprec.c
-@@ -32,6 +32,7 @@
- /* Headers */
- /***********/
- #include "H5private.h"      /* Generic Functions    */
-+#include "H5CXprivate.h"    /* API Contexts         */
- #include "H5Eprivate.h"     /* Error handling       */
- #include "H5Opkg.h"         /* Object headers       */
+@@ -54,6 +54,17 @@
+ /********************/
+ /* Local Prototypes */
+ /********************/
++herr_t
++H5CX_set_apl(hid_t *, const H5P_libclass_t *,
++             hid_t
++#ifndef H5_HAVE_PARALLEL
++H5_ATTR_UNUSED
++#endif /* H5_HAVE_PARALLEL */
++, hbool_t
++#ifndef H5_HAVE_PARALLEL
++             H5_ATTR_UNUSED
++#endif /* H5_HAVE_PARALLEL */
++);
  
-diff --git a/src/H5Oint.c b/src/H5Oint.c
-index 543637c127..92809e4d5a 100644
---- a/src/H5Oint.c
-+++ b/src/H5Oint.c
-@@ -31,6 +31,7 @@
- /* Headers */
- /***********/
- #include "H5private.h"          /* Generic Functions                        */
-+#include "H5CXprivate.h"        /* API Contexts                             */
- #include "H5Eprivate.h"         /* Error handling                           */
- #include "H5Fprivate.h"         /* File access                              */
- #include "H5FLprivate.h"        /* Free lists                               */
-diff --git a/src/H5Rint.c b/src/H5Rint.c
-index 159bccac34..6f8efb33a2 100644
---- a/src/H5Rint.c
-+++ b/src/H5Rint.c
-@@ -23,6 +23,7 @@
- /***********/
- #include "H5private.h"          /* Generic Functions                        */
- #include "H5ACprivate.h"        /* Metadata cache                           */
-+#include "H5CXprivate.h"        /* API Contexts                             */
- #include "H5Dprivate.h"         /* Datasets                                 */
- #include "H5Eprivate.h"         /* Error handling                           */
- #include "H5Gprivate.h"         /* Groups                                   */
+ 
+ /*********************/

--- a/recipes/hdf5/all/patches/fix-missing-function-prototypes-1.10.6.patch
+++ b/recipes/hdf5/all/patches/fix-missing-function-prototypes-1.10.6.patch
@@ -1,0 +1,24 @@
+diff --git a/src/H5Oint.c b/src/H5Oint.c
+index 543637c127..c8a6131a34 100644
+--- a/src/H5Oint.c
++++ b/src/H5Oint.c
+@@ -82,6 +82,7 @@ static herr_t H5O__free_visit_visited(void *item, void *key,
+ static herr_t H5O__visit_cb(hid_t group, const char *name, const H5L_info_t *linfo,
+     void *_udata);
+ static const H5O_obj_class_t *H5O__obj_class_real(const H5O_t *oh);
++H5_DLL herr_t H5CX_get_ohdr_flags(uint8_t *ohdr_flags);
+ 
+ 
+ /*********************/
+diff --git a/src/H5Rint.c b/src/H5Rint.c
+index 159bccac34..b48d2a706d 100644
+--- a/src/H5Rint.c
++++ b/src/H5Rint.c
+@@ -46,6 +46,7 @@
+ /********************/
+ /* Local Prototypes */
+ /********************/
++H5_DLL herr_t H5CX_set_libver_bounds(H5F_t *f);
+ 
+ /*********************/
+ /* Package Variables */

--- a/recipes/hdf5/all/test_package/CMakeLists.txt
+++ b/recipes/hdf5/all/test_package/CMakeLists.txt
@@ -1,9 +1,17 @@
 cmake_minimum_required(VERSION 3.1)
 
-project(test_package LANGUAGES CXX)
+project(test_package LANGUAGES C CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
+add_executable(${CMAKE_PROJECT_NAME} test_package.c)
+if (HDF5_CXX)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE CONAN_HDF5_CXX)
+    target_sources(${CMAKE_PROJECT_NAME} PRIVATE test_package.cpp)
+endif()
+if (HDF5_PARALLEL)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE CONAN_HDF5_PARALLEL)
+    target_sources(${CMAKE_PROJECT_NAME} PRIVATE test_parallel.c)
+endif()
 target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/hdf5/all/test_package/conanfile.py
+++ b/recipes/hdf5/all/test_package/conanfile.py
@@ -9,6 +9,10 @@ class Hdf5TestConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions.update({
+            "HDF5_CXX": self.options["hdf5"].enable_cxx,
+            "HDF5_PARALLEL": self.options["hdf5"].parallel
+        })
         cmake.configure()
         cmake.build()
 

--- a/recipes/hdf5/all/test_package/test_package.c
+++ b/recipes/hdf5/all/test_package/test_package.c
@@ -1,0 +1,50 @@
+#include "hdf5.h"
+#define FILE "dset.h5"
+
+extern void test_cxx_api();
+extern void test_parallel();
+
+void test_c_api()
+{
+
+    hid_t   file_id, dataset_id, dataspace_id; /* identifiers */
+    hsize_t dims[2];
+    herr_t  status;
+
+    /* Create a new file using default properties. */
+    file_id = H5Fcreate(FILE, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+
+    /* Create the data space for the dataset. */
+    dims[0]      = 4;
+    dims[1]      = 6;
+    dataspace_id = H5Screate_simple(2, dims, NULL);
+
+    /* Create the dataset. */
+    dataset_id =
+        H5Dcreate2(file_id, "/dset", H5T_STD_I32BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+
+    /* End access to the dataset and release resources used by it. */
+    status = H5Dclose(dataset_id);
+
+    /* Terminate access to the data space. */
+    status = H5Sclose(dataspace_id);
+
+    /* Close the file. */
+    status = H5Fclose(file_id);
+}
+
+int main(int argc, char **argv)
+{
+    printf("Testing C API\n");
+    test_c_api();
+    #ifdef CONAN_HDF5_CXX
+    printf("Testing C++ API\n");
+    test_cxx_api();
+    #endif
+    #ifdef CONAN_HDF5_PARALLEL
+    printf("Testing HDF5 Parallel\n");
+    test_parallel(argc, argv);
+    #endif
+
+    return 0;
+}

--- a/recipes/hdf5/all/test_package/test_package.cpp
+++ b/recipes/hdf5/all/test_package/test_package.cpp
@@ -1,8 +1,8 @@
 #include <H5Cpp.h>
 
-int main()
+extern "C" void test_cxx_api()
 {
-    hsize_t dimensions[] = {4, 6};  
+    hsize_t dimensions[] = {4, 6};
 	H5::H5File file("dataset.h5", H5F_ACC_TRUNC);
 	H5::DataSpace dataspace(2, dimensions);
 	H5::DataSet dataset = file.createDataSet("dataset", H5::PredType::STD_I32BE, dataspace);

--- a/recipes/hdf5/all/test_package/test_parallel.c
+++ b/recipes/hdf5/all/test_package/test_parallel.c
@@ -1,0 +1,99 @@
+/*
+ *  This example writes data to the HDF5 file.
+ *  Number of processes is assumed to be 1 or multiples of 2 (up to 8)
+ */
+
+#include "hdf5.h"
+#include "stdlib.h"
+
+#define H5FILE_NAME     "SDS.h5"
+#define DATASETNAME 	"IntArray"
+#define NX     8                      /* dataset dimensions */
+#define NY     5
+#define RANK   2
+
+int test_parallel(int argc, char **argv)
+{
+    /*
+     * HDF5 APIs definitions
+     */
+    hid_t       file_id, dset_id;         /* file and dataset identifiers */
+    hid_t       filespace;      /* file and memory dataspace identifiers */
+    hsize_t     dimsf[] = {NX, NY};                 /* dataset dimensions */
+    int         *data;                    /* pointer to data buffer to write */
+    hid_t	plist_id;                 /* property list identifier */
+    int         i;
+    herr_t      status;
+
+    /*
+     * MPI variables
+     */
+    int mpi_size, mpi_rank;
+    MPI_Comm comm  = MPI_COMM_WORLD;
+    MPI_Info info  = MPI_INFO_NULL;
+
+    /*
+     * Initialize MPI
+     */
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(comm, &mpi_size);
+    MPI_Comm_rank(comm, &mpi_rank);
+
+    /*
+     * Initialize data buffer
+     */
+    data = (int *) malloc(sizeof(int)*dimsf[0]*dimsf[1]);
+    for (i=0; i < dimsf[0]*dimsf[1]; i++) {
+        data[i] = i;
+    }
+    /*
+     * Set up file access property list with parallel I/O access
+     */
+     plist_id = H5Pcreate(H5P_FILE_ACCESS);
+                H5Pset_fapl_mpio(plist_id, comm, info);
+
+    /*
+     * Create a new file collectively and release property list identifier.
+     */
+    file_id = H5Fcreate(H5FILE_NAME, H5F_ACC_TRUNC, H5P_DEFAULT, plist_id);
+              H5Pclose(plist_id);
+
+
+    /*
+     * Create the dataspace for the dataset.
+     */
+    filespace = H5Screate_simple(RANK, dimsf, NULL);
+
+    /*
+     * Create the dataset with default properties and close filespace.
+     */
+    dset_id = H5Dcreate(file_id, DATASETNAME, H5T_NATIVE_INT, filespace,
+			H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    /*
+     * Create property list for collective dataset write.
+     */
+    plist_id = H5Pcreate(H5P_DATASET_XFER);
+               H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
+
+    /*
+     * To write dataset independently use
+     *
+     * H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_INDEPENDENT);
+     */
+
+    status = H5Dwrite(dset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL,
+		      plist_id, data);
+    free(data);
+
+    /*
+     * Close/release resources.
+     */
+    H5Dclose(dset_id);
+    H5Sclose(filespace);
+    H5Pclose(plist_id);
+    H5Fclose(file_id);
+
+    MPI_Finalize();
+
+    return 0;
+}


### PR DESCRIPTION
Specify library name and version:  **hdf5**

Adds support for Parallel HDF5 via Open MPI with the option `hdf5:parallel` (`False` by default)

Also added a test package for the C API as the existing test package will fail if `hdf5:enable_cxx` is `False`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
