### PR TITLE
Add protobuf v3.17.3

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "3.17.1":
     sha256: 036D66D6EEC216160DD898CFB162E9D82C1904627642667CC32B104D407BB411
     url: https://github.com/protocolbuffers/protobuf/archive/v3.17.1.tar.gz
+  "3.17.3":
+    sha256: c6003e1d2e7fefa78a3039f19f383b4f3a61e81be8c19356f85b6461998ad3db
+    url: https://github.com/protocolbuffers/protobuf/archive/v3.17.3.tar.gz
 patches:
   "3.12.4":
     - patch_file: "patches/upstream-pr-7761-cmake-regex-fix.patch"

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "3.17.1":
     folder: all
+  "3.17.3":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  protobuf/v3.17.3

Added Apple M1 support in this version.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
