### PR TITLE
spirv-cross: fix cross-build to iOS + fix pkgconfig and CMake imported targets + modernize

### DIFF
--- a/recipes/spirv-cross/all/conandata.yml
+++ b/recipes/spirv-cross/all/conandata.yml
@@ -14,3 +14,19 @@ sources:
   "20200403":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/2020-04-03.tar.gz"
     sha256: "93f3a6dfad17c9ca0bf4d2d80809e90118e13b47502eb395baba8784025d7e97"
+patches:
+  "20210115":
+    - patch_file: "patches/0001-fix-bundle-install-20210115.patch"
+      base_path: "source_subfolder"
+  "20200917":
+    - patch_file: "patches/0001-fix-bundle-install-20200403.patch"
+      base_path: "source_subfolder"
+  "20200629":
+    - patch_file: "patches/0001-fix-bundle-install-20200403.patch"
+      base_path: "source_subfolder"
+  "20200519":
+    - patch_file: "patches/0001-fix-bundle-install-20200403.patch"
+      base_path: "source_subfolder"
+  "20200403":
+    - patch_file: "patches/0001-fix-bundle-install-20200403.patch"
+      base_path: "source_subfolder"

--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -1,6 +1,5 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
-import glob
 import os
 
 required_conan_version = ">=1.33.0"
@@ -137,11 +136,8 @@ class SpirvCrossConan(ConanFile):
             self.copy(pattern="spirv-cross*", dst="bin", src=os.path.join("build_subfolder_exe", "bin"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
-        if self.settings.compiler == "Visual Studio" and self.settings.build_type == "Debug" and self.options.shared:
-            for pdb_file in glob.glob(os.path.join(self.package_folder, "bin", "*.pdb")):
-                os.remove(pdb_file)
-            for ilk_file in glob.glob(os.path.join(self.package_folder, "bin", "*.ilk")):
-                os.remove(ilk_file)
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.ilk")
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.pdb")
 
     def package_info(self):
         # TODO: set targets names when components available in conan

--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
+import textwrap
 
 required_conan_version = ">=1.33.0"
 
@@ -138,47 +139,90 @@ class SpirvCrossConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
         tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.ilk")
         tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.pdb")
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {target: "spirv-cross::{}".format(target) for target in self._spirv_cross_components.keys()}
+        )
+
+    @staticmethod
+    def _create_cmake_module_alias_targets(module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent("""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """.format(alias=alias, aliased=aliased))
+        tools.save(module_file, content)
+
+    @property
+    def _module_subfolder(self):
+        return os.path.join("lib", "cmake")
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join(self._module_subfolder,
+                            "conan-official-{}-targets.cmake".format(self.name))
+
+    @property
+    def _spirv_cross_components(self):
+        components = {}
+        if self.options.shared:
+            components.update({"spirv-cross-c-shared": []})
+        else:
+            components.update({"spirv-cross-core": []})
+            if self.options.glsl:
+                components.update({"spirv-cross-glsl": ["spirv-cross-core"]})
+                if self.options.hlsl:
+                    components.update({"spirv-cross-hlsl": ["spirv-cross-glsl"]})
+                if self.options.msl:
+                    components.update({"spirv-cross-msl": ["spirv-cross-glsl"]})
+                if self.options.cpp:
+                    components.update({"spirv-cross-cpp": ["spirv-cross-glsl"]})
+                if self.options.reflect:
+                    components.update({"spirv-cross-reflect": []})
+            if self.options.c_api:
+                c_api_requires = []
+                if self.options.glsl:
+                    c_api_requires.append("spirv-cross-glsl")
+                    if self.options.hlsl:
+                        c_api_requires.append("spirv-cross-hlsl")
+                    if self.options.msl:
+                        c_api_requires.append("spirv-cross-msl")
+                    if self.options.cpp:
+                        c_api_requires.append("spirv-cross-cpp")
+                    if self.options.reflect:
+                        c_api_requires.append("spirv-cross-reflect")
+                components.update({"spirv-cross-c": c_api_requires})
+            if self.options.util:
+                components.update({"spirv-cross-util": ["spirv-cross-core"]})
+        return components
 
     def package_info(self):
-        # TODO: set targets names when components available in conan
-        self.cpp_info.libs = self._get_ordered_libs()
-        self.cpp_info.includedirs.append(os.path.join("include", "spirv_cross"))
-        if self.settings.os == "Linux" and self.options.glsl:
-            self.cpp_info.system_libs.append("m")
-        if not self.options.shared and self.options.c_api and tools.stdcpp_library(self):
-            self.cpp_info.system_libs.append(tools.stdcpp_library(self))
+        # FIXME: we should provide one CMake config file per target (waiting for an implementation of https://github.com/conan-io/conan/issues/9000)
+        def _register_component(target_lib, requires):
+            self.cpp_info.components[target_lib].names["cmake_find_package"] = target_lib
+            self.cpp_info.components[target_lib].names["cmake_find_package_multi"] = target_lib
+            self.cpp_info.components[target_lib].builddirs.append(self._module_subfolder)
+            self.cpp_info.components[target_lib].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+            self.cpp_info.components[target_lib].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+            if self.options.shared:
+                self.cpp_info.components[target_lib].names["pkg_config"] = target_lib
+            prefix = "d" if self.settings.os == "Windows" and self.settings.build_type == "Debug" else ""
+            self.cpp_info.components[target_lib].libs = ["{}{}".format(target_lib, prefix)]
+            self.cpp_info.components[target_lib].includedirs.append(os.path.join("include", "spirv_cross"))
+            self.cpp_info.components[target_lib].defines.append("SPIRV_CROSS_NAMESPACE_OVERRIDE={}".format(self.options.namespace))
+            self.cpp_info.components[target_lib].requires = requires
+            if self.settings.os == "Linux" and self.options.glsl:
+                self.cpp_info.components[target_lib].system_libs.append("m")
+            if not self.options.shared and self.options.c_api and tools.stdcpp_library(self):
+                self.cpp_info.components[target_lib].system_libs.append(tools.stdcpp_library(self))
+
+        for target_lib, requires in self._spirv_cross_components.items():
+            _register_component(target_lib, requires)
+
         if self.options.build_executable:
             bin_path = os.path.join(self.package_folder, "bin")
             self.output.info("Appending PATH environment variable: {}".format(bin_path))
             self.env_info.PATH.append(bin_path)
-        self.cpp_info.defines.append("SPIRV_CROSS_NAMESPACE_OVERRIDE={}".format(self.options.namespace))
-
-    def _get_ordered_libs(self):
-        libs = []
-        if self.options.shared:
-            libs.append("spirv-cross-c-shared")
-        else:
-            # - spirv-cross-core is a dependency of spirv-cross-glsl and spirv-cross-util
-            # - spirv-cross-glsl is a dependency of spirv-cross-c, spirv-cross-hlsl, spirv-cross-msl and spirv-cross-cpp
-            # - spirv-cross-hlsl is a dependency of spirv-cross-c
-            # - spirv-cross-msl is a dependency of spirv-cross-c
-            # - spirv-cross-cpp is a dependency of spirv-cross-c
-            # - spirv-cross-reflect is a dependency of spirv-cross-c
-            if self.options.c_api:
-                libs.append("spirv-cross-c")
-            if self.options.hlsl:
-                libs.append("spirv-cross-hlsl")
-            if self.options.msl:
-                libs.append("spirv-cross-msl")
-            if self.options.cpp:
-                libs.append("spirv-cross-cpp")
-            if self.options.reflect:
-                libs.append("spirv-cross-reflect")
-            if self.options.glsl:
-                libs.append("spirv-cross-glsl")
-            if self.options.util:
-                libs.append("spirv-cross-util")
-            libs.append("spirv-cross-core")
-        if self.settings.os == "Windows" and self.settings.build_type == "Debug":
-            libs = [lib + "d" for lib in libs]
-        return libs

--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -12,7 +12,7 @@ class SpirvCrossConan(ConanFile):
     topics = ("conan", "spirv-cross", "reflection", "disassembler", "spirv", "spir-v", "glsl", "hlsl")
     homepage = "https://github.com/KhronosGroup/SPIRV-Cross"
     url = "https://github.com/conan-io/conan-center-index"
-    exports_sources = "CMakeLists.txt"
+    exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -73,6 +73,8 @@ class SpirvCrossConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
         if self.options.build_executable and not self._are_proper_binaries_available_for_executable:

--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -64,6 +64,8 @@ class SpirvCrossConan(ConanFile):
             # these options don't contribute to shared binary
             del self.options.c_api
             del self.options.util
+
+    def validate(self):
         if not self.options.glsl and \
            (self.options.hlsl or self.options.msl or self.options.cpp or self.options.reflect):
             raise ConanInvalidConfiguration("hlsl, msl, cpp and reflect require glsl enabled")

--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -1,8 +1,10 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 import glob
 import os
 
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+required_conan_version = ">=1.33.0"
+
 
 class SpirvCrossConan(ConanFile):
     name = "spirv-cross"
@@ -67,10 +69,8 @@ class SpirvCrossConan(ConanFile):
             raise ConanInvalidConfiguration("hlsl, msl, cpp and reflect require glsl enabled")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        url = self.conan_data["sources"][self.version]["url"]
-        extracted_dir = "SPIRV-Cross-" + os.path.basename(url).replace(".tar.gz", "").replace(".zip", "")
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/spirv-cross/all/patches/0001-fix-bundle-install-20200403.patch
+++ b/recipes/spirv-cross/all/patches/0001-fix-bundle-install-20200403.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -433,7 +433,7 @@ if (SPIRV_CROSS_CLI)
+ 	target_compile_definitions(spirv-cross PRIVATE ${spirv-compiler-defines} HAVE_SPIRV_CROSS_GIT_VERSION)
+ 	set_target_properties(spirv-cross PROPERTIES LINK_FLAGS "${spirv-cross-link-flags}")
+ 	if (NOT SPIRV_CROSS_SKIP_INSTALL)
+-		install(TARGETS spirv-cross RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++		install(TARGETS spirv-cross DESTINATION ${CMAKE_INSTALL_BINDIR})
+ 	endif()
+ 	target_link_libraries(spirv-cross PRIVATE
+ 			spirv-cross-glsl

--- a/recipes/spirv-cross/all/patches/0001-fix-bundle-install-20210115.patch
+++ b/recipes/spirv-cross/all/patches/0001-fix-bundle-install-20210115.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -441,7 +441,7 @@ if (SPIRV_CROSS_CLI)
+ 	target_compile_definitions(spirv-cross PRIVATE ${spirv-compiler-defines} HAVE_SPIRV_CROSS_GIT_VERSION)
+ 	set_target_properties(spirv-cross PROPERTIES LINK_FLAGS "${spirv-cross-link-flags}")
+ 	if (NOT SPIRV_CROSS_SKIP_INSTALL)
+-		install(TARGETS spirv-cross RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++		install(TARGETS spirv-cross DESTINATION ${CMAKE_INSTALL_BINDIR})
+ 	endif()
+ 	target_link_libraries(spirv-cross PRIVATE
+ 			spirv-cross-glsl

--- a/recipes/spirv-cross/all/test_package/CMakeLists.txt
+++ b/recipes/spirv-cross/all/test_package/CMakeLists.txt
@@ -2,7 +2,14 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+# FIXME: this is not the official way to find spirv-cross components
+find_package(spirv-cross REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+if(TARGET spirv-cross-c)
+    target_link_libraries(${PROJECT_NAME} spirv-cross-c)
+elseif(TARGET spirv-cross-c-shared)
+    target_link_libraries(${PROJECT_NAME} spirv-cross-c-shared)
+endif()

--- a/recipes/spirv-cross/all/test_package/conanfile.py
+++ b/recipes/spirv-cross/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

It's worth noting that spirv-tools creates one CMake config file per target, which can't be emulated by conan yet (https://github.com/conan-io/conan/issues/9000). So this PR provides correct CMake imported targets, but all in only one unofficial CMake config file.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
