### PR TITLE
autoconf: fix autoconf test_package for real when compiling with clang

### DIFF
--- a/recipes/autoconf/all/test_package/Makefile.in
+++ b/recipes/autoconf/all/test_package/Makefile.in
@@ -5,7 +5,7 @@ SRCS = test_package_c.c test_package_cpp.cpp
 OBJS := $(patsubst %.c,%.@OBJEXT@,$(patsubst %.cpp,%.@OBJEXT@,$(SRCS)))
 
 test_package@EXEEXT@: $(OBJS)
-	@CXX@ $^ -o $@ @LDFLAGS@
+	@CXX@ @CXXFLAGS@ @LDFLAGS@ $^ -o $@
 
 %.@OBJEXT@: %.cpp
 	@CXX@ @CXXFLAGS@ @CPPFLAGS@ -c $< @CC_MINUS_O@ $@


### PR DESCRIPTION
Specify library name and version:  **autoconf/all**

The linker (clang++) also needs `CXXFLAGS` apparently.
Closes #6198 for good
That issue might already be closed, but as you know when squashing bugs: it's always good to smash extra to be sure they're dead.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
