### PR TITLE
Build sentry-native with CXX 14

### DIFF
--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -21,17 +21,25 @@ patches:
   "0.4.10":
     - patch_file: "patches/0.4.10-0001-find-conan-qt.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0.4.10-0002-CXX-14.patch"
+      base_path: "source_subfolder"
   "0.4.9":
     - patch_file: "patches/0.4.9-0001-find-conan-qt.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0.4.9-0002-CXX-14.patch"
       base_path: "source_subfolder"
   "0.4.8":
     - patch_file: "patches/0.4.8-0001-find-conan-qt.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0.4.8-0002-CXX-14.patch"
+      base_path: "source_subfolder"
   "0.4.7":
     - patch_file: "patches/0.4.7-0001-find-conan-qt.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0.4.7-0002-CXX-14.patch"
       base_path: "source_subfolder"
   "0.2.6":
     - patch_file: "patches/0.2.6-0001-remove-sentry-handler-dependency.patch"
       base_path: "source_subfolder"
-    - patch_file: "patches/0.2.6-0002-set-cmake-cxx-standard-11.patch"
+    - patch_file: "patches/0.2.6-0002-set-cmake-cxx-standard-14.patch"
       base_path: "source_subfolder"

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -67,7 +67,7 @@ class SentryNativeConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
         if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 11)
+            tools.check_min_cppstd(self, 14)
         if self.options.backend == "inproc" and self.settings.os == "Windows" and tools.Version(self.version) < "0.4":
             raise ConanInvalidConfiguration("The in-process backend is not supported on Windows")
         if self.options.backend != "crashpad":

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -100,6 +100,10 @@ class SentryNativeConan(ConanFile):
         if tools.Version(self.version) >= "0.4.7" and self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) < "10.0":
             raise ConanInvalidConfiguration("apple-clang < 10.0 not supported")
 
+    def build_requirements(self):
+        if self.options.backend == "breakpad":
+            self.build_requires("pkgconf/1.7.4")
+
     def requirements(self):
         if self.options.transport == "curl":
             self.requires("libcurl/7.75.0")

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -16,7 +16,7 @@ class SentryNativeConan(ConanFile):
     topics = ("conan", "breakpad", "crashpad",
               "error-reporting", "crash-reporting")
     exports_sources = ["CMakeLists.txt", "patches/*"]
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package", "pkg_config"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -25,6 +25,7 @@ class SentryNativeConan(ConanFile):
         "transport": ["none", "curl", "winhttp"],
         "qt": [True, False],
         "with_crashpad": ["google", "sentry"],
+        "with_breakpad": ["google", "sentry"],
     }
     default_options = {
         "shared": False,
@@ -33,6 +34,8 @@ class SentryNativeConan(ConanFile):
         "transport": "curl",  # overwritten in config_options
         "qt": False,
         "with_crashpad": "sentry",
+        "with_breakpad": "sentry",
+
     }
 
     _cmake = None
@@ -58,8 +61,9 @@ class SentryNativeConan(ConanFile):
             # FIXME: for self.version < 0.4: default backend is "breakpad" when building with MSVC for Windows xp; else: backend=none
             self.options.backend = "crashpad"
         elif self.settings.os in ("FreeBSD", "Linux"):
-            # FIXME: default backend on Linux is "breakpad"
-            self.options.backend = "inproc"  # Should be "breakpad"
+            self.options.backend = "breakpad"
+        elif self.settings.os == "Android":
+            self.options.backend = "inproc"
         else:
             self.options.backend = "inproc"
 
@@ -72,6 +76,8 @@ class SentryNativeConan(ConanFile):
             raise ConanInvalidConfiguration("The in-process backend is not supported on Windows")
         if self.options.backend != "crashpad":
             del self.options.with_crashpad
+        if self.options.backend != "breakpad":
+            del self.options.with_breakpad
         if self.options.transport == "winhttp" and self.settings.os != "Windows":
             raise ConanInvalidConfiguration("The winhttp transport is only supported on Windows")
         if tools.Version(self.version) >= "0.4.7" and self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) < "10.0":
@@ -86,7 +92,10 @@ class SentryNativeConan(ConanFile):
             if self.options.with_crashpad == "google":
                 self.requires("crashpad/cci.20210507")
         elif self.options.backend == "breakpad":
-            raise ConanInvalidConfiguration("breakpad not available yet in CCI")
+            if self.options.with_breakpad == "sentry":
+                self.requires("sentry-breakpad/{}".format(self.version))
+            if self.options.with_breakpad == "google":
+                self.requires("breakpad/cci.20210521")
         if self.options.qt:
             self.requires("qt/5.15.2")
             self.requires("openssl/1.1.1k")
@@ -102,6 +111,7 @@ class SentryNativeConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["SENTRY_BACKEND"] = self.options.backend
         self._cmake.definitions["SENTRY_CRASHPAD_SYSTEM"] = True
+        self._cmake.definitions["SENTRY_BREAKPAD_SYSTEM"] = True
         self._cmake.definitions["SENTRY_ENABLE_INSTALL"] = True
         self._cmake.definitions["SENTRY_TRANSPORT"] = self.options.transport
         self._cmake.definitions["SENTRY_PIC"] = self.options.get_safe("fPIC", True)

--- a/recipes/sentry-native/all/patches/0.2.6-0002-set-cmake-cxx-standard-14.patch
+++ b/recipes/sentry-native/all/patches/0.2.6-0002-set-cmake-cxx-standard-14.patch
@@ -7,7 +7,7 @@ index c41d902..4793e9b 100644
  endif()
  
 +if(NOT CMAKE_CXX_STANDARD)
-+  set(CMAKE_CXX_STANDARD 11)
++  set(CMAKE_CXX_STANDARD 14)
 +endif()
 +
  include(GNUInstallDirs)

--- a/recipes/sentry-native/all/patches/0.4.10-0002-CXX-14.patch
+++ b/recipes/sentry-native/all/patches/0.4.10-0002-CXX-14.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 696d270..006bf68 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,7 +30,7 @@
+ endif()
+ 
+ if(NOT CMAKE_CXX_STANDARD)
+-  set(CMAKE_CXX_STANDARD 11)
++  set(CMAKE_CXX_STANDARD 14)
+ endif()
+ 
+ include(GNUInstallDirs)
+

--- a/recipes/sentry-native/all/patches/0.4.7-0002-CXX-14.patch
+++ b/recipes/sentry-native/all/patches/0.4.7-0002-CXX-14.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 696d270..006bf68 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,7 +30,7 @@
+ endif()
+ 
+ if(NOT CMAKE_CXX_STANDARD)
+-  set(CMAKE_CXX_STANDARD 11)
++  set(CMAKE_CXX_STANDARD 14)
+ endif()
+ 
+ include(GNUInstallDirs)
+

--- a/recipes/sentry-native/all/patches/0.4.8-0002-CXX-14.patch
+++ b/recipes/sentry-native/all/patches/0.4.8-0002-CXX-14.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 696d270..006bf68 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,7 +30,7 @@
+ endif()
+ 
+ if(NOT CMAKE_CXX_STANDARD)
+-  set(CMAKE_CXX_STANDARD 11)
++  set(CMAKE_CXX_STANDARD 14)
+ endif()
+ 
+ include(GNUInstallDirs)
+

--- a/recipes/sentry-native/all/patches/0.4.9-0002-CXX-14.patch
+++ b/recipes/sentry-native/all/patches/0.4.9-0002-CXX-14.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 696d270..006bf68 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,7 +30,7 @@
+ endif()
+ 
+ if(NOT CMAKE_CXX_STANDARD)
+-  set(CMAKE_CXX_STANDARD 11)
++  set(CMAKE_CXX_STANDARD 14)
+ endif()
+ 
+ include(GNUInstallDirs)
+

--- a/recipes/sentry-native/all/test_package/CMakeLists.txt
+++ b/recipes/sentry-native/all/test_package/CMakeLists.txt
@@ -8,4 +8,4 @@ find_package(sentry REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} sentry::sentry)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)


### PR DESCRIPTION
`sentry-crashpad` exposes CXX 14 code on its headers, so the build for `sentry-native` with `crashpad` as backend fails.
I reported this upstream and the devs agreed to make CXX 14 the default. 
https://github.com/getsentry/sentry-native/issues/574

Closes https://github.com/conan-io/conan-center-index/issues/6246

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
