### PR TITLE
qt6: fix compilation of qtdeclarative with ICU

### DIFF
--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -48,3 +48,7 @@ sources:
       - "https://www.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/6.1/6.1.2/single/qt-everywhere-src-6.1.2.tar.xz"
       - "https://ftp.fau.de/qtproject/archive/qt/6.1/6.1.2/single/qt-everywhere-src-6.1.2.tar.xz"
     sha256: "4b40f10eb188506656f13dbf067b714145047f41d7bf83f03b727fa1c7c4cdcb"
+patches:
+  "6.1.2":
+    - base_path: "qt6/qtdeclarative"
+      patch_file: "patches/32451d5.diff"

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -907,7 +907,7 @@ class QtConan(ConanFile):
                 component_name = m.replace("Qt6", "qt")
                 self.cpp_info.components[component_name].build_modules["cmake_find_package"].append(module)
                 self.cpp_info.components[component_name].build_modules["cmake_find_package_multi"].append(module)
-                self.cpp_info.components[component_name].builddirs.append(os.path.join("lib", "cmake", m))
+            self.cpp_info.components[component_name].builddirs.append(os.path.join("lib", "cmake", m))
 
         objects_dirs = glob.glob(os.path.join(self.package_folder, "lib", "objects-*/"))
         for object_dir in objects_dirs:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -904,8 +904,8 @@ class QtConan(ConanFile):
 
         for m in os.listdir(os.path.join("lib", "cmake")):
             module = os.path.join("lib", "cmake", m, "%sMacros.cmake" % m)
+            component_name = m.replace("Qt6", "qt")
             if os.path.isfile(module):
-                component_name = m.replace("Qt6", "qt")
                 self.cpp_info.components[component_name].build_modules["cmake_find_package"].append(module)
                 self.cpp_info.components[component_name].build_modules["cmake_find_package_multi"].append(module)
             self.cpp_info.components[component_name].builddirs.append(os.path.join("lib", "cmake", m))

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -644,6 +644,9 @@ class QtConan(ConanFile):
 
         _create_private_module("Core", ["Core"])
 
+        if self.options.gui:
+            _create_private_module("Gui", ["CorePrivate", "Gui"])
+
         if self.options.qtdeclarative:
             _create_private_module("Qml", ["CorePrivate", "Qml"])
 
@@ -894,6 +897,9 @@ class QtConan(ConanFile):
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_executables_file)
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package"].append(self._cmake_qt6_private_file("Core"))
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_qt6_private_file("Core"))
+
+        self.cpp_info.components["qtGui"].build_modules["cmake_find_package"].append(self._cmake_qt6_private_file("Gui"))
+        self.cpp_info.components["qtGui"].build_modules["cmake_find_package_multi"].append(self._cmake_qt6_private_file("Gui"))
 
         for m in os.listdir(os.path.join("lib", "cmake")):
             module = os.path.join("lib", "cmake", m, "%sMacros.cmake" % m)

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -903,10 +903,11 @@ class QtConan(ConanFile):
 
         for m in os.listdir(os.path.join("lib", "cmake")):
             module = os.path.join("lib", "cmake", m, "%sMacros.cmake" % m)
-            component_name = m.replace("Qt6", "qt")
-            self.cpp_info.components[component_name].build_modules["cmake_find_package"].append(module)
-            self.cpp_info.components[component_name].build_modules["cmake_find_package_multi"].append(module)
-            self.cpp_info.components[component_name].builddirs.append(os.path.join("lib", "cmake", m))
+            if os.path.isfile(module):
+                component_name = m.replace("Qt6", "qt")
+                self.cpp_info.components[component_name].build_modules["cmake_find_package"].append(module)
+                self.cpp_info.components[component_name].build_modules["cmake_find_package_multi"].append(module)
+                self.cpp_info.components[component_name].builddirs.append(os.path.join("lib", "cmake", m))
 
         objects_dirs = glob.glob(os.path.join(self.package_folder, "lib", "objects-*/"))
         for object_dir in objects_dirs:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -576,6 +576,7 @@ class QtConan(ConanFile):
             tools.remove_files_by_mask(self.package_folder, mask)
         tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la*")
         tools.remove_files_by_mask(self.package_folder, "*.pdb*")
+        tools.remove_files_by_mask(self.package_folder, "ensure_pro_file.cmake")
         os.remove(os.path.join(self.package_folder, "bin", "qt-cmake-private-install.cmake"))
 
         for m in os.listdir(os.path.join(self.package_folder, "lib", "cmake")):

--- a/recipes/qt/6.x.x/patches/32451d5.diff
+++ b/recipes/qt/6.x.x/patches/32451d5.diff
@@ -1,0 +1,32 @@
+From 32451d5c9126921180aad4bf78ec6af5eb27ec2a Mon Sep 17 00:00:00 2001
+From: Ulf Hermann <ulf.hermann@qt.io>
+Date: Tue, 13 Jul 2021 11:05:51 +0200
+Subject: [PATCH] Directly include Unicode.h in YarrCanonicalize.h
+
+The redirection via utypes.h can be problematic if you have another
+utypes.h around in a prominent place. It's easily avoided, though.
+
+Fixes: QTBUG-77528
+Change-Id: I50368f56b0d7eb957955900a32dbb625a38d02af
+---
+
+diff --git a/src/3rdparty/masm/stubs/wtf/unicode/utypes.h b/src/3rdparty/masm/stubs/wtf/unicode/utypes.h
+deleted file mode 100644
+index e1b4ff9..0000000
+--- a/src/3rdparty/masm/stubs/wtf/unicode/utypes.h
++++ /dev/null
+@@ -1 +0,0 @@
+-#include <unicode/Unicode.h>
+diff --git a/src/3rdparty/masm/yarr/YarrCanonicalize.h b/src/3rdparty/masm/yarr/YarrCanonicalize.h
+index cbd279e..17c9831 100644
+--- a/src/3rdparty/masm/yarr/YarrCanonicalize.h
++++ b/src/3rdparty/masm/yarr/YarrCanonicalize.h
+@@ -26,7 +26,7 @@
+ #pragma once
+ 
+ #include <stdint.h>
+-#include <unicode/utypes.h>
++#include <unicode/Unicode.h>
+ 
+ namespace JSC { namespace Yarr {
+ 


### PR DESCRIPTION
fixes conan-io/conan-center-index#5290
fixes conan-io/conan-center-index#5841

Specify library name and version:  **qt/6.1.2**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
