### PR TITLE
json-schema-validator: fix iOS build (2.1.0) + del fPIC if shared + fix CMake imported target + modernize

### DIFF
--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -12,7 +12,7 @@ class JsonSchemaValidatorConan(ConanFile):
     topics = ("json-schema-validator", "modern-json",
               "schema-validation", "json")
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
     exports_sources = ["CMakeLists.txt"]
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}

--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -81,10 +81,12 @@ class JsonSchemaValidatorConan(ConanFile):
 
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(os.path.join("src", "json-schema.hpp"), dst=os.path.join("include", "nlohmann"),  # This is not installed in 2.0.0 correctly
-                  src=self._source_subfolder, keep_path=False)
         cmake = self._configure_cmake()
         cmake.install()
+        if tools.Version(self.version) < "2.1.0":
+            self.copy("json-schema.hpp",
+                      dst=os.path.join("include", "nlohmann"),
+                      src=os.path.join(self._source_subfolder, "src"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):

--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -33,6 +33,10 @@ class JsonSchemaValidatorConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
     def requirements(self):
         self.requires("nlohmann_json/3.9.1")
 

--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -72,6 +72,8 @@ class JsonSchemaValidatorConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["BUILD_TESTS"] = False
         self._cmake.definitions["BUILD_EXAMPLES"] = False
+        if tools.Version(self.version) < "2.1.0":
+            self._cmake.definitions["NLOHMANN_JSON_DIR"] = ";".join(self.deps_cpp_info["nlohmann_json"].include_paths)
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 

--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -123,4 +123,4 @@ class JsonSchemaValidatorConan(ConanFile):
         self.cpp_info.builddirs.append(self._module_subfolder)
         self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
         self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
-        self.cpp_info.libs = ["json-schema-validator"]
+        self.cpp_info.libs = ["json-schema-validator" if tools.Version(self.version) < "2.1.0" else "nlohmann_json_schema_validator"]

--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class JsonSchemaValidatorConan(ConanFile):
     name = "json-schema-validator"
@@ -57,9 +59,8 @@ class JsonSchemaValidatorConan(ConanFile):
         self.requires("nlohmann_json/3.9.1")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -92,6 +92,6 @@ class JsonSchemaValidatorConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = ["json-schema-validator"]
         self.cpp_info.names["cmake_find_package"] = "nlohmann_json_schema_validator"
         self.cpp_info.names["cmake_find_package_multi"] = "nlohmann_json_schema_validator"

--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -33,7 +33,10 @@ class JsonSchemaValidatorConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
-    def configure(self):
+    def requirements(self):
+        self.requires("nlohmann_json/3.9.1")
+
+    def validate(self):
         version = tools.Version(self.version)
         min_vs_version = "16" if version < "2.1.0" else "14"
         min_cppstd = "17" if self.settings.compiler == "Visual Studio" and version < "2.1.0" else "11"
@@ -54,9 +57,6 @@ class JsonSchemaValidatorConan(ConanFile):
             if tools.Version(self.settings.compiler.version) < min_version:
                 raise ConanInvalidConfiguration("{} requires c++{} support. The current compiler {} {} does not support it.".format(
                     self.name, min_cppstd, self.settings.compiler, self.settings.compiler.version))
-
-    def requirements(self):
-        self.requires("nlohmann_json/3.9.1")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/json-schema-validator/all/test_package/CMakeLists.txt
+++ b/recipes/json-schema-validator/all/test_package/CMakeLists.txt
@@ -2,11 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(nlohmann_json_schema_validator CONFIG REQUIRED)
 
 add_executable(example example.cpp)
 set_property(TARGET example PROPERTY CXX_STANDARD 11)
-
-target_link_libraries(example nlohmann_json_schema_validator::nlohmann_json_schema_validator)
+target_link_libraries(example nlohmann_json_schema_validator)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

I tried to fix iOS build in 2.0.0, but `find_path` is not able to find `nlohmann_json` headers, it's silly: https://github.com/pboettch/json-schema-validator/blob/2.0.0/CMakeLists.txt#L17-L20
Maybe the same issue than https://github.com/conan-io/conan/issues/9202

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
