### PR TITLE
Add bloaty/1.1

### DIFF
--- a/recipes/bloaty/all/CMakeLists.txt
+++ b/recipes/bloaty/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.5)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/bloaty/all/conandata.yml
+++ b/recipes/bloaty/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "1.1":
+    url: "https://github.com/google/bloaty/archive/refs/tags/v1.1.tar.gz"
+    sha256: "682640678a748d043eea65df48831f807d39a1e761eacc461c756256f7ec6a26"
+patches:
+  "1.1":
+    - patch_file: "patches/cmake_dependencies.patch"
+      base_path: "source_subfolder"

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -37,9 +37,6 @@ class BloatyConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.compiler
-        # C++ standard in abseil must match the same in bloaty. Mismatching
-        # standard results in bloaty link error.
-        self.info.requires["abseil"].full_package_mode()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -16,7 +16,7 @@ class BloatyConan(ConanFile):
 
     settings = "os", "arch", "compiler", "build_type"
 
-    build_requires = (
+    requires = (
         "capstone/4.0.2",
         "protobuf/3.17.1",
         "pkgconf/1.7.4",

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -37,6 +37,9 @@ class BloatyConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.compiler
+        # C++ standard in abseil must match the same in bloaty. Mismatching
+        # standard results in bloaty link error.
+        self.info.requires["abseil"].full_package_mode()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -36,8 +36,6 @@ class BloatyConan(ConanFile):
         compiler = self.settings.compiler
         if compiler.cppstd:
             tools.check_min_cppstd(self, "11")
-        if compiler == "gcc" and version < "5.1":
-            raise ConanInvalidConfiguration("bloaty requires gcc 5.1+")
 
     def package_id(self):
         del self.info.settings.compiler
@@ -56,8 +54,6 @@ class BloatyConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-        if not self.settings.compiler.cppstd:
-            self._cmake.definitions["CMAKE_CXX_STANDARD"] = 11
         env_vars = {"PKG_CONFIG_PATH": self.build_folder}
         with tools.environment_append(env_vars):
             self._cmake.configure()

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -64,6 +64,7 @@ class BloatyConan(ConanFile):
     def package(self):
         cmake = self._configure_cmake()
         cmake.install()
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         tools.rmdir(os.path.join(self.package_folder, "lib"))
 
     def package_info(self):

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -71,11 +71,6 @@ class BloatyConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "bloaty-profiler"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "bloaty-profiler"
-        self.cpp_info.names["cmake_find_package"] = "bloaty"
-        self.cpp_info.names["cmake_find_package_multi"] = "bloaty"
-
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bindir))
         self.env_info.PATH.append(bindir)

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
 from conans import CMake, ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.33.0"
 
@@ -32,7 +33,7 @@ class BloatyConan(ConanFile):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "11")
         if self.settings.os != "Linux":
-            raise ConanInvalidConfiguration("bloaty package requires Linux"
+            raise ConanInvalidConfiguration("bloaty package requires Linux")
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -31,6 +31,8 @@ class BloatyConan(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "11")
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("bloaty package requires Linux"
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -32,7 +32,7 @@ class BloatyConan(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
-        if tools.os_info.is_windows:
+        if self.settings.os == "Windows":
             raise ConanInvalidConfiguration("bloaty package does not support Windows")
 
     def package_id(self):

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -30,12 +30,10 @@ class BloatyConan(ConanFile):
     _source_subfolder = "source_subfolder"
 
     def validate(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 11)
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("bloaty package requires Linux")
-        version = tools.Version(self.settings.compiler.version)
-        compiler = self.settings.compiler
-        if compiler.cppstd:
-            tools.check_min_cppstd(self, "11")
 
     def package_id(self):
         del self.info.settings.compiler
@@ -54,6 +52,8 @@ class BloatyConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        if not tools.valid_min_cppstd(self, 11):
+            self._cmake.definitions["CMAKE_CXX_STANDARD"] = 11
         env_vars = {"PKG_CONFIG_PATH": self.build_folder}
         with tools.environment_append(env_vars):
             self._cmake.configure()

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -30,10 +30,14 @@ class BloatyConan(ConanFile):
     _source_subfolder = "source_subfolder"
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, "11")
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("bloaty package requires Linux")
+        version = tools.Version(self.settings.compiler.version)
+        compiler = self.settings.compiler
+        if compiler.cppstd:
+            tools.check_min_cppstd(self, "11")
+        if compiler == "gcc" and version < "5.1":
+            raise ConanInvalidConfiguration("bloaty requires gcc 5.1+")
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -1,0 +1,74 @@
+import os
+
+from conans import CMake, ConanFile, tools
+
+required_conan_version = ">=1.33.0"
+
+
+class BloatyConan(ConanFile):
+    name = "bloaty"
+    description = """Bloaty McBloatface: a size profiler for binaries"""
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/google/bloaty"
+    license = "Apache-2.0"
+    topics = ("conan", "bloaty", "profiler", "size")
+
+    settings = "os", "arch", "compiler", "build_type"
+
+    requires = (
+        "capstone/4.0.2",
+        "protobuf/3.17.1",
+        "pkgconf/1.7.4",
+        "zlib/1.2.11",
+        "re2/20210601",
+        "abseil/20210324.2",
+    )
+    exports_sources = "CMakeLists.txt", "patches/**"
+    generators = "cmake", "cmake_find_package", "pkg_config"
+
+    _source_subfolder = "source_subfolder"
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, "17")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def _patch_sources(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+
+    _cmake = None
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        if not self.settings.compiler.cppstd:
+            self._cmake.definitions["CMAKE_CXX_STANDARD"] = 11
+        env_vars = {"PKG_CONFIG_PATH": self.build_folder}
+        with tools.environment_append(env_vars):
+            self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        self._patch_sources()
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib"))
+
+    def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "bloaty-profiler"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "bloaty-profiler"
+        self.cpp_info.names["cmake_find_package"] = "bloaty"
+        self.cpp_info.names["cmake_find_package_multi"] = "bloaty"
+
+        bindir = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bindir))
+        self.env_info.PATH.append(bindir)

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -30,7 +30,7 @@ class BloatyConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, "17")
+            tools.check_min_cppstd(self, "11")
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -32,6 +32,9 @@ class BloatyConan(ConanFile):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "17")
 
+    def package_id(self):
+        del self.info.settings.compiler
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -16,7 +16,7 @@ class BloatyConan(ConanFile):
 
     settings = "os", "arch", "compiler", "build_type"
 
-    requires = (
+    build_requires = (
         "capstone/4.0.2",
         "protobuf/3.17.1",
         "pkgconf/1.7.4",

--- a/recipes/bloaty/all/conanfile.py
+++ b/recipes/bloaty/all/conanfile.py
@@ -32,8 +32,8 @@ class BloatyConan(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
-        if self.settings.os != "Linux":
-            raise ConanInvalidConfiguration("bloaty package requires Linux")
+        if tools.os_info.is_windows:
+            raise ConanInvalidConfiguration("bloaty package does not support Windows")
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/bloaty/all/patches/cmake_dependencies.patch
+++ b/recipes/bloaty/all/patches/cmake_dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 08965ac..c05f5d7 100644
+index 08965ac..851c5cd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.5)
@@ -19,23 +19,24 @@ index 08965ac..c05f5d7 100644
  if(UNIX)
  find_package(PkgConfig)
  if(${PKG_CONFIG_FOUND})
-@@ -89,7 +90,6 @@ endif(UNIX)
+@@ -89,16 +90,8 @@ endif(UNIX)
  
  include_directories(.)
  include_directories(src)
 -include_directories(third_party/abseil-cpp)
  include_directories("${CMAKE_CURRENT_BINARY_DIR}/src")
  
- # Baseline build flags.
-@@ -97,7 +97,6 @@ set(CMAKE_CXX_FLAGS "-std=c++11 -W -Wall -Wno-sign-compare")
- set(CMAKE_CXX_FLAGS_DEBUG "-g1")
- set(CMAKE_CXX_FLAGS_RELEASE "-O2")
- set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g1")
+-# Baseline build flags.
+-set(CMAKE_CXX_FLAGS "-std=c++11 -W -Wall -Wno-sign-compare")
+-set(CMAKE_CXX_FLAGS_DEBUG "-g1")
+-set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g1")
 -set_source_files_properties(third_party/demumble/third_party/libcxxabi/cxa_demangle.cpp PROPERTIES COMPILE_FLAGS -Wno-implicit-fallthrough)
- 
+-
  if(APPLE)
  elseif(UNIX)
-@@ -159,27 +158,9 @@ add_library(libbloaty
+   if(BLOATY_ENABLE_BUILDID)
+@@ -159,27 +152,9 @@ add_library(libbloaty
      src/macho.cc
      src/range_map.cc
      src/webassembly.cc

--- a/recipes/bloaty/all/patches/cmake_dependencies.patch
+++ b/recipes/bloaty/all/patches/cmake_dependencies.patch
@@ -1,0 +1,67 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 08965ac..c05f5d7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.5)
+ cmake_policy(SET CMP0048 NEW)
+ project (Bloaty VERSION 1.0)
+ project (Bloaty VERSION 1.1)
+-set(CMAKE_CXX_STANDARD 11)
+ 
+ # Options we define for users.
+ option(BLOATY_ENABLE_ASAN "Enable address sanitizer." OFF)
+@@ -10,6 +9,8 @@ option(BLOATY_ENABLE_UBSAN "Enable undefined behavior sanitizer." OFF)
+ option(BLOATY_ENABLE_CMAKETARGETS "Enable installing cmake target files." ON)
+ option(BLOATY_ENABLE_BUILDID "Enable build id." ON)
+ 
++find_package(absl REQUIRED)
++
+ if(UNIX)
+ find_package(PkgConfig)
+ if(${PKG_CONFIG_FOUND})
+@@ -89,7 +90,6 @@ endif(UNIX)
+ 
+ include_directories(.)
+ include_directories(src)
+-include_directories(third_party/abseil-cpp)
+ include_directories("${CMAKE_CURRENT_BINARY_DIR}/src")
+ 
+ # Baseline build flags.
+@@ -97,7 +97,6 @@ set(CMAKE_CXX_FLAGS "-std=c++11 -W -Wall -Wno-sign-compare")
+ set(CMAKE_CXX_FLAGS_DEBUG "-g1")
+ set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g1")
+-set_source_files_properties(third_party/demumble/third_party/libcxxabi/cxa_demangle.cpp PROPERTIES COMPILE_FLAGS -Wno-implicit-fallthrough)
+ 
+ if(APPLE)
+ elseif(UNIX)
+@@ -159,27 +158,9 @@ add_library(libbloaty
+     src/macho.cc
+     src/range_map.cc
+     src/webassembly.cc
+-    # Until Abseil has a proper CMake build system
+-    third_party/abseil-cpp/absl/base/internal/raw_logging.cc # Grrrr...
+-    third_party/abseil-cpp/absl/base/internal/throw_delegate.cc
+-    third_party/abseil-cpp/absl/numeric/int128.cc
+-    third_party/abseil-cpp/absl/strings/ascii.cc
+-    third_party/abseil-cpp/absl/strings/charconv.cc
+-    third_party/abseil-cpp/absl/strings/escaping.cc
+-    third_party/abseil-cpp/absl/strings/internal/charconv_bigint.cc
+-    third_party/abseil-cpp/absl/strings/internal/charconv_parse.cc
+-    third_party/abseil-cpp/absl/strings/internal/memutil.cc
+-    third_party/abseil-cpp/absl/strings/internal/utf8.cc
+-    third_party/abseil-cpp/absl/strings/match.cc
+-    third_party/abseil-cpp/absl/strings/numbers.cc
+-    third_party/abseil-cpp/absl/strings/str_cat.cc
+-    third_party/abseil-cpp/absl/strings/string_view.cc
+-    third_party/abseil-cpp/absl/strings/str_split.cc
+-    third_party/abseil-cpp/absl/strings/substitute.cc
+-    third_party/abseil-cpp/absl/types/bad_optional_access.cc
+-    # One source file, no special build system needed.
+-    third_party/demumble/third_party/libcxxabi/cxa_demangle.cpp
+     )
++target_link_libraries(libbloaty PRIVATE
++    absl::strings)
+ 
+ if(UNIX)
+   set(LIBBLOATY_LIBS libbloaty)

--- a/recipes/bloaty/all/test_package/conanfile.py
+++ b/recipes/bloaty/all/test_package/conanfile.py
@@ -1,5 +1,3 @@
-import os
-
 from conans import ConanFile, tools
 
 

--- a/recipes/bloaty/all/test_package/conanfile.py
+++ b/recipes/bloaty/all/test_package/conanfile.py
@@ -1,0 +1,13 @@
+import os
+
+from conans import ConanFile, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os"
+
+    def test(self):
+        if tools.cross_building(self.settings):
+            return
+        bloaty_path = os.path.join(self.deps_cpp_info["bloaty"].bin_paths[0], "bloaty")
+        self.run("bloaty {}".format(bloaty_path), run_environment=True)

--- a/recipes/bloaty/all/test_package/conanfile.py
+++ b/recipes/bloaty/all/test_package/conanfile.py
@@ -9,5 +9,4 @@ class TestPackageConan(ConanFile):
     def test(self):
         if tools.cross_building(self.settings):
             return
-        bloaty_path = os.path.join(self.deps_cpp_info["bloaty"].bin_paths[0], "bloaty")
-        self.run("bloaty {}".format(bloaty_path), run_environment=True)
+        self.run("bloaty --version", run_environment=True)

--- a/recipes/bloaty/config.yml
+++ b/recipes/bloaty/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1":
+    folder: "all"


### PR DESCRIPTION
Ever wondered what's making your binary big? Bloaty McBloatface will show you a size profile of the binary so you can understand what's taking up space inside.

Specify library name and version:  **bloaty/1.1**

Bloaty performs a deep analysis of the binary size. Using custom ELF, DWARF, and Mach-O parsers, Bloaty aims to accurately attribute every byte of the binary to the symbol or compile unit that produced it. It will even disassemble the binary looking for references to anonymous data.

https://github.com/google/bloaty

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
