### PR TITLE
OpenSSL on Windows: multi-profile support

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -628,7 +628,10 @@ class OpenSSLConan(ConanFile):
     def _perl(self):
         if tools.os_info.is_windows and not self._win_bash:
             # enforce strawberry perl, otherwise wrong perl could be used (from Git bash, MSYS, etc.)
-            return os.path.join(self.deps_cpp_info["strawberryperl"].rootpath, "bin", "perl.exe")
+            if "strawberryperl" in self.deps_cpp_info.deps:
+                return os.path.join(self.deps_cpp_info["strawberryperl"].rootpath, "bin", "perl.exe")
+            elif hasattr(self, "user_info_build") and "strawberryperl" in self.user_info_build:
+                return self.user_info_build["strawberryperl"].perl
         return "perl"
 
     @property


### PR DESCRIPTION
Specify library name and version:  **openssl/1.x.x**

Using different profiles for build and host (`pr:b` and `pr:h`) leads to an error when using _OpenSSL_:

```
ERROR: openssl/1.1.1k: Error in build() method, line 709
        env_vars = {"PERL": self._perl}
while calling '_perl', line 630
        return os.path.join(self.deps_cpp_info["strawberryperl"].rootpath, "bin", "perl.exe")
        KeyError: 'strawberryperl'
```

This is due to assuming `deps_cpp_info` is always available. As [documented](https://docs.conan.io/en/1.36/reference/conanfile/attributes.html#deps-user-info) this is only true for packages on the host context, while _strawberryperl_ is in the "build" context .

This change modifies _strawberryperl_ to also set the `user_info` and then use this value in _openssl_, if a multi-profile build is used.

Depends on #6338 for multi-profile.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
