### PR TITLE
Add user_info to strawberryperl

### DIFF
--- a/recipes/strawberryperl/all/conanfile.py
+++ b/recipes/strawberryperl/all/conanfile.py
@@ -40,4 +40,4 @@ class StrawberryperlConan(ConanFile):
         self.output.info("Appending PATH environment variable: %s" % bin_path)
         self.env_info.PATH.append(bin_path)
 
-        self.deps_user_info.perl = os.path.join(self.package_folder, "bin", "perl.exe").replace("\\", "/")
+        self.user_info.perl = os.path.join(self.package_folder, "bin", "perl.exe").replace("\\", "/")


### PR DESCRIPTION
This allows usage of the perl-path in multi-profile environments.

Specify library name and version:  **strawberryperl/all**

Prerequisite for #6337

Fixes #4211 and https://github.com/conan-io/conan/issues/8313

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
