### PR TITLE
winpcap: add winpcap/4.1.3 recipe

### DIFF
--- a/recipes/winpcap/all/CMakeLists.txt
+++ b/recipes/winpcap/all/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+project(cmake_wrapper C)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+option(BUILD_SHARED_LIBS "Build shared libraries by default")
+
+if(WIN32)
+    include(cmake/packetntx.cmake)
+endif()
+
+include(cmake/winpcap.cmake)

--- a/recipes/winpcap/all/cmake/FindDAG.cmake
+++ b/recipes/winpcap/all/cmake/FindDAG.cmake
@@ -1,0 +1,16 @@
+find_path(DAG_INCLUDE_PATH NAMES dagapi.h)
+find_library(DAG_LIBRARY NAMES dag)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(DAG
+    REQUIRED_VARS DAG_LIBRARY DAG_INCLUDE_PATH
+)
+
+if(DAG_FOUND AND NOT TARGET DAG::DAG)
+    add_library(DAG::DAG UNKNOWN IMPORTED)
+    set_target_properties(DAG::DAG
+        PROPERTIES
+            IMPORTED_LOCATION "${DAG_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES"${DAG_INCLUDE_PATH}"
+    )
+endif()

--- a/recipes/winpcap/all/cmake/FindTurbocap.cmake
+++ b/recipes/winpcap/all/cmake/FindTurbocap.cmake
@@ -1,0 +1,16 @@
+find_path(TURBOCAP_INCLUDE_PATH NAMES TcApi.h)
+find_library(TURBOCAP_LIBRARY NAMES TcApi)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Turbocap
+    REQUIRED_VARS TURBOCAP_LIBRARY TURBOCAP_INCLUDE_PATH
+)
+
+if(DAG_FOUND AND NOT TARGET Turbocap::Turbocap)
+    add_library(Turbocap::Turbocap UNKNOWN IMPORTED)
+    set_target_properties(Turbocap::Turbocap
+        PROPERTIES
+            IMPORTED_LOCATION "${TURBOCAP_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES"${TURBOCAP_INCLUDE_PATH}"
+    )
+endif()

--- a/recipes/winpcap/all/cmake/FindWDK.cmake
+++ b/recipes/winpcap/all/cmake/FindWDK.cmake
@@ -1,0 +1,177 @@
+# Redistribution and use is allowed under the OSI-approved 3-clause BSD license.
+# Copyright (c) 2018 Sergey Podobry (sergey.podobry at gmail.com). All rights reserved.
+
+#.rst:
+# FindWDK
+# ----------
+#
+# This module searches for the installed Windows Development Kit (WDK) and
+# exposes commands for creating kernel drivers and kernel libraries.
+#
+# Output variables:
+# - `WDK_FOUND` -- if false, do not try to use WDK
+# - `WDK_ROOT` -- where WDK is installed
+# - `WDK_VERSION` -- the version of the selected WDK
+# - `WDK_WINVER` -- the WINVER used for kernel drivers and libraries
+#        (default value is `0x0601` and can be changed per target or globally)
+#
+# Example usage:
+#
+#   find_package(WDK REQUIRED)
+#
+#   wdk_add_library(KmdfCppLib STATIC KMDF 1.15
+#       KmdfCppLib.h
+#       KmdfCppLib.cpp
+#       )
+#   target_include_directories(KmdfCppLib INTERFACE .)
+#
+#   wdk_add_driver(KmdfCppDriver KMDF 1.15
+#       Main.cpp
+#       )
+#   target_link_libraries(KmdfCppDriver KmdfCppLib)
+#
+
+if(DEFINED ENV{WDKContentRoot})
+    file(GLOB WDK_NTDDK_FILES
+        "$ENV{WDKContentRoot}/Include/*/km/ntddk.h"
+    )
+else()
+    file(GLOB WDK_NTDDK_FILES
+        "C:/Program Files*/Windows Kits/10/Include/*/km/ntddk.h"
+    )
+endif()
+
+if(WDK_NTDDK_FILES)
+    list(GET WDK_NTDDK_FILES -1 WDK_LATEST_NTDDK_FILE)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WDK REQUIRED_VARS WDK_LATEST_NTDDK_FILE)
+
+if (NOT WDK_LATEST_NTDDK_FILE)
+    return()
+endif()
+
+get_filename_component(WDK_ROOT ${WDK_LATEST_NTDDK_FILE} DIRECTORY)
+get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+get_filename_component(WDK_VERSION ${WDK_ROOT} NAME)
+get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+get_filename_component(WDK_ROOT ${WDK_ROOT} DIRECTORY)
+
+message(STATUS "WDK_ROOT: " ${WDK_ROOT})
+message(STATUS "WDK_VERSION: " ${WDK_VERSION})
+
+set(WDK_WINVER "0x0601" CACHE STRING "Default WINVER for WDK targets")
+
+set(WDK_ADDITIONAL_FLAGS_FILE "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/wdkflags.h")
+file(WRITE ${WDK_ADDITIONAL_FLAGS_FILE} "#pragma runtime_checks(\"suc\", off)")
+
+set(WDK_COMPILE_FLAGS
+    "/Zp8" # set struct alignment
+    "/GF"  # enable string pooling
+    "/GR-" # disable RTTI
+    "/Gz" # __stdcall by default
+    "/kernel"  # create kernel mode binary
+    "/FIwarning.h" # disable warnings in WDK headers
+    "/FI${WDK_ADDITIONAL_FLAGS_FILE}" # include file to disable RTC
+    )
+
+set(WDK_COMPILE_DEFINITIONS "WINNT=1")
+set(WDK_COMPILE_DEFINITIONS_DEBUG "MSC_NOOPT;DEPRECATE_DDK_FUNCTIONS=1;DBG=1")
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    list(APPEND WDK_COMPILE_DEFINITIONS "_X86_=1;i386=1;STD_CALL")
+    set(WDK_PLATFORM "x86")
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    list(APPEND WDK_COMPILE_DEFINITIONS "_WIN64;_AMD64_;AMD64")
+    set(WDK_PLATFORM "x64")
+else()
+    message(FATAL_ERROR "Unsupported architecture")
+endif()
+
+string(CONCAT WDK_LINK_FLAGS
+    "/MANIFEST:NO " #
+    "/DRIVER " #
+    "/OPT:REF " #
+    "/INCREMENTAL:NO " #
+    "/OPT:ICF " #
+    "/SUBSYSTEM:NATIVE " #
+    "/MERGE:_TEXT=.text;_PAGE=PAGE " #
+    "/NODEFAULTLIB " # do not link default CRT
+    "/SECTION:INIT,d " #
+    "/VERSION:10.0 " #
+    )
+
+# Generate imported targets for WDK lib files
+file(GLOB WDK_LIBRARIES "${WDK_ROOT}/Lib/${WDK_VERSION}/km/${WDK_PLATFORM}/*.lib")
+foreach(LIBRARY IN LISTS WDK_LIBRARIES)
+    get_filename_component(LIBRARY_NAME ${LIBRARY} NAME_WE)
+    string(TOUPPER ${LIBRARY_NAME} LIBRARY_NAME)
+    add_library(WDK::${LIBRARY_NAME} INTERFACE IMPORTED)
+    set_property(TARGET WDK::${LIBRARY_NAME} PROPERTY INTERFACE_LINK_LIBRARIES  ${LIBRARY})
+endforeach(LIBRARY)
+unset(WDK_LIBRARIES)
+
+function(wdk_add_driver _target)
+    cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
+
+    add_executable(${_target} ${WDK_UNPARSED_ARGUMENTS})
+
+    set_target_properties(${_target} PROPERTIES SUFFIX ".sys")
+    set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
+    set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
+        "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG}>;_WIN32_WINNT=${WDK_WINVER}"
+        )
+    set_target_properties(${_target} PROPERTIES LINK_FLAGS "${WDK_LINK_FLAGS}")
+
+    target_include_directories(${_target} SYSTEM PRIVATE
+        "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
+        "${WDK_ROOT}/Include/${WDK_VERSION}/km"
+        )
+
+    target_link_libraries(${_target} WDK::NTOSKRNL WDK::HAL WDK::BUFFEROVERFLOWK WDK::WMILIB)
+
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        target_link_libraries(${_target} WDK::MEMCMP)
+    endif()
+
+    if(DEFINED WDK_KMDF)
+        target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
+        target_link_libraries(${_target}
+            "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfDriverEntry.lib"
+            "${WDK_ROOT}/Lib/wdf/kmdf/${WDK_PLATFORM}/${WDK_KMDF}/WdfLdr.lib"
+            )
+
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry@8")
+        elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
+            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:FxDriverEntry")
+        endif()
+    else()
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry@8")
+        elseif(CMAKE_SIZEOF_VOID_P  EQUAL 8)
+            set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS "/ENTRY:GsDriverEntry")
+        endif()
+    endif()
+endfunction()
+
+function(wdk_add_library _target)
+    cmake_parse_arguments(WDK "" "KMDF;WINVER" "" ${ARGN})
+
+    add_library(${_target} ${WDK_UNPARSED_ARGUMENTS})
+
+    set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${WDK_COMPILE_FLAGS}")
+    set_target_properties(${_target} PROPERTIES COMPILE_DEFINITIONS
+        "${WDK_COMPILE_DEFINITIONS};$<$<CONFIG:Debug>:${WDK_COMPILE_DEFINITIONS_DEBUG};_WIN32_WINNT=${WDK_WINVER}>"
+        )
+
+    target_include_directories(${_target} SYSTEM PRIVATE
+        "${WDK_ROOT}/Include/${WDK_VERSION}/shared"
+        "${WDK_ROOT}/Include/${WDK_VERSION}/km"
+        )
+
+    if(DEFINED WDK_KMDF)
+        target_include_directories(${_target} SYSTEM PRIVATE "${WDK_ROOT}/Include/wdf/kmdf/${WDK_KMDF}")
+    endif()
+endfunction()

--- a/recipes/winpcap/all/cmake/Findseptel.cmake
+++ b/recipes/winpcap/all/cmake/Findseptel.cmake
@@ -1,0 +1,16 @@
+find_path(SEPTEL_INCLUDE_PATH NAMES msg.h)
+find_library(SEPTEL_LIBRARY NAMES septel)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(septel
+    REQUIRED_VARS SEPTEL_LIBRARY SEPTEL_INCLUDE_PATH
+)
+
+if(septel_FOUND AND NOT TARGET septel::septel)
+    add_library(septel::septel UNKNOWN IMPORTED)
+    set_target_properties(septel::septel
+        PROPERTIES
+            IMPORTED_LOCATION "${SEPTEL_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES"${SEPTEL_INCLUDE_PATH}"
+    )
+endif()

--- a/recipes/winpcap/all/cmake/packetntx.cmake
+++ b/recipes/winpcap/all/cmake/packetntx.cmake
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.0)
+project(driver C)
+
+include(GNUInstallDirs)
+
+option(PACKET_TME "Enable (buggy) TME extensions")
+
+find_package(WDK REQUIRED)
+
+wdk_add_library(packet
+    ${CMAKE_CURRENT_LIST_FILE}
+
+    source_subfolder/packetNtx/driver/Openclos.c
+    source_subfolder/packetNtx/driver/Read.c
+    source_subfolder/packetNtx/driver/Write.c
+    source_subfolder/packetNtx/driver/win_bpf_filter.c
+    source_subfolder/packetNtx/driver/NPF.rc
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    target_sources(packet
+        PRIVATE
+            source_subfolder/packetNtx/jitter.c
+    )
+endif()
+
+target_compile_definitions(packet
+    PRIVATE
+        WIN_NT_DRIVER
+        WIN32_EXT
+        NDIS50  # NDIS30 __NPF_NT4__ for NT 4.0
+)
+
+if(PACKET_TME)
+    target_sources(packet
+        PRIVATE
+            source_subfolder/packetNtx/driver/tme.c
+            source_subfolder/packetNtx/driver/count_packets.c
+            source_subfolder/packetNtx/driver/tcp_session.c
+            source_subfolder/packetNtx/driver/functions.c
+            source_subfolder/packetNtx/driver/bucket_lookup.c
+            source_subfolder/packetNtx/driver/normal_lookup.c
+            source_subfolder/packetNtx/driver/win_bpf_filter_init.c
+    )
+    target_compile_definitions(driver PRIVATE HAVE_BUGGY_TME_SUPPORT)
+endif()
+
+install(TARGETS packet
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)

--- a/recipes/winpcap/all/cmake/packetntx.cmake
+++ b/recipes/winpcap/all/cmake/packetntx.cmake
@@ -42,7 +42,7 @@ if(PACKET_TME)
             source_subfolder/packetNtx/driver/normal_lookup.c
             source_subfolder/packetNtx/driver/win_bpf_filter_init.c
     )
-    target_compile_definitions(driver PRIVATE HAVE_BUGGY_TME_SUPPORT)
+    target_compile_definitions(packet PRIVATE HAVE_BUGGY_TME_SUPPORT)
 endif()
 
 install(TARGETS packet

--- a/recipes/winpcap/all/cmake/winpcap.cmake
+++ b/recipes/winpcap/all/cmake/winpcap.cmake
@@ -1,0 +1,610 @@
+cmake_minimum_required(VERSION 3.3)
+project(winpcap C)
+
+
+if(UNIX AND NOT (WIN32 OR APPLE))
+    set(LINUX ON)
+else()
+    set(LINUX OFF)
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES "^MSVC$")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -nologo")
+elseif(CMAKE_C_COMPILER_ID MATCHES "^AppleClang$")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-common")
+endif()
+
+include(CheckCSourceCompiles)
+include(CheckFunctionExists)
+include(CheckIncludeFile)
+include(CheckIncludeFiles)
+include(CheckLibraryExists)
+include(CheckSymbolExists)
+include(CheckTypeSize)
+include(CMakeDependentOption)
+include(CMakePushCheckState)
+include(GNUInstallDirs)
+
+option(WINPCAP_BUGGY_TM_SUPPORT "Build winpcap with buggy time support")
+option(WINPCAP_IPV6 "Enable ipv6 support" ON)
+cmake_dependent_option(WINPCAP_LFS "Enable Large File Support" ON "NOT WIN32" OFF)
+option(WINPCAP_PROTOCHAIN "Enable protochain support")
+option(WINPCAP_REMOTE "Enable remote capture capabilities" ON)
+option(WINPCAP_TURBOCAP "Enable support for turbocap adapters" ON)
+cmake_dependent_option(WINPCAP_USB "Support USB sniffing" ON LINUX OFF)
+set(WINPCAP_USB_DEVICE "" CACHE STRING "path for device for USB sniffing")
+
+if(WIN32)
+    set(WINPCAP_CAPTURE_TYPE_DEFAULT win32)
+elseif(LINUX)
+    set(WINPCAP_CAPTURE_TYPE_DEFAULT linux)
+else()
+    set(WINPCAP_CAPTURE_TYPE_DEFAULT null)
+endif()
+
+set(WINPCAP_CAPTURE_TYPES bpf dag dlpi enet nit null libdlpi linux pf sita snit snoop win32)
+set(WINPCAP_CAPTURE_TYPE "${WINPCAP_CAPTURE_TYPE_DEFAULT}" CACHE STRING "WinPcap capture type")
+set_property(CACHE WINPCAP_CAPTURE_TYPE PROPERTY STRINGS ${WINPCAP_CAPTURE_TYPES})
+if(NOT WINPCAP_CAPTURE_TYPE IN_LIST WINPCAP_CAPTURE_TYPES)
+    message(FATAL_ERROR "Invalid WINPCAP_CAPTURE_TYPE=${WINPCAP_CAPTURE_TYPE} (choices=${WINPCAP_CAPTURE_TYPES})")
+endif()
+
+message(STATUS "WINPCAP_BUGGY_TM_SUPPORT:   ${WINPCAP_BUGGY_TM_SUPPORT}")
+message(STATUS "WINPCAP_CAPTURE_TYPE:       ${WINPCAP_CAPTURE_TYPE}         (choices=${WINPCAP_CAPTURE_TYPES})")
+message(STATUS "WINPCAP_IPV6:               ${WINPCAP_IPV6}")
+message(STATUS "WINPCAP_LFS:                ${WINPCAP_LFS}")
+message(STATUS "WINPCAP_PROTOCHAIN:         ${WINPCAP_PROTOCHAIN}")
+message(STATUS "WINPCAP_REMOTE:             ${WINPCAP_REMOTE}")
+message(STATUS "WINPCAP_TURBOCAP:           ${WINPCAP_TURBOCAP}")
+
+set(WINPCAP_HAVE_DEFINES)
+set(WINPCAP_LIBRARIES)
+
+function(winpcap_check_include_file HEADER VARIABLE DEFINITIONS)
+    cmake_reset_check_state()
+    set(CMAKE_REQUIRED_DEFINITIONS)
+    foreach(def ${DEFINITIONS})
+        list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D${def}")
+    endforeach()
+    check_include_file("${HEADER}" "${VARIABLE}")
+    if(DEFINITIONS AND ${VARIABLE})
+        list(APPEND ${DEFINITIONS} ${VARIABLE})
+        set(${DEFINITIONS} "${${DEFINITIONS}}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(winpcap_check_include_files HEADERS VARIABLE DEFINITIONS)
+    cmake_reset_check_state()
+    set(CMAKE_REQUIRED_DEFINITIONS)
+    foreach(def ${DEFINITIONS})
+        list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D${def}")
+    endforeach()
+    check_include_files("${HEADERS}" "${VARIABLE}")
+    if(DEFINITIONS AND ${VARIABLE})
+        list(APPEND ${DEFINITIONS} ${VARIABLE})
+        set(${DEFINITIONS} "${${DEFINITIONS}}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(winpcap_check_c_source_compiles SOURCE VARIABLE DEFINITIONS)
+    cmake_reset_check_state()
+    set(CMAKE_REQUIRED_DEFINITIONS)
+    foreach(def ${DEFINITIONS})
+        list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D${def}")
+    endforeach()
+    check_c_source_compiles("${SOURCE}" "${VARIABLE}")
+    if(DEFINITIONS AND ${VARIABLE})
+        list(APPEND ${DEFINITIONS} ${VARIABLE})
+        set(${DEFINITIONS} "${${DEFINITIONS}}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(winpcap_check_function_exists FUNCTION VARIABLE DEFINITIONS)
+    cmake_reset_check_state()
+    set(CMAKE_REQUIRED_DEFINITIONS)
+    foreach(def ${DEFINITIONS})
+        list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D${def}")
+    endforeach()
+    check_function_exists("${FUNCTION}" "${VARIABLE}")
+    if(DEFINITIONS AND ${VARIABLE})
+        list(APPEND ${DEFINITIONS} ${VARIABLE})
+        set(${DEFINITIONS} "${${DEFINITIONS}}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(winpcap_check_symbol_exists FUNCTION HEADERS VARIABLE DEFINITIONS)
+    cmake_reset_check_state()
+    set(CMAKE_REQUIRED_DEFINITIONS)
+    foreach(def ${DEFINITIONS})
+        list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D${def}")
+    endforeach()
+    check_symbol_exists("${FUNCTION}" "${HEADERS}" "${VARIABLE}")
+    if(DEFINITIONS AND ${VARIABLE})
+        list(APPEND ${DEFINITIONS} ${VARIABLE})
+        set(${DEFINITIONS} "${${DEFINITIONS}}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(winpcap_check_type TYPE VARIABLE DEFINITIONS)
+    cmake_reset_check_state()
+    set(CMAKE_REQUIRED_DEFINITIONS)
+    foreach(def ${DEFINITIONS})
+        list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D${def}")
+    endforeach()
+    set(src [[
+        #include <sys/types.h>
+        #if STDC_HEADERS
+        # include <stdlib.h>
+        # include <stddef.h>
+        #endif
+        __TYPE__ i;
+    ]])
+    string(REPLACE __TYPE__ "${TYPE}" src "${src}")
+    winpcap_check_c_source_compiles("${src}" ${VARIABLE} "${DEFINITIONS}")
+    if(DEFINITIONS AND ${VARIABLE})
+        list(APPEND ${DEFINITIONS} ${VARIABLE})
+        set(${DEFINITIONS} "${${DEFINITIONS}}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(winpcap_find_library_containing_symbol LIBRARIES FUNCTION FOUND LIBRARY DEFINITIONS LIBS)
+    cmake_reset_check_state()
+    set(CMAKE_REQUIRED_DEFINITIONS)
+    foreach(def ${DEFINITIONS})
+        list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D${def}")
+    endforeach()
+    if(LIBS)
+        set(CMAKE_REQUIRED_LIBRARIES ${LIBS})
+    endif()
+    set(libfound OFF)
+    foreach(library ${LIBRARIES})
+        if(NOT libfound)
+            check_library_exists("${library}" "${FUNCTION}" "" "${library}_HAS_${FUNCTION}")
+            if(${library}_HAS_${FUNCTION})
+                set(libfound ON)
+                set(library "${library}")
+            endif()
+        endif()
+    endforeach()
+    set(${FOUND} ${libfound} PARENT_SCOPE)
+    if(libfound)
+        set(${LIBRARY} "${library}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+cmake_reset_check_state()
+check_type_size(char SIZEOF_CHAR)
+if(HAVE_SIZEOF_CHAR)
+    list(APPEND WINPCAP_HAVE_DEFINES SIZEOF_CHAR=${SIZEOF_CHAR})
+endif()
+
+check_type_size(short SIZEOF_SHORT)
+if(HAVE_SIZEOF_SHORT)
+    list(APPEND WINPCAP_HAVE_DEFINES SIZEOF_SHORT=${SIZEOF_SHORT})
+endif()
+
+check_type_size(int SIZEOF_INT)
+if(HAVE_SIZEOF_INT)
+    list(APPEND WINPCAP_HAVE_DEFINES SIZEOF_INT=${SIZEOF_INT})
+endif()
+
+check_type_size(long SIZEOF_LONG)
+if(HAVE_SIZEOF_LONG)
+    list(APPEND WINPCAP_HAVE_DEFINES SIZEOF_LONG=${SIZEOF_LONG})
+endif()
+
+check_type_size("long long" SIZEOF_LONG_LONG)
+if(HAVE_SIZEOF_LONG_LONG)
+    list(APPEND WINPCAP_HAVE_DEFINES SIZEOF_LONG_LONG=${SIZEOF_LONG_LONG})
+endif()
+
+cmake_reset_check_state()
+check_c_source_compiles([[
+        static void foo(void) __attribute__ ((noreturn));
+        static void foo(void) {
+            return;
+        }
+        int main(int argc, char **argv) {
+            foo();
+        }
+    ]] HAVE___ATTRIBUTE__)
+if(HAVE___ATTRIBUTE__)
+    list(APPEND WINPCAP_HAVE_DEFINES
+        HAVE___ATTRIBUTE__
+        "_U_=__attribute__((unused))"
+    )
+else()
+    list(APPEND WINPCAP_HAVE_DEFINES "_U_=")
+endif()
+
+cmake_reset_check_state()
+check_c_source_compiles([[
+        #include <sys/types.h>
+        #include <sys/socket.h>
+        int main() {
+            socklen_t x;
+        }
+    ]] HAVE_SOCKLEN_T)
+if(HAVE_SOCKLEN_T)
+    list(APPEND WINPCAP_HAVE_DEFINES HAVE_SOCKLEN_T)
+endif()
+
+cmake_reset_check_state()
+check_symbol_exists(SIOCGSTAMP "linux/sockios.h" NEED_LINUX_SOCKIOS_H)
+if(NEED_LINUX_SOCKIOS_H)
+    list(APPEND WINPCAP_HAVE_DEFINES NEED_LINUX_SOCKIOS_H)
+endif()
+
+winpcap_check_include_file("sys/ioccom.h" HAVE_SYS_IOCCOM_H WINPCAP_HAVE_DEFINES)
+winpcap_check_include_file("sys/sockio.h" HAVE_SYS_SOCKIO_H WINPCAP_HAVE_DEFINES)
+winpcap_check_include_file("limits.h" HAVE_LIMITS_H WINPCAP_HAVE_DEFINES)
+winpcap_check_include_file("paths.h" HAVE_PATHS_H WINPCAP_HAVE_DEFINES)
+
+winpcap_check_include_files("sys/types.h;sys/socket.h;net/if.h;net/pfvar.h" HAVE_NET_PFVAR_H WINPCAP_HAVE_DEFINES)
+if(HAVE_NET_PFVAR_H)
+    winpcap_check_c_source_compiles([[
+        #include <sys/types.h>
+        #include <sys/socket.h>
+        #include <net/if.h>
+        #include <net/pfvar.h>
+        int main() {
+            return PF_NAT+PF_NONAT+PF_BINAT+PF_NOBINAT+PF_RDR+PF_NORDR;
+        }
+    ]] HAVE_PF_NAT_THROUGH_PF_NORDR WINPCAP_HAVE_DEFINES)
+endif()
+
+check_include_file("netinit/if_ether.h" HAVE_NETINIT_IF_ETHER_H)
+if(NOT HAVE_NETINIT_IF_ETHER_H)
+    winpcap_check_c_source_compiles([[
+        #include <sys/socket.h>
+        #include <netinet/in.h>
+        struct mbuf;
+        struct rtentry;
+        #include <net/if.h>
+        #include <netinit/if_ether.h>
+    ]] HAVE_NETINIT_IF_ETHER_H WINPCAP_HAVE_DEFINES)
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang)$")
+    set(tmpdefines ${WINPCAP_HAVE_DEFINES})
+    winpcap_check_c_source_compiles([[
+            #include <sys/types.h>
+            #include <sys/time.h>
+            #include <sys/ioctl.h>
+            #ifdef HAVE_SYS_IOCCOM_H
+            #include <sys/ioccom.h>
+            #endif
+            int main() {
+                switch (0) {
+                    case _IO('A', 1):;
+                    case _IO('B', 1):;
+                }
+            }
+        ]] GCC_FIXINCLUDES tmpdefines)
+    if(NOT GCC_FIXINCLUDES)
+        message(FATAL_ERROR "see the INSTALL for more info")
+    endif()
+endif()
+
+winpcap_check_symbol_exists(strerror string.h HAVE_STRERROR WINPCAP_HAVE_DEFINES)
+winpcap_check_symbol_exists(strlcpy string.h HAVE_STRERROR WINPCAP_HAVE_DEFINES)
+
+winpcap_check_symbol_exists(snprintf stdio.h HAVE_SNPRINTF WINPCAP_HAVE_DEFINES)
+winpcap_check_symbol_exists(vsnprintf stdio.h HAVE_VSNPRINTF WINPCAP_HAVE_DEFINES)
+
+# Find libraries containing gethostbyname
+set(CMAKE_REQUIRED_DEFINITIONS)
+set(lib_with_gethostbyname)
+foreach(extra_req_lib "" nsl)
+    foreach(library nsl socket resolv)
+        if(NOT lib_with_gethostbyname)
+            cmake_reset_check_state()
+            set(req_libraries ${library})
+            if(extra_req_lib)
+                list(APPEND req_libraries extra_req_lib)
+            endif()
+            set(CMAKE_REQUIRED_LIBRARIES ${req_libraries})
+            check_library_exists("${library}" gethostbyname "" "GETHOSTBYNAME_IN_${library}_WITH_${extra_req_lib}")
+            if(GETHOSTBYNAME_IN_${library})
+                set(lib_with_gethostbyname ${req_libraries})
+                list(APPEND WINPCAP_LIBRARIES ${lib_with_gethostbyname})
+            endif()
+        endif()
+    endforeach()
+endforeach()
+
+cmake_reset_check_state()
+check_symbol_exists(getifaddrs ifaddrs.h HAVE_GETIFADDRS)
+
+cmake_reset_check_state()
+check_c_source_compiles([[
+        #include <sys/param.h>
+        #include <sys/file.h>
+        #include <sys/ioctl.h>
+        #include <sys/socket.h>
+        #include <sys/sockio.h>
+        int main() {
+            ioctl(0, SIOCGLIFCONF, (char *)0);
+        }
+    ]] HAVE_SIOCGLIFCONF)
+
+check_include_file(unistd.h HAVE_UNISTD_H)
+if(NOT HAVE_UNISTD_H)
+    list(APPEND WINPCAP_HAVE_DEFINES YY_NO_UNISTD_H)
+endif()
+
+find_package(FLEX REQUIRED)
+find_package(BISON REQUIRED)
+
+flex_target(wpcap_scanner
+    source_subfolder/wpcap/libpcap/scanner.l
+    "${CMAKE_CURRENT_BINARY_DIR}/scanner.c"
+    COMPILE_FLAGS "--prefix=pcap_"
+)
+bison_target(wpcap_grammar
+    source_subfolder/wpcap/libpcap/grammar.y
+    "${CMAKE_CURRENT_BINARY_DIR}/grammar.c"
+    COMPILE_FLAGS "-p pcap_"
+)
+
+add_library(pcap
+    ${CMAKE_CURRENT_LIST_FILE}
+
+    source_subfolder/wpcap/PRJ/WPCAP.DEF
+    source_subfolder/wpcap/libpcap/bpf/net/bpf_filter.c
+    source_subfolder/wpcap/libpcap/bpf_dump.c
+    source_subfolder/wpcap/libpcap/bpf_image.c
+    source_subfolder/wpcap/libpcap/etherent.c
+    source_subfolder/wpcap/libpcap/gencode.c
+    source_subfolder/wpcap/libpcap/inet.c
+    source_subfolder/wpcap/libpcap/nametoaddr.c
+    source_subfolder/wpcap/libpcap/optimize.c
+    source_subfolder/wpcap/libpcap/savefile.c
+
+    source_subfolder/wpcap/libpcap/missing/snprintf.c
+        source_subfolder/wpcap/libpcap/pcap-${WINPCAP_CAPTURE_TYPE}.c
+
+    source_subfolder/wpcap/libpcap/pcap.c
+
+    "${CMAKE_CURRENT_BINARY_DIR}/scanner.c"
+    "${CMAKE_CURRENT_BINARY_DIR}/grammar.c"
+)
+
+target_include_directories(pcap
+    PRIVATE
+        source_subfolder/wpcap/libpcap
+        source_subfolder/wpcap/libpcap/lbl
+        source_subfolder/wpcap/libpcap/bpf
+        source_subfolder/Common
+        source_subfolder/wpcap/../../AirPcap_DevPack/include
+)
+if(WIN32)
+    target_sources(pcap
+        PRIVATE
+            source_subfolder/wpcap/libpcap/pcap-win32.c
+    )
+    target_include_directories(pcap
+        PRIVATE
+            source_subfolder/wpcap/libpcap/Win32/Include
+            source_subfolder/wpcap/Win32-Extensions
+    )
+endif()
+
+set_target_properties(pcap
+    PROPERTIES
+        DEFINE_SYMBOL LIBPCAP_EXPORTS
+)
+
+target_compile_definitions(pcap
+    PRIVATE
+        LIBPCAP_EXPORTS
+        ${WINPCAP_HAVE_DEFINES}
+        YY_NEVER_INTERACTIVE
+        WPCAP
+)
+
+if(WINPCAP_LFS)
+    target_compile_definitions(pcap PRIVATE
+        _FILE_OFFSET_BITS=64
+        _LARGE_FILES
+        _LARGEFILE_SOURCE
+    )
+endif()
+
+
+if(WINPCAP_REMOTE)
+    set(capture_types_supporting_remote bpf linux win32)
+    if(WINPCAP_CAPTURE_TYPE IN_LIST capture_types_supporting_remote)
+        target_sources(pcap
+            PRIVATE
+                source_subfolder/wpcap/libpcap/sockutils.c
+                source_subfolder/wpcap/libpcap/pcap-new.c
+                source_subfolder/wpcap/libpcap/pcap-remote.c
+        )
+        target_compile_definitions(pcap PRIVATE HAVE_REMOTE)
+    else()
+        message(FATAL_ERROR "WINPCAP_REMOTE can only be enabled for WINPCAP_CAPTURE_TYPE=${capture_types_supporting_remote}")
+    endif()
+else()
+    if(WIN32)
+        message(FATAL_ERROR "Windows requires WINPCAP_REMOTE enabled")
+    endif()
+endif()
+
+if(WINPCAP_CAPTURE_TYPE MATCHES "^sita$")
+elseif(WINPCAP_CAPTURE_TYPE MATCHES "^null")
+    target_sources(pcap PRIVATE source_subfolder/wpcap/libpcap/fad-null.c)
+else()
+    if(HAVE_GETIFADDRS)
+        target_sources(pcap PRIVATE source_subfolder/wpcap/libpcap/fad-getad.c)
+    elseif(WINPCAP_CAPTURE_TYPE MATCHES "^(dlpi|libdlpi)$")
+        target_sources(pcap PRIVATE source_subfolder/wpcap/libpcap/dlpisubs.c)
+        if(HAVE_SIOCGLIFCONF)
+            target_sources(pcap PRIVATE source_subfolder/wpcap/libpcap/fad-glifc.c)
+        else()
+            target_sources(pcap PRIVATE source_subfolder/wpcap/libpcap/fad-gifc.c)
+        endif()
+    else()
+        target_sources(pcap PRIVATE source_subfolder/wpcap/libpcap/fad-gifc.c)
+    endif()
+endif()
+
+if(WINPCAP_CAPTURE_TYPE MATCHES "^sita$")
+    target_compile_definitions(pcap PRIVATE SITA=1)
+elseif(WINPCAP_CAPTURE_TYPE MATCHES "^dag$")
+    find_package(DAG REQUIRED)
+    target_link_libraries(pcap PRIVATE DAG::DAG)
+    target_compile_definitions(pcap PRIVATE HAVE_DAG_API DAG_ONLY)
+
+    cmake_reset_check_state()
+    set(CMAKE_REQUIRED_LIBRARIES "${DAG_LIBRARY}")
+
+    check_function_exists(dag_attach_stream HAVE_DAG_ATTACH_STREAM)
+    if(HAVE_DAG_ATTACH_STREAM)
+        target_compile_definitions(pcap PRIVATE HAVE_DAG_STREAMS_API)
+    endif()
+
+    check_function_exists(dag_get_erf_types HAVE_DAG_GET_ERF_TYPES)
+    if(HAVE_DAG_GET_ERF_TYPES)
+        target_compile_definitions(pcap PRIVATE HAVE_DAG_GET_ERF_TYPES)
+    endif()
+
+    check_function_exists(dag_get_stream_erf_types HAVE_DAG_GET_STREAM_ERF_TYPES)
+    if(HAVE_DAG_GET_STREAM_ERF_TYPES)
+        target_compile_definitions(pcap PRIVATE HAVE_DAG_GET_STREAM_ERF_TYPES)
+    endif()
+elseif(WINPCAP_CAPTURE_TYPE MATCHES "^septel")
+    find_package(septel REQUIRED)
+    target_link_libraries(pcap PRIVATE septel::septel)
+    target_compile_definitions(pcap PRIVATE HAVE_DAG_API HAVE_SEPTEL_API SEPTEL_ONLY)
+endif()
+
+if(WINPCAP_TURBOCAP)
+    set(capture_types_supporting_turbocap linux win32)
+    if(WINPCAP_CAPTURE_TYPE IN_LIST capture_types_supporting_turbocap)
+        target_sources(pcap
+            PRIVATE
+                source_subfolder/wpcap/libpcap/pcap-tc.c
+        )
+        target_compile_definitions(pcap PRIVATE HAVE_TC_API)
+        if(WIN32)
+            target_sources(pcap
+                PRIVATE
+                    source_subfolder/wpcap/Win32-Extensions/Win32-Extensions.c
+            )
+        else()
+            find_package(Turbocap REQUIRED)
+            find_package(Threads REQUIRED)
+            target_link_libraries(pcap
+                PRIVATE
+                    Threads::Threads
+                    Turbocap::Turbocap
+            )
+        endif()
+    else()
+        message(FATAL_ERROR "WINPCAP_TURBOCAP can only be enabled for WINPCAP_CAPTURE_TYPE=${capture_types_supporting_turbocap}")
+    endif()
+else()
+    if(WIN32)
+        message(FATAL_ERROR "Windows requires WINPCAP_TURBOCAP enabled")
+    endif()
+endif()
+
+if(MSVC)
+    target_compile_definitions(pcap
+        PRIVATE
+            _CRT_SECURE_NO_WARNINGS
+    )
+endif()
+
+if(WIN32)
+    target_sources(pcap
+        PRIVATE
+            source_subfolder/wpcap/libpcap/Win32/Src/ffs.c
+            source_subfolder/wpcap/libpcap/Win32/Src/getservent.c
+    )
+    target_link_libraries(pcap
+        PRIVATE
+            packet ws2_32
+    )
+    target_compile_definitions(pcap
+        PRIVATE
+            WIN32
+    )
+    set_target_properties(pcap
+        PROPERTIES
+            OUTPUT_NAME wpcap
+    )
+endif()
+
+if(WINPCAP_IPV6)
+    target_compile_definitions(pcap PRIVATE INET6=1)
+endif()
+
+if(NOT WINPCAP_PROTOCHAIN)
+    target_compile_definitions(pcap PRIVATE NO_PROTOCHAIN)
+endif()
+
+if(WINPCAP_BLUETOOTH)
+    find_package(bluez REQUIRED)
+    target_link_libraries(pcap PRIVATE bluez::bluez)
+    target_sources(pcap PRIVATE source_subfolder/wpcap/libpcap/pcap-bt-linux.c)
+    target_compile_definitions(pcap
+        PRIVATE
+            PCAP_SUPPORT_BT
+    )
+endif()
+
+if(WINPCAP_USB)
+    target_sources(pcap PRIVATE source_subfolder/wpcap/libpcap/pcap-usb-linux.c)
+    target_compile_definitions(pcap
+        PRIVATE
+            PCAP_SUPPORT_USB
+            "LINUX_USB_MON_DEV=\"${WINPCAP_USB_DEVICE}\""
+    )
+endif()
+
+install(TARGETS pcap
+    ARCHIVE DESTINATION "${cMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)
+
+# from create_include.bat
+file(GLOB WINPCAP_PCAP_HEADERS "source_subfolder/wpcap/libpcap/pcap/*.h")
+set(WINPCAP_HEADERS
+    source_subfolder/wpcap/libpcap/pcap.h
+    source_subfolder/wpcap/libpcap/pcap-bpf.h
+    source_subfolder/wpcap/libpcap/pcap-namedb.h
+    source_subfolder/wpcap/libpcap/remote-ext.h
+
+    source_subfolder/wpcap/libpcap/pcap-stdinc.h
+)
+if(WIN32)
+    list(APPEND WINPCAP_HEADERS
+        source_subfolder/wpcap/Win32-Extensions/Win32-Extensions.h
+        source_subfolder/wpcap/libpcap/Win32/Include/bittypes.h
+        source_subfolder/wpcap/libpcap/Win32/Include/ip6_misc.h
+    )
+endif()
+if(WINPCAP_BUGGY_TM_SUPPORT)
+    list(APPEND WINPCAP_HEADERS
+        source_subfolder/packetNtx/driver/bucket_lookup.h
+        source_subfolder/packetNtx/driver/count_packets.h
+        source_subfolder/packetNtx/driver/memory_t.h
+        source_subfolder/packetNtx/driver/normal_lookup.h
+        source_subfolder/packetNtx/driver/tcp_session.h
+        source_subfolder/packetNtx/driver/time_calls.h
+        source_subfolder/packetNtx/driver/tme.h
+    )
+endif()
+list(APPEND WINPCAP_HEADERS
+    source_subfolder/Common/Packet32.h
+)
+
+install(FILES ${WINPCAP_PCAP_HEADERS}
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/pcap"
+)
+install(FILES ${WINPCAP_HEADERS}
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)

--- a/recipes/winpcap/all/conandata.yml
+++ b/recipes/winpcap/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "4.1.3":
+    url: "https://www.winpcap.org/install/bin/WpcapSrc_4_1_3.zip"
+    sha256: "346a93f6b375ac4c1add5c8c7178498f1feed4172fb33383474a91b48ec6633a"
+patches:
+  "4.1.3":
+    - base_path: source_subfolder
+      patch_file: "patches/0001-linux-patch.cmake"

--- a/recipes/winpcap/all/conanfile.py
+++ b/recipes/winpcap/all/conanfile.py
@@ -1,0 +1,134 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class WinPcapConan(ConanFile):
+    name = "winpcap"
+    description = "For many years, WinPcap has been recognized as the industry-standard tool for link-layer network access in Windows environments, " \
+                  "allowing applications to capture and transmit network packets bypassing the protocol stack, and including kernel-level packet filtering, " \
+                  "a network statistics engine and support for remote packet capture."
+    license = "BSD-3-Clause"
+    topics = ("conan", "packet", "capture", "filtering", "network", "protocol")
+    homepage = "https://www.winpcap.org/"
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "capture_type": ["bpf", "dag", "dlpi", "enet", "nit", "null", "libdlpi", "linux", "pf", "sita", "snit", "snoop", "win32"],
+        "remote": [True, False],
+        "bluetooth": [True, False],
+        "usb_sniffing": [True, False],
+        "usb_sniffing_device": "ANY",
+        "turbocap": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "capture_type": "null",
+        "remote": True,
+        "bluetooth": False,
+        "usb_sniffing": True,
+        "usb_sniffing_device": "/dev/usbmon",
+        "turbocap": False,
+    }
+
+    exports_sources = "CMakeLists.txt", "cmake/*", "patches/*"
+    generators = "cmake"
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+            self.options.turbocap = True
+            self.options.capture_type = "win32"
+        elif self.settings.os == "Linux":
+            self.options.capture_type = "linux"
+        if self.settings.os != "Linux":
+            del self.options.bluetooth
+            del self.options.usb_sniffing
+            del self.options.usb_sniffing_device
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def requirements(self):
+        if self.options.capture_type == "dag":
+            # FIXME: missing dag recipe
+            raise ConanInvalidConfiguration("missing dag cci recipe")
+        if self.options.get_safe("bluetooth"):
+            # FIXME: missing bluez recipe
+            raise ConanInvalidConfiguration("missing bluez cci recipe")
+        if self.options.turbocap and self.settings.os != "Windows":
+            # FIXME: missing turbocap recipe
+            raise ConanInvalidConfiguration("missing turbocap cci recipe")
+
+    def build_requirements(self):
+        if tools.os_info.is_windows:
+            self.build_requires("winflexbison/2.5.24")
+        else:
+            self.build_requires("bison/3.7.1")
+            self.build_requires("flex/2.6.4")
+
+    def validate(self):
+        if self.settings.os == "Windows":
+            if not self.options.remote:
+                raise ConanInvalidConfiguration("os=Windows requires winpcap:remote=True")
+            if not self.options.turbocap:
+                raise ConanInvalidConfiguration("os=Windows requires winpcap:turbocap=True")
+        elif self.settings.os == "Linux":
+            if not str(self.options.usb_sniffing_device):
+                raise ConanInvalidConfiguration("winpcap:usb_sniffing_device is invalid")
+        else:
+            raise ConanInvalidConfiguration("This recipe has not been tested/validated on os={}".format(self.settings.os))
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["WINPCAP_CAPTURE_TYPE"] = self.options.capture_type
+        self._cmake.definitions["WINPCAP_REMOTE"] = self.options.remote
+        self._cmake.definitions["WINPCAP_TURBOCAP"] = self.options.turbocap
+        self._cmake.definitions["WINPCAP_BLUETOOTH"] = self.options.get_safe("bluetooth", False)
+        self._cmake.definitions["WINPCAP_USB"] = self.options.get_safe("usb_sniffing", False)
+        self._cmake.definitions["WINPCAP_USB_DEVICE"] = self.options.get_safe("usb_sniffing_device", "")
+        self._cmake.configure()
+        return self._cmake
+
+    def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+    def build(self):
+        self._patch_sources()
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", src=os.path.join(self._source_subfolder, "wpcap", "libpcap"), dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        if self.settings.os == "Windows":
+            libs = ["wpcap", "packet"]
+        else:
+            libs = ["pcap"]
+        self.cpp_info.libs = libs
+        if self.options.get_safe("remote"):
+            self.cpp_info.defines.append("HAVE_REMOTE")
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["ws2_32"]

--- a/recipes/winpcap/all/conanfile.py
+++ b/recipes/winpcap/all/conanfile.py
@@ -45,6 +45,13 @@ class WinPcapConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _build_os(self):
+        if hasattr(self, "settings_build"):
+            return self.settings_build.os
+        else:
+            return self.settings.os
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -73,7 +80,7 @@ class WinPcapConan(ConanFile):
             raise ConanInvalidConfiguration("missing turbocap cci recipe")
 
     def build_requirements(self):
-        if tools.os_info.is_windows:
+        if self._build_os == "Windows":
             self.build_requires("winflexbison/2.5.24")
         else:
             self.build_requires("bison/3.7.1")

--- a/recipes/winpcap/all/patches/0001-linux-patch.cmake
+++ b/recipes/winpcap/all/patches/0001-linux-patch.cmake
@@ -1,0 +1,16 @@
+--- wpcap/libpcap/pcap-linux.c
++++ wpcap/libpcap/pcap-linux.c
+@@ -129,10 +129,10 @@
+ #ifdef HAVE_REMOTE
+ #include <pcap-remote.h>
+ #endif
++#ifdef NEED_LINUX_SOCKIOS_H
++#include <linux/sockios.h>
++#endif
+-
+ /*
+- * If PF_PACKET is defined, we can use {SOCK_RAW,SOCK_DGRAM}/PF_PACKET
+- * sockets rather than SOCK_PACKET sockets.
+  *
+  * To use them, we include <linux/if_packet.h> rather than
+  * <netpacket/packet.h>; we do so because

--- a/recipes/winpcap/all/test_package/CMakeLists.txt
+++ b/recipes/winpcap/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup()
+
+add_executable(test_package test_package.c)
+target_link_libraries(test_package PRIVATE ${CONAN_LIBS})

--- a/recipes/winpcap/all/test_package/conanfile.py
+++ b/recipes/winpcap/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/winpcap/all/test_package/test_package.c
+++ b/recipes/winpcap/all/test_package/test_package.c
@@ -1,0 +1,107 @@
+/* Copied and modified from Examples/misc/basic_dump.c */
+
+#include "pcap.h"
+
+#include <stdlib.h>
+#include <time.h>
+
+/* prototype of the packet handler */
+void packet_handler(u_char *param, const struct pcap_pkthdr *header, const u_char *pkt_data);
+
+int main()
+{
+    pcap_if_t *alldevs;
+    pcap_if_t *d;
+    int inum;
+    int i=0;
+    pcap_t *adhandle;
+    char errbuf[PCAP_ERRBUF_SIZE];
+
+    printf("On unix'es, this program must be run as root.\n");
+
+    /* Retrieve the device list on the local machine */
+    if (pcap_findalldevs_ex(PCAP_SRC_IF_STRING, NULL, &alldevs, errbuf) == -1)
+    {
+        fprintf(stderr,"Error in pcap_findalldevs: %s\n", errbuf);
+        exit(0);
+    }
+
+    /* Print the list */
+    for(d=alldevs; d; d=d->next)
+    {
+        printf("%d. %s", ++i, d->name);
+        if (d->description)
+            printf(" (%s)\n", d->description);
+        else
+            printf(" (No description available)\n");
+    }
+
+    if(i==0)
+    {
+        printf("\nNo interfaces found! Make sure WinPcap is installed.\n");
+        return -1;
+    }
+
+    printf("Enter the interface number (1-%d):",i);
+    scanf("%d", &inum);
+
+    if(inum < 1 || inum > i)
+    {
+        printf("\nInterface number out of range.\n");
+        /* Free the device list */
+        pcap_freealldevs(alldevs);
+        return -1;
+    }
+
+    /* Jump to the selected adapter */
+    for(d=alldevs, i=0; i< inum-1 ;d=d->next, i++);
+
+    /* Open the device */
+    if ( (adhandle= pcap_open(d->name,            // name of the device
+                              65536,            // portion of the packet to capture
+                                                // 65536 guarantees that the whole packet will be captured on all the link layers
+                              PCAP_OPENFLAG_PROMISCUOUS,     // promiscuous mode
+                              1000,                // read timeout
+                              NULL,                // authentication on the remote machine
+                              errbuf            // error buffer
+                              ) ) == NULL)
+    {
+        fprintf(stderr,"\nUnable to open the adapter. %s is not supported by WinPcap\n", d->name);
+        /* Free the device list */
+        pcap_freealldevs(alldevs);
+        return -1;
+    }
+
+    printf("\nlistening on %s...\n", d->description);
+
+    /* At this point, we don't need any more the device list. Free it */
+    pcap_freealldevs(alldevs);
+
+    /* start the capture */
+    pcap_loop(adhandle, 0, packet_handler, NULL);
+
+    return 0;
+}
+
+
+/* Callback function invoked by libpcap for every incoming packet */
+void packet_handler(u_char *param, const struct pcap_pkthdr *header, const u_char *pkt_data)
+{
+    struct tm ltime;
+    char timestr[16];
+    time_t local_tv_sec;
+
+    /*
+     * unused variables
+     */
+    (void)(param);
+    (void)(pkt_data);
+
+    /* convert the timestamp to readable format */
+    local_tv_sec = header->ts.tv_sec;
+    localtime_r(&local_tv_sec, &ltime);
+    strftime( timestr, sizeof timestr, "%H:%M:%S", &ltime);
+
+    printf("%s,%.6d len:%d\n", timestr, header->ts.tv_usec, header->len);
+
+}

--- a/recipes/winpcap/config.yml
+++ b/recipes/winpcap/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "4.1.3":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **winpcap/4.1.3**


- Tested on Linux
- On Windows:
   - Needs the Windows DDK (=Driver Development Kit)
   - Fails to build on my machine because of a missing header inside the DDK (MSVC cannot find `ndis/types.h`). Feedback welcome.
   - Not tested with mingw
- other operating systems: not tested. The recipe raises an error. PRs are welcome to add macos support.


Closes https://github.com/bincrafters/community/pull/1395

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
