### PR TITLE
libfabric: Properly check supported OS

### DIFF
--- a/recipes/libfabric/all/conanfile.py
+++ b/recipes/libfabric/all/conanfile.py
@@ -51,8 +51,8 @@ class LibfabricConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def validate(self):
-        if self.settings.compiler == "Visual Studio":
-            raise ConanInvalidConfiguration("The libfabric package cannot be built on Visual Studio.")
+        if self.settings.os not in ["Linux", "FreeBSD", "Macos"]:
+            raise ConanInvalidConfiguration("libfabric only builds on Linux, Macos, and FreeBSD.")
         for p in self._providers:
             if self.options.get_safe(p) not in ["auto", "yes", "no", "dl"] and not os.path.isdir(str(self.options.get_safe(p))):
                 raise ConanInvalidConfiguration("Option {} can only be one of 'auto', 'yes', 'no', 'dl' or a directory path")
@@ -95,5 +95,5 @@ class LibfabricConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["pkg_config"] = "libfabric"
         self.cpp_info.libs = self.collect_libs()
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread", "m"]


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

libfabric is very explicit regarding supported OS, configure will not let you build for any other OS than Linux, FreeBSD and macOS.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
