### PR TITLE
autoconf: use only one package for everything + allow building with host/build profile

### DIFF
--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -14,7 +14,7 @@ class AutoconfConan(ConanFile):
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
     settings = "os", "arch", "compiler"
 
-    exports_sources = "patches/**"
+    exports_sources = "patches/*"
 
     _autotools = None
 
@@ -36,11 +36,7 @@ class AutoconfConan(ConanFile):
             self.build_requires("msys2/cci.latest")
 
     def package_id(self):
-        del self.info.settings.arch
-        del self.info.settings.os
-        del self.info.settings.compiler
-        # The m4 requirement does not change the contents of this package
-        self.info.requires.clear()
+        self.info.header_only()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -98,19 +98,19 @@ class AutoconfConan(ConanFile):
         self.output.info("Setting AC_MACRODIR to {}".format(ac_macrodir))
         self.env_info.AC_MACRODIR = ac_macrodir
 
-        autoconf = os.path.join(self.package_folder, "bin", "autoconf")
+        autoconf = tools.unix_path(os.path.join(self.package_folder, "bin", "autoconf"))
         self.output.info("Setting AUTOCONF to {}".format(autoconf))
         self.env_info.AUTOCONF = autoconf
 
-        autoreconf = os.path.join(self.package_folder, "bin", "autoreconf")
+        autoreconf = tools.unix_path(os.path.join(self.package_folder, "bin", "autoreconf"))
         self.output.info("Setting AUTORECONF to {}".format(autoreconf))
         self.env_info.AUTORECONF = autoreconf
 
-        autoheader = os.path.join(self.package_folder, "bin", "autoheader")
+        autoheader = tools.unix_path(os.path.join(self.package_folder, "bin", "autoheader"))
         self.output.info("Setting AUTOHEADER to {}".format(autoheader))
         self.env_info.AUTOHEADER = autoheader
 
-        autom4te = os.path.join(self.package_folder, "bin", "autom4te")
+        autom4te = tools.unix_path(os.path.join(self.package_folder, "bin", "autom4te"))
         self.output.info("Setting AUTOM4TE to {}".format(autom4te))
         self.env_info.AUTOM4TE = autom4te
 

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -37,6 +37,7 @@ class AutoconfConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.arch
+        del self.info.settings.os
         del self.info.settings.compiler
         # The m4 requirement does not change the contents of this package
         self.info.requires.clear()

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -89,14 +89,6 @@ class AutoconfConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "info"))
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "man"))
 
-        if self.settings.os == "Windows":
-            binpath = os.path.join(self.package_folder, "bin")
-            for filename in os.listdir(binpath):
-                fullpath = os.path.join(binpath, filename)
-                if not os.path.isfile(fullpath):
-                    continue
-                os.rename(fullpath, fullpath + ".exe")
-
     def package_info(self):
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH env var with : {}".format(bin_path))
@@ -107,26 +99,18 @@ class AutoconfConan(ConanFile):
         self.env_info.AC_MACRODIR = ac_macrodir
 
         autoconf = os.path.join(self.package_folder, "bin", "autoconf")
-        if self.settings.os == "Windows":
-            autoconf = tools.unix_path(autoconf) + ".exe"
         self.output.info("Setting AUTOCONF to {}".format(autoconf))
         self.env_info.AUTOCONF = autoconf
 
         autoreconf = os.path.join(self.package_folder, "bin", "autoreconf")
-        if self.settings.os == "Windows":
-            autoreconf = tools.unix_path(autoreconf) + ".exe"
         self.output.info("Setting AUTORECONF to {}".format(autoreconf))
         self.env_info.AUTORECONF = autoreconf
 
         autoheader = os.path.join(self.package_folder, "bin", "autoheader")
-        if self.settings.os == "Windows":
-            autoheader = tools.unix_path(autoheader) + ".exe"
         self.output.info("Setting AUTOHEADER to {}".format(autoheader))
         self.env_info.AUTOHEADER = autoheader
 
         autom4te = os.path.join(self.package_folder, "bin", "autom4te")
-        if self.settings.os == "Windows":
-            autom4te = tools.unix_path(autom4te) + ".exe"
         self.output.info("Setting AUTOM4TE to {}".format(autom4te))
         self.env_info.AUTOM4TE = autom4te
 

--- a/recipes/autoconf/all/test_package/conanfile.py
+++ b/recipes/autoconf/all/test_package/conanfile.py
@@ -31,8 +31,10 @@ class TestPackageConan(ConanFile):
     def build(self):
         for src in self.exports_sources:
             shutil.copy(os.path.join(self.source_folder, src), self.build_folder)
-        self.run("{} --verbose".format(os.environ["AUTOCONF"]), win_bash=tools.os_info.is_windows)
-        self.run("{} --help".format(os.path.join(self.build_folder, "configure").replace("\\", "/")), win_bash=tools.os_info.is_windows)
+        self.run("{} --verbose".format(os.environ["AUTOCONF"]),
+                 win_bash=tools.os_info.is_windows, run_environment=True)
+        self.run("{} --help".format(os.path.join(self.build_folder, "configure").replace("\\", "/")),
+                 win_bash=tools.os_info.is_windows, run_environment=True)
         autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         with self._build_context():
             autotools.configure()

--- a/recipes/autoconf/all/test_package/conanfile.py
+++ b/recipes/autoconf/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
 from conans import AutoToolsBuildEnvironment, ConanFile, tools
-from contextlib import contextmanager
+import contextlib
 import os
 import shutil
 
@@ -19,10 +19,10 @@ class TestPackageConan(ConanFile):
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 
-    @contextmanager
+    @contextlib.contextmanager
     def _build_context(self):
         if self.settings.compiler == "Visual Studio":
-            with tools.vcvars(self.settings):
+            with tools.vcvars(self):
                 with tools.environment_append({"CC": "cl -nologo", "CXX": "cl -nologo",}):
                     yield
         else:


### PR DESCRIPTION
Specify library name and version:  **autoconf/all**

- Allow building with 2 profile approach (with host==build)
- One package for every arch/os
- Remove usage of `tools.vcvars(self.settings)`


When using a x86_64 profile named `default64` (see below):

This now succeeds:
```
conan create . autoconf/2.71@ -pr:h default64 -pr:b default64
```

example `default64` profile:
```
$ conan profile show default64
Configuration for profile default64:

[settings]
os=Linux
arch=x86_64
compiler=gcc
compiler.version=11
compiler.libcxx=libstdc++11
build_type=Release
[options]
[conf]
[build_requires]
[env]
CC=/usr/bin/gcc
CXX=/usr/bin/g++
AS=/usr/bin/gcc
ASM=/usr/bin/gcc
CFLAGS=-m64
CXXFLAGS=-m64
ASFLAGS=-m64
ASMFLAGS=-m64
LDFLAGS=-m64
```


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
