### PR TITLE
libfdk_aac: add 2.0.2 + split build and installation + honor profile if msvc + modernize

### DIFF
--- a/recipes/libfdk_aac/all/CMakeLists.txt
+++ b/recipes/libfdk_aac/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/libfdk_aac/all/conandata.yml
+++ b/recipes/libfdk_aac/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
-  "2.0.0":
-    url: "https://github.com/mstorsjo/fdk-aac/archive/v2.0.0.tar.gz"
-    sha256: "6e6c7921713788e31df655911e1d42620b057180b00bf16874f5d630e1d5b9a2"
+  "2.0.2":
+    url: "https://github.com/mstorsjo/fdk-aac/archive/refs/tags/v2.0.2.tar.gz"
+    sha256: "7812b4f0cf66acda0d0fe4302545339517e702af7674dd04e5fe22a5ade16a90"
   "2.0.1":
     url: "https://github.com/mstorsjo/fdk-aac/archive/v2.0.1.tar.gz"
     sha256: "a4142815d8d52d0e798212a5adea54ecf42bcd4eec8092b37a8cb615ace91dc6"
+  "2.0.0":
+    url: "https://github.com/mstorsjo/fdk-aac/archive/v2.0.0.tar.gz"
+    sha256: "6e6c7921713788e31df655911e1d42620b057180b00bf16874f5d630e1d5b9a2"

--- a/recipes/libfdk_aac/all/conanfile.py
+++ b/recipes/libfdk_aac/all/conanfile.py
@@ -116,6 +116,6 @@ class FDKAACConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["fdk-aac"]
-        if self.settings.os == "Linux" or self.settings.os == "Android":
+        if self.settings.os in ["Linux", "FreeBSD", "Android"]:
             self.cpp_info.system_libs.append("m")
         self.cpp_info.names["pkg_config"] = "fdk-aac"

--- a/recipes/libfdk_aac/all/conanfile.py
+++ b/recipes/libfdk_aac/all/conanfile.py
@@ -24,9 +24,9 @@ class FDKAACConan(ConanFile):
             del self.options.fPIC
 
     def build_requirements(self):
-        if self._use_winbash and self.settings.compiler != 'Visual Studio':
-            if "CONAN_BASH_PATH" not in os.environ and tools.os_info.detect_windows_subsystem() != 'msys2':
-                self.build_requires("msys2/20190524")
+        if self.settings.compiler != "Visual Studio":
+            if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+                self.build_requires("msys2/cci.latest")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/libfdk_aac/all/conanfile.py
+++ b/recipes/libfdk_aac/all/conanfile.py
@@ -28,6 +28,10 @@ class FDKAACConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
     def build_requirements(self):
         if self.settings.compiler != "Visual Studio":
             self.build_requires("libtool/2.4.6")

--- a/recipes/libfdk_aac/all/conanfile.py
+++ b/recipes/libfdk_aac/all/conanfile.py
@@ -14,7 +14,7 @@ class FDKAACConan(ConanFile):
     homepage = "https://sourceforge.net/projects/opencore-amr/"
     topics = ("conan", "libfdk_aac", "multimedia", "audio", "fraunhofer", "aac", "decoder", "encoding", "decoding")
     options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {'shared': False, 'fPIC': True}
+    default_options = {"shared": False, "fPIC": True}
 
     @property
     def _source_subfolder(self):
@@ -22,10 +22,10 @@ class FDKAACConan(ConanFile):
 
     @property
     def _use_winbash(self):
-        return tools.os_info.is_windows and (self.settings.compiler == 'gcc' or tools.cross_building(self.settings))
+        return tools.os_info.is_windows and (self.settings.compiler == "gcc" or tools.cross_building(self.settings))
 
     def config_options(self):
-        if self.settings.os == 'Windows':
+        if self.settings.os == "Windows":
             del self.options.fPIC
 
     def build_requirements(self):
@@ -41,15 +41,15 @@ class FDKAACConan(ConanFile):
     def _build_vs(self):
         with tools.chdir(self._source_subfolder):
             with tools.vcvars(self.settings, force=True):
-                with tools.remove_from_path('mkdir'):
-                    tools.replace_in_file('Makefile.vc',
-                                          'CFLAGS   = /nologo /W3 /Ox /MT',
-                                          'CFLAGS   = /nologo /W3 /Ox /%s' % str(self.settings.compiler.runtime))
-                    tools.replace_in_file('Makefile.vc',
-                                          'MKDIR_FLAGS = -p',
-                                          'MKDIR_FLAGS =')
-                    self.run('nmake -f Makefile.vc')
-                    self.run('nmake -f Makefile.vc prefix="%s" install' % os.path.abspath(self.package_folder))
+                with tools.remove_from_path("mkdir"):
+                    tools.replace_in_file("Makefile.vc",
+                                          "CFLAGS   = /nologo /W3 /Ox /MT",
+                                          "CFLAGS   = /nologo /W3 /Ox /%s" % str(self.settings.compiler.runtime))
+                    tools.replace_in_file("Makefile.vc",
+                                          "MKDIR_FLAGS = -p",
+                                          "MKDIR_FLAGS =")
+                    self.run("nmake -f Makefile.vc")
+                    self.run("nmake -f Makefile.vc prefix=\"%s\" install" % os.path.abspath(self.package_folder))
 
     def _build_configure(self):
         with tools.chdir(self._source_subfolder):
@@ -57,47 +57,47 @@ class FDKAACConan(ConanFile):
             prefix = os.path.abspath(self.package_folder)
             if self._use_winbash:
                 prefix = tools.unix_path(prefix, tools.MSYS2)
-            args = ['--prefix=%s' % prefix]
+            args = ["--prefix=%s" % prefix]
             if self.options.shared:
-                args.extend(['--disable-static', '--enable-shared'])
+                args.extend(["--disable-static", "--enable-shared"])
             else:
-                args.extend(['--disable-shared', '--enable-static'])
+                args.extend(["--disable-shared", "--enable-static"])
             env_build = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
             self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows)
             if self.settings.os == "Android" and tools.os_info.is_windows:
                 # remove escape for quotation marks, to make ndk on windows happy
-                tools.replace_in_file('configure',
+                tools.replace_in_file("configure",
                     "s/[	 `~#$^&*(){}\\\\|;'\\\''\"<>?]/\\\\&/g", "s/[	 `~#$^&*(){}\\\\|;<>?]/\\\\&/g")
             env_build.configure(args=args)
             env_build.make()
             env_build.install()
 
     def build(self):
-        if self.settings.compiler == 'Visual Studio':
+        if self.settings.compiler == "Visual Studio":
             self._build_vs()
         else:
             self._build_configure()
 
     def package(self):
         self.copy(pattern="NOTICE", src=self._source_subfolder, dst="licenses")
-        if self.settings.compiler == 'Visual Studio':
+        if self.settings.compiler == "Visual Studio":
             if self.options.shared:
-                exts = ['fdk-aac.lib']
+                exts = ["fdk-aac.lib"]
             else:
-                exts = ['fdk-aac.dll.lib', 'fdk-aac-1.dll']
+                exts = ["fdk-aac.dll.lib", "fdk-aac-1.dll"]
             for root, _, filenames in os.walk(self.package_folder):
                 for ext in exts:
                     for filename in fnmatch.filter(filenames, ext):
                         os.unlink(os.path.join(root, filename))
-        tools.rmdir(os.path.join(self.package_folder, 'lib', 'pkgconfig'))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         if os.path.isfile(os.path.join(self.package_folder, "lib", "libfdk-aac.la")):
             os.remove(os.path.join(self.package_folder, "lib", "libfdk-aac.la"))
 
     def package_info(self):
-        if self.settings.compiler == 'Visual Studio' and self.options.shared:
-            self.cpp_info.libs = ['fdk-aac.dll.lib']
+        if self.settings.compiler == "Visual Studio" and self.options.shared:
+            self.cpp_info.libs = ["fdk-aac.dll.lib"]
         else:
-            self.cpp_info.libs = ['fdk-aac']
+            self.cpp_info.libs = ["fdk-aac"]
         if self.settings.os == "Linux" or self.settings.os == "Android":
             self.cpp_info.system_libs.append("m")
-        self.cpp_info.names['pkg_config'] = 'fdk-aac'
+        self.cpp_info.names["pkg_config"] = "fdk-aac"

--- a/recipes/libfdk_aac/all/conanfile.py
+++ b/recipes/libfdk_aac/all/conanfile.py
@@ -13,7 +13,10 @@ class FDKAACConan(ConanFile):
     topics = ("conan", "libfdk_aac", "multimedia", "audio", "fraunhofer", "aac", "decoder", "encoding", "decoding")
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {'shared': False, 'fPIC': True}
-    _source_subfolder = 'sources'
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
     @property
     def _use_winbash(self):
@@ -75,7 +78,7 @@ class FDKAACConan(ConanFile):
             self._build_configure()
 
     def package(self):
-        self.copy(pattern="NOTICE", src='sources', dst="licenses")
+        self.copy(pattern="NOTICE", src=self._source_subfolder, dst="licenses")
         if self.settings.compiler == 'Visual Studio':
             if self.options.shared:
                 exts = ['fdk-aac.lib']

--- a/recipes/libfdk_aac/all/conanfile.py
+++ b/recipes/libfdk_aac/all/conanfile.py
@@ -25,6 +25,7 @@ class FDKAACConan(ConanFile):
 
     def build_requirements(self):
         if self.settings.compiler != "Visual Studio":
+            self.build_requires("libtool/2.4.6")
             if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
                 self.build_requires("msys2/cci.latest")
 
@@ -57,8 +58,8 @@ class FDKAACConan(ConanFile):
                 args.extend(['--disable-static', '--enable-shared'])
             else:
                 args.extend(['--disable-shared', '--enable-static'])
-            env_build = AutoToolsBuildEnvironment(self, win_bash=win_bash)
-            self.run('autoreconf -fiv', win_bash=win_bash)
+            env_build = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows)
             if self.settings.os == "Android" and tools.os_info.is_windows:
                 # remove escape for quotation marks, to make ndk on windows happy
                 tools.replace_in_file('configure',

--- a/recipes/libfdk_aac/all/conanfile.py
+++ b/recipes/libfdk_aac/all/conanfile.py
@@ -10,11 +10,18 @@ class FDKAACConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     description = "A standalone library of the Fraunhofer FDK AAC code from Android"
     license = "https://github.com/mstorsjo/fdk-aac/blob/master/NOTICE"
-    settings = "os", "arch", "compiler", "build_type"
     homepage = "https://sourceforge.net/projects/opencore-amr/"
     topics = ("conan", "libfdk_aac", "multimedia", "audio", "fraunhofer", "aac", "decoder", "encoding", "decoding")
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
 
     _autotools = None
 

--- a/recipes/libfdk_aac/all/conanfile.py
+++ b/recipes/libfdk_aac/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, AutoToolsBuildEnvironment, tools
 import os
 import fnmatch
 
+required_conan_version = ">=1.33.0"
+
 
 class FDKAACConan(ConanFile):
     name = "libfdk_aac"
@@ -33,9 +35,8 @@ class FDKAACConan(ConanFile):
                 self.build_requires("msys2/cci.latest")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "fdk-aac-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _build_vs(self):
         with tools.chdir(self._source_subfolder):

--- a/recipes/libfdk_aac/all/test_package/CMakeLists.txt
+++ b/recipes/libfdk_aac/all/test_package/CMakeLists.txt
@@ -1,9 +1,10 @@
-
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(fdk-aac REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} FDK-AAC::fdk-aac)

--- a/recipes/libfdk_aac/all/test_package/conanfile.py
+++ b/recipes/libfdk_aac/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,7 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if tools.cross_building(self.settings, skip_x64_x86=True):
-            return
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self.settings, skip_x64_x86=True):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libfdk_aac/config.yml
+++ b/recipes/libfdk_aac/config.yml
@@ -1,5 +1,7 @@
 versions:
-  "2.0.0":
+  "2.0.2":
     folder: all
   "2.0.1":
+    folder: all
+  "2.0.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Actually it's a refactoring:
- split build and installation (in both autotools and nmake branches)
- nmake (Visual Studio):
  - honor build settings (runtime was injected, but not compile flags, we need `VisualStudioBuildEnvironment` for that)
  - build/install either static or shared
  - change extension of import lib (to `.lib` instead of `.dll.lib`)
  - do not build or install utilities (they are not installed in autotools)
  - do not install def file
- autotools:
  - rely on `AutoToolsBuildEnvironment` to inject stuff like `--prefix`
  - this recipe calls autoreconf, and it was not in build requirements. Therefore `libtool` is added (libtool is required, and it drags autoconf).
- bump msys2
- delete fPIC option if shared

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
