### PR TITLE
bullet3: fix exported lib name suffix for RelWithDebInfo build

### DIFF
--- a/recipes/bullet3/all/conanfile.py
+++ b/recipes/bullet3/all/conanfile.py
@@ -115,7 +115,8 @@ class Bullet3Conan(ConanFile):
                         "GIMPACTUtils"
                     ]
         if self.settings.os == "Windows" and self.settings.build_type in ("Debug", "MinSizeRel", "RelWithDebInfo"):
-            libs = [lib + "_{}".format(self.settings.build_type) for lib in libs]
+            lib_suffix = "RelWithDebugInfo" if self.settings.build_type == "RelWithDebInfo" else self.settings.build_type
+            libs = [lib + "_{}".format(lib_suffix) for lib in libs]
 
         self.cpp_info.names["cmake_find_package"] = "Bullet"
         self.cpp_info.names["cmake_find_package_multi"] = "Bullet"


### PR DESCRIPTION
**bullet3/3.17**

Bullet3 uses `RelWithDebugInfo` as a suffix for their libs, this lead to CMake not correctly linking to RelWithDebInfo libraries

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
