### PR TITLE
libgd: fix cross-build to iOS + enable gd format for >=2.3.0 + add several options + modernize

### DIFF
--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -91,3 +91,7 @@ class LibgdConan(ConanFile):
         if self.settings.os == "Windows" and not self.options.shared:
             self.cpp_info.defines.append("BGD_NONDLL")
             self.cpp_info.defines.append("BGDWIN32")
+
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)

--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -35,15 +35,18 @@ class LibgdConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
-    def _patch(self):
-        cmakelists = os.path.join(self._source_subfolder, "CMakeLists.txt")
-        tools.replace_in_file(cmakelists, "${CMAKE_SOURCE_DIR}", "${CMAKE_CURRENT_SOURCE_DIR}")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename(glob.glob("libgd-*")[0], self._source_subfolder)
+
+    def _patch(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        cmakelists = os.path.join(self._source_subfolder, "CMakeLists.txt")
+        tools.replace_in_file(cmakelists, "${CMAKE_SOURCE_DIR}", "${CMAKE_CURRENT_SOURCE_DIR}")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
+                              "RUNTIME DESTINATION bin",
+                              "RUNTIME DESTINATION bin BUNDLE DESTINATION bin")
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -1,6 +1,7 @@
-import glob
-import os
 from conans import ConanFile, tools, CMake
+import os
+
+required_conan_version = ">=1.33.0"
 
 
 class LibgdConan(ConanFile):
@@ -36,8 +37,8 @@ class LibgdConan(ConanFile):
         return "build_subfolder"
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(glob.glob("libgd-*")[0], self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _patch(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -17,10 +17,18 @@ class LibgdConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_png": [True, False],
+        "with_jpeg": [True, False],
+        "with_tiff": [True, False],
+        "with_freetype": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_png": False,
+        "with_jpeg": False,
+        "with_tiff": False,
+        "with_freetype": False,
     }
 
     exports_sources = "CMakeLists.txt", "patches/**"
@@ -45,6 +53,14 @@ class LibgdConan(ConanFile):
 
     def requirements(self):
         self.requires("zlib/1.2.11")
+        if self.options.with_png:
+            self.requires("libpng/1.6.37")
+        if self.options.with_jpeg:
+            self.requires("libjpeg/9d")
+        if self.options.with_tiff:
+            self.requires("libtiff/4.2.0")
+        if self.options.with_freetype:
+            self.requires("freetype/2.10.4")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -69,6 +85,20 @@ class LibgdConan(ConanFile):
         self._cmake.definitions["BUILD_STATIC_LIBS"] = not self.options.shared
         if tools.Version(self.version) >= "2.3.0":
             self._cmake.definitions["ENABLE_GD_FORMATS"] = True
+        self._cmake.definitions["ENABLE_PNG"] = self.options.with_png
+        self._cmake.definitions["ENABLE_LIQ"] = False
+        self._cmake.definitions["ENABLE_JPEG"] = self.options.with_jpeg
+        self._cmake.definitions["ENABLE_TIFF"] = self.options.with_tiff
+        self._cmake.definitions["ENABLE_ICONV"] = False
+        self._cmake.definitions["ENABLE_XPM"] = False
+        self._cmake.definitions["ENABLE_FREETYPE"] = self.options.with_freetype
+        self._cmake.definitions["ENABLE_FONTCONFIG"] = False
+        self._cmake.definitions["ENABLE_WEBP"] = False
+        if tools.Version(self.version) >= "2.3.2":
+            self._cmake.definitions["ENABLE_HEIF"] = False
+            self._cmake.definitions["ENABLE_AVIF"] = False
+        if tools.Version(self.version) >= "2.3.0":
+            self._cmake.definitions["ENABLE_RAQM"] = False
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 

--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -82,12 +82,12 @@ class LibgdConan(ConanFile):
         cmake.install()
         self.copy("COPYING", src=self._source_subfolder, dst="licenses",
                   ignore_case=True, keep_path=False)
-        tools.rmdir(os.path.join(self.package_folder, 'share'))
-        tools.rmdir(os.path.join(self.package_folder, 'lib', 'pkgconfig'))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         self.cpp_info.names["pkg_config"]= "gdlib"
         self.cpp_info.libs = tools.collect_libs(self)
-        if self.settings.os == 'Windows' and not self.options.shared:
-            self.cpp_info.defines.append('BGD_NONDLL')
-            self.cpp_info.defines.append('BGDWIN32')
+        if self.settings.os == "Windows" and not self.options.shared:
+            self.cpp_info.defines.append("BGD_NONDLL")
+            self.cpp_info.defines.append("BGDWIN32")


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- GD format is disabled by default since 2.3.0, while it was always enabled before (no option). So, I enable it, to make recipe consistent across versions.
  By the way, when GD format is disabled, `zlib` is not required.
- prefer `cmake_find_package` for discovery of `zlib`, since upstream uses `find_package()`
- add several options (but not all, I was too lazy to fix options with a requirement for which they have a custom Find module).

/cc @datalogics-kam

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
