### PR TITLE
tesseract: fix cross-build to ios + bump deps + modernize

### DIFF
--- a/recipes/tesseract/all/conandata.yml
+++ b/recipes/tesseract/all/conandata.yml
@@ -4,6 +4,8 @@ sources:
     sha256: "2a66ff0d8595bff8f04032165e6c936389b1e5727c3ce5a27b3e059d218db1cb"
 patches:
   "4.1.1":
+     - patch_file: "patches/0001-install-bundle.patch"
+       base_path: "source_subfolder"
      - patch_file: "patches/0002-Link-with-targets.patch"
        base_path: "source_subfolder"
      - patch_file: "patches/0003-Dont-change-locale.patch"

--- a/recipes/tesseract/all/conanfile.py
+++ b/recipes/tesseract/all/conanfile.py
@@ -54,6 +54,11 @@ class TesseractConan(ConanFile):
             # do not enforce failure and allow user to build with system cairo, pango, fontconfig
             self.output.warn("*** Build with training is not yet supported, continue on your own")
 
+    def requirements(self):
+        self.requires("leptonica/1.81.0")
+        self.requires("libarchive/3.5.1")
+
+    def validate(self):
         # Check compiler version
         compiler = str(self.settings.compiler)
         compiler_version = Version(self.settings.compiler.version.value)
@@ -69,10 +74,6 @@ class TesseractConan(ConanFile):
                 "%s recipe lacks information about the %s compiler standard version support" % (self.name, compiler))
         elif compiler_version < minimal_version[compiler]:
             raise ConanInvalidConfiguration("{} requires a {} version >= {}".format(self.name, compiler, compiler_version))
-
-    def requirements(self):
-        self.requires("leptonica/1.81.0")
-        self.requires("libarchive/3.5.1")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/tesseract/all/conanfile.py
+++ b/recipes/tesseract/all/conanfile.py
@@ -71,7 +71,7 @@ class TesseractConan(ConanFile):
             raise ConanInvalidConfiguration("{} requires a {} version >= {}".format(self.name, compiler, compiler_version))
 
     def requirements(self):
-        self.requires("leptonica/1.80.0")
+        self.requires("leptonica/1.81.0")
         self.requires("libarchive/3.5.1")
 
     def source(self):

--- a/recipes/tesseract/all/conanfile.py
+++ b/recipes/tesseract/all/conanfile.py
@@ -75,9 +75,8 @@ class TesseractConan(ConanFile):
         self.requires("libarchive/3.5.1")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/tesseract/all/patches/0001-install-bundle.patch
+++ b/recipes/tesseract/all/patches/0001-install-bundle.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -537,7 +537,7 @@ get_target_property(tesseract_VERSION libtesseract VERSION)
+ get_target_property(tesseract_OUTPUT_NAME libtesseract OUTPUT_NAME)
+ configure_file(tesseract.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/tesseract.pc @ONLY)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tesseract.pc DESTINATION lib/pkgconfig)
+-install(TARGETS tesseract RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
++install(TARGETS tesseract DESTINATION bin)
+ install(TARGETS libtesseract EXPORT TesseractTargets RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+ install(EXPORT TesseractTargets DESTINATION cmake)
+ install(FILES


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Actually cross-build to iOS is still broken due to https://github.com/conan-io/conan/issues/9202, but I can cross-build tesseract locally with this fix in conan client https://github.com/conan-io/conan/issues/9202#issuecomment-881762492

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
