### PR TITLE
gdal: fix cross-build (static only) + add tools option (disabled by default) + bump dependencies + modernize

### DIFF
--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -353,11 +353,15 @@ class GdalConan(ConanFile):
             elif mongocxx_version < "3.4.0":
                 raise ConanInvalidConfiguration("gdal with mongo-cxx-driver v3 requires 3.4.0 at least.")
 
+    @property
+    def _settings_build(self):
+        return self.settings_build if hasattr(self, "settings_build") else self.settings
+
     def build_requirements(self):
         if self.settings.compiler != "Visual Studio":
             self.build_requires("libtool/2.4.6")
             self.build_requires("pkgconf/1.7.4")
-            if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+            if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
                 self.build_requires("msys2/cci.latest")
 
     def source(self):

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -336,6 +336,11 @@ class GdalConan(ConanFile):
             raise ConanInvalidConfiguration("gdal:with_libdeflate=True requires gdal:with_zlib=True")
         if self.options.with_qhull and self.options["qhull"].reentrant:
             raise ConanInvalidConfiguration("gdal depends on non-reentrant qhull.")
+        if tools.cross_building(self.settings):
+            if self.options.shared:
+                raise ConanInvalidConfiguration("GDAL build system can't cross-build shared lib")
+            if self.options.tools:
+                raise ConanInvalidConfiguration("GDAL build system can't cross-build tools")
         # FIXME: Visual Studio 2015 & 2017 are supported but CI of CCI lacks several Win SDK components
         if tools.Version(self.version) >= "3.2.0" and self.settings.compiler == "Visual Studio" and \
            tools.Version(self.settings.compiler.version) < "16":

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -206,22 +206,22 @@ class GdalConan(ConanFile):
 
     def requirements(self):
         self.requires("json-c/0.15")
-        self.requires("libgeotiff/1.6.0")
+        self.requires("libgeotiff/1.7.0")
         # self.requires("libopencad/0.0.2") # TODO: use conan recipe when available instead of internal one
         self.requires("libtiff/4.2.0")
-        self.requires("proj/8.0.1")
+        self.requires("proj/8.1.0")
         if tools.Version(self.version) >= "3.1.0":
-            self.requires("flatbuffers/1.12.0")
+            self.requires("flatbuffers/2.0.0")
         if self.options.get_safe("with_zlib", True):
             self.requires("zlib/1.2.11")
         if self.options.get_safe("with_libdeflate"):
-            self.requires("libdeflate/1.7")
+            self.requires("libdeflate/1.8")
         if self.options.get_safe("with_libiconv", True):
             self.requires("libiconv/1.16")
         if self.options.get_safe("with_zstd"):
             self.requires("zstd/1.5.0")
         if self.options.with_pg:
-            self.requires("libpq/13.2")
+            self.requires("libpq/13.3")
         # if self.options.with_libgrass:
         #     self.requires("libgrass/x.x.x")
         if self.options.with_cfitsio:
@@ -265,7 +265,7 @@ class GdalConan(ConanFile):
         # if self.options.with_fgdb:
         #     self.requires("file-geodatabase-api/x.x.x")
         if self.options.with_mysql == "libmysqlclient":
-            self.requires("libmysqlclient/8.0.17")
+            self.requires("libmysqlclient/8.0.25")
         elif self.options.with_mysql == "mariadb-connector-c":
             self.requires("mariadb-connector-c/3.1.12")
         if self.options.with_xerces:
@@ -281,15 +281,15 @@ class GdalConan(ConanFile):
         if self.options.with_curl:
             self.requires("libcurl/7.77.0")
         if self.options.with_xml2:
-            self.requires("libxml2/2.9.10")
+            self.requires("libxml2/2.9.12")
         # if self.options.with_spatialite:
         #     self.requires("libspatialite/4.3.0a")
         if self.options.get_safe("with_sqlite3"):
-            self.requires("sqlite3/3.35.5")
+            self.requires("sqlite3/3.36.0")
         # if self.options.with_rasterlite2:
         #     self.requires("rasterlite2/x.x.x")
         if self.options.get_safe("with_pcre"):
-            self.requires("pcre/8.44")
+            self.requires("pcre/8.45")
         # if self.options.with_epsilon:
         #     self.requires("epsilon/0.9.2")
         if self.options.with_webp:

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -794,6 +794,10 @@ class GdalConan(ConanFile):
         else:
             with self._autotools_build_environment():
                 self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows)
+                # Required for cross-build to iOS, see https://github.com/OSGeo/gdal/issues/4123
+                tools.replace_in_file(os.path.join("port", "cpl_config.h.in"),
+                                      "/* port/cpl_config.h.in",
+                                      "#pragma once\n/* port/cpl_config.h.in")
                 autotools = self._configure_autotools()
                 autotools.make()
 

--- a/recipes/gdal/all/test_package/conanfile.py
+++ b/recipes/gdal/all/test_package/conanfile.py
@@ -1,6 +1,6 @@
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
@@ -13,7 +13,8 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self.settings):
-            self.run("gdal_translate --formats", run_environment=True)
+            if self.options["gdal"].tools:
+                self.run("gdal_translate --formats", run_environment=True)
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)
             bin_path_c = os.path.join("bin", "test_package_c")


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

There is no upstream tools option, so disabling tools is done via patch.
`tools` is disabled by default, because:
- there are many big executables (specially for static debug build on unix systems, it's crazy), and AFAIK it was a burden to handle packages of this recipe for CI of CCI.
- cross-build of executables (and shared lib) is broken.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
