### PR TITLE
libuvc: bump dependencies + modernize

### DIFF
--- a/recipes/libuvc/all/conanfile.py
+++ b/recipes/libuvc/all/conanfile.py
@@ -2,7 +2,8 @@ import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.28.0"
+required_conan_version = ">=1.33.0"
+
 
 class LibuvcConan(ConanFile):
     name = "libuvc"
@@ -49,9 +50,8 @@ class LibuvcConan(ConanFile):
             self.requires("libjpeg/9d")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if not self._cmake:

--- a/recipes/libuvc/all/conanfile.py
+++ b/recipes/libuvc/all/conanfile.py
@@ -42,9 +42,9 @@ class LibuvcConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("libusb/1.0.23")
+        self.requires("libusb/1.0.24")
         if self.options.jpeg_turbo:
-            self.requires("libjpeg-turbo/2.0.5")
+            self.requires("libjpeg-turbo/2.1.0")
         else:
             self.requires("libjpeg/9d")
 

--- a/recipes/libuvc/all/test_package/CMakeLists.txt
+++ b/recipes/libuvc/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(libuvc REQUIRED CONFIG)
 


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

libusb 1.0.24 has better support for cross-building than 1.0.23. With this bump of libusb version in libuvc recipe, it allows to cross-compile libuvc to iOS.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
