### PR TITLE
libxcrypt: fix test package if cross-building + fix MinGW build + modernize

### DIFF
--- a/recipes/libxcrypt/all/conanfile.py
+++ b/recipes/libxcrypt/all/conanfile.py
@@ -42,8 +42,14 @@ class LibxcryptConan(ConanFile):
         if self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration("libxcrypt does not support Visual Studio")
 
+    @property
+    def _settings_build(self):
+        return self.settings_build if hasattr(self, "settings_build") else self.settings
+
     def build_requirements(self):
         self.build_requires("libtool/2.4.6")
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/libxcrypt/all/conanfile.py
+++ b/recipes/libxcrypt/all/conanfile.py
@@ -1,6 +1,8 @@
-import os
 from conans import AutoToolsBuildEnvironment, ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
 
 
 class LibxcryptConan(ConanFile):
@@ -38,12 +40,12 @@ class LibxcryptConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
-
     def build_requirements(self):
         self.build_requires("libtool/2.4.6")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_autotools(self):
         if self._autotools:

--- a/recipes/libxcrypt/all/conanfile.py
+++ b/recipes/libxcrypt/all/conanfile.py
@@ -26,7 +26,7 @@ class LibxcryptConan(ConanFile):
 
     @property
     def _source_subfolder(self):
-        return os.path.join(self.source_folder, "source_subfolder")
+        return "source_subfolder"
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/libxcrypt/all/conanfile.py
+++ b/recipes/libxcrypt/all/conanfile.py
@@ -90,4 +90,5 @@ class LibxcryptConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
+        self.cpp_info.names["pkg_config"] = "libxcrypt"
         self.cpp_info.libs = ["crypt"]

--- a/recipes/libxcrypt/all/conanfile.py
+++ b/recipes/libxcrypt/all/conanfile.py
@@ -31,14 +31,14 @@ class LibxcryptConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
 
     def configure(self):
         if self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration("libxcrypt does not support Visual Studio")
         if self.options.shared:
             del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
 
     def build_requirements(self):
         self.build_requires("libtool/2.4.6")

--- a/recipes/libxcrypt/all/conanfile.py
+++ b/recipes/libxcrypt/all/conanfile.py
@@ -33,12 +33,14 @@ class LibxcryptConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if self.settings.compiler == "Visual Studio":
-            raise ConanInvalidConfiguration("libxcrypt does not support Visual Studio")
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+
+    def validate(self):
+        if self.settings.compiler == "Visual Studio":
+            raise ConanInvalidConfiguration("libxcrypt does not support Visual Studio")
 
     def build_requirements(self):
         self.build_requires("libtool/2.4.6")

--- a/recipes/libxcrypt/all/test_package/CMakeLists.txt
+++ b/recipes/libxcrypt/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/libxcrypt/all/test_package/conanfile.py
+++ b/recipes/libxcrypt/all/test_package/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -12,5 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Cross-build to Macos M1 works, but not to iOS (due to a m4 macro checking byte ordering and failing).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
