### PR TITLE
libyaml: fix CMake imported target + modernize

### DIFF
--- a/recipes/libyaml/all/conanfile.py
+++ b/recipes/libyaml/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, CMake, tools
 import os
 import textwrap
 
+required_conan_version = ">=1.33.0"
+
 
 class LibYAMLConan(ConanFile):
     name = "libyaml"
@@ -33,9 +35,8 @@ class LibYAMLConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = '{}-{}'.format(self.name, self.version)
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/libyaml/all/conanfile.py
+++ b/recipes/libyaml/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 import os
+import textwrap
 
 
 class LibYAMLConan(ConanFile):
@@ -56,13 +57,41 @@ class LibYAMLConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"yaml": "yaml::yaml"}
+        )
+
+    @staticmethod
+    def _create_cmake_module_alias_targets(module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent("""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """.format(alias=alias, aliased=aliased))
+        tools.save(module_file, content)
+
+    @property
+    def _module_subfolder(self):
+        return os.path.join("lib", "cmake")
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join(self._module_subfolder,
+                            "conan-official-{}-targets.cmake".format(self.name))
 
     def package_info(self):
-        self.cpp_info.components["yaml"].libs = ["yaml"]
+        self.cpp_info.libs = ["yaml"]
         if self.settings.compiler == "Visual Studio":
-            self.cpp_info.components["yaml"].defines = [
+            self.cpp_info.defines = [
                 "YAML_DECLARE_EXPORT" if self.options.shared
                 else "YAML_DECLARE_STATIC"
             ]
         self.cpp_info.names["cmake_find_package"] = "yaml"
         self.cpp_info.names["cmake_find_package_multi"] = "yaml"
+        self.cpp_info.builddirs.append(self._module_subfolder)
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/libyaml/all/test_package/CMakeLists.txt
+++ b/recipes/libyaml/all/test_package/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-find_package(yaml REQUIRED)
+find_package(yaml REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} yaml::yaml)
+target_link_libraries(${PROJECT_NAME} yaml)

--- a/recipes/libyaml/all/test_package/conanfile.py
+++ b/recipes/libyaml/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Official imported target is not namespaced: https://github.com/yaml/libyaml/blob/acd6f6f014c25e46363e718381e0b35205df2d83/CMakeLists.txt#L142-L147

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
