### PR TITLE
mpc: fix MinGW build

### DIFF
--- a/recipes/mpc/all/conanfile.py
+++ b/recipes/mpc/all/conanfile.py
@@ -32,12 +32,13 @@ class MpcConan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
-    def validate(self):
-        if self.settings.compiler == "Visual Studio":
-            raise ConanInvalidConfiguration("The mpc package cannot be built on Visual Studio.")
-
     def requirements(self):
         self.requires("mpfr/4.1.0")
+
+    def validate(self):
+        # FIXME: add Visual Studio support, upstream has a makefile.vc
+        if self.settings.compiler == "Visual Studio":
+            raise ConanInvalidConfiguration("mpc can be built with Visual Studio, but it's not supported yet in this recipe.")
 
     @property
     def _settings_build(self):

--- a/recipes/mpc/all/conanfile.py
+++ b/recipes/mpc/all/conanfile.py
@@ -42,7 +42,7 @@ class MpcConan(ConanFile):
 
     @property
     def _settings_build(self):
-        return self.settings_build if hasattr(self, "settings_build") else self.settings
+        return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):

--- a/recipes/mpc/all/test_package/CMakeLists.txt
+++ b/recipes/mpc/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/mpc/all/test_package/test_package.c
+++ b/recipes/mpc/all/test_package/test_package.c
@@ -12,4 +12,5 @@ int main (void) {
     mpc_out_str (stdout, 10, 0, z, MPC_RNDNN);
     printf ("\n%i %i\n", MPC_INEX_RE (inex), MPC_INEX_IM (inex));
     mpc_clear (z);
+    return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

I've also updated message for Visual Studio, it was misleading. mpc supports Visual Studio, but the recipe must use upstream Makefile.vc with NMake.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
