### PR TITLE
spdlog: add version 1.9.0

### DIFF
--- a/recipes/spdlog/all/conandata.yml
+++ b/recipes/spdlog/all/conandata.yml
@@ -26,3 +26,6 @@ sources:
   "1.8.5":
     sha256: 944d0bd7c763ac721398dca2bb0f3b5ed16f67cef36810ede5061f35a543b4b8
     url: https://github.com/gabime/spdlog/archive/v1.8.5.tar.gz
+  "1.9.0":
+    url: "https://github.com/gabime/spdlog/archive/v1.9.0.tar.gz"
+    sha256: "9ad181d75aaedbf47c8881e7b947a47cac3d306997e39de24dba60db633e70a7"

--- a/recipes/spdlog/config.yml
+++ b/recipes/spdlog/config.yml
@@ -17,3 +17,5 @@ versions:
     folder: "all"
   "1.8.5":
     folder: "all"
+  "1.9.0":
+    folder: "all"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **spdlog/1.9.0**

fixes conan-io/conan-center-index#6444

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
