### PR TITLE
qt 5.15.2: add patches for missing include errors when building with gcc11 

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -18,3 +18,7 @@ patches:
       base_path: "qt5/qtwebengine"
     - patch_file: "patches/7371d3a.diff"
       base_path: "qt5/qtbase"
+    - patch_file: "patches/QTBUG-90395.diff"
+      base_path: "qt5/qtbase"
+    - patch_file: "patches/declarative_missing_header.diff"
+      base_path: "qt5/qtdeclarative"

--- a/recipes/qt/5.x.x/patches/QTBUG-90395.diff
+++ b/recipes/qt/5.x.x/patches/QTBUG-90395.diff
@@ -1,0 +1,38 @@
+Description: include <limits> to fix some GCC 11 build issues
+Origin: upstream, commits:
+ https://code.qt.io/cgit/qt/qtbase.git/commit/?id=813a928c7c3cf986
+ https://code.qt.io/cgit/qt/qtbase.git/commit/?id=9c56d4da2ff631a8
+Last-Update: 2021-01-26
+
+--- a/src/corelib/global/qendian.h
++++ b/src/corelib/global/qendian.h
+@@ -44,6 +44,8 @@
+ #include <QtCore/qfloat16.h>
+ #include <QtCore/qglobal.h>
+ 
++#include <limits>
++
+ // include stdlib.h and hope that it defines __GLIBC__ for glibc-based systems
+ #include <stdlib.h>
+ #include <string.h>
+--- a/src/corelib/global/qfloat16.h
++++ b/src/corelib/global/qfloat16.h
+@@ -43,6 +43,7 @@
+ 
+ #include <QtCore/qglobal.h>
+ #include <QtCore/qmetatype.h>
++#include <limits>
+ #include <string.h>
+ 
+ #if defined(QT_COMPILER_SUPPORTS_F16C) && defined(__AVX2__) && !defined(__F16C__)
+--- a/src/corelib/text/qbytearraymatcher.h
++++ b/src/corelib/text/qbytearraymatcher.h
+@@ -42,6 +42,8 @@
+ 
+ #include <QtCore/qbytearray.h>
+ 
++#include <limits>
++
+ QT_BEGIN_NAMESPACE
+ 
+ 

--- a/recipes/qt/5.x.x/patches/declarative_missing_header.diff
+++ b/recipes/qt/5.x.x/patches/declarative_missing_header.diff
@@ -1,0 +1,11 @@
+--- a/src/qmldebug/qqmlprofilerevent_p.h
++++ b/src/qmldebug/qqmlprofilerevent_p.h
+@@ -49,7 +49,7 @@
+ 
+ #include <initializer_list>
+ #include <type_traits>
+-
++#include <limits>
+ //
+ //  W A R N I N G
+ //  -------------


### PR DESCRIPTION
Specify library name and version:  qt/5.15.2

Building Qt version 5.15.2 fails with gcc 11.1.0 because Qt has missing #include s in some files. See [this bug report](https://bugreports.qt.io/browse/QTBUG-90395) for example. 
This PR contains 2 patches that fix the missing includes. QTBUG-90395.diff addresses the bug report linked above. declarative_missing_header.diff fixes a missing include in qtdeclarative module.


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
