### PR TITLE
pybind11_json/0.2.11

### DIFF
--- a/recipes/pybind11_json/all/conandata.yml
+++ b/recipes/pybind11_json/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.2.11":
+    sha256: 7fbf30c2f184decf3987f4e177d0fb29a72adc86160e43907b18f0d93c935b36
+    url: https://github.com/pybind/pybind11_json/archive/refs/tags/0.2.11.tar.gz

--- a/recipes/pybind11_json/all/conanfile.py
+++ b/recipes/pybind11_json/all/conanfile.py
@@ -1,0 +1,48 @@
+from conans import ConanFile, tools
+import os
+
+
+class Pybind11JsonConan(ConanFile):
+    name = "pybind11_json"
+    homepage = "https://github.com/pybind/pybind11_json"
+    description = "An nlohmann_json to pybind11 bridge"
+    topics = (
+        "conan",
+        "header-only",
+        "json",
+        "nlohmann_json",
+        "pybind11",
+        "pybind11_json",
+        "python",
+        "python-binding",
+    )
+    url = "https://github.com/conan-io/conan-center-index"
+    no_copy_source = True
+    license = "BSD-3-Clause"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def package_id(self):
+        self.info.header_only()
+
+    def requirements(self):
+        self.requires("nlohmann_json/3.9.1")
+        self.requires("pybind11/2.6.2")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "pybind11_json-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        self.copy(pattern="LICENSE*", dst="licenses", src=self._source_subfolder)
+        self.copy(
+            "*", dst="include", src=os.path.join(self._source_subfolder, "include")
+        )
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "pybind11_json"
+        self.cpp_info.names["cmake_find_package_multi"] = "pybind11_json"
+        self.cpp_info.names["pkg_config"] = "pybind11_json"

--- a/recipes/pybind11_json/all/test_package/CMakeLists.txt
+++ b/recipes/pybind11_json/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(pybind11_json REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} pybind11_json::pybind11_json)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)

--- a/recipes/pybind11_json/all/test_package/conanfile.py
+++ b/recipes/pybind11_json/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/pybind11_json/all/test_package/test_package.cpp
+++ b/recipes/pybind11_json/all/test_package/test_package.cpp
@@ -1,0 +1,30 @@
+#include "pybind11_json/pybind11_json.hpp"
+
+#include "nlohmann/json.hpp"
+
+#include "pybind11/embed.h"
+#include "pybind11/pybind11.h"
+
+#include <iostream>
+#include <string>
+
+namespace nl = nlohmann;
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+int main() {
+    // Required to run a standalone C++ application (https://pybind11.readthedocs.io/en/stable/advanced/embedding.html)
+    py::scoped_interpreter guard{};
+
+    const py::dict original_py_dict{"number"_a=1234, "hello"_a="world"};
+    
+    const nl::json converted_nl_json{original_py_dict};
+    std::cout << "Converted nlohmann::json contents: " <<  converted_nl_json << std::endl;
+    
+    const py::dict converted_py_dict = converted_nl_json.front();  // assigning the only list element
+
+    std::cout << "Converted py::dict contents: {hello:" << converted_py_dict["hello"].cast<std::string>()
+              << ", number:" << converted_py_dict["number"].cast<int>()  << "}" << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/pybind11_json/config.yml
+++ b/recipes/pybind11_json/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.2.11":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **pybind11_json/0.2.11**

[pybind11_json](https://github.com/pybind/pybind11_json) is one of the dependencies in our private conan project. We deem this library useful for the general public, so everyone profits from having this in CCI.

- I verified that the versions I'm using for `nlohmann_json` and `pybind11` are [compatible with the proposed version 0.2.11](https://github.com/pybind/pybind11_json/tree/0.2.11#dependencies). All versions of `pybind11_json` specify the same dependency version range, so the `all` folder approach for different `pybind11_json` versions is viable.
- I took [`pybind11_json`'s example](https://github.com/pybind/pybind11_json#c-api-automatic-conversion-between-nlohmannjson-and-pybind11-python-objects) and modernized it slightly for the test package.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
