### PR TITLE
open62541: no more mbedtls apache/gpl logic + bump dependencies + package cmake macro file + modernize

### DIFF
--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -83,20 +83,19 @@ class Open62541Conan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
-    def configure(self):
-        if self.options.shared:
-            del self.options.fPIC
-
-        if self.options.web_socket:
-            self.options["libwebsockets"].with_ssl = self.options.encryption
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         if not self.options.cpp_compatible:
             del self.settings.compiler.cppstd
             del self.settings.compiler.libcxx
+
+        if self.options.web_socket:
+            self.options["libwebsockets"].with_ssl = self.options.encryption
 
     def requirements(self):
         if self.options.encryption == "mbedtls":

--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -103,10 +103,6 @@ class Open62541Conan(ConanFile):
         if self.options.discovery == "With Multicast":
             self.requires("pro-mdnsd/0.8.4")
 
-    def _patch_sources(self):
-        for patch in self.conan_data["patches"][self.version]:
-            tools.patch(**patch)
-
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
@@ -269,7 +265,8 @@ class Open62541Conan(ConanFile):
         return self._cmake
 
     def build(self):
-        self._patch_sources()
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import glob
 import os
 import yaml
 
@@ -276,9 +277,18 @@ class Open62541Conan(ConanFile):
         tools.remove_files_by_mask(os.path.join(
             self.package_folder, "lib"), '*.pdb')
 
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        for cmake_file in glob.glob(os.path.join(self.package_folder, self._module_subfolder, "*")):
+            if not cmake_file.endswith(self._module_file_rel_path):
+                os.remove(cmake_file)
         tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    @property
+    def _module_subfolder(self):
+        return os.path.join("lib", "cmake", "open62541")
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join(self._module_subfolder, "open62541Macros.cmake")
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "open62541"
@@ -296,8 +306,5 @@ class Open62541Conan(ConanFile):
             self.cpp_info.includedirs.append(os.path.join("include", "win32"))
         else:
             self.cpp_info.includedirs.append(os.path.join("include", "posix"))
-        self.cpp_info.builddirs = [
-            "lib",
-            os.path.join("lib", "cmake"),
-            os.path.join("lib", "cmake", "open62541")
-        ]
+        self.cpp_info.builddirs.append(self._module_subfolder)
+        self.cpp_info.build_modules = [self._module_file_rel_path]

--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -1,8 +1,9 @@
-import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
-import shutil
+import os
 import yaml
+
+required_conan_version = ">=1.33.0"
 
 
 class Open62541Conan(ConanFile):
@@ -156,9 +157,8 @@ class Open62541Conan(ConanFile):
                     "When web_socket is enabled, libwebsockets:with_ssl must have the value of open62541:encryption")
 
     def source(self):
-        archive_name = self.name + "-" + self.version
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(archive_name, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
         submodule_filename = os.path.join(
             self.recipe_folder, 'submoduledata.yml')
@@ -177,7 +177,7 @@ class Open62541Conan(ConanFile):
                 tools.get(**submodule_data)
                 submodule_source = os.path.join(self._source_subfolder, path)
                 tools.rmdir(submodule_source)
-                os.rename(archive_name, submodule_source)
+                tools.rename(archive_name, submodule_source)
 
     def _get_log_level(self):
         return {

--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -285,6 +285,7 @@ class Open62541Conan(ConanFile):
         for cmake_file in glob.glob(os.path.join(self.package_folder, self._module_subfolder, "*")):
             if not cmake_file.endswith(self._module_file_rel_path):
                 os.remove(cmake_file)
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     @property
@@ -298,6 +299,7 @@ class Open62541Conan(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "open62541"
         self.cpp_info.names["cmake_find_package_multi"] = "open62541"
+        self.cpp_info.names["pkg_config"] = "open62541"
         self.cpp_info.libs = tools.collect_libs(self)
         self.cpp_info.includedirs = [
             "include",

--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -12,7 +12,14 @@ class Open62541Conan(ConanFile):
     license = "MPLv2"
     homepage = "https://open62541.org/"
     url = "https://github.com/conan-io/conan-center-index"
-    description = "open62541 is an open source and free implementation of OPC UA (OPC Unified Architecture) written in the common subset of the C99 and C++98 languages. The library is usable with all major compilers and provides the necessary tools to implement dedicated OPC UA clients and servers, or to integrate OPC UA-based communication into existing applications. open62541 library is platform independent. All platform-specific functionality is implemented via exchangeable plugins. Plugin implementations are provided for the major operating systems."
+    description = "open62541 is an open source and free implementation of OPC UA " \
+                  "(OPC Unified Architecture) written in the common subset of the " \
+                  "C99 and C++98 languages. The library is usable with all major " \
+                  "compilers and provides the necessary tools to implement dedicated " \
+                  "OPC UA clients and servers, or to integrate OPC UA-based communication " \
+                  "into existing applications. open62541 library is platform independent. " \
+                  "All platform-specific functionality is implemented via exchangeable " \
+                  "plugins. Plugin implementations are provided for the major operating systems."
     topics = (
         "OPC UA", "open62541", "sdk", "server/client", "c", "iec-62541",
         "industrial automation", "tsn", "time sensetive networks", "publish-subscirbe", "pubsub"

--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -10,11 +10,6 @@ required_conan_version = ">=1.33.0"
 class Open62541Conan(ConanFile):
     name = "open62541"
     license = "MPLv2"
-    exports_sources = [
-        "CMakeLists.txt",
-        "patches/**"
-    ]
-    exports = "submoduledata.yml"
     homepage = "https://open62541.org/"
     url = "https://github.com/conan-io/conan-center-index"
     description = "open62541 is an open source and free implementation of OPC UA (OPC Unified Architecture) written in the common subset of the C99 and C++98 languages. The library is usable with all major compilers and provides the necessary tools to implement dedicated OPC UA clients and servers, or to integrate OPC UA-based communication into existing applications. open62541 library is platform independent. All platform-specific functionality is implemented via exchangeable plugins. Plugin implementations are provided for the major operating systems."
@@ -22,6 +17,7 @@ class Open62541Conan(ConanFile):
         "OPC UA", "open62541", "sdk", "server/client", "c", "iec-62541",
         "industrial automation", "tsn", "time sensetive networks", "publish-subscirbe", "pubsub"
     )
+
     settings = "os", "compiler", "build_type", "arch"
     options = {
         "fPIC": [True, False],
@@ -77,8 +73,10 @@ class Open62541Conan(ConanFile):
         "cpp_compatible": False,
         "readable_statuscodes": True
     }
-    generators = "cmake", "cmake_find_package"
 
+    exports_sources = ["CMakeLists.txt", "patches/**"]
+    exports = "submoduledata.yml"
+    generators = "cmake", "cmake_find_package"
     _cmake = None
 
     @property

--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -211,7 +211,6 @@ class Open62541Conan(ConanFile):
             return self._cmake
 
         self._cmake = CMake(self)
-        self._cmake.verbose = True
 
         version = tools.Version(self.version)
         self._cmake.definitions["OPEN62541_VER_MAJOR"] = version.major

--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -36,7 +36,7 @@ class Open62541Conan(ConanFile):
         "discovery": [True, False, "With Multicast"],
         "discovery_semaphore": [True, False],
         "query": [True, False],
-        "encryption": [False, "openssl", "mbedtls-apache", "mbedtls-gpl"],
+        "encryption": [False, "openssl", "mbedtls"],
         "json_support": [True, False],
         "pub_sub": [False, "Simple", "Ethernet", "Ethernet_XDP"],
         "data_access": [True, False],
@@ -82,26 +82,6 @@ class Open62541Conan(ConanFile):
     @property
     def _source_subfolder(self):
         return "source_subfolder"
-
-    def requirements(self):
-        if tools.Version(self.version) >= "1.1.0":
-            if self.options.encryption == "mbedtls-apache":
-                self.requires("mbedtls/2.16.3-apache")
-            elif self.options.encryption == "mbedtls-gpl":
-                self.requires("mbedtls/2.16.3-gpl")
-            elif self.options.encryption == "openssl":
-                self.requires("openssl/1.1.1j")
-
-            if self.options.web_socket:
-                self.requires("libwebsockets/4.1.6")
-        else:
-            if self.options.encryption == "mbedtls-apache":
-                self.requires("mbedtls/2.16.3-apache")
-            elif self.options.encryption == "mbedtls-gpl":
-                self.requires("mbedtls/2.16.3-gpl")
-
-        if self.options.discovery == "With Multicast":
-            self.requires("pro-mdnsd/0.8.4")
 
     def configure(self):
         if self.options.shared:
@@ -159,6 +139,16 @@ class Open62541Conan(ConanFile):
         if not self.options.cpp_compatible:
             del self.settings.compiler.cppstd
             del self.settings.compiler.libcxx
+
+    def requirements(self):
+        if self.options.encryption == "mbedtls":
+            self.requires("mbedtls/2.25.0")
+        elif self.options.encryption == "openssl":
+            self.requires("openssl/1.1.1k")
+        if self.options.web_socket:
+            self.requires("libwebsockets/4.2.0")
+        if self.options.discovery == "With Multicast":
+            self.requires("pro-mdnsd/0.8.4")
 
     def source(self):
         archive_name = self.name + "-" + self.version

--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -87,6 +87,28 @@ class Open62541Conan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+        if self.options.web_socket:
+            self.options["libwebsockets"].with_ssl = self.options.encryption
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+        if not self.options.cpp_compatible:
+            del self.settings.compiler.cppstd
+            del self.settings.compiler.libcxx
+
+    def requirements(self):
+        if self.options.encryption == "mbedtls":
+            self.requires("mbedtls/2.25.0")
+        elif self.options.encryption == "openssl":
+            self.requires("openssl/1.1.1k")
+        if self.options.web_socket:
+            self.requires("libwebsockets/4.2.0")
+        if self.options.discovery == "With Multicast":
+            self.requires("pro-mdnsd/0.8.4")
+
+    def validate(self):
         if not self.options.subscription:
             if self.options.subscription_events:
                 raise ConanInvalidConfiguration(
@@ -128,27 +150,6 @@ class Open62541Conan(ConanFile):
         if self.options.pub_sub != False and self.settings.os != "Linux":
             raise ConanInvalidConfiguration(
                 "PubSub over Ethernet is not supported for your OS!")
-
-        if self.options.web_socket:
-            self.options["libwebsockets"].with_ssl = self.options.encryption
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-        if not self.options.cpp_compatible:
-            del self.settings.compiler.cppstd
-            del self.settings.compiler.libcxx
-
-    def requirements(self):
-        if self.options.encryption == "mbedtls":
-            self.requires("mbedtls/2.25.0")
-        elif self.options.encryption == "openssl":
-            self.requires("openssl/1.1.1k")
-        if self.options.web_socket:
-            self.requires("libwebsockets/4.2.0")
-        if self.options.discovery == "With Multicast":
-            self.requires("pro-mdnsd/0.8.4")
 
     def source(self):
         archive_name = self.name + "-" + self.version

--- a/recipes/open62541/all/conanfile.py
+++ b/recipes/open62541/all/conanfile.py
@@ -150,6 +150,11 @@ class Open62541Conan(ConanFile):
             raise ConanInvalidConfiguration(
                 "PubSub over Ethernet is not supported for your OS!")
 
+        if self.options.web_socket:
+            if self.options["libwebsockets"].with_ssl != self.options.encryption:
+                raise ConanInvalidConfiguration(
+                    "When web_socket is enabled, libwebsockets:with_ssl must have the value of open62541:encryption")
+
     def source(self):
         archive_name = self.name + "-" + self.version
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/open62541/all/test_package/CMakeLists.txt
+++ b/recipes/open62541/all/test_package/CMakeLists.txt
@@ -1,13 +1,12 @@
 cmake_minimum_required(VERSION 3.1)
-project(PackageTest CXX)
+project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
+find_package(open62541 REQUIRED CONFIG)
 find_package(Threads)
 
-add_executable(test_package test_package.cpp)
-target_link_libraries(test_package ${CONAN_LIBS} Threads::Threads)
-set_target_properties(test_package PROPERTIES
-                                   CXX_STANDARD 11
-)
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} open62541::open62541 Threads::Threads)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)

--- a/recipes/open62541/all/test_package/conanfile.py
+++ b/recipes/open62541/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/open62541/all/test_package/conanfile.py
+++ b/recipes/open62541/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -628,7 +628,10 @@ class OpenSSLConan(ConanFile):
     def _perl(self):
         if tools.os_info.is_windows and not self._win_bash:
             # enforce strawberry perl, otherwise wrong perl could be used (from Git bash, MSYS, etc.)
-            return os.path.join(self.deps_cpp_info["strawberryperl"].rootpath, "bin", "perl.exe")
+            if "strawberryperl" in self.deps_cpp_info.deps:
+                return os.path.join(self.deps_cpp_info["strawberryperl"].rootpath, "bin", "perl.exe")
+            elif hasattr(self, "user_info_build") and "strawberryperl" in self.user_info_build:
+                return self.user_info_build["strawberryperl"].perl
         return "perl"
 
     @property


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- Verbose CMake is removed.

- Maybe I miss something, but this logic in `encryption` option doesn't scale. It prevents to bump `mbedtls`, and I don't undestand why a recipe option would control the version of its dependencies, even if there is license logic behind this. Consumers can override versions themselves, it's redundant. So I've removed this logic, now `encryption` can only be `[False, openssl, mbedtls]`.
Important: `libwebsockets` recipe must be updated accordingly because in some condition (not tested by default values), `open62541` checks a `libwebsockets` option value based on `encryption` value, and this `libwebsockets` option has also these mbedlts-apache/mbedtls-gpl values.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
