### PR TITLE
libwebsockets: improve mbedtls handling in options + bump dependencies + fix CMake imported targets + modernize

### DIFF
--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -1,5 +1,5 @@
 from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conans.errors import ConanException, ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.33.0"
@@ -276,7 +276,7 @@ class LibwebsocketsConan(ConanFile):
             print("Test : " + str(lib_fullpath))
             if os.path.isfile(lib_fullpath):
                 return lib_fullpath
-        raise ConanInvalidConfiguration("Library {} not found".format(lib_fullpath))
+        raise ConanException("Library {} not found".format(lib_fullpath))
 
     def _find_libraries(self, dep):
         return [self._find_library(lib, dep) for lib in self.deps_cpp_info[dep].libs]

--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -228,16 +228,16 @@ class LibwebsocketsConan(ConanFile):
         elif self.options.with_ssl == "wolfssl":
             self.requires("wolfssl/4.6.0")
 
-        if self.options.with_hubbub:
-            raise ConanInvalidConfiguration("Library hubbub not implemented (yet) in CCI")
-            # TODO - Add hubbub package when available.
-
     def validate(self):
         if self.options.shared and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "5":
             # https://github.com/conan-io/conan-center-index/pull/5321#issuecomment-826367276
             raise ConanInvalidConfiguration("{}/{} shared=True with gcc<5 does not build. Please submit a PR with a fix.".format(self.name, self.version))
         if tools.Version(self.version) <= "4.0.15" and self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) >= "12":
             raise ConanInvalidConfiguration("{}/{} with apple-clang>=12 does not build. Please submit a PR with a fix.".format(self.name, self.version))
+
+        if self.options.with_hubbub:
+            raise ConanInvalidConfiguration("Library hubbub not implemented (yet) in CCI")
+            # TODO - Add hubbub package when available.
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -198,13 +198,6 @@ class LibwebsocketsConan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
-    def validate(self):
-        if self.options.shared and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "5":
-                # https://github.com/conan-io/conan-center-index/pull/5321#issuecomment-826367276
-                raise ConanInvalidConfiguration("{}/{} shared=True with gcc<5 does not build. Please submit a PR with a fix.".format(self.name, self.version))
-        if tools.Version(self.version) <= "4.0.15" and self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) >= "12":
-                raise ConanInvalidConfiguration("{}/{} with apple-clang>=12 does not build. Please submit a PR with a fix.".format(self.name, self.version))
-
     def requirements(self):
         if self.options.with_libuv:
             self.requires("libuv/1.40.0")
@@ -235,6 +228,13 @@ class LibwebsocketsConan(ConanFile):
         if self.options.with_hubbub:
             raise ConanInvalidConfiguration("Library hubbub not implemented (yet) in CCI")
             # TODO - Add hubbub package when available.
+
+    def validate(self):
+        if self.options.shared and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "5":
+            # https://github.com/conan-io/conan-center-index/pull/5321#issuecomment-826367276
+            raise ConanInvalidConfiguration("{}/{} shared=True with gcc<5 does not build. Please submit a PR with a fix.".format(self.name, self.version))
+        if tools.Version(self.version) <= "4.0.15" and self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) >= "12":
+            raise ConanInvalidConfiguration("{}/{} with apple-clang>=12 does not build. Please submit a PR with a fix.".format(self.name, self.version))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -1,6 +1,9 @@
-import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
 
 class LibwebsocketsConan(ConanFile):
     name = "libwebsockets"
@@ -237,9 +240,8 @@ class LibwebsocketsConan(ConanFile):
             raise ConanInvalidConfiguration("{}/{} with apple-clang>=12 does not build. Please submit a PR with a fix.".format(self.name, self.version))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "{}-{}".format(self.name, self.version)
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _get_library_extension(self, dep):
         if self.options[dep].shared:

--- a/recipes/libwebsockets/all/conanfile.py
+++ b/recipes/libwebsockets/all/conanfile.py
@@ -200,7 +200,7 @@ class LibwebsocketsConan(ConanFile):
 
     def requirements(self):
         if self.options.with_libuv:
-            self.requires("libuv/1.40.0")
+            self.requires("libuv/1.41.1")
 
         if self.options.with_libevent == "libevent":
             self.requires("libevent/2.1.12")
@@ -210,20 +210,20 @@ class LibwebsocketsConan(ConanFile):
         if self.options.with_zlib == "zlib":
             self.requires("zlib/1.2.11")
         elif self.options.with_zlib == "miniz":
-            self.requires("miniz/2.1.0")
+            self.requires("miniz/2.2.0")
 
         if self.options.with_libmount:
-            self.requires("libmount/2.36")
+            self.requires("libmount/2.36.2")
 
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.34.0")
+            self.requires("sqlite3/3.36.0")
 
         if self.options.with_ssl == "openssl":
             self.requires("openssl/1.1.1k")
         elif self.options.with_ssl == "mbedtls":
             self.requires("mbedtls/2.25.0")
         elif self.options.with_ssl == "wolfssl":
-            self.requires("wolfssl/4.5.0")
+            self.requires("wolfssl/4.6.0")
 
         if self.options.with_hubbub:
             raise ConanInvalidConfiguration("Library hubbub not implemented (yet) in CCI")

--- a/recipes/libwebsockets/all/test_package/CMakeLists.txt
+++ b/recipes/libwebsockets/all/test_package/CMakeLists.txt
@@ -2,15 +2,14 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(Libwebsockets REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-# TODO: remove Libwebsockets:: namespace when fixed in cpp_info of recipe
-if(LIBWEBSOCKETS_SHARED)
-  target_link_libraries(${PROJECT_NAME} Libwebsockets::websockets_shared)
+if(TARGET websockets_shared)
+  target_link_libraries(${PROJECT_NAME} websockets_shared)
 else()
-  target_link_libraries(${PROJECT_NAME} Libwebsockets::websockets)
+  target_link_libraries(${PROJECT_NAME} websockets)
 endif()
 set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)

--- a/recipes/libwebsockets/all/test_package/conanfile.py
+++ b/recipes/libwebsockets/all/test_package/conanfile.py
@@ -8,7 +8,6 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["LIBWEBSOCKETS_SHARED"] = self.options["libwebsockets"].shared
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Modification of `mbedtls` in with_ssl option is tightly related to https://github.com/conan-io/conan-center-index/pull/6454#issue-694767267, but it's exactly the same idea: this duplication of values is useless and doesn't scale.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
