### PR TITLE
xorg-proto: add xorg-proto/2021.4 recipe

### DIFF
--- a/recipes/xorg-proto/all/conandata.yml
+++ b/recipes/xorg-proto/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2021.4":
+    url: "https://www.x.org/releases/individual/proto/xorgproto-2021.4.tar.gz"
+    sha256: "9de0babd3d8cb16b0c1c47b8389a52f3e1326bb0bc9a9ab34a9500778448a2bd"

--- a/recipes/xorg-proto/all/conanfile.py
+++ b/recipes/xorg-proto/all/conanfile.py
@@ -27,7 +27,7 @@ class XorgProtoConan(ConanFile):
 
     @property
     def _settings_build(self):
-        return self.settings_build if hasattr(self, "settings_build") else self.settings
+        return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
         self.build_requires("xorg-macros/1.19.3")

--- a/recipes/xorg-proto/all/conanfile.py
+++ b/recipes/xorg-proto/all/conanfile.py
@@ -1,0 +1,80 @@
+from conans import AutoToolsBuildEnvironment, ConanFile, tools
+import glob
+import os
+import re
+import yaml
+
+required_conan_version = ">=1.33.0"
+
+
+class XorgProtoConan(ConanFile):
+    name = "xorg-proto"
+    description = "This package provides the headers and specification documents defining " \
+        "the core protocol and (many) extensions for the X Window System."
+    topics = ("conan", "xproto", "header", "specification")
+    license = "X11"
+    homepage = "https://gitlab.freedesktop.org/xorg/proto/xorgproto"
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os"
+
+    _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _settings_build(self):
+        return self.settings_build if hasattr(self, "settings_build") else self.settings
+
+    def package_id(self):
+        self.info.header_only()
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self, win_bash=self._settings_build.os == "Windows")
+        self._autotools.configure(configure_dir=self._source_subfolder)
+        return self._autotools
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        autotools = self._configure_autotools()
+        autotools.make()
+
+    @property
+    def _pc_data_path(self):
+        return os.path.join(self.package_folder, "res", "pc_data.yml")
+
+    def package(self):
+        self.copy("COPYING-*", src=self._source_subfolder, dst="licenses")
+        autotools = self._configure_autotools()
+        autotools.install()
+
+        pc_data = {}
+        for fn in glob.glob(os.path.join(self.package_folder, "share", "pkgconfig", "*.pc")):
+            pc_text = tools.load(fn)
+            filename = os.path.basename(fn)[:-3]
+            name = next(re.finditer("^Name: ([^\n$]+)[$\n]", pc_text, flags=re.MULTILINE)).group(1)
+            version = next(re.finditer("^Version: ([^\n$]+)[$\n]", pc_text, flags=re.MULTILINE)).group(1)
+            pc_data[filename] = {
+                "version": version,
+                "name": name,
+            }
+        tools.mkdir(os.path.dirname(self._pc_data_path))
+        tools.save(self._pc_data_path, yaml.dump(pc_data))
+
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        for filename, name_version in yaml.safe_load(open(self._pc_data_path)).items():
+            # FIXME: generated .pc files contain `Name: xorg-proto-Xproto`, it should be `Name: Xproto`
+            self.cpp_info.components[filename].libdirs = []
+            self.cpp_info.components[filename].version = name_version["version"]
+
+        self.cpp_info.components["xproto"].includedirs.append(os.path.join("include", "X11"))

--- a/recipes/xorg-proto/all/conanfile.py
+++ b/recipes/xorg-proto/all/conanfile.py
@@ -15,7 +15,9 @@ class XorgProtoConan(ConanFile):
     license = "X11"
     homepage = "https://gitlab.freedesktop.org/xorg/proto/xorgproto"
     url = "https://github.com/conan-io/conan-center-index"
-    settings = "os"
+    settings = "os", "arch", "compiler", "build_type"
+
+    generators = "pkg_config"
 
     _autotools = None
 
@@ -26,6 +28,10 @@ class XorgProtoConan(ConanFile):
     @property
     def _settings_build(self):
         return self.settings_build if hasattr(self, "settings_build") else self.settings
+
+    def build_requirements(self):
+        self.build_requires("xorg-macros/1.19.3")
+        self.build_requires("pkgconf/1.7.4")
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/xorg-proto/all/conanfile.py
+++ b/recipes/xorg-proto/all/conanfile.py
@@ -110,6 +110,7 @@ class XorgProtoConan(ConanFile):
     def package_info(self):
         for filename, name_version in yaml.safe_load(open(self._pc_data_path)).items():
             # FIXME: generated .pc files contain `Name: xorg-proto-Xproto`, it should be `Name: Xproto`
+            self.cpp_info.components[filename].filenames["pkg_config"] = filename
             self.cpp_info.components[filename].libdirs = []
             self.cpp_info.components[filename].version = name_version["version"]
 

--- a/recipes/xorg-proto/all/conanfile.py
+++ b/recipes/xorg-proto/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import AutoToolsBuildEnvironment, ConanFile, tools
+import contextlib
 import glob
 import os
 import re
@@ -29,29 +30,57 @@ class XorgProtoConan(ConanFile):
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
+    @property
+    def _user_info_build(self):
+        return getattr(self, "user_info_build", self.deps_user_info)
+
     def build_requirements(self):
+        self.build_requires("automake/1.16.3")
         self.build_requires("xorg-macros/1.19.3")
         self.build_requires("pkgconf/1.7.4")
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
+
+    def requirements(self):
+        if hasattr(self, "settings_build"):
+            self.requires("xorg-macros/1.19.3")
 
     def package_id(self):
-        self.info.header_only()
+        # self.info.header_only() would be fine too, but keep the os to add c3i test coverage for Windows.
+        del self.info.settings.arch
+        del self.info.settings.build_type
+        del self.info.settings.compiler
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @contextlib.contextmanager
+    def _build_context(self):
+        if self.settings.compiler == "Visual Studio":
+            with tools.vcvars(self.settings):
+                env = {
+                    "CC": "{} cl -nologo".format(self._user_info_build["automake"].compile).replace("\\", "/"),
+                }
+                with tools.environment_append(env):
+                    yield
+        else:
+            yield
+
     def _configure_autotools(self):
         if self._autotools:
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=self._settings_build.os == "Windows")
+        self._autotools.libs = []
         self._autotools.configure(configure_dir=self._source_subfolder)
         return self._autotools
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
-        autotools = self._configure_autotools()
-        autotools.make()
+        with self._build_context():
+            autotools = self._configure_autotools()
+            autotools.make()
 
     @property
     def _pc_data_path(self):
@@ -59,8 +88,9 @@ class XorgProtoConan(ConanFile):
 
     def package(self):
         self.copy("COPYING-*", src=self._source_subfolder, dst="licenses")
-        autotools = self._configure_autotools()
-        autotools.install()
+        with self._build_context():
+            autotools = self._configure_autotools()
+            autotools.install()
 
         pc_data = {}
         for fn in glob.glob(os.path.join(self.package_folder, "share", "pkgconfig", "*.pc")):

--- a/recipes/xorg-proto/all/test_package/CMakeLists.txt
+++ b/recipes/xorg-proto/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)

--- a/recipes/xorg-proto/all/test_package/conanfile.py
+++ b/recipes/xorg-proto/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "pkg_config"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/xorg-proto/all/test_package/conanfile.py
+++ b/recipes/xorg-proto/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "pkg_config"
+    generators = "cmake"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/xorg-proto/all/test_package/test_package.c
+++ b/recipes/xorg-proto/all/test_package/test_package.c
@@ -1,0 +1,7 @@
+#include "X11/keysym.h"
+#include <stdio.h>
+
+int main() {
+    printf("XK_VoidSymbol: 0x%x\n", XK_VoidSymbol);
+    return 0;
+}

--- a/recipes/xorg-proto/config.yml
+++ b/recipes/xorg-proto/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2021.4":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **xorg-proto/2021.4**

For #6387

dependency tree: sdl -> nas -> imake -> **xorg-proto** -> xorg-macros

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
