### PR TITLE
prometheus-cpp: allow to build if compiler.cppstd not set and default cppstd lower than 11 + modernize

### DIFF
--- a/recipes/prometheus-cpp/all/conanfile.py
+++ b/recipes/prometheus-cpp/all/conanfile.py
@@ -70,7 +70,6 @@ class PrometheusCppConan(ConanFile):
         self._cmake.definitions["ENABLE_TESTING"] = False
         self._cmake.definitions["OVERRIDE_CXX_STANDARD_FLAGS"] = not tools.valid_min_cppstd(self, 11)
 
-        self._cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
         self._cmake.definitions["ENABLE_PULL"] = self.options.with_pull
         self._cmake.definitions["ENABLE_PUSH"] = self.options.with_push
         self._cmake.definitions["ENABLE_COMPRESSION"] = self.options.with_compression

--- a/recipes/prometheus-cpp/all/conanfile.py
+++ b/recipes/prometheus-cpp/all/conanfile.py
@@ -1,6 +1,8 @@
 from conans import ConanFile, CMake, tools
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class PrometheusCppConan(ConanFile):
     name = "prometheus-cpp"
@@ -57,9 +59,8 @@ class PrometheusCppConan(ConanFile):
             tools.check_min_cppstd(self, 11)
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/prometheus-cpp/all/conanfile.py
+++ b/recipes/prometheus-cpp/all/conanfile.py
@@ -45,13 +45,15 @@ class PrometheusCppConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        if not self.options.with_pull:
+            del self.options.with_compression
 
     def requirements(self):
         if self.options.with_pull:
             self.requires("civetweb/1.14")
         if self.options.with_push:
             self.requires("libcurl/7.77.0")
-        if self.options.with_compression:
+        if self.options.get_safe("with_compression"):
             self.requires("zlib/1.2.11")
 
     def validate(self):
@@ -72,7 +74,8 @@ class PrometheusCppConan(ConanFile):
 
         self._cmake.definitions["ENABLE_PULL"] = self.options.with_pull
         self._cmake.definitions["ENABLE_PUSH"] = self.options.with_push
-        self._cmake.definitions["ENABLE_COMPRESSION"] = self.options.with_compression
+        if self.options.with_pull:
+            self._cmake.definitions["ENABLE_COMPRESSION"] = self.options.with_compression
 
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake

--- a/recipes/prometheus-cpp/all/conanfile.py
+++ b/recipes/prometheus-cpp/all/conanfile.py
@@ -43,7 +43,6 @@ class PrometheusCppConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        tools.check_min_cppstd(self, 11)
 
     def requirements(self):
         if self.options.with_pull:
@@ -52,6 +51,10 @@ class PrometheusCppConan(ConanFile):
             self.requires("libcurl/7.77.0")
         if self.options.with_compression:
             self.requires("zlib/1.2.11")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -64,7 +67,7 @@ class PrometheusCppConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["USE_THIRDPARTY_LIBRARIES"] = False
         self._cmake.definitions["ENABLE_TESTING"] = False
-        self._cmake.definitions["OVERRIDE_CXX_STANDARD_FLAGS"] = False
+        self._cmake.definitions["OVERRIDE_CXX_STANDARD_FLAGS"] = not tools.valid_min_cppstd(self, 11)
 
         self._cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
         self._cmake.definitions["ENABLE_PULL"] = self.options.with_pull


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

If we don't do that, we drop all versions of apple-clang implicitly (and gcc 4.9 as well as clang < 5).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
