### PR TITLE
soci: add components + bump dependencies + many fixes + modernize

### DIFF
--- a/recipes/soci/all/conandata.yml
+++ b/recipes/soci/all/conandata.yml
@@ -5,3 +5,7 @@ sources:
   "4.0.1":
     url: "https://github.com/SOCI/soci/archive/4.0.1.tar.gz"
     sha256: "fa69347b1a1ef74450c0382b665a67bd6777cc7005bbe09726479625bcf1e29c"
+patches:
+  "4.0.2":
+    - patch_file: "patches/0001-handle-libmysqlclient8.patch"
+      base_path: "source_subfolder"

--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -66,7 +66,7 @@ class SociConan(ConanFile):
         if self.options.with_db2:
             # self.requires("db2/0.0.0") # TODO add support for db2
             raise ConanInvalidConfiguration("{} DB2 {} ".format(prefix, message))
-        if self.options.with_odbc:
+        if self.settings.os != "Windows" and self.options.with_odbc:
             self.requires("odbc/2.3.9")
         if self.options.with_oracle:
             # self.requires("oracle_db/0.0.0") # TODO add support for oracle
@@ -173,6 +173,9 @@ class SociConan(ConanFile):
         if self.settings.os == "Windows":
             for index, name in enumerate(self.cpp_info.libs):
                 self.cpp_info.libs[index] = self._rename_library_win(name)
+
+        if self.settings.os == "Windows" and self.options.with_odbc:
+            self.cpp_info.system_libs.append("odbc32")
 
     def _rename_library_win(self, name):
         if self.options.shared:

--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -41,7 +41,7 @@ class SociConan(ConanFile):
         "with_boost":       False
     }
 
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake", "cmake_find_package"
     _cmake = None
 
@@ -110,6 +110,8 @@ class SociConan(ConanFile):
                   destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmakelists = os.path.join(self._source_subfolder, "CMakeLists.txt")
         tools.replace_in_file(cmakelists,
                               "set(CMAKE_MODULE_PATH ${SOCI_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})",

--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -70,10 +70,6 @@ class SociConan(ConanFile):
             self.requires("boost/1.76.0")
 
     @property
-    def _minimum_cpp_standard(self):
-        return 11
-
-    @property
     def _minimum_compilers_version(self):
         return {
             "Visual Studio": "14",
@@ -84,7 +80,7 @@ class SociConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, self._minimum_cpp_standard)
+            tools.check_min_cppstd(self, 11)
 
         compiler = str(self.settings.compiler)
         compiler_version = tools.Version(self.settings.compiler.version.value)

--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -1,7 +1,10 @@
-import os
 from conans import ConanFile, CMake, tools
 from conans.tools import Version
 from conans.errors import ConanInvalidConfiguration, ConanException
+import os
+
+required_conan_version = ">=1.33.0"
+
 
 class SociConan(ConanFile):
     name = "soci"
@@ -104,8 +107,8 @@ class SociConan(ConanFile):
             raise ConanInvalidConfiguration("{} requires a {} version >= {}".format(self.name, compiler, compiler_version))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -62,12 +62,12 @@ class SociConan(ConanFile):
         message = "not configured in this conan package."
 
         if self.options.with_sqlite3:
-            self.requires("sqlite3/3.33.0")
+            self.requires("sqlite3/3.36.0")
         if self.options.with_db2:
             # self.requires("db2/0.0.0") # TODO add support for db2
             raise ConanInvalidConfiguration("{} DB2 {} ".format(prefix, message))
         if self.options.with_odbc:
-            self.requires("odbc/2.3.7")
+            self.requires("odbc/2.3.9")
         if self.options.with_oracle:
             # self.requires("oracle_db/0.0.0") # TODO add support for oracle
             raise ConanInvalidConfiguration("{} ORACLE {} ".format(prefix, message))
@@ -75,11 +75,11 @@ class SociConan(ConanFile):
             # self.requires("firebird/0.0.0") # TODO add support for firebird
             raise ConanInvalidConfiguration("{} firebird {} ".format(prefix, message))
         if self.options.with_mysql:
-            self.requires("libmysqlclient/8.0.17")
+            self.requires("libmysqlclient/8.0.25")
         if self.options.with_postgresql:
-            self.requires("libpq/11.5")
+            self.requires("libpq/13.3")
         if self.options.with_boost:
-            self.requires("boost/1.73.0")
+            self.requires("boost/1.76.0")
 
     @property
     def _minimum_cpp_standard(self):

--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -1,6 +1,5 @@
 from conans import ConanFile, CMake, tools
-from conans.tools import Version
-from conans.errors import ConanInvalidConfiguration, ConanException
+from conans.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.33.0"
@@ -100,7 +99,7 @@ class SociConan(ConanFile):
             tools.check_min_cppstd(self, self._minimum_cpp_standard)
 
         compiler = str(self.settings.compiler)
-        compiler_version = Version(self.settings.compiler.version.value)
+        compiler_version = tools.Version(self.settings.compiler.version.value)
         if compiler not in self._minimum_compilers_version:
             self.output.warn("{} recipe lacks information about the {} compiler support.".format(self.name, self.settings.compiler))
         elif compiler_version < self._minimum_compilers_version[compiler]:

--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -12,14 +12,11 @@ class SociConan(ConanFile):
     description = "The C++ Database Access Library "
     topics = ("mysql", "odbc", "postgresql", "sqlite3")
     license = "BSL-1.0"
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
-    exports_sources = ["CMakeLists.txt"]
-    _cmake = None
 
+    settings = "os", "compiler", "build_type", "arch"
     options = {
-        "fPIC":             [True, False],
         "shared":           [True, False],
+        "fPIC":             [True, False],
         "empty":            [True, False],
         "with_sqlite3":     [True, False],
         "with_db2":         [True, False],
@@ -30,10 +27,9 @@ class SociConan(ConanFile):
         "with_postgresql":  [True, False],
         "with_boost":       [True, False]
     }
-
     default_options = {
-        "fPIC":             True,
         "shared":           False,
+        "fPIC":             True,
         "empty":            False,
         "with_sqlite3":     False,
         "with_db2":         False,
@@ -44,6 +40,10 @@ class SociConan(ConanFile):
         "with_postgresql":  False,
         "with_boost":       False
     }
+
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake", "cmake_find_package"
+    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -58,22 +58,10 @@ class SociConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        prefix  = "Dependencies for"
-        message = "not configured in this conan package."
-
         if self.options.with_sqlite3:
             self.requires("sqlite3/3.36.0")
-        if self.options.with_db2:
-            # self.requires("db2/0.0.0") # TODO add support for db2
-            raise ConanInvalidConfiguration("{} DB2 {} ".format(prefix, message))
-        if self.settings.os != "Windows" and self.options.with_odbc:
+        if self.options.with_odbc and self.settings.os != "Windows":
             self.requires("odbc/2.3.9")
-        if self.options.with_oracle:
-            # self.requires("oracle_db/0.0.0") # TODO add support for oracle
-            raise ConanInvalidConfiguration("{} ORACLE {} ".format(prefix, message))
-        if self.options.with_firebird:
-            # self.requires("firebird/0.0.0") # TODO add support for firebird
-            raise ConanInvalidConfiguration("{} firebird {} ".format(prefix, message))
         if self.options.with_mysql:
             self.requires("libmysqlclient/8.0.25")
         if self.options.with_postgresql:
@@ -105,9 +93,30 @@ class SociConan(ConanFile):
         elif compiler_version < self._minimum_compilers_version[compiler]:
             raise ConanInvalidConfiguration("{} requires a {} version >= {}".format(self.name, compiler, compiler_version))
 
+        prefix  = "Dependencies for"
+        message = "not configured in this conan package."
+        if self.options.with_db2:
+            # self.requires("db2/0.0.0") # TODO add support for db2
+            raise ConanInvalidConfiguration("{} DB2 {} ".format(prefix, message))
+        if self.options.with_oracle:
+            # self.requires("oracle_db/0.0.0") # TODO add support for oracle
+            raise ConanInvalidConfiguration("{} ORACLE {} ".format(prefix, message))
+        if self.options.with_firebird:
+            # self.requires("firebird/0.0.0") # TODO add support for firebird
+            raise ConanInvalidConfiguration("{} firebird {} ".format(prefix, message))
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
+
+    def _patch_sources(self):
+        cmakelists = os.path.join(self._source_subfolder, "CMakeLists.txt")
+        tools.replace_in_file(cmakelists,
+                              "set(CMAKE_MODULE_PATH ${SOCI_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})",
+                              "list(APPEND CMAKE_MODULE_PATH ${SOCI_SOURCE_DIR}/cmake)")
+        tools.replace_in_file(cmakelists,
+                              "set(CMAKE_MODULE_PATH ${SOCI_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})",
+                              "list(APPEND CMAKE_MODULE_PATH ${SOCI_SOURCE_DIR}/cmake/modules)")
 
     def _configure_cmake(self):
         if self._cmake:
@@ -137,6 +146,7 @@ class SociConan(ConanFile):
         return self._cmake
 
     def build(self):
+        self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -158,31 +168,56 @@ class SociConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.libs = ["soci_core"]
+        self.cpp_info.names["cmake_find_package"] = "SOCI"
+        self.cpp_info.names["cmake_find_package_multi"] = "SOCI"
+
+        target_suffix = "" if self.options.shared else "_static"
+        lib_prefix = "lib" if self.settings.compiler == "Visual Studio" and not self.options.shared else ""
+        version = tools.Version(self.version)
+        lib_suffix = "_{}_{}".format(version.major, version.minor) if self.settings.os == "Windows" else ""
+
+        # soci_core
+        self.cpp_info.components["soci_core"].names["cmake_find_package"] = "soci_core{}".format(target_suffix)
+        self.cpp_info.components["soci_core"].names["cmake_find_package_multi"] = "soci_core{}".format(target_suffix)
+        self.cpp_info.components["soci_core"].libs = ["{}soci_core{}".format(lib_prefix, lib_suffix)]
+        if self.options.with_boost:
+            self.cpp_info.components["soci_core"].requires.append("boost::boost")
+
+        # soci_empty
         if self.options.empty:
-            self.cpp_info.libs.append("soci_empty")
+            self.cpp_info.components["soci_empty"].names["cmake_find_package"] = "soci_empty{}".format(target_suffix)
+            self.cpp_info.components["soci_empty"].names["cmake_find_package_multi"] = "soci_empty{}".format(target_suffix)
+            self.cpp_info.components["soci_empty"].libs = ["{}soci_empty{}".format(lib_prefix, lib_suffix)]
+            self.cpp_info.components["soci_empty"].requires = ["soci_core"]
+
+        # soci_sqlite3
         if self.options.with_sqlite3:
-            self.cpp_info.libs.append("soci_sqlite3")
-        if self.options.with_oracle:
-            self.cpp_info.libs.append("soci_oracle")
+            self.cpp_info.components["soci_sqlite3"].names["cmake_find_package"] = "soci_sqlite3{}".format(target_suffix)
+            self.cpp_info.components["soci_sqlite3"].names["cmake_find_package_multi"] = "soci_sqlite3{}".format(target_suffix)
+            self.cpp_info.components["soci_sqlite3"].libs = ["{}soci_sqlite3{}".format(lib_prefix, lib_suffix)]
+            self.cpp_info.components["soci_sqlite3"].requires = ["soci_core", "sqlite3::sqlite3"]
+
+        # soci_odbc
+        if self.options.with_odbc:
+            self.cpp_info.components["soci_odbc"].names["cmake_find_package"] = "soci_odbc{}".format(target_suffix)
+            self.cpp_info.components["soci_odbc"].names["cmake_find_package_multi"] = "soci_odbc{}".format(target_suffix)
+            self.cpp_info.components["soci_odbc"].libs = ["{}soci_odbc{}".format(lib_prefix, lib_suffix)]
+            self.cpp_info.components["soci_odbc"].requires = ["soci_core"]
+            if self.settings.os == "Windows":
+                self.cpp_info.components["soci_odbc"].system_libs.append("odbc32")
+            else:
+                self.cpp_info.components["soci_odbc"].requires.append("odbc::odbc")
+
+        # soci_mysql
         if self.options.with_mysql:
-            self.cpp_info.libs.append("soci_mysql")
+            self.cpp_info.components["soci_mysql"].names["cmake_find_package"] = "soci_mysql{}".format(target_suffix)
+            self.cpp_info.components["soci_mysql"].names["cmake_find_package_multi"] = "soci_mysql{}".format(target_suffix)
+            self.cpp_info.components["soci_mysql"].libs = ["{}soci_mysql{}".format(lib_prefix, lib_suffix)]
+            self.cpp_info.components["soci_mysql"].requires = ["soci_core", "libmysqlclient::libmysqlclient"]
+
+        # soci_postgresql
         if self.options.with_postgresql:
-            self.cpp_info.libs.append("soci_postgresql")
-
-        if self.settings.os == "Windows":
-            for index, name in enumerate(self.cpp_info.libs):
-                self.cpp_info.libs[index] = self._rename_library_win(name)
-
-        if self.settings.os == "Windows" and self.options.with_odbc:
-            self.cpp_info.system_libs.append("odbc32")
-
-    def _rename_library_win(self, name):
-        if self.options.shared:
-            prefix = ""
-        else:
-            prefix = "lib"
-
-        abi_version = tools.Version(self.version)
-        sufix = "_{}_{}".format(abi_version.major, abi_version.minor)
-        return "{}{}{}".format(prefix, name, sufix)
+            self.cpp_info.components["soci_postgresql"].names["cmake_find_package"] = "soci_postgresql{}".format(target_suffix)
+            self.cpp_info.components["soci_postgresql"].names["cmake_find_package_multi"] = "soci_postgresql{}".format(target_suffix)
+            self.cpp_info.components["soci_postgresql"].libs = ["{}soci_postgresql{}".format(lib_prefix, lib_suffix)]
+            self.cpp_info.components["soci_postgresql"].requires = ["soci_core", "libpq::libpq"]

--- a/recipes/soci/all/conanfile.py
+++ b/recipes/soci/all/conanfile.py
@@ -47,19 +47,6 @@ class SociConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
-    @property
-    def _minimum_cpp_standard(self):
-        return 11
-
-    @property
-    def _minimum_compilers_version(self):
-        return {
-            "Visual Studio": "14",
-            "gcc": "4.8",
-            "clang": "3.8",
-            "apple-clang": "8.0"
-        }
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -67,15 +54,6 @@ class SociConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-
-        compiler = str(self.settings.compiler)
-        compiler_version = Version(self.settings.compiler.version.value)
-        tools.check_min_cppstd(self, self._minimum_cpp_standard)
-
-        if compiler not in self._minimum_compilers_version:
-            self.output.warn("{} recipe lacks information about the {} compiler support.".format(self.name, self.settings.compiler))
-        elif compiler_version < self._minimum_compilers_version[compiler]:
-            raise ConanInvalidConfiguration("{} requires a {} version >= {}".format(self.name, compiler, compiler_version))
 
     def requirements(self):
         prefix  = "Dependencies for"
@@ -100,6 +78,30 @@ class SociConan(ConanFile):
             self.requires("libpq/11.5")
         if self.options.with_boost:
             self.requires("boost/1.73.0")
+
+    @property
+    def _minimum_cpp_standard(self):
+        return 11
+
+    @property
+    def _minimum_compilers_version(self):
+        return {
+            "Visual Studio": "14",
+            "gcc": "4.8",
+            "clang": "3.8",
+            "apple-clang": "8.0"
+        }
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, self._minimum_cpp_standard)
+
+        compiler = str(self.settings.compiler)
+        compiler_version = Version(self.settings.compiler.version.value)
+        if compiler not in self._minimum_compilers_version:
+            self.output.warn("{} recipe lacks information about the {} compiler support.".format(self.name, self.settings.compiler))
+        elif compiler_version < self._minimum_compilers_version[compiler]:
+            raise ConanInvalidConfiguration("{} requires a {} version >= {}".format(self.name, compiler, compiler_version))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/soci/all/patches/0001-handle-libmysqlclient8.patch
+++ b/recipes/soci/all/patches/0001-handle-libmysqlclient8.patch
@@ -1,0 +1,17 @@
+From https://github.com/SOCI/soci/commit/7c431d9f073dec786fede7a78d6ff4ed44bbdb92
+
+--- a/src/backends/mysql/session.cpp
++++ b/src/backends/mysql/session.cpp
+@@ -355,7 +355,11 @@ mysql_session_backend::mysql_session_backend(
+     }
+     if (reconnect_p)
+     {
+-        my_bool reconnect = 1;
++#if MYSQL_VERSION_ID < 8
++            my_bool reconnect = 1;
++#else
++            bool reconnect = 1;
++#endif
+         if (0 != mysql_options(conn_, MYSQL_OPT_RECONNECT, &reconnect))
+         {
+             clean_up();


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- properly define components in `package_info()`
- allow to build if `compiler.cppstd` not set and default standard < 11 (basically all versions of apple-clang !)
- don't require unixODBC (ie odbc recipe) if Windows
- robust discovery/injection of dependencies, it was broken for many options
- fix compilation in 4.0.2 if `with_mysql=True`

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
