### PR TITLE
Spdlog since version 1.9.0 supportd fmt v.8.*

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -51,7 +51,9 @@ class SpdlogConan(ConanFile):
             raise ConanInvalidConfiguration("Visual Studio build for shared library with MT runtime is not supported")
 
     def requirements(self):
-        if Version(self.version) >= "1.7.0":
+        if Version(self.version) >= "1.9.0":
+            self.requires("fmt/8.0.1")
+        elif Version(self.version) >= "1.7.0":
             self.requires("fmt/7.1.3")
         elif Version(self.version) >= "1.5.0":
             self.requires("fmt/6.2.1")


### PR DESCRIPTION
Specify library name and version:  **spdlog/1.9.0**

Since 1.9.0 spdlog supports for {fmt} lib version 8.x (https://github.com/gabime/spdlog/releases/tag/v1.9.0).
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
