### PR TITLE
Add protobuf version 3.16.0

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -17,6 +17,9 @@ sources:
   "3.15.5":
     sha256: bc3dbf1f09dba1b2eb3f2f70352ee97b9049066c9040ce0c9b67fb3294e91e4b
     url: https://github.com/protocolbuffers/protobuf/archive/v3.15.5.tar.gz
+  "3.16.0":
+    sha256: 7892a35d979304a404400a101c46ce90e85ec9e2a766a86041bb361f626247f5
+    url: https://github.com/protocolbuffers/protobuf/archive/v3.16.0.tar.gz
   "3.17.1":
     sha256: 036D66D6EEC216160DD898CFB162E9D82C1904627642667CC32B104D407BB411
     url: https://github.com/protocolbuffers/protobuf/archive/v3.17.1.tar.gz

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -11,5 +11,7 @@ versions:
     folder: all
   "3.15.5":
     folder: all
+  "3.16.0":
+    folder: all
   "3.17.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **protobuf/3.16.0**

Protobuf 3.16.0 is required by onnxruntime 1.8.0

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
