### PR TITLE
fix opencv/4.5.2: armv8 does not link libtregra_hal.a on linux arm cross-compile

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -576,7 +576,7 @@ class OpenCVConan(ConanFile):
                             self.cpp_info.components[conan_component].libdirs.append("lib")
                             self.cpp_info.components[conan_component].libs += tools.collect_libs(self)
 
-                if self.settings.os == "iOS" or self.settings.os == "Macos":
+                if self.settings.os == "iOS" or self.settings.os == "Macos" or self.settings.os == "Linux":
                     if not self.options.shared:
                         if conan_component == "opencv_core":
                             libs = list(filter(lambda x: not x.startswith("opencv"), tools.collect_libs(self)))

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -576,7 +576,7 @@ class OpenCVConan(ConanFile):
                             self.cpp_info.components[conan_component].libdirs.append("lib")
                             self.cpp_info.components[conan_component].libs += tools.collect_libs(self)
 
-                if self.settings.os == "iOS" or self.settings.os == "Macos" or self.settings.os == "Linux":
+                if self.settings.os in ["iOS", "Macos", "Linux"]:
                     if not self.options.shared:
                         if conan_component == "opencv_core":
                             libs = list(filter(lambda x: not x.startswith("opencv"), tools.collect_libs(self)))


### PR DESCRIPTION
fixes: https://github.com/conan-io/conan-center-index/issues/5366

Specify library name and version:  **lopencv/4.5.2**
libtegra_hal.a is build for linux arm during cross-compilation and is necessary to link during consumption. Nevertheless, this library is not detected and exported as an conan_component dependency for opencv_core. This pull-requests enables also the discoverage of the libs as opencv_core dependencies for os=Linux, which does fix the missing libtregra_hal.a issue linked above.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
