### PR TITLE
Fix libtiff build errors without jbig or zstd

### DIFF
--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -106,10 +106,10 @@ class LibtiffConan(ConanFile):
 
     def _patch_sources(self):
         # Rename the generated Findjbig.cmake and Findzstd.cmake to avoid case insensitive conflicts with FindJBIG.cmake and FindZSTD.cmake on Windows
-        if self.options.get_safe("jbig"):
+        if self.options.jbig:
             tools.rename(os.path.join(self.build_folder, "Findjbig.cmake"),
                          os.path.join(self.build_folder, "ConanFindjbig.cmake"))
-        if tools.Version(self.version) >= "4.1" and self.options.get_safe("zstd"):
+        if self.options.get_safe("zstd"):
             tools.rename(os.path.join(self.build_folder, "Findzstd.cmake"),
                          os.path.join(self.build_folder, "ConanFindzstd.cmake"))
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -106,9 +106,10 @@ class LibtiffConan(ConanFile):
 
     def _patch_sources(self):
         # Rename the generated Findjbig.cmake and Findzstd.cmake to avoid case insensitive conflicts with FindJBIG.cmake and FindZSTD.cmake on Windows
-        tools.rename(os.path.join(self.build_folder, "Findjbig.cmake"),
-                     os.path.join(self.build_folder, "ConanFindjbig.cmake"))
-        if tools.Version(self.version) >= "4.1":
+        if self.options.get_safe("jbig"):
+            tools.rename(os.path.join(self.build_folder, "Findjbig.cmake"),
+                         os.path.join(self.build_folder, "ConanFindjbig.cmake"))
+        if tools.Version(self.version) >= "4.1" and self.options.get_safe("zstd"):
             tools.rename(os.path.join(self.build_folder, "Findzstd.cmake"),
                          os.path.join(self.build_folder, "ConanFindzstd.cmake"))
         for patch in self.conan_data.get("patches", {}).get(self.version, []):


### PR DESCRIPTION
Should fix
```
ERROR: libtiff/4.2.0: Error in build() method, line 155
	self._patch_sources()
while calling '_patch_sources', line 109
	tools.rename(os.path.join(self.build_folder, "Findjbig.cmake"),
	ConanException: rename /cache/conan/.conan/data/libtiff/4.2.0/_/_/build/5dcd435e19ccad213b38f405159b5ca27dc88d80/Findjbig.cmake to /cache/conan/.conan/data/libtiff/4.2.0/_/_/build/5dcd435e19ccad213b38f405159b5ca27dc88d80/ConanFindjbig.cmake failed: [Errno 2] No such file or directory: '/cache/conan/.conan/data/libtiff/4.2.0/_/_/build/5dcd435e19ccad213b38f405159b5ca27dc88d80/Findjbig.cmake' -> '/cache/conan/.conan/data/libtiff/4.2.0/_/_/build/5dcd435e19ccad213b38f405159b5ca27dc88d80/ConanFindjbig.cmake'
```

Specify library name and version:  **libtiff/4.x**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
