### PR TITLE
[boost] fix library name for custom namespace and custom buildid cases

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -98,6 +98,8 @@ class BoostConan(ConanFile):
         "visibility": ["global", "protected", "hidden"],
         "addr2line_location": "ANY",
         "with_stacktrace_backtrace": [True, False],
+        "buildid": "ANY",
+        "python_buildid": "ANY",
     }
     options.update({"without_{}".format(_name): [True, False] for _name in CONFIGURE_OPTIONS})
 
@@ -132,6 +134,8 @@ class BoostConan(ConanFile):
         "visibility": "hidden",
         "addr2line_location": "/usr/bin/addr2line",
         "with_stacktrace_backtrace": True,
+        "buildid": None,
+        "python_buildid": None,
     }
     default_options.update({"without_{}".format(_name): False for _name in CONFIGURE_OPTIONS})
     default_options.update({"without_{}".format(_name): True for _name in ("graph_parallel", "mpi", "python")})
@@ -351,6 +355,8 @@ class BoostConan(ConanFile):
             if not self.options.python_version:
                 self.options.python_version = self._detect_python_version()
                 self.options.python_executable = self._python_executable
+        else:
+            del self.options.python_buildid
 
         if self._stacktrace_addr2line_available:
             if os.path.abspath(str(self.options.addr2line_location)) != str(self.options.addr2line_location):
@@ -1038,6 +1044,11 @@ class BoostConan(ConanFile):
         cxx_flags = 'cxxflags="%s"' % " ".join(cxx_flags) if cxx_flags else ""
         flags.append(cxx_flags)
 
+        if self.options.buildid:
+            flags.append("--buildid=%s" % self.options.buildid)
+        if not self.options.without_python and self.options.python_buildid:
+            flags.append("--python-buildid=%s" % self.options.python_buildid)
+
         if self.options.extra_b2_flags:
             flags.extend(shlex.split(str(self.options.extra_b2_flags)))
 
@@ -1329,6 +1340,13 @@ class BoostConan(ConanFile):
         if self.options.segmented_stacks:
             self.cpp_info.components["headers"].defines.extend(["BOOST_USE_SEGMENTED_STACKS", "BOOST_USE_UCONTEXT"])
 
+        if self.options.buildid:
+            # If you built Boost using the --buildid option then set this macro to the same value
+            # as you passed to bjam.
+            # For example if you built using bjam address-model=64 --buildid=amd64 then compile your code with
+            # -DBOOST_LIB_BUILDID=amd64 to ensure the correct libraries are selected at link time.
+            self.cpp_info.components["headers"].defines.append("BOOST_LIB_BUILDID=%s" % self.options.buildid)
+
         if not self.options.header_only:
             if self.options.error_code_header_only:
                 self.cpp_info.components["headers"].defines.append("BOOST_ERROR_CODE_HEADER_ONLY")
@@ -1449,6 +1467,11 @@ class BoostConan(ConanFile):
                     new_name = add_libprefix(name.format(**libformatdata)) + libsuffix
                     if self.options.namespace != 'boost':
                         new_name = new_name.replace('boost_', str(self.options.namespace) + '_')
+                    if name.startswith('boost_python') or name.startswith('boost_numpy'):
+                        if self.options.python_buildid:
+                            new_name += '-%s' % self.options.python_buildid
+                    if self.options.buildid:
+                        new_name += '-%s' % self.options.buildid
                     libs.append(new_name)
                 return libs
 

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1446,7 +1446,10 @@ class BoostConan(ConanFile):
                         continue
                     if not self.options.get_safe("numa") and "_numa" in name:
                         continue
-                    libs.append(add_libprefix(name.format(**libformatdata)) + libsuffix)
+                    new_name = add_libprefix(name.format(**libformatdata)) + libsuffix
+                    if self.options.namespace != 'boost':
+                        new_name = new_name.replace('boost_', str(self.options.namespace) + '_')
+                    libs.append(new_name)
                 return libs
 
             for module in self._dependencies["dependencies"].keys():

--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -4,6 +4,10 @@ project(test_package)
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup(TARGETS)
 
+if(BOOST_NAMESPACE)
+    add_definitions("-DBOOST_NAMESPACE=${BOOST_NAMESPACE}")
+endif()
+
 if(NOT HEADER_ONLY)
     if(WITH_RANDOM)
         find_package(Boost COMPONENTS random REQUIRED)

--- a/recipes/boost/all/test_package/chrono.cpp
+++ b/recipes/boost/all/test_package/chrono.cpp
@@ -4,6 +4,10 @@
 #include <iostream>
 #include <cmath>
 
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 int main()
 {
     boost::chrono::system_clock::time_point start = boost::chrono::system_clock::now();

--- a/recipes/boost/all/test_package/conanfile.py
+++ b/recipes/boost/all/test_package/conanfile.py
@@ -37,6 +37,8 @@ class TestPackageConan(ConanFile):
             cmake.definitions["WITH_STACKTRACE"] = not self.options["boost"].without_stacktrace
             cmake.definitions["WITH_STACKTRACE_ADDR2LINE"] = self.deps_user_info["boost"].stacktrace_addr2line_available
             cmake.definitions["WITH_STACKTRACE_BACKTRACE"] = self._boost_option("with_stacktrace_backtrace", False)
+            if self.options["boost"].namespace != 'boost' and not self.options["boost"].namespace_alias:
+                cmake.definitions['BOOST_NAMESPACE'] = self.options["boost"].namespace
             cmake.configure()
             # Disable parallel builds because c3i (=conan-center's test/build infrastructure) seems to choke here
             cmake.parallel = False

--- a/recipes/boost/all/test_package/coroutine.cpp
+++ b/recipes/boost/all/test_package/coroutine.cpp
@@ -1,6 +1,10 @@
 #include <boost/coroutine/all.hpp>
 #include <iostream>
 
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 using namespace boost::coroutines;
 
 void cooperative(coroutine<void>::push_type &sink)

--- a/recipes/boost/all/test_package/fiber.cpp
+++ b/recipes/boost/all/test_package/fiber.cpp
@@ -20,6 +20,10 @@
 
 #include <boost/fiber/detail/thread_barrier.hpp>
 
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 static std::size_t fiber_count{ 0 };
 static std::mutex mtx_count{};
 static boost::fibers::condition_variable_any cnd_count{};

--- a/recipes/boost/all/test_package/json.cpp
+++ b/recipes/boost/all/test_package/json.cpp
@@ -1,4 +1,9 @@
 #include <boost/json.hpp>
+
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 using namespace boost::json;
 
 #include <string>

--- a/recipes/boost/all/test_package/lambda.cpp
+++ b/recipes/boost/all/test_package/lambda.cpp
@@ -3,6 +3,10 @@
 #include <vector>
 #include <algorithm>
 
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 int main(int argc, const char * const argv[])
 {
     using namespace boost::lambda;

--- a/recipes/boost/all/test_package/locale.cpp
+++ b/recipes/boost/all/test_package/locale.cpp
@@ -9,6 +9,11 @@
 #include <iostream>
 #include <iomanip>
 #include <ctime>
+
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 int main()
 {
     using namespace boost::locale;

--- a/recipes/boost/all/test_package/nowide.cpp
+++ b/recipes/boost/all/test_package/nowide.cpp
@@ -5,6 +5,11 @@
 #include <boost/nowide/args.hpp>
 #include <boost/nowide/fstream.hpp>
 #include <boost/nowide/iostream.hpp>
+
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 int main(int argc,char **argv)
 {
     boost::nowide::args a(argc,argv); // Fix arguments - make them UTF-8

--- a/recipes/boost/all/test_package/numpy.cpp
+++ b/recipes/boost/all/test_package/numpy.cpp
@@ -1,6 +1,10 @@
 #include <boost/python/numpy.hpp>
 #include <iostream>
 
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 namespace p = boost::python;
 namespace np = boost::python::numpy;
 

--- a/recipes/boost/all/test_package/python.cpp
+++ b/recipes/boost/all/test_package/python.cpp
@@ -1,5 +1,9 @@
 #include <boost/python.hpp>
 
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 char const* greet()
 {
    return "hello, world!!!!!";

--- a/recipes/boost/all/test_package/random.cpp
+++ b/recipes/boost/all/test_package/random.cpp
@@ -4,6 +4,10 @@
 #include <boost/random/uniform_int_distribution.hpp>
 #include <iostream>
 
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 int main() {
     std::string chars(
         "abcdefghijklmnopqrstuvwxyz"

--- a/recipes/boost/all/test_package/regex.cpp
+++ b/recipes/boost/all/test_package/regex.cpp
@@ -1,6 +1,10 @@
 #include <boost/regex.hpp>
 #include <iostream>
 
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 int main(int argc, const char * const argv[])
 {
     std::string line;

--- a/recipes/boost/all/test_package/stacktrace.cpp
+++ b/recipes/boost/all/test_package/stacktrace.cpp
@@ -2,6 +2,10 @@
 
 #include <iostream>
 
+#if defined(BOOST_NAMESPACE)
+namespace boost = BOOST_NAMESPACE;
+#endif
+
 void f3() {
     std::cout << "==start stacktrace==\n" << boost::stacktrace::stacktrace() << "==end stacktrace==\n";
 }


### PR DESCRIPTION
Specify library name and version:  **boost/all**

closes: #6152
closes: #5632

/cc @madebr @grafikrobot 

I've checked all the layouts (versioned, tagged and system) as well as python/numpy libraries, works locally for me for the options:
- `-o namespace=myboost`
- `-o buildid=my_build`
- `-o python_buildid=my_python_build -o without_python=False`

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
