### PR TITLE
[boost] Pass sanitizer settings to b2

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -958,6 +958,16 @@ class BoostConan(ConanFile):
         if self.settings.get_safe("compiler.cppstd"):
             flags.append("cxxflags=%s" % cppstd_flag(self.settings))
 
+        if self.settings.compiler.sanitizer:
+          setting = str(self.settings.compiler.sanitizer)
+          setting = setting.replace('Behavior', '')  # UndefinedBehavior => Undefined
+          if setting != "AddressUndefined":
+            sanitizers = [setting.lower()]
+          else:
+            sanitizers = ['address', 'undefined']
+          for sanitizer in sanitizers:
+            flags.append("%s-sanitizer=on" % sanitizer)
+
         # LDFLAGS
         link_flags = []
 

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -958,7 +958,7 @@ class BoostConan(ConanFile):
         if self.settings.get_safe("compiler.cppstd"):
             flags.append("cxxflags=%s" % cppstd_flag(self.settings))
 
-        if self.settings.compiler.sanitizer:
+        if self.settings.get_safe("compiler.sanitizer"):
           setting = str(self.settings.compiler.sanitizer)
           setting = setting.replace('Behavior', '')  # UndefinedBehavior => Undefined
           if setting != "AddressUndefined":


### PR DESCRIPTION
Specify library name and version:  **boost/all**

Thread sanitizer requires all linked code to be instrumented in order to work properly (https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual#non-instrumented-code). Thus, it makes sense to support packages built with thread sanitizer.

I assume that `compiler.sanitizer` setting is defined as in the docs: https://docs.conan.io/en/latest/howtos/sanitizers.html

Specifying `CXXFLAGS=-fsanitize=thread` env in the profile indeed works for all other libraries that I tried, but not for boost. If I specify this env, boost not only does not build with the sanitizer, but also does not link with zlib. It is not clear to me why this happens, but the proper way to build boost with sanitizers is to pass this option directly to `b2`: https://www.boost.org/doc/libs/1_76_0/tools/build/doc/html/index.html#_sanitizers

That's exactly what I do in this PR. If `compiler.sanitizer` setting is not `None`, I pass it as an appropriate flag to `b2`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
