### PR TITLE
aws-c-common: add version 0.6.8

### DIFF
--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.8":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.6.8.tar.gz"
+    sha256: "2997e851ed690a614507a43f4c393f45a198614d94da1660ecdf9b5a729535fc"
   "0.6.7":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.6.7.tar.gz"
     sha256: "643b35c62f948367f484f3a436bc37b5799538f47b08aa72deb3818b8bcdc631"

--- a/recipes/aws-c-common/config.yml
+++ b/recipes/aws-c-common/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.8":
+    folder: all
   "0.6.7":
     folder: all
   "0.4.25":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **aws-c-common/0.6.8**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
