### PR TITLE
caf: add version 0.18.5

### DIFF
--- a/recipes/caf/all/conandata.yml
+++ b/recipes/caf/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "0.18.2":
     url: "https://github.com/actor-framework/actor-framework/archive/0.18.2.tar.gz"
     sha256: "03837dbef73a13c3e4cac76c009d018f48d1d97b182277230f204984c9542ccc"
+  "0.18.5":
+    url: "https://github.com/actor-framework/actor-framework/archive/0.18.5.tar.gz"
+    sha256: "4c96f896f000218bb65890b4d7175451834add73750d5f33b0c7fe82b7d5a679"
 patches:
   "0.17.6":
     - patch_file: "patches/win_install.patch"

--- a/recipes/caf/config.yml
+++ b/recipes/caf/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "0.18.2":
     folder: all
+  "0.18.5":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **caf/0.18.5**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
