### PR TITLE
fix wrong description

### DIFF
--- a/recipes/effcee/all/conanfile.py
+++ b/recipes/effcee/all/conanfile.py
@@ -6,7 +6,7 @@ class EffceeConan(ConanFile):
     name = "effcee"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/google/effcee/"
-    description = "Zstandard - Fast real-time compression algorithm"
+    description = "a C++ library for stateful pattern matching of strings, inspired by LLVM's FileCheck"
     topics = ("conan", "effcee", "strings", "algorithm", "matcher")
     license = "Apache-2.0"
     exports_sources = ["CMakeLists.txt", "patches/**"]


### PR DESCRIPTION
Specify library name and version:  **effcee/2019.1**

The description of effcee is wrong. It may be the description of Zstd.

---

- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [+] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [+] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
