### PR TITLE
structopt: add version 0.1.2

### DIFF
--- a/recipes/structopt/all/conandata.yml
+++ b/recipes/structopt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.2":
+    url: "https://github.com/p-ranav/structopt/archive/v0.1.2.tar.gz"
+    sha256: "904fb2e38cb1f547149b4bcd2a67f8bc4387dad1cd9a57d15c0a898faddd21b3"
   "0.1.1":
     url: "https://github.com/p-ranav/structopt/archive/v0.1.1.tar.gz"
     sha256: "a813250b3325e462df613fe6b0730a5f93012b1a5a09810f88943ebac5b178bb"

--- a/recipes/structopt/config.yml
+++ b/recipes/structopt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.1.2":
+    folder: "all"
   "0.1.1":
     folder: "all"
   "0.1.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **structopt/0.1.2**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
