### PR TITLE
readerwriterqueue: add version 1.0.5

### DIFF
--- a/recipes/readerwriterqueue/all/conandata.yml
+++ b/recipes/readerwriterqueue/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.5":
+    url: "https://github.com/cameron314/readerwriterqueue/archive/v1.0.5.tar.gz"
+    sha256: "7c88aac9924885d733355c72e3b3d2de30665a64e10bf079af85c95f8419ecb9"
   "1.0.3":
     url: https://github.com/cameron314/readerwriterqueue/archive/v1.0.3.zip
     sha256: a7dd85427ea50f76978f488d1de13b249f24385303deb2c480c225fec084a1b5

--- a/recipes/readerwriterqueue/config.yml
+++ b/recipes/readerwriterqueue/config.yml
@@ -1,3 +1,5 @@
-versions:  
+versions:
+  "1.0.5":
+    folder: all
   "1.0.3":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **readerwriterqueue/1.0.5**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
