### PR TITLE
octomap: add version 1.9.7

### DIFF
--- a/recipes/octomap/all/conandata.yml
+++ b/recipes/octomap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.9.7":
+    url: "https://github.com/OctoMap/octomap/archive/v1.9.7.tar.gz"
+    sha256: "3e9ac020686ceb4e17e161bffc5a0dafd9cccab33adeb9adee59a61c418ea1c1"
   "1.9.6":
     url: "https://github.com/OctoMap/octomap/archive/v1.9.6.tar.gz"
     sha256: "0f88c1c024f0d29ab74c7fb9f6ebfdddc8be725087372c6c4d8878be95831eb6"
@@ -9,6 +12,9 @@ sources:
     url: "https://github.com/OctoMap/octomap/archive/v1.9.3.tar.gz"
     sha256: "8488de97ed2c8f4757bfbaf3225e82a9e36783dce1f573b3bde1cf968aa89696"
 patches:
+  "1.9.7":
+    - patch_file: "patches/targets-outputname-collision-1.9.5.patch"
+      base_path: "source_subfolder"
   "1.9.6":
     - patch_file: "patches/targets-outputname-collision-1.9.5.patch"
       base_path: "source_subfolder"

--- a/recipes/octomap/config.yml
+++ b/recipes/octomap/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.7":
+    folder: all
   "1.9.6":
     folder: all
   "1.9.5":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **octomap/1.9.7**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
