### PR TITLE
libjpeg-turbo: fix cross-build to iOS + enable SIMD again for armv8 builds + modernize

### DIFF
--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -13,32 +13,37 @@ class LibjpegTurboConan(ConanFile):
     homepage = "https://libjpeg-turbo.org"
     license = "BSD-3-Clause, Zlib"
     provides = "libjpeg"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "SIMD": [True, False],
+        "arithmetic_encoder": [True, False],
+        "arithmetic_decoder": [True, False],
+        "libjpeg7_compatibility": [True, False],
+        "libjpeg8_compatibility": [True, False],
+        "mem_src_dst": [True, False],
+        "turbojpeg": [True, False],
+        "java": [True, False],
+        "enable12bit": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "SIMD": True,
+        "arithmetic_encoder": True,
+        "arithmetic_decoder": True,
+        "libjpeg7_compatibility": True,
+        "libjpeg8_compatibility": True,
+        "mem_src_dst": True,
+        "turbojpeg": True,
+        "java": False,
+        "enable12bit": False,
+    }
+
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
-    settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False],
-               "fPIC": [True, False],
-               "SIMD": [True, False],
-               "arithmetic_encoder": [True, False],
-               "arithmetic_decoder": [True, False],
-               "libjpeg7_compatibility": [True, False],
-               "libjpeg8_compatibility": [True, False],
-               "mem_src_dst": [True, False],
-               "turbojpeg": [True, False],
-               "java": [True, False],
-               "enable12bit": [True, False]}
-    default_options = {"shared": False,
-                       "fPIC": True,
-                       "SIMD": True,
-                       "arithmetic_encoder": True,
-                       "arithmetic_decoder": True,
-                       "libjpeg7_compatibility": True,
-                       "libjpeg8_compatibility": True,
-                       "mem_src_dst": True,
-                       "turbojpeg": True,
-                       "java": False,
-                       "enable12bit": False}
-
     _cmake = None
 
     @property

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -1,7 +1,9 @@
-import os
-import glob
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import glob
+import os
+
+required_conan_version = ">=1.33.0"
 
 
 class LibjpegTurboConan(ConanFile):
@@ -91,8 +93,8 @@ class LibjpegTurboConan(ConanFile):
             self.build_requires("nasm/2.14")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -50,10 +50,6 @@ class LibjpegTurboConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
-    def _simd_extensions_available(self):
-        macos_silicon = self.settings.os == "Macos" and self.settings.arch == "armv8"
-        return not (self.settings.os == "Emscripten" or macos_silicon)
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -67,7 +63,7 @@ class LibjpegTurboConan(ConanFile):
         if self.options.enable12bit:
             del self.options.java
             del self.options.turbojpeg
-        if self.options.enable12bit or not self._simd_extensions_available():
+        if self.options.enable12bit or self.settings.os == "Emscripten":
             del self.options.SIMD
         if self.options.enable12bit or self.options.libjpeg7_compatibility or self.options.libjpeg8_compatibility:
             del self.options.arithmetic_encoder

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -89,7 +89,7 @@ class LibjpegTurboConan(ConanFile):
                self.options.libjpeg7_compatibility or self.options.libjpeg8_compatibility
 
     def build_requirements(self):
-        if self.options.get_safe("SIMD"):
+        if self.options.get_safe("SIMD") and self.settings.arch in ["x86", "x86_64"]:
             self.build_requires("nasm/2.14")
 
     def source(self):

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -1,6 +1,5 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
-import glob
 import os
 
 required_conan_version = ">=1.33.0"
@@ -153,8 +152,7 @@ class LibjpegTurboConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "doc"))
         # remove binaries and pdb files
         for pattern_to_remove in ["cjpeg*", "djpeg*", "jpegtran*", "tjbench*", "wrjpgcom*", "rdjpgcom*", "*.pdb"]:
-            for bin_file in glob.glob(os.path.join(self.package_folder, "bin", pattern_to_remove)):
-                os.remove(bin_file)
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), pattern_to_remove)
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "libjpeg-turbo"


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Improvement of https://github.com/conan-io/conan-center-index/pull/6032:

- should handle more cross-build scenario
- there is no reason to disable SIMD on armv8, it works fine with neon.
- `nasm` doesn't make sense if arch is not x86/x86_64

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
