### PR TITLE
libxml2: fix CMake variables again in Find module file

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -241,22 +241,31 @@ class Libxml2Conan(ConanFile):
                       dst=os.path.join("include", "libxml2"), keep_path=False)
 
         self._create_cmake_module_variables(
-            os.path.join(self.package_folder, self._module_file_rel_path),
-            tools.Version(self.version)
+            os.path.join(self.package_folder, self._module_file_rel_path)
         )
 
     @staticmethod
-    def _create_cmake_module_variables(module_file, version):
+    def _create_cmake_module_variables(module_file):
         # FIXME: also define LIBXML2_XMLLINT_EXECUTABLE variable
         content = textwrap.dedent("""\
-            set(LIBXML2_FOUND TRUE)
-            set(LIBXML2_INCLUDE_DIR $<TARGET_PROPERTY:LibXml2::LibXml2,INTERFACE_INCLUDE_DIRECTORIES>)
-            set(LIBXML2_INCLUDE_DIRS ${{LIBXML2_INCLUDE_DIR}})
-            set(LIBXML2_LIBRARIES $<LINK_ONLY:LibXml2::LibXml2>)
-            set(LIBXML2_LIBRARY ${{LIBXML2_LIBRARIES}})
-            set(LIBXML2_DEFINITIONS $<TARGET_PROPERTY:LibXml2::LibXml2,INTERFACE_COMPILE_DEFINITIONS>)
-            set(LIBXML2_VERSION_STRING "{major}.{minor}.{patch}")
-        """.format(major=version.major, minor=version.minor, patch=version.patch))
+            if(DEFINED LibXml2_FOUND)
+                set(LIBXML2_FOUND ${LibXml2_FOUND})
+            endif()
+            if(DEFINED LibXml2_INCLUDE_DIR)
+                set(LIBXML2_INCLUDE_DIR ${LibXml2_INCLUDE_DIR})
+                set(LIBXML2_INCLUDE_DIRS ${LibXml2_INCLUDE_DIR})
+            endif()
+            if(DEFINED LibXml2_LIBRARIES)
+                set(LIBXML2_LIBRARIES ${LibXml2_LIBRARIES})
+                set(LIBXML2_LIBRARY ${LibXml2_LIBRARIES})
+            endif()
+            if(DEFINED LibXml2_DEFINITIONS)
+                set(LIBXML2_DEFINITIONS ${LibXml2_DEFINITIONS})
+            endif()
+            if(DEFINED LibXml2_VERSION)
+                set(LIBXML2_VERSION_STRING ${LibXml2_VERSION})
+            endif()
+        """)
         tools.save(module_file, content)
 
     @property
@@ -293,4 +302,3 @@ class Libxml2Conan(ConanFile):
         self.cpp_info.names["pkg_config"] = "libxml-2.0"
         self.cpp_info.builddirs.append(self._module_subfolder)
         self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]


### PR DESCRIPTION
it reverts https://github.com/conan-io/conan-center-index/commit/ed01e100165f837892439ed6f1b937965be1ba57
which breaks some downtream usage of cmake functions like check_c_source_compiles()

fixes https://github.com/conan-io/conan-center-index/issues/6545
fixes https://github.com/conan-io/conan-center-index/issues/6433

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
