### PR TITLE
Update pulseaudio to use components mirroring its .pc files

### DIFF
--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -130,8 +130,6 @@ class PulseAudioConan(ConanFile):
         self.cpp_info.components["pulse"].requires = ["libsndfile::libsndfile", "libcap::libcap"]
         if self.options.with_alsa:
             self.cpp_info.components["pulse"].requires.append("libalsa::libalsa")
-        if self.options.with_glib:
-            self.cpp_info.components["pulse"].requires.append("glib::glib")
         if self.options.get_safe("with_fftw"):
             self.cpp_info.components["pulse"].requires.append("fftw::fftw")
         if self.options.with_x11:

--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -58,11 +58,11 @@ class PulseAudioConan(ConanFile):
 
     def requirements(self):
         self.requires("libsndfile/1.0.31")
-        self.requires("libcap/2.48")
+        self.requires("libcap/2.50")
         if self.options.with_alsa:
             self.requires("libalsa/1.2.4")
         if self.options.with_glib:
-            self.requires("glib/2.68.2")
+            self.requires("glib/2.69.0")
         if self.options.get_safe("with_fftw"):
             self.requires("fftw/3.3.9")
         if self.options.with_x11:
@@ -122,12 +122,35 @@ class PulseAudioConan(ConanFile):
         tools.remove_files_by_mask(self.package_folder, "*.la")
 
     def package_info(self):
-        self.cpp_info.libdirs = ["lib", os.path.join("lib", "pulseaudio")]
-        if self.options.with_glib:
-            self.cpp_info.libs.append("pulse-mainloop-glib")
-        self.cpp_info.libs.extend(["pulse-simple", "pulse"])
+        self.cpp_info.components["pulse"].names["pkg_config"] = "libpulse"
+        self.cpp_info.components["pulse"].libs = ["pulse"]
         if not self.options.shared:
-            self.cpp_info.libs.append("pulsecommon-%s" % self.version)
-        self.cpp_info.defines = ["_REENTRANT"]
-        self.cpp_info.names["pkg_config"] = "libpulse"
+            self.cpp_info.components["pulse"].libs.append("pulsecommon-%s" % self.version)
+        self.cpp_info.components["pulse"].libdirs = ["lib", os.path.join("lib", "pulseaudio")]
+        self.cpp_info.components["pulse"].requires = ["libsndfile::libsndfile", "libcap::libcap"]
+        if self.options.with_alsa:
+            self.cpp_info.components["pulse"].requires.append("libalsa::libalsa")
+        if self.options.with_glib:
+            self.cpp_info.components["pulse"].requires.append("glib::glib")
+        if self.options.get_safe("with_fftw"):
+            self.cpp_info.components["pulse"].requires.append("fftw::fftw")
+        if self.options.with_x11:
+            self.cpp_info.components["pulse"].requires.append("xorg::xorg")
+        if self.options.with_openssl:
+            self.cpp_info.components["pulse"].requires.append("openssl::openssl")
+        if self.options.with_dbus:
+            self.cpp_info.components["pulse"].requires.append("dbus::dbus")
+        
+        self.cpp_info.components["pulse-mainloop-glib"].names["pkg_config"] = "libpulse-mainloop-glib"
+        self.cpp_info.components["pulse-mainloop-glib"].defines.append("_REENTRANT")
+        self.cpp_info.components["pulse-mainloop-glib"].libs = ["pulse-mainloop-glib"]
+        self.cpp_info.components["pulse-mainloop-glib"].requires = ["pulse", "glib::glib-2.0"]
+
+        self.cpp_info.components["pulse-simple"].names["pkg_config"] = "libpulse-simple"
+        self.cpp_info.components["pulse-simple"].libs = ["pulse-simple"]
+        self.cpp_info.components["pulse-simple"].defines.append("_REENTRANT")
+        self.cpp_info.components["pulse-simple"].requires = ["pulse"]
+
+        self.env_info.PULSEAUDIO_INCLUDE_DIR = os.path.join(self.package_folder, "include")
+        self.env_info.PULSEAUDIO_LIBRARY = os.path.join(self.package_folder, "lib")
         # FIXME: add cmake generators when conan can generate PULSEAUDIO_INCLUDE_DIR PULSEAUDIO_LIBRARY vars

--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -141,16 +141,15 @@ class PulseAudioConan(ConanFile):
         if self.options.with_dbus:
             self.cpp_info.components["pulse"].requires.append("dbus::dbus")
         
-        self.cpp_info.components["pulse-mainloop-glib"].names["pkg_config"] = "libpulse-mainloop-glib"
-        self.cpp_info.components["pulse-mainloop-glib"].defines.append("_REENTRANT")
-        self.cpp_info.components["pulse-mainloop-glib"].libs = ["pulse-mainloop-glib"]
-        self.cpp_info.components["pulse-mainloop-glib"].requires = ["pulse", "glib::glib-2.0"]
-
         self.cpp_info.components["pulse-simple"].names["pkg_config"] = "libpulse-simple"
         self.cpp_info.components["pulse-simple"].libs = ["pulse-simple"]
         self.cpp_info.components["pulse-simple"].defines.append("_REENTRANT")
         self.cpp_info.components["pulse-simple"].requires = ["pulse"]
-
-        self.env_info.PULSEAUDIO_INCLUDE_DIR = os.path.join(self.package_folder, "include")
-        self.env_info.PULSEAUDIO_LIBRARY = os.path.join(self.package_folder, "lib")
+        
+        if self.options.with_glib:
+            self.cpp_info.components["pulse-mainloop-glib"].names["pkg_config"] = "libpulse-mainloop-glib"
+            self.cpp_info.components["pulse-mainloop-glib"].libs = ["pulse-mainloop-glib"]
+            self.cpp_info.components["pulse-mainloop-glib"].defines.append("_REENTRANT")
+            self.cpp_info.components["pulse-mainloop-glib"].requires = ["pulse", "glib::glib-2.0"]
+        
         # FIXME: add cmake generators when conan can generate PULSEAUDIO_INCLUDE_DIR PULSEAUDIO_LIBRARY vars


### PR DESCRIPTION
Specify library name and version:  **pulseaudio/all**

Trying to build qt with pulseaudio I realized that Qt is looking for pulse-mainloop-glib.pc to determine if pulseaudio is present. Therefore I think it would be better to use components to better model the default build structure of the pulseaudio project.

---

- [✓] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [✓] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [✓] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [✓] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
