### PR TITLE
Add support for taocpp-json/1.0.0-beta.10

### DIFF
--- a/recipes/taocpp-json/1.0.0-beta.10/conandata.yml
+++ b/recipes/taocpp-json/1.0.0-beta.10/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0-beta.10":
+    sha256: c6e8eb2b3a1f8dd284e02303527d26c5856cac24e67f1f5a8fc622b892e2cd26
+    url: https://github.com/taocpp/json/archive/1.0.0-beta.10.tar.gz

--- a/recipes/taocpp-json/1.0.0-beta.10/conanfile.py
+++ b/recipes/taocpp-json/1.0.0-beta.10/conanfile.py
@@ -1,0 +1,59 @@
+import os
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.28.0"
+
+class TaoCPPJSONConan(ConanFile):
+    name = "taocpp-json"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/taocpp/json"
+    description = "C++ header-only JSON library"
+    topics = ("json", "jaxn", "cbor", "msgpack",
+              "ubjson", "json-pointer", "json-patch")
+    settings = "compiler"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _min_compilers_version(self):
+        return {
+            "gcc": "5",
+            "clang": "4",
+            "apple-clang": "10",
+            "Visual Studio": "15",
+        }
+
+    def configure(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, "11")
+        min_compiler_version = self._min_compilers_version.get(str(self.settings.compiler), False)
+        if min_compiler_version:
+            if tools.Version(self.settings.compiler.version) < min_compiler_version:
+                raise ConanInvalidConfiguration("taocpp-json requires C++11, which your compiler does not support.")
+        else:
+            self.output.warn("taocpp-json requires C++11. Your compiler is unknown. Assuming it supports C++11.")
+
+    def package_id(self):
+        self.info.header_only()
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "json-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        self.copy("LICENSE*", dst="licenses", src=self._source_subfolder)
+        self.copy("*", dst="include", src=os.path.join(self._source_subfolder, "include"))
+
+    def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "taocpp-json"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "taocpp-json"
+        self.cpp_info.names["cmake_find_package"] = "taocpp"
+        self.cpp_info.names["cmake_find_package_multi"] = "taocpp"
+        self.cpp_info.components["_taocpp-json"].names["cmake_find_package"] = "json"
+        self.cpp_info.components["_taocpp-json"].names["cmake_find_package_multi"] = "json"

--- a/recipes/taocpp-json/config.yml
+++ b/recipes/taocpp-json/config.yml
@@ -1,5 +1,5 @@
 versions:
   "1.0.0-beta.11":
     folder: all
-  "1.0.0-beta.11":
+  "1.0.0-beta.10":
     folder: 1.0.0-beta.10

--- a/recipes/taocpp-json/config.yml
+++ b/recipes/taocpp-json/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.0.0-beta.11":
     folder: all
+  "1.0.0-beta.11":
+    folder: 1.0.0-beta.10


### PR DESCRIPTION
Specify library name and version:  **taocpp-json/1.0.0-beta.10**

Older version of taocpp-json still build with C++11 that is why I wanted to add this version

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
