### PR TITLE
cassandra-cpp-driver: allow to build on macOS with apple-clang + modernize

### DIFF
--- a/recipes/cassandra-cpp-driver/all/conanfile.py
+++ b/recipes/cassandra-cpp-driver/all/conanfile.py
@@ -52,6 +52,10 @@ class CassandraCppDriverConan(ConanFile):
             del self.options.fPIC
             del self.options.use_timerfd
 
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
     def requirements(self):
         self.requires("libuv/1.41.1")
         self.requires("http_parser/2.9.4")

--- a/recipes/cassandra-cpp-driver/all/conanfile.py
+++ b/recipes/cassandra-cpp-driver/all/conanfile.py
@@ -1,6 +1,8 @@
-import os.path
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
 
 
 class CassandraCppDriverConan(ConanFile):
@@ -77,8 +79,8 @@ class CassandraCppDriverConan(ConanFile):
             self.requires("boost/1.76.0")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("cpp-driver-{}".format(self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/cassandra-cpp-driver/all/conanfile.py
+++ b/recipes/cassandra-cpp-driver/all/conanfile.py
@@ -35,6 +35,7 @@ class CassandraCppDriverConan(ConanFile):
         "use_timerfd": True,
     }
 
+    short_paths = True
     generators = "cmake"
     exports_sources = [
         "CMakeLists.txt",

--- a/recipes/cassandra-cpp-driver/all/conanfile.py
+++ b/recipes/cassandra-cpp-driver/all/conanfile.py
@@ -52,17 +52,6 @@ class CassandraCppDriverConan(ConanFile):
             del self.options.fPIC
             del self.options.use_timerfd
 
-    def configure(self):
-        if self.options.use_atomic == "boost":
-            # Compilation error on Linux
-            if self.settings.os == "Linux":
-                raise ConanInvalidConfiguration(
-                    "Boost.Atomic is not supported on Linux at the moment")
-
-        if self.options.with_kerberos:
-            raise ConanInvalidConfiguration(
-                "Kerberos is not supported at the moment")
-
     def requirements(self):
         self.requires("libuv/1.41.1")
         self.requires("http_parser/2.9.4")
@@ -77,6 +66,17 @@ class CassandraCppDriverConan(ConanFile):
 
         if self.options.use_atomic == "boost":
             self.requires("boost/1.76.0")
+
+    def validate(self):
+        if self.options.use_atomic == "boost":
+            # Compilation error on Linux
+            if self.settings.os == "Linux":
+                raise ConanInvalidConfiguration(
+                    "Boost.Atomic is not supported on Linux at the moment")
+
+        if self.options.with_kerberos:
+            raise ConanInvalidConfiguration(
+                "Kerberos is not supported at the moment")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/cassandra-cpp-driver/all/conanfile.py
+++ b/recipes/cassandra-cpp-driver/all/conanfile.py
@@ -20,7 +20,7 @@ class CassandraCppDriverConan(ConanFile):
         "with_openssl": [True, False],
         "with_zlib": [True, False],
         "with_kerberos": [True, False],
-        "use_timerfd": [True, False]
+        "use_timerfd": [True, False],
     }
     default_options = {
         "shared": False,
@@ -30,7 +30,7 @@ class CassandraCppDriverConan(ConanFile):
         "with_openssl": True,
         "with_zlib": True,
         "with_kerberos": False,
-        "use_timerfd": True
+        "use_timerfd": True,
     }
 
     generators = "cmake"
@@ -40,47 +40,6 @@ class CassandraCppDriverConan(ConanFile):
     ]
 
     _cmake = None
-
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-
-        self._cmake = CMake(self)
-        self._cmake.definitions["VERSION"] = self.version
-        self._cmake.definitions["CASS_BUILD_EXAMPLES"] = False
-        self._cmake.definitions["CASS_BUILD_INTEGRATION_TESTS"] = False
-        self._cmake.definitions["CASS_BUILD_SHARED"] = self.options.shared
-        self._cmake.definitions["CASS_BUILD_STATIC"] = not self.options.shared
-        self._cmake.definitions["CASS_BUILD_TESTS"] = False
-        self._cmake.definitions["CASS_BUILD_UNIT_TESTS"] = False
-        self._cmake.definitions["CASS_DEBUG_CUSTOM_ALLOC"] = False
-        self._cmake.definitions["CASS_INSTALL_HEADER_IN_SUBDIR"] = self.options.install_header_in_subdir
-        self._cmake.definitions["CASS_INSTALL_PKG_CONFIG"] = False
-
-        if self.options.use_atomic == "boost":
-            self._cmake.definitions["CASS_USE_BOOST_ATOMIC"] = True
-            self._cmake.definitions["CASS_USE_STD_ATOMIC"] = False
-
-        elif self.options.use_atomic == "std":
-            self._cmake.definitions["CASS_USE_BOOST_ATOMIC"] = False
-            self._cmake.definitions["CASS_USE_STD_ATOMIC"] = True
-        else:
-            self._cmake.definitions["CASS_USE_BOOST_ATOMIC"] = False
-            self._cmake.definitions["CASS_USE_STD_ATOMIC"] = False
-
-        self._cmake.definitions["CASS_USE_OPENSSL"] = self.options.with_openssl
-        self._cmake.definitions["CASS_USE_STATIC_LIBS"] = False
-        self._cmake.definitions["CASS_USE_ZLIB"] = self.options.with_zlib
-        self._cmake.definitions["CASS_USE_LIBSSH2"] = False
-
-        # FIXME: To use kerberos, its conan package is needed. Uncomment this when kerberos conan package is ready.
-        # self._cmake.definitions["CASS_USE_KERBEROS"] = self.options.with_kerberos
-
-        if self.settings.os == "Linux":
-            self._cmake.definitions["CASS_USE_TIMERFD"] = self.options.use_timerfd
-
-        self._cmake.configure()
-        return self._cmake
 
     @property
     def _source_subfolder(self):
@@ -127,6 +86,47 @@ class CassandraCppDriverConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "\"${CMAKE_CXX_COMPILER_ID}\" STREQUAL \"Clang\"",
                               "\"${CMAKE_CXX_COMPILER_ID}\" STREQUAL \"Clang\" OR \"${CMAKE_CXX_COMPILER_ID}\" STREQUAL \"AppleClang\"")
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+
+        self._cmake = CMake(self)
+        self._cmake.definitions["VERSION"] = self.version
+        self._cmake.definitions["CASS_BUILD_EXAMPLES"] = False
+        self._cmake.definitions["CASS_BUILD_INTEGRATION_TESTS"] = False
+        self._cmake.definitions["CASS_BUILD_SHARED"] = self.options.shared
+        self._cmake.definitions["CASS_BUILD_STATIC"] = not self.options.shared
+        self._cmake.definitions["CASS_BUILD_TESTS"] = False
+        self._cmake.definitions["CASS_BUILD_UNIT_TESTS"] = False
+        self._cmake.definitions["CASS_DEBUG_CUSTOM_ALLOC"] = False
+        self._cmake.definitions["CASS_INSTALL_HEADER_IN_SUBDIR"] = self.options.install_header_in_subdir
+        self._cmake.definitions["CASS_INSTALL_PKG_CONFIG"] = False
+
+        if self.options.use_atomic == "boost":
+            self._cmake.definitions["CASS_USE_BOOST_ATOMIC"] = True
+            self._cmake.definitions["CASS_USE_STD_ATOMIC"] = False
+
+        elif self.options.use_atomic == "std":
+            self._cmake.definitions["CASS_USE_BOOST_ATOMIC"] = False
+            self._cmake.definitions["CASS_USE_STD_ATOMIC"] = True
+        else:
+            self._cmake.definitions["CASS_USE_BOOST_ATOMIC"] = False
+            self._cmake.definitions["CASS_USE_STD_ATOMIC"] = False
+
+        self._cmake.definitions["CASS_USE_OPENSSL"] = self.options.with_openssl
+        self._cmake.definitions["CASS_USE_STATIC_LIBS"] = False
+        self._cmake.definitions["CASS_USE_ZLIB"] = self.options.with_zlib
+        self._cmake.definitions["CASS_USE_LIBSSH2"] = False
+
+        # FIXME: To use kerberos, its conan package is needed. Uncomment this when kerberos conan package is ready.
+        # self._cmake.definitions["CASS_USE_KERBEROS"] = self.options.with_kerberos
+
+        if self.settings.os == "Linux":
+            self._cmake.definitions["CASS_USE_TIMERFD"] = self.options.use_timerfd
+
+        self._cmake.configure()
+        return self._cmake
 
     def build(self):
         self._patch_sources()

--- a/recipes/cassandra-cpp-driver/all/conanfile.py
+++ b/recipes/cassandra-cpp-driver/all/conanfile.py
@@ -103,19 +103,19 @@ class CassandraCppDriverConan(ConanFile):
                 "Kerberos is not supported at the moment")
 
     def requirements(self):
-        self.requires("libuv/1.40.0")
+        self.requires("libuv/1.41.1")
         self.requires("http_parser/2.9.4")
         self.requires("rapidjson/cci.20200410")
 
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1i")
+            self.requires("openssl/1.1.1k")
 
         if self.options.with_zlib:
             self.requires("minizip/1.2.11")
             self.requires("zlib/1.2.11")
 
         if self.options.use_atomic == "boost":
-            self.requires("boost/1.75.0")
+            self.requires("boost/1.76.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Very bad practice of upstream CMakeLists: they raise if they don't know the compiler, but it's for trivial things like adding warnings or enabling C++11...

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
