### PR TITLE
cpuinfo: fix cross-build (not only armv8) + modernize

### DIFF
--- a/recipes/cpuinfo/all/conanfile.py
+++ b/recipes/cpuinfo/all/conanfile.py
@@ -1,7 +1,8 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
-import glob
 import os
+
+required_conan_version = ">=1.33.0"
 
 
 class CpuinfoConan(ConanFile):
@@ -47,9 +48,8 @@ class CpuinfoConan(ConanFile):
             raise ConanInvalidConfiguration("shared cpuinfo not supported on Windows")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = glob.glob("cpuinfo-*")[0]
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),

--- a/recipes/cpuinfo/all/conanfile.py
+++ b/recipes/cpuinfo/all/conanfile.py
@@ -44,6 +44,8 @@ class CpuinfoConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
+
+    def validate(self):
         if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration("shared cpuinfo not supported on Windows")
 

--- a/recipes/cpuinfo/all/conanfile.py
+++ b/recipes/cpuinfo/all/conanfile.py
@@ -72,8 +72,14 @@ class CpuinfoConan(ConanFile):
         self._cmake.definitions["CLOG_RUNTIME_TYPE"] = "default"
         self._cmake.definitions["CLOG_BUILD_TESTS"] = False
         self._cmake.definitions["CMAKE_POSITION_INDEPENDENT_CODE"] = self.options.get_safe("fPIC", True)
-        if self.settings.arch == "armv8":
-            self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = "armv8"
+
+        # CMAKE_SYSTEM_PROCESSOR must be manually set if cross-building
+        if tools.cross_building(self.settings):
+            cmake_system_processor = {
+                "armv8": "arm64",
+                "armv8.3": "arm64",
+            }.get(str(self.settings.arch), str(self.settings.arch))
+            self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = cmake_system_processor
 
         self._cmake.configure()
         return self._cmake


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Most of the logic based on `CMAKE_SYSTEM_PROCESSOR` is there: https://github.com/pytorch/cpuinfo/blob/866ae6e5ffe93a1f63be738078da94cf3005cce2/CMakeLists.txt#L125-L196

Using arm64 instead of aarch64 if armv8 or armv8-3 allows to handle more cases, otherwise settings.arch should be enough.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
