### PR TITLE
libstudxml: allow more cross-build hosts + fix MinGW

### DIFF
--- a/recipes/libstudxml/all/conanfile.py
+++ b/recipes/libstudxml/all/conanfile.py
@@ -111,7 +111,7 @@ class LibStudXmlConan(ConanFile):
         autotools.make()
 
     def build(self):
-        for patch in self.conan_data["patches"][self.version]:
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
 
         if self.settings.compiler == "Visual Studio":

--- a/recipes/libstudxml/all/conanfile.py
+++ b/recipes/libstudxml/all/conanfile.py
@@ -40,6 +40,9 @@ class LibStudXmlConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    def requirements(self):
+        self.requires("expat/2.4.1")
+
     def validate(self):
         if self.settings.compiler == "Visual Studio":
             if tools.Version(self.settings.compiler.version) < "9":
@@ -49,9 +52,6 @@ class LibStudXmlConan(ConanFile):
         if self.settings.compiler != "Visual Studio":
             self.build_requires("gnu-config/cci.20201022")
             self.build_requires("libtool/2.4.6")
-
-    def requirements(self):
-        self.requires("expat/2.4.1")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/libstudxml/all/conanfile.py
+++ b/recipes/libstudxml/all/conanfile.py
@@ -111,7 +111,7 @@ class LibStudXmlConan(ConanFile):
             tools.remove_files_by_mask(self._source_subfolder, "version")
 
         with tools.chdir(self._source_subfolder):
-            self.run("./bootstrap", win_bash=tools.os_info.is_windows)
+            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows)
 
         autotools = self._configure_autotools()
         autotools.make()

--- a/recipes/libstudxml/all/test_package/conanfile.py
+++ b/recipes/libstudxml/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Basically it allows to build for iOS armv8 (cross-build to macOS M1 was working).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
