### PR TITLE
gdal: Fix for forced libiconv in non Visual Studio environments

### DIFF
--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -196,8 +196,6 @@ class GdalConan(ConanFile):
             del self.options.with_null
             del self.options.with_zlib # zlib and png are always used in nmake build,
             del self.options.with_png  # and it's not trivial to fix
-        else:
-            del self.options.with_libiconv
         self._strict_options_requirements()
 
     def _strict_options_requirements(self):
@@ -216,7 +214,7 @@ class GdalConan(ConanFile):
             self.requires("zlib/1.2.11")
         if self.options.get_safe("with_libdeflate"):
             self.requires("libdeflate/1.8")
-        if self.options.get_safe("with_libiconv", True):
+        if self.options.with_libiconv:
             self.requires("libiconv/1.16")
         if self.options.get_safe("with_zstd"):
             self.requires("zstd/1.5.0")
@@ -654,7 +652,10 @@ class GdalConan(ConanFile):
         args.append("--with-libz={}".format("yes" if self.options.with_zlib else "no"))
         if self._has_with_libdeflate_option:
             args.append("--with-libdeflate={}".format("yes" if self.options.with_libdeflate else "no"))
-        args.append("--with-libiconv-prefix={}".format(tools.unix_path(self.deps_cpp_info["libiconv"].rootpath)))
+        if self.with_libiconv:
+            args.append("--with-libiconv-prefix={}".format(tools.unix_path(self.deps_cpp_info["libiconv"].rootpath)))
+        else:
+            args.append("--without-libiconv-prefix")
         args.append("--with-liblzma=no") # always disabled: liblzma is an optional transitive dependency of gdal (through libtiff).
         args.append("--with-zstd={}".format("yes" if self.options.get_safe("with_zstd") else "no")) # Optional direct dependency of gdal only if lerc lib enabled
         # Drivers:


### PR DESCRIPTION
The problem with forcing libiconv (LGPL 2.1) is mainly a matter of licensing, making impossible to statically build gdal (MIT license) in enviroments where LGPL is not permitted. The proposed fix honors the option to disable libiconv.

**gdal/3.2.1**

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
