### PR TITLE
spdlog: Bump to 1.9.1

### DIFF
--- a/recipes/spdlog/all/conandata.yml
+++ b/recipes/spdlog/all/conandata.yml
@@ -29,3 +29,6 @@ sources:
   "1.9.0":
     url: "https://github.com/gabime/spdlog/archive/v1.9.0.tar.gz"
     sha256: "9ad181d75aaedbf47c8881e7b947a47cac3d306997e39de24dba60db633e70a7"
+  "1.9.1":
+    url: "https://github.com/gabime/spdlog/archive/v1.9.1.tar.gz"
+    sha256: "9a452cfa24408baccc9b2bc2d421d68172a7630c99e9504a14754be840d31a62"

--- a/recipes/spdlog/config.yml
+++ b/recipes/spdlog/config.yml
@@ -19,3 +19,5 @@ versions:
     folder: "all"
   "1.9.0":
     folder: "all"
+  "1.9.1":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **spdlog/1.9.1**

Also bump fmt dependency to 8.0.0 (not anymore)

Signed-off-by: Alejandro Colomar (EXFO) <alx.manpages@gmail.com>


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
