### PR TITLE
prepare ACADO for conan v2

### DIFF
--- a/recipes/acado/all/conanfile.py
+++ b/recipes/acado/all/conanfile.py
@@ -102,11 +102,14 @@ class AcadoConan(ConanFile):
         else:
             self.cpp_info.libs = ["acado_toolkit", "acado_casadi"]
 
+        self.cpp_info.names["CMakeDeps"] = "ACADO"
         self.cpp_info.names["cmake_find_package"] = "ACADO"
         self.cpp_info.names["cmake_find_package_multi"] = "ACADO"
 
         self.cpp_info.builddirs.append(os.path.join("lib", "cmake"))
-        self.cpp_info.build_modules.append(os.path.join("lib", "cmake", "qpoases.cmake"))
+        self.cpp_info.build_modules["CMakeDeps"].append(os.path.join("lib", "cmake", "qpoases.cmake"))
+        self.cpp_info.build_modules["cmake_find_package"].append(os.path.join("lib", "cmake", "qpoases.cmake"))
+        self.cpp_info.build_modules["cmake_find_package_multi"].append(os.path.join("lib", "cmake", "qpoases.cmake"))
 
         self.cpp_info.includedirs.append(os.path.join("include", "acado"))
         self.cpp_info.includedirs.append(self._qpoases_sources)


### PR DESCRIPTION
Specify library name and version:  **ACADO /1.2.2-beta**

fixing conan v2 incompatibility

general questions:
- is it too early for that?
- what should be the supported generators, is `CMakeDeps` enough?
- What if I want this to apply to all generators, do they all need to be listed explicitly?

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
