### PR TITLE
poppler: fix includedirs + bump dependencies + modernize

### DIFF
--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -124,13 +124,13 @@ class PopplerConan(ConanFile):
         if self.options.with_cairo:
             self.requires("cairo/1.17.4")
         if self.options.get_safe("with_glib"):
-            self.requires("glib/2.68.1")
+            self.requires("glib/2.69.0")
         if self.options.get_safe("with_gobject_introspection"):
             self.requires("gobject-introspection/1.68.0")
         if self.options.with_qt:
-            self.requires("qt/6.0.3")
+            self.requires("qt/6.1.2")
         if self.options.get_safe("with_gtk"):
-            self.requires("gtk/3.24.24")
+            self.requires("gtk/4.1.2")
         if self.options.with_openjpeg:
             self.requires("openjpeg/2.4.0")
         if self.options.with_lcms:
@@ -143,11 +143,11 @@ class PopplerConan(ConanFile):
             # FIXME: missing nss recipe
             raise ConanInvalidConfiguration("nss is not (yet) available on cci")
         if self.options.with_tiff:
-            self.requires("libtiff/4.2.0")
+            self.requires("libtiff/4.3.0")
         if self.options.splash:
             self.requires("boost/1.76.0")
         if self.options.with_libcurl:
-            self.requires("libcurl/7.75.0")
+            self.requires("libcurl/7.78.0")
         if self.options.with_zlib:
             self.requires("zlib/1.2.11")
 

--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import CMake, ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class PopplerConan(ConanFile):
     name = "poppler"
@@ -153,8 +155,8 @@ class PopplerConan(ConanFile):
             self.requires("zlib/1.2.11")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("poppler-{}".format(self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     @property
     def _dct_decoder(self):
@@ -225,7 +227,6 @@ class PopplerConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "FREETYPE_INCLUDE_DIRS",
                               "Freetype_INCLUDE_DIRS")
-
 
     def build(self):
         self._patch_sources()

--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -81,7 +81,7 @@ class PopplerConan(ConanFile):
 
     @property
     def _minimum_compilers_version(self):
-        # Poppler requires C++14 
+        # Poppler requires C++14
         return {
             "Visual Studio": "15",
             "gcc": "5",
@@ -101,16 +101,16 @@ class PopplerConan(ConanFile):
             del self.options.with_libiconv
         if self.options.fontconfiguration == "win32" and self.settings.os != "Windows":
             raise ConanInvalidConfiguration("'win32' option of fontconfig is only available on Windows")
-        
+
         # C++ standard required
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, 14)
 
-        minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False) 
-        if not minimum_version: 
-            self.output.warn("C++14 support required. Your compiler is unknown. Assuming it supports C++14.") 
-        elif tools.Version(self.settings.compiler.version) < minimum_version: 
-            raise ConanInvalidConfiguration("C++14 support required, which your compiler does not support.") 
+        minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
+        if not minimum_version:
+            self.output.warn("C++14 support required. Your compiler is unknown. Assuming it supports C++14.")
+        elif tools.Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration("C++14 support required, which your compiler does not support.")
 
     def build_requirements(self):
         self.build_requires("pkgconf/1.7.3")
@@ -240,6 +240,7 @@ class PopplerConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.components["libpoppler"].libs = ["poppler"]
+        self.cpp_info.components["libpoppler"].includedirs.append(os.path.join("include", "poppler"))
         self.cpp_info.components["libpoppler"].names["pkg_config"] = "poppler"
         if not self.options.shared:
             self.cpp_info.components["libpoppler"].defines = ["POPPLER_STATIC"]

--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -114,9 +114,6 @@ class PopplerConan(ConanFile):
         elif tools.Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("C++14 support required, which your compiler does not support.")
 
-    def build_requirements(self):
-        self.build_requires("pkgconf/1.7.3")
-
     def requirements(self):
         self.requires("poppler-data/0.4.10")
         self.requires("freetype/2.10.4")
@@ -153,6 +150,9 @@ class PopplerConan(ConanFile):
             self.requires("libcurl/7.75.0")
         if self.options.with_zlib:
             self.requires("zlib/1.2.11")
+
+    def build_requirements(self):
+        self.build_requires("pkgconf/1.7.4")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

include dir was wrong, and gave me errors while compiling `gdal` with `poppler` support.

Indeed, here is the content of `poppler.pc` generated by upstream CMakeLists:

```
prefix=/Users/spaceim/.conan/data/poppler/20.09.0/_/_/package/1642c0838e1e86ae97faf2761a520267a204e68d
libdir=/Users/spaceim/.conan/data/poppler/20.09.0/_/_/package/1642c0838e1e86ae97faf2761a520267a204e68d/lib
includedir=/Users/spaceim/.conan/data/poppler/20.09.0/_/_/package/1642c0838e1e86ae97faf2761a520267a204e68d/include

Name: poppler
Description: PDF rendering library
Version: 20.09.0

Libs: -L${libdir} -lpoppler
Cflags: -I${includedir}/poppler
```

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
