### PR TITLE
bison: add missing build requirement flex

### DIFF
--- a/recipes/bison/all/conanfile.py
+++ b/recipes/bison/all/conanfile.py
@@ -40,7 +40,7 @@ class BisonConan(ConanFile):
             self.build_requires("msys2/20190524")
         if self.settings.compiler == "Visual Studio":
             self.build_requires("automake/1.16.2")
-        if not tools.os_info.is_windows:
+        if self.settings.os != "Windows":
             self.build_requires("flex/2.6.4")
 
     def config_options(self):

--- a/recipes/bison/all/conanfile.py
+++ b/recipes/bison/all/conanfile.py
@@ -40,7 +40,7 @@ class BisonConan(ConanFile):
             self.build_requires("msys2/20190524")
         if self.settings.compiler == "Visual Studio":
             self.build_requires("automake/1.16.2")
-        if self.settings.os == "Linux":
+        if not tools.os_info.is_windows:
             self.build_requires("flex/2.6.4")
 
     def config_options(self):

--- a/recipes/bison/all/conanfile.py
+++ b/recipes/bison/all/conanfile.py
@@ -40,6 +40,8 @@ class BisonConan(ConanFile):
             self.build_requires("msys2/20190524")
         if self.settings.compiler == "Visual Studio":
             self.build_requires("automake/1.16.2")
+        if self.settings.os == "Linux":
+            self.build_requires("flex/2.6.4")
 
     def config_options(self):
         if self.settings.os == "Windows":


### PR DESCRIPTION
Bison detects and uses flex. Without the build, the requirement build fails if the system flex is too old.
Note, bison only corrects flex from the build requirement if flex provides the `LEX` environment variable. See https://github.com/conan-io/conan-center-index/pull/6591

Specify library name and version:  **bison/***

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
