### PR TITLE
libcurl: Add missing options

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -325,10 +325,10 @@ class LibcurlConan(ConanFile):
         if self._has_metalink_option:
             params.append("--with-libmetalink={}".format(yes_no(self.options.with_libmetalink)))
         
-        if !self.options.with_proxy:
+        if not self.options.with_proxy:
             params.append("--disable-proxy")
        
-        if !self.options.with_rtsp:
+        if not self.options.with_rtsp:
             params.append("--disable-rtsp")
 
         # Cross building flags

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -39,6 +39,8 @@ class LibcurlConan(ConanFile):
         "with_brotli": [True, False],
         "with_zstd": [True, False],
         "with_c_ares": [True, False],
+        "with_proxy": [True, False],
+        "with_rtsp": [True, False],
     }
     default_options = {
         "shared": False,
@@ -60,6 +62,8 @@ class LibcurlConan(ConanFile):
         "with_brotli": False,
         "with_zstd": False,
         "with_c_ares": False,
+        "with_proxy": True,
+        "with_rtsp": True,
     }
 
     _autotools = None
@@ -144,8 +148,6 @@ class LibcurlConan(ConanFile):
 
         # These options are not used in CMake build yet
         if self._is_using_cmake_build:
-            del self.options.with_libidn
-            del self.options.with_librtmp
             del self.options.with_libpsl
 
     def requirements(self):
@@ -290,6 +292,8 @@ class LibcurlConan(ConanFile):
             "--enable-debug={}".format(yes_no(self.settings.build_type == "Debug")),
             "--enable-ares={}".format(yes_no(self.options.with_c_ares)),
             "--enable-threaded-resolver={}".format(yes_no(self.options.with_c_ares)),
+            "--disable-proxy={}".format(yes_no(self.options.with_proxy)),
+            "--disable-rtsp={}".format(yes_no(self.options.with_rtsp)),
         ]
         if self.options.with_ssl == "openssl":
             params.append("--with-ssl={}".format(tools.unix_path(self.deps_cpp_info["openssl"].rootpath)))
@@ -437,6 +441,10 @@ class LibcurlConan(ConanFile):
             self._cmake.definitions["CURL_ZSTD"] = self.options.with_zstd
         self._cmake.definitions["CMAKE_USE_LIBSSH2"] = self.options.with_libssh2
         self._cmake.definitions["ENABLE_ARES"] = self.options.with_c_ares
+        self._cmake.definitions["CURL_DISABLE_PROXY"] = not self.options.with_proxy
+        self._cmake.definitions["USE_LIBRTMP"] = self.options.with_librtmp
+        self._cmake.definitions["USE_LIBIDN2"] = self.options.with_libidn
+        self._cmake.definitions["CURL_DISABLE_RTSP"] = not self.options.with_rtsp
 
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -148,6 +148,8 @@ class LibcurlConan(ConanFile):
 
         # These options are not used in CMake build yet
         if self._is_using_cmake_build:
+            if tools.Version(self.version) < "7.75.0":
+                del self.options.with_libidn
             del self.options.with_libpsl
 
     def requirements(self):
@@ -443,7 +445,8 @@ class LibcurlConan(ConanFile):
         self._cmake.definitions["ENABLE_ARES"] = self.options.with_c_ares
         self._cmake.definitions["CURL_DISABLE_PROXY"] = not self.options.with_proxy
         self._cmake.definitions["USE_LIBRTMP"] = self.options.with_librtmp
-        self._cmake.definitions["USE_LIBIDN2"] = self.options.with_libidn
+        if tools.Version(self.version) >= "7.75.0":
+            self._cmake.definitions["USE_LIBIDN2"] = self.options.with_libidn
         self._cmake.definitions["CURL_DISABLE_RTSP"] = not self.options.with_rtsp
 
         self._cmake.configure(build_folder=self._build_subfolder)

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -294,8 +294,6 @@ class LibcurlConan(ConanFile):
             "--enable-debug={}".format(yes_no(self.settings.build_type == "Debug")),
             "--enable-ares={}".format(yes_no(self.options.with_c_ares)),
             "--enable-threaded-resolver={}".format(yes_no(self.options.with_c_ares)),
-            "--disable-proxy={}".format(yes_no(self.options.with_proxy)),
-            "--disable-rtsp={}".format(yes_no(self.options.with_rtsp)),
         ]
         if self.options.with_ssl == "openssl":
             params.append("--with-ssl={}".format(tools.unix_path(self.deps_cpp_info["openssl"].rootpath)))
@@ -326,6 +324,12 @@ class LibcurlConan(ConanFile):
 
         if self._has_metalink_option:
             params.append("--with-libmetalink={}".format(yes_no(self.options.with_libmetalink)))
+        
+        if !self.options.with_proxy:
+            params.append("--disable-proxy")
+       
+        if !self.options.with_rtsp:
+            params.append("--disable-rtsp")
 
         # Cross building flags
         if tools.cross_building(self.settings):


### PR DESCRIPTION
Update libcurl recipe to include additional options and add more existing options to the cmake build.

Found when porting existing internal dependency management over to conan that the recipe for libcurl didn't have the configuration options we need for our product. 

Rather than keeping these parameters internally wanted to upstream them to benefit the wider community.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
