### PR TITLE
cunit: make package suitable for cross building

### DIFF
--- a/recipes/cunit/all/test_package/conanfile.py
+++ b/recipes/cunit/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **cunit/2.1-3**

This PR replaces uses `self._deps_user_info` with `self._user_build_info` so the package is supports cross building (verified by compiling x86 on a x86_64 Windows system). Apart from that it also fixes what I think is a small typo: `_configure_autools` > `_configure_autotools`.

@madebr kindlly helped me along on #7565, in return I thought I'd open a PR instead of an issue. Thanks.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
