### PR TITLE
Update changelog from past deployments

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@
 
 - [feature] Do not run the CI for branches starting with `bot/...` (branches intended for automations).
 - [feature] Remove all remotes when configuring the Conan client.
-- [feature] ValidateInfrastructure: Update "Supported platformas and configurations" doc automatically.
+- [feature] ValidateInfrastructure: Update "Supported platforms and configurations" doc automatically.
 - [fix] UpdateSearchIndex: Fix parsing of package data.
 - [feature] BuildSingleReference: Add `MSBUILDDISABLENODEREUSE` environment variable for MSBuild to avoid errors when compiling in parallel.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,32 @@
 # Changelog
 
+### 13-July-2021 - 10:24 CEST
+
+- [fix] DeleteRepo: Fix JFrog CLI commands.
+
+### 07-July-2021 - 08:36 CEST
+
+- [feature] UpgradeConan: Upgrade pip before installing Conan.
+- [feature] Upgrade Conan client to the 1.37.2 version.
+
+### 02-July-2021 - 16:45 CEST
+
+- [feature] Do not run the CI for branches starting with `bot/...` (branches intended for automations).
+- [feature] Remove all remotes when configuring the Conan client.
+- [feature] ValidateInfrastructure: Update "Supported platformas and configurations" doc automatically.
+- [fix] UpdateSearchIndex: Fix parsing of package data.
+- [feature] BuildSingleReference: Add `MSBUILDDISABLENODEREUSE` environment variable for MSBuild to avoid errors when compiling in parallel.
+
 ### 01-June-2021 - 08:59 CEST
 
- - [request_reviews] Add column to enable/disable review requests (any user)
- - [testing] Use declared Conan version to run tests
- - [internal] Pay some technical debt
- - [internal] Simplify workflow, all packages already have properties
+ - [feature] RequestReviews: Add column to enable/disable review requests (any user).
+ - [testing] Use declared Conan version to run tests.
+ - [internal] Pay some technical debt.
+ - [internal] Simplify workflow, all packages already have properties.
+
+### 25-May-2021 - 13:42 CEST
+
+- [feature] AutomaticMerge: Skip pull-requests that fail to merge.
 
 ### 24-May-2021 - 15:59 CEST
 
@@ -14,7 +35,7 @@
 - [feature] Upgrade Conan version to 1.35.2.
 - [feature] Use only one Artifactory repository per pull request.
 
-### 13-May-2021 - 17:20 CEST
+### 14-May-2021 - 17:24 CEST
 
 - [fix] Add `--dry-build` to `conan info` commands, it will expand also the build-requires that would have
   failed during the build stage.


### PR DESCRIPTION
I've noticed that we did not update the changelog with the latest deployments.

We will get one more entry soon 😉 