### PR TITLE
(#6598) Add missing extra-cmake-modules versions

### DIFF
--- a/recipes/extra-cmake-modules/all/conandata.yml
+++ b/recipes/extra-cmake-modules/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "5.80.0":
     url: "https://download.kde.org/stable/frameworks/5.80/extra-cmake-modules-5.80.0.tar.xz"
     sha256: "2370fd80f685533d0b96efa6fa443ceea68e0ceba4e8a9d7c151d297b1c96f64"
+  "5.84.0":
+    url: "https://download.kde.org/stable/frameworks/5.84/extra-cmake-modules-5.84.0.tar.xz"
+    sha256: "bb085ef2e177c182ff46988516b6b31849d1497beb2ff5301165ad2ba12a1c41"

--- a/recipes/extra-cmake-modules/config.yml
+++ b/recipes/extra-cmake-modules/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: "all"
   "5.80.0":
     folder: "all"
+  "5.84.0":
+    folder: "all"


### PR DESCRIPTION
Add version 5.84 from extra-cmake-modules, a kde frameworks library with a bunch of cmake calls to ease the development of cmake based projects

Specify library name and version:  **extra-cmake-modules/5.84**

I'm part of the KDE team and I recently started to use conan. I see that most of the kde libraries are not packaged on conan for wider usage, updating ECM is the first step on that.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
