### PR TITLE
pkgconf: test functions by linking

### DIFF
--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -42,11 +42,11 @@ class PkgConfConan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
+    def build_requirements(self):
+        self.build_requires("meson/0.59.0")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
-
-    def build_requirements(self):
-        self.build_requires("meson/0.58.1")
 
     @property
     def _sharedstatedir(self):
@@ -62,7 +62,7 @@ class PkgConfConan(ConanFile):
         return self._meson
 
     def _patch_sources(self):
-        for patch in self.conan_data["patches"][self.version]:
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         if not self.options.shared:
             tools.replace_in_file(os.path.join(self._source_subfolder, "meson.build"),

--- a/recipes/pkgconf/all/patches/1.7.3-0002-clang-12-strndup-not-in-string-h.patch
+++ b/recipes/pkgconf/all/patches/1.7.3-0002-clang-12-strndup-not-in-string-h.patch
@@ -5,15 +5,15 @@
 -  ['HAVE_STRLCAT', 'strlcat', 'string.h'],
 -  ['HAVE_STRLCPY', 'strlcpy', 'string.h'],
 -  ['HAVE_STRNDUP', 'strndup', 'string.h'],
-+  ['HAVE_CYGWIN_CONV_PATH', 'cygwin_conv_path', 'sys/cygwin.h'],
-+  ['HAVE_STRLCAT', 'strlcat(NULL, NULL, 0)', 'string.h'],     
-+  ['HAVE_STRLCPY', 'strlcpy(NULL, NULL, 0)', 'string.h'],
-+  ['HAVE_STRNDUP', 'strndup(NULL, 0)', 'string.h'],
++  ['HAVE_CYGWIN_CONV_PATH', 'cygwin_conv_path(CCP_POSIX_TO_WIN_A, (void*)0, (void*)0, 0)', 'sys/cygwin.h'],
++  ['HAVE_STRLCAT', 'strlcat((void*)0, (void*)0, 0)', 'string.h'],     
++  ['HAVE_STRLCPY', 'strlcpy((void*)0, (void*)0, 0)', 'string.h'],
++  ['HAVE_STRNDUP', 'strndup((void*)0, 0)', 'string.h'],
  ]
  
  foreach f : check_functions
 -  if cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') and cc.has_header_symbol(f.get(2), f.get(1))
-+  if cc.links('#include <' + f.get(2) + '>\nint main() { f.get(1) }')
++  if cc.links('#include <' + f.get(2) + '>\nint main() { ' + f.get(1) + ';}')
      cdata.set(f.get(0), 1)
    endif
  endforeach

--- a/recipes/pkgconf/all/patches/1.7.3-0002-clang-12-strndup-not-in-string-h.patch
+++ b/recipes/pkgconf/all/patches/1.7.3-0002-clang-12-strndup-not-in-string-h.patch
@@ -1,11 +1,19 @@
 --- meson.build
 +++ meson.build
-@@ -35,7 +35,7 @@
+@@ -31,11 +31,11 @@
+-  ['HAVE_CYGWIN_CONV_PATH', 'cygwin_conv_path', 'sys/cygwin.h'],
+-  ['HAVE_STRLCAT', 'strlcat', 'string.h'],
+-  ['HAVE_STRLCPY', 'strlcpy', 'string.h'],
+-  ['HAVE_STRNDUP', 'strndup', 'string.h'],
++  ['HAVE_CYGWIN_CONV_PATH', 'cygwin_conv_path', 'sys/cygwin.h'],
++  ['HAVE_STRLCAT', 'strlcat(NULL, NULL, 0)', 'string.h'],     
++  ['HAVE_STRLCPY', 'strlcpy(NULL, NULL, 0)', 'string.h'],
++  ['HAVE_STRNDUP', 'strndup(NULL, 0)', 'string.h'],
  ]
  
  foreach f : check_functions
 -  if cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') and cc.has_header_symbol(f.get(2), f.get(1))
-+  if cc.has_function(f.get(1)) or (cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') and cc.has_header_symbol(f.get(2), f.get(1)))
++  if cc.links('#include <' + f.get(2) + '>\nint main() { f.get(1) }')
      cdata.set(f.get(0), 1)
    endif
  endforeach

--- a/recipes/pkgconf/all/patches/1.7.4-0001-clang-12-strndup-not-in-string-h.patch
+++ b/recipes/pkgconf/all/patches/1.7.4-0001-clang-12-strndup-not-in-string-h.patch
@@ -5,15 +5,15 @@
 -  ['HAVE_STRLCAT', 'strlcat', 'string.h'],
 -  ['HAVE_STRLCPY', 'strlcpy', 'string.h'],
 -  ['HAVE_STRNDUP', 'strndup', 'string.h'],
-+  ['HAVE_CYGWIN_CONV_PATH', 'cygwin_conv_path', 'sys/cygwin.h'],
-+  ['HAVE_STRLCAT', 'strlcat(NULL, NULL, 0)', 'string.h'],     
-+  ['HAVE_STRLCPY', 'strlcpy(NULL, NULL, 0)', 'string.h'],
-+  ['HAVE_STRNDUP', 'strndup(NULL, 0)', 'string.h'],
++  ['HAVE_CYGWIN_CONV_PATH', 'cygwin_conv_path(CCP_POSIX_TO_WIN_A, (void*)0, (void*)0, 0)', 'sys/cygwin.h'],
++  ['HAVE_STRLCAT', 'strlcat((void*)0, (void*)0, 0)', 'string.h'],     
++  ['HAVE_STRLCPY', 'strlcpy((void*)0, (void*)0, 0)', 'string.h'],
++  ['HAVE_STRNDUP', 'strndup((void*)0, 0)', 'string.h'],
  ]
  
  foreach f : check_functions
 -  if cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') and cc.has_header_symbol(f.get(2), f.get(1))
-+  if cc.links('#include <' + f.get(2) + '>\nint main() { f.get(1) }')
++  if cc.links('#include <' + f.get(2) + '>\nint main() { ' + f.get(1) + ';}')
      cdata.set(f.get(0), 1)
    endif
  endforeach

--- a/recipes/pkgconf/all/patches/1.7.4-0001-clang-12-strndup-not-in-string-h.patch
+++ b/recipes/pkgconf/all/patches/1.7.4-0001-clang-12-strndup-not-in-string-h.patch
@@ -1,11 +1,19 @@
 --- meson.build
 +++ meson.build
-@@ -17,7 +17,7 @@
+@@ -13,11 +13,11 @@
+-  ['HAVE_CYGWIN_CONV_PATH', 'cygwin_conv_path', 'sys/cygwin.h'],
+-  ['HAVE_STRLCAT', 'strlcat', 'string.h'],
+-  ['HAVE_STRLCPY', 'strlcpy', 'string.h'],
+-  ['HAVE_STRNDUP', 'strndup', 'string.h'],
++  ['HAVE_CYGWIN_CONV_PATH', 'cygwin_conv_path', 'sys/cygwin.h'],
++  ['HAVE_STRLCAT', 'strlcat(NULL, NULL, 0)', 'string.h'],     
++  ['HAVE_STRLCPY', 'strlcpy(NULL, NULL, 0)', 'string.h'],
++  ['HAVE_STRNDUP', 'strndup(NULL, 0)', 'string.h'],
  ]
  
  foreach f : check_functions
 -  if cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') and cc.has_header_symbol(f.get(2), f.get(1))
-+  if cc.has_function(f.get(1)) or (cc.has_function(f.get(1), prefix : '#include <' + f.get(2) + '>') and cc.has_header_symbol(f.get(2), f.get(1)))
++  if cc.links('#include <' + f.get(2) + '>\nint main() { f.get(1) }')
      cdata.set(f.get(0), 1)
    endif
  endforeach

--- a/recipes/pkgconf/all/test_package/conanfile.py
+++ b/recipes/pkgconf/all/test_package/conanfile.py
@@ -8,17 +8,20 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
 
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
     def build_requirements(self):
         self.build_requires("automake/1.16.3")
-        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH") \
-                and tools.os_info.detect_windows_subsystem() != "msys2":
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 
     def build(self):
         # Test pkg.m4 integration into automake
         shutil.copy(os.path.join(self.source_folder, "configure.ac"),
                     os.path.join(self.build_folder, "configure.ac"))
-        self.run("autoreconf -fiv", run_environment=True, win_bash=tools.os_info.is_windows)
+        self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True, win_bash=tools.os_info.is_windows)
         autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         with tools.environment_append(RunEnvironment(self).vars):
             autotools.configure()
@@ -28,7 +31,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             self.run(os.path.join("bin", "test_package"), run_environment=True)
 
             pkg_config = tools.get_env("PKG_CONFIG")


### PR DESCRIPTION
Specify library name and version:  **pkgconf/all**

It looks like mingw-w64 has `strndup` available when compiling, but not when linking.
Test this by doing a test compile + link instead of only testing for availability.


Fixes #6489

Tested with mingw-w64 + Visual Studio 16 2019
Not tested on clang 12 yet, for which this patch was meant initially.
=> tested with clang 12 and it works!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
