### PR TITLE
glu/system: Fix cpp_info.includedirs typo

### DIFF
--- a/recipes/glu/all/conanfile.py
+++ b/recipes/glu/all/conanfile.py
@@ -55,7 +55,7 @@ class SysConfigGLUConan(ConanFile):
         self.cpp_info.cxxflags.extend(cflags)
 
     def package_info(self):
-        self.cpp_info.include_dirs = []
+        self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []
 
         if self.settings.os == "Windows":


### PR DESCRIPTION
Specify library name and version:  **glu/system**

Fixes https://github.com/conan-io/conan-center-index/issues/6575

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
