### PR TITLE
abseil: inject CMAKE_SYSTEM_PROCESSOR if cross-building

### DIFF
--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -51,6 +51,8 @@ class ConanRecipe(ConanFile):
             self._cmake.definitions["CMAKE_CXX_STANDARD"] = 11
         self._cmake.definitions["ABSL_ENABLE_INSTALL"] = True
         self._cmake.definitions["BUILD_TESTING"] = False
+        if tools.cross_building(self):
+            self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = str(self.settings.arch)
         self._cmake.configure()
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

When you cross-compile abseil, you can see this warning:

```
CMake Warning at source_subfolder/absl/copts/AbseilConfigureCopts.cmake:30 (message):
  Value of CMAKE_SYSTEM_PROCESSOR () is unknown and cannot be used to set
  ABSL_RANDOM_RANDEN_COPTS
Call Stack (most recent call first):
  source_subfolder/CMake/AbseilHelpers.cmake:18 (include)
  source_subfolder/CMakeLists.txt:73 (include)
```

Indeed, abseil has some logic based on CMAKE_SYSTEM_PROCESSOR: https://github.com/abseil/abseil-cpp/blob/20210324.2/absl/copts/AbseilConfigureCopts.cmake#L15-L32
When you cross-compile, CMAKE_SYSTEM_PROCESSOR is empty by default (and conan doesn't set this variable for you).

`self.settings.arch` should be sufficient.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
