### PR TITLE
gdal: hotfix - cross-build detection in validate()

### DIFF
--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -330,7 +330,7 @@ class GdalConan(ConanFile):
             raise ConanInvalidConfiguration("gdal:with_libdeflate=True requires gdal:with_zlib=True")
         if self.options.with_qhull and self.options["qhull"].reentrant:
             raise ConanInvalidConfiguration("gdal depends on non-reentrant qhull.")
-        if tools.cross_building(self):
+        if hasattr(self, "settings_build") and tools.cross_building(self):
             if self.options.shared:
                 raise ConanInvalidConfiguration("GDAL build system can't cross-build shared lib")
             if self.options.tools:


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

see this comment https://github.com/conan-io/conan-center-index/pull/6586#discussion_r680421209
Without this fix, shared macOS & Windows packages are not generated in CI of CCI

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
