### PR TITLE
opencv: add option to enable ADE for opencv/4.x

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -21,6 +21,7 @@ class OpenCVConan(ConanFile):
         "contrib_freetype": [True, False],
         "contrib_sfm": [True, False],
         "parallel": [False, "tbb", "openmp"],
+        "with_ade": [True, False],
         "with_jpeg": [False, "libjpeg", "libjpeg-turbo"],
         "with_png": [True, False],
         "with_tiff": [True, False],
@@ -49,6 +50,7 @@ class OpenCVConan(ConanFile):
         "contrib": False,
         "contrib_freetype": False,
         "contrib_sfm": False,
+        "with_ade": True,
         "with_jpeg": "libjpeg",
         "with_png": True,
         "with_tiff": True,
@@ -162,6 +164,8 @@ class OpenCVConan(ConanFile):
             self.requires("gtk/system")
         if self.options.dnn:
             self.requires("protobuf/3.17.1")
+        if self.options.with_ade:
+            self.requires("ade/0.1.1f")
 
     def validate(self):
         if self.settings.compiler == "Visual Studio" and \
@@ -220,6 +224,17 @@ class OpenCVConan(ConanFile):
                 tools.replace_in_file(find_protobuf,
                                       'if(TARGET "${Protobuf_LIBRARIES}")',
                                       'if(FALSE)  # patch: disable if(TARGET "${Protobuf_LIBRARIES}")')
+        if self.options.with_ade:
+            ade_cmake = os.path.join(self._source_subfolder, "modules", "gapi",
+                                     "cmake", "init.cmake")
+            replacement = '''find_package(ade REQUIRED)
+            if(ade_DIR)'''
+            tools.replace_in_file(ade_cmake, 'if(ade_DIR)', replacement, strict=False)
+            tools.replace_in_file(ade_cmake, 'if (ade_DIR)', replacement, strict=False)
+            tools.replace_in_file(ade_cmake, "TARGET ade", "TARGET ade::ade")
+            gapi_cmake = os.path.join(self._source_subfolder, "modules", "gapi", "CMakeLists.txt")
+            tools.replace_in_file(gapi_cmake, "ade", "ade::ade")
+
 
     def _configure_cmake(self):
         if self._cmake:
@@ -351,6 +366,7 @@ class OpenCVConan(ConanFile):
             self._cmake.definitions["WITH_OPENMP"] = self.options.parallel == "openmp"
 
         self._cmake.definitions["WITH_CUDA"] = self.options.with_cuda
+        self._cmake.definitions["WITH_ADE"] = self.options.with_ade
         if self.options.with_cuda:
             # This allows compilation on older GCC/NVCC, otherwise build errors.
             self._cmake.definitions["CUDA_NVCC_FLAGS"] = "--expt-relaxed-constexpr"
@@ -560,6 +576,11 @@ class OpenCVConan(ConanFile):
                 {"target": "opencv_cudastereo",     "lib": "cudastereo",        "requires": ["opencv_core", "opencv_calib3d"] + eigen()},
                 {"target": "opencv_cudawarping",    "lib": "cudawarping",       "requires": ["opencv_core", "opencv_imgproc"] + eigen()},
                 {"target": "opencv_cudev",          "lib": "cudev",             "requires": [] + eigen()},
+            ])
+
+        if self.options.with_ade:
+            opencv_components.extend([
+                {"target": "opencv_gapi",           "lib": "gapi",              "requires": ["opencv_imgproc", "opencv_calib3d", "opencv_video", "ade::ade"]},
             ])
 
         return opencv_components

--- a/recipes/opencv/4.x/test_package/CMakeLists.txt
+++ b/recipes/opencv/4.x/test_package/CMakeLists.txt
@@ -6,6 +6,11 @@ conan_basic_setup(TARGETS)
 
 find_package(OpenCV REQUIRED imgcodecs highgui objdetect CONFIG)
 
+option(built_with_ade "Enabled if opencv is built with ade" OFF)
+if(built_with_ade)
+    add_definitions(-DBUILT_WITH_ADE)
+endif()
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} opencv_imgcodecs opencv_highgui opencv_objdetect)
+target_link_libraries(${PROJECT_NAME} opencv_imgcodecs opencv_highgui opencv_objdetect $<TARGET_NAME_IF_EXISTS:opencv_gapi>)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/opencv/4.x/test_package/conanfile.py
+++ b/recipes/opencv/4.x/test_package/conanfile.py
@@ -8,6 +8,7 @@ class OpenCVTestConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["built_with_ade"] = self.options["opencv"].with_ade
         cmake.configure()
         cmake.build()
 

--- a/recipes/opencv/4.x/test_package/test_package.cpp
+++ b/recipes/opencv/4.x/test_package/test_package.cpp
@@ -7,6 +7,11 @@
  */
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>
+#ifdef BUILT_WITH_ADE
+#include <opencv2/gapi.hpp>
+#include <opencv2/gapi/core.hpp>
+#include <opencv2/gapi/imgproc.hpp>
+#endif
 
 #define w 400
 
@@ -17,6 +22,8 @@ void MyEllipse( Mat img, double angle );
 void MyFilledCircle( Mat img, Point center );
 void MyPolygon( Mat img );
 void MyLine( Mat img, Point start, Point end );
+// to test `with_ade` option
+void TestGAPI();
 
 /**
  * @function main
@@ -71,6 +78,7 @@ int main( void ){
   MyLine( rook_image, Point( w/2, 7*w/8 ), Point( w/2, w ) );
   MyLine( rook_image, Point( 3*w/4, 7*w/8 ), Point( 3*w/4, w ) );
   //![draw_rook]
+  TestGAPI();
 
   return(0);
 }
@@ -177,3 +185,23 @@ void MyLine( Mat img, Point start, Point end )
     lineType );
 }
 //![my_line]
+
+/**
+ * @function TestGAPI
+   @brief to test `with_ade`
+   derived from https://docs.opencv.org/4.5.0/d0/d1e/gapi.html
+*/
+void TestGAPI()
+{
+#ifdef BUILT_WITH_ADE
+    cv::GMat in;
+    cv::GMat vga      = cv::gapi::resize(in, cv::Size(), 0.5, 0.5);
+    cv::GMat gray     = cv::gapi::BGR2Gray(vga);
+    cv::GMat blurred  = cv::gapi::blur(gray, cv::Size(5,5));
+    cv::GMat edges    = cv::gapi::Canny(blurred, 32, 128, 3);
+    cv::GMat b,g,r;
+    std::tie(b,g,r)   = cv::gapi::split3(vga);
+    cv::GMat out      = cv::gapi::merge3(b, g | edges, r);
+    cv::GComputation ac(in, out);
+#endif
+}


### PR DESCRIPTION
Specify library name and version:  **opencv/4.x**

Allow opencv to be built with ADE enabled.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
