### PR TITLE
Add dav1d/0.9.1, modernize

### DIFF
--- a/recipes/dav1d/all/conandata.yml
+++ b/recipes/dav1d/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "0.8.1":
     url: "https://code.videolan.org/videolan/dav1d/-/archive/0.8.1/dav1d-0.8.1.tar.gz"
     sha256: "39f52cccc31180c7180ebe8f223de6d12351c0407de0dfac087e8a9cc3feb8da"
+  "0.9.1":
+    url: "https://code.videolan.org/videolan/dav1d/-/archive/0.9.1/dav1d-0.9.1.tar.gz"
+    sha256: "097db6f370b88bf09fec62919c0d3af64e07d58210c665ec461d63f4ec79f6a2"

--- a/recipes/dav1d/all/conanfile.py
+++ b/recipes/dav1d/all/conanfile.py
@@ -1,7 +1,8 @@
 import os
 from conans import ConanFile, Meson, tools
 
-required_conan_version = ">= 1.29.1"
+required_conan_version = ">=1.33.0"
+
 
 class Dav1dConan(ConanFile):
     name = "dav1d"
@@ -63,8 +64,8 @@ class Dav1dConan(ConanFile):
             self.build_requires("nasm/2.15.05")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("dav1d-{}".format(self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
         tools.replace_in_file(os.path.join(self._source_subfolder, "meson.build"),

--- a/recipes/dav1d/all/conanfile.py
+++ b/recipes/dav1d/all/conanfile.py
@@ -49,7 +49,7 @@ class Dav1dConan(ConanFile):
             self.options.assembly = False
 
     def validate(self):
-        if tools.cross_building(self):
+        if hasattr(self, "settings_build") and tools.cross_building(self):
             raise ConanInvalidConfiguration("Cross-building not implemented")
 
     def configure(self):

--- a/recipes/dav1d/all/conanfile.py
+++ b/recipes/dav1d/all/conanfile.py
@@ -1,5 +1,6 @@
 import os
 from conans import ConanFile, Meson, tools
+from conans.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.33.0"
 
@@ -46,6 +47,10 @@ class Dav1dConan(ConanFile):
         if self.settings.compiler == "Visual Studio" and self.settings.build_type == "Debug":
             # debug builds with assembly often causes linker hangs or LNK1000
             self.options.assembly = False
+
+    def validate(self):
+        if tools.cross_building(self):
+            raise ConanInvalidConfiguration("Cross-building not implemented")
 
     def configure(self):
         if self.options.shared:

--- a/recipes/dav1d/all/test_package/CMakeLists.txt
+++ b/recipes/dav1d/all/test_package/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-find_package(dav1d REQUIRED CONFIG)
+conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} dav1d::dav1d)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/dav1d/all/test_package/CMakeLists.txt
+++ b/recipes/dav1d/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(dav1d REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} dav1d::dav1d)

--- a/recipes/dav1d/all/test_package/conanfile.py
+++ b/recipes/dav1d/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/dav1d/all/test_package/conanfile.py
+++ b/recipes/dav1d/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "cmake"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/dav1d/config.yml
+++ b/recipes/dav1d/config.yml
@@ -1,3 +1,5 @@
 versions:
   "0.8.1":
     folder: "all"
+  "0.9.1":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **dav1d/0.9.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

Note: it still uses meson 0.51.0 because the upstream bug was not fixed yet. Meson version is still stored in Conan Center.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
