### PR TITLE
libzip: Honor zstd option enabled

### DIFF
--- a/recipes/libzip/all/test_package/conanfile.py
+++ b/recipes/libzip/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Without this patch, due to casing issues (they have a custom FindZstd.cmake defining Zstd_FOUND and Zstd::Zstd target, while we generate Findzstd.cmake with zstd_FOUND and zstd::zstd target), upstream CMakeLists may fail to enable zstd.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
