### PR TITLE
pdfium: add pdfium/cci.20210730 recipe

### DIFF
--- a/recipes/pdfium/all/CMakeLists.txt
+++ b/recipes/pdfium/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(pdfium-cmake/cmake)

--- a/recipes/pdfium/all/conandata.yml
+++ b/recipes/pdfium/all/conandata.yml
@@ -2,8 +2,8 @@ sources:
   "cci.20210730":
     pdfium-cmake:
       # FIXME: create release + use hash
-      url: "https://github.com/madebr/pdfium-cmake/archive/refs/heads/master.zip"
-      sha256: "ec791f2b6a4a752002bb280c6a7329710b887ba958971fce872d4e37206ae765"
+      url: "https://github.com/madebr/pdfium-cmake/archive/0abc6ac8b3ecd2faac45bf46ee79bf381b5b5890.zip"
+      sha256: "8bcbb1eb6ec171604d669585f289c609d3b6c95045525d0e510c3fee7851d44e"
     pdfium:
       url: "https://pdfium.googlesource.com/pdfium/+archive/6c8cd905587809a0ff299d1edb34fc85bed4c976.tar.gz"
       # sha256 is volatile on googlesource, no up-to-date github fork

--- a/recipes/pdfium/all/conandata.yml
+++ b/recipes/pdfium/all/conandata.yml
@@ -1,0 +1,15 @@
+sources:
+  "cci.20210730":
+    pdfium-cmake:
+      # FIXME: create release + use hash
+      url: "https://github.com/madebr/pdfium-cmake/archive/refs/heads/master.zip"
+      sha256: "ec791f2b6a4a752002bb280c6a7329710b887ba958971fce872d4e37206ae765"
+    pdfium:
+      url: "https://pdfium.googlesource.com/pdfium/+archive/6c8cd905587809a0ff299d1edb34fc85bed4c976.tar.gz"
+      # sha256 is volatile on googlesource, no up-to-date github fork
+    trace_event:
+      url: "https://chromium.googlesource.com/chromium/src/base/trace_event/common/+archive/ad56859ef8c85cc09a3d8e95dcedadb5109a0af8.tar.gz"
+      # sha256 is volatile on googlesource, no up-to-date github fork
+    chromium_build:
+      url: "https://chromium.googlesource.com/chromium/src/build/+archive/95667421554b672f9330df8efb8148b6c2d00594.tar.gz"
+      # sha256 is volatile on googlesource, no up-to-date github fork

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -26,6 +26,7 @@ class PdfiumConan(ConanFile):
 
     exports_sources = "CMakeLists.txt"
     generators = "cmake", "cmake_find_package", "pkg_config"
+    short_paths = True
 
     _cmake = None
 

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -1,0 +1,96 @@
+from conans import CMake, ConanFile, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class PdfiumConan(ConanFile):
+    name = "pdfium"
+    description = "PDF generation and rendering library."
+    license = "BSD-3-Clause"
+    topics = ("conan", "pdfium", "generate", "generation", "rendering", "pdf", "document", "print")
+    homepage = "https://opensource.google/projects/pdfium"
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_libjpeg": ["libjpeg", "libjpeg-turbo"],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_libjpeg": "libjpeg",
+    }
+
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake", "cmake_find_package", "pkg_config"
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def requirements(self):
+        self.requires("freetype/2.10.4")
+        self.requires("icu/69.1")
+        self.requires("lcms/2.11")
+        self.requires("openjpeg/2.4.0")
+        if self.options.with_libjpeg == "libjpeg":
+            self.requires("libjpeg/9d")
+        elif self.options.with_libjpeg == "libjpeg-turbo":
+            self.requires("libjpeg-turbo/2.1.0")
+
+    def build_requirements(self):
+        self.build_requires("pkgconf/1.7.4")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 14)
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version]["pdfium-cmake"],
+                  destination="pdfium-cmake", strip_root=True)
+        tools.get(**self.conan_data["sources"][self.version]["pdfium"],
+                  destination=self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version]["trace_event"],
+                  destination=os.path.join(self._source_subfolder, "base", "trace_event", "common"))
+        tools.get(**self.conan_data["sources"][self.version]["chromium_build"],
+                  destination=os.path.join(self._source_subfolder, "build"))
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["PDFIUM_ROOT"] = os.path.join(self.source_folder, self._source_subfolder).replace("\\", "/")
+        self._cmake.definitions["USE_LIBJPEG_TURBO"] = self.options.with_libjpeg == "libjpeg-turbo"
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+        cmake.configure()
+        cmake.build()
+
+    @property
+    def _use_cmake(self):
+        return True
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["pdfium"]
+        if tools.is_apple_os(self.settings.os):
+            self.cpp_info.frameworks.extend(["Appkit", "CoreFoundation", "CoreGraphics"])

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -82,10 +82,6 @@ class PdfiumConan(ConanFile):
         cmake.configure()
         cmake.build()
 
-    @property
-    def _use_cmake(self):
-        return True
-
     def package(self):
         cmake = self._configure_cmake()
         cmake.install()

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -87,6 +87,7 @@ class PdfiumConan(ConanFile):
         cmake.build()
 
     def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
         cmake = self._configure_cmake()
         cmake.install()
 

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -94,3 +94,7 @@ class PdfiumConan(ConanFile):
         self.cpp_info.libs = ["pdfium"]
         if tools.is_apple_os(self.settings.os):
             self.cpp_info.frameworks.extend(["Appkit", "CoreFoundation", "CoreGraphics"])
+
+        stdcpp_library = tools.stdcpp_library(self)
+        if stdcpp_library:
+            self.cpp_info.system_libs.append(stdcpp_library)

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import CMake, ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.33.0"
@@ -56,6 +57,9 @@ class PdfiumConan(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 14)
+        if self.settings.compiler == "gcc":
+            if tools.Version(self.settings.compiler.version) < 8:
+                raise ConanInvalidConfiguration("pdfium needs at least gcc 8")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version]["pdfium-cmake"],

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -72,7 +72,7 @@ class PdfiumConan(ConanFile):
             return self._cmake
         self._cmake = CMake(self)
         self._cmake.definitions["PDFIUM_ROOT"] = os.path.join(self.source_folder, self._source_subfolder).replace("\\", "/")
-        self._cmake.definitions["USE_LIBJPEG_TURBO"] = self.options.with_libjpeg == "libjpeg-turbo"
+        self._cmake.definitions["PDF_LIBJPEG_TURBO"] = self.options.with_libjpeg == "libjpeg-turbo"
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/pdfium/all/conanfile.py
+++ b/recipes/pdfium/all/conanfile.py
@@ -57,9 +57,14 @@ class PdfiumConan(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 14)
-        if self.settings.compiler == "gcc":
-            if tools.Version(self.settings.compiler.version) < 8:
-                raise ConanInvalidConfiguration("pdfium needs at least gcc 8")
+        minimum_compiler_versions = {
+            "gcc": 8,
+            "Visual Studio": 15,
+        }
+        min_compiler_version = minimum_compiler_versions.get(str(self.settings.compiler))
+        if min_compiler_version:
+            if tools.Version(self.settings.compiler.version) < min_compiler_version:
+                raise ConanInvalidConfiguration("pdfium needs at least compiler version {}".format(min_compiler_version))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version]["pdfium-cmake"],

--- a/recipes/pdfium/all/test_package/CMakeLists.txt
+++ b/recipes/pdfium/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/pdfium/all/test_package/conanfile.py
+++ b/recipes/pdfium/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/pdfium/all/test_package/conanfile.py
+++ b/recipes/pdfium/all/test_package/conanfile.py
@@ -13,6 +13,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not tools.build.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/pdfium/all/test_package/conanfile.py
+++ b/recipes/pdfium/all/test_package/conanfile.py
@@ -1,7 +1,7 @@
 import os
 
 from conans import ConanFile, CMake, tools
-
+from conan.tools.build import cross_building
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
@@ -13,6 +13,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.build.cross_building(self):
+        if not cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/pdfium/all/test_package/test_package.c
+++ b/recipes/pdfium/all/test_package/test_package.c
@@ -1,0 +1,7 @@
+#include "fpdfview.h"
+
+int main() {
+    FPDF_InitLibrary();
+    FPDF_DestroyLibrary();
+    return 0;
+}

--- a/recipes/pdfium/config.yml
+++ b/recipes/pdfium/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20210730":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **pdfium/cci.20210703**

The upstream pdfium project uses gn as build system, but I found it hard to patch that system to create a minimal pdfium library using system packages instead of vendored libraries and also using as less git submodules as possible.

https://github.com/madebr/pdfium-cmake contains the cmake build scripts.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
