### PR TITLE
paho-mqtt-c: robust discovery of openssl + modernize

### DIFF
--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -59,12 +59,13 @@ class PahoMqttcConan(ConanFile):
         if self.options.samples != "deprecated":
             self.output.warn("samples option is deprecated and they are no longer provided in the package.")
 
-        if not self.options.shared and tools.Version(self.version) < "1.3.4":
-            raise ConanInvalidConfiguration("{}/{} does not support static linking".format(self.name, self.version))
-
     def requirements(self):
         if self.options.ssl:
             self.requires("openssl/1.1.1k")
+
+    def validate(self):
+        if not self.options.shared and tools.Version(self.version) < "1.3.4":
+            raise ConanInvalidConfiguration("{}/{} does not support static linking".format(self.name, self.version))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -67,6 +67,9 @@ class PahoMqttcConan(ConanFile):
         if not self.options.shared and tools.Version(self.version) < "1.3.4":
             raise ConanInvalidConfiguration("{}/{} does not support static linking".format(self.name, self.version))
 
+    def package_id(self):
+        del self.info.options.samples
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
@@ -116,9 +119,6 @@ class PahoMqttcConan(ConanFile):
         self.copy(os.path.join("bin", "*{}.*".format(self._lib_target)), dst="bin", keep_path=False)
         tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.pdb")
         tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.pdb")
-
-    def package_id(self):
-        del self.info.options.samples
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "eclipse-paho-mqtt-c"

--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -2,7 +2,7 @@ from conans import CMake, ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.29.1"
+required_conan_version = ">=1.33.0"
 
 
 class PahoMqttcConan(ConanFile):
@@ -67,9 +67,8 @@ class PahoMqttcConan(ConanFile):
             self.requires("openssl/1.1.1k")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name.replace("-", ".") + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/paho-mqtt-c/all/test_package/conanfile.py
+++ b/recipes/paho-mqtt-c/all/test_package/conanfile.py
@@ -14,7 +14,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)
 

--- a/recipes/paho-mqtt-c/all/test_package/test_package_async.c
+++ b/recipes/paho-mqtt-c/all/test_package/test_package_async.c
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
     conn_opts.onFailure = onConnectFailure;
     conn_opts.context = client;
 
-    printf("finished!");
+    printf("finished!\n");
 
     MQTTAsync_destroy(&client);
     return 0;


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

It was using FindOpenSSL shipped by CMake, less robust than FindOpenSSL generated by cmake_find_package (basically cross-build to iOS/tvOS/watchOS was broken).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
