### PR TITLE
dbus/1.x.x: Fix building with systemd and remove documentation.

### DIFF
--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -60,6 +60,9 @@ class DbusConan(ConanFile):
             args.append("--disable-asserts")
             args.append("--disable-checks")
 
+            args.append("--with-systemdsystemunitdir=%s" % os.path.join(self.package_folder, "lib", "systemd", "system"))
+            args.append("--with-systemduserunitdir=%s" % os.path.join(self.package_folder, "lib", "systemd", "user"))
+
             self._autotools.configure(args=args, configure_dir=self._source_subfolder)
         return self._autotools
 
@@ -73,11 +76,13 @@ class DbusConan(ConanFile):
         autotools = self._configure_autotools()
         autotools.install()
 
+        tools.rmdir(os.path.join(self.package_folder, "share", "doc"))
         for i in ["var", "share", "etc"]:
             shutil.move(os.path.join(self.package_folder, i), os.path.join(self.package_folder, "res", i))
 
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "systemd"))
         tools.remove_files_by_mask(self.package_folder, "*.la")
 
     def package_info(self):


### PR DESCRIPTION
Specify library name and version:  **dbus/1.12.20**

When dbus configuration detects systemd it will try to install systemd unit files in default folders e.g. `/lib/systemd/system` etc. To avoid this we supply new `--with-systemdsystemunitdir` and `--with-systemduserunitdir` arguments.

Additionally added packaging commands to remove generated systemd unit files and remove documentation folder.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
