### PR TITLE
Add args library

### DIFF
--- a/recipes/args/all/conandata.yml
+++ b/recipes/args/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.1":
+    url: "https://github.com/p-ranav/argparse/archive/v2.1.tar.gz"
+    sha256: "0a82f464b568b8ee6650fc837f371eb9c81417e2ef9fb3b51f65ad50fa3b8662"

--- a/recipes/args/all/conandata.yml
+++ b/recipes/args/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
-  "2.1":
-    url: "https://github.com/p-ranav/argparse/archive/v2.1.tar.gz"
-    sha256: "0a82f464b568b8ee6650fc837f371eb9c81417e2ef9fb3b51f65ad50fa3b8662"
+  "6.2.2":
+    url: "https://github.com/Taywee/args/archive/refs/tags/6.2.2.tar.gz"
+    sha256: "8016fb0fc079d746433be3df9cf662e3e931e730aaf9f69f2287eac79ac643c1"
+  "6.2.6":
+    url: "https://github.com/Taywee/args/archive/refs/tags/6.2.6.tar.gz"
+    sha256: "f0b2b41a0d06c4739abb6b62ccad0e655fe494d1de606688454ea397a3313d46"

--- a/recipes/args/all/conanfile.py
+++ b/recipes/args/all/conanfile.py
@@ -1,0 +1,49 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class ArgparseConan(ConanFile):
+    name = "argparse"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/p-ranav/argparse"
+    topics = ("conan", "argparse", "argument", "parsing")
+    license = "MIT"
+    description = "Argument Parser for Modern C++"
+    settings = "compiler"
+    no_copy_source = True
+
+    _compiler_required_cpp17 = {
+        "gcc": "7",
+        "clang": "5",
+        "Visual Studio": "15",
+        "apple-clang": "10",
+    }
+
+    @property
+    def _source_subfolder(self):
+        return os.path.join(self.source_folder, "source_subfolder")
+
+    def configure(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            tools.check_min_cppstd(self, "17")
+        try:
+            minimum_required_compiler_version = self._compiler_required_cpp17[str(self.settings.compiler)]
+            if tools.Version(self.settings.compiler.version) < minimum_required_compiler_version:
+                raise ConanInvalidConfiguration("This package requires c++17 support. The current compiler does not support it.")
+        except KeyError:
+            self.output.warn("This recipe has no support for the current compiler. Please consider adding it.")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("argparse-{}".format(self.version), self._source_subfolder)
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        self.copy("*.hpp", src=os.path.join(self._source_subfolder, "include"), dst=os.path.join("include", "argparse"))
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.includedirs.append(os.path.join("include", "argparse"))

--- a/recipes/args/all/conanfile.py
+++ b/recipes/args/all/conanfile.py
@@ -1,49 +1,30 @@
 from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
-import os
 
 
-class ArgparseConan(ConanFile):
-    name = "argparse"
+class ArgsConan(ConanFile):
+    name = "args"
+    description = "A simple header-only C++ argument parser library."
+    topics = ("conan", "args", "argument", "parsing")
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/p-ranav/argparse"
-    topics = ("conan", "argparse", "argument", "parsing")
+    homepage = "https://github.com/Taywee/args"
     license = "MIT"
-    description = "Argument Parser for Modern C++"
-    settings = "compiler"
     no_copy_source = True
-
-    _compiler_required_cpp17 = {
-        "gcc": "7",
-        "clang": "5",
-        "Visual Studio": "15",
-        "apple-clang": "10",
-    }
 
     @property
     def _source_subfolder(self):
-        return os.path.join(self.source_folder, "source_subfolder")
-
-    def configure(self):
-        if self.settings.get_safe("compiler.cppstd"):
-            tools.check_min_cppstd(self, "17")
-        try:
-            minimum_required_compiler_version = self._compiler_required_cpp17[str(self.settings.compiler)]
-            if tools.Version(self.settings.compiler.version) < minimum_required_compiler_version:
-                raise ConanInvalidConfiguration("This package requires c++17 support. The current compiler does not support it.")
-        except KeyError:
-            self.output.warn("This recipe has no support for the current compiler. Please consider adding it.")
+        return "source_subfolder"
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("argparse-{}".format(self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  strip_root=True,
+                  destination=self._source_subfolder)
 
     def package(self):
-        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        self.copy("*.hpp", src=os.path.join(self._source_subfolder, "include"), dst=os.path.join("include", "argparse"))
+        self.copy("LICENSE", src=self._source_subfolder, dst="license")
+        self.copy("args.hxx", src=self._source_subfolder, dst="include")
 
     def package_id(self):
         self.info.header_only()
 
     def package_info(self):
-        self.cpp_info.includedirs.append(os.path.join("include", "argparse"))
+        self.cpp_info.includedirs.append("include")

--- a/recipes/args/all/test_package/CMakeLists.txt
+++ b/recipes/args/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/recipes/args/all/test_package/conanfile.py
+++ b/recipes/args/all/test_package/conanfile.py
@@ -1,0 +1,23 @@
+from conans import ConanFile, CMake, tools
+from io import StringIO
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            output = StringIO()
+            bin_path = os.path.join("bin", "test_package")
+            val = 42
+            self.run("{} {}".format(bin_path, val), run_environment=True, output=output)
+            text = output.getvalue()
+            print(text)
+            assert(str(val*val) in text)

--- a/recipes/args/all/test_package/conanfile.py
+++ b/recipes/args/all/test_package/conanfile.py
@@ -17,7 +17,10 @@ class TestPackageConan(ConanFile):
             output = StringIO()
             bin_path = os.path.join("bin", "test_package")
             val = 42
-            self.run("{} {}".format(bin_path, val), run_environment=True, output=output)
+            self.run("{} {}".format(bin_path, val),
+                     run_environment=True,
+                     output=output)
             text = output.getvalue()
+            print(f'{val}*{val}=')
             print(text)
-            assert(str(val*val) in text)
+            assert (str(val * val) in text)

--- a/recipes/args/all/test_package/test_package.cpp
+++ b/recipes/args/all/test_package/test_package.cpp
@@ -1,0 +1,26 @@
+#include <argparse.hpp>
+
+#include <iostream>
+
+int main(int argc, char *argv[]) {
+  argparse::ArgumentParser program("test_package");
+
+  program.add_argument("square")
+    .help("display the square of a given integer")
+    .action([](const std::string& value) { return std::stoi(value); });
+
+  try {
+    program.parse_args(argc, argv);
+  }
+  catch (const std::runtime_error& err) {
+    std::cout << err.what() << std::endl;
+    std::cout << program;
+    return 0;
+  }
+
+  auto input = program.get<int>("square");
+  std::cout << (input * input) << std::endl;
+
+  return 0;
+}
+

--- a/recipes/args/all/test_package/test_package.cpp
+++ b/recipes/args/all/test_package/test_package.cpp
@@ -1,26 +1,22 @@
-#include <argparse.hpp>
+#include <args.hxx>
 
 #include <iostream>
 
 int main(int argc, char *argv[]) {
-  argparse::ArgumentParser program("test_package");
+  args::ArgumentParser parser("test_package");
 
-  program.add_argument("square")
-    .help("display the square of a given integer")
-    .action([](const std::string& value) { return std::stoi(value); });
+  args::Positional<int> arg{parser, "arg",
+                            "display the square of the given integer"};
 
   try {
-    program.parse_args(argc, argv);
-  }
-  catch (const std::runtime_error& err) {
-    std::cout << err.what() << std::endl;
-    std::cout << program;
-    return 0;
+    parser.ParseCLI(argc, argv);
+  } catch (const args::Error &e) {
+    std::cout << e.what() << std::endl;
+    return 1;
   }
 
-  auto input = program.get<int>("square");
+  int input = arg.Get();
   std::cout << (input * input) << std::endl;
 
   return 0;
 }
-

--- a/recipes/args/config.yml
+++ b/recipes/args/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.1":
+    folder: all

--- a/recipes/args/config.yml
+++ b/recipes/args/config.yml
@@ -1,3 +1,5 @@
 versions:
-  "2.1":
+  "6.2.2":
+    folder: all
+  "6.2.6":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **args/2.6.6**

This library exists in conan-center, since it contains its own `conanfile.py`. However, IIUC the proper place for the recipes is CCI, so that all recipes use the same conventions and leverage dedicated CI.

* 6.2.2 is the latest released version
* 6.2.6 is the latest tagged version

The content is based on the args-parse library, which I copy-pasted as a template.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
