### PR TITLE
premake: fix patches for MinGW builds

### DIFF
--- a/recipes/premake/5.x/patches/0001-5.0.0-alpha14-mingw.patch
+++ b/recipes/premake/5.x/patches/0001-5.0.0-alpha14-mingw.patch
@@ -1,3 +1,15 @@
+--- a/contrib/curl/lib/select.h
++++ b/contrib/curl/lib/select.h
+@@ -36,7 +36,8 @@
+
+ #if !defined(HAVE_STRUCT_POLLFD) && \
+     !defined(HAVE_SYS_POLL_H) && \
+-    !defined(HAVE_POLL_H)
++    !defined(HAVE_POLL_H)  && \
++    !defined(POLLIN)
+
+ #define POLLIN      0x01
+ #define POLLPRI     0x02
 --- src/host/os_isdir.c
 +++ src/host/os_isdir.c
 @@ -9,7 +9,7 @@

--- a/recipes/premake/5.x/patches/0001-5.0.0-alpha15-mingw.patch
+++ b/recipes/premake/5.x/patches/0001-5.0.0-alpha15-mingw.patch
@@ -1,3 +1,15 @@
+--- a/contrib/curl/lib/select.h
++++ b/contrib/curl/lib/select.h
+@@ -36,7 +36,8 @@
+
+ #if !defined(HAVE_STRUCT_POLLFD) && \
+     !defined(HAVE_SYS_POLL_H) && \
+-    !defined(HAVE_POLL_H)
++    !defined(HAVE_POLL_H)  && \
++    !defined(POLLIN)
+
+ #define POLLIN      0x01
+ #define POLLPRI     0x02
 --- src/host/os_isdir.c
 +++ src/host/os_isdir.c
 @@ -9,7 +9,7 @@


### PR DESCRIPTION
Specify library name and version:  **premake/5.0.0-alpha14** and  **premake/5.0.0-alpha15**

Fixes #6600 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
