### PR TITLE
[changelog] Enable M1 builds (and more things)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### TBD
+
+- [feature] BuildSingleReference: Create packages for apple-clang armv8 (Apple M1) in pull-requests' builds.
+- [feature] BuildSingleReference: Enforce empty workspace for Windows and MacOS nodes.
+- [feature] Different approach to work with configuration files for profiles (internal modularibility).
+- [feature] Allow jobs to use multiple configuration files for profiles.
+- [fix] ValidateInfrastructure: Minor fixes to the automatic generation of "Supported platforms and configurations" documentation page.
+- [fix] PromotePackages: Fix promotion of references that contain symbols.
+
 ### 13-July-2021 - 10:24 CEST
 
 - [fix] DeleteRepo: Fix JFrog CLI commands.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### TBD
+### 3-August-2021 - 13:29 CEST
 
 - [feature] BuildSingleReference: Create packages for apple-clang armv8 (Apple M1) in pull-requests' builds.
 - [feature] BuildSingleReference: Enforce empty workspace for Windows and MacOS nodes.


### PR DESCRIPTION
Some words about the biggest change here:

- [feature] BuildSingleReference: Create packages for apple-clang armv8 (Apple M1) in pull-requests' builds.

   It's been a while since we started to think about M1 configurations in ConanCenter. During this time we have implemented the changes required in the CI library and, mostly, we have tried to prepare as many recipes as possible for this new configuration (special thanks to @SSE4 and @SpaceIm). 
   
   This configuration is not only new by itself, but it is the first one that uses two profiles (`--profile:host` and `--profile:build`) to create the binaries. **We are cross-compiling from a regular Macos (x64) to ARM architecture, so be aware, some builds and libraries might become challenging**.
   
   It is expected (sorry in advance) that some PRs will start to fail. We have tried our best, but it is impossible for us alone to keep the pace and fix all the recipes at the time they are being added. Expected errors could be:
   * **Missing dependencies**: if any of the dependencies is not already available, the PR will fail with that message. To fix it, a PR to the offending library must be created. We understand you might be focused only on the consumer library, we'll try to be proactive, but feel free to mention any of us and we will take care of fixing the dependency for you.
   * **Errors for M1 configuration**: it's very likely that a library (or even a PR that was opened before this change) was working and now M1 configuration fails. This error probably is not related to the changes in your PR, it is just that the library was not working before. We would love it if you can fix this configuration, I'm sure reviewers will help, but if you prefer to keep your PR simpler it is ok if you just raise a `ConanInvalidConfiguration` for that configuration and the CI will skip the build.
   * **Unexpected errors**: ... well, these are unexpected, ping us and we will have a look at them. 

