### PR TITLE
add protobuf version 3.6.1

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.1":
+    sha256: 3d4e589d81b2006ca603c1ab712c9715a76227293032d05b26fca603f90b3f5b
+    url: https://github.com/protocolbuffers/protobuf/archive/v3.6.1.tar.gz
   "3.9.1":
     sha256: 98e615d592d237f94db8bf033fba78cd404d979b0b70351a9e5aaff725398357
     url: https://github.com/protocolbuffers/protobuf/archive/v3.9.1.tar.gz

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.1":
+    folder: all
   "3.9.1":
     folder: all
   "3.11.3":


### PR DESCRIPTION
Specify library name and version:  **protobuf/3.6.1**

As protoc files are very version specific, I need this specific version for a project of mine.
To use conan as package manager I'd love to see v3.6.1 in the conan center index.

---

- [ x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
