### PR TITLE
sentry-crashpad/0.4.12

### DIFF
--- a/recipes/sentry-crashpad/all/conandata.yml
+++ b/recipes/sentry-crashpad/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.4.12":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.12/sentry-native.zip"
+    sha256: "d7fa804995124c914a3abe077a73307960bbcadfbba9021e8ccbd05c7ba45f88"
   "0.4.11":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.11/sentry-native.zip"
     sha256: "4a0dae61ab718ac23fc7041de3236a2929a12a5a6594b7ec375dc55fb33aabce"

--- a/recipes/sentry-crashpad/config.yml
+++ b/recipes/sentry-crashpad/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.4.12":
+    folder: all
   "0.4.11":
     folder: all
   "0.4.10":


### PR DESCRIPTION
Specify library name and version:  **sentry-crashpad/0.4.12**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
