### PR TITLE
qt/6.x.x: Fix compilation with Vulkan and Zstd.

### DIFF
--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -49,6 +49,14 @@ sources:
       - "https://ftp.fau.de/qtproject/archive/qt/6.1/6.1.2/single/qt-everywhere-src-6.1.2.tar.xz"
     sha256: "4b40f10eb188506656f13dbf067b714145047f41d7bf83f03b727fa1c7c4cdcb"
 patches:
+  "6.1.0":
+    - base_path: "qt6/qtbase/cmake"
+      patch_file: "patches/qt6-pri-helpers-fix.diff"
+  "6.1.1":
+    - base_path: "qt6/qtbase/cmake"
+      patch_file: "patches/qt6-pri-helpers-fix.diff"
   "6.1.2":
     - base_path: "qt6/qtdeclarative"
       patch_file: "patches/32451d5.diff"
+    - base_path: "qt6/qtbase/cmake"
+      patch_file: "patches/qt6-pri-helpers-fix.diff"

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -709,6 +709,8 @@ class QtConan(ConanFile):
             core_reqs.append("double-conversion::double-conversion")
         if self.options.get_safe("with_icu", False):
             core_reqs.append("icu::icu")
+        if self.options.with_zstd:
+            core_reqs.append("zstd::zstd")
 
         _create_module("Core", core_reqs)
         if tools.Version(self.version) < "6.1.0":
@@ -727,6 +729,8 @@ class QtConan(ConanFile):
                     gui_reqs.append("xkbcommon::xkbcommon")
             if self.settings.os != "Windows" and self.options.get_safe("opengl", "no") != "no":
                 gui_reqs.append("opengl::opengl")
+            if self.options.get_safe("with_vulkan", False):
+                gui_reqs.append("vulkan-loader::vulkan-loader")
             if self.options.with_harfbuzz:
                 gui_reqs.append("harfbuzz::harfbuzz")
             if self.options.with_libjpeg == "libjpeg-turbo":

--- a/recipes/qt/6.x.x/patches/qt6-pri-helpers-fix.diff
+++ b/recipes/qt/6.x.x/patches/qt6-pri-helpers-fix.diff
@@ -1,0 +1,15 @@
+--- QtPriHelpers.cmake.original	2021-08-03 23:38:06.343653948 +0300
++++ QtPriHelpers.cmake	2021-08-03 23:26:24.483637483 +0300
+@@ -30,7 +30,11 @@
+                 if(lib_target_type STREQUAL "INTERFACE_LIBRARY")
+                     get_target_property(iface_libs ${lib_target} INTERFACE_LINK_LIBRARIES)
+                     if(iface_libs)
+-                        list(PREPEND lib_targets ${iface_libs})
++                        foreach (iface_lib ${iface_libs})
++                            if (NOT "${iface_lib}" STREQUAL "${lib_target}")
++                                list(PREPEND lib_targets ${iface_lib})
++                            endif ()
++                        endforeach ()
+                     endif()
+                 else()
+                     list(APPEND lib_libs "$<TARGET_LINKER_FILE:${lib_target}>")


### PR DESCRIPTION
Specify library name and version:  **qt/6.1.2**

### Fix infinite loop in `QtPriHelpers.cmake` (issue #6076).

Qt helper function `qt_generate_qmake_libraries_pri_content` in `QtPriHelpers.cmake` iterates over targets that Qt links against. For each target it also obtains `INTERFACE_LINK_LIBRARIES` and adds them to the list of targets to process. In Conan the `Vulkan::Vulkan` property `INTERFACE_LINK_LIBRARIES` contains `Vulkan::Vulkan` which leads to infinite loop due to aforementioned mechanism. This patch adds a check to `qt_generate_qmake_libraries_pri_content` to avoid duplicate targets and hence fixes the infinite loop issue.

### Fix `with_zstd` and `with_vulkan` module requirements.

QtCore module requires `zstd::zstd` when `with_zstd` option is set and QtGui module requires `vulkan-loader::vulkan-loader` when `with_vulkan` option is set.

Tested with 6.1.2, 6.1.1 and 6.1.0 locally. Qt 6.0.4 fails due to other unrelated issues.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
