### PR TITLE
autoconf: modernize + add m4 build requirement

### DIFF
--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -1,5 +1,7 @@
-import os
 from conans import AutoToolsBuildEnvironment, ConanFile, tools
+import os
+
+required_conan_version = ">=1.33.0"
 
 
 class AutoconfConan(ConanFile):
@@ -9,20 +11,27 @@ class AutoconfConan(ConanFile):
     description = "Autoconf is an extensible package of M4 macros that produce shell scripts to automatically configure software source code packages"
     topics = ("conan", "autoconf", "configure", "build")
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
-    exports_sources = "patches/**"
     settings = "os", "arch", "compiler"
+
+    exports_sources = "patches/**"
+
     _autotools = None
 
     @property
     def _source_subfolder(self):
         return os.path.join(self.source_folder, "source_subfolder")
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
     def requirements(self):
         self.requires("m4/1.4.18")
+
+    def build_requirements(self):
+        self.build_requires("m4/1.4.18")
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
 
     def package_id(self):
         del self.info.settings.arch
@@ -30,9 +39,9 @@ class AutoconfConan(ConanFile):
         # The m4 requirement does not change the contents of this package
         self.info.requires.clear()
 
-    def build_requirements(self):
-        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires("msys2/cci.latest")
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     @property
     def _datarootdir(self):

--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -29,7 +29,8 @@ class AutoconfConan(ConanFile):
         self.requires("m4/1.4.18")
 
     def build_requirements(self):
-        self.build_requires("m4/1.4.18")
+        if hasattr(self, "settings_build"):
+            self.build_requires("m4/1.4.18")
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 

--- a/recipes/autoconf/all/test_package/conanfile.py
+++ b/recipes/autoconf/all/test_package/conanfile.py
@@ -3,13 +3,20 @@ from contextlib import contextmanager
 import os
 import shutil
 
+required_conan_version = ">=1.36.0"
+
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     exports_sources = "configure.ac", "config.h.in", "Makefile.in", "test_package_c.c", "test_package_cpp.cpp",
+    test_type = "build_requires"
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
-        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 
     @contextmanager
@@ -32,5 +39,5 @@ class TestPackageConan(ConanFile):
             autotools.make()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             self.run(os.path.join(".", "test_package"), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **autoconf/all**

Modernize + add build requirement on m4 + run test package always in build requirement configuration.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
