### PR TITLE
inih: attempt to fix cross-build by using MesonToolchain

### DIFF
--- a/recipes/inih/all/test_package/conanfile.py
+++ b/recipes/inih/all/test_package/conanfile.py
@@ -21,6 +21,6 @@ class TestPackageConan(ConanFile):
                 name = conan-center-index
                 email = info@conan.io
                 """))
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

This is an attempt to provide a POC of cross-build with Meson based recipes, since inih is quite simple.

Native build still works. Cross-build is still broken.

@SSE4 Any idea?

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
