### PR TITLE
Update cmake find package review

### DIFF
--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -114,7 +114,7 @@ When components are defined in the `package_info` in `conanfile.py` the followin
 
 * use `cmake_find_package` if library has an [official](cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules) CMake module emulated in the recipe.
 * use `cmake_find_package_multi` if library provides an official cmake config file emulated in the recipe. If there are more than one target, try to use all of them, or add another executable linking to the global (usually unofficial) target. There are some ways to identify when to use it:
-    * Usually, project install their cmake files on `package_folder/lib/cmake`. The folder are removed from package folder by calling `tools.rmdir(os.path.join(self.package_folder), "lib", "cmake")`
+    * Usually, project installs its cmake files into `package_folder/lib/cmake`. The folder is removed from package folder by calling `tools.rmdir(os.path.join(self.package_folder), "lib", "cmake")`
     * Also, the upstream's cmakefile can use [install(EXPORT ..)](https://cmake.org/cmake/help/latest/command/install.html#export)
       to indicate an exported CMake config file.
     * When `self.cpp_info.filenames["cmake_find_package_multi"]`, `self.cpp_info.names["cmake_find_package_multi"]` are declared

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -105,17 +105,20 @@ def _configure_cmake(self):
 
 ### Minimalistic Source Code
 
-The contents of `test_package.c` or `test_package.cpp` should be as minimal as possible, including a few headers at most with simple instatiation of objects to ensure linkage
+The contents of `test_package.c` or `test_package.cpp` should be as minimal as possible, including a few headers at most with simple instantiation of objects to ensure linkage
 and dependencies are correct.
 
 ### Verifying Components
 
 When components are defined in the `package_info` in `conanfile.py` the following conditions are desired
 
-- use `cmake_find_package` if library has an [official](cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules) CMake module emulated in the recipe.
-- use `cmake_find_package_multi` if library provides official cmake config file emulated in the recipe. If there are more than one target, try to use all of
-them, or add an other executable linking to the global (usually unofficial) target.
-- otherwise, use cmake generator to not suggest an unofficial cmake target in test package.
+* use `cmake_find_package` if library has an [official](cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules) CMake module emulated in the recipe.
+* use `cmake_find_package_multi` if library provides official cmake config file emulated in the recipe. If there are more than one target, try to use all of them, or add an other executable linking to the global (usually unofficial) target. There are some ways to identify when use it:
+    * Usually, project install their cmake files on `package_folder/lib/cmake`. The folder are removed from package folder by calling `tools.rmdir(os.path.join(self.package_folder), "lib", "cmake")`
+    * Also, the upstream's cmakefile can use [install(EXPORT ..)](https://cmake.org/cmake/help/latest/command/install.html#export)
+      to indicate an exported CMake config file.
+    * When `self.cpp_info.filenames["cmake_find_package_multi"]`, `self.cpp_info.names["cmake_find_package_multi"]` are declared
+* otherwise, use [cmake generator](https://docs.conan.io/en/latest/reference/generators/cmake.html) to not suggest an unofficial cmake target in test package.
 
 ### Recommended feature options names
 

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -115,7 +115,7 @@ When components are defined in the `package_info` in `conanfile.py` the followin
 * use `cmake_find_package` if library has an [official](cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules) CMake module emulated in the recipe.
 * use `cmake_find_package_multi` if library provides an official cmake config file emulated in the recipe. If there are more than one target, try to use all of them, or add another executable linking to the global (usually unofficial) target. There are some ways to identify when to use it:
     * Usually, project installs its cmake files into `package_folder/lib/cmake`. The folder is removed from package folder by calling `tools.rmdir(os.path.join(self.package_folder), "lib", "cmake")`
-    * Also, the upstream's cmakefile can use [install(EXPORT ..)](https://cmake.org/cmake/help/latest/command/install.html#export)
+    * Also, the library's CMake scripts can use [install(EXPORT ..)](https://cmake.org/cmake/help/latest/command/install.html#export) and/or may install [package configuration helpers](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html)
       to indicate an exported CMake config file.
     * When `self.cpp_info.filenames["cmake_find_package_multi"]`, `self.cpp_info.names["cmake_find_package_multi"]` are declared
 * otherwise, use [cmake generator](https://docs.conan.io/en/latest/reference/generators/cmake.html) to not suggest an unofficial cmake target in test package.

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -113,7 +113,7 @@ and dependencies are correct.
 When components are defined in the `package_info` in `conanfile.py` the following conditions are desired
 
 * use `cmake_find_package` if library has an [official](cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules) CMake module emulated in the recipe.
-* use `cmake_find_package_multi` if library provides official cmake config file emulated in the recipe. If there are more than one target, try to use all of them, or add an other executable linking to the global (usually unofficial) target. There are some ways to identify when use it:
+* use `cmake_find_package_multi` if library provides an official cmake config file emulated in the recipe. If there are more than one target, try to use all of them, or add another executable linking to the global (usually unofficial) target. There are some ways to identify when to use it:
     * Usually, project install their cmake files on `package_folder/lib/cmake`. The folder are removed from package folder by calling `tools.rmdir(os.path.join(self.package_folder), "lib", "cmake")`
     * Also, the upstream's cmakefile can use [install(EXPORT ..)](https://cmake.org/cmake/help/latest/command/install.html#export)
       to indicate an exported CMake config file.

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -27,7 +27,7 @@ Avoid trailing white-space characters, if possible
 
 If possible, try to avoid mixing single quotes (`'`) and double quotes (`"`) in python code (`conanfile.py`, `test_package/conanfile.py`). Consistency is preferred.
 
-## Subfolder Properties 
+## Subfolder Properties
 
 When extracting sources or performing out-of-source builds, it is preferable to use a _subfolder_ attribute, `_source_subfolder` and `_build_subfolder` respectively.
 
@@ -112,8 +112,10 @@ and dependencies are correct.
 
 When components are defined in the `package_info` in `conanfile.py` the following conditions are desired
 
-- use the `cmake_find_package` or `cmake_find_package_multi` generators in `test_package/conanfile.py`
-- corresponding call to `find_package()` with the components _explicitly_ used in `target_link_libraries`
+- use `cmake_find_package` if library has an [official](cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules) CMake module emulated in the recipe.
+- use `cmake_find_package_multi` if library provides official cmake config file emulated in the recipe. If there are more than one target, try to use all of
+them, or add an other executable linking to the global (usually unofficial) target.
+- otherwise, use cmake generator to not suggest an unofficial cmake target in test package.
 
 ### Recommended feature options names
 

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -113,7 +113,7 @@ and dependencies are correct.
 When components are defined in the `package_info` in `conanfile.py` the following conditions are desired
 
 * use `cmake_find_package` if library has an [official](cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules) CMake module emulated in the recipe.
-* use `cmake_find_package_multi` if library provides an official cmake config file emulated in the recipe. If there are more than one target, try to use all of them, or add another executable linking to the global (usually unofficial) target. There are some ways to identify when to use it:
+* use `cmake_find_package_multi` if library provides an official cmake config file emulated in the recipe. If there are more than one target, try to use all of them, or add another executable linking to the global (usually unofficial) target. There may additionally be variables that are emulated by the recipe which should be used as well. There are some ways to identify when to use it:
     * Usually, project installs its cmake files into `package_folder/lib/cmake`. The folder is removed from package folder by calling `tools.rmdir(os.path.join(self.package_folder), "lib", "cmake")`
     * Also, the library's CMake scripts can use [install(EXPORT ..)](https://cmake.org/cmake/help/latest/command/install.html#export) and/or may install [package configuration helpers](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html)
       to indicate an exported CMake config file.


### PR DESCRIPTION
For most reviewers, the relation between `cmake`, `cmake_find_package` and `cmake_find_package_multi` is daily, there is no official consensus documented or automatic validation for it yet.

This PR add the suggestions made by @SpaceIm, related to the correct usage for Cmake generators on test package.

A hook should be created to validate it, so reviewers don't need to remember it every time.

Related to #6681
/cc @SpaceIm @madebr @prince-chrismc 

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
