### PR TITLE
m4: modernize recipe + don't add `-rtlib=compiler-rt`

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -30,10 +30,6 @@ class M4Conan(ConanFile):
     def _is_msvc(self):
         return self.settings.compiler == "Visual Studio"
 
-    @property
-    def _is_clang(self):
-        return str(self.settings.compiler).endswith("clang")
-
     def build_requirements(self):
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
@@ -70,10 +66,9 @@ class M4Conan(ConanFile):
 
     @contextmanager
     def _build_context(self):
-        env = {}
         if self.settings.compiler == "Visual Studio":
             with tools.vcvars(self.settings):
-                env.update({
+                env = {
                     "AR": "{}/build-aux/ar-lib lib".format(tools.unix_path(self._source_subfolder)),
                     "CC": "cl -nologo",
                     "CXX": "cl -nologo",
@@ -82,14 +77,11 @@ class M4Conan(ConanFile):
                     "OBJDUMP": ":",
                     "RANLIB": ":",
                     "STRIP": ":",
-                })
+                }
                 with tools.environment_append(env):
                     yield
         else:
-            if self._is_clang:
-                env["CFLAGS"] = "-rtlib=compiler-rt"
-            with tools.environment_append(env):
-                yield
+            yield
 
     def _patch_sources(self):
         for patch in self.conan_data["patches"][self.version]:

--- a/recipes/m4/all/test_package/conanfile.py
+++ b/recipes/m4/all/test_package/conanfile.py
@@ -2,36 +2,40 @@ from conans import ConanFile, tools
 from conans.errors import ConanException
 from io import StringIO
 import os
-
-
-M4_CONTENTS = """\
-m4_define(NAME1, `Harry, Jr.')
-m4_define(NAME2, `Sally')
-m4_define(MET, `$1 met $2')
-MET(`NAME1', `NAME2')
-"""
+import textwrap
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
 
     @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    @property
     def _m4_input_path(self):
         return os.path.join(self.build_folder, "input.m4")
 
     def build_requirements(self):
-        if tools.os_info.is_windows:
-            self.build_requires("msys2/20200517")
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
+        if hasattr(self, "settings_build"):
+            self.build_requires(str(self.requires["m4"]))
 
     def build(self):
-        tools.save(self._m4_input_path, M4_CONTENTS)
+        tools.save(self._m4_input_path, textwrap.dedent("""\
+            m4_define(NAME1, `Harry, Jr.')
+            m4_define(NAME2, `Sally')
+            m4_define(MET, `$1 met $2')
+            MET(`NAME1', `NAME2')
+        """))
 
     def test(self):
         m4_bin = tools.get_env("M4")
         if m4_bin is None or not m4_bin.startswith(self.deps_cpp_info["m4"].rootpath):
             raise ConanException("M4 environment variable not set")
 
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             self.run("{} --version".format(m4_bin), run_environment=True)
             self.run("{} -P {}".format(m4_bin, self._m4_input_path))
 

--- a/recipes/m4/all/test_package/conanfile.py
+++ b/recipes/m4/all/test_package/conanfile.py
@@ -12,10 +12,6 @@ class TestPackageConan(ConanFile):
     def _m4_input_path(self):
         return os.path.join(self.build_folder, "input.m4")
 
-    def build_requirements(self):
-        if hasattr(self, "settings_build"):
-            self.build_requires(str(self.requires["m4"]))
-
     def build(self):
         tools.save(self._m4_input_path, textwrap.dedent("""\
             m4_define(NAME1, `Harry, Jr.')


### PR DESCRIPTION
Specify library name and version:  **m4/1.4.18**

- Modernize recipe
- Also revert https://github.com/conan-io/conan-center-index/commit/7c5762b976f80459026fe79e29c16cf853154412 .
Adding this flag does not belong in m4. It should be put in a profile.
For #6777

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
