### PR TITLE
gobject-introspection/all: Fix hardcoded 'share' directory path.

### DIFF
--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -46,7 +46,7 @@ class GobjectIntrospectionConan(ConanFile):
             self.build_requires("bison/3.7.1")
 
     def requirements(self):
-        self.requires("glib/2.68.2")
+        self.requires("glib/2.69.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
@@ -55,6 +55,7 @@ class GobjectIntrospectionConan(ConanFile):
         meson = Meson(self)
         defs = dict()
         defs["build_introspection_data"] = self.options["glib"].shared
+        defs["datadir"] = os.path.join(self.package_folder, "res")
 
         meson.configure(
             source_folder=self._source_subfolder,
@@ -92,10 +93,7 @@ class GobjectIntrospectionConan(ConanFile):
             meson = self._configure_meson()
             meson.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        shutil.move(
-            os.path.join(self.package_folder, "share"),
-            os.path.join(self.package_folder, "res"),
-        )
+        tools.rmdir(os.path.join(self.package_folder, "share"))
         for pdb_file in glob.glob(os.path.join(self.package_folder, "bin", "*.pdb")):
             os.unlink(pdb_file)
 


### PR DESCRIPTION
Specify library name and version:  **gobject-introspection/1.68.0**

The `g-ir-scanner` tool contains hardcoded path to `share` folder specified during compile time. This is used to access files such as `gobject-introspection-1.0/gdump.c` later on.

Previously the hardcoded `share` folder was renamed to `res` in packing stage. This made those files inaccessible to tools. We now specify `datadir` argument to hardcode a correct path.

The remaining `share` folder contains only documentation so we delete that.

Also bump glib dependency version to 2.69.0.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
