### PR TITLE
gstreamer/all: Add 'with_introspection' option.

### DIFF
--- a/recipes/gstreamer/all/conanfile.py
+++ b/recipes/gstreamer/all/conanfile.py
@@ -13,8 +13,16 @@ class GStreamerConan(ConanFile):
     homepage = "https://gstreamer.freedesktop.org/"
     license = "GPL-2.0-only"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_introspection": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_introspection": False,
+    }
     generators = "pkg_config"
     _meson = None
 
@@ -27,7 +35,7 @@ class GStreamerConan(ConanFile):
         return "build_subfolder"
 
     def requirements(self):
-        self.requires("glib/2.67.1")
+        self.requires("glib/2.69.0")
 
     @property
     def _is_msvc(self):
@@ -46,6 +54,8 @@ class GStreamerConan(ConanFile):
     def build_requirements(self):
         self.build_requires("meson/0.56.2")
         self.build_requires("pkgconf/1.7.3")
+        if self.options.with_introspection:
+            self.build_requires("gobject-introspection/1.68.0")
         if self.settings.os == 'Windows':
             self.build_requires("winflexbison/2.5.22")
         else:
@@ -70,6 +80,7 @@ class GStreamerConan(ConanFile):
         meson.options["examples"] = "disabled"
         meson.options["benchmarks"] = "disabled"
         meson.options["tests"] = "disabled"
+        meson.options["introspection"] = "enabled" if self.options.with_introspection else "disabled"
         meson.configure(build_folder=self._build_subfolder,
                         source_folder=self._source_subfolder,
                         args=['--wrap-mode=nofallback'])


### PR DESCRIPTION
Specify library name and version:  **gstreamer/1.19.1**

~~Currently there are multiple issues with introspection and the `g-ir-scanner` tool will fail. Automatic introspection flag detection
does not seem to work consistently. Therefore we force disable introspection until things improve.~~
Edit 2: I have reworked the PR to add `with_introspection` flag instead so anyone can enable or disable introspection. See comments below for discussion.

Edit: Also bumped glib dependency that I forgot in initial PR.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
