### PR TITLE
cairo/all: Fix binutils 2.34 libbfd compatibility.

### DIFF
--- a/recipes/cairo/all/conandata.yml
+++ b/recipes/cairo/all/conandata.yml
@@ -12,6 +12,8 @@ patches:
   "1.17.4":
     - patch_file: "patches/0001-msvc-update-build-scripts-to-compile-with-more-featu.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/binutils-2.34-libbfd-fix.patch"
+      base_path: "source_subfolder/util/cairo-trace"
   "1.17.2":
     - patch_file: "patches/0001-msvc-update-build-scripts-to-compile-with-more-featu.patch"
       base_path: "source_subfolder"

--- a/recipes/cairo/all/patches/binutils-2.34-libbfd-fix.patch
+++ b/recipes/cairo/all/patches/binutils-2.34-libbfd-fix.patch
@@ -1,0 +1,43 @@
+The libbfd issues were fixed in upstream with following commit:
+
+  From e30259f6237571c61992433c110bc6e1ef900244 Mon Sep 17 00:00:00 2001
+  From: =?UTF-8?q?Tim-Philipp=20M=C3=BCller?= <tim@centricular.com>
+  Date: Tue, 23 Feb 2021 11:36:24 +0000
+  Subject: cairo-trace: fix build with newer versions of bfd
+
+  https://cgit.freedesktop.org/cairo/commit/?id=e30259f6237571c61992433c110bc6e1ef900244
+
+Note that the upstream commit was more comprehensive, but cannot be directly
+applied to 1.17.4 version. Any new cairo version beyond 1.17.4 will likely
+not need this fix.
+
+--- lookup-symbol.c.original	2021-08-05 22:21:15.819998378 +0300
++++ lookup-symbol.c	2021-08-05 22:26:05.212448342 +0300
+@@ -145,14 +145,26 @@
+     if (symbol->found)
+ 	return;
+ 
++#ifdef bfd_get_section_flags
+     if ((bfd_get_section_flags (symtab->bfd, section) & SEC_ALLOC) == 0)
++#else
++    if ((bfd_section_flags (section) & SEC_ALLOC) == 0)
++#endif
+ 	return;
+ 
++#ifdef bfd_get_section_vma
+     vma = bfd_get_section_vma (symtab->bfd, section);
++#else
++    vma = bfd_section_vma (section);
++#endif
+     if (symbol->pc < vma)
+ 	return;
+ 
+-    size = bfd_section_size (symtab->bfd, section);
++#ifdef bfd_get_section_size
++    size = bfd_get_section_size (section);
++#else
++    size = bfd_section_size (section);
++#endif
+     if (symbol->pc >= vma + size)
+ 	return;
+ 


### PR DESCRIPTION
Specify library name and version:  **cairo/1.17.4**

The libbfd is included in binutils package. In binutils 2.34 some header macros like `bfd_get_section_flags` were removed/modified. This breaks cairo <=1.17.4 compilation with binutils >=2.34.

This issue is fixed in cairo master branch, but it is not clear when we can expect a release so we resort to this ugly patch. It should work with older binutils as well.

Gentoo bug for similar issue: https://bugs.gentoo.org/707846

Tested locally with binutils 2.34. Will rely on CI to test for older versions.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
