### PR TITLE
exiv2: fix cross-build to iOS + fix exiv2-xmp CMake imported target

### DIFF
--- a/recipes/exiv2/all/conandata.yml
+++ b/recipes/exiv2/all/conandata.yml
@@ -8,4 +8,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0002-fpic.patch"
       base_path: "source_subfolder"
-
+    - patch_file: "patches/0003-fix-ios.patch"
+      base_path: "source_subfolder"

--- a/recipes/exiv2/all/conanfile.py
+++ b/recipes/exiv2/all/conanfile.py
@@ -61,10 +61,12 @@ class Exiv2Conan(ConanFile):
             self.requires("libpng/1.6.37")
         if self.options.with_xmp == "bundled":
             self.requires("expat/2.4.1")
-        elif self.options.with_xmp == "external":
-            raise ConanInvalidConfiguration("adobe-xmp-toolkit is not available on cci (yet)")
         if self.options.with_curl:
             self.requires("libcurl/7.64.1")
+
+    def validate(self):
+        if self.options.with_xmp == "external":
+            raise ConanInvalidConfiguration("adobe-xmp-toolkit is not available on cci (yet)")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/exiv2/all/conanfile.py
+++ b/recipes/exiv2/all/conanfile.py
@@ -104,9 +104,12 @@ class Exiv2Conan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
+        targets = {"exiv2lib": "exiv2::exiv2lib"}
+        if self.options.with_xmp == "bundled":
+            targets.update({"exiv2-xmp": "exiv2::exiv2-xmp"})
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),
-            {"exiv2lib": "exiv2::exiv2lib"}
+            targets
         )
 
     @staticmethod

--- a/recipes/exiv2/all/patches/0003-fix-ios.patch
+++ b/recipes/exiv2/all/patches/0003-fix-ios.patch
@@ -1,0 +1,30 @@
+patch from https://github.com/Exiv2/exiv2/pull/1718
+
+--- a/src/futils.cpp
++++ b/src/futils.cpp
+@@ -47,8 +47,11 @@
+ #if defined(_MSC_VER)
+ #define S_ISREG(m)      (((m) & S_IFMT) == S_IFREG)
+ #elif defined(__APPLE__)
++#include <Targetconditionals.h>
++#ifndef TARGET_OS_IPHONE
+ #include <libproc.h>
+ #endif
++#endif
+ 
+ #if defined(__FreeBSD__)
+ #include <sys/mount.h>
+@@ -445,11 +448,13 @@ namespace Exiv2 {
+             CloseHandle(processHandle);
+         }
+     #elif defined(__APPLE__)
++    #ifndef TARGET_OS_IPHONE
+         const int pid = getpid();
+         char pathbuf[PROC_PIDPATHINFO_MAXSIZE];
+         if (proc_pidpath (pid, pathbuf, sizeof(pathbuf)) > 0) {
+             ret = pathbuf;
+         }
++    #endif
+     #elif defined(__FreeBSD__)
+         unsigned int       n;
+         char               buffer[PATH_MAX] = {};

--- a/recipes/exiv2/all/test_package/conanfile.py
+++ b/recipes/exiv2/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Fix for iOS comes from https://github.com/Exiv2/exiv2/pull/1718

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
