### PR TITLE
xorg-makedepend: add xorg-makedepend/1.0.6 recipe

### DIFF
--- a/recipes/xorg-makedepend/all/conandata.yml
+++ b/recipes/xorg-makedepend/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.6":
+    url: "https://www.x.org/archive/individual/util/makedepend-1.0.6.tar.gz"
+    sha256: "845f6708fc850bf53f5b1d0fb4352c4feab3949f140b26f71b22faba354c3365"

--- a/recipes/xorg-makedepend/all/conanfile.py
+++ b/recipes/xorg-makedepend/all/conanfile.py
@@ -1,0 +1,86 @@
+from conans import ConanFile, tools, AutoToolsBuildEnvironment
+from conans.errors import ConanInvalidConfiguration
+import os
+import re
+
+required_conan_version = ">=1.33.0"
+
+
+class XorgMakedepend(ConanFile):
+    name = "xorg-makedepend"
+    description = "Utility to parse C source files to make dependency lists for Makefiles"
+    topics = ("conan", "xorg", "dependency", "obsolete")
+    license = "MIT"
+    homepage = "https://gitlab.freedesktop.org/xorg/util/cf"
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "arch", "compiler", "build_type"
+
+    exports_sources = "patches/*"
+    generators = "pkg_config"
+
+    _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def requirements(self):
+        self.requires("xorg-macros/1.19.3")
+        self.requires("xorg-proto/2021.4")
+
+    def build_requirements(self):
+        self.build_requires("pkgconf/1.7.4")
+
+    def validate(self):
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration("Windows is not supported by xorg-gccmakedep")
+
+    def configure(self):
+        del self.settings.compiler.cppstd
+        del self.settings.compiler.libcxx
+
+    def package_id(self):
+        del self.info.settings.compiler
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    @property
+    def _user_info_build(self):
+        return getattr(self, "user_info_build", self.deps_user_info)
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self, win_bash=self._settings_build.os == "Windows")
+        self._autotools.libs = []
+        self._autotools.configure(configure_dir=self._source_subfolder)
+        return self._autotools
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        autotools = self._configure_autotools()
+        autotools.make()
+
+    def package(self):
+        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
+        def_h_text = tools.load(os.path.join(self._source_subfolder, "def.h"))
+        license_text = next(re.finditer(r"/\*([^*]+)\*/", def_h_text)).group(1)
+        tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), license_text)
+
+        autotools = self._configure_autotools()
+        autotools.install()
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.libdirs = []
+
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)

--- a/recipes/xorg-makedepend/all/conanfile.py
+++ b/recipes/xorg-makedepend/all/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.33.0"
 class XorgMakedepend(ConanFile):
     name = "xorg-makedepend"
     description = "Utility to parse C source files to make dependency lists for Makefiles"
-    topics = ("conan", "xorg", "dependency", "obsolete")
+    topics = ("xorg", "dependency", "obsolete")
     license = "MIT"
     homepage = "https://gitlab.freedesktop.org/xorg/util/cf"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/xorg-makedepend/all/conanfile.py
+++ b/recipes/xorg-makedepend/all/conanfile.py
@@ -37,7 +37,7 @@ class XorgMakedepend(ConanFile):
 
     def validate(self):
         if self.settings.os == "Windows":
-            raise ConanInvalidConfiguration("Windows is not supported by xorg-gccmakedep")
+            raise ConanInvalidConfiguration("Windows is not supported by xorg-makedepend")
 
     def configure(self):
         del self.settings.compiler.cppstd

--- a/recipes/xorg-makedepend/all/test_package/conanfile.py
+++ b/recipes/xorg-makedepend/all/test_package/conanfile.py
@@ -1,0 +1,13 @@
+from conans import ConanFile, tools
+import os
+
+required_conan_version = ">=1.36.0"
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+
+    def test(self):
+        if not tools.cross_building(self):
+            src = os.path.join(self.source_folder, "test_package.c")
+            self.run("makedepend -f- -- -- {}".format(src), run_environment=True)

--- a/recipes/xorg-makedepend/all/test_package/test_package.c
+++ b/recipes/xorg-makedepend/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include "test_package.h"
+
+#include <stdio.h>
+
+int main() {
+    printf(TEXT);
+    return EXIT_SUCCESS;
+}

--- a/recipes/xorg-makedepend/all/test_package/test_package.h
+++ b/recipes/xorg-makedepend/all/test_package/test_package.h
@@ -1,0 +1,8 @@
+#ifndef TEST_PACKAGE_H
+#define TEST_PACKAGE_H
+
+#include <stdlib.h>
+
+#define TEXT "hello world\n"
+
+#endif // TEST_PACKAGE_H

--- a/recipes/xorg-makedepend/config.yml
+++ b/recipes/xorg-makedepend/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.8":
+    folder: all

--- a/recipes/xorg-makedepend/config.yml
+++ b/recipes/xorg-makedepend/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.0.8":
+  "1.0.6":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **xorg-makedepend/1.0.6**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
