### PR TITLE
xmlsec: add version 1.2.32

### DIFF
--- a/recipes/xmlsec/all/conandata.yml
+++ b/recipes/xmlsec/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.32":
+    url: "https://github.com/lsh123/xmlsec/archive/xmlsec-1_2_32.tar.gz"
+    sha256: "e33e551fb9f6da5576b1a55ce962048adf337332c27e6be9dba04d360b6a5584"
   "1.2.31":
     url: "https://github.com/lsh123/xmlsec/archive/xmlsec-1_2_31.tar.gz"
     sha256: "3d975c7c945b6f8f84e956934b562f794fa6b469d78d913190d3a1c32d1a3ddb"

--- a/recipes/xmlsec/config.yml
+++ b/recipes/xmlsec/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.32":
+    folder: all
   "1.2.31":
     folder: all
   "1.2.30":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **xmlsec/1.2.32**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
