### PR TITLE
Bump kuba-zip/0.2.0

### DIFF
--- a/recipes/kuba-zip/all/conandata.yml
+++ b/recipes/kuba-zip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.0":
+    url: "https://github.com/kuba--/zip/archive/refs/tags/v0.2.0.tar.gz"
+    sha256: "59ee52b717933b90ea1fff53d5381b612bab8ffbcb3b5f65d2cdfd0814b3068a"
   "0.1.31":
     url: "https://github.com/kuba--/zip/archive/refs/tags/v0.1.31.tar.gz"
     sha256: "65ad5e63497e48ee773fdec86a4c36752a92e53da9cd8da4f1f77b5d743794f1"

--- a/recipes/kuba-zip/all/conanfile.py
+++ b/recipes/kuba-zip/all/conanfile.py
@@ -44,6 +44,9 @@ class ZipConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    def _patch_sources(self):
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"), "-Werror", "")
+
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake
@@ -56,6 +59,7 @@ class ZipConan(ConanFile):
         return self._cmake
 
     def build(self):
+        self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/kuba-zip/all/test_package/conanfile.py
+++ b/recipes/kuba-zip/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/kuba-zip/config.yml
+++ b/recipes/kuba-zip/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.2.0":
+    folder: "all"
   "0.1.31":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

I was hoping to be able to unvendor miniz in this version, but It's not possible yet. See https://github.com/kuba--/zip/issues/144#issuecomment-894648252

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
