### PR TITLE
hipony-enumerate: add version 2.4.1

### DIFF
--- a/recipes/hipony-enumerate/all/conandata.yml
+++ b/recipes/hipony-enumerate/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.4.1":
+    url: "https://github.com/hipony/enumerate/archive/v2.4.1.tar.gz"
+    sha256: "a071f6014711dcd09e752cd042651d96f2917925ff743208064ebd0d6bdc4e55"
   "2.4.0":
     url: "https://github.com/hipony/enumerate/archive/v2.4.0.tar.gz"
     sha256: "21ee64fc3b1fda25356df0ee0e0292b529bb9b99931ee2b388222d2f498d7a45"

--- a/recipes/hipony-enumerate/config.yml
+++ b/recipes/hipony-enumerate/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.4.1":
+    folder: "all"
   "2.4.0":
     folder: "all"
   "2.2.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **hipony-enumerate/2.4.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
