### PR TITLE
xtensor: add version 0.23.10

### DIFF
--- a/recipes/xtensor/all/conandata.yml
+++ b/recipes/xtensor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.23.10":
+    url: "https://github.com/xtensor-stack/xtensor/archive/0.23.10.tar.gz"
+    sha256: "2e770a6d636962eedc868fef4930b919e26efe783cd5d8732c11e14cf72d871c"
   "0.23.9":
     sha256: 5bdb9d85ee82c60be0bce32d891b5cc20eb633284a0aabb907f55bbe722cc8e3
     url: https://github.com/xtensor-stack/xtensor/archive/refs/tags/0.23.9.tar.gz

--- a/recipes/xtensor/config.yml
+++ b/recipes/xtensor/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.23.10":
+    folder: all
   "0.23.9":
     folder: all
   "0.21.5":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **xtensor/0.23.10**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
