### PR TITLE
benchmark: add version 1.5.5

### DIFF
--- a/recipes/benchmark/all/conandata.yml
+++ b/recipes/benchmark/all/conandata.yml
@@ -11,3 +11,6 @@ sources:
   "1.5.3":
     sha256: e4fbb85eec69e6668ad397ec71a3a3ab165903abe98a8327db920b94508f720e
     url: https://github.com/google/benchmark/archive/v1.5.3.tar.gz
+  "1.5.5":
+    url: "https://github.com/google/benchmark/archive/v1.5.5.tar.gz"
+    sha256: "3bff5f237c317ddfd8d5a9b96b3eede7c0802e799db520d38ce756a2a46a18a0"

--- a/recipes/benchmark/config.yml
+++ b/recipes/benchmark/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "1.5.3":
     folder: all
+  "1.5.5":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **benchmark/1.5.5**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
