### PR TITLE
glib: add version 2.69.1

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -56,3 +56,6 @@ sources:
   "2.69.0":
     url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.69.0/glib-2.69.0.tar.gz"
     sha256: "35af83aedf34b96f1e99ed9c995c50960509f504750fb4def2440a9406b00a95"
+  "2.69.1":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.69.1/glib-2.69.1.tar.gz"
+    sha256: "017781fdb1eb8bcbeeeff6e7876ce6b435e6eb487c7c9786a8f5cacb1316d8dd"

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -37,3 +37,5 @@ versions:
     folder: all
   "2.69.0":
     folder: all
+  "2.69.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **glib/2.69.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
