### PR TITLE
ade: initialize recipe for ade

### DIFF
--- a/recipes/ade/all/CMakeLists.txt
+++ b/recipes/ade/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.2)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/ade/all/conandata.yml
+++ b/recipes/ade/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.1f":
+    - sha256: c316680efbb5dd3ac4e10bb8cea345cf26a6a25ebc22418f8f0b8ca931a550e9
+      url: https://github.com/opencv/ade/archive/refs/tags/v0.1.1f.tar.gz

--- a/recipes/ade/all/conanfile.py
+++ b/recipes/ade/all/conanfile.py
@@ -1,0 +1,69 @@
+import os
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.33.0"
+
+
+class AdeConan(ConanFile):
+    name = "ade"
+    license = "Apache-2.0"
+    homepage = "https://github.com/opencv/ade"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "Graph construction, manipulation, and processing framework"
+    topics = ("graphs", "opencv")
+    exports_sources = "CMakeLists.txt",
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+    }
+    generators = "cmake"
+
+    _cmake = None
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+
+    def _configure_cmake(self):
+        if self._cmake is not None:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version][0],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+        self.copy(pattern="LICENSE",
+                  dst="licenses",
+                  src=self._source_subfolder)
+
+    def package_info(self):
+        # FIXME opencv expects this target to be "ade" but conan will bind it as ade::ade
+        self.cpp_info.names["cmake_find_package"] = "ade"
+        self.cpp_info.names["cmake_find_package_multi"] = "ade"
+        self.cpp_info.libs = ["ade"]

--- a/recipes/ade/all/test_package/CMakeLists.txt
+++ b/recipes/ade/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/ade/all/test_package/conanfile.py
+++ b/recipes/ade/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class AdeTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/ade/all/test_package/test_package.cpp
+++ b/recipes/ade/all/test_package/test_package.cpp
@@ -1,0 +1,5 @@
+#include "ade/graph.hpp"
+
+int main() {
+  ade::Graph graph;
+}

--- a/recipes/ade/config.yml
+++ b/recipes/ade/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.1f":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **ade/0.1.1f**

`opencv`, when built with `WITH_ADE`, depends on this library. This PR is related to #6614 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
