### PR TITLE
libx264: get it building using mingw on Windows

### DIFF
--- a/recipes/libx264/all/conandata.yml
+++ b/recipes/libx264/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "20190605":
-    url: "http://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-20190605-2245.tar.bz2"
-    sha256: "c75203ef4759e4d7bc38e686b156c54c43b78edc73123c0b25db5224758bd1fc"
   "20191217":
     url: "https://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-20191217-2245.tar.bz2"
     sha256: "0bb67d095513391e637b3b47e8efc3ba4603c3844f1b4c2690f4d36da7763055"
+  "20190605":
+    url: "http://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-20190605-2245.tar.bz2"
+    sha256: "c75203ef4759e4d7bc38e686b156c54c43b78edc73123c0b25db5224758bd1fc"

--- a/recipes/libx264/all/conanfile.py
+++ b/recipes/libx264/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools, AutoToolsBuildEnvironment
+import contextlib
 import os
 
 required_conan_version = ">=1.33.0"
@@ -13,25 +14,34 @@ class LibX264Conan(ConanFile):
     topics = ("conan", "libx264", "video", "encoding")
     license = "GPL-2.0"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False], "bit_depth": [8, 10, "all"]}
-    default_options = {'shared': False, 'fPIC': True, 'bit_depth': 'all'}
-    _override_env = {}
-    _autotools = None
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "bit_depth": [8, 10, "all"],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "bit_depth": "all",
+    }
 
-    @property
-    def _is_mingw(self):
-        return self.settings.os == "Windows" and self.settings.compiler == 'gcc'
+    _autotools = None
+    _override_env = {}
 
     @property
     def _is_msvc(self):
-        return self.settings.compiler == 'Visual Studio'
+        return self.settings.compiler == "Visual Studio"
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
     def config_options(self):
-        if self.settings.os == 'Windows':
+        if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
@@ -40,14 +50,24 @@ class LibX264Conan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
+    @property
+    def _with_nasm(self):
+        return self.settings.arch in ("x86", "x86_64")
+
     def build_requirements(self):
-        self.build_requires("nasm/2.15.05")
-        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
+        if self._with_nasm:
+            self.build_requires("nasm/2.15.05")
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
+
+    @contextlib.contextmanager
+    def _build_context(self):
+        with tools.vcvars(self) if self._is_msvc else tools.no_op():
+            yield
 
     @property
     def env(self):
@@ -56,64 +76,68 @@ class LibX264Conan(ConanFile):
         return ret
 
     def _configure_autotools(self):
-        if not self._autotools:
-            prefix = tools.unix_path(self.package_folder)
-            args = ['--disable-cli', '--prefix={}'.format(prefix)]
-            if self.options.shared:
-                args.append('--enable-shared')
-            else:
-                args.append('--enable-static')
-            if self.settings.os != 'Windows' and self.options.get_safe("fPIC"):
-                args.append('--enable-pic')
-            if self.settings.build_type == 'Debug':
-                args.append('--enable-debug')
-            args.append('--bit-depth=%s' % str(self.options.bit_depth))
-            if self.settings.os == "Macos" and self.settings.arch == "armv8":
-                # bitstream-a.S:29:18: error: unknown token in expression
-                args.append('--extra-asflags=-arch arm64')
-                args.append('--extra-ldflags=-arch arm64')
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        args = [
+            "--bit-depth=%s" % str(self.options.bit_depth),
+            "--disable-cli",
+            "--prefix={}".format(tools.unix_path(self.package_folder)),
+        ]
+        if self.options.shared:
+            args.append("--enable-shared")
+        else:
+            args.append("--enable-static")
+        if self.options.get_safe("fPIC", self.settings.os != "Windows"):
+            args.append("--enable-pic")
+        if self.settings.build_type == "Debug":
+            args.append("--enable-debug")
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            # bitstream-a.S:29:18: error: unknown token in expression
+            args.append("--extra-asflags=-arch arm64")
+            args.append("--extra-ldflags=-arch arm64")
 
-            if tools.cross_building(self.settings):
-                if self.settings.os == "Android":
-                    # the as of ndk does not work well for building libx264
-                    self._override_env["AS"] = os.environ["CC"]
-                    ndk_root = tools.unix_path(os.environ["NDK_ROOT"])
-                    arch = {'armv7': 'arm',
-                            'armv8': 'aarch64',
-                            'x86': 'i686',
-                            'x86_64': 'x86_64'}.get(str(self.settings.arch))
-                    abi = 'androideabi' if self.settings.arch == 'armv7' else 'android'
-                    cross_prefix = "%s/bin/%s-linux-%s-" % (ndk_root, arch, abi)
-                    args.append('--cross-prefix=%s' % cross_prefix)
-
-            if self._is_msvc:
-                self._override_env['CC'] = 'cl'
-            self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-            if self._is_msvc:
-                self._autotools.flags.append('-%s' % str(self.settings.compiler.runtime))
-                # cannot open program database ... if multiple CL.EXE write to the same .PDB file, please use /FS
-                self._autotools.flags.append('-FS')
-            build_canonical_name = None
-            host_canonical_name = None
-            if self.settings.compiler == "Visual Studio":
-                # autotools does not know about the msvc canonical name(s)
-                build_canonical_name = False
-                host_canonical_name = False
-            self._autotools.configure(args=args, vars=self._override_env, configure_dir=self._source_subfolder, build=build_canonical_name, host=host_canonical_name)
-
+        if self._with_nasm:
+            # FIXME: get using user_build_info
+            self._override_env["AS"] = os.path.join(self.deps_cpp_info["nasm"].rootpath, "bin", "nasm{}".format(".exe" if tools.os_info.is_windows else "")).replace("\\", "/")
+        if tools.cross_building(self):
+            if self.settings.os == "Android":
+                # the as of ndk does not work well for building libx264
+                self._override_env["AS"] = os.environ["CC"]
+                ndk_root = tools.unix_path(os.environ["NDK_ROOT"])
+                arch = {
+                    "armv7": "arm",
+                    "armv8": "aarch64",
+                    "x86": "i686",
+                    "x86_64": "x86_64",
+                }.get(str(self.settings.arch))
+                abi = "androideabi" if self.settings.arch == "armv7" else "android"
+                args.append("--cross-prefix={}".format("{}/bin/{}-linux-{}-".format(ndk_root, arch, abi)))
+        if self._is_msvc:
+            self._override_env["CC"] = "cl -nologo"
+            self._autotools.flags.append("-%s" % str(self.settings.compiler.runtime))
+            # cannot open program database ... if multiple CL.EXE write to the same .PDB file, please use /FS
+            self._autotools.flags.append("-FS")
+        build_canonical_name = None
+        host_canonical_name = None
+        if self._is_msvc:
+            # autotools does not know about the msvc canonical name(s)
+            build_canonical_name = False
+            host_canonical_name = False
+        self._autotools.configure(args=args, vars=self._override_env, configure_dir=self._source_subfolder, build=build_canonical_name, host=host_canonical_name)
         return self._autotools
 
     def build(self):
-        with tools.vcvars(self.settings) if self._is_msvc else tools.no_op():
+        with self._build_context():
             autotools = self._configure_autotools()
             autotools.make()
 
     def package(self):
-        with tools.vcvars(self.settings) if self._is_msvc else tools.no_op():
+        self.copy(pattern="COPYING", src=self._source_subfolder, dst="licenses")
+        with self._build_context():
             autotools = self._configure_autotools()
             autotools.install()
-        self.copy(pattern="COPYING", src=self._source_subfolder, dst='licenses')
-        tools.rmdir(os.path.join(self.package_folder, 'lib', 'pkgconfig'))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         if self._is_msvc:
             ext = ".dll.lib" if self.options.shared else ".lib"
             tools.rename(os.path.join(self.package_folder, "lib", "libx264{}".format(ext)),
@@ -123,8 +147,8 @@ class LibX264Conan(ConanFile):
         self.cpp_info.libs = ["x264"]
         if self._is_msvc and self.options.shared:
             self.cpp_info.defines.append("X264_API_IMPORTS")
-        if self.settings.os == "Linux":
-            self.cpp_info.system_libs.extend(['dl', 'pthread', 'm'])
+        if self.settings.os in ("FreeBSD", "Linux"):
+            self.cpp_info.system_libs.extend(["dl", "pthread", "m"])
         elif self.settings.os == "Android":
-            self.cpp_info.system_libs.extend(['dl', 'm'])
-        self.cpp_info.names['pkg_config'] = 'x264'
+            self.cpp_info.system_libs.extend(["dl", "m"])
+        self.cpp_info.names["pkg_config"] = "x264"

--- a/recipes/libx264/all/test_package/CMakeLists.txt
+++ b/recipes/libx264/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/libx264/all/test_package/conanfile.py
+++ b/recipes/libx264/all/test_package/conanfile.py
@@ -12,7 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if tools.cross_building(self.settings, skip_x64_x86=True):
-            return
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libx264/all/test_package/test_package.c
+++ b/recipes/libx264/all/test_package/test_package.c
@@ -1,16 +1,16 @@
-#include <cstdlib>
-#include <iostream>
 #include <stdint.h>
-#include <inttypes.h>
 #include "x264.h"
+
+#include <stdlib.h>
 
 int main()
 {
     x264_param_t preset;
+    x264_t *encoder;
     x264_param_default_preset(&preset, "ultrafast", "zerolatency");
     preset.i_width = 640;
     preset.i_height = 480;
-    x264_t * encoder = x264_encoder_open(&preset);
+    encoder = x264_encoder_open(&preset);
     x264_encoder_close(encoder);
     return EXIT_SUCCESS;
 }

--- a/recipes/libx264/config.yml
+++ b/recipes/libx264/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "20190605":
-    folder: all
   "20191217":
+    folder: all
+  "20190605":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libx264/all**

Get it building on mingw on Windows

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
