### PR TITLE
qt/6.0.4: Backport Vulkan support fix.

### DIFF
--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -49,6 +49,9 @@ sources:
       - "https://ftp.fau.de/qtproject/archive/qt/6.1/6.1.2/single/qt-everywhere-src-6.1.2.tar.xz"
     sha256: "4b40f10eb188506656f13dbf067b714145047f41d7bf83f03b727fa1c7c4cdcb"
 patches:
+  "6.0.4":
+    - base_path: "qt6/qtbase/cmake"
+      patch_file: "patches/qt6-pri-helpers-fix.diff"
   "6.1.0":
     - base_path: "qt6/qtbase/cmake"
       patch_file: "patches/qt6-pri-helpers-fix.diff"


### PR DESCRIPTION
Specify library name and version:  **qt/6.0.4**

Backported as requested [here](https://github.com/conan-io/conan-center-index/pull/6668#issuecomment-895062579). Enables patch to `QtPriHelpers.cmake` for Qt 6.0.4 to fix support for compilation with Vulkan. More details are in PR #6668.

Patch seems to work cleanly, but I could not currently do a full compile of 6.0.4 as there is an unrelated GCC 11 issue with this particular Qt release.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
