### PR TITLE
[[botan] Fixes  #6323 compile native aarch64

### DIFF
--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -226,13 +226,13 @@ class BotanConan(ConanFile):
         if self._is_linux_clang_libcxx:
             botan_abi_flags.extend(['-stdlib=libc++', '-lc++abi'])
 
-        if botan_compiler in ['clang', 'apple-clang', 'gcc']:
+        if self.settings.compiler in ['clang', 'apple-clang', 'gcc']:
             if self.settings.arch == 'x86':
                 botan_abi_flags.append('-m32')
             elif self.settings.arch == 'x86_64':
                 botan_abi_flags.append('-m64')
 
-        if botan_compiler in ['apple-clang']:
+        if self.settings.compiler in ['apple-clang']:
             if self.settings.arch in ['armv7']:
                 botan_abi_flags.append('-arch armv7')
             elif self.settings.arch in ['armv8']:

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -231,7 +231,9 @@ class BotanConan(ConanFile):
                 botan_abi_flags.append('-m32')
             elif self.settings.arch == 'x86_64':
                 botan_abi_flags.append('-m64')
-            elif self.settings.arch in ['armv7']:
+
+        if botan_compiler in ['apple-clang']:
+            if self.settings.arch in ['armv7']:
                 botan_abi_flags.append('-arch armv7')
             elif self.settings.arch in ['armv8']:
                 botan_abi_flags.append('-arch arm64')


### PR DESCRIPTION
closes: #6323

Package and Environment Details (include every applicable attribute)

    Package Name/Version: botan/2.18.1
    Operating System+version: Linux Ubuntu 18.04 (aarch64 docker image running through qemu-user-static)
    Compiler+version: GCC 9.4.0
    Conan version: conan 1.37.2
    Python version: Python 3.6.9

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
