### PR TITLE
libjpeg-turbo/2.1.1

### DIFF
--- a/recipes/libjpeg-turbo/all/conandata.yml
+++ b/recipes/libjpeg-turbo/all/conandata.yml
@@ -14,3 +14,6 @@ sources:
   "2.1.0":
     url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.1.0.tar.gz"
     sha256: "d6b7790927d658108dfd3bee2f0c66a2924c51ee7f9dc930f62c452f4a638c52"
+  "2.1.1":
+    url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.1.1.tar.gz"
+    sha256: "20e9cd3e5f517950dfb7a300ad344543d88719c254407ffb5ad88d891bf701c4"

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -114,7 +114,8 @@ class LibjpegTurboConan(ConanFile):
         if self.settings.compiler == "Visual Studio":
             self._cmake.definitions["WITH_CRT_DLL"] = True # avoid replacing /MD by /MT in compiler flags
 
-        self._cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False # avoid configuration error if building for iOS/tvOS/watchOS
+        if tools.Version(self.version) <= "2.1.0":
+            self._cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False # avoid configuration error if building for iOS/tvOS/watchOS
 
         if tools.cross_building(self.settings):
             # TODO: too specific and error prone, should be delegated to a conan helper function

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -137,6 +137,11 @@ class LibjpegTurboConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "sharedlib", "CMakeLists.txt"),
                               """string(REGEX REPLACE "/MT" "/MD" ${var} "${${var}}")""",
                               "")
+        if tools.Version(self.version) >= "2.1.1":
+            # avoid explicit fPIC
+            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                                  """set_target_properties(simd PROPERTIES POSITION_INDEPENDENT_CODE 1)""",
+                                  "")
 
     def build(self):
         self._patch_sources()

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -137,11 +137,6 @@ class LibjpegTurboConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "sharedlib", "CMakeLists.txt"),
                               """string(REGEX REPLACE "/MT" "/MD" ${var} "${${var}}")""",
                               "")
-        if tools.Version(self.version) >= "2.1.1":
-            # avoid explicit fPIC
-            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                                  """set_target_properties(simd PROPERTIES POSITION_INDEPENDENT_CODE 1)""",
-                                  "")
 
     def build(self):
         self._patch_sources()

--- a/recipes/libjpeg-turbo/config.yml
+++ b/recipes/libjpeg-turbo/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "2.1.0":
     folder: all
+  "2.1.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libjpeg-turbo/2.1.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

Changes:
- remove one workaround with osx bundle
- drop explicit CMAKE_POSITION_INDEPENDENT_CODE (@SpaceIm , please take a look as you worked with 2.1.0)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
