### PR TITLE
fix flatbuffers/2.0 build error in macOS

### DIFF
--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -82,7 +82,8 @@ class FlatbuffersConan(ConanFile):
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = self.options.flatbuffers and not self.options.shared
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATC"] = self.options.flatc
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATHASH"] = False
-        self._cmake.definitions["FLATBUFFERS_STATIC_FLATC"] = False
+        if self.settings.os != "Macos":
+             self._cmake.definitions["FLATBUFFERS_STATIC_FLATC"] = not self.options.shared
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -82,8 +82,7 @@ class FlatbuffersConan(ConanFile):
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = self.options.flatbuffers and not self.options.shared
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATC"] = self.options.flatc
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATHASH"] = False
-        if self.settings.os != "Macos":
-             self._cmake.definitions["FLATBUFFERS_STATIC_FLATC"] = not self.options.shared
+        self._cmake.definitions["FLATBUFFERS_STATIC_FLATC"] = False
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -82,6 +82,8 @@ class FlatbuffersConan(ConanFile):
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = self.options.flatbuffers and not self.options.shared
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATC"] = self.options.flatc
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATHASH"] = False
+        if self.settings.os != "Macos":
+             self._cmake.definitions["FLATBUFFERS_STATIC_FLATC"] = not self.options.shared
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -82,8 +82,6 @@ class FlatbuffersConan(ConanFile):
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = self.options.flatbuffers and not self.options.shared
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATC"] = self.options.flatc
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATHASH"] = False
-        if self.settings.os != "Macos":
-            self._cmake.definitions["FLATBUFFERS_STATIC_FLATC"] = not self.options.shared
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -82,7 +82,8 @@ class FlatbuffersConan(ConanFile):
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = self.options.flatbuffers and not self.options.shared
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATC"] = self.options.flatc
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATHASH"] = False
-        self._cmake.definitions["FLATBUFFERS_STATIC_FLATC"] = not self.options.shared
+        if self.settings.os != "Macos":
+            self._cmake.definitions["FLATBUFFERS_STATIC_FLATC"] = not self.options.shared
         self._cmake.configure()
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **flatbuffers/2.0**

This is the command I installed manually
> conan install flatbuffers/2.0.0@ -r conancenter --build -o flatbuffers:options_from_context=False

In this command, bin/flatc will be build and throw error
> ld: library not found for -lcrt0.o

In macOS, when options is shared, FLATBUFFERS_STATIC_FLATC will be ON,This happens in all versions of macOS.Because macOS is not allow to build a executables with -static.
ref man ld
> Produces a mach-o file that does not the dyld.  Only used building the kernel.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
