### PR TITLE
Fix non-shared build of flatbuffers on Macos

### DIFF
--- a/recipes/flatbuffers/all/conanfile.py
+++ b/recipes/flatbuffers/all/conanfile.py
@@ -34,7 +34,7 @@ class FlatbuffersConan(ConanFile):
     @property
     def _source_subfolder(self):
         return "source_subfolder"
-    
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -59,7 +59,7 @@ class FlatbuffersConan(ConanFile):
 
         if (self.options.shared and self.options.flatbuffers) or self._header_only or (not self.options.flatbuffers and self.options.flatc):
             del self.options.fPIC
-            
+
         if self._header_only and not self.options.flatc:
             del self.options.shared
 
@@ -71,7 +71,8 @@ class FlatbuffersConan(ConanFile):
             self.info.header_only()
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:
@@ -82,7 +83,7 @@ class FlatbuffersConan(ConanFile):
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATLIB"] = self.options.flatbuffers and not self.options.shared
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATC"] = self.options.flatc
         self._cmake.definitions["FLATBUFFERS_BUILD_FLATHASH"] = False
-        self._cmake.definitions["FLATBUFFERS_STATIC_FLATC"] = not self.options.shared
+        self._cmake.definitions["FLATBUFFERS_STATIC_FLATC"] = self.settings.os != "Macos" and not self.options.shared
         self._cmake.configure()
         return self._cmake
 
@@ -93,7 +94,8 @@ class FlatbuffersConan(ConanFile):
             cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="LICENSE.txt", dst="licenses",
+                  src=self._source_subfolder)
 
         # Run cmake if there is anything to build
         if (self.options.flatbuffers and not self._header_only) or self.options.flatc:
@@ -103,10 +105,12 @@ class FlatbuffersConan(ConanFile):
             tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
         if self.options.flatbuffers:
-            self.copy(pattern="BuildFlatBuffers.cmake", dst="bin/cmake", src=os.path.join(self._source_subfolder, "CMake"))
+            self.copy(pattern="BuildFlatBuffers.cmake", dst="bin/cmake",
+                      src=os.path.join(self._source_subfolder, "CMake"))
 
             if self._header_only:
-                header_dir = os.path.join(self._source_subfolder, "include", "flatbuffers")
+                header_dir = os.path.join(
+                    self._source_subfolder, "include", "flatbuffers")
                 dst_dir = os.path.join("include", "flatbuffers")
                 self.copy("*.h", dst=dst_dir, src=header_dir)
 
@@ -114,7 +118,8 @@ class FlatbuffersConan(ConanFile):
                 if self.settings.os == "Windows" and self.options.shared:
                     tools.mkdir(os.path.join(self.package_folder, "bin"))
                     for dll_path in glob.glob(os.path.join(self.package_folder, "lib", "*.dll")):
-                        shutil.move(dll_path, os.path.join(self.package_folder, "bin", os.path.basename(dll_path)))
+                        shutil.move(dll_path, os.path.join(
+                            self.package_folder, "bin", os.path.basename(dll_path)))
         elif self.options.flatc:
             tools.rmdir(os.path.join(self.package_folder, "include"))
 
@@ -129,15 +134,21 @@ class FlatbuffersConan(ConanFile):
                 cmake_target = "flatbuffers_shared" if self.options.shared else "flatbuffers"
                 self.cpp_info.components["libflatbuffers"].names["cmake_find_package"] = cmake_target
                 self.cpp_info.components["libflatbuffers"].names["cmake_find_package_multi"] = cmake_target
-                self.cpp_info.components["libflatbuffers"].libs = tools.collect_libs(self)
-                self.cpp_info.components["libflatbuffers"].builddirs.append("bin/cmake")
-                self.cpp_info.components["libflatbuffers"].build_modules.append("bin/cmake/BuildFlatBuffers.cmake")
+                self.cpp_info.components["libflatbuffers"].libs = tools.collect_libs(
+                    self)
+                self.cpp_info.components["libflatbuffers"].builddirs.append(
+                    "bin/cmake")
+                self.cpp_info.components["libflatbuffers"].build_modules.append(
+                    "bin/cmake/BuildFlatBuffers.cmake")
                 if self.settings.os == "Linux":
-                    self.cpp_info.components["libflatbuffers"].system_libs.append("m")
+                    self.cpp_info.components["libflatbuffers"].system_libs.append(
+                        "m")
             else:
                 self.cpp_info.builddirs.append("bin/cmake")
-                self.cpp_info.build_modules.append("bin/cmake/BuildFlatBuffers.cmake")
+                self.cpp_info.build_modules.append(
+                    "bin/cmake/BuildFlatBuffers.cmake")
         if self.options.flatc:
             bindir = os.path.join(self.package_folder, "bin")
-            self.output.info("Appending PATH environment variable: {}".format(bindir))
+            self.output.info(
+                "Appending PATH environment variable: {}".format(bindir))
             self.env_info.PATH.append(bindir)


### PR DESCRIPTION
Specify library name and version:  **flatbuffers/2.0.0**

Macos doesn't support `-static`, the current recipe will fail installing on Macos with:

```
ld: library not found for -lcrt0.o
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
