### PR TITLE
OpenCV/4.x: Allow for configuring builtin imgcodecs

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -34,6 +34,10 @@ class OpenCVConan(ConanFile):
         "with_cublas": [True, False],
         "with_cufft": [True, False],
         "with_v4l": [True, False],
+        "with_imgcodec_hdr": [True, False],
+        "with_imgcodec_pfm": [True, False],
+        "with_imgcodec_pxm": [True, False],
+        "with_imgcodec_sunraster": [True, False],
         "neon": [True, False],
         "dnn": [True, False],
         "detect_cpu_baseline": [True, False]
@@ -58,6 +62,10 @@ class OpenCVConan(ConanFile):
         "with_cublas": False,
         "with_cufft": False,
         "with_v4l": False,
+        "with_imgcodec_hdr": False,
+        "with_imgcodec_pfm": False,
+        "with_imgcodec_pxm": False,
+        "with_imgcodec_sunraster": False,
         "neon": True,
         "dnn": True,
         "detect_cpu_baseline": False
@@ -265,10 +273,10 @@ class OpenCVConan(ConanFile):
         self._cmake.definitions["WITH_GSTREAMER"] = False
         self._cmake.definitions["WITH_HALIDE"] = False
         self._cmake.definitions["WITH_HPX"] = False
-        self._cmake.definitions["WITH_IMGCODEC_HDR"] = False
-        self._cmake.definitions["WITH_IMGCODEC_PFM"] = False
-        self._cmake.definitions["WITH_IMGCODEC_PXM"] = False
-        self._cmake.definitions["WITH_IMGCODEC_SUNRASTER"] = False
+        self._cmake.definitions["WITH_IMGCODEC_HDR"] = self.options.with_imgcodec_hdr
+        self._cmake.definitions["WITH_IMGCODEC_PFM"] = self.options.with_imgcodec_pfm
+        self._cmake.definitions["WITH_IMGCODEC_PXM"] = self.options.with_imgcodec_pxm
+        self._cmake.definitions["WITH_IMGCODEC_SUNRASTER"] = self.options.with_imgcodec_sunraster
         self._cmake.definitions["WITH_INF_ENGINE"] = False
         self._cmake.definitions["WITH_IPP"] = False
         self._cmake.definitions["WITH_ITT"] = False


### PR DESCRIPTION
Specify library name and version:  **opencv/4.x**

This problem has already bitten me twice: By default OpenCV enables all its internal image codecs, which have no 3rd party dependencies! However, the current conanfile.py turns them off and offers no option for turning them on again.
I decided to leave them off by default to avoid changing the conanfile's defaults.

This PR adds configuration options for all those embedded image codecs. They report the following file extensions:

* HDR
  * Radiance HDR (*.hdr;*.pic)
* PFM
  * Portable image format - float (*.pfm)
* PXM
  * Portable arbitrary format (*.pam)
  * Portable image format - auto (*.pnm)
  * Portable image format - monochrome (*.pbm)
  * Portable image format - gray (*.pgm)
  * Portable image format - color (*.ppm)
* SUNRASTER
  * Sun raster files (*.sr;*.ras)
  
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
