### PR TITLE
libbasisu: Add option to use only the trancoder library part

### DIFF
--- a/recipes/libbasisu/all/conanfile.py
+++ b/recipes/libbasisu/all/conanfile.py
@@ -20,13 +20,15 @@ class LibBasisUniversalConan(ConanFile):
         "shared": [True, False],
         "use_sse4": [True, False],
         "with_zstd": [True, False],
+        "transcoder_only": [True, False],
         "custom_iterator_debug_level": [True, False]
     }
     default_options = {
         "fPIC": True,
         "shared": False,
-        "use_sse4": True,
+        "use_sse4": False,
         "with_zstd": True,
+        "transcoder_only": False,
         "custom_iterator_debug_level": False
     }
 
@@ -77,6 +79,7 @@ class LibBasisUniversalConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["SSE4"] = self.options.use_sse4
         self._cmake.definitions["ZSTD"] = self.options.with_zstd
+        self._cmake.definitions["TRANSCODER_ONLY"] = self.options.transcoder_only
         self._cmake.definitions["BASISU_NO_ITERATOR_DEBUG_LEVEL"] = not self.options.get_safe("custom_iterator_debug_level", default=self.default_options["custom_iterator_debug_level"])
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake

--- a/recipes/libbasisu/all/conanfile.py
+++ b/recipes/libbasisu/all/conanfile.py
@@ -42,6 +42,9 @@ class LibBasisUniversalConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    def _use_custom_iterator_debug_level(self):
+        return self.options.get_safe("custom_iterator_debug_level", default=self.default_options["custom_iterator_debug_level"])
+ 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -55,7 +58,7 @@ class LibBasisUniversalConan(ConanFile):
             "clang": "3.9",
             "apple-clang": "10"
         }
- 
+
     def validate(self):
         min_version = self._minimum_compiler_version().get(str(self.settings.compiler))
         if not min_version:
@@ -80,7 +83,7 @@ class LibBasisUniversalConan(ConanFile):
         self._cmake.definitions["SSE4"] = self.options.use_sse4
         self._cmake.definitions["ZSTD"] = self.options.with_zstd
         self._cmake.definitions["ENABLE_ENCODER"] = self.options.enable_encoder
-        self._cmake.definitions["BASISU_NO_ITERATOR_DEBUG_LEVEL"] = not self.options.get_safe("custom_iterator_debug_level", default=self.default_options["custom_iterator_debug_level"])
+        self._cmake.definitions["NO_ITERATOR_DEBUG_LEVEL"] = not self._use_custom_iterator_debug_level()
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
  
@@ -93,7 +96,8 @@ class LibBasisUniversalConan(ConanFile):
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         self.copy("*.h", dst=os.path.join("include", self.name, "transcoder"), src=os.path.join(self._source_subfolder, "transcoder"))
-        self.copy("*.h", dst=os.path.join("include", self.name, "encoder"), src=os.path.join(self._source_subfolder, "encoder"))
+        if self.options.enable_encoder:
+            self.copy("*.h", dst=os.path.join("include", self.name, "encoder"), src=os.path.join(self._source_subfolder, "encoder"))
         self.copy(pattern="*.a", dst="lib", keep_path=False)
         self.copy(pattern="*.so", dst="lib", keep_path=False)
         self.copy(pattern="*.dylib*", dst="lib", keep_path=False)
@@ -107,3 +111,4 @@ class LibBasisUniversalConan(ConanFile):
         self.cpp_info.includedirs = ["include", os.path.join("include", self.name)]
         if self.settings.os == "Linux":
             self.cpp_info.system_libs = ["m", "pthread"]
+        self.cpp_info.defines.append("BASISU_NO_ITERATOR_DEBUG_LEVEL={}".format("1" if self._use_custom_iterator_debug_level() else "0"))

--- a/recipes/libbasisu/all/conanfile.py
+++ b/recipes/libbasisu/all/conanfile.py
@@ -20,7 +20,7 @@ class LibBasisUniversalConan(ConanFile):
         "shared": [True, False],
         "use_sse4": [True, False],
         "with_zstd": [True, False],
-        "transcoder_only": [True, False],
+        "enable_encoder": [True, False],
         "custom_iterator_debug_level": [True, False]
     }
     default_options = {
@@ -28,7 +28,7 @@ class LibBasisUniversalConan(ConanFile):
         "shared": False,
         "use_sse4": False,
         "with_zstd": True,
-        "transcoder_only": False,
+        "enable_encoder": True,
         "custom_iterator_debug_level": False
     }
 
@@ -79,7 +79,7 @@ class LibBasisUniversalConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["SSE4"] = self.options.use_sse4
         self._cmake.definitions["ZSTD"] = self.options.with_zstd
-        self._cmake.definitions["TRANSCODER_ONLY"] = self.options.transcoder_only
+        self._cmake.definitions["ENABLE_ENCODER"] = self.options.enable_encoder
         self._cmake.definitions["BASISU_NO_ITERATOR_DEBUG_LEVEL"] = not self.options.get_safe("custom_iterator_debug_level", default=self.default_options["custom_iterator_debug_level"])
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake

--- a/recipes/libbasisu/all/patches/cmakelist_build_lib.patch
+++ b/recipes/libbasisu/all/patches/cmakelist_build_lib.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1,14 +1,14 @@
+@@ -1,14 +1,15 @@
 -project(basisu)
 -
  cmake_minimum_required(VERSION 3.0)
@@ -8,12 +8,13 @@
 -option(STATIC "static linking" FALSE)
 -option(SSE "SSE 4.1 support" FALSE)
 +
-+project(libbasisu VERSION 1.15.0 LANGUAGES CXX)
++project(basisu VERSION 1.15.0 LANGUAGES CXX)
 +
 +option(SSE4 "SSE4 4.1 support" FALSE)
  option(ZSTD "ZSTD support for KTX2 transcoding/encoding" TRUE)
 +option(BASISU_NO_ITERATOR_DEBUG_LEVEL "Change Iterator debug level" FALSE)
 +option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" OFF)
++option(TRANSCODER_ONLY "Build only transcoder part of basisu library")
  
 -message("Initial BUILD_X64=${BUILD_X64}")
  message("Initial CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
@@ -22,7 +23,7 @@
  message("Initial ZSTD=${ZSTD}")
  
  if( NOT CMAKE_BUILD_TYPE )
-@@ -17,16 +17,10 @@ endif()
+@@ -17,16 +18,10 @@ endif()
  
  message( ${PROJECT_NAME} " build type: " ${CMAKE_BUILD_TYPE} )
  
@@ -42,7 +43,7 @@
  endif()
  
  if (ZSTD)
-@@ -42,38 +36,24 @@ if (NOT MSVC)
+@@ -42,38 +37,24 @@ if (NOT MSVC)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
  
@@ -87,7 +88,7 @@
     endif()
  
     set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${GCC_COMPILE_FLAGS}")
-@@ -84,7 +64,7 @@ if (NOT MSVC)
+@@ -84,7 +65,7 @@ if (NOT MSVC)
     set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE} ${GCC_COMPILE_FLAGS}")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${GCC_COMPILE_FLAGS} -D_DEBUG")
  else()
@@ -96,20 +97,57 @@
  		set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=1")
  		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=1")
  	else()
-@@ -94,7 +74,6 @@ else()
+@@ -93,64 +74,51 @@ else()
+ 	endif()
  endif()
  
- set(BASISU_SRC_LIST ${COMMON_SRC_LIST} 
+-set(BASISU_SRC_LIST ${COMMON_SRC_LIST} 
 -	basisu_tool.cpp
- 	encoder/basisu_backend.cpp
- 	encoder/basisu_basis_file.cpp
- 	encoder/basisu_comp.cpp
-@@ -115,42 +94,27 @@ set(BASISU_SRC_LIST ${COMMON_SRC_LIST}
- 	encoder/jpgd.cpp
- 	encoder/basisu_kernels_sse.cpp
- 	transcoder/basisu_transcoder.cpp
--	)
-+)
+-	encoder/basisu_backend.cpp
+-	encoder/basisu_basis_file.cpp
+-	encoder/basisu_comp.cpp
+-	encoder/basisu_enc.cpp
+-	encoder/basisu_etc.cpp
+-	encoder/basisu_frontend.cpp
+-	encoder/basisu_global_selector_palette_helpers.cpp
+-	encoder/basisu_gpu_texture.cpp
+-	encoder/basisu_pvrtc1_4.cpp
+-	encoder/basisu_resampler.cpp
+-	encoder/basisu_resample_filters.cpp
+-	encoder/basisu_ssim.cpp
+-	encoder/basisu_astc_decomp.cpp
+-	encoder/basisu_uastc_enc.cpp
+-	encoder/basisu_bc7enc.cpp
+-	encoder/lodepng.cpp
+-	encoder/apg_bmp.c
+-	encoder/jpgd.cpp
+-	encoder/basisu_kernels_sse.cpp
+-	transcoder/basisu_transcoder.cpp
++set(BASISU_SRC_LIST ${COMMON_SRC_LIST} transcoder/basisu_transcoder.cpp)
++
++if (NOT TRANSCODER_ONLY)
++	set(BASISU_SRC_LIST ${BASISU_SRC_LIST}
++		encoder/basisu_backend.cpp
++		encoder/basisu_basis_file.cpp
++		encoder/basisu_comp.cpp
++		encoder/basisu_enc.cpp
++		encoder/basisu_etc.cpp
++		encoder/basisu_frontend.cpp
++		encoder/basisu_global_selector_palette_helpers.cpp
++		encoder/basisu_gpu_texture.cpp
++		encoder/basisu_pvrtc1_4.cpp
++		encoder/basisu_resampler.cpp
++		encoder/basisu_resample_filters.cpp
++		encoder/basisu_ssim.cpp
++		encoder/basisu_astc_decomp.cpp
++		encoder/basisu_uastc_enc.cpp
++		encoder/basisu_bc7enc.cpp
++		encoder/lodepng.cpp
++		encoder/apg_bmp.c
++		encoder/jpgd.cpp
++		encoder/basisu_kernels_sse.cpp
+ 	)
++endif()
  
  if (ZSTD)
  	set(BASISU_SRC_LIST ${BASISU_SRC_LIST} zstd/zstd.c)

--- a/recipes/libbasisu/all/patches/cmakelist_build_lib.patch
+++ b/recipes/libbasisu/all/patches/cmakelist_build_lib.patch
@@ -1,37 +1,29 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1,14 +1,15 @@
+@@ -1,39 +1,11 @@
 -project(basisu)
 -
  cmake_minimum_required(VERSION 3.0)
 -option(BUILD_X64 "build 64-bit" TRUE)
 -option(STATIC "static linking" FALSE)
 -option(SSE "SSE 4.1 support" FALSE)
-+
-+project(basisu VERSION 1.15.0 LANGUAGES CXX)
-+
-+option(SSE4 "SSE4 4.1 support" FALSE)
- option(ZSTD "ZSTD support for KTX2 transcoding/encoding" TRUE)
-+option(BASISU_NO_ITERATOR_DEBUG_LEVEL "Change Iterator debug level" FALSE)
-+option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" FALSE)
-+option(ENABLE_ENCODER "Build also encoder part of basisu library" TRUE)
+-option(ZSTD "ZSTD support for KTX2 transcoding/encoding" TRUE)
  
 -message("Initial BUILD_X64=${BUILD_X64}")
- message("Initial CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+-message("Initial CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 -message("Initial SSE=${SSE}")
-+message("Initial SSE4=${SSE4}")
- message("Initial ZSTD=${ZSTD}")
+-message("Initial ZSTD=${ZSTD}")
+-
+-if( NOT CMAKE_BUILD_TYPE )
+-  set( CMAKE_BUILD_TYPE Release )
+-endif()
++project(basisu VERSION 1.15.0 LANGUAGES CXX)
  
- if( NOT CMAKE_BUILD_TYPE )
-@@ -17,16 +18,10 @@ endif()
- 
- message( ${PROJECT_NAME} " build type: " ${CMAKE_BUILD_TYPE} )
- 
+-message( ${PROJECT_NAME} " build type: " ${CMAKE_BUILD_TYPE} )
+-
 -if (BUILD_X64)
 -	message("Building 64-bit")
-+if (SSE4)
-+	message("SSE4.1 enabled")
- else()
+-else()
 -	message("Building 32-bit")
 -endif()
 -
@@ -39,11 +31,21 @@
 -	message("SSE enabled")
 -else()
 -	message("SSE disabled")
-+	message("SSE4.1 disabled")
- endif()
+-endif()
+-
+-if (ZSTD)
+-	message("Zstandard enabled")
+-else()
+-	message("Zstandard disabled")
+-endif()
++option(SSE4 "SSE4 4.1 support" FALSE)
++option(ZSTD "ZSTD support for KTX2 transcoding/encoding" TRUE)
++option(NO_ITERATOR_DEBUG_LEVEL "Change Iterator debug level" FALSE)
++option(ENABLE_ENCODER "Build also encoder part of basisu library" TRUE)
  
- if (ZSTD)
-@@ -42,38 +37,24 @@ if (NOT MSVC)
+ if (NOT MSVC)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
+@@ -42,38 +14,24 @@ if (NOT MSVC)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
  
@@ -53,12 +55,12 @@
 -   if (NOT BUILD_X64)
 -	  set(GCC_COMPILE_FLAGS "${GCC_COMPILE_FLAGS} -m32")
 -   endif()
--
++   set(GCC_COMPILE_FLAGS "-fPIC -fno-strict-aliasing -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wno-unused-local-typedefs -Wno-unused-value -Wno-unused-parameter -Wno-unused-variable")
+ 
 -   if (EMSCRIPTEN)
 -	  set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -s ALLOW_MEMORY_GROWTH=1 -DBASISU_SUPPORT_SSE=0")
 -	  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -s ALLOW_MEMORY_GROWTH=1 -DBASISU_SUPPORT_SSE=0")
-+   set(GCC_COMPILE_FLAGS "-fPIC -fno-strict-aliasing -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64 -Wall -Wextra -Wno-unused-local-typedefs -Wno-unused-value -Wno-unused-parameter -Wno-unused-variable")
- 
+-
 -	  set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_LINK_FLAGS}")
 -   elseif (STATIC)
 -      if (SSE)
@@ -88,7 +90,7 @@
     endif()
  
     set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${GCC_COMPILE_FLAGS}")
-@@ -84,7 +65,7 @@ if (NOT MSVC)
+@@ -84,7 +42,7 @@ if (NOT MSVC)
     set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE} ${GCC_COMPILE_FLAGS}")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${GCC_COMPILE_FLAGS} -D_DEBUG")
  else()
@@ -97,7 +99,7 @@
  		set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DBASISU_SUPPORT_SSE=1")
  		set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -DBASISU_SUPPORT_SSE=1")
  	else()
-@@ -93,64 +74,51 @@ else()
+@@ -93,64 +51,57 @@ else()
  	endif()
  endif()
  
@@ -155,15 +157,19 @@
  
 -if (APPLE)
 -   set(BIN_DIRECTORY "bin_osx")
--else()
++add_library(${PROJECT_NAME} ${BASISU_SRC_LIST})
++
++if (NO_ITERATOR_DEBUG_LEVEL)
++	target_compile_definitions(${PROJECT_NAME} PRIVATE BASISU_NO_ITERATOR_DEBUG_LEVEL=1)
+ else()
 -   set(BIN_DIRECTORY "bin")
--endif()
--
++	target_compile_definitions(${PROJECT_NAME} PRIVATE BASISU_NO_ITERATOR_DEBUG_LEVEL=0)
+ endif()
+ 
 -set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${BIN_DIRECTORY})
 -
 -add_executable(basisu ${BASISU_SRC_LIST})
-+add_library(${PROJECT_NAME} ${BASISU_SRC_LIST})
- 
+-
  if (ZSTD)
 -	target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
 +	target_compile_definitions(${PROJECT_NAME} PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)

--- a/recipes/libbasisu/all/patches/cmakelist_build_lib.patch
+++ b/recipes/libbasisu/all/patches/cmakelist_build_lib.patch
@@ -13,8 +13,8 @@
 +option(SSE4 "SSE4 4.1 support" FALSE)
  option(ZSTD "ZSTD support for KTX2 transcoding/encoding" TRUE)
 +option(BASISU_NO_ITERATOR_DEBUG_LEVEL "Change Iterator debug level" FALSE)
-+option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" OFF)
-+option(TRANSCODER_ONLY "Build only transcoder part of basisu library")
++option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" FALSE)
++option(ENABLE_ENCODER "Build also encoder part of basisu library" TRUE)
  
 -message("Initial BUILD_X64=${BUILD_X64}")
  message("Initial CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
@@ -125,7 +125,7 @@
 -	transcoder/basisu_transcoder.cpp
 +set(BASISU_SRC_LIST ${COMMON_SRC_LIST} transcoder/basisu_transcoder.cpp)
 +
-+if (NOT TRANSCODER_ONLY)
++if (ENABLE_ENCODER)
 +	set(BASISU_SRC_LIST ${BASISU_SRC_LIST}
 +		encoder/basisu_backend.cpp
 +		encoder/basisu_basis_file.cpp


### PR DESCRIPTION
Specify library name and version:  **libbasisu/1.15.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

As there are a lot of exotic platforms which may not have SSE4 support, we have decided to disable the usage of SSE4.1 by default, it can still be enabled by the package consumer. For similar reasons, we are adding an option for building only the transcoder part of the library, as the encoder uses some possibly unsupported commands (e.g. ftello from stdio.h).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
