### PR TITLE
[apr-util] fix apple-clang 12

### DIFF
--- a/recipes/apr-util/all/conandata.yml
+++ b/recipes/apr-util/all/conandata.yml
@@ -10,3 +10,7 @@ patches:
       patch_file: "patches/0002-apu-config-prefix-env.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/0003-disable-check-APR_LIBRARIES.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0004-clang12-apple.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0005-apr-build-files.patch"

--- a/recipes/apr-util/all/conanfile.py
+++ b/recipes/apr-util/all/conanfile.py
@@ -106,6 +106,10 @@ class AprUtilConan(ConanFile):
         if self.options.with_postgresql:
             self.requires("libpq/13.2")
 
+    def build_requirements(self):
+        if self.settings.os == "Macos":
+            self.build_requires("libtool/2.4.6")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
@@ -132,6 +136,15 @@ class AprUtilConan(ConanFile):
     def _configure_autotools(self):
         if self._autotools:
             return self._autotools
+
+        if (self.settings.compiler == "apple-clang" and
+            tools.Version(self.settings.compiler.version) == "12" and
+            self.version == "1.6.1"):
+
+            with tools.chdir( self._source_subfolder ):
+                os.remove( "configure" )
+                self.run("./buildconf --with-apr={}".format(tools.unix_path(self.deps_cpp_info["apr"].rootpath)))
+
         self._autotools = AutoToolsBuildEnvironment(self)
         self._autotools.libs = []
         self._autotools.include_paths = []

--- a/recipes/apr-util/all/conanfile.py
+++ b/recipes/apr-util/all/conanfile.py
@@ -141,9 +141,9 @@ class AprUtilConan(ConanFile):
             tools.Version(self.settings.compiler.version) == "12" and
             self.version == "1.6.1"):
 
-            with tools.chdir( self._source_subfolder ):
-                os.remove( "configure" )
-                self.run("./buildconf --with-apr={}".format(tools.unix_path(self.deps_cpp_info["apr"].rootpath)))
+            with tools.chdir(self._source_subfolder):
+                os.remove("configure")
+                self.run("./buildconf")
 
         self._autotools = AutoToolsBuildEnvironment(self)
         self._autotools.libs = []

--- a/recipes/apr-util/all/patches/0004-clang12-apple.patch
+++ b/recipes/apr-util/all/patches/0004-clang12-apple.patch
@@ -1,0 +1,12 @@
+diff --git a/build/apr_common.m4 b/build/apr_common.m4
+index 6b5c0f0..48b704f 100644
+--- a/build/apr_common.m4
++++ b/build/apr_common.m4
+@@ -467,6 +467,7 @@ changequote([, ])dnl
+ AC_MSG_CHECKING(size of $2)
+ AC_CACHE_VAL(AC_CV_NAME,
+ [AC_TRY_RUN([#include <stdio.h>
++#include <stdlib.h>
+ $1
+ #ifdef WIN32
+ #define binmode "b"

--- a/recipes/apr-util/all/patches/0005-apr-build-files.patch
+++ b/recipes/apr-util/all/patches/0005-apr-build-files.patch
@@ -1,0 +1,4467 @@
+diff --git a/build/apr_common.m4 b/build/apr_common.m4
+index 48b704f..01d9a44 100644
+--- a/build/apr_common.m4
++++ b/build/apr_common.m4
+@@ -512,9 +512,9 @@ AC_DEFUN([APR_TRY_COMPILE_NO_WARNING],
+    [int main(int argc, const char *const *argv) {]
+    [[$2]]
+    [   return 0; }]
+-  )],
+-  [$3], [$4])
+- CFLAGS=$apr_save_CFLAGS
++  )], [CFLAGS=$apr_save_CFLAGS
++$3],  [CFLAGS=$apr_save_CFLAGS
++$4])
+ ])
+ 
+ dnl
+@@ -975,12 +975,45 @@ fi
+ AC_SUBST(MKDEP)
+ ])
+ 
++dnl
++dnl APR_CHECK_TYPES_FMT_COMPATIBLE(TYPE-1, TYPE-2, FMT-TAG, 
++dnl                                [ACTION-IF-TRUE], [ACTION-IF-FALSE])
++dnl
++dnl Try to determine whether two types are the same and accept the given
++dnl printf formatter (bare token, e.g. literal d, ld, etc).
++dnl
++AC_DEFUN([APR_CHECK_TYPES_FMT_COMPATIBLE], [
++define([apr_cvname], apr_cv_typematch_[]translit([$1], [ ], [_])_[]translit([$2], [ ], [_])_[][$3])
++AC_CACHE_CHECK([whether $1 and $2 use fmt %$3], apr_cvname, [
++APR_TRY_COMPILE_NO_WARNING([#include <sys/types.h>
++#include <stdio.h>
++#ifdef HAVE_STDINT_H
++#include <stdint.h>
++#endif
++], [
++    $1 chk1, *ptr1;
++    $2 chk2, *ptr2 = &chk1;
++    ptr1 = &chk2;
++    *ptr1 = *ptr2 = 0;
++    printf("%$3 %$3", chk1, chk2);
++], [apr_cvname=yes], [apr_cvname=no])])
++if test "$apr_cvname" = "yes"; then
++    :
++    $4
++else
++    :
++    $5
++fi
++])
++
+ dnl
+ dnl APR_CHECK_TYPES_COMPATIBLE(TYPE-1, TYPE-2, [ACTION-IF-TRUE])
+ dnl
+ dnl Try to determine whether two types are the same. Only works
+ dnl for gcc and icc.
+ dnl
++dnl @deprecated @see APR_CHECK_TYPES_FMT_COMPATIBLE
++dnl
+ AC_DEFUN([APR_CHECK_TYPES_COMPATIBLE], [
+ define([apr_cvname], apr_cv_typematch_[]translit([$1], [ ], [_])_[]translit([$2], [ ], [_]))
+ AC_CACHE_CHECK([whether $1 and $2 are the same], apr_cvname, [
+diff --git a/build/config.guess b/build/config.guess
+index 8bd1095..0f9b29c 100755
+--- a/build/config.guess
++++ b/build/config.guess
+@@ -1,8 +1,8 @@
+ #! /bin/sh
+ # Attempt to guess a canonical system name.
+-#   Copyright 1992-2017 Free Software Foundation, Inc.
++#   Copyright 1992-2019 Free Software Foundation, Inc.
+ 
+-timestamp='2017-09-16'
++timestamp='2019-01-01'
+ 
+ # This file is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by
+@@ -39,7 +39,7 @@ Usage: $0 [OPTION]
+ 
+ Output the configuration name of the system \`$me' is run on.
+ 
+-Operation modes:
++Options:
+   -h, --help         print this help, then exit
+   -t, --time-stamp   print date of last modification, then exit
+   -v, --version      print version number, then exit
+@@ -50,7 +50,7 @@ version="\
+ GNU config.guess ($timestamp)
+ 
+ Originally written by Per Bothner.
+-Copyright 1992-2017 Free Software Foundation, Inc.
++Copyright 1992-2019 Free Software Foundation, Inc.
+ 
+ This is free software; see the source for copying conditions.  There is NO
+ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+@@ -84,8 +84,6 @@ if test $# != 0; then
+   exit 1
+ fi
+ 
+-trap 'exit 1' 1 2 15
+-
+ # CC_FOR_BUILD -- compiler used by this script. Note that the use of a
+ # compiler to aid in system detection is discouraged as it requires
+ # temporary files to be created and, as you can see below, it is a
+@@ -96,34 +94,38 @@ trap 'exit 1' 1 2 15
+ 
+ # Portable tmp directory creation inspired by the Autoconf team.
+ 
+-set_cc_for_build='
+-trap "exitcode=\$?; (rm -f \$tmpfiles 2>/dev/null; rmdir \$tmp 2>/dev/null) && exit \$exitcode" 0 ;
+-trap "rm -f \$tmpfiles 2>/dev/null; rmdir \$tmp 2>/dev/null; exit 1" 1 2 13 15 ;
+-: ${TMPDIR=/tmp} ;
+- { tmp=`(umask 077 && mktemp -d "$TMPDIR/cgXXXXXX") 2>/dev/null` && test -n "$tmp" && test -d "$tmp" ; } ||
+- { test -n "$RANDOM" && tmp=$TMPDIR/cg$$-$RANDOM && (umask 077 && mkdir $tmp) ; } ||
+- { tmp=$TMPDIR/cg-$$ && (umask 077 && mkdir $tmp) && echo "Warning: creating insecure temp directory" >&2 ; } ||
+- { echo "$me: cannot create a temporary directory in $TMPDIR" >&2 ; exit 1 ; } ;
+-dummy=$tmp/dummy ;
+-tmpfiles="$dummy.c $dummy.o $dummy.rel $dummy" ;
+-case $CC_FOR_BUILD,$HOST_CC,$CC in
+- ,,)    echo "int x;" > $dummy.c ;
+-	for c in cc gcc c89 c99 ; do
+-	  if ($c -c -o $dummy.o $dummy.c) >/dev/null 2>&1 ; then
+-	     CC_FOR_BUILD="$c"; break ;
+-	  fi ;
+-	done ;
+-	if test x"$CC_FOR_BUILD" = x ; then
+-	  CC_FOR_BUILD=no_compiler_found ;
+-	fi
+-	;;
+- ,,*)   CC_FOR_BUILD=$CC ;;
+- ,*,*)  CC_FOR_BUILD=$HOST_CC ;;
+-esac ; set_cc_for_build= ;'
++tmp=
++# shellcheck disable=SC2172
++trap 'test -z "$tmp" || rm -fr "$tmp"' 0 1 2 13 15
++
++set_cc_for_build() {
++    : "${TMPDIR=/tmp}"
++    # shellcheck disable=SC2039
++    { tmp=`(umask 077 && mktemp -d "$TMPDIR/cgXXXXXX") 2>/dev/null` && test -n "$tmp" && test -d "$tmp" ; } ||
++	{ test -n "$RANDOM" && tmp=$TMPDIR/cg$$-$RANDOM && (umask 077 && mkdir "$tmp" 2>/dev/null) ; } ||
++	{ tmp=$TMPDIR/cg-$$ && (umask 077 && mkdir "$tmp" 2>/dev/null) && echo "Warning: creating insecure temp directory" >&2 ; } ||
++	{ echo "$me: cannot create a temporary directory in $TMPDIR" >&2 ; exit 1 ; }
++    dummy=$tmp/dummy
++    case ${CC_FOR_BUILD-},${HOST_CC-},${CC-} in
++	,,)    echo "int x;" > "$dummy.c"
++	       for driver in cc gcc c89 c99 ; do
++		   if ($driver -c -o "$dummy.o" "$dummy.c") >/dev/null 2>&1 ; then
++		       CC_FOR_BUILD="$driver"
++		       break
++		   fi
++	       done
++	       if test x"$CC_FOR_BUILD" = x ; then
++		   CC_FOR_BUILD=no_compiler_found
++	       fi
++	       ;;
++	,,*)   CC_FOR_BUILD=$CC ;;
++	,*,*)  CC_FOR_BUILD=$HOST_CC ;;
++    esac
++}
+ 
+ # This is needed to find uname on a Pyramid OSx when run in the BSD universe.
+ # (ghazi@noc.rutgers.edu 1994-08-24)
+-if (test -f /.attbin/uname) >/dev/null 2>&1 ; then
++if test -f /.attbin/uname ; then
+ 	PATH=$PATH:/.attbin ; export PATH
+ fi
+ 
+@@ -132,14 +134,14 @@ UNAME_RELEASE=`(uname -r) 2>/dev/null` || UNAME_RELEASE=unknown
+ UNAME_SYSTEM=`(uname -s) 2>/dev/null`  || UNAME_SYSTEM=unknown
+ UNAME_VERSION=`(uname -v) 2>/dev/null` || UNAME_VERSION=unknown
+ 
+-case "${UNAME_SYSTEM}" in
++case "$UNAME_SYSTEM" in
+ Linux|GNU|GNU/*)
+ 	# If the system lacks a compiler, then just pick glibc.
+ 	# We could probably try harder.
+ 	LIBC=gnu
+ 
+-	eval $set_cc_for_build
+-	cat <<-EOF > $dummy.c
++	set_cc_for_build
++	cat <<-EOF > "$dummy.c"
+ 	#include <features.h>
+ 	#if defined(__UCLIBC__)
+ 	LIBC=uclibc
+@@ -149,13 +151,20 @@ Linux|GNU|GNU/*)
+ 	LIBC=gnu
+ 	#endif
+ 	EOF
+-	eval `$CC_FOR_BUILD -E $dummy.c 2>/dev/null | grep '^LIBC' | sed 's, ,,g'`
++	eval "`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^LIBC' | sed 's, ,,g'`"
++
++	# If ldd exists, use it to detect musl libc.
++	if command -v ldd >/dev/null && \
++		ldd --version 2>&1 | grep -q ^musl
++	then
++	    LIBC=musl
++	fi
+ 	;;
+ esac
+ 
+ # Note: order is significant - the case branches are not exclusive.
+ 
+-case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
++case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
+     *:NetBSD:*:*)
+ 	# NetBSD (nbsd) targets should (where applicable) match one or
+ 	# more of the tuples: *-*-netbsdelf*, *-*-netbsdaout*,
+@@ -169,30 +178,30 @@ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+ 	# portion of the name.  We always set it to "unknown".
+ 	sysctl="sysctl -n hw.machine_arch"
+ 	UNAME_MACHINE_ARCH=`(uname -p 2>/dev/null || \
+-	    /sbin/$sysctl 2>/dev/null || \
+-	    /usr/sbin/$sysctl 2>/dev/null || \
++	    "/sbin/$sysctl" 2>/dev/null || \
++	    "/usr/sbin/$sysctl" 2>/dev/null || \
+ 	    echo unknown)`
+-	case "${UNAME_MACHINE_ARCH}" in
++	case "$UNAME_MACHINE_ARCH" in
+ 	    armeb) machine=armeb-unknown ;;
+ 	    arm*) machine=arm-unknown ;;
+ 	    sh3el) machine=shl-unknown ;;
+ 	    sh3eb) machine=sh-unknown ;;
+ 	    sh5el) machine=sh5le-unknown ;;
+ 	    earmv*)
+-		arch=`echo ${UNAME_MACHINE_ARCH} | sed -e 's,^e\(armv[0-9]\).*$,\1,'`
+-		endian=`echo ${UNAME_MACHINE_ARCH} | sed -ne 's,^.*\(eb\)$,\1,p'`
+-		machine=${arch}${endian}-unknown
++		arch=`echo "$UNAME_MACHINE_ARCH" | sed -e 's,^e\(armv[0-9]\).*$,\1,'`
++		endian=`echo "$UNAME_MACHINE_ARCH" | sed -ne 's,^.*\(eb\)$,\1,p'`
++		machine="${arch}${endian}"-unknown
+ 		;;
+-	    *) machine=${UNAME_MACHINE_ARCH}-unknown ;;
++	    *) machine="$UNAME_MACHINE_ARCH"-unknown ;;
+ 	esac
+ 	# The Operating System including object format, if it has switched
+ 	# to ELF recently (or will in the future) and ABI.
+-	case "${UNAME_MACHINE_ARCH}" in
++	case "$UNAME_MACHINE_ARCH" in
+ 	    earm*)
+ 		os=netbsdelf
+ 		;;
+ 	    arm*|i386|m68k|ns32k|sh3*|sparc|vax)
+-		eval $set_cc_for_build
++		set_cc_for_build
+ 		if echo __ELF__ | $CC_FOR_BUILD -E - 2>/dev/null \
+ 			| grep -q __ELF__
+ 		then
+@@ -208,10 +217,10 @@ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+ 		;;
+ 	esac
+ 	# Determine ABI tags.
+-	case "${UNAME_MACHINE_ARCH}" in
++	case "$UNAME_MACHINE_ARCH" in
+ 	    earm*)
+ 		expr='s/^earmv[0-9]/-eabi/;s/eb$//'
+-		abi=`echo ${UNAME_MACHINE_ARCH} | sed -e "$expr"`
++		abi=`echo "$UNAME_MACHINE_ARCH" | sed -e "$expr"`
+ 		;;
+ 	esac
+ 	# The OS release
+@@ -219,49 +228,55 @@ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+ 	# thus, need a distinct triplet. However, they do not need
+ 	# kernel version information, so it can be replaced with a
+ 	# suitable tag, in the style of linux-gnu.
+-	case "${UNAME_VERSION}" in
++	case "$UNAME_VERSION" in
+ 	    Debian*)
+ 		release='-gnu'
+ 		;;
+ 	    *)
+-		release=`echo ${UNAME_RELEASE} | sed -e 's/[-_].*//' | cut -d. -f1,2`
++		release=`echo "$UNAME_RELEASE" | sed -e 's/[-_].*//' | cut -d. -f1,2`
+ 		;;
+ 	esac
+ 	# Since CPU_TYPE-MANUFACTURER-KERNEL-OPERATING_SYSTEM:
+ 	# contains redundant information, the shorter form:
+ 	# CPU_TYPE-MANUFACTURER-OPERATING_SYSTEM is used.
+-	echo "${machine}-${os}${release}${abi}"
++	echo "$machine-${os}${release}${abi-}"
+ 	exit ;;
+     *:Bitrig:*:*)
+ 	UNAME_MACHINE_ARCH=`arch | sed 's/Bitrig.//'`
+-	echo ${UNAME_MACHINE_ARCH}-unknown-bitrig${UNAME_RELEASE}
++	echo "$UNAME_MACHINE_ARCH"-unknown-bitrig"$UNAME_RELEASE"
+ 	exit ;;
+     *:OpenBSD:*:*)
+ 	UNAME_MACHINE_ARCH=`arch | sed 's/OpenBSD.//'`
+-	echo ${UNAME_MACHINE_ARCH}-unknown-openbsd${UNAME_RELEASE}
++	echo "$UNAME_MACHINE_ARCH"-unknown-openbsd"$UNAME_RELEASE"
+ 	exit ;;
+     *:LibertyBSD:*:*)
+ 	UNAME_MACHINE_ARCH=`arch | sed 's/^.*BSD\.//'`
+-	echo ${UNAME_MACHINE_ARCH}-unknown-libertybsd${UNAME_RELEASE}
++	echo "$UNAME_MACHINE_ARCH"-unknown-libertybsd"$UNAME_RELEASE"
++	exit ;;
++    *:MidnightBSD:*:*)
++	echo "$UNAME_MACHINE"-unknown-midnightbsd"$UNAME_RELEASE"
+ 	exit ;;
+     *:ekkoBSD:*:*)
+-	echo ${UNAME_MACHINE}-unknown-ekkobsd${UNAME_RELEASE}
++	echo "$UNAME_MACHINE"-unknown-ekkobsd"$UNAME_RELEASE"
+ 	exit ;;
+     *:SolidBSD:*:*)
+-	echo ${UNAME_MACHINE}-unknown-solidbsd${UNAME_RELEASE}
++	echo "$UNAME_MACHINE"-unknown-solidbsd"$UNAME_RELEASE"
+ 	exit ;;
+     macppc:MirBSD:*:*)
+-	echo powerpc-unknown-mirbsd${UNAME_RELEASE}
++	echo powerpc-unknown-mirbsd"$UNAME_RELEASE"
+ 	exit ;;
+     *:MirBSD:*:*)
+-	echo ${UNAME_MACHINE}-unknown-mirbsd${UNAME_RELEASE}
++	echo "$UNAME_MACHINE"-unknown-mirbsd"$UNAME_RELEASE"
+ 	exit ;;
+     *:Sortix:*:*)
+-	echo ${UNAME_MACHINE}-unknown-sortix
++	echo "$UNAME_MACHINE"-unknown-sortix
+ 	exit ;;
+     *:Redox:*:*)
+-	echo ${UNAME_MACHINE}-unknown-redox
++	echo "$UNAME_MACHINE"-unknown-redox
+ 	exit ;;
++    mips:OSF1:*.*)
++        echo mips-dec-osf1
++        exit ;;
+     alpha:OSF1:*:*)
+ 	case $UNAME_RELEASE in
+ 	*4.0)
+@@ -313,7 +328,7 @@ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+ 	# A Tn.n version is a released field test version.
+ 	# A Xn.n version is an unreleased experimental baselevel.
+ 	# 1.2 uses "1.2" for uname -r.
+-	echo ${UNAME_MACHINE}-dec-osf`echo ${UNAME_RELEASE} | sed -e 's/^[PVTX]//' | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz`
++	echo "$UNAME_MACHINE"-dec-osf"`echo "$UNAME_RELEASE" | sed -e 's/^[PVTX]//' | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz`"
+ 	# Reset EXIT trap before exiting to avoid spurious non-zero exit code.
+ 	exitcode=$?
+ 	trap '' 0
+@@ -322,10 +337,10 @@ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+ 	echo m68k-unknown-sysv4
+ 	exit ;;
+     *:[Aa]miga[Oo][Ss]:*:*)
+-	echo ${UNAME_MACHINE}-unknown-amigaos
++	echo "$UNAME_MACHINE"-unknown-amigaos
+ 	exit ;;
+     *:[Mm]orph[Oo][Ss]:*:*)
+-	echo ${UNAME_MACHINE}-unknown-morphos
++	echo "$UNAME_MACHINE"-unknown-morphos
+ 	exit ;;
+     *:OS/390:*:*)
+ 	echo i370-ibm-openedition
+@@ -337,7 +352,7 @@ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+ 	echo powerpc-ibm-os400
+ 	exit ;;
+     arm:RISC*:1.[012]*:*|arm:riscix:1.[012]*:*)
+-	echo arm-acorn-riscix${UNAME_RELEASE}
++	echo arm-acorn-riscix"$UNAME_RELEASE"
+ 	exit ;;
+     arm*:riscos:*:*|arm*:RISCOS:*:*)
+ 	echo arm-unknown-riscos
+@@ -364,19 +379,19 @@ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+ 	    sparc) echo sparc-icl-nx7; exit ;;
+ 	esac ;;
+     s390x:SunOS:*:*)
+-	echo ${UNAME_MACHINE}-ibm-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
++	echo "$UNAME_MACHINE"-ibm-solaris2"`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`"
+ 	exit ;;
+     sun4H:SunOS:5.*:*)
+-	echo sparc-hal-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
++	echo sparc-hal-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+ 	exit ;;
+     sun4*:SunOS:5.*:* | tadpole*:SunOS:5.*:*)
+-	echo sparc-sun-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
++	echo sparc-sun-solaris2"`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`"
+ 	exit ;;
+     i86pc:AuroraUX:5.*:* | i86xen:AuroraUX:5.*:*)
+-	echo i386-pc-auroraux${UNAME_RELEASE}
++	echo i386-pc-auroraux"$UNAME_RELEASE"
+ 	exit ;;
+     i86pc:SunOS:5.*:* | i86xen:SunOS:5.*:*)
+-	eval $set_cc_for_build
++	set_cc_for_build
+ 	SUN_ARCH=i386
+ 	# If there is a compiler, see if it is configured for 64-bit objects.
+ 	# Note that the Sun cc does not turn __LP64__ into 1 like gcc does.
+@@ -389,13 +404,13 @@ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+ 		SUN_ARCH=x86_64
+ 	    fi
+ 	fi
+-	echo ${SUN_ARCH}-pc-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
++	echo "$SUN_ARCH"-pc-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+ 	exit ;;
+     sun4*:SunOS:6*:*)
+ 	# According to config.sub, this is the proper way to canonicalize
+ 	# SunOS6.  Hard to guess exactly what SunOS6 will be like, but
+ 	# it's likely to be more like Solaris than SunOS4.
+-	echo sparc-sun-solaris3`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
++	echo sparc-sun-solaris3"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+ 	exit ;;
+     sun4*:SunOS:*:*)
+ 	case "`/usr/bin/arch -k`" in
+@@ -404,25 +419,25 @@ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+ 		;;
+ 	esac
+ 	# Japanese Language versions have a version number like `4.1.3-JL'.
+-	echo sparc-sun-sunos`echo ${UNAME_RELEASE}|sed -e 's/-/_/'`
++	echo sparc-sun-sunos"`echo "$UNAME_RELEASE"|sed -e 's/-/_/'`"
+ 	exit ;;
+     sun3*:SunOS:*:*)
+-	echo m68k-sun-sunos${UNAME_RELEASE}
++	echo m68k-sun-sunos"$UNAME_RELEASE"
+ 	exit ;;
+     sun*:*:4.2BSD:*)
+ 	UNAME_RELEASE=`(sed 1q /etc/motd | awk '{print substr($5,1,3)}') 2>/dev/null`
+-	test "x${UNAME_RELEASE}" = x && UNAME_RELEASE=3
++	test "x$UNAME_RELEASE" = x && UNAME_RELEASE=3
+ 	case "`/bin/arch`" in
+ 	    sun3)
+-		echo m68k-sun-sunos${UNAME_RELEASE}
++		echo m68k-sun-sunos"$UNAME_RELEASE"
+ 		;;
+ 	    sun4)
+-		echo sparc-sun-sunos${UNAME_RELEASE}
++		echo sparc-sun-sunos"$UNAME_RELEASE"
+ 		;;
+ 	esac
+ 	exit ;;
+     aushp:SunOS:*:*)
+-	echo sparc-auspex-sunos${UNAME_RELEASE}
++	echo sparc-auspex-sunos"$UNAME_RELEASE"
+ 	exit ;;
+     # The situation for MiNT is a little confusing.  The machine name
+     # can be virtually everything (everything which is not
+@@ -433,44 +448,44 @@ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+     # MiNT.  But MiNT is downward compatible to TOS, so this should
+     # be no problem.
+     atarist[e]:*MiNT:*:* | atarist[e]:*mint:*:* | atarist[e]:*TOS:*:*)
+-	echo m68k-atari-mint${UNAME_RELEASE}
++	echo m68k-atari-mint"$UNAME_RELEASE"
+ 	exit ;;
+     atari*:*MiNT:*:* | atari*:*mint:*:* | atarist[e]:*TOS:*:*)
+-	echo m68k-atari-mint${UNAME_RELEASE}
++	echo m68k-atari-mint"$UNAME_RELEASE"
+ 	exit ;;
+     *falcon*:*MiNT:*:* | *falcon*:*mint:*:* | *falcon*:*TOS:*:*)
+-	echo m68k-atari-mint${UNAME_RELEASE}
++	echo m68k-atari-mint"$UNAME_RELEASE"
+ 	exit ;;
+     milan*:*MiNT:*:* | milan*:*mint:*:* | *milan*:*TOS:*:*)
+-	echo m68k-milan-mint${UNAME_RELEASE}
++	echo m68k-milan-mint"$UNAME_RELEASE"
+ 	exit ;;
+     hades*:*MiNT:*:* | hades*:*mint:*:* | *hades*:*TOS:*:*)
+-	echo m68k-hades-mint${UNAME_RELEASE}
++	echo m68k-hades-mint"$UNAME_RELEASE"
+ 	exit ;;
+     *:*MiNT:*:* | *:*mint:*:* | *:*TOS:*:*)
+-	echo m68k-unknown-mint${UNAME_RELEASE}
++	echo m68k-unknown-mint"$UNAME_RELEASE"
+ 	exit ;;
+     m68k:machten:*:*)
+-	echo m68k-apple-machten${UNAME_RELEASE}
++	echo m68k-apple-machten"$UNAME_RELEASE"
+ 	exit ;;
+     powerpc:machten:*:*)
+-	echo powerpc-apple-machten${UNAME_RELEASE}
++	echo powerpc-apple-machten"$UNAME_RELEASE"
+ 	exit ;;
+     RISC*:Mach:*:*)
+ 	echo mips-dec-mach_bsd4.3
+ 	exit ;;
+     RISC*:ULTRIX:*:*)
+-	echo mips-dec-ultrix${UNAME_RELEASE}
++	echo mips-dec-ultrix"$UNAME_RELEASE"
+ 	exit ;;
+     VAX*:ULTRIX*:*:*)
+-	echo vax-dec-ultrix${UNAME_RELEASE}
++	echo vax-dec-ultrix"$UNAME_RELEASE"
+ 	exit ;;
+     2020:CLIX:*:* | 2430:CLIX:*:*)
+-	echo clipper-intergraph-clix${UNAME_RELEASE}
++	echo clipper-intergraph-clix"$UNAME_RELEASE"
+ 	exit ;;
+     mips:*:*:UMIPS | mips:*:*:RISCos)
+-	eval $set_cc_for_build
+-	sed 's/^	//' << EOF >$dummy.c
++	set_cc_for_build
++	sed 's/^	//' << EOF > "$dummy.c"
+ #ifdef __cplusplus
+ #include <stdio.h>  /* for printf() prototype */
+ 	int main (int argc, char *argv[]) {
+@@ -479,23 +494,23 @@ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+ #endif
+ 	#if defined (host_mips) && defined (MIPSEB)
+ 	#if defined (SYSTYPE_SYSV)
+-	  printf ("mips-mips-riscos%ssysv\n", argv[1]); exit (0);
++	  printf ("mips-mips-riscos%ssysv\\n", argv[1]); exit (0);
+ 	#endif
+ 	#if defined (SYSTYPE_SVR4)
+-	  printf ("mips-mips-riscos%ssvr4\n", argv[1]); exit (0);
++	  printf ("mips-mips-riscos%ssvr4\\n", argv[1]); exit (0);
+ 	#endif
+ 	#if defined (SYSTYPE_BSD43) || defined(SYSTYPE_BSD)
+-	  printf ("mips-mips-riscos%sbsd\n", argv[1]); exit (0);
++	  printf ("mips-mips-riscos%sbsd\\n", argv[1]); exit (0);
+ 	#endif
+ 	#endif
+ 	  exit (-1);
+ 	}
+ EOF
+-	$CC_FOR_BUILD -o $dummy $dummy.c &&
+-	  dummyarg=`echo "${UNAME_RELEASE}" | sed -n 's/\([0-9]*\).*/\1/p'` &&
+-	  SYSTEM_NAME=`$dummy $dummyarg` &&
++	$CC_FOR_BUILD -o "$dummy" "$dummy.c" &&
++	  dummyarg=`echo "$UNAME_RELEASE" | sed -n 's/\([0-9]*\).*/\1/p'` &&
++	  SYSTEM_NAME=`"$dummy" "$dummyarg"` &&
+ 	    { echo "$SYSTEM_NAME"; exit; }
+-	echo mips-mips-riscos${UNAME_RELEASE}
++	echo mips-mips-riscos"$UNAME_RELEASE"
+ 	exit ;;
+     Motorola:PowerMAX_OS:*:*)
+ 	echo powerpc-motorola-powermax
+@@ -521,17 +536,17 @@ EOF
+     AViiON:dgux:*:*)
+ 	# DG/UX returns AViiON for all architectures
+ 	UNAME_PROCESSOR=`/usr/bin/uname -p`
+-	if [ $UNAME_PROCESSOR = mc88100 ] || [ $UNAME_PROCESSOR = mc88110 ]
++	if [ "$UNAME_PROCESSOR" = mc88100 ] || [ "$UNAME_PROCESSOR" = mc88110 ]
+ 	then
+-	    if [ ${TARGET_BINARY_INTERFACE}x = m88kdguxelfx ] || \
+-	       [ ${TARGET_BINARY_INTERFACE}x = x ]
++	    if [ "$TARGET_BINARY_INTERFACE"x = m88kdguxelfx ] || \
++	       [ "$TARGET_BINARY_INTERFACE"x = x ]
+ 	    then
+-		echo m88k-dg-dgux${UNAME_RELEASE}
++		echo m88k-dg-dgux"$UNAME_RELEASE"
+ 	    else
+-		echo m88k-dg-dguxbcs${UNAME_RELEASE}
++		echo m88k-dg-dguxbcs"$UNAME_RELEASE"
+ 	    fi
+ 	else
+-	    echo i586-dg-dgux${UNAME_RELEASE}
++	    echo i586-dg-dgux"$UNAME_RELEASE"
+ 	fi
+ 	exit ;;
+     M88*:DolphinOS:*:*)	# DolphinOS (SVR3)
+@@ -548,7 +563,7 @@ EOF
+ 	echo m68k-tektronix-bsd
+ 	exit ;;
+     *:IRIX*:*:*)
+-	echo mips-sgi-irix`echo ${UNAME_RELEASE}|sed -e 's/-/_/g'`
++	echo mips-sgi-irix"`echo "$UNAME_RELEASE"|sed -e 's/-/_/g'`"
+ 	exit ;;
+     ????????:AIX?:[12].1:2)   # AIX 2.2.1 or AIX 2.1.1 is RT/PC AIX.
+ 	echo romp-ibm-aix     # uname -m gives an 8 hex-code CPU id
+@@ -560,14 +575,14 @@ EOF
+ 	if [ -x /usr/bin/oslevel ] ; then
+ 		IBM_REV=`/usr/bin/oslevel`
+ 	else
+-		IBM_REV=${UNAME_VERSION}.${UNAME_RELEASE}
++		IBM_REV="$UNAME_VERSION.$UNAME_RELEASE"
+ 	fi
+-	echo ${UNAME_MACHINE}-ibm-aix${IBM_REV}
++	echo "$UNAME_MACHINE"-ibm-aix"$IBM_REV"
+ 	exit ;;
+     *:AIX:2:3)
+ 	if grep bos325 /usr/include/stdio.h >/dev/null 2>&1; then
+-		eval $set_cc_for_build
+-		sed 's/^		//' << EOF >$dummy.c
++		set_cc_for_build
++		sed 's/^		//' << EOF > "$dummy.c"
+ 		#include <sys/systemcfg.h>
+ 
+ 		main()
+@@ -578,7 +593,7 @@ EOF
+ 			exit(0);
+ 			}
+ EOF
+-		if $CC_FOR_BUILD -o $dummy $dummy.c && SYSTEM_NAME=`$dummy`
++		if $CC_FOR_BUILD -o "$dummy" "$dummy.c" && SYSTEM_NAME=`"$dummy"`
+ 		then
+ 			echo "$SYSTEM_NAME"
+ 		else
+@@ -592,7 +607,7 @@ EOF
+ 	exit ;;
+     *:AIX:*:[4567])
+ 	IBM_CPU_ID=`/usr/sbin/lsdev -C -c processor -S available | sed 1q | awk '{ print $1 }'`
+-	if /usr/sbin/lsattr -El ${IBM_CPU_ID} | grep ' POWER' >/dev/null 2>&1; then
++	if /usr/sbin/lsattr -El "$IBM_CPU_ID" | grep ' POWER' >/dev/null 2>&1; then
+ 		IBM_ARCH=rs6000
+ 	else
+ 		IBM_ARCH=powerpc
+@@ -601,18 +616,18 @@ EOF
+ 		IBM_REV=`/usr/bin/lslpp -Lqc bos.rte.libc |
+ 			   awk -F: '{ print $3 }' | sed s/[0-9]*$/0/`
+ 	else
+-		IBM_REV=${UNAME_VERSION}.${UNAME_RELEASE}
++		IBM_REV="$UNAME_VERSION.$UNAME_RELEASE"
+ 	fi
+-	echo ${IBM_ARCH}-ibm-aix${IBM_REV}
++	echo "$IBM_ARCH"-ibm-aix"$IBM_REV"
+ 	exit ;;
+     *:AIX:*:*)
+ 	echo rs6000-ibm-aix
+ 	exit ;;
+-    ibmrt:4.4BSD:*|romp-ibm:BSD:*)
++    ibmrt:4.4BSD:*|romp-ibm:4.4BSD:*)
+ 	echo romp-ibm-bsd4.4
+ 	exit ;;
+     ibmrt:*BSD:*|romp-ibm:BSD:*)            # covers RT/PC BSD and
+-	echo romp-ibm-bsd${UNAME_RELEASE}   # 4.3 with uname added to
++	echo romp-ibm-bsd"$UNAME_RELEASE"   # 4.3 with uname added to
+ 	exit ;;                             # report: romp-ibm BSD 4.3
+     *:BOSX:*:*)
+ 	echo rs6000-bull-bosx
+@@ -627,28 +642,28 @@ EOF
+ 	echo m68k-hp-bsd4.4
+ 	exit ;;
+     9000/[34678]??:HP-UX:*:*)
+-	HPUX_REV=`echo ${UNAME_RELEASE}|sed -e 's/[^.]*.[0B]*//'`
+-	case "${UNAME_MACHINE}" in
+-	    9000/31? )            HP_ARCH=m68000 ;;
+-	    9000/[34]?? )         HP_ARCH=m68k ;;
++	HPUX_REV=`echo "$UNAME_RELEASE"|sed -e 's/[^.]*.[0B]*//'`
++	case "$UNAME_MACHINE" in
++	    9000/31?)            HP_ARCH=m68000 ;;
++	    9000/[34]??)         HP_ARCH=m68k ;;
+ 	    9000/[678][0-9][0-9])
+ 		if [ -x /usr/bin/getconf ]; then
+ 		    sc_cpu_version=`/usr/bin/getconf SC_CPU_VERSION 2>/dev/null`
+ 		    sc_kernel_bits=`/usr/bin/getconf SC_KERNEL_BITS 2>/dev/null`
+-		    case "${sc_cpu_version}" in
++		    case "$sc_cpu_version" in
+ 		      523) HP_ARCH=hppa1.0 ;; # CPU_PA_RISC1_0
+ 		      528) HP_ARCH=hppa1.1 ;; # CPU_PA_RISC1_1
+ 		      532)                      # CPU_PA_RISC2_0
+-			case "${sc_kernel_bits}" in
++			case "$sc_kernel_bits" in
+ 			  32) HP_ARCH=hppa2.0n ;;
+ 			  64) HP_ARCH=hppa2.0w ;;
+ 			  '') HP_ARCH=hppa2.0 ;;   # HP-UX 10.20
+ 			esac ;;
+ 		    esac
+ 		fi
+-		if [ "${HP_ARCH}" = "" ]; then
+-		    eval $set_cc_for_build
+-		    sed 's/^		//' << EOF >$dummy.c
++		if [ "$HP_ARCH" = "" ]; then
++		    set_cc_for_build
++		    sed 's/^		//' << EOF > "$dummy.c"
+ 
+ 		#define _HPUX_SOURCE
+ 		#include <stdlib.h>
+@@ -681,13 +696,13 @@ EOF
+ 		    exit (0);
+ 		}
+ EOF
+-		    (CCOPTS="" $CC_FOR_BUILD -o $dummy $dummy.c 2>/dev/null) && HP_ARCH=`$dummy`
++		    (CCOPTS="" $CC_FOR_BUILD -o "$dummy" "$dummy.c" 2>/dev/null) && HP_ARCH=`"$dummy"`
+ 		    test -z "$HP_ARCH" && HP_ARCH=hppa
+ 		fi ;;
+ 	esac
+-	if [ ${HP_ARCH} = hppa2.0w ]
++	if [ "$HP_ARCH" = hppa2.0w ]
+ 	then
+-	    eval $set_cc_for_build
++	    set_cc_for_build
+ 
+ 	    # hppa2.0w-hp-hpux* has a 64-bit kernel and a compiler generating
+ 	    # 32-bit code.  hppa64-hp-hpux* has the same kernel and a compiler
+@@ -706,15 +721,15 @@ EOF
+ 		HP_ARCH=hppa64
+ 	    fi
+ 	fi
+-	echo ${HP_ARCH}-hp-hpux${HPUX_REV}
++	echo "$HP_ARCH"-hp-hpux"$HPUX_REV"
+ 	exit ;;
+     ia64:HP-UX:*:*)
+-	HPUX_REV=`echo ${UNAME_RELEASE}|sed -e 's/[^.]*.[0B]*//'`
+-	echo ia64-hp-hpux${HPUX_REV}
++	HPUX_REV=`echo "$UNAME_RELEASE"|sed -e 's/[^.]*.[0B]*//'`
++	echo ia64-hp-hpux"$HPUX_REV"
+ 	exit ;;
+     3050*:HI-UX:*:*)
+-	eval $set_cc_for_build
+-	sed 's/^	//' << EOF >$dummy.c
++	set_cc_for_build
++	sed 's/^	//' << EOF > "$dummy.c"
+ 	#include <unistd.h>
+ 	int
+ 	main ()
+@@ -739,11 +754,11 @@ EOF
+ 	  exit (0);
+ 	}
+ EOF
+-	$CC_FOR_BUILD -o $dummy $dummy.c && SYSTEM_NAME=`$dummy` &&
++	$CC_FOR_BUILD -o "$dummy" "$dummy.c" && SYSTEM_NAME=`"$dummy"` &&
+ 		{ echo "$SYSTEM_NAME"; exit; }
+ 	echo unknown-hitachi-hiuxwe2
+ 	exit ;;
+-    9000/7??:4.3bsd:*:* | 9000/8?[79]:4.3bsd:*:* )
++    9000/7??:4.3bsd:*:* | 9000/8?[79]:4.3bsd:*:*)
+ 	echo hppa1.1-hp-bsd
+ 	exit ;;
+     9000/8??:4.3bsd:*:*)
+@@ -752,7 +767,7 @@ EOF
+     *9??*:MPE/iX:*:* | *3000*:MPE/iX:*:*)
+ 	echo hppa1.0-hp-mpeix
+ 	exit ;;
+-    hp7??:OSF1:*:* | hp8?[79]:OSF1:*:* )
++    hp7??:OSF1:*:* | hp8?[79]:OSF1:*:*)
+ 	echo hppa1.1-hp-osf
+ 	exit ;;
+     hp8??:OSF1:*:*)
+@@ -760,9 +775,9 @@ EOF
+ 	exit ;;
+     i*86:OSF1:*:*)
+ 	if [ -x /usr/sbin/sysversion ] ; then
+-	    echo ${UNAME_MACHINE}-unknown-osf1mk
++	    echo "$UNAME_MACHINE"-unknown-osf1mk
+ 	else
+-	    echo ${UNAME_MACHINE}-unknown-osf1
++	    echo "$UNAME_MACHINE"-unknown-osf1
+ 	fi
+ 	exit ;;
+     parisc*:Lites*:*:*)
+@@ -787,109 +802,120 @@ EOF
+ 	echo c4-convex-bsd
+ 	exit ;;
+     CRAY*Y-MP:*:*:*)
+-	echo ymp-cray-unicos${UNAME_RELEASE} | sed -e 's/\.[^.]*$/.X/'
++	echo ymp-cray-unicos"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
+ 	exit ;;
+     CRAY*[A-Z]90:*:*:*)
+-	echo ${UNAME_MACHINE}-cray-unicos${UNAME_RELEASE} \
++	echo "$UNAME_MACHINE"-cray-unicos"$UNAME_RELEASE" \
+ 	| sed -e 's/CRAY.*\([A-Z]90\)/\1/' \
+ 	      -e y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/ \
+ 	      -e 's/\.[^.]*$/.X/'
+ 	exit ;;
+     CRAY*TS:*:*:*)
+-	echo t90-cray-unicos${UNAME_RELEASE} | sed -e 's/\.[^.]*$/.X/'
++	echo t90-cray-unicos"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
+ 	exit ;;
+     CRAY*T3E:*:*:*)
+-	echo alphaev5-cray-unicosmk${UNAME_RELEASE} | sed -e 's/\.[^.]*$/.X/'
++	echo alphaev5-cray-unicosmk"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
+ 	exit ;;
+     CRAY*SV1:*:*:*)
+-	echo sv1-cray-unicos${UNAME_RELEASE} | sed -e 's/\.[^.]*$/.X/'
++	echo sv1-cray-unicos"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
+ 	exit ;;
+     *:UNICOS/mp:*:*)
+-	echo craynv-cray-unicosmp${UNAME_RELEASE} | sed -e 's/\.[^.]*$/.X/'
++	echo craynv-cray-unicosmp"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
+ 	exit ;;
+     F30[01]:UNIX_System_V:*:* | F700:UNIX_System_V:*:*)
+ 	FUJITSU_PROC=`uname -m | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz`
+ 	FUJITSU_SYS=`uname -p | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/\///'`
+-	FUJITSU_REL=`echo ${UNAME_RELEASE} | sed -e 's/ /_/'`
++	FUJITSU_REL=`echo "$UNAME_RELEASE" | sed -e 's/ /_/'`
+ 	echo "${FUJITSU_PROC}-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}"
+ 	exit ;;
+     5000:UNIX_System_V:4.*:*)
+ 	FUJITSU_SYS=`uname -p | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/\///'`
+-	FUJITSU_REL=`echo ${UNAME_RELEASE} | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/ /_/'`
++	FUJITSU_REL=`echo "$UNAME_RELEASE" | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/ /_/'`
+ 	echo "sparc-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}"
+ 	exit ;;
+     i*86:BSD/386:*:* | i*86:BSD/OS:*:* | *:Ascend\ Embedded/OS:*:*)
+-	echo ${UNAME_MACHINE}-pc-bsdi${UNAME_RELEASE}
++	echo "$UNAME_MACHINE"-pc-bsdi"$UNAME_RELEASE"
+ 	exit ;;
+     sparc*:BSD/OS:*:*)
+-	echo sparc-unknown-bsdi${UNAME_RELEASE}
++	echo sparc-unknown-bsdi"$UNAME_RELEASE"
+ 	exit ;;
+     *:BSD/OS:*:*)
+-	echo ${UNAME_MACHINE}-unknown-bsdi${UNAME_RELEASE}
++	echo "$UNAME_MACHINE"-unknown-bsdi"$UNAME_RELEASE"
++	exit ;;
++    arm:FreeBSD:*:*)
++	UNAME_PROCESSOR=`uname -p`
++	set_cc_for_build
++	if echo __ARM_PCS_VFP | $CC_FOR_BUILD -E - 2>/dev/null \
++	    | grep -q __ARM_PCS_VFP
++	then
++	    echo "${UNAME_PROCESSOR}"-unknown-freebsd"`echo ${UNAME_RELEASE}|sed -e 's/[-(].*//'`"-gnueabi
++	else
++	    echo "${UNAME_PROCESSOR}"-unknown-freebsd"`echo ${UNAME_RELEASE}|sed -e 's/[-(].*//'`"-gnueabihf
++	fi
+ 	exit ;;
+     *:FreeBSD:*:*)
+ 	UNAME_PROCESSOR=`/usr/bin/uname -p`
+-	case ${UNAME_PROCESSOR} in
++	case "$UNAME_PROCESSOR" in
+ 	    amd64)
+ 		UNAME_PROCESSOR=x86_64 ;;
+ 	    i386)
+ 		UNAME_PROCESSOR=i586 ;;
+ 	esac
+-	echo ${UNAME_PROCESSOR}-unknown-freebsd`echo ${UNAME_RELEASE}|sed -e 's/[-(].*//'`
++	echo "$UNAME_PROCESSOR"-unknown-freebsd"`echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`"
+ 	exit ;;
+     i*:CYGWIN*:*)
+-	echo ${UNAME_MACHINE}-pc-cygwin
++	echo "$UNAME_MACHINE"-pc-cygwin
+ 	exit ;;
+     *:MINGW64*:*)
+-	echo ${UNAME_MACHINE}-pc-mingw64
++	echo "$UNAME_MACHINE"-pc-mingw64
+ 	exit ;;
+     *:MINGW*:*)
+-	echo ${UNAME_MACHINE}-pc-mingw32
++	echo "$UNAME_MACHINE"-pc-mingw32
+ 	exit ;;
+     *:MSYS*:*)
+-	echo ${UNAME_MACHINE}-pc-msys
++	echo "$UNAME_MACHINE"-pc-msys
+ 	exit ;;
+     i*:PW*:*)
+-	echo ${UNAME_MACHINE}-pc-pw32
++	echo "$UNAME_MACHINE"-pc-pw32
+ 	exit ;;
+     *:Interix*:*)
+-	case ${UNAME_MACHINE} in
++	case "$UNAME_MACHINE" in
+ 	    x86)
+-		echo i586-pc-interix${UNAME_RELEASE}
++		echo i586-pc-interix"$UNAME_RELEASE"
+ 		exit ;;
+ 	    authenticamd | genuineintel | EM64T)
+-		echo x86_64-unknown-interix${UNAME_RELEASE}
++		echo x86_64-unknown-interix"$UNAME_RELEASE"
+ 		exit ;;
+ 	    IA64)
+-		echo ia64-unknown-interix${UNAME_RELEASE}
++		echo ia64-unknown-interix"$UNAME_RELEASE"
+ 		exit ;;
+ 	esac ;;
+     i*:UWIN*:*)
+-	echo ${UNAME_MACHINE}-pc-uwin
++	echo "$UNAME_MACHINE"-pc-uwin
+ 	exit ;;
+     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
+-	echo x86_64-unknown-cygwin
++	echo x86_64-pc-cygwin
+ 	exit ;;
+     prep*:SunOS:5.*:*)
+-	echo powerpcle-unknown-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
++	echo powerpcle-unknown-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+ 	exit ;;
+     *:GNU:*:*)
+ 	# the GNU system
+-	echo `echo ${UNAME_MACHINE}|sed -e 's,[-/].*$,,'`-unknown-${LIBC}`echo ${UNAME_RELEASE}|sed -e 's,/.*$,,'`
++	echo "`echo "$UNAME_MACHINE"|sed -e 's,[-/].*$,,'`-unknown-$LIBC`echo "$UNAME_RELEASE"|sed -e 's,/.*$,,'`"
+ 	exit ;;
+     *:GNU/*:*:*)
+ 	# other systems with GNU libc and userland
+-	echo ${UNAME_MACHINE}-unknown-`echo ${UNAME_SYSTEM} | sed 's,^[^/]*/,,' | tr "[:upper:]" "[:lower:]"``echo ${UNAME_RELEASE}|sed -e 's/[-(].*//'`-${LIBC}
++	echo "$UNAME_MACHINE-unknown-`echo "$UNAME_SYSTEM" | sed 's,^[^/]*/,,' | tr "[:upper:]" "[:lower:]"``echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`-$LIBC"
+ 	exit ;;
+-    i*86:Minix:*:*)
+-	echo ${UNAME_MACHINE}-pc-minix
++    *:Minix:*:*)
++	echo "$UNAME_MACHINE"-unknown-minix
+ 	exit ;;
+     aarch64:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     aarch64_be:Linux:*:*)
+ 	UNAME_MACHINE=aarch64_be
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     alpha:Linux:*:*)
+ 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
+@@ -903,63 +929,63 @@ EOF
+ 	esac
+ 	objdump --private-headers /bin/sh | grep -q ld.so.1
+ 	if test "$?" = 0 ; then LIBC=gnulibc1 ; fi
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     arc:Linux:*:* | arceb:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     arm*:Linux:*:*)
+-	eval $set_cc_for_build
++	set_cc_for_build
+ 	if echo __ARM_EABI__ | $CC_FOR_BUILD -E - 2>/dev/null \
+ 	    | grep -q __ARM_EABI__
+ 	then
+-	    echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	    echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	else
+ 	    if echo __ARM_PCS_VFP | $CC_FOR_BUILD -E - 2>/dev/null \
+ 		| grep -q __ARM_PCS_VFP
+ 	    then
+-		echo ${UNAME_MACHINE}-unknown-linux-${LIBC}eabi
++		echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"eabi
+ 	    else
+-		echo ${UNAME_MACHINE}-unknown-linux-${LIBC}eabihf
++		echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"eabihf
+ 	    fi
+ 	fi
+ 	exit ;;
+     avr32*:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     cris:Linux:*:*)
+-	echo ${UNAME_MACHINE}-axis-linux-${LIBC}
++	echo "$UNAME_MACHINE"-axis-linux-"$LIBC"
+ 	exit ;;
+     crisv32:Linux:*:*)
+-	echo ${UNAME_MACHINE}-axis-linux-${LIBC}
++	echo "$UNAME_MACHINE"-axis-linux-"$LIBC"
+ 	exit ;;
+     e2k:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     frv:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     hexagon:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     i*86:Linux:*:*)
+-	echo ${UNAME_MACHINE}-pc-linux-${LIBC}
++	echo "$UNAME_MACHINE"-pc-linux-"$LIBC"
+ 	exit ;;
+     ia64:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     k1om:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     m32r*:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     m68*:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     mips:Linux:*:* | mips64:Linux:*:*)
+-	eval $set_cc_for_build
+-	sed 's/^	//' << EOF >$dummy.c
++	set_cc_for_build
++	sed 's/^	//' << EOF > "$dummy.c"
+ 	#undef CPU
+ 	#undef ${UNAME_MACHINE}
+ 	#undef ${UNAME_MACHINE}el
+@@ -973,70 +999,70 @@ EOF
+ 	#endif
+ 	#endif
+ EOF
+-	eval `$CC_FOR_BUILD -E $dummy.c 2>/dev/null | grep '^CPU'`
+-	test x"${CPU}" != x && { echo "${CPU}-unknown-linux-${LIBC}"; exit; }
++	eval "`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^CPU'`"
++	test "x$CPU" != x && { echo "$CPU-unknown-linux-$LIBC"; exit; }
+ 	;;
+     mips64el:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     openrisc*:Linux:*:*)
+-	echo or1k-unknown-linux-${LIBC}
++	echo or1k-unknown-linux-"$LIBC"
+ 	exit ;;
+     or32:Linux:*:* | or1k*:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     padre:Linux:*:*)
+-	echo sparc-unknown-linux-${LIBC}
++	echo sparc-unknown-linux-"$LIBC"
+ 	exit ;;
+     parisc64:Linux:*:* | hppa64:Linux:*:*)
+-	echo hppa64-unknown-linux-${LIBC}
++	echo hppa64-unknown-linux-"$LIBC"
+ 	exit ;;
+     parisc:Linux:*:* | hppa:Linux:*:*)
+ 	# Look for CPU level
+ 	case `grep '^cpu[^a-z]*:' /proc/cpuinfo 2>/dev/null | cut -d' ' -f2` in
+-	  PA7*) echo hppa1.1-unknown-linux-${LIBC} ;;
+-	  PA8*) echo hppa2.0-unknown-linux-${LIBC} ;;
+-	  *)    echo hppa-unknown-linux-${LIBC} ;;
++	  PA7*) echo hppa1.1-unknown-linux-"$LIBC" ;;
++	  PA8*) echo hppa2.0-unknown-linux-"$LIBC" ;;
++	  *)    echo hppa-unknown-linux-"$LIBC" ;;
+ 	esac
+ 	exit ;;
+     ppc64:Linux:*:*)
+-	echo powerpc64-unknown-linux-${LIBC}
++	echo powerpc64-unknown-linux-"$LIBC"
+ 	exit ;;
+     ppc:Linux:*:*)
+-	echo powerpc-unknown-linux-${LIBC}
++	echo powerpc-unknown-linux-"$LIBC"
+ 	exit ;;
+     ppc64le:Linux:*:*)
+-	echo powerpc64le-unknown-linux-${LIBC}
++	echo powerpc64le-unknown-linux-"$LIBC"
+ 	exit ;;
+     ppcle:Linux:*:*)
+-	echo powerpcle-unknown-linux-${LIBC}
++	echo powerpcle-unknown-linux-"$LIBC"
+ 	exit ;;
+     riscv32:Linux:*:* | riscv64:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     s390:Linux:*:* | s390x:Linux:*:*)
+-	echo ${UNAME_MACHINE}-ibm-linux-${LIBC}
++	echo "$UNAME_MACHINE"-ibm-linux-"$LIBC"
+ 	exit ;;
+     sh64*:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     sh*:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     sparc:Linux:*:* | sparc64:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     tile*:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     vax:Linux:*:*)
+-	echo ${UNAME_MACHINE}-dec-linux-${LIBC}
++	echo "$UNAME_MACHINE"-dec-linux-"$LIBC"
+ 	exit ;;
+     x86_64:Linux:*:*)
+-	echo ${UNAME_MACHINE}-pc-linux-${LIBC}
++	echo "$UNAME_MACHINE"-pc-linux-"$LIBC"
+ 	exit ;;
+     xtensa*:Linux:*:*)
+-	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
++	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     i*86:DYNIX/ptx:4*:*)
+ 	# ptx 4.0 does uname -s correctly, with DYNIX/ptx in there.
+@@ -1050,34 +1076,34 @@ EOF
+ 	# I am not positive that other SVR4 systems won't match this,
+ 	# I just have to hope.  -- rms.
+ 	# Use sysv4.2uw... so that sysv4* matches it.
+-	echo ${UNAME_MACHINE}-pc-sysv4.2uw${UNAME_VERSION}
++	echo "$UNAME_MACHINE"-pc-sysv4.2uw"$UNAME_VERSION"
+ 	exit ;;
+     i*86:OS/2:*:*)
+ 	# If we were able to find `uname', then EMX Unix compatibility
+ 	# is probably installed.
+-	echo ${UNAME_MACHINE}-pc-os2-emx
++	echo "$UNAME_MACHINE"-pc-os2-emx
+ 	exit ;;
+     i*86:XTS-300:*:STOP)
+-	echo ${UNAME_MACHINE}-unknown-stop
++	echo "$UNAME_MACHINE"-unknown-stop
+ 	exit ;;
+     i*86:atheos:*:*)
+-	echo ${UNAME_MACHINE}-unknown-atheos
++	echo "$UNAME_MACHINE"-unknown-atheos
+ 	exit ;;
+     i*86:syllable:*:*)
+-	echo ${UNAME_MACHINE}-pc-syllable
++	echo "$UNAME_MACHINE"-pc-syllable
+ 	exit ;;
+     i*86:LynxOS:2.*:* | i*86:LynxOS:3.[01]*:* | i*86:LynxOS:4.[02]*:*)
+-	echo i386-unknown-lynxos${UNAME_RELEASE}
++	echo i386-unknown-lynxos"$UNAME_RELEASE"
+ 	exit ;;
+     i*86:*DOS:*:*)
+-	echo ${UNAME_MACHINE}-pc-msdosdjgpp
++	echo "$UNAME_MACHINE"-pc-msdosdjgpp
+ 	exit ;;
+-    i*86:*:4.*:* | i*86:SYSTEM_V:4.*:*)
+-	UNAME_REL=`echo ${UNAME_RELEASE} | sed 's/\/MP$//'`
++    i*86:*:4.*:*)
++	UNAME_REL=`echo "$UNAME_RELEASE" | sed 's/\/MP$//'`
+ 	if grep Novell /usr/include/link.h >/dev/null 2>/dev/null; then
+-		echo ${UNAME_MACHINE}-univel-sysv${UNAME_REL}
++		echo "$UNAME_MACHINE"-univel-sysv"$UNAME_REL"
+ 	else
+-		echo ${UNAME_MACHINE}-pc-sysv${UNAME_REL}
++		echo "$UNAME_MACHINE"-pc-sysv"$UNAME_REL"
+ 	fi
+ 	exit ;;
+     i*86:*:5:[678]*)
+@@ -1087,12 +1113,12 @@ EOF
+ 	    *Pentium)	     UNAME_MACHINE=i586 ;;
+ 	    *Pent*|*Celeron) UNAME_MACHINE=i686 ;;
+ 	esac
+-	echo ${UNAME_MACHINE}-unknown-sysv${UNAME_RELEASE}${UNAME_SYSTEM}${UNAME_VERSION}
++	echo "$UNAME_MACHINE-unknown-sysv${UNAME_RELEASE}${UNAME_SYSTEM}{$UNAME_VERSION}"
+ 	exit ;;
+     i*86:*:3.2:*)
+ 	if test -f /usr/options/cb.name; then
+ 		UNAME_REL=`sed -n 's/.*Version //p' </usr/options/cb.name`
+-		echo ${UNAME_MACHINE}-pc-isc$UNAME_REL
++		echo "$UNAME_MACHINE"-pc-isc"$UNAME_REL"
+ 	elif /bin/uname -X 2>/dev/null >/dev/null ; then
+ 		UNAME_REL=`(/bin/uname -X|grep Release|sed -e 's/.*= //')`
+ 		(/bin/uname -X|grep i80486 >/dev/null) && UNAME_MACHINE=i486
+@@ -1102,9 +1128,9 @@ EOF
+ 			&& UNAME_MACHINE=i686
+ 		(/bin/uname -X|grep '^Machine.*Pentium Pro' >/dev/null) \
+ 			&& UNAME_MACHINE=i686
+-		echo ${UNAME_MACHINE}-pc-sco$UNAME_REL
++		echo "$UNAME_MACHINE"-pc-sco"$UNAME_REL"
+ 	else
+-		echo ${UNAME_MACHINE}-pc-sysv32
++		echo "$UNAME_MACHINE"-pc-sysv32
+ 	fi
+ 	exit ;;
+     pc:*:*:*)
+@@ -1124,9 +1150,9 @@ EOF
+ 	exit ;;
+     i860:*:4.*:*) # i860-SVR4
+ 	if grep Stardent /usr/include/sys/uadmin.h >/dev/null 2>&1 ; then
+-	  echo i860-stardent-sysv${UNAME_RELEASE} # Stardent Vistra i860-SVR4
++	  echo i860-stardent-sysv"$UNAME_RELEASE" # Stardent Vistra i860-SVR4
+ 	else # Add other i860-SVR4 vendors below as they are discovered.
+-	  echo i860-unknown-sysv${UNAME_RELEASE}  # Unknown i860-SVR4
++	  echo i860-unknown-sysv"$UNAME_RELEASE"  # Unknown i860-SVR4
+ 	fi
+ 	exit ;;
+     mini*:CTIX:SYS*5:*)
+@@ -1146,9 +1172,9 @@ EOF
+ 	test -r /etc/.relid \
+ 	&& OS_REL=.`sed -n 's/[^ ]* [^ ]* \([0-9][0-9]\).*/\1/p' < /etc/.relid`
+ 	/bin/uname -p 2>/dev/null | grep 86 >/dev/null \
+-	  && { echo i486-ncr-sysv4.3${OS_REL}; exit; }
++	  && { echo i486-ncr-sysv4.3"$OS_REL"; exit; }
+ 	/bin/uname -p 2>/dev/null | /bin/grep entium >/dev/null \
+-	  && { echo i586-ncr-sysv4.3${OS_REL}; exit; } ;;
++	  && { echo i586-ncr-sysv4.3"$OS_REL"; exit; } ;;
+     3[34]??:*:4.0:* | 3[34]??,*:*:4.0:*)
+ 	/bin/uname -p 2>/dev/null | grep 86 >/dev/null \
+ 	  && { echo i486-ncr-sysv4; exit; } ;;
+@@ -1157,28 +1183,28 @@ EOF
+ 	test -r /etc/.relid \
+ 	    && OS_REL=.`sed -n 's/[^ ]* [^ ]* \([0-9][0-9]\).*/\1/p' < /etc/.relid`
+ 	/bin/uname -p 2>/dev/null | grep 86 >/dev/null \
+-	    && { echo i486-ncr-sysv4.3${OS_REL}; exit; }
++	    && { echo i486-ncr-sysv4.3"$OS_REL"; exit; }
+ 	/bin/uname -p 2>/dev/null | /bin/grep entium >/dev/null \
+-	    && { echo i586-ncr-sysv4.3${OS_REL}; exit; }
++	    && { echo i586-ncr-sysv4.3"$OS_REL"; exit; }
+ 	/bin/uname -p 2>/dev/null | /bin/grep pteron >/dev/null \
+-	    && { echo i586-ncr-sysv4.3${OS_REL}; exit; } ;;
++	    && { echo i586-ncr-sysv4.3"$OS_REL"; exit; } ;;
+     m68*:LynxOS:2.*:* | m68*:LynxOS:3.0*:*)
+-	echo m68k-unknown-lynxos${UNAME_RELEASE}
++	echo m68k-unknown-lynxos"$UNAME_RELEASE"
+ 	exit ;;
+     mc68030:UNIX_System_V:4.*:*)
+ 	echo m68k-atari-sysv4
+ 	exit ;;
+     TSUNAMI:LynxOS:2.*:*)
+-	echo sparc-unknown-lynxos${UNAME_RELEASE}
++	echo sparc-unknown-lynxos"$UNAME_RELEASE"
+ 	exit ;;
+     rs6000:LynxOS:2.*:*)
+-	echo rs6000-unknown-lynxos${UNAME_RELEASE}
++	echo rs6000-unknown-lynxos"$UNAME_RELEASE"
+ 	exit ;;
+     PowerPC:LynxOS:2.*:* | PowerPC:LynxOS:3.[01]*:* | PowerPC:LynxOS:4.[02]*:*)
+-	echo powerpc-unknown-lynxos${UNAME_RELEASE}
++	echo powerpc-unknown-lynxos"$UNAME_RELEASE"
+ 	exit ;;
+     SM[BE]S:UNIX_SV:*:*)
+-	echo mips-dde-sysv${UNAME_RELEASE}
++	echo mips-dde-sysv"$UNAME_RELEASE"
+ 	exit ;;
+     RM*:ReliantUNIX-*:*:*)
+ 	echo mips-sni-sysv4
+@@ -1189,7 +1215,7 @@ EOF
+     *:SINIX-*:*:*)
+ 	if uname -p 2>/dev/null >/dev/null ; then
+ 		UNAME_MACHINE=`(uname -p) 2>/dev/null`
+-		echo ${UNAME_MACHINE}-sni-sysv4
++		echo "$UNAME_MACHINE"-sni-sysv4
+ 	else
+ 		echo ns32k-sni-sysv
+ 	fi
+@@ -1209,23 +1235,23 @@ EOF
+ 	exit ;;
+     i*86:VOS:*:*)
+ 	# From Paul.Green@stratus.com.
+-	echo ${UNAME_MACHINE}-stratus-vos
++	echo "$UNAME_MACHINE"-stratus-vos
+ 	exit ;;
+     *:VOS:*:*)
+ 	# From Paul.Green@stratus.com.
+ 	echo hppa1.1-stratus-vos
+ 	exit ;;
+     mc68*:A/UX:*:*)
+-	echo m68k-apple-aux${UNAME_RELEASE}
++	echo m68k-apple-aux"$UNAME_RELEASE"
+ 	exit ;;
+     news*:NEWS-OS:6*:*)
+ 	echo mips-sony-newsos6
+ 	exit ;;
+     R[34]000:*System_V*:*:* | R4000:UNIX_SYSV:*:* | R*000:UNIX_SV:*:*)
+ 	if [ -d /usr/nec ]; then
+-		echo mips-nec-sysv${UNAME_RELEASE}
++		echo mips-nec-sysv"$UNAME_RELEASE"
+ 	else
+-		echo mips-unknown-sysv${UNAME_RELEASE}
++		echo mips-unknown-sysv"$UNAME_RELEASE"
+ 	fi
+ 	exit ;;
+     BeBox:BeOS:*:*)	# BeOS running on hardware made by Be, PPC only.
+@@ -1244,39 +1270,39 @@ EOF
+ 	echo x86_64-unknown-haiku
+ 	exit ;;
+     SX-4:SUPER-UX:*:*)
+-	echo sx4-nec-superux${UNAME_RELEASE}
++	echo sx4-nec-superux"$UNAME_RELEASE"
+ 	exit ;;
+     SX-5:SUPER-UX:*:*)
+-	echo sx5-nec-superux${UNAME_RELEASE}
++	echo sx5-nec-superux"$UNAME_RELEASE"
+ 	exit ;;
+     SX-6:SUPER-UX:*:*)
+-	echo sx6-nec-superux${UNAME_RELEASE}
++	echo sx6-nec-superux"$UNAME_RELEASE"
+ 	exit ;;
+     SX-7:SUPER-UX:*:*)
+-	echo sx7-nec-superux${UNAME_RELEASE}
++	echo sx7-nec-superux"$UNAME_RELEASE"
+ 	exit ;;
+     SX-8:SUPER-UX:*:*)
+-	echo sx8-nec-superux${UNAME_RELEASE}
++	echo sx8-nec-superux"$UNAME_RELEASE"
+ 	exit ;;
+     SX-8R:SUPER-UX:*:*)
+-	echo sx8r-nec-superux${UNAME_RELEASE}
++	echo sx8r-nec-superux"$UNAME_RELEASE"
+ 	exit ;;
+     SX-ACE:SUPER-UX:*:*)
+-	echo sxace-nec-superux${UNAME_RELEASE}
++	echo sxace-nec-superux"$UNAME_RELEASE"
+ 	exit ;;
+     Power*:Rhapsody:*:*)
+-	echo powerpc-apple-rhapsody${UNAME_RELEASE}
++	echo powerpc-apple-rhapsody"$UNAME_RELEASE"
+ 	exit ;;
+     *:Rhapsody:*:*)
+-	echo ${UNAME_MACHINE}-apple-rhapsody${UNAME_RELEASE}
++	echo "$UNAME_MACHINE"-apple-rhapsody"$UNAME_RELEASE"
+ 	exit ;;
+     *:Darwin:*:*)
+ 	UNAME_PROCESSOR=`uname -p` || UNAME_PROCESSOR=unknown
+-	eval $set_cc_for_build
++	set_cc_for_build
+ 	if test "$UNAME_PROCESSOR" = unknown ; then
+ 	    UNAME_PROCESSOR=powerpc
+ 	fi
+-	if test `echo "$UNAME_RELEASE" | sed -e 's/\..*//'` -le 10 ; then
++	if test "`echo "$UNAME_RELEASE" | sed -e 's/\..*//'`" -le 10 ; then
+ 	    if [ "$CC_FOR_BUILD" != no_compiler_found ]; then
+ 		if (echo '#ifdef __LP64__'; echo IS_64BIT_ARCH; echo '#endif') | \
+ 		       (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
+@@ -1304,7 +1330,7 @@ EOF
+ 	    # that Apple uses in portable devices.
+ 	    UNAME_PROCESSOR=x86_64
+ 	fi
+-	echo ${UNAME_PROCESSOR}-apple-darwin${UNAME_RELEASE}
++	echo "$UNAME_PROCESSOR"-apple-darwin"$UNAME_RELEASE"
+ 	exit ;;
+     *:procnto*:*:* | *:QNX:[0123456789]*:*)
+ 	UNAME_PROCESSOR=`uname -p`
+@@ -1312,22 +1338,25 @@ EOF
+ 		UNAME_PROCESSOR=i386
+ 		UNAME_MACHINE=pc
+ 	fi
+-	echo ${UNAME_PROCESSOR}-${UNAME_MACHINE}-nto-qnx${UNAME_RELEASE}
++	echo "$UNAME_PROCESSOR"-"$UNAME_MACHINE"-nto-qnx"$UNAME_RELEASE"
+ 	exit ;;
+     *:QNX:*:4*)
+ 	echo i386-pc-qnx
+ 	exit ;;
+     NEO-*:NONSTOP_KERNEL:*:*)
+-	echo neo-tandem-nsk${UNAME_RELEASE}
++	echo neo-tandem-nsk"$UNAME_RELEASE"
+ 	exit ;;
+     NSE-*:NONSTOP_KERNEL:*:*)
+-	echo nse-tandem-nsk${UNAME_RELEASE}
++	echo nse-tandem-nsk"$UNAME_RELEASE"
+ 	exit ;;
+     NSR-*:NONSTOP_KERNEL:*:*)
+-	echo nsr-tandem-nsk${UNAME_RELEASE}
++	echo nsr-tandem-nsk"$UNAME_RELEASE"
++	exit ;;
++    NSV-*:NONSTOP_KERNEL:*:*)
++	echo nsv-tandem-nsk"$UNAME_RELEASE"
+ 	exit ;;
+     NSX-*:NONSTOP_KERNEL:*:*)
+-	echo nsx-tandem-nsk${UNAME_RELEASE}
++	echo nsx-tandem-nsk"$UNAME_RELEASE"
+ 	exit ;;
+     *:NonStop-UX:*:*)
+ 	echo mips-compaq-nonstopux
+@@ -1336,18 +1365,19 @@ EOF
+ 	echo bs2000-siemens-sysv
+ 	exit ;;
+     DS/*:UNIX_System_V:*:*)
+-	echo ${UNAME_MACHINE}-${UNAME_SYSTEM}-${UNAME_RELEASE}
++	echo "$UNAME_MACHINE"-"$UNAME_SYSTEM"-"$UNAME_RELEASE"
+ 	exit ;;
+     *:Plan9:*:*)
+ 	# "uname -m" is not consistent, so use $cputype instead. 386
+ 	# is converted to i386 for consistency with other x86
+ 	# operating systems.
++	# shellcheck disable=SC2154
+ 	if test "$cputype" = 386; then
+ 	    UNAME_MACHINE=i386
+ 	else
+ 	    UNAME_MACHINE="$cputype"
+ 	fi
+-	echo ${UNAME_MACHINE}-unknown-plan9
++	echo "$UNAME_MACHINE"-unknown-plan9
+ 	exit ;;
+     *:TOPS-10:*:*)
+ 	echo pdp10-unknown-tops10
+@@ -1368,14 +1398,14 @@ EOF
+ 	echo pdp10-unknown-its
+ 	exit ;;
+     SEI:*:*:SEIUX)
+-	echo mips-sei-seiux${UNAME_RELEASE}
++	echo mips-sei-seiux"$UNAME_RELEASE"
+ 	exit ;;
+     *:DragonFly:*:*)
+-	echo ${UNAME_MACHINE}-unknown-dragonfly`echo ${UNAME_RELEASE}|sed -e 's/[-(].*//'`
++	echo "$UNAME_MACHINE"-unknown-dragonfly"`echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`"
+ 	exit ;;
+     *:*VMS:*:*)
+ 	UNAME_MACHINE=`(uname -p) 2>/dev/null`
+-	case "${UNAME_MACHINE}" in
++	case "$UNAME_MACHINE" in
+ 	    A*) echo alpha-dec-vms ; exit ;;
+ 	    I*) echo ia64-dec-vms ; exit ;;
+ 	    V*) echo vax-dec-vms ; exit ;;
+@@ -1384,24 +1414,39 @@ EOF
+ 	echo i386-pc-xenix
+ 	exit ;;
+     i*86:skyos:*:*)
+-	echo ${UNAME_MACHINE}-pc-skyos`echo ${UNAME_RELEASE} | sed -e 's/ .*$//'`
++	echo "$UNAME_MACHINE"-pc-skyos"`echo "$UNAME_RELEASE" | sed -e 's/ .*$//'`"
+ 	exit ;;
+     i*86:rdos:*:*)
+-	echo ${UNAME_MACHINE}-pc-rdos
++	echo "$UNAME_MACHINE"-pc-rdos
+ 	exit ;;
+     i*86:AROS:*:*)
+-	echo ${UNAME_MACHINE}-pc-aros
++	echo "$UNAME_MACHINE"-pc-aros
+ 	exit ;;
+     x86_64:VMkernel:*:*)
+-	echo ${UNAME_MACHINE}-unknown-esx
++	echo "$UNAME_MACHINE"-unknown-esx
+ 	exit ;;
+     amd64:Isilon\ OneFS:*:*)
+ 	echo x86_64-unknown-onefs
+ 	exit ;;
++    *:Unleashed:*:*)
++	echo "$UNAME_MACHINE"-unknown-unleashed"$UNAME_RELEASE"
++	exit ;;
++esac
++
++echo "$0: unable to guess system type" >&2
++
++case "$UNAME_MACHINE:$UNAME_SYSTEM" in
++    mips:Linux | mips64:Linux)
++	# If we got here on MIPS GNU/Linux, output extra information.
++	cat >&2 <<EOF
++
++NOTE: MIPS GNU/Linux systems require a C compiler to fully recognize
++the system type. Please install a C compiler and try again.
++EOF
++	;;
+ esac
+ 
+ cat >&2 <<EOF
+-$0: unable to guess system type
+ 
+ This script (version $timestamp), has failed to recognize the
+ operating system you are using. If your script is old, overwrite *all*
+@@ -1432,16 +1477,16 @@ hostinfo               = `(hostinfo) 2>/dev/null`
+ /usr/bin/oslevel       = `(/usr/bin/oslevel) 2>/dev/null`
+ /usr/convex/getsysinfo = `(/usr/convex/getsysinfo) 2>/dev/null`
+ 
+-UNAME_MACHINE = ${UNAME_MACHINE}
+-UNAME_RELEASE = ${UNAME_RELEASE}
+-UNAME_SYSTEM  = ${UNAME_SYSTEM}
+-UNAME_VERSION = ${UNAME_VERSION}
++UNAME_MACHINE = "$UNAME_MACHINE"
++UNAME_RELEASE = "$UNAME_RELEASE"
++UNAME_SYSTEM  = "$UNAME_SYSTEM"
++UNAME_VERSION = "$UNAME_VERSION"
+ EOF
+ 
+ exit 1
+ 
+ # Local variables:
+-# eval: (add-hook 'write-file-hooks 'time-stamp)
++# eval: (add-hook 'before-save-hook 'time-stamp)
+ # time-stamp-start: "timestamp='"
+ # time-stamp-format: "%:y-%02m-%02d"
+ # time-stamp-end: "'"
+diff --git a/build/config.sub b/build/config.sub
+index 95dc3d0..a8f3f7e 100755
+--- a/build/config.sub
++++ b/build/config.sub
+@@ -1,8 +1,8 @@
+ #! /bin/sh
+ # Configuration validation subroutine script.
+-#   Copyright 1992-2017 Free Software Foundation, Inc.
++#   Copyright 1992-2019 Free Software Foundation, Inc.
+ 
+-timestamp='2017-09-16'
++timestamp='2019-01-01'
+ 
+ # This file is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by
+@@ -57,7 +57,7 @@ Usage: $0 [OPTION] CPU-MFR-OPSYS or ALIAS
+ 
+ Canonicalize a configuration name.
+ 
+-Operation modes:
++Options:
+   -h, --help         print this help, then exit
+   -t, --time-stamp   print date of last modification, then exit
+   -v, --version      print version number, then exit
+@@ -67,7 +67,7 @@ Report bugs and patches to <config-patches@gnu.org>."
+ version="\
+ GNU config.sub ($timestamp)
+ 
+-Copyright 1992-2017 Free Software Foundation, Inc.
++Copyright 1992-2019 Free Software Foundation, Inc.
+ 
+ This is free software; see the source for copying conditions.  There is NO
+ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+@@ -89,12 +89,12 @@ while test $# -gt 0 ; do
+     - )	# Use stdin as input.
+        break ;;
+     -* )
+-       echo "$me: invalid option $1$help"
++       echo "$me: invalid option $1$help" >&2
+        exit 1 ;;
+ 
+     *local*)
+        # First pass through any local machine types.
+-       echo $1
++       echo "$1"
+        exit ;;
+ 
+     * )
+@@ -110,1252 +110,1160 @@ case $# in
+     exit 1;;
+ esac
+ 
+-# Separate what the user gave into CPU-COMPANY and OS or KERNEL-OS (if any).
+-# Here we must recognize all the valid KERNEL-OS combinations.
+-maybe_os=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\2/'`
+-case $maybe_os in
+-  nto-qnx* | linux-gnu* | linux-android* | linux-dietlibc | linux-newlib* | \
+-  linux-musl* | linux-uclibc* | uclinux-uclibc* | uclinux-gnu* | kfreebsd*-gnu* | \
+-  knetbsd*-gnu* | netbsd*-gnu* | netbsd*-eabi* | \
+-  kopensolaris*-gnu* | cloudabi*-eabi* | \
+-  storm-chaos* | os2-emx* | rtmk-nova*)
+-    os=-$maybe_os
+-    basic_machine=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/'`
+-    ;;
+-  android-linux)
+-    os=-linux-android
+-    basic_machine=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/'`-unknown
+-    ;;
+-  *)
+-    basic_machine=`echo $1 | sed 's/-[^-]*$//'`
+-    if [ $basic_machine != $1 ]
+-    then os=`echo $1 | sed 's/.*-/-/'`
+-    else os=; fi
+-    ;;
+-esac
++# Split fields of configuration type
++IFS="-" read field1 field2 field3 field4 <<EOF
++$1
++EOF
+ 
+-### Let's recognize common machines as not being operating systems so
+-### that things like config.sub decstation-3100 work.  We also
+-### recognize some manufacturers as not being operating systems, so we
+-### can provide default operating systems below.
+-case $os in
+-	-sun*os*)
+-		# Prevent following clause from handling this invalid input.
+-		;;
+-	-dec* | -mips* | -sequent* | -encore* | -pc532* | -sgi* | -sony* | \
+-	-att* | -7300* | -3300* | -delta* | -motorola* | -sun[234]* | \
+-	-unicom* | -ibm* | -next | -hp | -isi* | -apollo | -altos* | \
+-	-convergent* | -ncr* | -news | -32* | -3600* | -3100* | -hitachi* |\
+-	-c[123]* | -convex* | -sun | -crds | -omron* | -dg | -ultra | -tti* | \
+-	-harris | -dolphin | -highlevel | -gould | -cbm | -ns | -masscomp | \
+-	-apple | -axis | -knuth | -cray | -microblaze*)
+-		os=
+-		basic_machine=$1
+-		;;
+-	-bluegene*)
+-		os=-cnk
+-		;;
+-	-sim | -cisco | -oki | -wec | -winbond)
+-		os=
+-		basic_machine=$1
+-		;;
+-	-scout)
+-		;;
+-	-wrs)
+-		os=-vxworks
+-		basic_machine=$1
+-		;;
+-	-chorusos*)
+-		os=-chorusos
+-		basic_machine=$1
+-		;;
+-	-chorusrdb)
+-		os=-chorusrdb
+-		basic_machine=$1
+-		;;
+-	-hiux*)
+-		os=-hiuxwe2
+-		;;
+-	-sco6)
+-		os=-sco5v6
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco5)
+-		os=-sco3.2v5
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco4)
+-		os=-sco3.2v4
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco3.2.[4-9]*)
+-		os=`echo $os | sed -e 's/sco3.2./sco3.2v/'`
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco3.2v[4-9]*)
+-		# Don't forget version if it is 3.2v4 or newer.
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco5v6*)
+-		# Don't forget version if it is 3.2v4 or newer.
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco*)
+-		os=-sco3.2v2
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-udk*)
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-isc)
+-		os=-isc2.2
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-clix*)
+-		basic_machine=clipper-intergraph
+-		;;
+-	-isc*)
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-lynx*178)
+-		os=-lynxos178
+-		;;
+-	-lynx*5)
+-		os=-lynxos5
++# Separate into logical components for further validation
++case $1 in
++	*-*-*-*-*)
++		echo Invalid configuration \`"$1"\': more than four components >&2
++		exit 1
+ 		;;
+-	-lynx*)
+-		os=-lynxos
++	*-*-*-*)
++		basic_machine=$field1-$field2
++		os=$field3-$field4
+ 		;;
+-	-ptx*)
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-sequent/'`
++	*-*-*)
++		# Ambiguous whether COMPANY is present, or skipped and KERNEL-OS is two
++		# parts
++		maybe_os=$field2-$field3
++		case $maybe_os in
++			nto-qnx* | linux-gnu* | linux-android* | linux-dietlibc \
++			| linux-newlib* | linux-musl* | linux-uclibc* | uclinux-uclibc* \
++			| uclinux-gnu* | kfreebsd*-gnu* | knetbsd*-gnu* | netbsd*-gnu* \
++			| netbsd*-eabi* | kopensolaris*-gnu* | cloudabi*-eabi* \
++			| storm-chaos* | os2-emx* | rtmk-nova*)
++				basic_machine=$field1
++				os=$maybe_os
++				;;
++			android-linux)
++				basic_machine=$field1-unknown
++				os=linux-android
++				;;
++			*)
++				basic_machine=$field1-$field2
++				os=$field3
++				;;
++		esac
+ 		;;
+-	-psos*)
+-		os=-psos
++	*-*)
++		# A lone config we happen to match not fitting any pattern
++		case $field1-$field2 in
++			decstation-3100)
++				basic_machine=mips-dec
++				os=
++				;;
++			*-*)
++				# Second component is usually, but not always the OS
++				case $field2 in
++					# Prevent following clause from handling this valid os
++					sun*os*)
++						basic_machine=$field1
++						os=$field2
++						;;
++					# Manufacturers
++					dec* | mips* | sequent* | encore* | pc533* | sgi* | sony* \
++					| att* | 7300* | 3300* | delta* | motorola* | sun[234]* \
++					| unicom* | ibm* | next | hp | isi* | apollo | altos* \
++					| convergent* | ncr* | news | 32* | 3600* | 3100* \
++					| hitachi* | c[123]* | convex* | sun | crds | omron* | dg \
++					| ultra | tti* | harris | dolphin | highlevel | gould \
++					| cbm | ns | masscomp | apple | axis | knuth | cray \
++					| microblaze* | sim | cisco \
++					| oki | wec | wrs | winbond)
++						basic_machine=$field1-$field2
++						os=
++						;;
++					*)
++						basic_machine=$field1
++						os=$field2
++						;;
++				esac
++			;;
++		esac
+ 		;;
+-	-mint | -mint[0-9]*)
+-		basic_machine=m68k-atari
+-		os=-mint
++	*)
++		# Convert single-component short-hands not valid as part of
++		# multi-component configurations.
++		case $field1 in
++			386bsd)
++				basic_machine=i386-pc
++				os=bsd
++				;;
++			a29khif)
++				basic_machine=a29k-amd
++				os=udi
++				;;
++			adobe68k)
++				basic_machine=m68010-adobe
++				os=scout
++				;;
++			alliant)
++				basic_machine=fx80-alliant
++				os=
++				;;
++			altos | altos3068)
++				basic_machine=m68k-altos
++				os=
++				;;
++			am29k)
++				basic_machine=a29k-none
++				os=bsd
++				;;
++			amdahl)
++				basic_machine=580-amdahl
++				os=sysv
++				;;
++			amiga)
++				basic_machine=m68k-unknown
++				os=
++				;;
++			amigaos | amigados)
++				basic_machine=m68k-unknown
++				os=amigaos
++				;;
++			amigaunix | amix)
++				basic_machine=m68k-unknown
++				os=sysv4
++				;;
++			apollo68)
++				basic_machine=m68k-apollo
++				os=sysv
++				;;
++			apollo68bsd)
++				basic_machine=m68k-apollo
++				os=bsd
++				;;
++			aros)
++				basic_machine=i386-pc
++				os=aros
++				;;
++			aux)
++				basic_machine=m68k-apple
++				os=aux
++				;;
++			balance)
++				basic_machine=ns32k-sequent
++				os=dynix
++				;;
++			blackfin)
++				basic_machine=bfin-unknown
++				os=linux
++				;;
++			cegcc)
++				basic_machine=arm-unknown
++				os=cegcc
++				;;
++			convex-c1)
++				basic_machine=c1-convex
++				os=bsd
++				;;
++			convex-c2)
++				basic_machine=c2-convex
++				os=bsd
++				;;
++			convex-c32)
++				basic_machine=c32-convex
++				os=bsd
++				;;
++			convex-c34)
++				basic_machine=c34-convex
++				os=bsd
++				;;
++			convex-c38)
++				basic_machine=c38-convex
++				os=bsd
++				;;
++			cray)
++				basic_machine=j90-cray
++				os=unicos
++				;;
++			crds | unos)
++				basic_machine=m68k-crds
++				os=
++				;;
++			da30)
++				basic_machine=m68k-da30
++				os=
++				;;
++			decstation | pmax | pmin | dec3100 | decstatn)
++				basic_machine=mips-dec
++				os=
++				;;
++			delta88)
++				basic_machine=m88k-motorola
++				os=sysv3
++				;;
++			dicos)
++				basic_machine=i686-pc
++				os=dicos
++				;;
++			djgpp)
++				basic_machine=i586-pc
++				os=msdosdjgpp
++				;;
++			ebmon29k)
++				basic_machine=a29k-amd
++				os=ebmon
++				;;
++			es1800 | OSE68k | ose68k | ose | OSE)
++				basic_machine=m68k-ericsson
++				os=ose
++				;;
++			gmicro)
++				basic_machine=tron-gmicro
++				os=sysv
++				;;
++			go32)
++				basic_machine=i386-pc
++				os=go32
++				;;
++			h8300hms)
++				basic_machine=h8300-hitachi
++				os=hms
++				;;
++			h8300xray)
++				basic_machine=h8300-hitachi
++				os=xray
++				;;
++			h8500hms)
++				basic_machine=h8500-hitachi
++				os=hms
++				;;
++			harris)
++				basic_machine=m88k-harris
++				os=sysv3
++				;;
++			hp300)
++				basic_machine=m68k-hp
++				;;
++			hp300bsd)
++				basic_machine=m68k-hp
++				os=bsd
++				;;
++			hp300hpux)
++				basic_machine=m68k-hp
++				os=hpux
++				;;
++			hppaosf)
++				basic_machine=hppa1.1-hp
++				os=osf
++				;;
++			hppro)
++				basic_machine=hppa1.1-hp
++				os=proelf
++				;;
++			i386mach)
++				basic_machine=i386-mach
++				os=mach
++				;;
++			vsta)
++				basic_machine=i386-pc
++				os=vsta
++				;;
++			isi68 | isi)
++				basic_machine=m68k-isi
++				os=sysv
++				;;
++			m68knommu)
++				basic_machine=m68k-unknown
++				os=linux
++				;;
++			magnum | m3230)
++				basic_machine=mips-mips
++				os=sysv
++				;;
++			merlin)
++				basic_machine=ns32k-utek
++				os=sysv
++				;;
++			mingw64)
++				basic_machine=x86_64-pc
++				os=mingw64
++				;;
++			mingw32)
++				basic_machine=i686-pc
++				os=mingw32
++				;;
++			mingw32ce)
++				basic_machine=arm-unknown
++				os=mingw32ce
++				;;
++			monitor)
++				basic_machine=m68k-rom68k
++				os=coff
++				;;
++			morphos)
++				basic_machine=powerpc-unknown
++				os=morphos
++				;;
++			moxiebox)
++				basic_machine=moxie-unknown
++				os=moxiebox
++				;;
++			msdos)
++				basic_machine=i386-pc
++				os=msdos
++				;;
++			msys)
++				basic_machine=i686-pc
++				os=msys
++				;;
++			mvs)
++				basic_machine=i370-ibm
++				os=mvs
++				;;
++			nacl)
++				basic_machine=le32-unknown
++				os=nacl
++				;;
++			ncr3000)
++				basic_machine=i486-ncr
++				os=sysv4
++				;;
++			netbsd386)
++				basic_machine=i386-pc
++				os=netbsd
++				;;
++			netwinder)
++				basic_machine=armv4l-rebel
++				os=linux
++				;;
++			news | news700 | news800 | news900)
++				basic_machine=m68k-sony
++				os=newsos
++				;;
++			news1000)
++				basic_machine=m68030-sony
++				os=newsos
++				;;
++			necv70)
++				basic_machine=v70-nec
++				os=sysv
++				;;
++			nh3000)
++				basic_machine=m68k-harris
++				os=cxux
++				;;
++			nh[45]000)
++				basic_machine=m88k-harris
++				os=cxux
++				;;
++			nindy960)
++				basic_machine=i960-intel
++				os=nindy
++				;;
++			mon960)
++				basic_machine=i960-intel
++				os=mon960
++				;;
++			nonstopux)
++				basic_machine=mips-compaq
++				os=nonstopux
++				;;
++			os400)
++				basic_machine=powerpc-ibm
++				os=os400
++				;;
++			OSE68000 | ose68000)
++				basic_machine=m68000-ericsson
++				os=ose
++				;;
++			os68k)
++				basic_machine=m68k-none
++				os=os68k
++				;;
++			paragon)
++				basic_machine=i860-intel
++				os=osf
++				;;
++			parisc)
++				basic_machine=hppa-unknown
++				os=linux
++				;;
++			pw32)
++				basic_machine=i586-unknown
++				os=pw32
++				;;
++			rdos | rdos64)
++				basic_machine=x86_64-pc
++				os=rdos
++				;;
++			rdos32)
++				basic_machine=i386-pc
++				os=rdos
++				;;
++			rom68k)
++				basic_machine=m68k-rom68k
++				os=coff
++				;;
++			sa29200)
++				basic_machine=a29k-amd
++				os=udi
++				;;
++			sei)
++				basic_machine=mips-sei
++				os=seiux
++				;;
++			sequent)
++				basic_machine=i386-sequent
++				os=
++				;;
++			sps7)
++				basic_machine=m68k-bull
++				os=sysv2
++				;;
++			st2000)
++				basic_machine=m68k-tandem
++				os=
++				;;
++			stratus)
++				basic_machine=i860-stratus
++				os=sysv4
++				;;
++			sun2)
++				basic_machine=m68000-sun
++				os=
++				;;
++			sun2os3)
++				basic_machine=m68000-sun
++				os=sunos3
++				;;
++			sun2os4)
++				basic_machine=m68000-sun
++				os=sunos4
++				;;
++			sun3)
++				basic_machine=m68k-sun
++				os=
++				;;
++			sun3os3)
++				basic_machine=m68k-sun
++				os=sunos3
++				;;
++			sun3os4)
++				basic_machine=m68k-sun
++				os=sunos4
++				;;
++			sun4)
++				basic_machine=sparc-sun
++				os=
++				;;
++			sun4os3)
++				basic_machine=sparc-sun
++				os=sunos3
++				;;
++			sun4os4)
++				basic_machine=sparc-sun
++				os=sunos4
++				;;
++			sun4sol2)
++				basic_machine=sparc-sun
++				os=solaris2
++				;;
++			sun386 | sun386i | roadrunner)
++				basic_machine=i386-sun
++				os=
++				;;
++			sv1)
++				basic_machine=sv1-cray
++				os=unicos
++				;;
++			symmetry)
++				basic_machine=i386-sequent
++				os=dynix
++				;;
++			t3e)
++				basic_machine=alphaev5-cray
++				os=unicos
++				;;
++			t90)
++				basic_machine=t90-cray
++				os=unicos
++				;;
++			toad1)
++				basic_machine=pdp10-xkl
++				os=tops20
++				;;
++			tpf)
++				basic_machine=s390x-ibm
++				os=tpf
++				;;
++			udi29k)
++				basic_machine=a29k-amd
++				os=udi
++				;;
++			ultra3)
++				basic_machine=a29k-nyu
++				os=sym1
++				;;
++			v810 | necv810)
++				basic_machine=v810-nec
++				os=none
++				;;
++			vaxv)
++				basic_machine=vax-dec
++				os=sysv
++				;;
++			vms)
++				basic_machine=vax-dec
++				os=vms
++				;;
++			vxworks960)
++				basic_machine=i960-wrs
++				os=vxworks
++				;;
++			vxworks68)
++				basic_machine=m68k-wrs
++				os=vxworks
++				;;
++			vxworks29k)
++				basic_machine=a29k-wrs
++				os=vxworks
++				;;
++			xbox)
++				basic_machine=i686-pc
++				os=mingw32
++				;;
++			ymp)
++				basic_machine=ymp-cray
++				os=unicos
++				;;
++			*)
++				basic_machine=$1
++				os=
++				;;
++		esac
+ 		;;
+ esac
+ 
+-# Decode aliases for certain CPU-COMPANY combinations.
++# Decode 1-component or ad-hoc basic machines
+ case $basic_machine in
+-	# Recognize the basic CPU types without company name.
+-	# Some are omitted here because they have special meanings below.
+-	1750a | 580 \
+-	| a29k \
+-	| aarch64 | aarch64_be \
+-	| alpha | alphaev[4-8] | alphaev56 | alphaev6[78] | alphapca5[67] \
+-	| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] | alpha64pca5[67] \
+-	| am33_2.0 \
+-	| arc | arceb \
+-	| arm | arm[bl]e | arme[lb] | armv[2-8] | armv[3-8][lb] | armv7[arm] \
+-	| avr | avr32 \
+-	| ba \
+-	| be32 | be64 \
+-	| bfin \
+-	| c4x | c8051 | clipper \
+-	| d10v | d30v | dlx | dsp16xx \
+-	| e2k | epiphany \
+-	| fido | fr30 | frv | ft32 \
+-	| h8300 | h8500 | hppa | hppa1.[01] | hppa2.0 | hppa2.0[nw] | hppa64 \
+-	| hexagon \
+-	| i370 | i860 | i960 | ia16 | ia64 \
+-	| ip2k | iq2000 \
+-	| k1om \
+-	| le32 | le64 \
+-	| lm32 \
+-	| m32c | m32r | m32rle | m68000 | m68k | m88k \
+-	| maxq | mb | microblaze | microblazeel | mcore | mep | metag \
+-	| mips | mipsbe | mipseb | mipsel | mipsle \
+-	| mips16 \
+-	| mips64 | mips64el \
+-	| mips64octeon | mips64octeonel \
+-	| mips64orion | mips64orionel \
+-	| mips64r5900 | mips64r5900el \
+-	| mips64vr | mips64vrel \
+-	| mips64vr4100 | mips64vr4100el \
+-	| mips64vr4300 | mips64vr4300el \
+-	| mips64vr5000 | mips64vr5000el \
+-	| mips64vr5900 | mips64vr5900el \
+-	| mipsisa32 | mipsisa32el \
+-	| mipsisa32r2 | mipsisa32r2el \
+-	| mipsisa32r6 | mipsisa32r6el \
+-	| mipsisa64 | mipsisa64el \
+-	| mipsisa64r2 | mipsisa64r2el \
+-	| mipsisa64r6 | mipsisa64r6el \
+-	| mipsisa64sb1 | mipsisa64sb1el \
+-	| mipsisa64sr71k | mipsisa64sr71kel \
+-	| mipsr5900 | mipsr5900el \
+-	| mipstx39 | mipstx39el \
+-	| mn10200 | mn10300 \
+-	| moxie \
+-	| mt \
+-	| msp430 \
+-	| nds32 | nds32le | nds32be \
+-	| nios | nios2 | nios2eb | nios2el \
+-	| ns16k | ns32k \
+-	| open8 | or1k | or1knd | or32 \
+-	| pdp10 | pdp11 | pj | pjl \
+-	| powerpc | powerpc64 | powerpc64le | powerpcle \
+-	| pru \
+-	| pyramid \
+-	| riscv32 | riscv64 \
+-	| rl78 | rx \
+-	| score \
+-	| sh | sh[1234] | sh[24]a | sh[24]aeb | sh[23]e | sh[234]eb | sheb | shbe | shle | sh[1234]le | sh3ele \
+-	| sh64 | sh64le \
+-	| sparc | sparc64 | sparc64b | sparc64v | sparc86x | sparclet | sparclite \
+-	| sparcv8 | sparcv9 | sparcv9b | sparcv9v \
+-	| spu \
+-	| tahoe | tic4x | tic54x | tic55x | tic6x | tic80 | tron \
+-	| ubicom32 \
+-	| v850 | v850e | v850e1 | v850e2 | v850es | v850e2v3 \
+-	| visium \
+-	| wasm32 \
+-	| we32k \
+-	| x86 | xc16x | xstormy16 | xtensa \
+-	| z8k | z80)
+-		basic_machine=$basic_machine-unknown
+-		;;
+-	c54x)
+-		basic_machine=tic54x-unknown
+-		;;
+-	c55x)
+-		basic_machine=tic55x-unknown
+-		;;
+-	c6x)
+-		basic_machine=tic6x-unknown
+-		;;
+-	leon|leon[3-9])
+-		basic_machine=sparc-$basic_machine
++	# Here we handle the default manufacturer of certain CPU types.  It is in
++	# some cases the only manufacturer, in others, it is the most popular.
++	w89k)
++		cpu=hppa1.1
++		vendor=winbond
+ 		;;
+-	m6811 | m68hc11 | m6812 | m68hc12 | m68hcs12x | nvptx | picochip)
+-		basic_machine=$basic_machine-unknown
+-		os=-none
++	op50n)
++		cpu=hppa1.1
++		vendor=oki
+ 		;;
+-	m88110 | m680[12346]0 | m683?2 | m68360 | m5200 | v70 | w65 | z8k)
++	op60c)
++		cpu=hppa1.1
++		vendor=oki
+ 		;;
+-	ms1)
+-		basic_machine=mt-unknown
++	ibm*)
++		cpu=i370
++		vendor=ibm
+ 		;;
+-
+-	strongarm | thumb | xscale)
+-		basic_machine=arm-unknown
+-		;;
+-	xgate)
+-		basic_machine=$basic_machine-unknown
+-		os=-none
++	orion105)
++		cpu=clipper
++		vendor=highlevel
+ 		;;
+-	xscaleeb)
+-		basic_machine=armeb-unknown
++	mac | mpw | mac-mpw)
++		cpu=m68k
++		vendor=apple
+ 		;;
+-
+-	xscaleel)
+-		basic_machine=armel-unknown
++	pmac | pmac-mpw)
++		cpu=powerpc
++		vendor=apple
+ 		;;
+ 
+-	# We use `pc' rather than `unknown'
+-	# because (1) that's what they normally are, and
+-	# (2) the word "unknown" tends to confuse beginning users.
+-	i*86 | x86_64)
+-	  basic_machine=$basic_machine-pc
+-	  ;;
+-	# Object if more than one company name word.
+-	*-*-*)
+-		echo Invalid configuration \`$1\': machine \`$basic_machine\' not recognized 1>&2
+-		exit 1
+-		;;
+-	# Recognize the basic CPU types with company name.
+-	580-* \
+-	| a29k-* \
+-	| aarch64-* | aarch64_be-* \
+-	| alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
+-	| alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
+-	| alphapca5[67]-* | alpha64pca5[67]-* | arc-* | arceb-* \
+-	| arm-*  | armbe-* | armle-* | armeb-* | armv*-* \
+-	| avr-* | avr32-* \
+-	| ba-* \
+-	| be32-* | be64-* \
+-	| bfin-* | bs2000-* \
+-	| c[123]* | c30-* | [cjt]90-* | c4x-* \
+-	| c8051-* | clipper-* | craynv-* | cydra-* \
+-	| d10v-* | d30v-* | dlx-* \
+-	| e2k-* | elxsi-* \
+-	| f30[01]-* | f700-* | fido-* | fr30-* | frv-* | fx80-* \
+-	| h8300-* | h8500-* \
+-	| hppa-* | hppa1.[01]-* | hppa2.0-* | hppa2.0[nw]-* | hppa64-* \
+-	| hexagon-* \
+-	| i*86-* | i860-* | i960-* | ia16-* | ia64-* \
+-	| ip2k-* | iq2000-* \
+-	| k1om-* \
+-	| le32-* | le64-* \
+-	| lm32-* \
+-	| m32c-* | m32r-* | m32rle-* \
+-	| m68000-* | m680[012346]0-* | m68360-* | m683?2-* | m68k-* \
+-	| m88110-* | m88k-* | maxq-* | mcore-* | metag-* \
+-	| microblaze-* | microblazeel-* \
+-	| mips-* | mipsbe-* | mipseb-* | mipsel-* | mipsle-* \
+-	| mips16-* \
+-	| mips64-* | mips64el-* \
+-	| mips64octeon-* | mips64octeonel-* \
+-	| mips64orion-* | mips64orionel-* \
+-	| mips64r5900-* | mips64r5900el-* \
+-	| mips64vr-* | mips64vrel-* \
+-	| mips64vr4100-* | mips64vr4100el-* \
+-	| mips64vr4300-* | mips64vr4300el-* \
+-	| mips64vr5000-* | mips64vr5000el-* \
+-	| mips64vr5900-* | mips64vr5900el-* \
+-	| mipsisa32-* | mipsisa32el-* \
+-	| mipsisa32r2-* | mipsisa32r2el-* \
+-	| mipsisa32r6-* | mipsisa32r6el-* \
+-	| mipsisa64-* | mipsisa64el-* \
+-	| mipsisa64r2-* | mipsisa64r2el-* \
+-	| mipsisa64r6-* | mipsisa64r6el-* \
+-	| mipsisa64sb1-* | mipsisa64sb1el-* \
+-	| mipsisa64sr71k-* | mipsisa64sr71kel-* \
+-	| mipsr5900-* | mipsr5900el-* \
+-	| mipstx39-* | mipstx39el-* \
+-	| mmix-* \
+-	| mt-* \
+-	| msp430-* \
+-	| nds32-* | nds32le-* | nds32be-* \
+-	| nios-* | nios2-* | nios2eb-* | nios2el-* \
+-	| none-* | np1-* | ns16k-* | ns32k-* \
+-	| open8-* \
+-	| or1k*-* \
+-	| orion-* \
+-	| pdp10-* | pdp11-* | pj-* | pjl-* | pn-* | power-* \
+-	| powerpc-* | powerpc64-* | powerpc64le-* | powerpcle-* \
+-	| pru-* \
+-	| pyramid-* \
+-	| riscv32-* | riscv64-* \
+-	| rl78-* | romp-* | rs6000-* | rx-* \
+-	| sh-* | sh[1234]-* | sh[24]a-* | sh[24]aeb-* | sh[23]e-* | sh[34]eb-* | sheb-* | shbe-* \
+-	| shle-* | sh[1234]le-* | sh3ele-* | sh64-* | sh64le-* \
+-	| sparc-* | sparc64-* | sparc64b-* | sparc64v-* | sparc86x-* | sparclet-* \
+-	| sparclite-* \
+-	| sparcv8-* | sparcv9-* | sparcv9b-* | sparcv9v-* | sv1-* | sx*-* \
+-	| tahoe-* \
+-	| tic30-* | tic4x-* | tic54x-* | tic55x-* | tic6x-* | tic80-* \
+-	| tile*-* \
+-	| tron-* \
+-	| ubicom32-* \
+-	| v850-* | v850e-* | v850e1-* | v850es-* | v850e2-* | v850e2v3-* \
+-	| vax-* \
+-	| visium-* \
+-	| wasm32-* \
+-	| we32k-* \
+-	| x86-* | x86_64-* | xc16x-* | xps100-* \
+-	| xstormy16-* | xtensa*-* \
+-	| ymp-* \
+-	| z8k-* | z80-*)
+-		;;
+-	# Recognize the basic CPU types without company name, with glob match.
+-	xtensa*)
+-		basic_machine=$basic_machine-unknown
+-		;;
+ 	# Recognize the various machine names and aliases which stand
+ 	# for a CPU type and a company and sometimes even an OS.
+-	386bsd)
+-		basic_machine=i386-unknown
+-		os=-bsd
+-		;;
+ 	3b1 | 7300 | 7300-att | att-7300 | pc7300 | safari | unixpc)
+-		basic_machine=m68000-att
++		cpu=m68000
++		vendor=att
+ 		;;
+ 	3b*)
+-		basic_machine=we32k-att
+-		;;
+-	a29khif)
+-		basic_machine=a29k-amd
+-		os=-udi
+-		;;
+-	abacus)
+-		basic_machine=abacus-unknown
+-		;;
+-	adobe68k)
+-		basic_machine=m68010-adobe
+-		os=-scout
+-		;;
+-	alliant | fx80)
+-		basic_machine=fx80-alliant
+-		;;
+-	altos | altos3068)
+-		basic_machine=m68k-altos
+-		;;
+-	am29k)
+-		basic_machine=a29k-none
+-		os=-bsd
+-		;;
+-	amd64)
+-		basic_machine=x86_64-pc
+-		;;
+-	amd64-*)
+-		basic_machine=x86_64-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	amdahl)
+-		basic_machine=580-amdahl
+-		os=-sysv
+-		;;
+-	amiga | amiga-*)
+-		basic_machine=m68k-unknown
+-		;;
+-	amigaos | amigados)
+-		basic_machine=m68k-unknown
+-		os=-amigaos
+-		;;
+-	amigaunix | amix)
+-		basic_machine=m68k-unknown
+-		os=-sysv4
+-		;;
+-	apollo68)
+-		basic_machine=m68k-apollo
+-		os=-sysv
+-		;;
+-	apollo68bsd)
+-		basic_machine=m68k-apollo
+-		os=-bsd
+-		;;
+-	aros)
+-		basic_machine=i386-pc
+-		os=-aros
+-		;;
+-	asmjs)
+-		basic_machine=asmjs-unknown
+-		;;
+-	aux)
+-		basic_machine=m68k-apple
+-		os=-aux
+-		;;
+-	balance)
+-		basic_machine=ns32k-sequent
+-		os=-dynix
+-		;;
+-	blackfin)
+-		basic_machine=bfin-unknown
+-		os=-linux
+-		;;
+-	blackfin-*)
+-		basic_machine=bfin-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		os=-linux
++		cpu=we32k
++		vendor=att
+ 		;;
+ 	bluegene*)
+-		basic_machine=powerpc-ibm
+-		os=-cnk
+-		;;
+-	c54x-*)
+-		basic_machine=tic54x-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	c55x-*)
+-		basic_machine=tic55x-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	c6x-*)
+-		basic_machine=tic6x-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	c90)
+-		basic_machine=c90-cray
+-		os=-unicos
+-		;;
+-	cegcc)
+-		basic_machine=arm-unknown
+-		os=-cegcc
+-		;;
+-	convex-c1)
+-		basic_machine=c1-convex
+-		os=-bsd
+-		;;
+-	convex-c2)
+-		basic_machine=c2-convex
+-		os=-bsd
+-		;;
+-	convex-c32)
+-		basic_machine=c32-convex
+-		os=-bsd
+-		;;
+-	convex-c34)
+-		basic_machine=c34-convex
+-		os=-bsd
+-		;;
+-	convex-c38)
+-		basic_machine=c38-convex
+-		os=-bsd
+-		;;
+-	cray | j90)
+-		basic_machine=j90-cray
+-		os=-unicos
+-		;;
+-	craynv)
+-		basic_machine=craynv-cray
+-		os=-unicosmp
+-		;;
+-	cr16 | cr16-*)
+-		basic_machine=cr16-unknown
+-		os=-elf
+-		;;
+-	crds | unos)
+-		basic_machine=m68k-crds
+-		;;
+-	crisv32 | crisv32-* | etraxfs*)
+-		basic_machine=crisv32-axis
+-		;;
+-	cris | cris-* | etrax*)
+-		basic_machine=cris-axis
+-		;;
+-	crx)
+-		basic_machine=crx-unknown
+-		os=-elf
+-		;;
+-	da30 | da30-*)
+-		basic_machine=m68k-da30
+-		;;
+-	decstation | decstation-3100 | pmax | pmax-* | pmin | dec3100 | decstatn)
+-		basic_machine=mips-dec
++		cpu=powerpc
++		vendor=ibm
++		os=cnk
+ 		;;
+ 	decsystem10* | dec10*)
+-		basic_machine=pdp10-dec
+-		os=-tops10
++		cpu=pdp10
++		vendor=dec
++		os=tops10
+ 		;;
+ 	decsystem20* | dec20*)
+-		basic_machine=pdp10-dec
+-		os=-tops20
++		cpu=pdp10
++		vendor=dec
++		os=tops20
+ 		;;
+ 	delta | 3300 | motorola-3300 | motorola-delta \
+ 	      | 3300-motorola | delta-motorola)
+-		basic_machine=m68k-motorola
++		cpu=m68k
++		vendor=motorola
+ 		;;
+-	delta88)
+-		basic_machine=m88k-motorola
+-		os=-sysv3
+-		;;
+-	dicos)
+-		basic_machine=i686-pc
+-		os=-dicos
+-		;;
+-	djgpp)
+-		basic_machine=i586-pc
+-		os=-msdosdjgpp
+-		;;
+-	dpx20 | dpx20-*)
+-		basic_machine=rs6000-bull
+-		os=-bosx
+-		;;
+-	dpx2* | dpx2*-bull)
+-		basic_machine=m68k-bull
+-		os=-sysv3
+-		;;
+-	e500v[12])
+-		basic_machine=powerpc-unknown
+-		os=$os"spe"
+-		;;
+-	e500v[12]-*)
+-		basic_machine=powerpc-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		os=$os"spe"
+-		;;
+-	ebmon29k)
+-		basic_machine=a29k-amd
+-		os=-ebmon
+-		;;
+-	elxsi)
+-		basic_machine=elxsi-elxsi
+-		os=-bsd
++	dpx2*)
++		cpu=m68k
++		vendor=bull
++		os=sysv3
+ 		;;
+ 	encore | umax | mmax)
+-		basic_machine=ns32k-encore
++		cpu=ns32k
++		vendor=encore
+ 		;;
+-	es1800 | OSE68k | ose68k | ose | OSE)
+-		basic_machine=m68k-ericsson
+-		os=-ose
++	elxsi)
++		cpu=elxsi
++		vendor=elxsi
++		os=${os:-bsd}
+ 		;;
+ 	fx2800)
+-		basic_machine=i860-alliant
++		cpu=i860
++		vendor=alliant
+ 		;;
+ 	genix)
+-		basic_machine=ns32k-ns
+-		;;
+-	gmicro)
+-		basic_machine=tron-gmicro
+-		os=-sysv
+-		;;
+-	go32)
+-		basic_machine=i386-pc
+-		os=-go32
++		cpu=ns32k
++		vendor=ns
+ 		;;
+ 	h3050r* | hiux*)
+-		basic_machine=hppa1.1-hitachi
+-		os=-hiuxwe2
+-		;;
+-	h8300hms)
+-		basic_machine=h8300-hitachi
+-		os=-hms
+-		;;
+-	h8300xray)
+-		basic_machine=h8300-hitachi
+-		os=-xray
+-		;;
+-	h8500hms)
+-		basic_machine=h8500-hitachi
+-		os=-hms
+-		;;
+-	harris)
+-		basic_machine=m88k-harris
+-		os=-sysv3
+-		;;
+-	hp300-*)
+-		basic_machine=m68k-hp
+-		;;
+-	hp300bsd)
+-		basic_machine=m68k-hp
+-		os=-bsd
+-		;;
+-	hp300hpux)
+-		basic_machine=m68k-hp
+-		os=-hpux
++		cpu=hppa1.1
++		vendor=hitachi
++		os=hiuxwe2
+ 		;;
+ 	hp3k9[0-9][0-9] | hp9[0-9][0-9])
+-		basic_machine=hppa1.0-hp
++		cpu=hppa1.0
++		vendor=hp
+ 		;;
+ 	hp9k2[0-9][0-9] | hp9k31[0-9])
+-		basic_machine=m68000-hp
++		cpu=m68000
++		vendor=hp
+ 		;;
+ 	hp9k3[2-9][0-9])
+-		basic_machine=m68k-hp
++		cpu=m68k
++		vendor=hp
+ 		;;
+ 	hp9k6[0-9][0-9] | hp6[0-9][0-9])
+-		basic_machine=hppa1.0-hp
++		cpu=hppa1.0
++		vendor=hp
+ 		;;
+ 	hp9k7[0-79][0-9] | hp7[0-79][0-9])
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k78[0-9] | hp78[0-9])
+ 		# FIXME: really hppa2.0-hp
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k8[67]1 | hp8[67]1 | hp9k80[24] | hp80[24] | hp9k8[78]9 | hp8[78]9 | hp9k893 | hp893)
+ 		# FIXME: really hppa2.0-hp
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k8[0-9][13679] | hp8[0-9][13679])
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k8[0-9][0-9] | hp8[0-9][0-9])
+-		basic_machine=hppa1.0-hp
+-		;;
+-	hppa-next)
+-		os=-nextstep3
+-		;;
+-	hppaosf)
+-		basic_machine=hppa1.1-hp
+-		os=-osf
+-		;;
+-	hppro)
+-		basic_machine=hppa1.1-hp
+-		os=-proelf
+-		;;
+-	i370-ibm* | ibm*)
+-		basic_machine=i370-ibm
++		cpu=hppa1.0
++		vendor=hp
+ 		;;
+ 	i*86v32)
+-		basic_machine=`echo $1 | sed -e 's/86.*/86-pc/'`
+-		os=-sysv32
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		os=sysv32
+ 		;;
+ 	i*86v4*)
+-		basic_machine=`echo $1 | sed -e 's/86.*/86-pc/'`
+-		os=-sysv4
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		os=sysv4
+ 		;;
+ 	i*86v)
+-		basic_machine=`echo $1 | sed -e 's/86.*/86-pc/'`
+-		os=-sysv
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		os=sysv
+ 		;;
+ 	i*86sol2)
+-		basic_machine=`echo $1 | sed -e 's/86.*/86-pc/'`
+-		os=-solaris2
+-		;;
+-	i386mach)
+-		basic_machine=i386-mach
+-		os=-mach
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		os=solaris2
+ 		;;
+-	i386-vsta | vsta)
+-		basic_machine=i386-unknown
+-		os=-vsta
++	j90 | j90-cray)
++		cpu=j90
++		vendor=cray
++		os=${os:-unicos}
+ 		;;
+ 	iris | iris4d)
+-		basic_machine=mips-sgi
++		cpu=mips
++		vendor=sgi
+ 		case $os in
+-		    -irix*)
++		    irix*)
+ 			;;
+ 		    *)
+-			os=-irix4
++			os=irix4
+ 			;;
+ 		esac
+ 		;;
+-	isi68 | isi)
+-		basic_machine=m68k-isi
+-		os=-sysv
+-		;;
+-	leon-*|leon[3-9]-*)
+-		basic_machine=sparc-`echo $basic_machine | sed 's/-.*//'`
+-		;;
+-	m68knommu)
+-		basic_machine=m68k-unknown
+-		os=-linux
+-		;;
+-	m68knommu-*)
+-		basic_machine=m68k-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		os=-linux
+-		;;
+-	m88k-omron*)
+-		basic_machine=m88k-omron
+-		;;
+-	magnum | m3230)
+-		basic_machine=mips-mips
+-		os=-sysv
+-		;;
+-	merlin)
+-		basic_machine=ns32k-utek
+-		os=-sysv
+-		;;
+-	microblaze*)
+-		basic_machine=microblaze-xilinx
+-		;;
+-	mingw64)
+-		basic_machine=x86_64-pc
+-		os=-mingw64
+-		;;
+-	mingw32)
+-		basic_machine=i686-pc
+-		os=-mingw32
+-		;;
+-	mingw32ce)
+-		basic_machine=arm-unknown
+-		os=-mingw32ce
+-		;;
+ 	miniframe)
+-		basic_machine=m68000-convergent
+-		;;
+-	*mint | -mint[0-9]* | *MiNT | *MiNT[0-9]*)
+-		basic_machine=m68k-atari
+-		os=-mint
+-		;;
+-	mips3*-*)
+-		basic_machine=`echo $basic_machine | sed -e 's/mips3/mips64/'`
+-		;;
+-	mips3*)
+-		basic_machine=`echo $basic_machine | sed -e 's/mips3/mips64/'`-unknown
+-		;;
+-	monitor)
+-		basic_machine=m68k-rom68k
+-		os=-coff
+-		;;
+-	morphos)
+-		basic_machine=powerpc-unknown
+-		os=-morphos
+-		;;
+-	moxiebox)
+-		basic_machine=moxie-unknown
+-		os=-moxiebox
+-		;;
+-	msdos)
+-		basic_machine=i386-pc
+-		os=-msdos
+-		;;
+-	ms1-*)
+-		basic_machine=`echo $basic_machine | sed -e 's/ms1-/mt-/'`
+-		;;
+-	msys)
+-		basic_machine=i686-pc
+-		os=-msys
+-		;;
+-	mvs)
+-		basic_machine=i370-ibm
+-		os=-mvs
+-		;;
+-	nacl)
+-		basic_machine=le32-unknown
+-		os=-nacl
++		cpu=m68000
++		vendor=convergent
+ 		;;
+-	ncr3000)
+-		basic_machine=i486-ncr
+-		os=-sysv4
+-		;;
+-	netbsd386)
+-		basic_machine=i386-unknown
+-		os=-netbsd
+-		;;
+-	netwinder)
+-		basic_machine=armv4l-rebel
+-		os=-linux
+-		;;
+-	news | news700 | news800 | news900)
+-		basic_machine=m68k-sony
+-		os=-newsos
+-		;;
+-	news1000)
+-		basic_machine=m68030-sony
+-		os=-newsos
++	*mint | mint[0-9]* | *MiNT | *MiNT[0-9]*)
++		cpu=m68k
++		vendor=atari
++		os=mint
+ 		;;
+ 	news-3600 | risc-news)
+-		basic_machine=mips-sony
+-		os=-newsos
++		cpu=mips
++		vendor=sony
++		os=newsos
+ 		;;
+-	necv70)
+-		basic_machine=v70-nec
+-		os=-sysv
+-		;;
+-	next | m*-next )
+-		basic_machine=m68k-next
++	next | m*-next)
++		cpu=m68k
++		vendor=next
+ 		case $os in
+-		    -nextstep* )
++		    nextstep* )
+ 			;;
+-		    -ns2*)
+-		      os=-nextstep2
++		    ns2*)
++		      os=nextstep2
+ 			;;
+ 		    *)
+-		      os=-nextstep3
++		      os=nextstep3
+ 			;;
+ 		esac
+ 		;;
+-	nh3000)
+-		basic_machine=m68k-harris
+-		os=-cxux
+-		;;
+-	nh[45]000)
+-		basic_machine=m88k-harris
+-		os=-cxux
+-		;;
+-	nindy960)
+-		basic_machine=i960-intel
+-		os=-nindy
+-		;;
+-	mon960)
+-		basic_machine=i960-intel
+-		os=-mon960
+-		;;
+-	nonstopux)
+-		basic_machine=mips-compaq
+-		os=-nonstopux
+-		;;
+ 	np1)
+-		basic_machine=np1-gould
+-		;;
+-	neo-tandem)
+-		basic_machine=neo-tandem
+-		;;
+-	nse-tandem)
+-		basic_machine=nse-tandem
+-		;;
+-	nsr-tandem)
+-		basic_machine=nsr-tandem
+-		;;
+-	nsx-tandem)
+-		basic_machine=nsx-tandem
++		cpu=np1
++		vendor=gould
+ 		;;
+ 	op50n-* | op60c-*)
+-		basic_machine=hppa1.1-oki
+-		os=-proelf
+-		;;
+-	openrisc | openrisc-*)
+-		basic_machine=or32-unknown
+-		;;
+-	os400)
+-		basic_machine=powerpc-ibm
+-		os=-os400
+-		;;
+-	OSE68000 | ose68000)
+-		basic_machine=m68000-ericsson
+-		os=-ose
+-		;;
+-	os68k)
+-		basic_machine=m68k-none
+-		os=-os68k
++		cpu=hppa1.1
++		vendor=oki
++		os=proelf
+ 		;;
+ 	pa-hitachi)
+-		basic_machine=hppa1.1-hitachi
+-		os=-hiuxwe2
+-		;;
+-	paragon)
+-		basic_machine=i860-intel
+-		os=-osf
+-		;;
+-	parisc)
+-		basic_machine=hppa-unknown
+-		os=-linux
+-		;;
+-	parisc-*)
+-		basic_machine=hppa-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		os=-linux
++		cpu=hppa1.1
++		vendor=hitachi
++		os=hiuxwe2
+ 		;;
+ 	pbd)
+-		basic_machine=sparc-tti
++		cpu=sparc
++		vendor=tti
+ 		;;
+ 	pbb)
+-		basic_machine=m68k-tti
+-		;;
+-	pc532 | pc532-*)
+-		basic_machine=ns32k-pc532
++		cpu=m68k
++		vendor=tti
+ 		;;
+-	pc98)
+-		basic_machine=i386-pc
+-		;;
+-	pc98-*)
+-		basic_machine=i386-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	pentium | p5 | k5 | k6 | nexgen | viac3)
+-		basic_machine=i586-pc
+-		;;
+-	pentiumpro | p6 | 6x86 | athlon | athlon_*)
+-		basic_machine=i686-pc
+-		;;
+-	pentiumii | pentium2 | pentiumiii | pentium3)
+-		basic_machine=i686-pc
+-		;;
+-	pentium4)
+-		basic_machine=i786-pc
+-		;;
+-	pentium-* | p5-* | k5-* | k6-* | nexgen-* | viac3-*)
+-		basic_machine=i586-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	pentiumpro-* | p6-* | 6x86-* | athlon-*)
+-		basic_machine=i686-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	pentiumii-* | pentium2-* | pentiumiii-* | pentium3-*)
+-		basic_machine=i686-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	pentium4-*)
+-		basic_machine=i786-`echo $basic_machine | sed 's/^[^-]*-//'`
++	pc532)
++		cpu=ns32k
++		vendor=pc532
+ 		;;
+ 	pn)
+-		basic_machine=pn-gould
++		cpu=pn
++		vendor=gould
+ 		;;
+-	power)	basic_machine=power-ibm
+-		;;
+-	ppc | ppcbe)	basic_machine=powerpc-unknown
+-		;;
+-	ppc-* | ppcbe-*)
+-		basic_machine=powerpc-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	ppcle | powerpclittle)
+-		basic_machine=powerpcle-unknown
+-		;;
+-	ppcle-* | powerpclittle-*)
+-		basic_machine=powerpcle-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	ppc64)	basic_machine=powerpc64-unknown
+-		;;
+-	ppc64-*) basic_machine=powerpc64-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	ppc64le | powerpc64little)
+-		basic_machine=powerpc64le-unknown
+-		;;
+-	ppc64le-* | powerpc64little-*)
+-		basic_machine=powerpc64le-`echo $basic_machine | sed 's/^[^-]*-//'`
++	power)
++		cpu=power
++		vendor=ibm
+ 		;;
+ 	ps2)
+-		basic_machine=i386-ibm
+-		;;
+-	pw32)
+-		basic_machine=i586-unknown
+-		os=-pw32
+-		;;
+-	rdos | rdos64)
+-		basic_machine=x86_64-pc
+-		os=-rdos
+-		;;
+-	rdos32)
+-		basic_machine=i386-pc
+-		os=-rdos
+-		;;
+-	rom68k)
+-		basic_machine=m68k-rom68k
+-		os=-coff
++		cpu=i386
++		vendor=ibm
+ 		;;
+ 	rm[46]00)
+-		basic_machine=mips-siemens
++		cpu=mips
++		vendor=siemens
+ 		;;
+ 	rtpc | rtpc-*)
+-		basic_machine=romp-ibm
+-		;;
+-	s390 | s390-*)
+-		basic_machine=s390-ibm
+-		;;
+-	s390x | s390x-*)
+-		basic_machine=s390x-ibm
+-		;;
+-	sa29200)
+-		basic_machine=a29k-amd
+-		os=-udi
+-		;;
+-	sb1)
+-		basic_machine=mipsisa64sb1-unknown
+-		;;
+-	sb1el)
+-		basic_machine=mipsisa64sb1el-unknown
++		cpu=romp
++		vendor=ibm
+ 		;;
+ 	sde)
+-		basic_machine=mipsisa32-sde
+-		os=-elf
++		cpu=mipsisa32
++		vendor=sde
++		os=${os:-elf}
+ 		;;
+-	sei)
+-		basic_machine=mips-sei
+-		os=-seiux
++	simso-wrs)
++		cpu=sparclite
++		vendor=wrs
++		os=vxworks
+ 		;;
+-	sequent)
+-		basic_machine=i386-sequent
++	tower | tower-32)
++		cpu=m68k
++		vendor=ncr
+ 		;;
+-	sh)
+-		basic_machine=sh-hitachi
+-		os=-hms
++	vpp*|vx|vx-*)
++		cpu=f301
++		vendor=fujitsu
+ 		;;
+-	sh5el)
+-		basic_machine=sh5le-unknown
++	w65)
++		cpu=w65
++		vendor=wdc
+ 		;;
+-	sh64)
+-		basic_machine=sh64-unknown
++	w89k-*)
++		cpu=hppa1.1
++		vendor=winbond
++		os=proelf
+ 		;;
+-	sparclite-wrs | simso-wrs)
+-		basic_machine=sparclite-wrs
+-		os=-vxworks
++	none)
++		cpu=none
++		vendor=none
+ 		;;
+-	sps7)
+-		basic_machine=m68k-bull
+-		os=-sysv2
++	leon|leon[3-9])
++		cpu=sparc
++		vendor=$basic_machine
+ 		;;
+-	spur)
+-		basic_machine=spur-unknown
++	leon-*|leon[3-9]-*)
++		cpu=sparc
++		vendor=`echo "$basic_machine" | sed 's/-.*//'`
+ 		;;
+-	st2000)
+-		basic_machine=m68k-tandem
++
++	*-*)
++		IFS="-" read cpu vendor <<EOF
++$basic_machine
++EOF
+ 		;;
+-	stratus)
+-		basic_machine=i860-stratus
+-		os=-sysv4
++	# We use `pc' rather than `unknown'
++	# because (1) that's what they normally are, and
++	# (2) the word "unknown" tends to confuse beginning users.
++	i*86 | x86_64)
++		cpu=$basic_machine
++		vendor=pc
+ 		;;
+-	strongarm-* | thumb-*)
+-		basic_machine=arm-`echo $basic_machine | sed 's/^[^-]*-//'`
++	# These rules are duplicated from below for sake of the special case above;
++	# i.e. things that normalized to x86 arches should also default to "pc"
++	pc98)
++		cpu=i386
++		vendor=pc
+ 		;;
+-	sun2)
+-		basic_machine=m68000-sun
++	x64 | amd64)
++		cpu=x86_64
++		vendor=pc
+ 		;;
+-	sun2os3)
+-		basic_machine=m68000-sun
+-		os=-sunos3
++	# Recognize the basic CPU types without company name.
++	*)
++		cpu=$basic_machine
++		vendor=unknown
+ 		;;
+-	sun2os4)
+-		basic_machine=m68000-sun
+-		os=-sunos4
++esac
++
++unset -v basic_machine
++
++# Decode basic machines in the full and proper CPU-Company form.
++case $cpu-$vendor in
++	# Here we handle the default manufacturer of certain CPU types in canonical form. It is in
++	# some cases the only manufacturer, in others, it is the most popular.
++	craynv-unknown)
++		vendor=cray
++		os=${os:-unicosmp}
+ 		;;
+-	sun3os3)
+-		basic_machine=m68k-sun
+-		os=-sunos3
++	c90-unknown | c90-cray)
++		vendor=cray
++		os=${os:-unicos}
+ 		;;
+-	sun3os4)
+-		basic_machine=m68k-sun
+-		os=-sunos4
++	fx80-unknown)
++		vendor=alliant
+ 		;;
+-	sun4os3)
+-		basic_machine=sparc-sun
+-		os=-sunos3
++	romp-unknown)
++		vendor=ibm
+ 		;;
+-	sun4os4)
+-		basic_machine=sparc-sun
+-		os=-sunos4
++	mmix-unknown)
++		vendor=knuth
+ 		;;
+-	sun4sol2)
+-		basic_machine=sparc-sun
+-		os=-solaris2
++	microblaze-unknown | microblazeel-unknown)
++		vendor=xilinx
+ 		;;
+-	sun3 | sun3-*)
+-		basic_machine=m68k-sun
++	rs6000-unknown)
++		vendor=ibm
+ 		;;
+-	sun4)
+-		basic_machine=sparc-sun
++	vax-unknown)
++		vendor=dec
+ 		;;
+-	sun386 | sun386i | roadrunner)
+-		basic_machine=i386-sun
++	pdp11-unknown)
++		vendor=dec
+ 		;;
+-	sv1)
+-		basic_machine=sv1-cray
+-		os=-unicos
++	we32k-unknown)
++		vendor=att
+ 		;;
+-	symmetry)
+-		basic_machine=i386-sequent
+-		os=-dynix
++	cydra-unknown)
++		vendor=cydrome
+ 		;;
+-	t3e)
+-		basic_machine=alphaev5-cray
+-		os=-unicos
++	i370-ibm*)
++		vendor=ibm
+ 		;;
+-	t90)
+-		basic_machine=t90-cray
+-		os=-unicos
++	orion-unknown)
++		vendor=highlevel
+ 		;;
+-	tile*)
+-		basic_machine=$basic_machine-unknown
+-		os=-linux-gnu
++	xps-unknown | xps100-unknown)
++		cpu=xps100
++		vendor=honeywell
+ 		;;
+-	tx39)
+-		basic_machine=mipstx39-unknown
++
++	# Here we normalize CPU types with a missing or matching vendor
++	dpx20-unknown | dpx20-bull)
++		cpu=rs6000
++		vendor=bull
++		os=${os:-bosx}
+ 		;;
+-	tx39el)
+-		basic_machine=mipstx39el-unknown
++
++	# Here we normalize CPU types irrespective of the vendor
++	amd64-*)
++		cpu=x86_64
+ 		;;
+-	toad1)
+-		basic_machine=pdp10-xkl
+-		os=-tops20
++	blackfin-*)
++		cpu=bfin
++		os=linux
+ 		;;
+-	tower | tower-32)
+-		basic_machine=m68k-ncr
++	c54x-*)
++		cpu=tic54x
+ 		;;
+-	tpf)
+-		basic_machine=s390x-ibm
+-		os=-tpf
++	c55x-*)
++		cpu=tic55x
+ 		;;
+-	udi29k)
+-		basic_machine=a29k-amd
+-		os=-udi
++	c6x-*)
++		cpu=tic6x
+ 		;;
+-	ultra3)
+-		basic_machine=a29k-nyu
+-		os=-sym1
++	e500v[12]-*)
++		cpu=powerpc
++		os=$os"spe"
+ 		;;
+-	v810 | necv810)
+-		basic_machine=v810-nec
+-		os=-none
++	mips3*-*)
++		cpu=mips64
+ 		;;
+-	vaxv)
+-		basic_machine=vax-dec
+-		os=-sysv
++	ms1-*)
++		cpu=mt
+ 		;;
+-	vms)
+-		basic_machine=vax-dec
+-		os=-vms
++	m68knommu-*)
++		cpu=m68k
++		os=linux
+ 		;;
+-	vpp*|vx|vx-*)
+-		basic_machine=f301-fujitsu
++	m9s12z-* | m68hcs12z-* | hcs12z-* | s12z-*)
++		cpu=s12z
+ 		;;
+-	vxworks960)
+-		basic_machine=i960-wrs
+-		os=-vxworks
++	openrisc-*)
++		cpu=or32
+ 		;;
+-	vxworks68)
+-		basic_machine=m68k-wrs
+-		os=-vxworks
++	parisc-*)
++		cpu=hppa
++		os=linux
+ 		;;
+-	vxworks29k)
+-		basic_machine=a29k-wrs
+-		os=-vxworks
++	pentium-* | p5-* | k5-* | k6-* | nexgen-* | viac3-*)
++		cpu=i586
+ 		;;
+-	wasm32)
+-		basic_machine=wasm32-unknown
++	pentiumpro-* | p6-* | 6x86-* | athlon-* | athalon_*-*)
++		cpu=i686
+ 		;;
+-	w65*)
+-		basic_machine=w65-wdc
+-		os=-none
++	pentiumii-* | pentium2-* | pentiumiii-* | pentium3-*)
++		cpu=i686
+ 		;;
+-	w89k-*)
+-		basic_machine=hppa1.1-winbond
+-		os=-proelf
++	pentium4-*)
++		cpu=i786
+ 		;;
+-	x64)
+-		basic_machine=x86_64-pc
++	pc98-*)
++		cpu=i386
+ 		;;
+-	xbox)
+-		basic_machine=i686-pc
+-		os=-mingw32
++	ppc-* | ppcbe-*)
++		cpu=powerpc
+ 		;;
+-	xps | xps100)
+-		basic_machine=xps100-honeywell
++	ppcle-* | powerpclittle-*)
++		cpu=powerpcle
+ 		;;
+-	xscale-* | xscalee[bl]-*)
+-		basic_machine=`echo $basic_machine | sed 's/^xscale/arm/'`
++	ppc64-*)
++		cpu=powerpc64
+ 		;;
+-	ymp)
+-		basic_machine=ymp-cray
+-		os=-unicos
++	ppc64le-* | powerpc64little-*)
++		cpu=powerpc64le
+ 		;;
+-	z8k-*-coff)
+-		basic_machine=z8k-unknown
+-		os=-sim
++	sb1-*)
++		cpu=mipsisa64sb1
+ 		;;
+-	z80-*-coff)
+-		basic_machine=z80-unknown
+-		os=-sim
++	sb1el-*)
++		cpu=mipsisa64sb1el
+ 		;;
+-	none)
+-		basic_machine=none-none
+-		os=-none
++	sh5e[lb]-*)
++		cpu=`echo "$cpu" | sed 's/^\(sh.\)e\(.\)$/\1\2e/'`
+ 		;;
+-
+-# Here we handle the default manufacturer of certain CPU types.  It is in
+-# some cases the only manufacturer, in others, it is the most popular.
+-	w89k)
+-		basic_machine=hppa1.1-winbond
++	spur-*)
++		cpu=spur
+ 		;;
+-	op50n)
+-		basic_machine=hppa1.1-oki
++	strongarm-* | thumb-*)
++		cpu=arm
+ 		;;
+-	op60c)
+-		basic_machine=hppa1.1-oki
++	tx39-*)
++		cpu=mipstx39
+ 		;;
+-	romp)
+-		basic_machine=romp-ibm
++	tx39el-*)
++		cpu=mipstx39el
+ 		;;
+-	mmix)
+-		basic_machine=mmix-knuth
++	x64-*)
++		cpu=x86_64
+ 		;;
+-	rs6000)
+-		basic_machine=rs6000-ibm
++	xscale-* | xscalee[bl]-*)
++		cpu=`echo "$cpu" | sed 's/^xscale/arm/'`
+ 		;;
+-	vax)
+-		basic_machine=vax-dec
++
++	# Recognize the canonical CPU Types that limit and/or modify the
++	# company names they are paired with.
++	cr16-*)
++		os=${os:-elf}
+ 		;;
+-	pdp10)
+-		# there are many clones, so DEC is not a safe bet
+-		basic_machine=pdp10-unknown
++	crisv32-* | etraxfs*-*)
++		cpu=crisv32
++		vendor=axis
+ 		;;
+-	pdp11)
+-		basic_machine=pdp11-dec
++	cris-* | etrax*-*)
++		cpu=cris
++		vendor=axis
+ 		;;
+-	we32k)
+-		basic_machine=we32k-att
++	crx-*)
++		os=${os:-elf}
+ 		;;
+-	sh[1234] | sh[24]a | sh[24]aeb | sh[34]eb | sh[1234]le | sh[23]ele)
+-		basic_machine=sh-unknown
++	neo-tandem)
++		cpu=neo
++		vendor=tandem
+ 		;;
+-	sparc | sparcv8 | sparcv9 | sparcv9b | sparcv9v)
+-		basic_machine=sparc-sun
++	nse-tandem)
++		cpu=nse
++		vendor=tandem
+ 		;;
+-	cydra)
+-		basic_machine=cydra-cydrome
++	nsr-tandem)
++		cpu=nsr
++		vendor=tandem
+ 		;;
+-	orion)
+-		basic_machine=orion-highlevel
++	nsv-tandem)
++		cpu=nsv
++		vendor=tandem
+ 		;;
+-	orion105)
+-		basic_machine=clipper-highlevel
++	nsx-tandem)
++		cpu=nsx
++		vendor=tandem
+ 		;;
+-	mac | mpw | mac-mpw)
+-		basic_machine=m68k-apple
++	s390-*)
++		cpu=s390
++		vendor=ibm
+ 		;;
+-	pmac | pmac-mpw)
+-		basic_machine=powerpc-apple
++	s390x-*)
++		cpu=s390x
++		vendor=ibm
+ 		;;
+-	*-unknown)
+-		# Make sure to match an already-canonicalized machine name.
++	tile*-*)
++		os=${os:-linux-gnu}
+ 		;;
++
+ 	*)
+-		echo Invalid configuration \`$1\': machine \`$basic_machine\' not recognized 1>&2
+-		exit 1
++		# Recognize the canonical CPU types that are allowed with any
++		# company name.
++		case $cpu in
++			1750a | 580 \
++			| a29k \
++			| aarch64 | aarch64_be \
++			| abacus \
++			| alpha | alphaev[4-8] | alphaev56 | alphaev6[78] \
++			| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] \
++			| alphapca5[67] | alpha64pca5[67] \
++			| am33_2.0 \
++			| amdgcn \
++			| arc | arceb \
++			| arm  | arm[lb]e | arme[lb] | armv* \
++			| avr | avr32 \
++			| asmjs \
++			| ba \
++			| be32 | be64 \
++			| bfin | bs2000 \
++			| c[123]* | c30 | [cjt]90 | c4x \
++			| c8051 | clipper | craynv | csky | cydra \
++			| d10v | d30v | dlx | dsp16xx \
++			| e2k | elxsi | epiphany \
++			| f30[01] | f700 | fido | fr30 | frv | ft32 | fx80 \
++			| h8300 | h8500 \
++			| hppa | hppa1.[01] | hppa2.0 | hppa2.0[nw] | hppa64 \
++			| hexagon \
++			| i370 | i*86 | i860 | i960 | ia16 | ia64 \
++			| ip2k | iq2000 \
++			| k1om \
++			| le32 | le64 \
++			| lm32 \
++			| m32c | m32r | m32rle \
++			| m5200 | m68000 | m680[012346]0 | m68360 | m683?2 | m68k | v70 | w65 \
++			| m6811 | m68hc11 | m6812 | m68hc12 | m68hcs12x | nvptx | picochip \
++			| m88110 | m88k | maxq | mb | mcore | mep | metag \
++			| microblaze | microblazeel \
++			| mips | mipsbe | mipseb | mipsel | mipsle \
++			| mips16 \
++			| mips64 | mips64el \
++			| mips64octeon | mips64octeonel \
++			| mips64orion | mips64orionel \
++			| mips64r5900 | mips64r5900el \
++			| mips64vr | mips64vrel \
++			| mips64vr4100 | mips64vr4100el \
++			| mips64vr4300 | mips64vr4300el \
++			| mips64vr5000 | mips64vr5000el \
++			| mips64vr5900 | mips64vr5900el \
++			| mipsisa32 | mipsisa32el \
++			| mipsisa32r2 | mipsisa32r2el \
++			| mipsisa32r6 | mipsisa32r6el \
++			| mipsisa64 | mipsisa64el \
++			| mipsisa64r2 | mipsisa64r2el \
++			| mipsisa64r6 | mipsisa64r6el \
++			| mipsisa64sb1 | mipsisa64sb1el \
++			| mipsisa64sr71k | mipsisa64sr71kel \
++			| mipsr5900 | mipsr5900el \
++			| mipstx39 | mipstx39el \
++			| mmix \
++			| mn10200 | mn10300 \
++			| moxie \
++			| mt \
++			| msp430 \
++			| nds32 | nds32le | nds32be \
++			| nfp \
++			| nios | nios2 | nios2eb | nios2el \
++			| none | np1 | ns16k | ns32k \
++			| open8 \
++			| or1k* \
++			| or32 \
++			| orion \
++			| pdp10 | pdp11 | pj | pjl | pn | power \
++			| powerpc | powerpc64 | powerpc64le | powerpcle | powerpcspe \
++			| pru \
++			| pyramid \
++			| riscv | riscv32 | riscv64 \
++			| rl78 | romp | rs6000 | rx \
++			| score \
++			| sh | sh[1234] | sh[24]a | sh[24]ae[lb] | sh[23]e | she[lb] | sh[lb]e \
++			| sh[1234]e[lb] |  sh[12345][lb]e | sh[23]ele | sh64 | sh64le \
++			| sparc | sparc64 | sparc64b | sparc64v | sparc86x | sparclet \
++			| sparclite \
++			| sparcv8 | sparcv9 | sparcv9b | sparcv9v | sv1 | sx* \
++			| spu \
++			| tahoe \
++			| tic30 | tic4x | tic54x | tic55x | tic6x | tic80 \
++			| tron \
++			| ubicom32 \
++			| v850 | v850e | v850e1 | v850es | v850e2 | v850e2v3 \
++			| vax \
++			| visium \
++			| wasm32 \
++			| we32k \
++			| x86 | x86_64 | xc16x | xgate | xps100 \
++			| xstormy16 | xtensa* \
++			| ymp \
++			| z8k | z80)
++				;;
++
++			*)
++				echo Invalid configuration \`"$1"\': machine \`"$cpu-$vendor"\' not recognized 1>&2
++				exit 1
++				;;
++		esac
+ 		;;
+ esac
+ 
+ # Here we canonicalize certain aliases for manufacturers.
+-case $basic_machine in
+-	*-digital*)
+-		basic_machine=`echo $basic_machine | sed 's/digital.*/dec/'`
++case $vendor in
++	digital*)
++		vendor=dec
+ 		;;
+-	*-commodore*)
+-		basic_machine=`echo $basic_machine | sed 's/commodore.*/cbm/'`
++	commodore*)
++		vendor=cbm
+ 		;;
+ 	*)
+ 		;;
+@@ -1363,200 +1271,246 @@ esac
+ 
+ # Decode manufacturer-specific aliases for certain operating systems.
+ 
+-if [ x"$os" != x"" ]
++if [ x$os != x ]
+ then
+ case $os in
+ 	# First match some system type aliases that might get confused
+ 	# with valid system types.
+-	# -solaris* is a basic system type, with this one exception.
+-	-auroraux)
+-		os=-auroraux
++	# solaris* is a basic system type, with this one exception.
++	auroraux)
++		os=auroraux
+ 		;;
+-	-solaris1 | -solaris1.*)
+-		os=`echo $os | sed -e 's|solaris1|sunos4|'`
++	bluegene*)
++		os=cnk
+ 		;;
+-	-solaris)
+-		os=-solaris2
++	solaris1 | solaris1.*)
++		os=`echo $os | sed -e 's|solaris1|sunos4|'`
+ 		;;
+-	-svr4*)
+-		os=-sysv4
++	solaris)
++		os=solaris2
+ 		;;
+-	-unixware*)
+-		os=-sysv4.2uw
++	unixware*)
++		os=sysv4.2uw
+ 		;;
+-	-gnu/linux*)
++	gnu/linux*)
+ 		os=`echo $os | sed -e 's|gnu/linux|linux-gnu|'`
+ 		;;
++	# es1800 is here to avoid being matched by es* (a different OS)
++	es1800*)
++		os=ose
++		;;
++	# Some version numbers need modification
++	chorusos*)
++		os=chorusos
++		;;
++	isc)
++		os=isc2.2
++		;;
++	sco6)
++		os=sco5v6
++		;;
++	sco5)
++		os=sco3.2v5
++		;;
++	sco4)
++		os=sco3.2v4
++		;;
++	sco3.2.[4-9]*)
++		os=`echo $os | sed -e 's/sco3.2./sco3.2v/'`
++		;;
++	sco3.2v[4-9]* | sco5v6*)
++		# Don't forget version if it is 3.2v4 or newer.
++		;;
++	scout)
++		# Don't match below
++		;;
++	sco*)
++		os=sco3.2v2
++		;;
++	psos*)
++		os=psos
++		;;
+ 	# Now accept the basic system types.
+ 	# The portable systems comes first.
+ 	# Each alternative MUST end in a * to match a version number.
+-	# -sysv* is not here because it comes later, after sysvr4.
+-	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
+-	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -cnk* | -sunos | -sunos[34]*\
+-	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -auroraux* | -solaris* \
+-	      | -sym* | -kopensolaris* | -plan9* \
+-	      | -amigaos* | -amigados* | -msdos* | -newsos* | -unicos* | -aof* \
+-	      | -aos* | -aros* | -cloudabi* | -sortix* \
+-	      | -nindy* | -vxsim* | -vxworks* | -ebmon* | -hms* | -mvs* \
+-	      | -clix* | -riscos* | -uniplus* | -iris* | -rtu* | -xenix* \
+-	      | -hiux* | -386bsd* | -knetbsd* | -mirbsd* | -netbsd* \
+-	      | -bitrig* | -openbsd* | -solidbsd* | -libertybsd* \
+-	      | -ekkobsd* | -kfreebsd* | -freebsd* | -riscix* | -lynxos* \
+-	      | -bosx* | -nextstep* | -cxux* | -aout* | -elf* | -oabi* \
+-	      | -ptx* | -coff* | -ecoff* | -winnt* | -domain* | -vsta* \
+-	      | -udi* | -eabi* | -lites* | -ieee* | -go32* | -aux* \
+-	      | -chorusos* | -chorusrdb* | -cegcc* | -glidix* \
+-	      | -cygwin* | -msys* | -pe* | -psos* | -moss* | -proelf* | -rtems* \
+-	      | -midipix* | -mingw32* | -mingw64* | -linux-gnu* | -linux-android* \
+-	      | -linux-newlib* | -linux-musl* | -linux-uclibc* \
+-	      | -uxpv* | -beos* | -mpeix* | -udk* | -moxiebox* \
+-	      | -interix* | -uwin* | -mks* | -rhapsody* | -darwin* | -opened* \
+-	      | -openstep* | -oskit* | -conix* | -pw32* | -nonstopux* \
+-	      | -storm-chaos* | -tops10* | -tenex* | -tops20* | -its* \
+-	      | -os2* | -vos* | -palmos* | -uclinux* | -nucleus* \
+-	      | -morphos* | -superux* | -rtmk* | -rtmk-nova* | -windiss* \
+-	      | -powermax* | -dnix* | -nx6 | -nx7 | -sei* | -dragonfly* \
+-	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es* \
+-	      | -onefs* | -tirtos* | -phoenix* | -fuchsia* | -redox*)
++	# sysv* is not here because it comes later, after sysvr4.
++	gnu* | bsd* | mach* | minix* | genix* | ultrix* | irix* \
++	     | *vms* | esix* | aix* | cnk* | sunos | sunos[34]*\
++	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* \
++	     | sym* | kopensolaris* | plan9* \
++	     | amigaos* | amigados* | msdos* | newsos* | unicos* | aof* \
++	     | aos* | aros* | cloudabi* | sortix* \
++	     | nindy* | vxsim* | vxworks* | ebmon* | hms* | mvs* \
++	     | clix* | riscos* | uniplus* | iris* | isc* | rtu* | xenix* \
++	     | knetbsd* | mirbsd* | netbsd* \
++	     | bitrig* | openbsd* | solidbsd* | libertybsd* \
++	     | ekkobsd* | kfreebsd* | freebsd* | riscix* | lynxos* \
++	     | bosx* | nextstep* | cxux* | aout* | elf* | oabi* \
++	     | ptx* | coff* | ecoff* | winnt* | domain* | vsta* \
++	     | udi* | eabi* | lites* | ieee* | go32* | aux* | hcos* \
++	     | chorusrdb* | cegcc* | glidix* \
++	     | cygwin* | msys* | pe* | moss* | proelf* | rtems* \
++	     | midipix* | mingw32* | mingw64* | linux-gnu* | linux-android* \
++	     | linux-newlib* | linux-musl* | linux-uclibc* \
++	     | uxpv* | beos* | mpeix* | udk* | moxiebox* \
++	     | interix* | uwin* | mks* | rhapsody* | darwin* \
++	     | openstep* | oskit* | conix* | pw32* | nonstopux* \
++	     | storm-chaos* | tops10* | tenex* | tops20* | its* \
++	     | os2* | vos* | palmos* | uclinux* | nucleus* \
++	     | morphos* | superux* | rtmk* | windiss* \
++	     | powermax* | dnix* | nx6 | nx7 | sei* | dragonfly* \
++	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
++	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
++	     | midnightbsd* | amdhsa* | unleashed* | emscripten*)
+ 	# Remember, each alternative MUST END IN *, to match a version number.
+ 		;;
+-	-qnx*)
+-		case $basic_machine in
+-		    x86-* | i*86-*)
++	qnx*)
++		case $cpu in
++		    x86 | i*86)
+ 			;;
+ 		    *)
+-			os=-nto$os
++			os=nto-$os
+ 			;;
+ 		esac
+ 		;;
+-	-nto-qnx*)
++	hiux*)
++		os=hiuxwe2
+ 		;;
+-	-nto*)
+-		os=`echo $os | sed -e 's|nto|nto-qnx|'`
++	nto-qnx*)
+ 		;;
+-	-sim | -es1800* | -hms* | -xray | -os68k* | -none* | -v88r* \
+-	      | -windows* | -osx | -abug | -netware* | -os9* | -beos* | -haiku* \
+-	      | -macos* | -mpw* | -magic* | -mmixware* | -mon960* | -lnews*)
++	nto*)
++		os=`echo $os | sed -e 's|nto|nto-qnx|'`
+ 		;;
+-	-mac*)
+-		os=`echo $os | sed -e 's|mac|macos|'`
++	sim | xray | os68k* | v88r* \
++	    | windows* | osx | abug | netware* | os9* \
++	    | macos* | mpw* | magic* | mmixware* | mon960* | lnews*)
+ 		;;
+-	-linux-dietlibc)
+-		os=-linux-dietlibc
++	linux-dietlibc)
++		os=linux-dietlibc
+ 		;;
+-	-linux*)
++	linux*)
+ 		os=`echo $os | sed -e 's|linux|linux-gnu|'`
+ 		;;
+-	-sunos5*)
+-		os=`echo $os | sed -e 's|sunos5|solaris2|'`
++	lynx*178)
++		os=lynxos178
++		;;
++	lynx*5)
++		os=lynxos5
++		;;
++	lynx*)
++		os=lynxos
+ 		;;
+-	-sunos6*)
+-		os=`echo $os | sed -e 's|sunos6|solaris3|'`
++	mac*)
++		os=`echo "$os" | sed -e 's|mac|macos|'`
+ 		;;
+-	-opened*)
+-		os=-openedition
++	opened*)
++		os=openedition
+ 		;;
+-	-os400*)
+-		os=-os400
++	os400*)
++		os=os400
+ 		;;
+-	-wince*)
+-		os=-wince
++	sunos5*)
++		os=`echo "$os" | sed -e 's|sunos5|solaris2|'`
+ 		;;
+-	-osfrose*)
+-		os=-osfrose
++	sunos6*)
++		os=`echo "$os" | sed -e 's|sunos6|solaris3|'`
+ 		;;
+-	-osf*)
+-		os=-osf
++	wince*)
++		os=wince
+ 		;;
+-	-utek*)
+-		os=-bsd
++	utek*)
++		os=bsd
+ 		;;
+-	-dynix*)
+-		os=-bsd
++	dynix*)
++		os=bsd
+ 		;;
+-	-acis*)
+-		os=-aos
++	acis*)
++		os=aos
+ 		;;
+-	-atheos*)
+-		os=-atheos
++	atheos*)
++		os=atheos
+ 		;;
+-	-syllable*)
+-		os=-syllable
++	syllable*)
++		os=syllable
+ 		;;
+-	-386bsd)
+-		os=-bsd
++	386bsd)
++		os=bsd
+ 		;;
+-	-ctix* | -uts*)
+-		os=-sysv
++	ctix* | uts*)
++		os=sysv
+ 		;;
+-	-nova*)
+-		os=-rtmk-nova
++	nova*)
++		os=rtmk-nova
+ 		;;
+-	-ns2 )
+-		os=-nextstep2
++	ns2)
++		os=nextstep2
+ 		;;
+-	-nsk*)
+-		os=-nsk
++	nsk*)
++		os=nsk
+ 		;;
+ 	# Preserve the version number of sinix5.
+-	-sinix5.*)
++	sinix5.*)
+ 		os=`echo $os | sed -e 's|sinix|sysv|'`
+ 		;;
+-	-sinix*)
+-		os=-sysv4
+-		;;
+-	-tpf*)
+-		os=-tpf
++	sinix*)
++		os=sysv4
+ 		;;
+-	-triton*)
+-		os=-sysv3
++	tpf*)
++		os=tpf
+ 		;;
+-	-oss*)
+-		os=-sysv3
++	triton*)
++		os=sysv3
+ 		;;
+-	-svr4)
+-		os=-sysv4
++	oss*)
++		os=sysv3
+ 		;;
+-	-svr3)
+-		os=-sysv3
++	svr4*)
++		os=sysv4
+ 		;;
+-	-sysvr4)
+-		os=-sysv4
++	svr3)
++		os=sysv3
+ 		;;
+-	# This must come after -sysvr4.
+-	-sysv*)
++	sysvr4)
++		os=sysv4
+ 		;;
+-	-ose*)
+-		os=-ose
++	# This must come after sysvr4.
++	sysv*)
+ 		;;
+-	-es1800*)
+-		os=-ose
++	ose*)
++		os=ose
+ 		;;
+-	-xenix)
+-		os=-xenix
++	*mint | mint[0-9]* | *MiNT | MiNT[0-9]*)
++		os=mint
+ 		;;
+-	-*mint | -mint[0-9]* | -*MiNT | -MiNT[0-9]*)
+-		os=-mint
++	zvmoe)
++		os=zvmoe
+ 		;;
+-	-aros*)
+-		os=-aros
++	dicos*)
++		os=dicos
+ 		;;
+-	-zvmoe)
+-		os=-zvmoe
++	pikeos*)
++		# Until real need of OS specific support for
++		# particular features comes up, bare metal
++		# configurations are quite functional.
++		case $cpu in
++		    arm*)
++			os=eabi
++			;;
++		    *)
++			os=elf
++			;;
++		esac
+ 		;;
+-	-dicos*)
+-		os=-dicos
++	nacl*)
+ 		;;
+-	-nacl*)
++	ios)
+ 		;;
+-	-ios)
++	none)
+ 		;;
+-	-none)
++	*-eabi)
+ 		;;
+ 	*)
+-		# Get rid of the `-' at the beginning of $os.
+-		os=`echo $os | sed 's/[^-]*-//'`
+-		echo Invalid configuration \`$1\': system \`$os\' not recognized 1>&2
++		echo Invalid configuration \`"$1"\': system \`"$os"\' not recognized 1>&2
+ 		exit 1
+ 		;;
+ esac
+@@ -1572,264 +1526,265 @@ else
+ # will signal an error saying that MANUFACTURER isn't an operating
+ # system, and we'll never get to this point.
+ 
+-case $basic_machine in
++case $cpu-$vendor in
+ 	score-*)
+-		os=-elf
++		os=elf
+ 		;;
+ 	spu-*)
+-		os=-elf
++		os=elf
+ 		;;
+ 	*-acorn)
+-		os=-riscix1.2
++		os=riscix1.2
+ 		;;
+ 	arm*-rebel)
+-		os=-linux
++		os=linux
+ 		;;
+ 	arm*-semi)
+-		os=-aout
++		os=aout
+ 		;;
+ 	c4x-* | tic4x-*)
+-		os=-coff
++		os=coff
+ 		;;
+ 	c8051-*)
+-		os=-elf
++		os=elf
++		;;
++	clipper-intergraph)
++		os=clix
+ 		;;
+ 	hexagon-*)
+-		os=-elf
++		os=elf
+ 		;;
+ 	tic54x-*)
+-		os=-coff
++		os=coff
+ 		;;
+ 	tic55x-*)
+-		os=-coff
++		os=coff
+ 		;;
+ 	tic6x-*)
+-		os=-coff
++		os=coff
+ 		;;
+ 	# This must come before the *-dec entry.
+ 	pdp10-*)
+-		os=-tops20
++		os=tops20
+ 		;;
+ 	pdp11-*)
+-		os=-none
++		os=none
+ 		;;
+ 	*-dec | vax-*)
+-		os=-ultrix4.2
++		os=ultrix4.2
+ 		;;
+ 	m68*-apollo)
+-		os=-domain
++		os=domain
+ 		;;
+ 	i386-sun)
+-		os=-sunos4.0.2
++		os=sunos4.0.2
+ 		;;
+ 	m68000-sun)
+-		os=-sunos3
++		os=sunos3
+ 		;;
+ 	m68*-cisco)
+-		os=-aout
++		os=aout
+ 		;;
+ 	mep-*)
+-		os=-elf
++		os=elf
+ 		;;
+ 	mips*-cisco)
+-		os=-elf
++		os=elf
+ 		;;
+ 	mips*-*)
+-		os=-elf
++		os=elf
+ 		;;
+ 	or32-*)
+-		os=-coff
++		os=coff
+ 		;;
+ 	*-tti)	# must be before sparc entry or we get the wrong os.
+-		os=-sysv3
++		os=sysv3
+ 		;;
+ 	sparc-* | *-sun)
+-		os=-sunos4.1.1
++		os=sunos4.1.1
+ 		;;
+ 	pru-*)
+-		os=-elf
++		os=elf
+ 		;;
+ 	*-be)
+-		os=-beos
+-		;;
+-	*-haiku)
+-		os=-haiku
++		os=beos
+ 		;;
+ 	*-ibm)
+-		os=-aix
++		os=aix
+ 		;;
+ 	*-knuth)
+-		os=-mmixware
++		os=mmixware
+ 		;;
+ 	*-wec)
+-		os=-proelf
++		os=proelf
+ 		;;
+ 	*-winbond)
+-		os=-proelf
++		os=proelf
+ 		;;
+ 	*-oki)
+-		os=-proelf
++		os=proelf
+ 		;;
+ 	*-hp)
+-		os=-hpux
++		os=hpux
+ 		;;
+ 	*-hitachi)
+-		os=-hiux
++		os=hiux
+ 		;;
+ 	i860-* | *-att | *-ncr | *-altos | *-motorola | *-convergent)
+-		os=-sysv
++		os=sysv
+ 		;;
+ 	*-cbm)
+-		os=-amigaos
++		os=amigaos
+ 		;;
+ 	*-dg)
+-		os=-dgux
++		os=dgux
+ 		;;
+ 	*-dolphin)
+-		os=-sysv3
++		os=sysv3
+ 		;;
+ 	m68k-ccur)
+-		os=-rtu
++		os=rtu
+ 		;;
+ 	m88k-omron*)
+-		os=-luna
++		os=luna
+ 		;;
+-	*-next )
+-		os=-nextstep
++	*-next)
++		os=nextstep
+ 		;;
+ 	*-sequent)
+-		os=-ptx
++		os=ptx
+ 		;;
+ 	*-crds)
+-		os=-unos
++		os=unos
+ 		;;
+ 	*-ns)
+-		os=-genix
++		os=genix
+ 		;;
+ 	i370-*)
+-		os=-mvs
+-		;;
+-	*-next)
+-		os=-nextstep3
++		os=mvs
+ 		;;
+ 	*-gould)
+-		os=-sysv
++		os=sysv
+ 		;;
+ 	*-highlevel)
+-		os=-bsd
++		os=bsd
+ 		;;
+ 	*-encore)
+-		os=-bsd
++		os=bsd
+ 		;;
+ 	*-sgi)
+-		os=-irix
++		os=irix
+ 		;;
+ 	*-siemens)
+-		os=-sysv4
++		os=sysv4
+ 		;;
+ 	*-masscomp)
+-		os=-rtu
++		os=rtu
+ 		;;
+ 	f30[01]-fujitsu | f700-fujitsu)
+-		os=-uxpv
++		os=uxpv
+ 		;;
+ 	*-rom68k)
+-		os=-coff
++		os=coff
+ 		;;
+ 	*-*bug)
+-		os=-coff
++		os=coff
+ 		;;
+ 	*-apple)
+-		os=-macos
++		os=macos
+ 		;;
+ 	*-atari*)
+-		os=-mint
++		os=mint
++		;;
++	*-wrs)
++		os=vxworks
+ 		;;
+ 	*)
+-		os=-none
++		os=none
+ 		;;
+ esac
+ fi
+ 
+ # Here we handle the case where we know the os, and the CPU type, but not the
+ # manufacturer.  We pick the logical manufacturer.
+-vendor=unknown
+-case $basic_machine in
+-	*-unknown)
++case $vendor in
++	unknown)
+ 		case $os in
+-			-riscix*)
++			riscix*)
+ 				vendor=acorn
+ 				;;
+-			-sunos*)
++			sunos*)
+ 				vendor=sun
+ 				;;
+-			-cnk*|-aix*)
++			cnk*|-aix*)
+ 				vendor=ibm
+ 				;;
+-			-beos*)
++			beos*)
+ 				vendor=be
+ 				;;
+-			-hpux*)
++			hpux*)
+ 				vendor=hp
+ 				;;
+-			-mpeix*)
++			mpeix*)
+ 				vendor=hp
+ 				;;
+-			-hiux*)
++			hiux*)
+ 				vendor=hitachi
+ 				;;
+-			-unos*)
++			unos*)
+ 				vendor=crds
+ 				;;
+-			-dgux*)
++			dgux*)
+ 				vendor=dg
+ 				;;
+-			-luna*)
++			luna*)
+ 				vendor=omron
+ 				;;
+-			-genix*)
++			genix*)
+ 				vendor=ns
+ 				;;
+-			-mvs* | -opened*)
++			clix*)
++				vendor=intergraph
++				;;
++			mvs* | opened*)
+ 				vendor=ibm
+ 				;;
+-			-os400*)
++			os400*)
+ 				vendor=ibm
+ 				;;
+-			-ptx*)
++			ptx*)
+ 				vendor=sequent
+ 				;;
+-			-tpf*)
++			tpf*)
+ 				vendor=ibm
+ 				;;
+-			-vxsim* | -vxworks* | -windiss*)
++			vxsim* | vxworks* | windiss*)
+ 				vendor=wrs
+ 				;;
+-			-aux*)
++			aux*)
+ 				vendor=apple
+ 				;;
+-			-hms*)
++			hms*)
+ 				vendor=hitachi
+ 				;;
+-			-mpw* | -macos*)
++			mpw* | macos*)
+ 				vendor=apple
+ 				;;
+-			-*mint | -mint[0-9]* | -*MiNT | -MiNT[0-9]*)
++			*mint | mint[0-9]* | *MiNT | MiNT[0-9]*)
+ 				vendor=atari
+ 				;;
+-			-vos*)
++			vos*)
+ 				vendor=stratus
+ 				;;
+ 		esac
+-		basic_machine=`echo $basic_machine | sed "s/unknown/$vendor/"`
+ 		;;
+ esac
+ 
+-echo $basic_machine$os
++echo "$cpu-$vendor-$os"
+ exit
+ 
+ # Local variables:
+-# eval: (add-hook 'write-file-hooks 'time-stamp)
++# eval: (add-hook 'before-save-hook 'time-stamp)
+ # time-stamp-start: "timestamp='"
+ # time-stamp-format: "%:y-%02m-%02d"
+ # time-stamp-end: "'"
+diff --git a/buildconf b/buildconf
+index 3abfe10..7b68cfd 100755
+--- a/buildconf
++++ b/buildconf
+@@ -43,28 +43,6 @@ do
+   shift
+ done
+ 
+-if [ -f "$apr_src_dir/build/apr_common.m4" ]; then
+-  apr_src_dir=`cd $apr_src_dir; pwd`
+-  echo ""
+-  echo "Looking for apr source in $apr_src_dir"
+-else
+-  echo ""
+-  echo "Problem finding apr source in $apr_src_dir."
+-  echo "Use:"
+-  echo "  --with-apr=[directory]" 
+-  exit 1
+-fi
+-
+-set -e
+-
+-# Remove some files, then copy them from apr source tree
+-rm -f build/apr_common.m4 build/find_apr.m4 build/install.sh \
+-      build/config.guess build/config.sub build/get-version.sh
+-cp -p $apr_src_dir/build/apr_common.m4 $apr_src_dir/build/find_apr.m4 \
+-      $apr_src_dir/build/install.sh $apr_src_dir/build/config.guess \
+-      $apr_src_dir/build/config.sub $apr_src_dir/build/get-version.sh \
+-      build/
+-
+ # Remove aclocal.m4 as it'll break some builds...
+ rm -rf aclocal.m4 autom4te*.cache
+ 
+@@ -87,7 +65,7 @@ fi
+ # Generate build-outputs.mk for the build system
+ #
+ echo "Generating 'make' outputs ..."
+-$apr_src_dir/build/gen-build.py $verbose make
++build/gen-build.py $verbose make
+ 
+ # Remove autoconf cache again
+ rm -rf autom4te*.cache


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

I've tried here an approach similar to https://github.com/conan-io/conan-center-index/pull/6622... but I've found that the `buildconf` script here is copying files from `apr` source-tree 😮 ... so I've written a patch that replaces those operations (and removes them from the `buildconf` script).

Maybe someone figures out a better approach. Thanks!

