### PR TITLE
add linux-headers-generic recipe

### DIFF
--- a/recipes/linux-headers-generic/all/conandata.yml
+++ b/recipes/linux-headers-generic/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "5.13.9":
+    url: "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.13.9.tar.gz"
+    sha256: "cc82e4461d5f759c820b74079164450d1f1ad09def9f3356a58814abd0268787"

--- a/recipes/linux-headers-generic/all/conanfile.py
+++ b/recipes/linux-headers-generic/all/conanfile.py
@@ -21,7 +21,7 @@ class LinuxHeadersGenericConan(ConanFile):
     def validate(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("linux-headers-generic supports only Linux")
-        if tools.cross_building(self):
+        if hasattr(self, "settings_build") and tools.cross_building(self):
             raise ConanInvalidConfiguration("linux-headers-generic can not be cross-compiled")
 
     def source(self):

--- a/recipes/linux-headers-generic/all/conanfile.py
+++ b/recipes/linux-headers-generic/all/conanfile.py
@@ -11,11 +11,15 @@ class LinuxHeadersGenericConan(ConanFile):
     license = "GPL-2.0-only"
     description = "Generic Linux kernel headers"
     topics = ("linux", "headers", "generic")
-    settings = "arch"
+    settings = "os", "arch"
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("linux-headers-generic supports only Linux")
 
     def build_requirements(self):
         self.build_requires("make/4.3")

--- a/recipes/linux-headers-generic/all/conanfile.py
+++ b/recipes/linux-headers-generic/all/conanfile.py
@@ -26,8 +26,8 @@ class LinuxHeadersGenericConan(ConanFile):
 
     def build(self):
         with tools.chdir(os.path.join(self._source_subfolder)):
-            self.run("{} headers_install".format(tools.get_env("CONAN_MAKE_PROGRAM")))
+            self.run("{} headers".format(tools.get_env("CONAN_MAKE_PROGRAM")))
 
     def package(self):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)
-        self.copy("include/*", src=os.path.join(self._source_subfolder, "usr"))
+        self.copy("include/*.h", src=os.path.join(self._source_subfolder, "usr"))

--- a/recipes/linux-headers-generic/all/conanfile.py
+++ b/recipes/linux-headers-generic/all/conanfile.py
@@ -1,0 +1,33 @@
+from conans import ConanFile, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class LinuxHeadersGenericConan(ConanFile):
+    name = "linux-headers-generic"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.kernel.org/"
+    license = "GPL-2.0-only"
+    description = "Generic Linux kernel headers"
+    topics = ("linux", "headers", "generic")
+    settings = "arch"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def build_requirements(self):
+        self.build_requires("make/4.3")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def build(self):
+        with tools.chdir(os.path.join(self._source_subfolder)):
+            self.run("{} headers_install".format(tools.get_env("CONAN_MAKE_PROGRAM")))
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        self.copy("include/*", src=os.path.join(self._source_subfolder, "usr"))

--- a/recipes/linux-headers-generic/all/conanfile.py
+++ b/recipes/linux-headers-generic/all/conanfile.py
@@ -18,6 +18,9 @@ class LinuxHeadersGenericConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    def package_id(self):
+        del self.info.settings.os
+
     def validate(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("linux-headers-generic supports only Linux")

--- a/recipes/linux-headers-generic/all/conanfile.py
+++ b/recipes/linux-headers-generic/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, tools
+from conans import AutotoolsBuildEnvironment, ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
@@ -24,16 +24,14 @@ class LinuxHeadersGenericConan(ConanFile):
         if tools.cross_building(self):
             raise ConanInvalidConfiguration("linux-headers-generic can not be cross-compiled")
 
-    def build_requirements(self):
-        self.build_requires("make/4.3")
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
     def build(self):
         with tools.chdir(os.path.join(self._source_subfolder)):
-            self.run("{} headers".format(tools.get_env("CONAN_MAKE_PROGRAM")))
+            autotools = AutotoolsBuildEnvironment(self)
+            autotools.make(target="headers")
 
     def package(self):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)

--- a/recipes/linux-headers-generic/all/conanfile.py
+++ b/recipes/linux-headers-generic/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.33.0"
@@ -20,6 +21,8 @@ class LinuxHeadersGenericConan(ConanFile):
     def validate(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("linux-headers-generic supports only Linux")
+        if tools.cross_building(self):
+            raise ConanInvalidConfiguration("linux-headers-generic can not be cross-compiled")
 
     def build_requirements(self):
         self.build_requires("make/4.3")

--- a/recipes/linux-headers-generic/all/conanfile.py
+++ b/recipes/linux-headers-generic/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import AutotoolsBuildEnvironment, ConanFile, tools
+from conans import AutoToolsBuildEnvironment, ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
@@ -30,7 +30,7 @@ class LinuxHeadersGenericConan(ConanFile):
 
     def build(self):
         with tools.chdir(os.path.join(self._source_subfolder)):
-            autotools = AutotoolsBuildEnvironment(self)
+            autotools = AutoToolsBuildEnvironment(self)
             autotools.make(target="headers")
 
     def package(self):

--- a/recipes/linux-headers-generic/all/test_package/CMakeLists.txt
+++ b/recipes/linux-headers-generic/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/linux-headers-generic/all/test_package/conanfile.py
+++ b/recipes/linux-headers-generic/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/linux-headers-generic/all/test_package/test_package.c
+++ b/recipes/linux-headers-generic/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include "linux/gpio.h"
+#include "linux/fs.h"
+#include "linux/dma-buf.h"
+#include "linux/io_uring.h"
+
+int main() {
+    return 0;
+}

--- a/recipes/linux-headers-generic/config.yml
+++ b/recipes/linux-headers-generic/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "5.13.9":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  linux-headers-generic/5.13.9

I'm submitting this PR because it is a requirement of another package I want to package: see https://github.com/conan-io/conan-center-index/pull/6803 

open questions for review:
- Some of the headers are architecture-dependent, that's why I included the 'arch' attribute. Is it enough or 'os' should be added too?
- There is a way to install the arch-dependent headers for all architectures. In that case, 'arch' can be removed from the settings. Should I do that?
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
