### PR TITLE
libgpg-error: fPIC is True by default

### DIFF
--- a/recipes/libgpg-error/all/conanfile.py
+++ b/recipes/libgpg-error/all/conanfile.py
@@ -19,7 +19,7 @@ class GPGErrorConan(ConanFile):
     }
     default_options = {
         "shared": False,
-        "fPIC": False,
+        "fPIC": True,
     }
     exports_sources = "patches/**"
     _autotools = None


### PR DESCRIPTION
by default fPIC is True as other packages define

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
