### PR TITLE
tar: add tar/1.32.90 recipe

### DIFF
--- a/recipes/tar/all/conandata.yml
+++ b/recipes/tar/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.32.90":
+    url: "https://alpha.gnu.org/gnu/tar/tar-1.32.90.tar.gz"
+    sha256: "641fe07b7403c8eb801e7bfb91d1b7e5800ab15df524e22e0b2e89501280b6d7"

--- a/recipes/tar/all/conanfile.py
+++ b/recipes/tar/all/conanfile.py
@@ -67,7 +67,7 @@ class TarConan(ConanFile):
             "--with-lzma={}".format(lzma_exe),
             # "--without-lzop",  # FIXME: this will use sytem lzop
             "--with-xz={}".format(xz_exe),
-            "--without-zstd",  # FIXME: zstd does not build programs
+            # "--without-zstd",  # FIXME: this will use system zstd (current zstd recipe does not build programs)
         ]
         self._autotools.configure(args=args, configure_dir=self._source_subfolder)
         return self._autotools

--- a/recipes/tar/all/conanfile.py
+++ b/recipes/tar/all/conanfile.py
@@ -1,0 +1,98 @@
+from conans import AutoToolsBuildEnvironment, ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class TarConan(ConanFile):
+    name = "tar"
+    description = "GNU Tar provides the ability to create tar archives, as well as various other kinds of manipulation."
+    topics = ("tar", "archive")
+    license = "GPL-3-or-later"
+    homepage = "https://www.gnu.org/software/tar/"
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "arch", "compiler", "build_type"
+
+    _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def requirements(self):
+        self.requires("bzip2/1.0.8")
+        self.requires("lzip/1.21")
+        self.requires("xz_utils/5.2.5")
+
+    def validate(self):
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration("This recipe does not support Windows builds of tar")  # FIXME: fails on MSVC and mingw-w64
+        if not self.options["bzip2"].build_executable:
+            raise ConanInvalidConfiguration("bzip2:build_executable must be enabled")
+
+    def package_id(self):
+        del self.info.settings.compiler
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self)
+        self._autotools.libs = []
+        bzip2_exe = "bzip2"  # FIXME: get from bzip2 recipe
+        lzip_exe = "lzip"  # FIXME: get from lzip recipe
+        lzma_exe = "lzma"  # FIXME: get from xz_utils recipe
+        xz_exe = "xz"  # FIXME: get from xz_utils recipe
+        args = [
+            "--disable-acl",
+            "--disable-nls",
+            "--disable-rpath",
+            # "--without-gzip",  # FIXME: this will use system gzip
+            "--without-posix-acls",
+            "--without-selinux",
+            "--with-bzip2={}".format(bzip2_exe),
+            "--with-lzip={}".format(lzip_exe),
+            "--with-lzma={}".format(lzma_exe),
+            # "--without-lzop",  # FIXME: this will use sytem lzop
+            "--with-xz={}".format(xz_exe),
+            "--without-zstd",  # FIXME: zstd does not build programs
+        ]
+        self._autotools.configure(args=args, configure_dir=self._source_subfolder)
+        return self._autotools
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        if self.settings.compiler == "Visual Studio":
+            tools.replace_in_file(os.path.join(self._source_subfolder, "gnu", "faccessat.c"),
+                                  "_GL_INCLUDING_UNISTD_H", "_GL_INCLUDING_UNISTD_H_NOP")
+        autotools = self._configure_autotools()
+        autotools.make()
+
+    def package(self):
+        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
+        autotools = self._configure_autotools()
+        autotools.install()
+
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)
+
+        tar_bin = os.path.join(self.package_folder, "bin", "tar")
+        self.user_info.tar = tar_bin
+        self.env_info.TAR = tar_bin

--- a/recipes/tar/all/test_package/conanfile.py
+++ b/recipes/tar/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+
+    def test(self):
+        tar_bin = self.deps_user_info["tar"].tar
+        if not tools.cross_building(self):
+            with tools.chdir(self.source_folder):
+                test_tar = os.path.join(self.build_folder, "test.tar.gz")
+                self.run("{} -czf {} conanfile.py".format(tar_bin, test_tar), run_environment=True)
+            assert os.path.isfile("test.tar.gz")
+            self.run("{} -tf test.tar.gz".format(tar_bin), run_environment=True)
+            self.run("{} -xf test.tar.gz".format(tar_bin), run_environment=True)
+            assert tools.load(os.path.join(self.source_folder, "conanfile.py")) == tools.load(os.path.join(self.build_folder, "conanfile.py"))

--- a/recipes/tar/config.yml
+++ b/recipes/tar/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.32.90":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **tar/1.32.90**

Do there exist linux systems without `tar`?

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
