### PR TITLE
[qt6] fix compilation of qt6 with_vulkan on MacOs

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -239,7 +239,7 @@ class QtConan(ConanFile):
             self.requires("vulkan-loader/1.2.172")
             if tools.is_apple_os(self.settings.os):
                 self.requires("moltenvk/1.1.1")
-
+                self.requires("vulkan-headers/1.2.172", override=True)
         if self.options.with_glib:
             self.requires("glib/2.68.3")
         if self.options.with_doubleconversion and not self.options.multiconfiguration:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -238,7 +238,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("with_vulkan"):
             self.requires("vulkan-loader/1.2.172")
             if tools.is_apple_os(self.settings.os):
-                self.requires("moltenvk/1.1.1")
+                self.requires("moltenvk/1.1.4")
                 self.requires("vulkan-headers/1.2.172", override=True)
         if self.options.with_glib:
             self.requires("glib/2.68.3")

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -236,10 +236,9 @@ class QtConan(ConanFile):
         if self.options.with_pcre2:
             self.requires("pcre2/10.36")
         if self.options.get_safe("with_vulkan"):
-            self.requires("vulkan-loader/1.2.172")
+            self.requires("vulkan-loader/1.2.182")
             if tools.is_apple_os(self.settings.os):
                 self.requires("moltenvk/1.1.4")
-                self.requires("vulkan-headers/1.2.172", override=True)
         if self.options.with_glib:
             self.requires("glib/2.68.3")
         if self.options.with_doubleconversion and not self.options.multiconfiguration:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -237,6 +237,8 @@ class QtConan(ConanFile):
             self.requires("pcre2/10.36")
         if self.options.get_safe("with_vulkan"):
             self.requires("vulkan-loader/1.2.172")
+            if tools.is_apple_os(self.settings.os):
+                self.requires("moltenvk/1.1.1")
 
         if self.options.with_glib:
             self.requires("glib/2.68.3")
@@ -746,6 +748,8 @@ class QtConan(ConanFile):
                 gui_reqs.append("opengl::opengl")
             if self.options.get_safe("with_vulkan", False):
                 gui_reqs.append("vulkan-loader::vulkan-loader")
+                if tools.is_apple_os(self.settings.os):
+                    gui_reqs.append("moltenvk::moltenvk")
             if self.options.with_harfbuzz:
                 gui_reqs.append("harfbuzz::harfbuzz")
             if self.options.with_libjpeg == "libjpeg-turbo":


### PR DESCRIPTION
Specify library name and version:  **qt/6.1.2@**

relates to https://github.com/conan-io/conan-center-index/issues/6812
This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
