### PR TITLE
sqlitecpp: add sqlcipher support

### DIFF
--- a/recipes/sqlcipher/all/conandata.yml
+++ b/recipes/sqlcipher/all/conandata.yml
@@ -40,3 +40,5 @@ patches:
       base_path: source_subfolder
     - patch_file: patches/fix_configure-v4.4.3.patch
       base_path: source_subfolder
+    - patch_file: patches/fix_stdcall-v4.4.3.patch
+      base_path: source_subfolder

--- a/recipes/sqlcipher/all/patches/fix_stdcall-v4.4.3.patch
+++ b/recipes/sqlcipher/all/patches/fix_stdcall-v4.4.3.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.msc b/Makefile.msc
+index 312b40c..4131bf4 100644
+--- a/Makefile.msc
++++ b/Makefile.msc
+@@ -575,7 +575,7 @@ RCC = $(RC) -DSQLITE_OS_WIN=1 -I. -I$(TOP) -I$(TOP)\src $(RCOPTS) $(RCCOPTS)
+ # to how the Tcl library functions are declared and exported (i.e. without
+ # an explicit calling convention, which results in "cdecl").
+ #
+-!IF $(USE_STDCALL)!=0 || $(FOR_WIN10)!=0
++!IF $(USE_STDCALL)!=0
+ !IF "$(PLATFORM)"=="x86"
+ CORE_CCONV_OPTS = -Gz -DSQLITE_CDECL=__cdecl -DSQLITE_APICALL=__stdcall -DSQLITE_CALLBACK=__stdcall -DSQLITE_SYSAPI=__stdcall
+ SHELL_CCONV_OPTS = -Gz -DSQLITE_CDECL=__cdecl -DSQLITE_APICALL=__stdcall -DSQLITE_CALLBACK=__stdcall -DSQLITE_SYSAPI=__stdcall

--- a/recipes/sqlitecpp/all/conandata.yml
+++ b/recipes/sqlitecpp/all/conandata.yml
@@ -15,3 +15,6 @@ patches:
   "2.5.0":
     - base_path: "source_subfolder"
       patch_file: "patches/2.5.0/0001-conan.patch"
+  "3.1.1":
+    - base_path: "source_subfolder"
+      patch_file: "patches/3.1.1/0001-sqlcipher.patch"

--- a/recipes/sqlitecpp/all/conanfile.py
+++ b/recipes/sqlitecpp/all/conanfile.py
@@ -19,11 +19,13 @@ class SQLiteCppConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "lint": [True, False, "deprecated"],
+        "sqlcipher": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "lint": "deprecated",
+        "sqlcipher" : False
     }
 
     exports_sources = ["CMakeLists.txt", "patches/*"]
@@ -49,7 +51,10 @@ class SQLiteCppConan(ConanFile):
             self.output.warn("lint option is deprecated, do not use anymore")
 
     def requirements(self):
-        self.requires("sqlite3/3.36.0")
+        if self.options.sqlcipher:
+            self.requires("sqlcipher/4.4.3")
+        else:
+            self.requires("sqlite3/3.36.0")
 
     def validate(self):
         if tools.Version(self.version) >= "3.0.0" and self.settings.compiler.get_safe("cppstd"):
@@ -86,6 +91,9 @@ class SQLiteCppConan(ConanFile):
         self._cmake.definitions["SQLITECPP_RUN_DOXYGEN"] = False
         self._cmake.definitions["SQLITECPP_BUILD_EXAMPLES"] = False
         self._cmake.definitions["SQLITECPP_BUILD_TESTS"] = False
+        if self.options.sqlcipher:
+            self._cmake.definitions["SQLITE_HAS_CODEC"] = True
+            self._cmake.definitions["SQLITE_ENABLE_COLUMN_METADATA"] = False
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 

--- a/recipes/sqlitecpp/all/conanfile.py
+++ b/recipes/sqlitecpp/all/conanfile.py
@@ -25,11 +25,11 @@ class SQLiteCppConan(ConanFile):
         "shared": False,
         "fPIC": True,
         "lint": "deprecated",
-        "sqlcipher" : False
+        "sqlcipher": False
     }
 
     exports_sources = ["CMakeLists.txt", "patches/*"]
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package", "pkg_config"
     _cmake = None
 
     @property
@@ -60,7 +60,8 @@ class SQLiteCppConan(ConanFile):
         if tools.Version(self.version) >= "3.0.0" and self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, 11)
         if self.settings.os == "Windows" and self.options.shared:
-            raise ConanInvalidConfiguration("SQLiteCpp can not be built as shared lib on Windows")
+            raise ConanInvalidConfiguration(
+                "SQLiteCpp can not be built as shared lib on Windows")
 
     def package_id(self):
         del self.info.options.lint

--- a/recipes/sqlitecpp/all/patches/3.1.1/0001-sqlcipher.patch
+++ b/recipes/sqlitecpp/all/patches/3.1.1/0001-sqlcipher.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 85c1061..6c564ea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -232,16 +232,17 @@ if (SQLITECPP_INTERNAL_SQLITE)
+     add_subdirectory(sqlite3)
+     target_link_libraries(SQLiteCpp PUBLIC sqlite3)
+ else (SQLITECPP_INTERNAL_SQLITE)
+-    find_package (SQLite3 REQUIRED)
+-    message(STATUS "Link to sqlite3 system library")
+-    target_link_libraries(SQLiteCpp PUBLIC SQLite::SQLite3)
+-    if(SQLite3_VERSION VERSION_LESS "3.19")
+-        set_target_properties(SQLiteCpp PROPERTIES COMPILE_FLAGS "-DSQLITECPP_HAS_MEM_STRUCT")
+-    endif()
++    if (NOT SQLITE_HAS_CODEC)
++        find_package (SQLite3 REQUIRED)
++        message(STATUS "Link to sqlite3 system library")
++        target_link_libraries(SQLiteCpp PUBLIC SQLite::SQLite3)
++        if(SQLite3_VERSION VERSION_LESS "3.19")
++            set_target_properties(SQLiteCpp PROPERTIES COMPILE_FLAGS "-DSQLITECPP_HAS_MEM_STRUCT")
++        endif()
+ 
+     # When using the SQLite codec, we need to link against the sqlcipher lib & include <sqlcipher/sqlite3.h>
+     # So this gets the lib & header, and links/includes everything
+-    if(SQLITE_HAS_CODEC)
++    else()
+         # Make PkgConfig optional since Windows doesn't usually have it installed.
+         find_package(PkgConfig QUIET)
+         if(PKG_CONFIG_FOUND)


### PR DESCRIPTION
Specify library name and version:  **sqlitecpp/3.1.1** **sqlcipher/4.4.3**

I'm adding sqlcipher backend support to sqlitecpp, which is officially supported, but needs a minor patch to make it work.

I've tested it on these platforms:

- armv8-android (android api level 24)
- x86-windows (version 21H1)
- x86_64-windows (version 21H1)

I noticed that on armv8-android, sqlitecpp won't build due-to missing PkgConfig files for sqlcipher, so I included a small fix for it.

I noticed that on x86-windows, sqlcipher failed to test due to calling convention difference - sqlcipher was using `__stdcall` convention while rest of the world is using `__cdecl`, so I included another patch to fix it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
