### PR TITLE
Added sizecheck option

### DIFF
--- a/recipes/foonathan-memory/all/conanfile.py
+++ b/recipes/foonathan-memory/all/conanfile.py
@@ -15,12 +15,14 @@ class FoonathanMemory(ConanFile):
     options = {
         "shared":          [True, False],
         "fPIC":            [True, False],
-        "with_tools":      [True, False]
+        "with_tools":      [True, False],
+        "with_sizecheck":  [True, False]
     }
     default_options = {
         "shared":            False,
         "fPIC":              True,
-        "with_tools":        False
+        "with_tools":        False,
+        "with_sizecheck":    True
     }
     generators = "cmake"
     exports_sources =  ["patches/**","CMakeLists.txt"]
@@ -70,6 +72,7 @@ class FoonathanMemory(ConanFile):
             self._cmake.definitions["FOONATHAN_MEMORY_BUILD_EXAMPLES"] = False
             self._cmake.definitions["FOONATHAN_MEMORY_BUILD_TESTS"] = False
             self._cmake.definitions["FOONATHAN_MEMORY_BUILD_TOOLS"] = self.options.with_tools
+            self._cmake.definitions["FOONATHAN_MEMORY_CHECK_ALLOCATION_SIZE"] = self.options.with_sizecheck
             self._cmake.configure()
         return self._cmake
 


### PR DESCRIPTION
foonathan-memory 0.7.0 

Related to issue https://github.com/conan-io/conan-center-index/issues/6731 

foonathan-memory offers build option to check allocated size - this is on by default - in fast-dds package this leads to crash when consuming it and building simple publish subscribe programs. 

It's a quick fix - i will also asking fast-dds team why they do not using the 0.7.0 but instead a small (non functional) patched commit instead of release and will ask if they also using the "dont check size" option. 

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
