### PR TITLE
[cpprestsdk] Fix warning LNK4286/LNK4217

### DIFF
--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -131,7 +131,7 @@ class CppRestSDKConan(ConanFile):
         elif self.settings.os == "Macos":
             self.cpp_info.components["cpprest"].frameworks.extend(["CoreFoundation", "Security"])
         if not self.options.shared:
-            self.cpp_info.components["cpprest"].defines.append("_NO_ASYNCRTIMP")
+            self.cpp_info.components["cpprest"].defines.extend(["_NO_ASYNCRTIMP", "_NO_PPLXIMP"])
         # cpprestsdk_zlib_internal
         if self.options.with_compression:
             self.cpp_info.components["cpprestsdk_zlib_internal"].includedirs = []


### PR DESCRIPTION
Fix warnings like these when linking to cpprestsdk built by Conan with `cpprestsdk:pplx_impl=winpplx` (and default `cpprestsdk:shared=False`)

Compare https://github.com/microsoft/cpprestsdk/blob/bfe34877914fd280512c97d41aaa99e88564fd8d/Release/src/CMakeLists.txt#L205

```
10>LINK : warning LNK4286: symbol '?wait@event_impl@details@pplx@@QEAAII@Z (public: unsigned int __cdecl pplx::details::event_impl::wait(unsigned int))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)'
10>LINK : warning LNK4217: symbol '?wait@event_impl@details@pplx@@QEAAII@Z (public: unsigned int __cdecl pplx::details::event_impl::wait(unsigned int))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)' in function '"void foo()" (foo)'
10>LINK : warning LNK4286: symbol '?GetCurrentThreadId@platform@details@pplx@@YAJXZ (long __cdecl pplx::details::platform::GetCurrentThreadId(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)'
10>LINK : warning LNK4217: symbol '?GetCurrentThreadId@platform@details@pplx@@YAJXZ (long __cdecl pplx::details::platform::GetCurrentThreadId(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)' in function '"void foo()" (foo)'
10>LINK : warning LNK4286: symbol '??0event_impl@details@pplx@@QEAA@XZ (public: __cdecl pplx::details::event_impl::event_impl(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)'
10>LINK : warning LNK4217: symbol '??0event_impl@details@pplx@@QEAA@XZ (public: __cdecl pplx::details::event_impl::event_impl(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)' in function '"void foo()" (foo)'
10>LINK : warning LNK4286: symbol '??1event_impl@details@pplx@@QEAA@XZ (public: __cdecl pplx::details::event_impl::~event_impl(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)'
10>LINK : warning LNK4217: symbol '??1event_impl@details@pplx@@QEAA@XZ (public: __cdecl pplx::details::event_impl::~event_impl(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)' in function '"void foo()" (foo)'
10>LINK : warning LNK4286: symbol '?set@event_impl@details@pplx@@QEAAXXZ (public: void __cdecl pplx::details::event_impl::set(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)'
10>LINK : warning LNK4217: symbol '?set@event_impl@details@pplx@@QEAAXXZ (public: void __cdecl pplx::details::event_impl::set(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)' in function '"void foo()" (foo)'
10>LINK : warning LNK4286: symbol '??0critical_section_impl@details@pplx@@QEAA@XZ (public: __cdecl pplx::details::critical_section_impl::critical_section_impl(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)'
10>LINK : warning LNK4217: symbol '??0critical_section_impl@details@pplx@@QEAA@XZ (public: __cdecl pplx::details::critical_section_impl::critical_section_impl(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)' in function '"void foo()" (foo)'
10>LINK : warning LNK4286: symbol '?unlock@critical_section_impl@details@pplx@@QEAAXXZ (public: void __cdecl pplx::details::critical_section_impl::unlock(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)'
10>LINK : warning LNK4217: symbol '?unlock@critical_section_impl@details@pplx@@QEAAXXZ (public: void __cdecl pplx::details::critical_section_impl::unlock(void))' defined in 'cpprest142_2_10.lib(pplxwin.obj)' is imported by 'my.lib(my.obj)' in function '"void foo()" (foo)'
10>LINK : warning LNK4286: symbol '?get_ambient_scheduler@pplx@@YA?AV?$shared_ptr@Uscheduler_interface@pplx@@@std@@XZ (class std::shared_ptr<struct pplx::scheduler_interface> __cdecl pplx::get_ambient_scheduler(void))' defined in 'cpprest142_2_10.lib(pplx.obj)' is imported by 'my.lib(my.obj)'
10>LINK : warning LNK4217: symbol '?get_ambient_scheduler@pplx@@YA?AV?$shared_ptr@Uscheduler_interface@pplx@@@std@@XZ (class std::shared_ptr<struct pplx::scheduler_interface> __cdecl pplx::get_ambient_scheduler(void))' defined in 'cpprest142_2_10.lib(pplx.obj)' is imported by 'my.lib(my.obj)' in function '"void foo()" (foo)'
```

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
