### PR TITLE
libnova: fix version (0.16.0 instead of 0.1.16)

### DIFF
--- a/recipes/libnova/all/conandata.yml
+++ b/recipes/libnova/all/conandata.yml
@@ -1,11 +1,11 @@
 sources:
-  "0.1.16":
+  "0.16.0":
     url:
       post: "https://sourceforge.net/p/libnova/libnova/ci/v0.16/tarball"
       archive: "https://sourceforge.net/code-snapshots/git/l/li/libnova/libnova.git/libnova-libnova-edbf65abe27ef1a2520eb9e839daaf58f15a6941.zip"
     sha256: "2703497573f949146895dedb6fdf74c8d1f15dbdb831074bbaabc5052bdedc07"
 patches:
-  "0.1.16":
+  "0.16.0":
     - patch_file: "patches/0001-fix-cmake.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0002-fix-win32-def.patch"

--- a/recipes/libnova/config.yml
+++ b/recipes/libnova/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1.16":
+  "0.16.0":
     folder: all


### PR DESCRIPTION
it's 0.16.0, not 0.1.16

Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
