### PR TITLE
[qt] winextras links to dwmapi

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1077,7 +1077,6 @@ Examples = bin/datadir/examples""")
 
         if self.options.qtwinextras:
             _create_module("WinExtras")
-            self.cpp_info.components["qtWinExtras"].system_libs.append("dwmapi")
 
         if self.options.qtxmlpatterns:
              _create_module("XmlPatterns", ["Network"])
@@ -1090,7 +1089,10 @@ Examples = bin/datadir/examples""")
                 self.cpp_info.components["qtCore"].system_libs.append("userenv")  # qtcore requires "__imp_GetUserProfileDirectoryW " which is in "UserEnv.Lib" library
                 self.cpp_info.components["qtCore"].system_libs.append("ws2_32")  # qtcore requires "WSAStartup " which is in "Ws2_32.Lib" library
                 self.cpp_info.components["qtNetwork"].system_libs.append("dnsapi")  # qtnetwork from qtbase requires "DnsFree" which is in "Dnsapi.lib" library
-                self.cpp_info.components["qtNetwork"].system_libs.append("iphlpapi")
+                self.cpp_info.components["qtNetwork"].system_libs.append("iphlpapi")            
+                if self.options.qtwinextras:
+                    self.cpp_info.components["qtWinExtras"].system_libs.append("dwmapi")  # qtwinextras requires "DwmGetColorizationColor" which is in "dwmapi.lib" library
+
 
             if self.settings.os == "Macos":
                 self.cpp_info.components["qtCore"].frameworks.append("IOKit")     # qtcore requires "_IORegistryEntryCreateCFProperty", "_IOServiceGetMatchingService" and much more which are in "IOKit" framework

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1089,7 +1089,7 @@ Examples = bin/datadir/examples""")
                 self.cpp_info.components["qtCore"].system_libs.append("userenv")  # qtcore requires "__imp_GetUserProfileDirectoryW " which is in "UserEnv.Lib" library
                 self.cpp_info.components["qtCore"].system_libs.append("ws2_32")  # qtcore requires "WSAStartup " which is in "Ws2_32.Lib" library
                 self.cpp_info.components["qtNetwork"].system_libs.append("dnsapi")  # qtnetwork from qtbase requires "DnsFree" which is in "Dnsapi.lib" library
-                self.cpp_info.components["qtNetwork"].system_libs.append("iphlpapi")            
+                self.cpp_info.components["qtNetwork"].system_libs.append("iphlpapi")
                 if self.options.qtwinextras:
                     self.cpp_info.components["qtWinExtras"].system_libs.append("dwmapi")  # qtwinextras requires "DwmGetColorizationColor" which is in "dwmapi.lib" library
 

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1077,6 +1077,7 @@ Examples = bin/datadir/examples""")
 
         if self.options.qtwinextras:
             _create_module("WinExtras")
+            self.cpp_info.components["qtWinExtras"].system_libs.append("dwmapi")
 
         if self.options.qtxmlpatterns:
              _create_module("XmlPatterns", ["Network"])


### PR DESCRIPTION
Specify library name and version:  **qt/5.15.2**

There were linker issues using QT Winextras component that is solved by this PR
Fixes #6855

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
