### PR TITLE
libgpiod: fpic handling + del C++-related settings when building a C library

### DIFF
--- a/recipes/libgpiod/all/conanfile.py
+++ b/recipes/libgpiod/all/conanfile.py
@@ -14,11 +14,13 @@ class LibgpiodConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
+        "fPIC": [True, False],
         "enable_bindings_cxx": [True, False],
         "enable_tools": [True, False],
     }
     default_options = {
         "shared": False,
+        "fPIC": True,
         "enable_bindings_cxx": False,
         "enable_tools": False,
     }
@@ -32,6 +34,13 @@ class LibgpiodConan(ConanFile):
     def validate(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("libgpiod supports only Linux")
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        if not self.options.enable_bindings_cxx:
+            del self.settings.compiler.libcxx
+            del self.settings.compiler.cppstd
 
     def build_requirements(self):
         self.build_requires("libtool/2.4.6")


### PR DESCRIPTION
Specify library name and version:  libgpiod

This fixes 2 things:
- adds a `fPIC` option to the recipe
- deletes `compiler.cppstd` and `compiler.libcxx` settings when building a C library
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
