### PR TITLE
Feature/qt 6.x.x Platform/LinguistTools Components

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -711,6 +711,7 @@ class QtConan(ConanFile):
             core_reqs.append("icu::icu")
 
         _create_module("Core", core_reqs)
+        _create_module("Platform")
         if tools.Version(self.version) < "6.1.0":
             self.cpp_info.components["qtCore"].libs.append("Qt6Core_qobject%s" % libsuffix)
         if self.options.gui:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -712,6 +712,8 @@ class QtConan(ConanFile):
 
         _create_module("Core", core_reqs)
         _create_module("Platform")
+        self.cpp_info.components["qtPlatform"].libs = [] # this is a collection of abstract classes, so this is header-only
+        self.cpp_info.components["qtPlatform"].libdirs = []
         if tools.Version(self.version) < "6.1.0":
             self.cpp_info.components["qtCore"].libs.append("Qt6Core_qobject%s" % libsuffix)
         if self.options.gui:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -782,6 +782,7 @@ class QtConan(ConanFile):
             _create_module("QuickTest", ["Test"])
 
         if self.options.qttools and self.options.gui and self.options.widgets:
+            _create_module("LinguistTools", ["Gui", "Widgets"])
             _create_module("UiPlugin", ["Gui", "Widgets"])
             self.cpp_info.components["qtUiPlugin"].libs = [] # this is a collection of abstract classes, so this is header-only
             self.cpp_info.components["qtUiPlugin"].libdirs = []


### PR DESCRIPTION
Specify library name and version:  **qt/6.x.x**

The `Platform` component is a base Interface library used in auxiliary CMake files:
* https://github.com/qt/qtbase/blob/6.1.2/cmake/QtPublicTargetsHelpers.cmake

The `LinguistTools` component is a `linguist` tool component:
* https://github.com/qt/qttools/blob/6.1.2/src/linguist/CMakeLists.txt

/cc @ericLemanissier 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
