### PR TITLE
taglib: fix build when compiler does not have atomics

### DIFF
--- a/recipes/taglib/all/conandata.yml
+++ b/recipes/taglib/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "1.12":
     url: "https://taglib.org/releases/taglib-1.12.tar.gz"
     sha256: "7fccd07669a523b07a15bd24c8da1bbb92206cb19e9366c3692af3d79253b703"
+patches:
+  "1.12":
+    - patch_file: "patches/1.12-0001-fix-error-duplicate-volatile.patch"
+      base_path: "source_subfolder"

--- a/recipes/taglib/all/conanfile.py
+++ b/recipes/taglib/all/conanfile.py
@@ -24,7 +24,7 @@ class TaglibConan(ConanFile):
         "bindings": True,
     }
 
-    exports_sources = "CMakeLists.txt"
+    exports_sources = "CMakeLists.txt", "patches/*"
     generators = "cmake", "cmake_find_package"
     _cmake = None
 
@@ -60,6 +60,8 @@ class TaglibConan(ConanFile):
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/taglib/all/patches/1.12-0001-fix-error-duplicate-volatile.patch
+++ b/recipes/taglib/all/patches/1.12-0001-fix-error-duplicate-volatile.patch
@@ -1,22 +1,30 @@
-From eecfd3eeed5c98c0e0c85d7e0d093d3253ae43fe Mon Sep 17 00:00:00 2001
+From 1d24bd3399f2284104cbe87d017f87325b1797ab Mon Sep 17 00:00:00 2001
 From: Oleg Antonyan <oleg.b.antonyan@gmail.com>
-Date: Sat, 8 May 2021 21:16:58 +0200
-Subject: [PATCH] fix error: duplicate volatile
+Date: Thu, 13 May 2021 16:41:35 +0200
+Subject: [PATCH] =?UTF-8?q?Fix=20"error:=20duplicate=20=E2=80=98volatile?=
+ =?UTF-8?q?=E2=80=99"=20on=20systems=20without=20HAVE=5FGCC=5FATOMIC=20in?=
+ =?UTF-8?q?=201.12=20(#1012)?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
+* fix error: duplicate volatile
+
+* fix volatile ATOMIC_INT in constructor
 ---
  taglib/toolkit/trefcounter.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/taglib/toolkit/trefcounter.cpp b/taglib/toolkit/trefcounter.cpp
-index 18cb596c0..ae9f30935 100644
+index 18cb596c0..5b089abf9 100644
 --- a/taglib/toolkit/trefcounter.cpp
 +++ b/taglib/toolkit/trefcounter.cpp
-@@ -66,7 +66,7 @@ namespace TagLib
-     RefCounterPrivate() :
-       refCount(1) {}
- 
--    volatile ATOMIC_INT refCount;
-+    ATOMIC_INT refCount;
-   };
- 
-   RefCounter::RefCounter() :
+@@ -52,7 +52,7 @@
+ # define ATOMIC_INC(x) __sync_add_and_fetch(&x, 1)
+ # define ATOMIC_DEC(x) __sync_sub_and_fetch(&x, 1)
+ #else
+-# define ATOMIC_INT volatile int
++# define ATOMIC_INT int
+ # define ATOMIC_INC(x) (++x)
+ # define ATOMIC_DEC(x) (--x)
+ #endif

--- a/recipes/taglib/all/patches/1.12-0001-fix-error-duplicate-volatile.patch
+++ b/recipes/taglib/all/patches/1.12-0001-fix-error-duplicate-volatile.patch
@@ -1,0 +1,22 @@
+From eecfd3eeed5c98c0e0c85d7e0d093d3253ae43fe Mon Sep 17 00:00:00 2001
+From: Oleg Antonyan <oleg.b.antonyan@gmail.com>
+Date: Sat, 8 May 2021 21:16:58 +0200
+Subject: [PATCH] fix error: duplicate volatile
+
+---
+ taglib/toolkit/trefcounter.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/taglib/toolkit/trefcounter.cpp b/taglib/toolkit/trefcounter.cpp
+index 18cb596c0..ae9f30935 100644
+--- a/taglib/toolkit/trefcounter.cpp
++++ b/taglib/toolkit/trefcounter.cpp
+@@ -66,7 +66,7 @@ namespace TagLib
+     RefCounterPrivate() :
+       refCount(1) {}
+ 
+-    volatile ATOMIC_INT refCount;
++    ATOMIC_INT refCount;
+   };
+ 
+   RefCounter::RefCounter() :


### PR DESCRIPTION
Specify library name and version:  **taglib/all**

Fixes #6876

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
