### PR TITLE
Build openssl for emscripten

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -78,7 +78,6 @@ class OpenSSLConan(ConanFile):
                "386": [True, False],
                "no_stdio": [True, False],
                "no_tests": [True, False],
-               "no_hw": [True, False],
                "no_sse2": [True, False],
                "no_bf": [True, False],
                "no_cast": [True, False],
@@ -177,11 +176,6 @@ class OpenSSLConan(ConanFile):
 
         if self.settings.os == "Emscripten":
             self.options.no_asm = True
-#            self.options.no_ssl = True
-#            self.options.no_ssl3 = True
-#            self.options.no_comp = True
-#            self.options.no_hw = True
-#            self.options.no_engine = True
             self.options.no_deprecated = True
             self.options.no_dso = True
             self.options.no_threads = True

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -176,8 +176,6 @@ class OpenSSLConan(ConanFile):
 
         if self.settings.os == "Emscripten":
             self.options.no_asm = True
-            self.options.no_deprecated = True
-            self.options.no_dso = True
             self.options.no_threads = True
             self.options.no_stdio = True
             self.options.no_tests = True
@@ -860,8 +858,8 @@ class OpenSSLConan(ConanFile):
 
     def validate(self):
         if self.settings.os == "Emscripten":
-            if not all((self.options.no_asm, self.options.no_deprecated, self.options.no_dso, self.options.no_threads, self.options.no_stdio, self.options.no_tests)):
-                raise ConanInvalidConfiguration("os=Emscripten requires openssl:{no_asm,no_deprecated,no_dso,no_threads,no_stdio,no_tests}=True")
+            if not all((self.options.no_asm, self.options.no_threads, self.options.no_stdio, self.options.no_tests)):
+                raise ConanInvalidConfiguration("os=Emscripten requires openssl:{no_asm,,no_threads,no_stdio,no_tests}=True")
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "OpenSSL"

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -858,6 +858,11 @@ class OpenSSLConan(ConanFile):
         return os.path.join(self._module_subfolder,
                             "conan-official-{}-variables.cmake".format(self.name))
 
+    def validate(self):
+        if self.settings.os == "Emscripten":
+            if not all((self.options.no_asm, self.options.no_deprecated, self.options.no_dso, self.options.no_threads, self.options.no_stdio, self.options.no_tests)):
+                raise ConanInvalidConfiguration("os=Emscripten requires openssl:{no_asm,no_deprecated,no_dso,no_threads,no_stdio,no_tests}=True")
+
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "OpenSSL"
         self.cpp_info.names["cmake_find_package_multi"] = "OpenSSL"

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -76,6 +76,9 @@ class OpenSSLConan(ConanFile):
                "no_asm": [True, False],
                "enable_weak_ssl_ciphers": [True, False],
                "386": [True, False],
+               "no_stdio": [True, False],
+               "no_tests": [True, False],
+               "no_hw": [True, False],
                "no_sse2": [True, False],
                "no_bf": [True, False],
                "no_cast": [True, False],
@@ -171,6 +174,19 @@ class OpenSSLConan(ConanFile):
             del self.options.enable_capieng
         else:
             del self.options.fPIC
+
+        if self.settings.os == "Emscripten":
+            self.options.no_asm = True
+            self.options.no_ssl = True
+            self.options.no_ssl3 = True
+            self.options.no_comp = True
+            self.options.no_hw = True
+            self.options.no_engine = True
+            self.options.no_deprecated = True
+            self.options.no_dso = True
+            self.options.no_threads = True
+            self.options.no_stdio = True
+            self.options.no_tests = True
 
     def build_requirements(self):
         if tools.os_info.is_windows:

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -177,11 +177,11 @@ class OpenSSLConan(ConanFile):
 
         if self.settings.os == "Emscripten":
             self.options.no_asm = True
-            self.options.no_ssl = True
-            self.options.no_ssl3 = True
-            self.options.no_comp = True
-            self.options.no_hw = True
-            self.options.no_engine = True
+#            self.options.no_ssl = True
+#            self.options.no_ssl3 = True
+#            self.options.no_comp = True
+#            self.options.no_hw = True
+#            self.options.no_engine = True
             self.options.no_deprecated = True
             self.options.no_dso = True
             self.options.no_threads = True

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -859,7 +859,7 @@ class OpenSSLConan(ConanFile):
     def validate(self):
         if self.settings.os == "Emscripten":
             if not all((self.options.no_asm, self.options.no_threads, self.options.no_stdio, self.options.no_tests)):
-                raise ConanInvalidConfiguration("os=Emscripten requires openssl:{no_asm,,no_threads,no_stdio,no_tests}=True")
+                raise ConanInvalidConfiguration("os=Emscripten requires openssl:{no_asm,no_threads,no_stdio,no_tests}=True")
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "OpenSSL"


### PR DESCRIPTION
Made few changes which make it possible to build OpenSSL for Emsccripten very easy.

Emscripten installed as per manual on official website emscripten.org.
Emscripten activated in terminal/console and using custom profile below.

```
[settings]
os=Emscripten
arch=wasm
compiler=emcc
compiler.version=2.0.13
compiler.libcxx=libc++
build_type=Release
[options]

[env]
CONAN_CMAKE_FIND_ROOT_PATH=$EMSDK/upstream/emscripten/system
CONAN_CMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
CC="emcc"
AR="emar"
RANLIB="emranlib"
```

the command used to build library
`conan create . openssl/1.1.1k@ -pr emsdk_profile`

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
