### PR TITLE
moltenvk: append moltenvk icd to VK_ICD_FILENAMES env var if shared + modernize

### DIFF
--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.32.0"
+required_conan_version = ">=1.33.0"
 
 
 class MoltenVKConan(ConanFile):
@@ -123,8 +123,8 @@ class MoltenVKConan(ConanFile):
                 raise ConanInvalidConfiguration("MoltenVK {} requires XCode 12.0 or higher at build time".format(self.version))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("MoltenVK-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -155,6 +155,11 @@ class MoltenVKConan(ConanFile):
         elif self.settings.os in ["iOS", "tvOS"]:
             self.cpp_info.frameworks.append("UIKit")
 
+        if self.options.shared:
+            moltenvk_icd_path = os.path.join(self.package_folder, "lib", "MoltenVK_icd.json")
+            self.output.info("Appending VK_ICD_FILENAMES environment variable: {}".format(moltenvk_icd_path))
+            self.env_info.VK_ICD_FILENAMES.append(moltenvk_icd_path)
+
         if self.options.tools:
             bin_path = os.path.join(self.package_folder, "bin")
             self.output.info("Appending PATH environment variable: {}".format(bin_path))

--- a/recipes/moltenvk/all/conanfile.py
+++ b/recipes/moltenvk/all/conanfile.py
@@ -42,12 +42,6 @@ class MoltenVKConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 11)
-        if self.settings.os not in ["Macos", "iOS", "tvOS"]:
-            raise ConanInvalidConfiguration("MoltenVK only supported on MacOS, iOS and tvOS")
-        if self.settings.compiler != "apple-clang":
-            raise ConanInvalidConfiguration("MoltenVK requires apple-clang")
 
     def requirements(self):
         self.requires("cereal/1.3.0")
@@ -118,6 +112,12 @@ class MoltenVKConan(ConanFile):
                 self.compatible_packages.append(compatible_pkg)
 
     def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+        if self.settings.os not in ["Macos", "iOS", "tvOS"]:
+            raise ConanInvalidConfiguration("MoltenVK only supported on MacOS, iOS and tvOS")
+        if self.settings.compiler != "apple-clang":
+            raise ConanInvalidConfiguration("MoltenVK requires apple-clang")
         if tools.Version(self.version) >= "1.0.42":
             if tools.Version(self.settings.compiler.version) < "12.0":
                 raise ConanInvalidConfiguration("MoltenVK {} requires XCode 12.0 or higher at build time".format(self.version))

--- a/recipes/moltenvk/all/test_package/conanfile.py
+++ b/recipes/moltenvk/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Vulkan-loader searches in several standard paths a manifest file related to an ICD to load (usually provided by the graphical driver, except on Apple OS).
On Apple OS, MoltenVK is the (unofficial) ICD you want to load (if you use vulkan-loader, because MoltenVK is a little bit special, you can also link directly to it without Vulkan-loader but you lose some nice features like validation layers), but the conan package is obviously not installed in a standard path.
Vulkan-loader also looks into json files listed in `VK_ICD_FILENAMES` environment variable, so we add abs path of MoltenVK manifest file to this var. Obviously, when MoltenVK is static, it can't be used as an ICD by Vulkan-Loader, so it doesn't make sense to add this path in `VK_ICD_FILENAMES` (and actually the manifest file is not even installed if static).

(In Vulkan SDK of LunarG for macOS, those environment variables are optionals, because they install files in /usr/local).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
