### PR TITLE
Add nmos-cpp

### DIFF
--- a/recipes/nmos-cpp/all/CMakeLists.txt
+++ b/recipes/nmos-cpp/all/CMakeLists.txt
@@ -2,12 +2,7 @@
 cmake_minimum_required(VERSION 3.17)
 project(cmake_wrapper)
 
-if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-    include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-else()
-    # for out-of-source builds
-    include(conanbuildinfo.cmake)
-endif()
+include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 # conanfile.py source() method extracts to source_subfolder

--- a/recipes/nmos-cpp/all/CMakeLists.txt
+++ b/recipes/nmos-cpp/all/CMakeLists.txt
@@ -1,0 +1,15 @@
+# see https://github.com/conan-io/cmake-conan/issues/249#issuecomment-737011732
+cmake_minimum_required(VERSION 3.17)
+project(cmake_wrapper)
+
+if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+else()
+    # for out-of-source builds
+    include(conanbuildinfo.cmake)
+endif()
+conan_basic_setup()
+
+# conanfile.py source() method extracts to source_subfolder
+# nmos-cpp top-level CMakeLists.txt is in Development
+add_subdirectory("source_subfolder/Development")

--- a/recipes/nmos-cpp/all/conandata.yml
+++ b/recipes/nmos-cpp/all/conandata.yml
@@ -1,5 +1,5 @@
 sources:
   # see https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-version-should-packages-use-for-libraries-without-official-releases
-  "cci.20210828":
-    url: "https://github.com/garethsb/nmos-cpp/archive/841b5cd6f5a3378e724d451463cd939bfa605843.tar.gz"
-    sha256: "4a02415065af3a7c60c6464872bca150bb1be65e2a51c7d7095c42b375d03270"
+  "cci.20210831":
+    url: "https://github.com/sony/nmos-cpp/archive/a657d5ef2e07431cace2baeb0f6acbc9be9f290a.tar.gz"
+    sha256: "e5b3f8886f11d8cfb063a53bba4ab5fbe1668464637d6ebbe16a5075feafeeca"

--- a/recipes/nmos-cpp/all/conandata.yml
+++ b/recipes/nmos-cpp/all/conandata.yml
@@ -1,5 +1,5 @@
 sources:
   # see https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-version-should-packages-use-for-libraries-without-official-releases
-  "cci.20210827":
-    url: "https://github.com/sony/nmos-cpp/archive/14663d595f71d51136ffcd60dd469197bfcbf17d.tar.gz"
-    sha256: "de3fef5bcaefad06c3b5d8452f341701e4c938568672ab6204210a12dd673a17"
+  "cci.20210828":
+    url: "https://github.com/garethsb/nmos-cpp/archive/841b5cd6f5a3378e724d451463cd939bfa605843.tar.gz"
+    sha256: "4a02415065af3a7c60c6464872bca150bb1be65e2a51c7d7095c42b375d03270"

--- a/recipes/nmos-cpp/all/conandata.yml
+++ b/recipes/nmos-cpp/all/conandata.yml
@@ -1,5 +1,5 @@
 sources:
   # see https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-version-should-packages-use-for-libraries-without-official-releases
-  "cci.20210831":
-    url: "https://github.com/sony/nmos-cpp/archive/a657d5ef2e07431cace2baeb0f6acbc9be9f290a.tar.gz"
-    sha256: "e5b3f8886f11d8cfb063a53bba4ab5fbe1668464637d6ebbe16a5075feafeeca"
+  "cci.20210902":
+    url: "https://github.com/sony/nmos-cpp/archive/d3a8c7935f80ce5de6d4727c307ddcef667b5d57.tar.gz"
+    sha256: "f5bd0b96542810ac1ed3ebaf7237d7471f3c42e68d966ae8b2d39db2601a38f9"

--- a/recipes/nmos-cpp/all/conandata.yml
+++ b/recipes/nmos-cpp/all/conandata.yml
@@ -1,4 +1,5 @@
 sources:
   # see https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-version-should-packages-use-for-libraries-without-official-releases
-  "cci.20210826":
-    url: https://github.com/garethsb/nmos-cpp/archive/7f085d9cca890cf518677f4fd2b18e77db4e249a.tar.gz
+  "cci.20210827":
+    url: "https://github.com/sony/nmos-cpp/archive/14663d595f71d51136ffcd60dd469197bfcbf17d.tar.gz"
+    sha256: "de3fef5bcaefad06c3b5d8452f341701e4c938568672ab6204210a12dd673a17"

--- a/recipes/nmos-cpp/all/conandata.yml
+++ b/recipes/nmos-cpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   # see https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-version-should-packages-use-for-libraries-without-official-releases
-  "cci.20210817":
-    url: https://github.com/garethsb/nmos-cpp/archive/59e8f39474f09001513ae18a3316fa7c3210aa0f.tar.gz
+  "cci.20210826":
+    url: https://github.com/garethsb/nmos-cpp/archive/7f085d9cca890cf518677f4fd2b18e77db4e249a.tar.gz

--- a/recipes/nmos-cpp/all/conandata.yml
+++ b/recipes/nmos-cpp/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  # see https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-version-should-packages-use-for-libraries-without-official-releases
+  "cci.YYYYMMDD":
+    url: https://github.com/sony/nmos-cpp/archive/<last-commit-id-on-YYYYMMDD>.tar.gz
+  "sony.master":
+    url: https://github.com/sony/nmos-cpp/archive/master.tar.gz
+  "garethsb.library-cmake":
+    url: https://github.com/garethsb/nmos-cpp/archive/library-cmake.tar.gz

--- a/recipes/nmos-cpp/all/conandata.yml
+++ b/recipes/nmos-cpp/all/conandata.yml
@@ -1,8 +1,4 @@
 sources:
   # see https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-version-should-packages-use-for-libraries-without-official-releases
-  "cci.YYYYMMDD":
-    url: https://github.com/sony/nmos-cpp/archive/<last-commit-id-on-YYYYMMDD>.tar.gz
-  "sony.master":
-    url: https://github.com/sony/nmos-cpp/archive/master.tar.gz
-  "garethsb.library-cmake":
-    url: https://github.com/garethsb/nmos-cpp/archive/library-cmake.tar.gz
+  "cci.20210817":
+    url: https://github.com/garethsb/nmos-cpp/archive/59e8f39474f09001513ae18a3316fa7c3210aa0f.tar.gz

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -63,7 +63,8 @@ class NmosCppConan(ConanFile):
             self.requires("avahi/0.8")
 
     def build_requirements(self):
-        self.build_requires("cmake/[>3.17]")
+        # nmos-cpp needs CMake 3.17 or higher but CCI doesn't allow version ranges
+        self.build_requires("cmake/3.21.1")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -30,6 +30,8 @@ class NmosCppConan(ConanFile):
     # use cmake_find_package_multi and prefer config-file packages
     generators = "cmake", "cmake_find_package_multi"
 
+    short_paths = True
+
     _cmake = None
 
     # for out-of-source build, cf. wrapper CMakeLists.txt

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -65,6 +65,10 @@ class NmosCppConan(ConanFile):
     def build_requirements(self):
         self.build_requires("cmake/[>3.17]")
 
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -54,10 +54,10 @@ class NmosCppConan(ConanFile):
         self.requires("websocketpp/0.8.2")
         self.requires("openssl/1.1.1k")
         self.requires("json-schema-validator/2.1.0")
-        if self.options.with_dnssd == "mdnsresponder":
+        if self.options.get_safe("with_dnssd") == "mdnsresponder":
             self.requires("mdnsresponder/878.200.35")
             self.options["mdnsresponder"].with_opt_patches = True
-        elif self.options.with_dnssd == "avahi":
+        elif self.options.get_safe("with_dnssd") == "avahi":
             self.requires("avahi/0.8")
 
     def source(self):
@@ -72,7 +72,7 @@ class NmosCppConan(ConanFile):
         # over any system-installed find-module packages
         self._cmake.definitions["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = True
         # (on Linux) select Avahi or mDNSResponder
-        self._cmake.definitions["NMOS_CPP_USE_AVAHI"] = self.options.with_dnssd == "avahi"
+        self._cmake.definitions["NMOS_CPP_USE_AVAHI"] = self.options.get_safe("with_dnssd") == "avahi"
         # (on Windows) use the Conan package for DNSSD (mdnsresponder), not the project's own DLL stub library
         self._cmake.definitions["NMOS_CPP_USE_BONJOUR_SDK"] = True
         # no need to build unit tests

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -35,8 +35,13 @@ class NmosCppConan(ConanFile):
     _cmake = None
 
     # for out-of-source build, cf. wrapper CMakeLists.txt
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -59,7 +59,7 @@ class NmosCppConan(ConanFile):
         self.requires("boost/1.76.0")
         self.requires("cpprestsdk/2.10.18")
         self.requires("websocketpp/0.8.2")
-        self.requires("openssl/1.1.1l")
+        self.requires("openssl/1.1.1k")
         self.requires("json-schema-validator/2.1.0")
 
         if self.options.get_safe("with_dnssd") == "mdnsresponder":

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -165,6 +165,8 @@ class NmosCppConan(ConanFile):
                                 elif dependency == "DNSSD::DNSSD":
                                     dependency = "mdnsresponder::mdnsresponder"
                                 components[component_name].setdefault("requires" if not match_private else "requires_private", []).append(dependency.lower())
+                            elif "${_IMPORT_PREFIX}/lib/" in dependency:
+                                self.output.warn("{} recipe does not handle {} {} (yet)".format(self.name, property_type, dependency))
                             else:
                                 components[component_name].setdefault("system_libs", []).append(dependency)
                     elif property_type == "INTERFACE_COMPILE_DEFINITIONS":
@@ -173,7 +175,7 @@ class NmosCppConan(ConanFile):
                     elif property_type == "INTERFACE_COMPILE_FEATURES":
                         for property_value in property_values:
                             if property_value not in ["cxx_std_11"]:
-                                self.output.warn("{} recipe does not handle INTERFACE_COMPILE_FEATURE {}".format(self.name, property_value))
+                                self.output.warn("{} recipe does not handle {} {} (yet)".format(self.name, property_type, property_value))
                     elif property_type == "INTERFACE_COMPILE_OPTIONS":
                         for property_value in property_values:
                             # handle forced include (Visual Studio /FI, gcc -include) by relying on includedirs containing "include"
@@ -182,7 +184,7 @@ class NmosCppConan(ConanFile):
                     elif property_type == "INTERFACE_INCLUDE_DIRECTORIES":
                         for property_value in property_values:
                             if property_value not in ["${_IMPORT_PREFIX}/include"]:
-                                self.output.warn("{} recipe does not handle INTERFACE_INCLUDE_DIRECTORIES {}".format(self.name, property_value))
+                                self.output.warn("{} recipe does not handle {} {} (yet)".format(self.name, property_type, property_value))
                     elif property_type == "INTERFACE_LINK_OPTIONS":
                         for property_value in property_values:
                             # workaround required because otherwise "/ignore:4099" gets converted to "\ignore:4099.obj"
@@ -194,7 +196,7 @@ class NmosCppConan(ConanFile):
                             property_value = re.sub(r"^/", r"-", property_value)
                             components[component_name].setdefault("linkflags", []).append(property_value)
                     else:
-                        self.output.warn("{} recipe does not handle {}".format(self.name, property_type))
+                        self.output.warn("{} recipe does not handle {} (yet)".format(self.name, property_type))
 
         # Save components informations in json file
         with open(self._components_helper_filepath, "w") as json_file:

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -60,6 +60,9 @@ class NmosCppConan(ConanFile):
         elif self.options.get_safe("with_dnssd") == "avahi":
             self.requires("avahi/0.8")
 
+    def build_requirements(self):
+        self.build_requires("cmake/[>3.17]")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -115,17 +115,20 @@ class NmosCppConan(ConanFile):
             # Conan component name cannot be the same as the package name
             if component_name == "nmos-cpp":
                 component_name = "nmos-cpp-lib"
-            lib_name = cmake_target_nonamespace
-            # hmm, where is this info?
-            # set_property(TARGET Bonjour PROPERTY OUTPUT_NAME dnssd)
-            if lib_name == "Bonjour":
-                lib_name = "dnssd"
 
             components.setdefault(component_name, {"cmake_target": cmake_target_nonamespace})
 
             if cmake_function_name == "add_library":
                 cmake_imported_target_type = cmake_function_args[1]
                 if cmake_imported_target_type in ["STATIC", "SHARED"]:
+                    # library filenames are based on the target name by default
+                    lib_name = cmake_target_nonamespace
+                    # the filename may be changed by a straightforward command:
+                    # set_property(TARGET Bonjour PROPERTY OUTPUT_NAME dnssd)
+                    # but we'd have to read the nmos-cpp-targets-<config>.cmake files
+                    # and parse the IMPORTED_LOCATION_<CONFIG> values
+                    if lib_name == "Bonjour":
+                        lib_name = "dnssd"
                     components[component_name]["libs"] = [lib_name]
             elif cmake_function_name == "set_target_properties":
                 target_properties = re.findall(r"(?P<property>INTERFACE_[A-Z_]+)[\n|\s]+\"(?P<values>.+)\"", cmake_function_args[2])

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -54,7 +54,7 @@ class NmosCppConan(ConanFile):
         self.requires("boost/1.76.0")
         self.requires("cpprestsdk/2.10.18")
         self.requires("websocketpp/0.8.2")
-        self.requires("openssl/1.1.1k")
+        self.requires("openssl/1.1.1l")
         self.requires("json-schema-validator/2.1.0")
 
         if self.options.get_safe("with_dnssd") == "mdnsresponder":

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -112,9 +112,7 @@ class NmosCppConan(ConanFile):
     def _create_components_file_from_cmake_target_file(self, target_file_path):
         components = {}
 
-        target_file = open(target_file_path, "r")
-        target_content = target_file.read()
-        target_file.close()
+        target_content = tools.load(target_file_path)
 
         cmake_functions = re.findall(r"(?P<func>add_library|set_target_properties)[\n|\s]*\([\n|\s]*(?P<args>[^)]*)\)", target_content)
         for (cmake_function_name, cmake_function_args) in cmake_functions:

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -59,7 +59,7 @@ class NmosCppConan(ConanFile):
         self.requires("boost/1.76.0")
         self.requires("cpprestsdk/2.10.18")
         self.requires("websocketpp/0.8.2")
-        self.requires("openssl/1.1.1k")
+        self.requires("openssl/1.1.1l")
         self.requires("json-schema-validator/2.1.0")
 
         if self.options.get_safe("with_dnssd") == "mdnsresponder":
@@ -73,7 +73,7 @@ class NmosCppConan(ConanFile):
 
     def build_requirements(self):
         # nmos-cpp needs CMake 3.17 or higher but CCI doesn't allow version ranges
-        self.build_requires("cmake/3.21.1")
+        self.build_requires("cmake/3.21.2")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -56,7 +56,7 @@ class NmosCppConan(ConanFile):
         self.requires("json-schema-validator/2.1.0")
         if self.options.get_safe("with_dnssd") == "mdnsresponder":
             self.requires("mdnsresponder/878.200.35")
-            self.options["mdnsresponder"].with_opt_patches = True
+            #self.options["mdnsresponder"].with_opt_patches = True
         elif self.options.get_safe("with_dnssd") == "avahi":
             self.requires("avahi/0.8")
 

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -59,7 +59,10 @@ class NmosCppConan(ConanFile):
 
         if self.options.get_safe("with_dnssd") == "mdnsresponder":
             self.requires("mdnsresponder/878.200.35")
-            #self.options["mdnsresponder"].with_opt_patches = True
+            # The option mdnsresponder:with_opt_patches=True is recommended in order to permit the
+            # over-long service type _nmos-registration._tcp used in IS-04 v1.2, and also to enable
+            # support for unicast DNS-SD on Linux, since NMOS recommends this in preference to mDNS.
+            # See https://specs.amwa.tv/is-04/releases/v1.3.1/docs/3.1._Discovery_-_Registered_Operation.html#dns-sd-advertisement
         elif self.options.get_safe("with_dnssd") == "avahi":
             self.requires("avahi/0.8")
 

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -11,7 +11,7 @@ class NmosCppConan(ConanFile):
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/sony/nmos-cpp"
-    topics = ("NMOS")
+    topics = ("amwa", "nmos", "is-04", "is-05", "is-07", "is-08", "is-09", "broadcasting", "network", "media")
 
     settings = "os", "compiler", "build_type", "arch"
     # for now, no "shared" option support

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -56,6 +56,7 @@ class NmosCppConan(ConanFile):
         self.requires("websocketpp/0.8.2")
         self.requires("openssl/1.1.1k")
         self.requires("json-schema-validator/2.1.0")
+
         if self.options.get_safe("with_dnssd") == "mdnsresponder":
             self.requires("mdnsresponder/878.200.35")
             #self.options["mdnsresponder"].with_opt_patches = True

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -42,6 +42,24 @@ class NmosCppConan(ConanFile):
         self.requires("openssl/1.1.1k")
         self.requires("json-schema-validator/2.1.0")
 
+    def system_requirements(self):
+        packages = []
+        if self.settings.os == "Windows":
+            self.output.warn("Bonjour must be installed on Windows, see https://developer.apple.com/bonjour/")
+        elif self.settings.os == "Macos":
+            pass
+        elif self.settings.os == "Linux" and tools.os_info.is_linux:
+            if tools.os_info.with_apt:
+                packages = ["libavahi-compat-libdnssd-dev", "libnss-mdns", "avahi-utils"]
+            else:
+                self.output.warn("Do not know how to install Avahi Apple Bonjour compatibility library for {}.".format(tools.os_info.linux_distro))
+        else:
+            self.output.warn("Do not know how to install Avahi Apple Bonjour compatibility library for {}.".format(self.settings.os))
+        if packages:
+            package_tool = tools.SystemPackageTool(conanfile=self, default_mode='verify')
+            for package in packages:
+                package_tool.install(update=True, packages=package)
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -1,0 +1,191 @@
+import json
+import os
+import re
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.33.0"
+
+class NmosCppConan(ConanFile):
+    name = "nmos-cpp"
+    description = "An NMOS C++ Implementation"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/sony/nmos-cpp"
+    topics = ("NMOS")
+
+    settings = "os", "compiler", "build_type", "arch"
+    # for now, no "shared" option support
+    options = {"fPIC": [True, False]}
+    # "fPIC" is handled automatically by Conan, injecting CMAKE_POSITION_INDEPENDENT_CODE
+    default_options = {"fPIC": True}
+
+    # wrapper CMakeLists.txt to call conan_basic_setup()
+    exports_sources = ["CMakeLists.txt"]
+    # use cmake_find_package_multi and prefer config-file packages
+    generators = "cmake", "cmake_find_package_multi"
+
+    _cmake = None
+
+    # for out-of-source build, cf. wrapper CMakeLists.txt
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def requirements(self):
+        # for now, consistent with project's conanfile.txt
+        self.requires("boost/1.76.0")
+        self.requires("cpprestsdk/2.10.18")
+        self.requires("websocketpp/0.8.2")
+        self.requires("openssl/1.1.1k")
+        self.requires("json-schema-validator/2.1.0")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        # prefer config-file packages created by cmake_find_package_multi
+        # over any system-installed find-module packages
+        self._cmake.definitions["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = True
+        # no need to build unit tests
+        self._cmake.definitions["NMOS_CPP_BUILD_TESTS"] = False
+        # the examples (nmos-cpp-registry and nmos-cpp-node) are useful utilities for users
+        self._cmake.definitions["NMOS_CPP_BUILD_EXAMPLES"] = True
+        # out-of-source build
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        cmake_folder = os.path.join(self.package_folder, "lib", "cmake")
+        self._create_components_file_from_cmake_target_file(os.path.join(cmake_folder, "nmos-cpp", "nmos-cpp-targets.cmake"))
+        # remove the project's own generated config-file package
+        tools.rmdir(cmake_folder)
+
+    # based on abseil recipe
+    # see https://github.com/conan-io/conan-center-index/blob/master/recipes/abseil/all/conanfile.py
+    def _create_components_file_from_cmake_target_file(self, target_file_path):
+        components = {}
+
+        target_file = open(target_file_path, "r")
+        target_content = target_file.read()
+        target_file.close()
+
+        cmake_functions = re.findall(r"(?P<func>add_library|set_target_properties)[\n|\s]*\([\n|\s]*(?P<args>[^)]*)\)", target_content)
+        for (cmake_function_name, cmake_function_args) in cmake_functions:
+            cmake_function_args = re.split(r"[\s|\n]+", cmake_function_args, maxsplit=2)
+
+            cmake_imported_target_name = cmake_function_args[0]
+            cmake_target_nonamespace = cmake_imported_target_name.replace("nmos-cpp::", "")
+            component_name = cmake_target_nonamespace.lower()
+            # Conan component name cannot be the same as the package name
+            if component_name == "nmos-cpp":
+                component_name = "nmos-cpp-lib"
+            lib_name = cmake_target_nonamespace
+            # hmm, where is this info?
+            # set_property(TARGET Bonjour PROPERTY OUTPUT_NAME dnssd)
+            if lib_name == "Bonjour":
+                lib_name = "dnssd"
+
+            components.setdefault(component_name, {"cmake_target": cmake_target_nonamespace})
+
+            if cmake_function_name == "add_library":
+                cmake_imported_target_type = cmake_function_args[1]
+                if cmake_imported_target_type in ["STATIC", "SHARED"]:
+                    components[component_name]["libs"] = [lib_name]
+            elif cmake_function_name == "set_target_properties":
+                target_properties = re.findall(r"(?P<property>INTERFACE_[A-Z_]+)[\n|\s]+\"(?P<values>.+)\"", cmake_function_args[2])
+                for target_property in target_properties:
+                    property_type = target_property[0]
+                    # '\', '$' and '"' are escaped; '$' especially is important here
+                    # see https://github.com/conan-io/conan/blob/release/1.39/conans/client/generators/cmake_common.py#L43-L48
+                    property_values = re.sub(r"\\(.)", r"\1", target_property[1]).split(";")
+                    if property_type == "INTERFACE_LINK_LIBRARIES":
+                        for dependency in property_values:
+                            match_private = re.fullmatch(r"\$<LINK_ONLY:(.+)>", dependency)
+                            if match_private:
+                                dependency = match_private.group(1)
+                            if "::" in dependency:
+                                dependency = dependency.replace("nmos-cpp::", "")
+                                # Conan component name cannot be the same as the package name
+                                if dependency == "nmos-cpp":
+                                    dependency = "nmos-cpp-lib"
+                                # Conan packages for Boost, cpprestsdk, websocketpp and OpenSSL have component names that match the CMake targets
+                                # json-schema-validator overrides cmake_find_package[_multi] names
+                                elif dependency == "nlohmann_json_schema_validator::nlohmann_json_schema_validator":
+                                    dependency = "json-schema-validator::json-schema-validator"
+                                components[component_name].setdefault("requires" if not match_private else "requires_private", []).append(dependency.lower())
+                            else:
+                                components[component_name].setdefault("system_libs", []).append(dependency)
+                    elif property_type == "INTERFACE_COMPILE_DEFINITIONS":
+                        for property_value in property_values:
+                            components[component_name].setdefault("defines", []).append(property_value)
+                    elif property_type == "INTERFACE_COMPILE_OPTIONS":
+                        for property_value in property_values:
+                            components[component_name].setdefault("cxxflags", []).append(property_value)
+                    elif property_type == "INTERFACE_LINK_OPTIONS":
+                        for property_value in property_values:
+                            # workaround required because otherwise "/ignore:4099" gets converted to "\ignore:4099.obj"
+                            # thankfully the MSVC linker accepts both '/' and '-' for the option specifier and Visual Studio
+                            # handles link options appearing in Link/AdditionalDependencies rather than Link/AdditionalOptions
+                            # because the CMake generators put them in INTERFACE_LINK_LIBRARIES rather than INTERFACE_LINK_OPTIONS
+                            # see https://github.com/conan-io/conan/pull/8812
+                            # and https://docs.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-160#command-line
+                            property_value = re.sub(r"^/", r"-", property_value)
+                            components[component_name].setdefault("linkflags", []).append(property_value)
+
+        # Save components informations in json file
+        with open(self._components_helper_filepath, "w") as json_file:
+            json.dump(components, json_file, indent=4)
+
+    @property
+    def _components_helper_filepath(self):
+        return os.path.join(self.package_folder, "lib", "components.json")
+
+    def package_info(self):
+        bindir = "bin"
+        libdir = "lib"
+        # on Windows, cmake_install() puts the binaries in a config-specific sub-folder
+        if self.settings.os == "Windows":
+            config_install_dir = "Debug" if self.settings.build_type == "Debug" else "Release"
+            bindir = os.path.join(bindir, config_install_dir)
+            libdir = os.path.join(libdir, config_install_dir)
+
+        def _register_components():
+            components_json_file = tools.load(self._components_helper_filepath)
+            components = json.loads(components_json_file)
+            for component_name, values in components.items():
+                cmake_target = values["cmake_target"]
+                self.cpp_info.components[component_name].names["cmake_find_package"] = cmake_target
+                self.cpp_info.components[component_name].names["cmake_find_package_multi"] = cmake_target
+                self.cpp_info.components[component_name].libs = values.get("libs", [])
+                self.cpp_info.components[component_name].libdirs = [libdir]
+                self.cpp_info.components[component_name].defines = values.get("defines", [])
+                self.cpp_info.components[component_name].cxxflags = values.get("cxxflags", [])
+                linkflags = values.get("linkflags", [])
+                self.cpp_info.components[component_name].sharedlinkflags = linkflags
+                self.cpp_info.components[component_name].exelinkflags = linkflags
+                self.cpp_info.components[component_name].system_libs = values.get("system_libs", [])
+                self.cpp_info.components[component_name].frameworks = values.get("frameworks", [])
+                self.cpp_info.components[component_name].requires = values.get("requires", [])
+                # hmm, how should private requirements be indicated? this results in a string format error...
+                #self.cpp_info.components[component_name].requires.extend([(r, "private") for r in values.get("requires_private", [])])
+                self.cpp_info.components[component_name].requires.extend(values.get("requires_private", []))
+        _register_components()
+
+        # add nmos-cpp-registry and nmos-cpp-node to the path
+        bin_path = os.path.join(self.package_folder, bindir)
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -42,10 +42,10 @@ class NmosCppConan(ConanFile):
 
         if self.settings.os == "Macos":
             del self.options.with_dnssd
-        elif self.settings.os == "Linux":
-            self.options.with_dnssd = "avahi"
-        elif self.settings.os == "Windows":
-            self.options.with_dnssd = "bonjour"
+        #elif self.settings.os == "Linux":
+        #    self.options.with_dnssd = "avahi"
+        #elif self.settings.os == "Windows":
+        #    self.options.with_dnssd = "bonjour"
 
     @property
     def _with_dnssd_requires(self):

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -126,7 +126,7 @@ class NmosCppConan(ConanFile):
                 if cmake_imported_target_type in ["STATIC", "SHARED"]:
                     components[component_name]["libs"] = [lib_name]
                 # inject the DNS-SD dependency as the CMake isn't currently using find_package for this
-                if component_name == "DNSSD":
+                if cmake_target_nonamespace == "DNSSD":
                     dependency = None
                     if self.options.with_dnssd == "avahi":
                         dependency = "avahi-mdnsresponder::avahi-mdnsresponder"

--- a/recipes/nmos-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/nmos-cpp/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(NmosCppTestPackage CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(nmos-cpp REQUIRED)
 

--- a/recipes/nmos-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/nmos-cpp/all/test_package/CMakeLists.txt
@@ -8,3 +8,4 @@ find_package(nmos-cpp REQUIRED)
 
 add_executable(test_package main.cpp)
 target_link_libraries(test_package nmos-cpp::compile-settings nmos-cpp::nmos-cpp)
+set_target_properties(test_package PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)

--- a/recipes/nmos-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/nmos-cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(NmosCppTestPackage CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(nmos-cpp REQUIRED)
+
+add_executable(test_package main.cpp)
+target_link_libraries(test_package nmos-cpp::compile-settings nmos-cpp::nmos-cpp)

--- a/recipes/nmos-cpp/all/test_package/conanfile.py
+++ b/recipes/nmos-cpp/all/test_package/conanfile.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+from six import StringIO
+from conans import ConanFile, CMake, tools
+
+class NmosCppTestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    # use cmake_find_package_multi because the project installs a config-file package
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            with open("registry-config.json", "w") as config:
+                config.write('{"http_port": 10000, "domain": "local.", "pri": 51967}')
+            with open("node-config.json", "w") as config:
+                config.write('{"http_port": 20000, "domain": "local.", "highest_pri": 51967, "lowest_pri": 51967}')
+
+            # start up the installed nmos-cpp-registry to check it works
+            registry = subprocess.Popen(["nmos-cpp-registry", "registry-config.json"],
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.STDOUT,
+                                        universal_newlines=True)
+
+            # run the test_package node which should have time to register and then exit
+            node_out = StringIO()
+            try:
+                bin_path = os.path.join("bin", "test_package")
+                self.run(bin_path + " node-config.json", run_environment=True, output=node_out)
+            finally:
+                registry.terminate()
+            if "Adopting registered operation" not in node_out.getvalue():
+                self.output.warn("test_package node failed to register with nmos-cpp-registry\n"
+                                 "\n"
+                                 "nmos-cpp-registry log:\n"
+                                 "{}\n"
+                                 "test_package log:\n"
+                                 "{}"
+                                 .format(registry.communicate()[0], node_out.getvalue()))

--- a/recipes/nmos-cpp/all/test_package/main.cpp
+++ b/recipes/nmos-cpp/all/test_package/main.cpp
@@ -32,9 +32,9 @@ int main(int argc, char* argv[])
         nmos::server_guard node_server_guard(node_server);
         std::this_thread::sleep_for(std::chrono::milliseconds(how_long(node_model.settings)));
     }
-    catch (const web::http::http_exception& e)
+    catch (const std::exception& e)
     {
-        slog::log<slog::severities::error>(gate, SLOG_FLF) << "HTTP error: " << e.what() << " [" << e.error_code() << "]";
+        slog::log<slog::severities::error>(gate, SLOG_FLF) << "Exception: " << e.what();
     }
     return 0;
 }

--- a/recipes/nmos-cpp/all/test_package/main.cpp
+++ b/recipes/nmos-cpp/all/test_package/main.cpp
@@ -8,7 +8,7 @@
 #include "nmos/node_server.h"
 #include "nmos/server.h"
 
-const web::json::field_with_default<std::chrono::milliseconds::rep> how_long{ U("how_long"), 2000 };
+const web::json::field_with_default<int64_t> how_long{ U("how_long"), 2000 };
 
 int main(int argc, char* argv[])
 {

--- a/recipes/nmos-cpp/all/test_package/main.cpp
+++ b/recipes/nmos-cpp/all/test_package/main.cpp
@@ -1,0 +1,33 @@
+#include <fstream>
+#include <thread>
+#include "cpprest/json_utils.h"
+#include "nmos/id.h"
+#include "nmos/log_gate.h"
+#include "nmos/model.h"
+#include "nmos/node_resource.h"
+#include "nmos/node_server.h"
+#include "nmos/server.h"
+
+const web::json::field_with_default<std::chrono::milliseconds::rep> how_long{ U("how_long"), 2000 };
+
+int main(int argc, char* argv[])
+{
+    nmos::node_model node_model;
+    nmos::experimental::log_model log_model;
+    nmos::experimental::log_gate gate(std::cerr, std::cout, log_model);
+    nmos::experimental::node_implementation node_implementation;
+
+    if (argc > 1)
+    {
+        std::ifstream file(argv[1]);
+        node_model.settings = web::json::value::parse(file);
+    }
+    nmos::insert_node_default_settings(node_model.settings);
+
+    auto node_server = nmos::experimental::make_node_server(node_model, node_implementation, log_model, gate);
+    nmos::insert_resource(node_model.node_resources, nmos::make_node(nmos::make_id(), node_model.settings));
+
+    nmos::server_guard node_server_guard(node_server);
+    std::this_thread::sleep_for(std::chrono::milliseconds(how_long(node_model.settings)));
+    return 0;
+}

--- a/recipes/nmos-cpp/all/test_package/main.cpp
+++ b/recipes/nmos-cpp/all/test_package/main.cpp
@@ -27,7 +27,14 @@ int main(int argc, char* argv[])
     auto node_server = nmos::experimental::make_node_server(node_model, node_implementation, log_model, gate);
     nmos::insert_resource(node_model.node_resources, nmos::make_node(nmos::make_id(), node_model.settings));
 
-    nmos::server_guard node_server_guard(node_server);
-    std::this_thread::sleep_for(std::chrono::milliseconds(how_long(node_model.settings)));
+    try
+    {
+        nmos::server_guard node_server_guard(node_server);
+        std::this_thread::sleep_for(std::chrono::milliseconds(how_long(node_model.settings)));
+    }
+    catch (const web::http::http_exception& e)
+    {
+        slog::log<slog::severities::error>(gate, SLOG_FLF) << "HTTP error: " << e.what() << " [" << e.error_code() << "]";
+    }
     return 0;
 }

--- a/recipes/nmos-cpp/config.yml
+++ b/recipes/nmos-cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20210827":
+  "cci.20210828":
     folder: all

--- a/recipes/nmos-cpp/config.yml
+++ b/recipes/nmos-cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20210831":
+  "cci.20210902":
     folder: all

--- a/recipes/nmos-cpp/config.yml
+++ b/recipes/nmos-cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20210828":
+  "cci.20210831":
     folder: all

--- a/recipes/nmos-cpp/config.yml
+++ b/recipes/nmos-cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20210826":
+  "cci.20210827":
     folder: all

--- a/recipes/nmos-cpp/config.yml
+++ b/recipes/nmos-cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20210817":
+  "cci.20210826":
     folder: all

--- a/recipes/nmos-cpp/config.yml
+++ b/recipes/nmos-cpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20210817":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **nmos-cpp**

This is a new addition to ConanCenter. This library is an implementation of the AMWA [Networked Media Open Specifications](https://specs.amwa.tv/nmos/) in C++, licensed under the terms of the Apache License 2.0.

**Done:** ~The _conandata.yml_ currently refers to sources from my fork of nmos-cpp, but that will be switched to the upstream when https://github.com/sony/nmos-cpp/pull/195 is merged in the next few days.~


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
