### PR TITLE
jwt-cpp: add version 0.5.1

### DIFF
--- a/recipes/jwt-cpp/all/conandata.yml
+++ b/recipes/jwt-cpp/all/conandata.yml
@@ -1,20 +1,26 @@
 sources:
-    "0.5.0":
-        url: https://github.com/Thalhammer/jwt-cpp/archive/v0.5.0.tar.gz
-        sha256: 079a273f070dd11213e301712319a65881e51ab81535cc436d5313191df852a2
-    "0.4.0":
-        url: https://github.com/Thalhammer/jwt-cpp/archive/v0.4.0.tar.gz
-        sha256: f0dcc7b0e8bef8f9c3f434e7121f9941145042c9fe3055a5bdd709085a4f2be4
-    "0.3.1":
-        url: https://github.com/Thalhammer/jwt-cpp/archive/v0.3.1.tar.gz
-        sha256: 399345e81883f2959df658cd945de39548ddfefdab2acf7b23ee07b9e9a02938
+  "0.5.1":
+    url: "https://github.com/Thalhammer/jwt-cpp/archive/v0.5.1.tar.gz"
+    sha256: "d8f5ffb361824630b3b6f4aad26c730c915081071040c232ac57947d6177ef4f"
+  "0.5.0":
+    url: https://github.com/Thalhammer/jwt-cpp/archive/v0.5.0.tar.gz
+    sha256: 079a273f070dd11213e301712319a65881e51ab81535cc436d5313191df852a2
+  "0.4.0":
+    url: https://github.com/Thalhammer/jwt-cpp/archive/v0.4.0.tar.gz
+    sha256: f0dcc7b0e8bef8f9c3f434e7121f9941145042c9fe3055a5bdd709085a4f2be4
+  "0.3.1":
+    url: https://github.com/Thalhammer/jwt-cpp/archive/v0.3.1.tar.gz
+    sha256: 399345e81883f2959df658cd945de39548ddfefdab2acf7b23ee07b9e9a02938
 patches:
-    "0.5.0":
-        - patch_file: patches/0004-fix-picojson-header-location-for-conan.patch
-          base_path: source_subfolder
-    "0.4.0":
-        - patch_file: patches/0003-fix-picojson-header-location-for-conan.patch
-          base_path: source_subfolder
-    "0.3.1":
-        - patch_file: patches/0002-fix-openssl-change-version.patch
-          base_path: source_subfolder
+  "0.5.1":
+    - patch_file: patches/0004-fix-picojson-header-location-for-conan.patch
+      base_path: source_subfolder
+  "0.5.0":
+    - patch_file: patches/0004-fix-picojson-header-location-for-conan.patch
+      base_path: source_subfolder
+  "0.4.0":
+    - patch_file: patches/0003-fix-picojson-header-location-for-conan.patch
+      base_path: source_subfolder
+  "0.3.1":
+    - patch_file: patches/0002-fix-openssl-change-version.patch
+      base_path: source_subfolder

--- a/recipes/jwt-cpp/config.yml
+++ b/recipes/jwt-cpp/config.yml
@@ -1,7 +1,9 @@
 versions:
-    "0.3.1":
-        folder: all
-    "0.4.0":
-        folder: all
-    "0.5.0":
-        folder: all
+  "0.3.1":
+    folder: all
+  "0.4.0":
+    folder: all
+  "0.5.0":
+    folder: all
+  "0.5.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **jwt-cpp/0.5.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): 
- is it a dependency of other libraries you want to package? No
- Are you the author of the library? Yes

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
