### PR TITLE
Wt: 4.5.0 patch for gcc11

### DIFF
--- a/recipes/wt/all/conandata.yml
+++ b/recipes/wt/all/conandata.yml
@@ -8,3 +8,8 @@ sources:
   "4.5.0":
     url: "https://github.com/emweb/wt/archive/4.5.0.tar.gz"
     sha256: "119b1eae83285a153b9c901d3f4f25775c7a460d30b1e48242d7d2d649d61deb"
+
+patches:
+    "4.5.0":
+      - patch_file: "patches/wt_4_5_0_gcc_11.patch"
+        base_path: "source_subfolder"

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -13,7 +13,7 @@ class WtConan(ConanFile):
     homepage = "https://github.com/emweb/wt"
     topics = ("conan", "wt", "web", "webapp")
     license = "GPL-2.0-only"
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = ["patches/*", "CMakeLists.txt"]
     generators = "cmake"
 
     settings = "os", "arch", "compiler", "build_type"
@@ -203,6 +203,11 @@ class WtConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"), "INCLUDE(cmake/WtFindPostgresql.txt)", "#INCLUDE(cmake/WtFindPostgresql.txt)")
         if self.settings.os != "Windows":
             tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"), "INCLUDE(cmake/WtFindOdbc.txt)", "#INCLUDE(cmake/WtFindOdbc.txt)")
+
+
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/wt/all/patches/wt_4_5_0_gcc_11.patch
+++ b/recipes/wt/all/patches/wt_4_5_0_gcc_11.patch
@@ -1,0 +1,10 @@
+--- a/src/Wt/Render/WTextRenderer.C
++++ b/src/Wt/Render/WTextRenderer.C
+@@ -14,6 +14,7 @@
+ #include "Block.h"
+ 
+ #include <fstream>
++#include <limits>
+ #include <string>
+ 
+ namespace {


### PR DESCRIPTION
Gcc 11 moved includes and what used to build, builds no more.
This patch fixes Wt to build on gcc11, only tested on
Wt 4.5.0 (latest)
