### PR TITLE
pango: add version 1.48.9

### DIFF
--- a/recipes/pango/all/conandata.yml
+++ b/recipes/pango/all/conandata.yml
@@ -23,3 +23,6 @@ sources:
   "1.48.7":
     url: "https://github.com/GNOME/pango/archive/1.48.7.tar.gz"
     sha256: "8783c82927582437d3a224eb18ea90d195b7451ff2effdffba16039df5346170"
+  "1.48.9":
+    url: "https://github.com/GNOME/pango/archive/1.48.9.tar.gz"
+    sha256: "6c78162507debd3389dab9f045cfa0b03cb44c432fb21979d4acf45db1b93781"

--- a/recipes/pango/config.yml
+++ b/recipes/pango/config.yml
@@ -15,3 +15,5 @@ versions:
     folder: all
   "1.48.7":
     folder: all
+  "1.48.9":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **pango/1.48.9**

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
