### PR TITLE
pcre/all: Turn 'with_utf' and 'with_unicode_properties' on by default.

### DIFF
--- a/recipes/pcre/all/conanfile.py
+++ b/recipes/pcre/all/conanfile.py
@@ -38,8 +38,8 @@ class PCREConan(ConanFile):
         "with_bzip2": True,
         "with_zlib": True,
         "with_jit": False,
-        "with_utf": False,
-        "with_unicode_properties": False,
+        "with_utf": True,
+        "with_unicode_properties": True,
         "with_stack_for_recursion": True
     }
 


### PR DESCRIPTION
Specify library name and version:  **pcre/8.45**

I propose to turn `with_utf` and `with_unicode_properties` properties on by default. Some libraries like Glib require these properties to be turned on when dealing with regexes most of the time. AFAIK unicode support has to be turned on runtime as well so there should not be any drawbacks beyond larger code size.

@ericLemanissier Was there a reason for keeping these options off when you created the pcre recipe?

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
