### PR TITLE
[qt6] Fixes linguisttools

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -232,7 +232,7 @@ class QtConan(ConanFile):
         if self.options.openssl:
             self.requires("openssl/1.1.1k")
         if self.options.with_pcre2:
-            self.requires("pcre2/10.36")
+            self.requires("pcre2/10.37")
         if self.options.get_safe("with_vulkan"):
             self.requires("vulkan-loader/1.2.172")
 
@@ -268,7 +268,7 @@ class QtConan(ConanFile):
         if self.options.gui and self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("xorg/system")
             if not tools.cross_building(self, skip_x64_x86=True):
-                self.requires("xkbcommon/1.2.1")
+                self.requires("xkbcommon/1.3.0")
         if self.settings.os != "Windows" and self.options.get_safe("opengl", "no") != "no":
             self.requires("opengl/system")
         if self.options.with_zstd:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -788,7 +788,6 @@ class QtConan(ConanFile):
             _create_module("QuickTest", ["Test"])
 
         if self.options.qttools and self.options.gui and self.options.widgets:
-            _create_module("LinguistTools", ["Gui", "Widgets"])
             _create_module("UiPlugin", ["Gui", "Widgets"])
             self.cpp_info.components["qtUiPlugin"].libs = [] # this is a collection of abstract classes, so this is header-only
             self.cpp_info.components["qtUiPlugin"].libdirs = []

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -713,9 +713,8 @@ class QtConan(ConanFile):
             core_reqs.append("zstd::zstd")
 
         _create_module("Core", core_reqs)
-        _create_module("Platform")
-        self.cpp_info.components["qtPlatform"].libs = [] # this is a collection of abstract classes, so this is header-only
-        self.cpp_info.components["qtPlatform"].libdirs = []
+        self.cpp_info.components["qtPlatform"].names["cmake_find_package"] = "Platform"
+        self.cpp_info.components["qtPlatform"].names["cmake_find_package_multi"] = "Platform"
         if tools.Version(self.version) < "6.1.0":
             self.cpp_info.components["qtCore"].libs.append("Qt6Core_qobject%s" % libsuffix)
         if self.options.gui:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -788,6 +788,8 @@ class QtConan(ConanFile):
             _create_module("QuickTest", ["Test"])
 
         if self.options.qttools and self.options.gui and self.options.widgets:
+            self.cpp_info.components["qtLinguistTools"].names["cmake_find_package"] = "LinguistTools"
+            self.cpp_info.components["qtLinguistTools"].names["cmake_find_package_multi"] = "LinguistTools"
             _create_module("UiPlugin", ["Gui", "Widgets"])
             self.cpp_info.components["qtUiPlugin"].libs = [] # this is a collection of abstract classes, so this is header-only
             self.cpp_info.components["qtUiPlugin"].libdirs = []


### PR DESCRIPTION
Specify library name and version:  **qt/6.x.x**

Linguist Tools is not a library but a collection of targets (which refer to binaries) and needs to be added in a different manner. Now you will find that things will start and try linking Qt6LinguistTools.lib.

Ref. #6877
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
