### PR TITLE
fix grpc cross compile

### DIFF
--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -64,11 +64,8 @@ class grpcConan(ConanFile):
         self.build_requires('protobuf/3.17.1')
 
         #when cross compiling we need pre compiled grpc plugins for protoc
-        if tools.cross_building(self):
-            if not hasattr(self, "settings_build"):
-                return
-            else:
-                self.build_requires('grpc/{}'.format(self.version))
+        if hasattr(self, "settings_build") and tools.cross_building(self):
+            self.build_requires('grpc/{}'.format(self.version))
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -65,7 +65,10 @@ class grpcConan(ConanFile):
 
         #when cross compiling we need pre compiled grpc plugins for protoc
         if tools.cross_building(self):
-            self.build_requires('grpc/{}'.format(self.version))
+            if not hasattr(self, "settings_build"):
+                return
+            else:
+                self.build_requires('grpc/{}'.format(self.version))
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -60,6 +60,13 @@ class grpcConan(ConanFile):
         self.requires('abseil/20210324.1')
         self.requires('re2/20210401')
 
+    def build_requirements(self):
+        self.build_requires('protobuf/3.17.1')
+
+        #when cross compiling we need pre compiled grpc plugins for protoc
+        if tools.cross_building(self):
+            self.build_requires('grpc/{}'.format(self.version))
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -72,6 +79,11 @@ class grpcConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+        #fix the protoc search path for cross compiling
+        tools.replace_in_file("{}/cmake/protobuf.cmake".format(self._source_subfolder),
+                "find_program(_gRPC_PROTOBUF_PROTOC_EXECUTABLE protoc)",
+                "find_program(_gRPC_PROTOBUF_PROTOC_EXECUTABLE protoc PATHS ENV PATH NO_DEFAULT_PATH)"
+        )
 
     def _configure_cmake(self):
         if self._cmake is not None:

--- a/recipes/grpc/all/test_package/CMakeLists.txt
+++ b/recipes/grpc/all/test_package/CMakeLists.txt
@@ -17,7 +17,7 @@ message(STATUS "Using protobuf ${protobuf_VERSION}")
 if (CMAKE_CROSSCOMPILING)
   find_program(Protoc_Executable protoc PATHS ENV PATH NO_DEFAULT_PATH)
 else()
-  set(Protoc_Executable Protobuf_PROTOC_EXECUTABLE)
+  set(Protoc_Executable ${Protobuf_PROTOC_EXECUTABLE})
 endif()
 
 # Find gRPC installation

--- a/recipes/grpc/all/test_package/CMakeLists.txt
+++ b/recipes/grpc/all/test_package/CMakeLists.txt
@@ -14,11 +14,22 @@ set(CMAKE_CXX_STANDARD 11)
 set(protobuf_MODULE_COMPATIBLE TRUE)
 find_package(protobuf CONFIG REQUIRED)
 message(STATUS "Using protobuf ${protobuf_VERSION}")
+if (CMAKE_CROSSCOMPILING)
+  find_program(Protoc_Executable protoc PATHS ENV PATH NO_DEFAULT_PATH)
+else()
+  set(Protoc_Executable Protobuf_PROTOC_EXECUTABLE)
+endif()
 
 # Find gRPC installation
 find_package(gRPC CONFIG REQUIRED)
 message(STATUS "Using gRPC ${gRPC_VERSION}")
-set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+
+if (CMAKE_CROSSCOMPILING)
+  find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin PATHS ENV PATH NO_DEFAULT_PATH)
+else()
+  set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+endif()
+
 
 # Proto file
 get_filename_component(hw_proto "helloworld.proto" ABSOLUTE)
@@ -31,7 +42,7 @@ set(hw_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.cc")
 set(hw_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.h")
 add_custom_command(
       OUTPUT "${hw_proto_srcs}" "${hw_proto_hdrs}" "${hw_grpc_srcs}" "${hw_grpc_hdrs}"
-      COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+      COMMAND ${Protoc_Executable}
       ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
         --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
         -I "${hw_proto_path}"

--- a/recipes/grpc/all/test_package/conanfile.py
+++ b/recipes/grpc/all/test_package/conanfile.py
@@ -7,8 +7,8 @@ class TestPackageConan(ConanFile):
     generators = "cmake", "cmake_find_package_multi"
 
     def build_requirements(self):
-        if tools.cross_building(self.settings):
-            self.build_requires(str(self.requires['protobuf']))
+        if hasattr(self, "settings_build") and tools.cross_building(self):
+            self.build_requires(str(self.requires['grpc']))
             
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **grpc/1.38.0**

Fixes issues when trying to cross compile grpc and get a working grpc with reflections and ensures both host and target protobuf dependency is included. you can remove codegen but then you also loose two of the libraries.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
