### PR TITLE
meson: add version 0.59.1

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -71,3 +71,6 @@ sources:
   "0.59.0":
     url: "https://github.com/mesonbuild/meson/archive/0.59.0.tar.gz"
     sha256: "fdbbe8ea8a47f9e21cf4f578f85be8ec3d9c030df3d8cb17df1ae59d8683813a"
+  "0.59.1":
+    url: "https://github.com/mesonbuild/meson/archive/0.59.1.tar.gz"
+    sha256: "f256eb15329a6064f8cc1f23b29de1fa8d21e324f939041e1a4efe77cf1362ef"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -47,3 +47,5 @@ versions:
     folder: all
   "0.59.0":
     folder: all
+  "0.59.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/0.59.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
