### PR TITLE
First attempt at Conan package for system-installed Avahi Apple Bonjour compatibility library

### DIFF
--- a/recipes/avahi-system/all/conanfile.py
+++ b/recipes/avahi-system/all/conanfile.py
@@ -1,0 +1,44 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+
+
+class SysConfigAvahiSystemConan(ConanFile):
+    name = "avahi-system"
+    version = "system"
+    description = "Conan package for system-installed Avahi - Service Discovery for Linux using mDNS/DNS-SD - compatible with Bonjour"
+    topics = ("Avahi", "Bonjour", "DNS-SD", "mDNS")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/lathiat/avahi"
+    license = "LGPL-2.1-only"
+    settings = "os"
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("Only Linux is supported for this package.")
+
+    def system_requirements(self):
+        packages = []
+        if self.settings.os == "Linux" and tools.os_info.is_linux:
+            # for building against Avahi Apple Bonjour compatibility library, libdns_sd and dns_sd.h are required
+            # the Name Service Switch integration and command-line utilities are useful
+            if tools.os_info.with_apt:
+                # Debian/Ubuntu
+                packages = ["libavahi-compat-libdnssd-dev", "libnss-mdns", "avahi-utils"]
+            elif tools.os_info.with_yum:
+                # RHEL/CentOS/Fedora
+                packages = ["avahi-compat-libdns_sd-devel", "nss-mdns", "avahi-tools"]
+            elif tools.os_info.with_pacman:
+                # Arch Linux
+                packages = ["avahi", "nss-mdns"]
+            elif tools.os_info.with_zypper:
+                # openSUSE
+                packages = ["libdns_sd", "nss-mdns", "avahi-utils"]
+            else:
+                self.output.warn("Do not know how to install Avahi Apple Bonjour compatibility library for {}.".format(tools.os_info.linux_distro))
+        if packages:
+            package_tool = tools.SystemPackageTool(conanfile=self, default_mode='verify')
+            for package in packages:
+                package_tool.install(update=True, packages=package)
+
+    def package_info(self):
+        self.cpp_info.system_libs = ["dns_sd"]

--- a/recipes/avahi-system/all/test_package/CMakeLists.txt
+++ b/recipes/avahi-system/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/avahi-system/all/test_package/conanfile.py
+++ b/recipes/avahi-system/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/avahi-system/all/test_package/test_package.c
+++ b/recipes/avahi-system/all/test_package/test_package.c
@@ -1,0 +1,18 @@
+#include <dns_sd.h>
+#include <stdio.h>
+
+int main()
+{
+    DNSServiceRef sdRef;
+    DNSServiceErrorType err = DNSServiceBrowse(&sdRef, 0, 0, "_example._tcp", NULL, NULL, NULL);
+    if (err == kDNSServiceErr_NoError)
+    {
+        printf("DNSServiceBrowse succeeded\n");
+        DNSServiceRefDeallocate(sdRef);
+    }
+    else
+    {
+        printf("DNSServiceBrowse failed: %d\n", err);
+    }
+    return 0;
+}

--- a/recipes/avahi-system/config.yml
+++ b/recipes/avahi-system/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "system":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **avahi-system/system**

Related to #6891, see https://github.com/conan-io/conan-center-index/pull/6891#issuecomment-901295117.

I have named this **avahi-system** since I think it would be possible to make another package that built from the source at https://github.com/lathiat/avahi, but I believe most users will want to use the installer package for their system.

I have tested the `apt` install locally, the `yum`, `pacman` and `zypper` package lists are my best guess only.

I'm not sure precisely what needs to go in the `package_info`, e.g. `system_libs`, `includedirs`, `libdirs`.

Presumably this will need white-listing in order to build in CI.
@uilianries, @madebr, @prince-chrismc, thanks for your help so far!
I will submit a second PR for building `mDNSResponder` from the Apple tarballs.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
