### PR TITLE
wayland: declare variables in pc files

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -2,6 +2,7 @@ from conans import ConanFile, Meson, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.36.0"
 
 class WaylandConan(ConanFile):
     name = "wayland"
@@ -96,17 +97,40 @@ class WaylandConan(ConanFile):
         self.cpp_info.components["wayland-scanner"].requires = ["expat::expat"]
         if self.options.enable_dtd_validation:
             self.cpp_info.components["wayland-scanner"].requires.append("libxml2::libxml2")
+        pkgconfig_variables = {
+            'datarootdir': '${prefix}/res',
+            'pkgdatadir': '${datarootdir}/wayland',
+            'bindir': '${prefix}/bin',
+            'wayland_scanner': '${bindir}/wayland-scanner',
+        }
+        self.cpp_info.components["wayland-scanner"].set_property(
+            "pkg_config_custom_content",
+            "\n".join("%s=%s" % (key, value) for key,value in pkgconfig_variables.items()))
 
         if self.options.enable_libraries:
             self.cpp_info.components["wayland-server"].libs = ["wayland-server"]
             self.cpp_info.components["wayland-server"].names["pkg_config"] = "wayland-server"
             self.cpp_info.components["wayland-server"].requires = ["libffi::libffi"]
             self.cpp_info.components["wayland-server"].system_libs = ["pthread", "m"]
+            pkgconfig_variables = {
+                'datarootdir': '${prefix}/res',
+                'pkgdatadir': '${datarootdir}/wayland',
+            }
+            self.cpp_info.components["wayland-server"].set_property(
+                "pkg_config_custom_content",
+                "\n".join("%s=%s" % (key, value) for key,value in pkgconfig_variables.items()))
 
             self.cpp_info.components["wayland-client"].libs = ["wayland-client"]
             self.cpp_info.components["wayland-client"].names["pkg_config"] = "wayland-client"
             self.cpp_info.components["wayland-client"].requires = ["libffi::libffi"]
             self.cpp_info.components["wayland-client"].system_libs = ["pthread", "m"]
+            pkgconfig_variables = {
+                'datarootdir': '${prefix}/res',
+                'pkgdatadir': '${datarootdir}/wayland',
+            }
+            self.cpp_info.components["wayland-client"].set_property(
+                "pkg_config_custom_content",
+                "\n".join("%s=%s" % (key, value) for key,value in pkgconfig_variables.items()))
 
             self.cpp_info.components["wayland-cursor"].libs = ["wayland-cursor"]
             self.cpp_info.components["wayland-cursor"].names["pkg_config"] = "wayland-cursor"
@@ -118,7 +142,3 @@ class WaylandConan(ConanFile):
 
             self.cpp_info.components["wayland-egl-backend"].names["pkg_config"] = "wayland-egl-backend"
             self.cpp_info.components["wayland-egl-backend"].version = "3"
-
-        bindir = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable: {}".format(bindir))
-        self.env_info.PATH.append(bindir)

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -142,3 +142,7 @@ class WaylandConan(ConanFile):
 
             self.cpp_info.components["wayland-egl-backend"].names["pkg_config"] = "wayland-egl-backend"
             self.cpp_info.components["wayland-egl-backend"].version = "3"
+
+        bindir = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bindir))
+        self.env_info.PATH.append(bindir)

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -47,13 +47,13 @@ class WaylandConan(ConanFile):
 
     def requirements(self):
         if self.options.enable_libraries:
-            self.requires("libffi/3.3")
+            self.requires("libffi/3.4.2")
         if self.options.enable_dtd_validation:
-            self.requires("libxml2/2.9.10")
+            self.requires("libxml2/2.9.12")
         self.requires("expat/2.4.1")
 
     def build_requirements(self):
-        self.build_requires("meson/0.58.1")
+        self.build_requires("meson/0.59.1")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/wayland/all/test_package/conanfile.py
+++ b/recipes/wayland/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "pkg_config"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/wayland/all/test_package/conanfile.py
+++ b/recipes/wayland/all/test_package/conanfile.py
@@ -10,6 +10,10 @@ class TestPackageConan(ConanFile):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
+        if not tools.cross_building(self, skip_x64_x86=True):
+            with tools.environment_append({'PKG_CONFIG_PATH': "."}):
+                pkg_config = tools.PkgConfig("wayland-scanner")
+                self.run('%s --version' % pkg_config.variables[wayland_scanner], run_environment=True)
 
     def test(self):
         if not tools.cross_building(self.settings):

--- a/recipes/wayland/all/test_package/conanfile.py
+++ b/recipes/wayland/all/test_package/conanfile.py
@@ -13,7 +13,7 @@ class TestPackageConan(ConanFile):
         if not tools.cross_building(self, skip_x64_x86=True):
             with tools.environment_append({'PKG_CONFIG_PATH': "."}):
                 pkg_config = tools.PkgConfig("wayland-scanner")
-                self.run('%s --version' % pkg_config.variables[wayland_scanner], run_environment=True)
+                self.run('%s --version' % pkg_config.variables["wayland_scanner"], run_environment=True)
 
     def test(self):
         if not tools.cross_building(self.settings):


### PR DESCRIPTION
Specify library name and version:  **wayland/***

according to what upstream does in https://github.com/wayland-project/wayland/blob/f452e41264387dee4fd737cbf1af58b34b53941b/src/meson.build#L59 https://github.com/wayland-project/wayland/blob/f452e41264387dee4fd737cbf1af58b34b53941b/src/meson.build#L187 and https://github.com/wayland-project/wayland/blob/f452e41264387dee4fd737cbf1af58b34b53941b/src/meson.build#L219

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
