### PR TITLE
First attempt at Conan package for Apple's Bonjour

### DIFF
--- a/recipes/bonjour/config.yml
+++ b/recipes/bonjour/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "system":
+    folder: system

--- a/recipes/bonjour/system/conanfile.py
+++ b/recipes/bonjour/system/conanfile.py
@@ -1,0 +1,26 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+
+
+class BonjourSystemConan(ConanFile):
+    name = "bonjour"
+    version = "system"
+    description = "Conan package for Apple's Bonjour"
+    topics = ("Bonjour", "DNS-SD", "mDNS")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://developer.apple.com/bonjour/"
+    license = "Apache-2.0", "BSD-3-Clause"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def validate(self):
+        if self.settings.os != "Windows" or tools.cross_building(self):
+            raise ConanInvalidConfiguration("Only Windows is supported for this package.")
+
+    def system_requirements(self):
+        # extract and install Bonjour64.msi from downloaded BonjourPSSetup.exe
+        # see https://community.chocolatey.org/packages/bonjour#files
+        package_tool = tools.SystemPackageTool(tool=tools.ChocolateyTool())
+        package_tool.install(packages=["bonjour"])
+
+    def package_info(self):
+        self.cpp_info.system_libs = ["dns_sd"]

--- a/recipes/bonjour/system/test_package/CMakeLists.txt
+++ b/recipes/bonjour/system/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/bonjour/system/test_package/conanfile.py
+++ b/recipes/bonjour/system/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/bonjour/system/test_package/test_package.c
+++ b/recipes/bonjour/system/test_package/test_package.c
@@ -1,0 +1,18 @@
+#include <dns_sd.h>
+#include <stdio.h>
+
+int main()
+{
+    DNSServiceRef sdRef;
+    DNSServiceErrorType err = DNSServiceBrowse(&sdRef, 0, 0, "_example._tcp", NULL, NULL, NULL);
+    if (err == kDNSServiceErr_NoError)
+    {
+        printf("DNSServiceBrowse succeeded\n");
+        DNSServiceRefDeallocate(sdRef);
+    }
+    else
+    {
+        printf("DNSServiceBrowse failed: %d\n", err);
+    }
+    return 0;
+}


### PR DESCRIPTION
Specify library name and version:  **bonjour/system**

See also #6928, #6930.

In order to _run_ Windows applications that use the _dns_sd.h_ API, the Bonjour service and the _dns_sd.dll_ must be installed.
Apple include _Bonjour64.msi_ in the _BonjourPSSetup.exe_ Print Services for Windows installer which can be freely downloaded from https://support.apple.com/kb/DL999?locale=en_GB (linked from https://developer.apple.com/bonjour/). I've previously written CI scripts that do this directly, but it turns out there's a Chocolatey package that does it (thanks for the find, @prince-chrismc).

In order to _build_ Windows applications that use this API, the _dns_sd.h_ header file and _dns_sd.lib_ DLL stub library (it's a tiny static library that uses `LoadLibrary`, rather than just a DLL import library) are required. Apple include these in the Bonjour SDK, which is also available via https://developer.apple.com/bonjour/, **but only by logging in with an Apple ID.**

Alternatively, the DLL stub library can be built just using the 3 files _DLLStub.cpp_, _DLLStub.h_ and _dns_sd.h_. Would it be acceptable to include these OSS files directly in this recipe? Where should they go?

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
