### PR TITLE
Add conan recipe for certify

### DIFF
--- a/recipes/certify/all/conandata.yml
+++ b/recipes/certify/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1":
+    url: "https://github.com/jhabermas/certify/archive/refs/tags/v0.1.tar.gz"
+    sha256: 75cd7f0d606dd583ccc4f86e0e952073ff57f131e2793cb11a7c087c52a3e12c

--- a/recipes/certify/all/conanfile.py
+++ b/recipes/certify/all/conanfile.py
@@ -1,0 +1,50 @@
+from conans import ConanFile, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class CertifyConan(ConanFile):
+    name = "certify"
+    description = "Platform-specific TLS keystore abstraction for use with Boost.ASIO and OpenSSL"
+    topics = ("conan", "boost", "asio", "tls", "ssl", "https")
+    url = "https://github.com/djarek/certify"
+    homepage = "https://djarek.github.io/certify/"
+    license = "BSL-1.0"
+    settings = "compiler"
+    generators = "cmake", "cmake_find_package"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _min_cppstd(self):
+        return "17"
+
+    def requirements(self):
+        self.requires("boost/1.76.0")
+        self.requires("openssl/1.1.1k")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  strip_root=True, destination=self._source_subfolder)
+
+    def package(self):
+        self.copy(pattern="LICENSE_1_0.txt", dst="licenses",
+                  src=self._source_subfolder)
+        self.copy(pattern="*", dst="include",
+                  src=os.path.join(self._source_subfolder, "include"))
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "certify"
+        self.cpp_info.names["cmake_find_package_multi"] = "certify"
+        self.cpp_info.names["pkg_config"] = "certify"

--- a/recipes/certify/all/test_package/CMakeLists.txt
+++ b/recipes/certify/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} CONAN_PKG::certify)

--- a/recipes/certify/all/test_package/conanfile.py
+++ b/recipes/certify/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/certify/all/test_package/test_package.cpp
+++ b/recipes/certify/all/test_package/test_package.cpp
@@ -1,0 +1,21 @@
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ssl.hpp>
+#include <boost/certify/extensions.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+#include <iostream>
+
+int main() {
+      boost::asio::io_context ioc{1};
+      boost::asio::ssl::context context{
+      boost::asio::ssl::context_base::method::tls_client};
+      boost::asio::ssl::stream<boost::asio::ip::tcp::socket> stream{ioc, context};
+      boost::string_view hostname = "example.com";
+
+      BOOST_TEST(boost::certify::sni_hostname(stream).empty());
+      boost::certify::sni_hostname(stream, static_cast<std::string>(hostname));
+      BOOST_TEST(boost::certify::sni_hostname(stream) == hostname);
+      std::cout << boost::report_errors();
+
+      return 0;
+}

--- a/recipes/certify/config.yml
+++ b/recipes/certify/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **certify/0.1**

This adds conan recipe for a header only [certify ](https://github.com/djarek/certify) library which abstracts and simplifies platform-specific operations, such as using X.509 certificates from the Operating System’s keystore to perform peer authentication during a TLS handshake. It is a necessary component for implementing HTTPS/WSS communication on top of `boost` networking libraries and has been [recommended](https://www.boost.org/doc/libs/develop/libs/beast/example/common/root_certificates.hpp) by `boost::beast` author Vinnie Falco for production code.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
