### PR TITLE
[llvm-core] Use CMake class instead of barely running CMake

### DIFF
--- a/recipes/llvm-core/all/conanfile.py
+++ b/recipes/llvm-core/all/conanfile.py
@@ -236,7 +236,7 @@ class LLVMCoreConan(ConanFile):
                 lib = '*LLVMTableGenGlobalISel{}'.format(ext)
                 self.copy(lib, dst='lib', src='lib')
 
-            self.run('cmake --graphviz=graph/llvm.dot .')
+            CMake(self).configure(args=['--graphviz=graph/llvm.dot'], source_dir='.', build_dir='.')
             with tools.chdir('graph'):
                 dot_text = tools.load('llvm.dot').replace('\r\n', '\n')
 


### PR DESCRIPTION
This fixed package failure in Visual Studio, because the environment will not be set properly if run CMake barely

Specify library name and version:  **llvm-core/12.0.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
