### PR TITLE
qt/5.x.x: Add pulseaudio option

### DIFF
--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -62,7 +62,7 @@ class PulseAudioConan(ConanFile):
         if self.options.with_alsa:
             self.requires("libalsa/1.2.4")
         if self.options.with_glib:
-            self.requires("glib/2.69.0")
+            self.requires("glib/2.69.2")
         if self.options.get_safe("with_fftw"):
             self.requires("fftw/3.3.9")
         if self.options.with_x11:

--- a/recipes/pulseaudio/all/conanfile.py
+++ b/recipes/pulseaudio/all/conanfile.py
@@ -62,7 +62,7 @@ class PulseAudioConan(ConanFile):
         if self.options.with_alsa:
             self.requires("libalsa/1.2.4")
         if self.options.with_glib:
-            self.requires("glib/2.69.2")
+            self.requires("glib/2.69.0")
         if self.options.get_safe("with_fftw"):
             self.requires("fftw/3.3.9")
         if self.options.with_x11:


### PR DESCRIPTION
Specify library name and version:  **qt/5.x.x**

Adds pulseaudio option, needed on Linux platforms for audio capabilities of QtMultimedia.

---

- [✓] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [✓] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [✓] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [✓] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
