### PR TITLE
sqlcipher: fix build errors for armv8-windows (cross-compile)

### DIFF
--- a/recipes/sqlcipher/all/conanfile.py
+++ b/recipes/sqlcipher/all/conanfile.py
@@ -113,10 +113,12 @@ class SqlcipherConan(ConanFile):
         if self.settings.build_type == "Debug":
             nmake_flags.append("DEBUG=2")
         nmake_flags.append("FOR_WIN10=1")
-        platforms = {"x86": "x86", "x86_64": "x64"}
+        platforms = {"x86": "x86", "x86_64": "x64", "armv8": "arm64"}
         nmake_flags.append("PLATFORM=%s" % platforms[self.settings.arch.value])
-        vcvars = tools.vcvars_command(self.settings)
-        self.run("%s && nmake /f Makefile.msc %s %s" % (vcvars, main_target, " ".join(nmake_flags)), cwd=self._source_subfolder)
+        with tools.vcvars(self.settings_build):
+            self.run("nmake /f Makefile.msc sqlite3.c %s" % (" ".join(nmake_flags)), cwd=self._source_subfolder)
+        with tools.vcvars(self.settings):
+            self.run("nmake /f Makefile.msc %s %s" % (main_target, " ".join(nmake_flags)), cwd=self._source_subfolder)
 
     @property
     def _user_info_build(self):

--- a/recipes/sqlcipher/all/conanfile.py
+++ b/recipes/sqlcipher/all/conanfile.py
@@ -115,7 +115,7 @@ class SqlcipherConan(ConanFile):
         nmake_flags.append("FOR_WIN10=1")
         platforms = {"x86": "x86", "x86_64": "x64", "armv8": "arm64"}
         nmake_flags.append("PLATFORM=%s" % platforms[self.settings.arch.value])
-        with tools.vcvars(self.settings_build):
+        with tools.vcvars(getattr(self, 'settings_build', self.settings)):
             self.run("nmake /f Makefile.msc sqlite3.c %s" % (" ".join(nmake_flags)), cwd=self._source_subfolder)
         with tools.vcvars(self.settings):
             self.run("nmake /f Makefile.msc %s %s" % (main_target, " ".join(nmake_flags)), cwd=self._source_subfolder)


### PR DESCRIPTION
This commit add "armv8" to "arm64" mapping to conanfile.py to avoid
"KeyError" when building for armv8-windows.

This commit fixes "Invalid argument" error for sqlcipher when cross-
compiling sqlcipher from x64-windows to armv8-windows. Original error
was produced because NMake is trying to execute arm64 binary on x64 host.

fixes #6864

Specify library name and version:  **sqlcipher/4.4.3**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
