### PR TITLE
libe57format: fix CMake imported target

### DIFF
--- a/recipes/libe57format/all/conanfile.py
+++ b/recipes/libe57format/all/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.33.0"

--- a/recipes/libe57format/all/conanfile.py
+++ b/recipes/libe57format/all/conanfile.py
@@ -92,7 +92,8 @@ class LibE57FormatConan(ConanFile):
                             "conan-official-{}-targets.cmake".format(self.name))
 
     def package_info(self):
-        self.cpp_info.libs = ["E57Format-d" if self.settings.build_type == "Debug" else "E57Format"]
+        suffix = "-d" if self.settings.build_type == "Debug" else ""
+        self.cpp_info.libs = ["E57Format{}".format(suffix)]
         self.cpp_info.filenames["cmake_find_package"] = "e57format"
         self.cpp_info.filenames["cmake_find_package_multi"] = "e57format"
         self.cpp_info.names["cmake_find_package"] = "E57Format"

--- a/recipes/libe57format/all/conanfile.py
+++ b/recipes/libe57format/all/conanfile.py
@@ -27,9 +27,9 @@ class LibE57FormatConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
@@ -42,9 +42,9 @@ class LibE57FormatConan(ConanFile):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "11")
 
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/libe57format/all/test_package/CMakeLists.txt
+++ b/recipes/libe57format/all/test_package/CMakeLists.txt
@@ -6,6 +6,6 @@ conan_basic_setup(TARGETS)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 
-find_package(e57format REQUIRED)
-target_link_libraries(${PROJECT_NAME} PRIVATE E57Format::E57Format)
+find_package(e57format REQUIRED CONFIG)
+target_link_libraries(${PROJECT_NAME} PRIVATE E57Format)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)

--- a/recipes/libe57format/all/test_package/conanfile.py
+++ b/recipes/libe57format/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

CMake imported target is not namespaced: https://github.com/asmaloney/libE57Format/blob/65c0d2380711ddf3c7ec8a7fc9f03d5b453b9d7c/CMakeLists.txt#L143-L147

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
