### PR TITLE
fix cross compilation for realz

### DIFF
--- a/recipes/gsoap/all/conanfile.py
+++ b/recipes/gsoap/all/conanfile.py
@@ -35,7 +35,6 @@ class ConanFileDefault(ConanFile):
         'with_cookies': True,
         'with_c_locale': True}
 
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
@@ -49,6 +48,8 @@ class ConanFileDefault(ConanFile):
         else:
             self.build_requires("bison/3.5.3")
             self.build_requires("flex/2.6.4")
+        if hasattr(self, "settings_build") and tools.cross_building(self):
+            self.build_requires("gsoap/{}".format(self.version))
 
     def requirements(self):
         if self.options.with_openssl:
@@ -59,8 +60,10 @@ class ConanFileDefault(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+
         self._cmake.definitions["GSOAP_PATH"] = self._source_subfolder
         self._cmake.definitions["BUILD_TOOLS"] = True
+        # not self._cross_building()
         self._cmake.definitions["WITH_OPENSSL"] = self.options.with_openssl
         self._cmake.definitions["WITH_IPV6"] = self.options.with_ipv6
         self._cmake.definitions["WITH_COOKIES"] = self.options.with_cookies

--- a/recipes/gsoap/all/src/soapcpp2.cmake
+++ b/recipes/gsoap/all/src/soapcpp2.cmake
@@ -1,6 +1,7 @@
 
 # Generate project for soapcpp2 executable
 
+
 set(STDCPP2_PATH ${CMAKE_SOURCE_DIR}/${GSOAP_PATH}/gsoap/src)
 
 set(SRC_CPP
@@ -33,15 +34,18 @@ if(WIN32)
     )
 
 else()
+    find_program(_Flex_EXECUTABLE flex PATHS ENV PATH NO_DEFAULT_PATH)
+    find_program(_Yacc_EXECUTABLE yacc PATHS ENV PATH NO_DEFAULT_PATH)
+
     add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/generated/soapcpp2_yacc.tab.c
-        COMMAND ${CONAN_BISON_ROOT}/bin/yacc -d -v -o ${CMAKE_BINARY_DIR}/generated/soapcpp2_yacc.tab.c ${STDCPP2_PATH}/soapcpp2_yacc.y
+        COMMAND ${_Yacc_EXECUTABLE} -d -v -o ${CMAKE_BINARY_DIR}/generated/soapcpp2_yacc.tab.c ${STDCPP2_PATH}/soapcpp2_yacc.y
         COMMENT "Run YACC on soapcpp2"
     )
 
     add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/generated/lex.yy.c
-        COMMAND ${CONAN_FLEX_ROOT}/bin/flex -o ${CMAKE_BINARY_DIR}/generated/lex.yy.c ${STDCPP2_PATH}/soapcpp2_lex.l
+        COMMAND ${_Flex_EXECUTABLE} -o ${CMAKE_BINARY_DIR}/generated/lex.yy.c ${STDCPP2_PATH}/soapcpp2_lex.l
         COMMENT "Run FLEX on soapcpp2"
     )
 endif()

--- a/recipes/gsoap/all/src/wsdl2h.cmake
+++ b/recipes/gsoap/all/src/wsdl2h.cmake
@@ -29,9 +29,14 @@ endif()
 set_source_files_properties(${SRC_CPP} PROPERTIES LANGUAGE CXX)
 set_source_files_properties(${CMAKE_BINARY_DIR}/generated/wsdlC.cpp PROPERTIES GENERATED TRUE)
 
+if (CMAKE_CROSSCOMPILING)
+    find_program(_soapCPP2_EXECUTABLE soapcpp2 PATHS ENV PATH NO_DEFAULT_PATH)
+else()
+    set(_soapCPP2_EXECUTABLE $<TARGET_FILE:soapcpp2>)
+endif()
 add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/generated/wsdlC.cpp
-    COMMAND $<TARGET_FILE:soapcpp2> -I${GSOAP_PATH}/gsoap/import -SC -pwsdl -d${CMAKE_BINARY_DIR}/generated ${WSDL2H_PATH}/wsdl.h
+    COMMAND ${_soapCPP2_EXECUTABLE} -I${GSOAP_PATH}/gsoap/import -SC -pwsdl -d${CMAKE_BINARY_DIR}/generated ${WSDL2H_PATH}/wsdl.h
     COMMENT "Parsing WSDL and Schema definitions"
     WORKING_DIRECTORY ${WSDL2H_PATH}
     )

--- a/recipes/gsoap/all/test_package/conanfile.py
+++ b/recipes/gsoap/all/test_package/conanfile.py
@@ -5,6 +5,10 @@ class TestGsoapConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 
+    def build_requirements(self):
+        if hasattr(self, "settings_build") and tools.cross_building(self):
+            self.build_requires(str(self.requires['gsoap']))
+
     def build(self):
         calc_wsdl = os.path.join(os.path.dirname(__file__), 'calc.wsdl')
         self.run("wsdl2h -o calc.h {}".format(calc_wsdl), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  *gsoap/ALL**

cross compilation fails because it tries to run self buildt executables therefore the recursive pattern from grpc etc is used to get the right soapcpp2 binary.  

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
