### PR TITLE
Remove cairo dependence on which command and failing if gtkdocize isn't installed.

### DIFF
--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -176,7 +176,16 @@ class CairoConan(ConanFile):
                 tools.replace_in_file(os.path.join(self.source_folder, self._source_subfolder, "src", "cairo-ft-font.c"),
                                       "#if HAVE_UNISTD_H", "#ifdef HAVE_UNISTD_H")
 
-            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows, run_environment=True)
+            tools.touch(os.path.join("boilerplate", "Makefile.am.features"))
+            tools.touch(os.path.join("src", "Makefile.am.features"))
+            tools.touch("ChangeLog")
+
+            with tools.environment_append({"GTKDOCIZE": "echo"}):
+                self.run(
+                    "{} -fiv".format(tools.get_env("AUTORECONF")),
+                    run_environment=True,
+                    win_bash=tools.os_info.is_windows,
+                )
         autotools = self._configure_autotools()
         autotools.make()
 


### PR DESCRIPTION
Specify library name and version:  **cairo/all**

The cairo package will fail to build if you don't have `which` installed, it also appears that it will fail without the `gtkdocize` command, despite `autogen.sh` appearing to check for the command prior to running it. `autogen.sh` is a fairly simple script so I moved it's functionality into the conanfile.

fixes #5674

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
