### PR TITLE
imgui: fix shared build

### DIFF
--- a/recipes/imgui/all/CMakeLists.txt
+++ b/recipes/imgui/all/CMakeLists.txt
@@ -4,13 +4,16 @@ project(imgui CXX)
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
-if (WIN32 AND MSVC AND BUILD_SHARED_LIBS)
-    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-endif(WIN32 AND MSVC AND BUILD_SHARED_LIBS)
+if (BUILD_SHARED_LIBS)
+    set(IMGUI_API _IMGUI_SHARED)
+else()
+    set(IMGUI_API _IMGUI_STATIC)
+endif()
 
 set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder)
 set(MISC_DIR ${SOURCE_DIR}/misc)
 set(EXTRA_FONTS_DIR ${MISC_DIR}/fonts)
+set(IMGUI_USER_CONFIG imgui_user_config.h)
 
 file(GLOB SOURCE_FILES ${SOURCE_DIR}/*.cpp)
 file(GLOB HEADER_FILES ${SOURCE_DIR}/*.h)
@@ -25,6 +28,9 @@ add_executable(${BINARY_TO_COMPRESSED_BIN} ${EXTRA_FONTS_DIR}/binary_to_compress
 
 add_library(${PROJECT_NAME} ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${SOURCE_DIR})
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+                           ${IMGUI_API}
+                           IMGUI_USER_CONFIG=\"${IMGUI_USER_CONFIG}\")
 
 include(GNUInstallDirs)
 

--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -32,3 +32,39 @@ sources:
   "1.84.1":
     url: "https://github.com/ocornut/imgui/archive/v1.84.1.tar.gz"
     sha256: "292ab54cfc328c80d63a3315a242a4785d7c1cf7689fbb3d70da39b34db071ea"
+
+patches:
+  "1.74":
+    - patch_file: "patches/imgui_user_config.patch"
+      base_path: "source_subfolder"
+  "1.75":
+    - patch_file: "patches/imgui_user_config.patch"
+      base_path: "source_subfolder"
+  "1.76":
+    - patch_file: "patches/imgui_user_config.patch"
+      base_path: "source_subfolder"
+  "1.77":
+    - patch_file: "patches/imgui_user_config.patch"
+      base_path: "source_subfolder"
+  "1.78":
+    - patch_file: "patches/imgui_user_config.patch"
+      base_path: "source_subfolder"
+  "1.79":
+    - patch_file: "patches/imgui_user_config.patch"
+      base_path: "source_subfolder"
+  "1.80":
+    - patch_file: "patches/imgui_user_config.patch"
+      base_path: "source_subfolder"
+  "1.81":
+    - patch_file: "patches/imgui_user_config.patch"
+      base_path: "source_subfolder"
+  "1.82":
+    - patch_file: "patches/imgui_user_config.patch"
+      base_path: "source_subfolder"
+  "1.83":
+    - patch_file: "patches/imgui_user_config.patch"
+      base_path: "source_subfolder"
+  "1.84.1":
+    - patch_file: "patches/imgui_user_config.patch"
+      base_path: "source_subfolder"
+

--- a/recipes/imgui/all/patches/imgui_user_config.patch
+++ b/recipes/imgui/all/patches/imgui_user_config.patch
@@ -1,0 +1,12 @@
+--- /dev/null
++++ b/imgui_user_config.h
+@@ -0,0 +1,9 @@
++#pragma once
++
++#ifndef IMGUI_API
++#if defined(_WIN32) && defined(_IMGUI_SHARED)
++#define IMGUI_API __declspec(dllexport)
++#elif defined(_WIN32) && !defined(_IMGUI_STATIC)
++#define IMGUI_API __declspec(dllimport)
++#endif
++#endif

--- a/recipes/imgui/all/test_package/test_package.cpp
+++ b/recipes/imgui/all/test_package/test_package.cpp
@@ -6,6 +6,9 @@ int main(int, char**)
     ImGuiContext* context =ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO();
 
+    ImGuiTextBuffer textBuffer;
+    textBuffer.append("Hello, ImGui");
+
     // Build atlas
     unsigned char* tex_pixels = NULL;
     int tex_w, tex_h;
@@ -20,6 +23,7 @@ int main(int, char**)
 
         static float f = 0.0f;
         ImGui::Text("Hello, world!");
+        ImGui::Text(textBuffer.begin());
         ImGui::SliderFloat("float", &f, 0.0f, 1.0f);
         ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / io.Framerate, io.Framerate);
         ImGui::ShowDemoWindow(NULL);


### PR DESCRIPTION
Specify library name and version:  **imgui/all**

Fixes shared library on Windows by defining `IMGUI_API` as `__declspec(dllimport)` when using the library.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Closes #6970