### PR TITLE
Fixes sentry-native crashpad compilation on Linux

### DIFF
--- a/recipes/sentry-native/all/conandata.yml
+++ b/recipes/sentry-native/all/conandata.yml
@@ -24,6 +24,12 @@ sources:
     url: "https://github.com/getsentry/sentry-native/releases/download/0.2.6/sentry-native-0.2.6.zip"
     sha256: "0d93bd77f70a64f3681d4928dfca6b327374218a84d33ee31489114d8e4716c0"
 patches:
+  "0.4.12":
+    - patch_file: "patches/0.4.xx-CXX-14.patch"
+      base_path: "source_subfolder"
+  "0.4.11":
+    - patch_file: "patches/0.4.xx-CXX-14.patch"
+      base_path: "source_subfolder"
   "0.4.10":
     - patch_file: "patches/0.4.xx-CXX-14.patch"
       base_path: "source_subfolder"


### PR DESCRIPTION
Specify library name and version:  **sentry-native/0.4.12**

Without this patch sentry does not compile, ref. https://github.com/getsentry/sentry-native/issues/574

Made PR upstream, ref. https://github.com/getsentry/sentry-native/pull/585

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
