### PR TITLE
Add option to freeglut to replace glut

### DIFF
--- a/recipes/freeglut/all/conanfile.py
+++ b/recipes/freeglut/all/conanfile.py
@@ -21,6 +21,7 @@ class freeglutConan(ConanFile):
         "gles": [True, False],
         "print_errors_at_runtime": [True, False],
         "print_warnings_at_runtime": [True, False],
+        "replace_glut": [True, False],
     }
     default_options = {
         "shared": False,
@@ -28,6 +29,7 @@ class freeglutConan(ConanFile):
         "gles": False,
         "print_errors_at_runtime": True,
         "print_warnings_at_runtime": True,
+        "replace_glut": True,
     }
     _cmake = None
 
@@ -85,6 +87,7 @@ class freeglutConan(ConanFile):
         self._cmake.definitions["FREEGLUT_PRINT_WARNINGS"] = self.options.print_warnings_at_runtime
         self._cmake.definitions["FREEGLUT_INSTALL_PDB"] = False
         self._cmake.definitions["INSTALL_PDB"] = False
+        self._cmake.definitions["FREEGLUT_REPLACE_GLUT"] = self.options.replace_glut
         # cmake.definitions["FREEGLUT_WAYLAND"] = "ON" if self.options.wayland else "OFF" # nightly version only as of now
 
         self._cmake.configure(build_folder=self._build_subfolder)


### PR DESCRIPTION
Expose the underlying CMake option to make freeglut a drop-in replacement for glut.

Specify library name and version:  freeglut/3.2.1

A common usecase for freeglut is to use it as a drop-in replacement for glut. The standard CMake find_package for glut checks for presence of `GL/glut.h`, but this header (a simple wrapper for `GL/freeglut.h` is not generated by default with freeglut. There is a CMake option to control its generation though, and the proposed change to the conan recipe exposes this option. I took the liberty to make the drop-in replacement the default, since I think it's by far the most common usage of freeglut, but I'd be happy to change it if following the upstream default is considered more important.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
