### PR TITLE
ginkgo: update to 1.4.0

### DIFF
--- a/recipes/ginkgo/all/conandata.yml
+++ b/recipes/ginkgo/all/conandata.yml
@@ -2,9 +2,16 @@ sources:
   "1.3.0":
     sha256: 1b0e907b4046cdf7cef16d1730c12ba812b38f2764f49f74f454239a27f63596
     url: https://github.com/ginkgo-project/ginkgo/archive/v1.3.0.tar.gz
+  "1.4.0":
+    sha256: 6dcadbd3e93f6ec58ef6cda5b980fbf51ea3c7c13e27952ef38804058ac93f08
+    url: https://github.com/ginkgo-project/ginkgo/archive/v1.4.0.tar.gz
 patches:
   "1.3.0":
     - patch_file: "patches/cmake-fixes.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/windows-iterator.patch"
       base_path: "source_subfolder"
+  "1.4.0":
+    - patch_file: "patches/windows-symbols.patch"
+      base_path: "source_subfolder"
+

--- a/recipes/ginkgo/all/conanfile.py
+++ b/recipes/ginkgo/all/conanfile.py
@@ -61,6 +61,12 @@ class GinkgoConan(ConanFile):
             if tools.Version(self.settings.compiler.version) < min_version:
                 raise ConanInvalidConfiguration("{} requires C++{} support. The current compiler {} {} does not support it.".format(
                     self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
+            if self.settings.compiler == "Visual Studio":
+                static_crt = str(
+                    self.settings.compiler.runtime).startswith("MT")
+                if static_crt and self.options.shared:
+                    raise ConanInvalidConfiguration(
+                        "Ginkgo does not support mixing static CRT and shared library")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/ginkgo/all/conanfile.py
+++ b/recipes/ginkgo/all/conanfile.py
@@ -108,44 +108,52 @@ class GinkgoConan(ConanFile):
         self.cpp_info.components["ginkgo_core"].names["cmake_find_package"] = "ginkgo"
         self.cpp_info.components["ginkgo_core"].names["cmake_find_package_multi"] = "ginkgo"
         self.cpp_info.components["ginkgo_core"].names["pkg_config"] = "ginkgo"
-        self.cpp_info.components["ginkgo_core"].libs = ["ginkgo" + debug_suffix]
+        self.cpp_info.components["ginkgo_core"].libs = [
+            "ginkgo" + debug_suffix]
         self.cpp_info.components["ginkgo_core"].requires = [
             "ginkgo_omp", "ginkgo_cuda", "ginkgo_reference", "ginkgo_hip"
         ]
 
         self.cpp_info.components["ginkgo_cuda"].names["cmake_find_package"] = "ginkgo_cuda"
         self.cpp_info.components["ginkgo_cuda"].names["cmake_find_package_multi"] = "ginkgo_cuda"
-        self.cpp_info.components["ginkgo_cuda"].libs = ["ginkgo_cuda" + debug_suffix]
+        self.cpp_info.components["ginkgo_cuda"].libs = [
+            "ginkgo_cuda" + debug_suffix]
         self.cpp_info.components["ginkgo_cuda"].requires = ["ginkgo_hip"]
 
         self.cpp_info.components["ginkgo_omp"].names["cmake_find_package"] = "ginkgo_omp"
         self.cpp_info.components["ginkgo_omp"].names["cmake_find_package_multi"] = "ginkgo_omp"
-        self.cpp_info.components["ginkgo_omp"].libs = ["ginkgo_omp" + debug_suffix]
-        self.cpp_info.components["ginkgo_omp"].requires = ["ginkgo_cuda", "ginkgo_hip"]
+        self.cpp_info.components["ginkgo_omp"].libs = [
+            "ginkgo_omp" + debug_suffix]
+        self.cpp_info.components["ginkgo_omp"].requires = [
+            "ginkgo_cuda", "ginkgo_hip"]
 
         self.cpp_info.components["ginkgo_hip"].names["cmake_find_package"] = "ginkgo_hip"
         self.cpp_info.components["ginkgo_hip"].names["cmake_find_package_multi"] = "ginkgo_hip"
-        self.cpp_info.components["ginkgo_hip"].libs = ["ginkgo_hip" + debug_suffix]
-        
+        self.cpp_info.components["ginkgo_hip"].libs = [
+            "ginkgo_hip" + debug_suffix]
+
         self.cpp_info.components["ginkgo_reference"].names["cmake_find_package"] = "ginkgo_reference"
         self.cpp_info.components["ginkgo_reference"].names["cmake_find_package_multi"] = "ginkgo_reference"
-        self.cpp_info.components["ginkgo_reference"].libs = ["ginkgo_reference" + debug_suffix]
-        
+        self.cpp_info.components["ginkgo_reference"].libs = [
+            "ginkgo_reference" + debug_suffix]
+
         if has_dpcpp_device:
             self.cpp_info.components["ginkgo_core"].requires += ["ginkgo_dpcpp"]
             self.cpp_info.components["ginkgo_core"].requires += ["ginkgo_device"]
 
             self.cpp_info.components["ginkgo_dpcpp"].names["cmake_find_package"] = "ginkgo_dpcpp"
             self.cpp_info.components["ginkgo_dpcpp"].names["cmake_find_package_multi"] = "ginkgo_dpcpp"
-            self.cpp_info.components["ginkgo_dpcpp"].libs = ["ginkgo_dpcpp" + debug_suffix]
-            
+            self.cpp_info.components["ginkgo_dpcpp"].libs = [
+                "ginkgo_dpcpp" + debug_suffix]
+
             self.cpp_info.components["ginkgo_device"].names["cmake_find_package"] = "ginkgo_device"
             self.cpp_info.components["ginkgo_device"].names["cmake_find_package_multi"] = "ginkgo_device"
-            self.cpp_info.components["ginkgo_device"].libs = ["ginkgo_device" + debug_suffix]
+            self.cpp_info.components["ginkgo_device"].libs = [
+                "ginkgo_device" + debug_suffix]
 
-            self.cpp_info.components["ginkgo_omp"].requires += ["ginkgo_dpcpp", "ginkgo_device"]
+            self.cpp_info.components["ginkgo_omp"].requires += [
+                "ginkgo_dpcpp", "ginkgo_device"]
             self.cpp_info.components["ginkgo_reference"].requires += ["ginkgo_device"]
             self.cpp_info.components["ginkgo_hip"].requires += ["ginkgo_device"]
             self.cpp_info.components["ginkgo_cuda"].requires += ["ginkgo_device"]
             self.cpp_info.components["ginkgo_dpcpp"].requires += ["ginkgo_device"]
-

--- a/recipes/ginkgo/all/conanfile.py
+++ b/recipes/ginkgo/all/conanfile.py
@@ -143,7 +143,8 @@ class GinkgoConan(ConanFile):
         self.cpp_info.components["ginkgo_reference"].libs = [
             "ginkgo_reference" + debug_suffix]
 
-        if has_dpcpp_device:
+        if has_dpcpp_device: # Always add these components
+            # See https://github.com/conan-io/conan-center-index/pull/7044#discussion_r698181588
             self.cpp_info.components["ginkgo_core"].requires += ["ginkgo_dpcpp"]
             self.cpp_info.components["ginkgo_core"].requires += ["ginkgo_device"]
 

--- a/recipes/ginkgo/all/patches/windows-symbols.patch
+++ b/recipes/ginkgo/all/patches/windows-symbols.patch
@@ -1,0 +1,710 @@
+diff --git a/core/base/array.cpp b/core/base/array.cpp
+index 0f31b3d9ba7..3a2ad7b5568 100644
+--- a/core/base/array.cpp
++++ b/core/base/array.cpp
+@@ -42,20 +42,24 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ namespace gko {
+ namespace conversion {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(convert, components::convert_precision);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace conversion
+ 
+ 
+ namespace array {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(fill_array, components::fill_array);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace array
+ 
+ 
+diff --git a/core/base/composition.cpp b/core/base/composition.cpp
+index d383b0174b6..3a67a8ebff6 100644
+--- a/core/base/composition.cpp
++++ b/core/base/composition.cpp
+@@ -46,11 +46,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ namespace gko {
+ namespace composition {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(fill_array, components::fill_array);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace composition
+ 
+ 
+diff --git a/core/factorization/ic.cpp b/core/factorization/ic.cpp
+index 3c8b6dd29ba..34bbbcb048d 100644
+--- a/core/factorization/ic.cpp
++++ b/core/factorization/ic.cpp
+@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace factorization {
+ namespace ic_factorization {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(compute, ic_factorization::compute);
+@@ -58,6 +59,7 @@ GKO_REGISTER_OPERATION(initialize_row_ptrs_l,
+ GKO_REGISTER_OPERATION(initialize_l, factorization::initialize_l);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace ic_factorization
+ 
+ 
+diff --git a/core/factorization/ilu.cpp b/core/factorization/ilu.cpp
+index 1518853b9b8..8359bf3f465 100644
+--- a/core/factorization/ilu.cpp
++++ b/core/factorization/ilu.cpp
+@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace factorization {
+ namespace ilu_factorization {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(compute_ilu, ilu_factorization::compute_lu);
+@@ -58,6 +59,7 @@ GKO_REGISTER_OPERATION(initialize_row_ptrs_l_u,
+ GKO_REGISTER_OPERATION(initialize_l_u, factorization::initialize_l_u);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace ilu_factorization
+ 
+ 
+diff --git a/core/factorization/par_ic.cpp b/core/factorization/par_ic.cpp
+index 33e40d85bb0..6266816a059 100644
+--- a/core/factorization/par_ic.cpp
++++ b/core/factorization/par_ic.cpp
+@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace factorization {
+ namespace par_ic_factorization {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(add_diagonal_elements,
+@@ -66,6 +67,7 @@ GKO_REGISTER_OPERATION(csr_transpose, csr::transpose);
+ GKO_REGISTER_OPERATION(convert_to_coo, csr::convert_to_coo);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace par_ic_factorization
+ 
+ 
+diff --git a/core/factorization/par_ict.cpp b/core/factorization/par_ict.cpp
+index 69025ecd305..93050b5c67a 100644
+--- a/core/factorization/par_ict.cpp
++++ b/core/factorization/par_ict.cpp
+@@ -57,6 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace factorization {
+ namespace par_ict_factorization {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(threshold_select,
+@@ -77,6 +78,7 @@ GKO_REGISTER_OPERATION(convert_to_coo, csr::convert_to_coo);
+ GKO_REGISTER_OPERATION(spgemm, csr::spgemm);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace par_ict_factorization
+ 
+ 
+diff --git a/core/factorization/par_ilu.cpp b/core/factorization/par_ilu.cpp
+index 3b5bf605a4c..995902b9bb4 100644
+--- a/core/factorization/par_ilu.cpp
++++ b/core/factorization/par_ilu.cpp
+@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace factorization {
+ namespace par_ilu_factorization {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(add_diagonal_elements,
+@@ -64,6 +65,7 @@ GKO_REGISTER_OPERATION(compute_l_u_factors,
+ GKO_REGISTER_OPERATION(csr_transpose, csr::transpose);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace par_ilu_factorization
+ 
+ 
+diff --git a/core/factorization/par_ilut.cpp b/core/factorization/par_ilut.cpp
+index 69370659cc3..3cd7f12b0f7 100644
+--- a/core/factorization/par_ilut.cpp
++++ b/core/factorization/par_ilut.cpp
+@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace factorization {
+ namespace par_ilut_factorization {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(threshold_select,
+@@ -77,6 +78,7 @@ GKO_REGISTER_OPERATION(convert_to_coo, csr::convert_to_coo);
+ GKO_REGISTER_OPERATION(spgemm, csr::spgemm);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace par_ilut_factorization
+ 
+ 
+diff --git a/core/matrix/coo.cpp b/core/matrix/coo.cpp
+index efa2b160a92..4eda43b2dd8 100644
+--- a/core/matrix/coo.cpp
++++ b/core/matrix/coo.cpp
+@@ -53,9 +53,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ namespace gko {
+ namespace matrix {
+-
+-
+ namespace coo {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(spmv, coo::spmv);
+@@ -72,6 +71,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
+                        components::outplace_absolute_array);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace coo
+ 
+ 
+diff --git a/core/matrix/csr.cpp b/core/matrix/csr.cpp
+index cd09474cf63..571a90ca351 100644
+--- a/core/matrix/csr.cpp
++++ b/core/matrix/csr.cpp
+@@ -55,6 +55,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace matrix {
+ namespace csr {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(spmv, csr::spmv);
+@@ -90,6 +91,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
+                        components::outplace_absolute_array);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace csr
+ 
+ 
+diff --git a/core/matrix/dense.cpp b/core/matrix/dense.cpp
+index abf0fe57ac5..ef997adbaf7 100644
+--- a/core/matrix/dense.cpp
++++ b/core/matrix/dense.cpp
+@@ -59,6 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace matrix {
+ namespace dense {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(simple_apply, dense::simple_apply);
+@@ -102,6 +103,7 @@ GKO_REGISTER_OPERATION(get_real, dense::get_real);
+ GKO_REGISTER_OPERATION(get_imag, dense::get_imag);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace dense
+ 
+ 
+diff --git a/core/matrix/diagonal.cpp b/core/matrix/diagonal.cpp
+index 8a6d36a8759..9f158bc1650 100644
+--- a/core/matrix/diagonal.cpp
++++ b/core/matrix/diagonal.cpp
+@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace matrix {
+ namespace diagonal {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(apply_to_dense, diagonal::apply_to_dense);
+@@ -60,6 +61,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
+                        components::outplace_absolute_array);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace diagonal
+ 
+ 
+diff --git a/core/matrix/ell.cpp b/core/matrix/ell.cpp
+index fcb198106cd..5cd026c6310 100644
+--- a/core/matrix/ell.cpp
++++ b/core/matrix/ell.cpp
+@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace matrix {
+ namespace ell {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(spmv, ell::spmv);
+@@ -70,6 +71,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
+                        components::outplace_absolute_array);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace ell
+ 
+ 
+diff --git a/core/matrix/fbcsr.cpp b/core/matrix/fbcsr.cpp
+index 9e4a264b3e6..8911b72ff43 100644
+--- a/core/matrix/fbcsr.cpp
++++ b/core/matrix/fbcsr.cpp
+@@ -57,6 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace matrix {
+ namespace fbcsr {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(spmv, fbcsr::spmv);
+@@ -80,6 +81,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
+                        components::outplace_absolute_array);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace fbcsr
+ 
+ 
+diff --git a/core/matrix/hybrid.cpp b/core/matrix/hybrid.cpp
+index f6cf69f2955..7ad40dfe529 100644
+--- a/core/matrix/hybrid.cpp
++++ b/core/matrix/hybrid.cpp
+@@ -54,6 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace matrix {
+ namespace hybrid {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(convert_to_dense, hybrid::convert_to_dense);
+@@ -68,6 +69,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
+                        components::outplace_absolute_array);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace hybrid
+ 
+ 
+diff --git a/core/matrix/sellp.cpp b/core/matrix/sellp.cpp
+index 07542e3ab40..d51b0fb04c7 100644
+--- a/core/matrix/sellp.cpp
++++ b/core/matrix/sellp.cpp
+@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace matrix {
+ namespace sellp {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(spmv, sellp::spmv);
+@@ -66,6 +67,7 @@ GKO_REGISTER_OPERATION(outplace_absolute_array,
+                        components::outplace_absolute_array);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace sellp
+ 
+ 
+diff --git a/core/matrix/sparsity_csr.cpp b/core/matrix/sparsity_csr.cpp
+index d253792c6a3..e5a45557934 100644
+--- a/core/matrix/sparsity_csr.cpp
++++ b/core/matrix/sparsity_csr.cpp
+@@ -47,6 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace matrix {
+ namespace sparsity_csr {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(spmv, sparsity_csr::spmv);
+@@ -62,6 +63,7 @@ GKO_REGISTER_OPERATION(is_sorted_by_column_index,
+                        sparsity_csr::is_sorted_by_column_index);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace sparsity_csr
+ 
+ 
+diff --git a/core/multigrid/amgx_pgm.cpp b/core/multigrid/amgx_pgm.cpp
+index e38d10d27c3..ff4e2423636 100644
+--- a/core/multigrid/amgx_pgm.cpp
++++ b/core/multigrid/amgx_pgm.cpp
+@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace multigrid {
+ namespace amgx_pgm {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(match_edge, amgx_pgm::match_edge);
+@@ -64,6 +65,7 @@ GKO_REGISTER_OPERATION(fill_array, components::fill_array);
+ GKO_REGISTER_OPERATION(fill_seq_array, components::fill_seq_array);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace amgx_pgm
+ 
+ 
+diff --git a/core/preconditioner/isai.cpp b/core/preconditioner/isai.cpp
+index 7247b9a04e7..4ee7d718db3 100644
+--- a/core/preconditioner/isai.cpp
++++ b/core/preconditioner/isai.cpp
+@@ -58,6 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace preconditioner {
+ namespace isai {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(generate_tri_inverse, isai::generate_tri_inverse);
+@@ -71,6 +72,7 @@ GKO_REGISTER_OPERATION(initialize_row_ptrs_l,
+ GKO_REGISTER_OPERATION(initialize_l, factorization::initialize_l);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace isai
+ 
+ 
+diff --git a/core/preconditioner/jacobi.cpp b/core/preconditioner/jacobi.cpp
+index d62d97ec0b5..d908a7e0ac3 100644
+--- a/core/preconditioner/jacobi.cpp
++++ b/core/preconditioner/jacobi.cpp
+@@ -55,6 +55,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace preconditioner {
+ namespace jacobi {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(simple_apply, jacobi::simple_apply);
+@@ -73,6 +74,7 @@ GKO_REGISTER_OPERATION(scalar_convert_to_dense,
+ GKO_REGISTER_OPERATION(initialize_precisions, jacobi::initialize_precisions);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace jacobi
+ 
+ 
+diff --git a/core/reorder/rcm.cpp b/core/reorder/rcm.cpp
+index f2ec8f0fd63..7224bad4ef3 100644
+--- a/core/reorder/rcm.cpp
++++ b/core/reorder/rcm.cpp
+@@ -54,12 +54,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace reorder {
+ namespace rcm {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(get_permutation, rcm::get_permutation);
+ GKO_REGISTER_OPERATION(get_degree_of_nodes, rcm::get_degree_of_nodes);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace rcm
+ 
+ 
+diff --git a/core/solver/bicg.cpp b/core/solver/bicg.cpp
+index f79832dedc0..0f67a4f1ce1 100644
+--- a/core/solver/bicg.cpp
++++ b/core/solver/bicg.cpp
+@@ -47,9 +47,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ namespace gko {
+ namespace solver {
+-
+-
+ namespace bicg {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(initialize, bicg::initialize);
+@@ -57,6 +56,7 @@ GKO_REGISTER_OPERATION(step_1, bicg::step_1);
+ GKO_REGISTER_OPERATION(step_2, bicg::step_2);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace bicg
+ 
+ 
+diff --git a/core/solver/bicgstab.cpp b/core/solver/bicgstab.cpp
+index 7c8c852fa11..cf583b5dbd6 100644
+--- a/core/solver/bicgstab.cpp
++++ b/core/solver/bicgstab.cpp
+@@ -47,6 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace solver {
+ namespace bicgstab {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(initialize, bicgstab::initialize);
+@@ -56,6 +57,7 @@ GKO_REGISTER_OPERATION(step_3, bicgstab::step_3);
+ GKO_REGISTER_OPERATION(finalize, bicgstab::finalize);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace bicgstab
+ 
+ 
+diff --git a/core/solver/cb_gmres.cpp b/core/solver/cb_gmres.cpp
+index 8478ea49b5e..104d77ccbbb 100644
+--- a/core/solver/cb_gmres.cpp
++++ b/core/solver/cb_gmres.cpp
+@@ -54,9 +54,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ namespace gko {
+ namespace solver {
+-
+-
+ namespace cb_gmres {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(initialize_1, cb_gmres::initialize_1);
+@@ -65,6 +64,7 @@ GKO_REGISTER_OPERATION(step_1, cb_gmres::step_1);
+ GKO_REGISTER_OPERATION(step_2, cb_gmres::step_2);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace cb_gmres
+ 
+ 
+diff --git a/core/solver/cg.cpp b/core/solver/cg.cpp
+index 4dc624584e8..ae0fb37f2a9 100644
+--- a/core/solver/cg.cpp
++++ b/core/solver/cg.cpp
+@@ -47,9 +47,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ namespace gko {
+ namespace solver {
+-
+-
+ namespace cg {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(initialize, cg::initialize);
+@@ -57,6 +56,7 @@ GKO_REGISTER_OPERATION(step_1, cg::step_1);
+ GKO_REGISTER_OPERATION(step_2, cg::step_2);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace cg
+ 
+ 
+diff --git a/core/solver/cgs.cpp b/core/solver/cgs.cpp
+index c33a3b7b9c1..16589ffbeb3 100644
+--- a/core/solver/cgs.cpp
++++ b/core/solver/cgs.cpp
+@@ -46,9 +46,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ namespace gko {
+ namespace solver {
+-
+-
+ namespace cgs {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(initialize, cgs::initialize);
+@@ -57,6 +56,7 @@ GKO_REGISTER_OPERATION(step_2, cgs::step_2);
+ GKO_REGISTER_OPERATION(step_3, cgs::step_3);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace cgs
+ 
+ 
+diff --git a/core/solver/fcg.cpp b/core/solver/fcg.cpp
+index ee1eff61434..fc081a21b23 100644
+--- a/core/solver/fcg.cpp
++++ b/core/solver/fcg.cpp
+@@ -47,6 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace solver {
+ namespace fcg {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(initialize, fcg::initialize);
+@@ -54,6 +55,7 @@ GKO_REGISTER_OPERATION(step_1, fcg::step_1);
+ GKO_REGISTER_OPERATION(step_2, fcg::step_2);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace fcg
+ 
+ 
+diff --git a/core/solver/gmres.cpp b/core/solver/gmres.cpp
+index ac0c484a34b..f5e933631c8 100644
+--- a/core/solver/gmres.cpp
++++ b/core/solver/gmres.cpp
+@@ -50,9 +50,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ namespace gko {
+ namespace solver {
+-
+-
+ namespace gmres {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(initialize_1, gmres::initialize_1);
+@@ -61,6 +60,7 @@ GKO_REGISTER_OPERATION(step_1, gmres::step_1);
+ GKO_REGISTER_OPERATION(step_2, gmres::step_2);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace gmres
+ 
+ 
+diff --git a/core/solver/idr.cpp b/core/solver/idr.cpp
+index 411ab892dd9..d3190414678 100644
+--- a/core/solver/idr.cpp
++++ b/core/solver/idr.cpp
+@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace solver {
+ namespace idr {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(initialize, idr::initialize);
+@@ -58,6 +59,7 @@ GKO_REGISTER_OPERATION(compute_omega, idr::compute_omega);
+ GKO_REGISTER_OPERATION(fill_array, components::fill_array);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace idr
+ 
+ 
+diff --git a/core/solver/ir.cpp b/core/solver/ir.cpp
+index 5d7aa749b87..9b61d78cb33 100644
+--- a/core/solver/ir.cpp
++++ b/core/solver/ir.cpp
+@@ -43,11 +43,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace solver {
+ namespace ir {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(initialize, ir::initialize);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace ir
+ 
+ 
+diff --git a/core/solver/lower_trs.cpp b/core/solver/lower_trs.cpp
+index 9c9f8306a92..cbe5f332f9a 100644
+--- a/core/solver/lower_trs.cpp
++++ b/core/solver/lower_trs.cpp
+@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace solver {
+ namespace lower_trs {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(generate, lower_trs::generate);
+@@ -60,6 +61,7 @@ GKO_REGISTER_OPERATION(should_perform_transpose,
+ GKO_REGISTER_OPERATION(solve, lower_trs::solve);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace lower_trs
+ 
+ 
+diff --git a/core/solver/upper_trs.cpp b/core/solver/upper_trs.cpp
+index d4529fefd69..bae00182fc8 100644
+--- a/core/solver/upper_trs.cpp
++++ b/core/solver/upper_trs.cpp
+@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace solver {
+ namespace upper_trs {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(generate, upper_trs::generate);
+@@ -60,6 +61,7 @@ GKO_REGISTER_OPERATION(should_perform_transpose,
+ GKO_REGISTER_OPERATION(solve, upper_trs::solve);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace upper_trs
+ 
+ 
+diff --git a/core/stop/criterion.cpp b/core/stop/criterion.cpp
+index 59d1db2839e..ca902912307 100644
+--- a/core/stop/criterion.cpp
++++ b/core/stop/criterion.cpp
+@@ -39,11 +39,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace stop {
+ namespace criterion {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(set_all_statuses, set_all_statuses::set_all_statuses);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace criterion
+ 
+ 
+diff --git a/core/stop/residual_norm.cpp b/core/stop/residual_norm.cpp
+index 73630204a22..bd31e67caef 100644
+--- a/core/stop/residual_norm.cpp
++++ b/core/stop/residual_norm.cpp
+@@ -40,21 +40,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ namespace gko {
+ namespace stop {
+ namespace residual_norm {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(residual_norm, residual_norm::residual_norm);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace residual_norm
+ 
+ 
+ namespace implicit_residual_norm {
++namespace {
+ 
+ 
+ GKO_REGISTER_OPERATION(implicit_residual_norm,
+                        implicit_residual_norm::implicit_residual_norm);
+ 
+ 
++}  // anonymous namespace
+ }  // namespace implicit_residual_norm
+ 
+ 

--- a/recipes/ginkgo/config.yml
+++ b/recipes/ginkgo/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.3.0":
     folder: all
+  "1.4.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **ginkgo/1.4.0**

This adds the latest release of Ginkgo to the recipe, including a patch that enables compilation on Windows by reducing the number of symbols in the exported DLL (https://github.com/ginkgo-project/ginkgo/pull/868).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
