### PR TITLE
Add Avahi

### DIFF
--- a/recipes/avahi/all/conandata.yml
+++ b/recipes/avahi/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.8":
+    url: "https://github.com/lathiat/avahi/releases/download/v0.8/avahi-0.8.tar.gz"
+    sha256: "060309d7a333d38d951bc27598c677af1796934dbd98e1024e7ad8de798fedda"

--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -83,15 +83,36 @@ class AvahiConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.libs = [
-            "avahi-client",
-            "avahi-common",
-            "avahi-core",
-            "avahi-glib",
-            "avahi-gobject",
-            "avahi-libevent",
-            "dns_sd"
-        ]
+        self.cpp_info.names["cmake_find_package"] = "Avahi"
+        self.cpp_info.names["cmake_find_package_multi"] = "Avahi"
+
+        for lib in ("client", "common", "core", "glib", "gobject", "libevent", "compat-libdns_sd"):
+            self.cpp_info.components[lib].names["cmake_find_package"] = lib
+            self.cpp_info.components[lib].names["cmake_find_package_multi"] = lib
+            self.cpp_info.components[lib].names["pkg_config"] = "avahi-{}".format(lib)
+            self.cpp_info.components[lib].libs = ["avahi-{}".format(lib)]
+        self.cpp_info.components["compat-libdns_sd"].libs = ["dns_sd"]
+
+        self.cpp_info.components["client"].requires = ["common", "dbus::dbus"]
+        self.cpp_info.components["common"].system_libs = ["pthread"]
+        self.cpp_info.components["core"].requires = ["common"]
+        self.cpp_info.components["glib"].requires = ["common", "glib::glib"]
+        self.cpp_info.components["gobject"].requires = ["client", "glib"]
+        self.cpp_info.components["libevent"].requires = ["common", "libevent::libevent"]
+        self.cpp_info.components["compat-libdns_sd"].requires = ["client"]
+
+        for app in ("autoipd", "browse", "daemon", "dnsconfd", "publish", "resolve", "set-host-name"):
+            self.cpp_info.components[app].names["cmake_find_package"] = app
+            self.cpp_info.components[app].names["cmake_find_package_multi"] = app
+            self.cpp_info.components[app].names["pkg_config"] = "avahi-{}".format(app)
+
+        self.cpp_info.components["autoipd"].requires = ["libdaemon::libdaemon"]
+        self.cpp_info.components["browse"].requires = ["client", "gdbm::gdbm"]
+        self.cpp_info.components["daemon"].requires = ["core", "expat::expat", "libdaemon::libdaemon"]
+        self.cpp_info.components["dnsconfd"].requires = ["common", "libdaemon::libdaemon"]
+        self.cpp_info.components["publish"].requires = ["client"]
+        self.cpp_info.components["resolve"].requires = ["client"]
+        self.cpp_info.components["set-host-name"].requires = ["client"]
 
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bin_path))

--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -53,7 +53,10 @@ class AvahiConan(ConanFile):
 
     @property
     def _configure_args(self):
+        yes_no = lambda v: "yes" if v else "no"
         return [
+            "--enable-shared={}".format(yes_no(self.options.shared)),
+            "--enable-static={}".format(yes_no(not self.options.shared)),
             "--disable-gtk3",
             "--disable-mono",
             "--disable-python",
@@ -87,10 +90,12 @@ class AvahiConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "Avahi"
 
         for lib in ("client", "common", "core", "glib", "gobject", "libevent", "compat-libdns_sd"):
+            avahi_lib = "avahi-{}".format(lib)
             self.cpp_info.components[lib].names["cmake_find_package"] = lib
             self.cpp_info.components[lib].names["cmake_find_package_multi"] = lib
-            self.cpp_info.components[lib].names["pkg_config"] = "avahi-{}".format(lib)
-            self.cpp_info.components[lib].libs = ["avahi-{}".format(lib)]
+            self.cpp_info.components[lib].names["pkg_config"] = avahi_lib
+            self.cpp_info.components[lib].libs = [avahi_lib]
+            self.cpp_info.components[lib].includedirs = [os.path.join("include", avahi_lib)]
         self.cpp_info.components["compat-libdns_sd"].libs = ["dns_sd"]
 
         self.cpp_info.components["client"].requires = ["common", "dbus::dbus"]
@@ -102,9 +107,10 @@ class AvahiConan(ConanFile):
         self.cpp_info.components["compat-libdns_sd"].requires = ["client"]
 
         for app in ("autoipd", "browse", "daemon", "dnsconfd", "publish", "resolve", "set-host-name"):
+            avahi_app = "avahi-{}".format(app)
             self.cpp_info.components[app].names["cmake_find_package"] = app
             self.cpp_info.components[app].names["cmake_find_package_multi"] = app
-            self.cpp_info.components[app].names["pkg_config"] = "avahi-{}".format(app)
+            self.cpp_info.components[app].names["pkg_config"] = avahi_app
 
         self.cpp_info.components["autoipd"].requires = ["libdaemon::libdaemon"]
         self.cpp_info.components["browse"].requires = ["client", "gdbm::gdbm"]

--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -77,7 +77,11 @@ class AvahiConan(ConanFile):
         autotools = self._configure_autotools()
         autotools.install()
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        
+        tools.rmdir(os.path.join(self.package_folder, "etc"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
     def package_info(self):
         self.cpp_info.libs = [
             "avahi-client",

--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -1,0 +1,94 @@
+from conans import ConanFile, tools, AutoToolsBuildEnvironment
+import os
+from conans.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.33.0"
+
+class AvahiConan(ConanFile):
+    name = "avahi"
+    description = "Avahi - Service Discovery for Linux using mDNS/DNS-SD -- compatible with Bonjour"
+    topics = ("avahi", "Bonjour", "DNS-SD", "mDNS")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/lathiat/avahi"
+    license = "LGPL-2.1-only"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "pkg_config"
+
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True
+    }
+
+    _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def requirements(self):
+        self.requires("glib/2.68.3")
+        self.requires("expat/2.4.1")
+        self.requires("libdaemon/0.14")
+        self.requires("dbus/1.12.20")
+        self.requires("gdbm/1.19")
+        self.requires("libevent/2.1.12")
+
+    def validate(self):
+        if self.settings.os != "Linux" or tools.cross_building(self):
+            raise ConanInvalidConfiguration("Only Linux is supported for this package.")
+
+    def configure(self):
+        del self.settings.compiler.cppstd
+        del self.settings.compiler.libcxx
+        if self.options.shared:
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    @property
+    def _configure_args(self):
+        return [
+            "--disable-gtk3",
+            "--disable-mono",
+            "--disable-python",
+            "--disable-qt5",
+            "--disable-monodoc",
+            "--enable-compat-libdns_sd",
+        ]
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self)
+        self._autotools.configure(configure_dir=self._source_subfolder, args=self._configure_args)
+        return self._autotools
+
+    def build(self):
+        autotools = self._configure_autotools()
+        autotools.make()
+
+    def package(self):
+        autotools = self._configure_autotools()
+        autotools.install()
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        
+    def package_info(self):
+        self.cpp_info.libs = [
+            "avahi-client",
+            "avahi-common",
+            "avahi-core",
+            "avahi-glib",
+            "avahi-gobject",
+            "avahi-libevent",
+            "dns_sd"
+        ]
+
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)

--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -63,6 +63,7 @@ class AvahiConan(ConanFile):
             "--disable-qt5",
             "--disable-monodoc",
             "--enable-compat-libdns_sd",
+            "--with-systemdsystemunitdir={}/lib/systemd/system".format(self.package_folder),
         ]
 
     def _configure_autotools(self):

--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -6,6 +6,8 @@ required_conan_version = ">=1.33.0"
 
 class AvahiConan(ConanFile):
     name = "avahi"
+    # --enable-compat-libdns_sd
+    provides = "mdnsresponder"
     description = "Avahi - Service Discovery for Linux using mDNS/DNS-SD -- compatible with Bonjour"
     topics = ("avahi", "Bonjour", "DNS-SD", "mDNS")
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -1,12 +1,13 @@
 from conans import ConanFile, tools, AutoToolsBuildEnvironment
-import os
 from conans.errors import ConanInvalidConfiguration
+import os
 
 required_conan_version = ">=1.33.0"
 
+
 class AvahiConan(ConanFile):
     name = "avahi"
-    # --enable-compat-libdns_sd
+    # --enable-compat-libdns_sd means that this recipe provides the mdnsresponder compile interface
     provides = "mdnsresponder"
     description = "Avahi - Service Discovery for Linux using mDNS/DNS-SD -- compatible with Bonjour"
     topics = ("avahi", "Bonjour", "DNS-SD", "mDNS")

--- a/recipes/avahi/all/test_package/CMakeLists.txt
+++ b/recipes/avahi/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/avahi/all/test_package/CMakeLists.txt
+++ b/recipes/avahi/all/test_package/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
 find_package(Avahi CONFIG REQUIRED)

--- a/recipes/avahi/all/test_package/CMakeLists.txt
+++ b/recipes/avahi/all/test_package/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
+find_package(Avahi CONFIG REQUIRED)
+ 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} Avahi::compat-libdns_sd)

--- a/recipes/avahi/all/test_package/conanfile.py
+++ b/recipes/avahi/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/avahi/all/test_package/conanfile.py
+++ b/recipes/avahi/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/avahi/all/test_package/test_package.c
+++ b/recipes/avahi/all/test_package/test_package.c
@@ -1,0 +1,18 @@
+#include <dns_sd.h>
+#include <stdio.h>
+
+int main()
+{
+    DNSServiceRef sdRef;
+    DNSServiceErrorType err = DNSServiceBrowse(&sdRef, 0, 0, "_example._tcp", NULL, NULL, NULL);
+    if (err == kDNSServiceErr_NoError)
+    {
+        printf("DNSServiceBrowse succeeded\n");
+        DNSServiceRefDeallocate(sdRef);
+    }
+    else
+    {
+        printf("DNSServiceBrowse failed: %d\n", err);
+    }
+    return 0;
+}

--- a/recipes/avahi/config.yml
+++ b/recipes/avahi/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.8":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **avahi/0.8**

Still trying to get an Apple _dns_sd.h_-compatible implementation available everywhere. See #6930, and compare #6928.

This relies on #7028 for **libdaemon**.

As mentioned by @prince-chrismc in https://github.com/conan-io/conan-center-index/pull/6928#discussion_r693353429 in response to @Croydon, @ericLemanissier, @SpaceIm, it's not clear (to me at least) how to manage singleton daemons/services with Conan.

Building Avahi from source is OK, but the install target will attempt to update startup scripts and create sockets in _/lib/systemd/system_, stop/restart the daemon, etc.

The recipe completes successfully when run with `sudo` or by adding the following to `_configure_args`:
```python
            "--with-systemdsystemunitdir={}/lib/systemd/system".format(self.package_folder)
```
But what do we really want?

Possibly still to do - add `components` corresponding to the different libraries and executables. Some _FindAvahi.cmake_ scripts have this idea, although since the isn't a standard CMake find-module, they're all different.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
