### PR TITLE
imgui: add version 1.84.2

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -32,3 +32,6 @@ sources:
   "1.84.1":
     url: "https://github.com/ocornut/imgui/archive/v1.84.1.tar.gz"
     sha256: "292ab54cfc328c80d63a3315a242a4785d7c1cf7689fbb3d70da39b34db071ea"
+  "1.84.2":
+    url: "https://github.com/ocornut/imgui/archive/v1.84.2.tar.gz"
+    sha256: "35cb5ca0fb42cb77604d4f908553f6ef3346ceec4fcd0189675bdfb764f62b9b"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -21,3 +21,5 @@ versions:
     folder: all
   "1.84.1":
     folder: all
+  "1.84.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **imgui/1.84.2**

The author wrote that there are still issues in the previous version (1.84.1)
_-- Apologies, 1.84.1 still had issue with nested BeginDisabled()/EndDisabled() calls. What a botched release! Issuing a fix for it._

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
