### PR TITLE
zlib: fix clang@Windows (msys2+mingw64+clang)

### DIFF
--- a/recipes/zlib/1.2.11/conanfile.py
+++ b/recipes/zlib/1.2.11/conanfile.py
@@ -88,13 +88,10 @@ class ZlibConan(ConanFile):
                 if self.settings.compiler == "Visual Studio":
                     current_lib = os.path.join(lib_path, "zlibstatic%s.lib" % suffix)
                     tools.rename(current_lib, os.path.join(lib_path, "zlib.lib"))
-                elif self.settings.compiler == "gcc":
-                    if self.settings.os != "Windows" or not self.settings.os.subsystem:
+                elif self.settings.compiler in ("clang", "gcc", ):
+                    if not self.settings.os.subsystem:
                         current_lib = os.path.join(lib_path, "libzlibstatic.a")
                         tools.rename(current_lib, os.path.join(lib_path, "libzlib.a"))
-                elif self.settings.compiler == "clang":
-                    current_lib = os.path.join(lib_path, "zlibstatic.lib")
-                    tools.rename(current_lib, os.path.join(lib_path, "zlib.lib"))
 
     def _extract_license(self):
         with tools.chdir(os.path.join(self.source_folder, self._source_subfolder)):


### PR DESCRIPTION
Specify library name and version:  **zlib/1.2.11**

clang-cl has the following profile:
```
compiler=Visual Studio
compiler.toolset=ClangCL
```
Not
```
compiler=clang
```
For https://github.com/conan-io/conan-center-index/issues/3521#issuecomment-907362434

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
