### PR TITLE
pdal: back to shared by default + bump dependencies + modernize

### DIFF
--- a/recipes/pdal/all/conandata.yml
+++ b/recipes/pdal/all/conandata.yml
@@ -1,11 +1,16 @@
 sources:
-  "2.2.0":
-    url: "https://github.com/PDAL/PDAL/releases/download/2.2.0/PDAL-2.2.0-src.tar.bz2"
-    sha256: "7f6406d8f6536701f28f215d7b77c2c476f2fa100c1a391ebbcc868210114273"
   "2.3.0":
     url: "https://github.com/PDAL/PDAL/releases/download/2.3.0/PDAL-2.3.0-src.tar.bz2"
     sha256: "63d8d4fee491675f0fa3dca58c26d57fb2afcaa37c24b10f595b3fbff174996e"
+  "2.2.0":
+    url: "https://github.com/PDAL/PDAL/releases/download/2.2.0/PDAL-2.2.0-src.tar.bz2"
+    sha256: "7f6406d8f6536701f28f215d7b77c2c476f2fa100c1a391ebbcc868210114273"
 patches:
+  "2.3.0":
+    - patch_file: "patches/0001-cmakelists.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0005-vendor-nanoflann.patch"
+      base_path: "source_subfolder"
   "2.2.0":
     - patch_file: "patches/0001-cmakelists.patch"
       base_path: "source_subfolder"
@@ -18,9 +23,4 @@ patches:
     - patch_file: "patches/0005-vendor-nanoflann.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0006-pointview.patch"
-      base_path: "source_subfolder"
-  "2.3.0":
-    - patch_file: "patches/0001-cmakelists.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0005-vendor-nanoflann.patch"
       base_path: "source_subfolder"

--- a/recipes/pdal/all/conandata.yml
+++ b/recipes/pdal/all/conandata.yml
@@ -9,12 +9,14 @@ patches:
   "2.3.0":
     - patch_file: "patches/0001-cmakelists.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0002-cmake-deps-2.3.0.patch"
+      base_path: "source_subfolder"
     - patch_file: "patches/0005-vendor-nanoflann.patch"
       base_path: "source_subfolder"
   "2.2.0":
     - patch_file: "patches/0001-cmakelists.patch"
       base_path: "source_subfolder"
-    - patch_file: "patches/0002-cmake-deps.patch"
+    - patch_file: "patches/0002-cmake-deps-2.2.0.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0003-stdexcept.patch"
       base_path: "source_subfolder"

--- a/recipes/pdal/all/conanfile.py
+++ b/recipes/pdal/all/conanfile.py
@@ -93,6 +93,8 @@ class PdalConan(ConanFile):
             tools.check_min_cppstd(self, 11)
         if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < 5:
             raise ConanInvalidConfiguration ("This compiler version is unsupported")
+        if self.options.shared and self.settings.compiler == "Visual Studio" and "MT" in str(self.settings.compiler.runtime):
+            raise ConanInvalidConfiguration("pdal shared doesn't support MT runtime with Visual Studio")
         miss_boost_required_comp = any(getattr(self.options["boost"], "without_{}".format(boost_comp), True) for boost_comp in self._required_boost_components)
         if self.options["boost"].header_only or miss_boost_required_comp:
             raise ConanInvalidConfiguration("{0} requires non header-only boost with these components: {1}".format(self.name, ", ".join(self._required_boost_components)))

--- a/recipes/pdal/all/conanfile.py
+++ b/recipes/pdal/all/conanfile.py
@@ -187,8 +187,11 @@ class PdalConan(ConanFile):
         self.cpp_info.libs = [pdal_base_name, "pdal_util"]
         if not self.options.shared:
             self.cpp_info.libs.extend(["pdal_arbiter", "pdal_kazhdan"])
-        if self.settings.os == "Linux":
-            self.cpp_info.system_libs.extend(["dl", "m"])
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                self.cpp_info.system_libs.extend(["dl", "m"])
+            elif self.settings.os == "Windows":
+                # dependency of pdal_arbiter
+                self.cpp_info.system_libs.append("shlwapi")
         self.cpp_info.requires = [
             "boost::filesystem", "eigen::eigen", "gdal::gdal",
             "libcurl::libcurl", "libgeotiff::libgeotiff", "nanoflann::nanoflann"

--- a/recipes/pdal/all/conanfile.py
+++ b/recipes/pdal/all/conanfile.py
@@ -26,7 +26,7 @@ class PdalConan(ConanFile):
         "with_zstd": [True, False],
     }
     default_options = {
-        "shared": False,
+        "shared": True,
         "fPIC": True,
         "with_unwind": False,
         "with_xml": True,

--- a/recipes/pdal/all/conanfile.py
+++ b/recipes/pdal/all/conanfile.py
@@ -63,14 +63,14 @@ class PdalConan(ConanFile):
         # TODO package improvements:
         # - switch from vendored arbiter (not in CCI). disabled openssl and curl are deps of arbiter
         # - switch from vendor/nlohmann to nlohmann_json (in CCI)
-        self.requires("boost/1.76.0")
-        self.requires("eigen/3.3.9")
-        self.requires("gdal/3.2.1")
-        self.requires("libcurl/7.77.0") # mandatory dependency of arbiter (to remove if arbiter is unvendored)
-        self.requires("libgeotiff/1.6.0")
+        self.requires("boost/1.77.0")
+        self.requires("eigen/3.4.0")
+        self.requires("gdal/3.3.3")
+        self.requires("libcurl/7.79.1.0") # mandatory dependency of arbiter (to remove if arbiter is unvendored)
+        self.requires("libgeotiff/1.7.0")
         self.requires("nanoflann/1.3.2")
         if self.options.with_xml:
-            self.requires("libxml2/2.9.10")
+            self.requires("libxml2/2.9.12")
         if self.options.with_zstd:
             self.requires("zstd/1.5.0")
         if self.options.with_lazperf:

--- a/recipes/pdal/all/conanfile.py
+++ b/recipes/pdal/all/conanfile.py
@@ -96,8 +96,8 @@ class PdalConan(ConanFile):
         miss_boost_required_comp = any(getattr(self.options["boost"], "without_{}".format(boost_comp), True) for boost_comp in self._required_boost_components)
         if self.options["boost"].header_only or miss_boost_required_comp:
             raise ConanInvalidConfiguration("{0} requires non header-only boost with these components: {1}".format(self.name, ", ".join(self._required_boost_components)))
-        if self.settings.arch not in ("x86_64", ):
-            raise ConanInvalidConfiguration(f"Unsupported arch={self.settings.arch}")
+        if hasattr(self, "settings_build") and tools.cross_building(self):
+            raise ConanInvalidConfiguration("pdal doesn't support cross-build yet")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/pdal/all/patches/0002-cmake-deps-2.2.0.patch
+++ b/recipes/pdal/all/patches/0002-cmake-deps-2.2.0.patch
@@ -1,18 +1,3 @@
-diff --git a/cmake/geotiff.cmake b/cmake/geotiff.cmake
-index 1d1e8af85..a3969996b 100644
---- a/cmake/geotiff.cmake
-+++ b/cmake/geotiff.cmake
-@@ -4,8 +4,8 @@
- 
- find_package(GeoTIFF REQUIRED 1.3.0)
- set_package_properties(GeoTIFF PROPERTIES TYPE REQUIRED)
--if (GEOTIFF_FOUND)
--    include_directories("${GEOTIFF_INCLUDE_DIR}")
-+if (GeoTIFF_FOUND)
-+    include_directories("${GeoTIFF_INCLUDE_DIR}")
-     set(PDAL_HAVE_LIBGEOTIFF 1)
-     mark_as_advanced(CLEAR TIFF_INCLUDE_DIR)
-     mark_as_advanced(CLEAR TIFF_LIBRARY)
 diff --git a/cmake/unwind.cmake b/cmake/unwind.cmake
 index 460a43c15..aa4356070 100644
 --- a/cmake/unwind.cmake

--- a/recipes/pdal/all/patches/0002-cmake-deps-2.3.0.patch
+++ b/recipes/pdal/all/patches/0002-cmake-deps-2.3.0.patch
@@ -1,0 +1,40 @@
+--- a/cmake/unwind.cmake
++++ b/cmake/unwind.cmake
+@@ -3,6 +3,6 @@
+ #
+ 
+ set(FPHSA_NAME_MISMATCHED 1) # Suppress warnings, see https://cmake.org/cmake/help/v3.17/module/FindPackageHandleStandardArgs.html
+-find_package(Libunwind QUIET)
++find_package(libunwind QUIET)
+ set(FPHSA_NAME_MISMATCHED 0)
+ 
+--- a/cmake/zstd.cmake
++++ b/cmake/zstd.cmake
+@@ -4,10 +4,10 @@
+ option(WITH_ZSTD
+     "Build support for compression/decompression with Zstd." TRUE)
+ if (WITH_ZSTD)
+-    find_package(ZSTD QUIET)
+-    set_package_properties(ZSTD PROPERTIES TYPE
++    find_package(zstd QUIET)
++    set_package_properties(zstd PROPERTIES TYPE
+         PURPOSE "General compression support")
+-    if (ZSTD_FOUND)
++    if (zstd_FOUND)
+         set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES}
+             "${ZSTD_STATIC_LIB}")
+         mark_as_advanced(CLEAR ZSTD_INCLUDE_DIRS)
+--- a/pdal/util/CMakeLists.txt
++++ b/pdal/util/CMakeLists.txt
+@@ -10,9 +10,9 @@ include(${PDAL_CMAKE_DIR}/execinfo.cmake)
+ include(${PDAL_CMAKE_DIR}/threads.cmake)
+ include(${PDAL_CMAKE_DIR}/unwind.cmake)
+ 
+-if(LIBUNWIND_FOUND)
++if(libunwind_FOUND)
+     set(BACKTRACE_SOURCE BacktraceUnwind.cpp)
+-    set(BACKTRACE_LIBRARIES ${LIBUNWIND_LIBRARIES})
++    set(BACKTRACE_LIBRARIES ${libunwind_LIBRARIES})
+ elseif(LIBEXECINFO_FOUND)
+     set(BACKTRACE_SOURCE BacktraceExecinfo.cpp)
+     set(BACKTRACE_LIBRARIES ${LIBEXECINFO_LIBRARIES})

--- a/recipes/pdal/all/test_package/conanfile.py
+++ b/recipes/pdal/all/test_package/conanfile.py
@@ -1,9 +1,9 @@
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package"
 
     def build(self):
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/pdal/all/test_package/test_package.cpp
+++ b/recipes/pdal/all/test_package/test_package.cpp
@@ -1,10 +1,17 @@
 #include <pdal/pdal_config.hpp>
+#include <pdal/StageFactory.hpp>
+#include <pdal/PluginManager.hpp>
 #include <iostream>
 
 int main()
 {
-  std::cout << pdal::Config::fullVersionString() << std::endl;
-  std::cout << pdal::Config::debugInformation() << std::endl;
+    std::cout << pdal::Config::fullVersionString() << std::endl;
+    std::cout << pdal::Config::debugInformation() << std::endl;
 
-  return 0;
+    std::cout << "Available plugins:" << std::endl;
+    for (auto const &name : pdal::PluginManager<pdal::Stage>::names()) {
+        std::cout << "- " << name << std::endl;
+    }
+
+    return 0;
 }

--- a/recipes/pdal/config.yml
+++ b/recipes/pdal/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.2.0":
-    folder: all
   "2.3.0":
+    folder: all
+  "2.2.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

~I want to regenerate binaries, package ids are not coherent anymore.~

cross-build is broken for the moment:
- it's broken by design in pdal CMakeLists (due to https://github.com/PDAL/PDAL/blob/2.2.0/cmake/dimension.cmake), I'll see if can fix it.
- ~gdal packages (and flatbuffers packages, dependency of gdal) for Macos M1 are not available in conan-center~

closes https://github.com/conan-io/conan-center-index/issues/8104

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
