### PR TITLE
Add alsa-plugins

### DIFF
--- a/recipes/alsa-plugins/all/conandata.yml
+++ b/recipes/alsa-plugins/all/conandata.yml
@@ -1,0 +1,13 @@
+sources:
+  "1.2.5":
+    url: "https://github.com/alsa-project/alsa-plugins/archive/v1.2.5.tar.gz"
+    sha256: "e1935e34766a461fd89e74743a83782d05db04242d9bbc7b60ea63f8451a41d1"
+  "1.2.2":
+    url: "https://github.com/alsa-project/alsa-plugins/archive/v1.2.2.tar.gz"
+    sha256: "1872622227c474db9db57bf5b6ec91bbef391f9750e9d64d00d05af29f579e1a"
+  "1.2.1":
+    url: "https://github.com/alsa-project/alsa-plugins/archive/v1.2.1.tar.gz"
+    sha256: "8a2b94e18aea42bc69beebfcc343fc37100fadd3c11f91ba702b2fca30fac489"
+  "1.1.9":
+    url: "https://github.com/alsa-project/alsa-plugins/archive/v1.1.9.tar.gz"
+    sha256: "4e16a5efddb57dba5b80b1abcbb49566c0949aab79422b83a429a396743b9e83"

--- a/recipes/alsa-plugins/all/conanfile.py
+++ b/recipes/alsa-plugins/all/conanfile.py
@@ -1,0 +1,88 @@
+from conans import AutoToolsBuildEnvironment, ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class AlsaPluginsConan(ConanFile):
+    name = "alsa-plugins"
+    license = "LGPL-2.1"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/alsa-project/alsa-plugins"
+    topics = ("conan", "libalsa", "alsa", "sound", "audio", "midi")
+    description = "The Advanced Linux Sound Architecture (ALSA) - plugins"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_pulse": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_pulse": True
+    }
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "pkg_config"
+    _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def requirements(self):
+        self.requires("libalsa/1.2.5.1")
+        if self.options.with_pulse:
+            self.requires("pulseaudio/14.2")
+    
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("Only Linux supported")
+        if not self.options.shared:
+            raise ConanInvalidConfiguration("Static build is not supported")
+    
+    def build_requirements(self):
+        self.build_requires("libtool/2.4.6")
+        self.build_requires("pkgconf/1.7.4")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+
+        self._autotools = AutoToolsBuildEnvironment(self)
+        yes_no = lambda v: "yes" if v else "no"
+        args = [
+            "--enable-shared={}".format(yes_no(self.options.shared)),
+            "--enable-static={}".format(yes_no(not self.options.shared)),
+            "--datarootdir={}".format(tools.unix_path(os.path.join(self.package_folder, "res"))),
+        ]
+        self._autotools.configure(args=args, configure_dir=self._source_subfolder)
+        return self._autotools
+
+    def build(self):
+        self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True, cwd=self._source_subfolder)
+        autotools = self._configure_autotools()
+        autotools.make()
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        autotools = self._configure_autotools()
+        autotools.install()
+
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+
+    def package_info(self):
+        self.env_info.ALSA_CONFIG_DIR.append(os.path.join(self.package_folder, "res", "alsa", "alsa.conf.d"))
+        alsa_plugin_dir = os.path.join(self.package_folder, "lib", "alsa-lib")
+        if self.options.shared:
+            self.output.info("Appending ALSA_PLUGIN_DIR env var : %s" % alsa_plugin_dir)
+            self.env_info.ALSA_PLUGIN_DIR.append(alsa_plugin_dir)

--- a/recipes/alsa-plugins/config.yml
+++ b/recipes/alsa-plugins/config.yml
@@ -1,0 +1,9 @@
+versions:
+  "1.2.5":
+    folder: all
+  "1.2.2":
+    folder: all
+  "1.2.1":
+    folder: all
+  "1.1.9":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **alsa-plugins/1.x**

Adds alsa-plugins recipe. Since the plugin .so files are a runtime dependency only, I am not adding anything to `self.cpp_info.libs`. Static builds also seem to not be supported:
https://github.com/alsa-project/alsa-plugins/issues/34

---

- [✓] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [✓] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [✓] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [✓] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
