### PR TITLE
libalsa: append to ALSA_CONFIG_DIR environment variable

### DIFF
--- a/recipes/libalsa/all/conanfile.py
+++ b/recipes/libalsa/all/conanfile.py
@@ -89,4 +89,4 @@ class LibalsaConan(ConanFile):
         self.cpp_info.names["pkg_config"] = "alsa"
         self.cpp_info.names["cmake_find_package"] = "ALSA"
         self.cpp_info.names["cmake_find_package_multi"] = "ALSA"
-        self.env_info.ALSA_CONFIG_DIR = os.path.join(self.package_folder, "res", "alsa")
+        self.env_info.ALSA_CONFIG_DIR.append(os.path.join(self.package_folder, "res", "alsa"))


### PR DESCRIPTION
Append to `ALSA_CONFIG_DIR` environment variable instead of setting it

Specify library name and version:  **libalsa/1.x**

This patch is needed for https://github.com/conan-io/conan-center-index/pull/7096 to work properly since that recipe also appends to `ALSA_CONFIG_DIR`.

---

- [✓] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [✓] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [✓] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [✓] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
