### PR TITLE
Migrates libalsa to alsa (to include alsa-plugins)

### DIFF
--- a/recipes/libalsa/all/conandata.yml
+++ b/recipes/libalsa/all/conandata.yml
@@ -15,3 +15,16 @@ patches:
   "1.2.5.1":
     - patch_file: "patches/1.2.5.1-0001-control-empty-fix-the-static-build.patch"
       base_path: "source_subfolder"
+plugins:
+  "1.2.5.1":
+    url: "https://github.com/alsa-project/alsa-plugins/archive/v1.2.5.tar.gz"
+    sha256: "e1935e34766a461fd89e74743a83782d05db04242d9bbc7b60ea63f8451a41d1"
+  "1.2.4":
+    url: "https://github.com/alsa-project/alsa-plugins/archive/v1.2.2.tar.gz"
+    sha256: "1872622227c474db9db57bf5b6ec91bbef391f9750e9d64d00d05af29f579e1a"
+  "1.2.2":
+    url: "https://github.com/alsa-project/alsa-plugins/archive/v1.2.2.tar.gz"
+    sha256: "1872622227c474db9db57bf5b6ec91bbef391f9750e9d64d00d05af29f579e1a"
+  "1.1.9":
+    url: "https://github.com/alsa-project/alsa-plugins/archive/v1.1.9.tar.gz"
+    sha256: "4e16a5efddb57dba5b80b1abcbb49566c0949aab79422b83a429a396743b9e83"

--- a/recipes/libalsa/all/conanfile.py
+++ b/recipes/libalsa/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import AutoToolsBuildEnvironment, ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
+import shutil
 
 required_conan_version = ">=1.33.0"
 
@@ -10,75 +11,98 @@ class LibalsaConan(ConanFile):
     license = "LGPL-2.1"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/alsa-project/alsa-lib"
-    topics = ("conan", "libalsa", "alsa", "sound", "audio", "midi")
+    topics = ("alsa", "libalsa", "alsa-plugins", "sound", "audio", "midi")
     description = "Library of ALSA: The Advanced Linux Sound Architecture, that provides audio " \
                   "and MIDI functionality to the Linux operating system"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
         "disable_python": [True, False],
+        "with_plugins": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "disable_python": True,
+        "with_plugins": False
     }
     settings = "os", "compiler", "build_type", "arch"
 
-    exports_sources = "patches/*"
-
+    exports_sources = ["patches/*"]
+    generators = "pkg_config"
     _autotools = None
+    _plugins_autotools = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _plugins_source_subfolder(self):
+        return os.path.join(self._source_subfolder, "plugins")
+    
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
-    def build_requirements(self):
-        self.build_requires("libtool/2.4.6")
+    def requirements(self):
+        if self.options.with_plugins:
+            self.requires("pulseaudio/14.2")
 
     def validate(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("Only Linux supported")
+    
+    def build_requirements(self):
+        self.build_requires("libtool/2.4.6")
+        self.build_requires("pkgconf/1.7.4")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+        tools.get(**self.conan_data["plugins"][self.version], destination=self._plugins_source_subfolder, strip_root=True)
 
-    def _configure_autotools(self):
-        if self._autotools:
-            return self._autotools
-
-        self._autotools = AutoToolsBuildEnvironment(self)
+    def _configure_autotools(self, is_plugin):
+        autotools = AutoToolsBuildEnvironment(self)
         yes_no = lambda v: "yes" if v else "no"
         args = [
-            "--enable-shared={}".format(yes_no(self.options.shared)),
-            "--enable-static={}".format(yes_no(not self.options.shared)),
-            "--enable-python={}".format(yes_no(not self.options.disable_python)),
+            "--enable-shared={}".format("yes" if is_plugin else yes_no(self.options.shared)),
+            "--enable-static={}".format("no" if is_plugin else yes_no(not self.options.shared)),
             "--datarootdir={}".format(tools.unix_path(os.path.join(self.package_folder, "res"))),
         ]
-        self._autotools.configure(args=args)
-        return self._autotools
-
+        if not is_plugin:
+            args.append("--enable-python={}".format(yes_no(not self.options.disable_python)))
+        
+        source_dir = self._plugins_source_subfolder if is_plugin else self._source_subfolder
+        autotools.configure(args=args, configure_dir=source_dir)
+        return autotools
+    
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        with tools.chdir(self._source_subfolder):
-            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True)
+            tools.patch(**patch) 
+        
+        self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True, cwd=self._source_subfolder)
+        self._autotools = self._configure_autotools(is_plugin=False)
+        self._autotools.make()
+        
+        if self.options.with_plugins:
+            # we have to package libalsa so that it can be used to build the plugins
+            self._autotools.install()
+            shutil.copyfile(os.path.join("utils", "alsa.pc"), "alsa.pc")
 
-            autotools = self._configure_autotools()
-            autotools.make()
+            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True, cwd=self._plugins_source_subfolder)
+            self._plugins_autotools = self._configure_autotools(is_plugin=True)
+            self._plugins_autotools.make()
 
     def package(self):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)
-        with tools.chdir(self._source_subfolder):
-            autotools = self._configure_autotools()
-            autotools.install()
+        if not self.options.with_plugins:
+            self._autotools.install()
+
+        if self.options.with_plugins:
+            self.copy("COPYING", dst=os.path.join("licenses", "plugins"), src=os.path.join(self._source_subfolder, "plugins"))
+            self._plugins_autotools.install()
 
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
@@ -90,3 +114,7 @@ class LibalsaConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "ALSA"
         self.cpp_info.names["cmake_find_package_multi"] = "ALSA"
         self.env_info.ALSA_CONFIG_DIR = os.path.join(self.package_folder, "res", "alsa")
+        if self.options.with_plugins:
+            alsa_plugin_dir = os.path.join(self.package_folder, "lib", "alsa-lib")
+            self.output.info("Appending ALSA_PLUGIN_DIR env var : %s" % alsa_plugin_dir)
+            self.env_info.ALSA_PLUGIN_DIR = alsa_plugin_dir

--- a/recipes/libalsa/all/test_package/conanfile.py
+++ b/recipes/libalsa/all/test_package/conanfile.py
@@ -1,7 +1,7 @@
 import os
 from conans import ConanFile, CMake, tools
 
-class LibalsaTestConan(ConanFile):
+class AlsaTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 
@@ -11,6 +11,7 @@ class LibalsaTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        # TODO: Add test for plugins
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "example")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **alsa/1.x**

I need to add `alsa-plugins` (see draft https://github.com/conan-io/conan-center-index/pull/7096). However as seen from this comment (https://github.com/conan-io/conan-center-index/pull/7098#discussion_r697920460) this is not possible. I have also opened a ticket in upstream to see if that can be fixed (https://github.com/alsa-project/alsa-lib/issues/175). But as it stands, it seems that the current solution is to combine `libalsa` and my draft `alsa-plugins` recipes into a single recipe. I am calling this recipe `alsa` because it now also includes `alsa-plugins` in addition to `libalsa`.

---

- [✓] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [✓] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [✓] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [✓] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
