### PR TITLE
libraw/all: Add 'with_*' option flags and bump dependencies.

### DIFF
--- a/recipes/libraw/all/CMakeLists.txt
+++ b/recipes/libraw/all/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.1)
 project(LibRaw)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 file(GLOB_RECURSE headers "source_subfolder/libraw/*.h")
 
@@ -26,7 +26,15 @@ if(WIN32)
     endif()
 endif()
 
-add_definitions(-DUSE_JPEG -DUSE_JPEG8 -DUSE_JASPER)
+if (TARGET CONAN_PKG::libjpeg OR TARGET CONAN_PKG::libjpeg-turbo)
+    add_definitions(-DUSE_JPEG -DUSE_JPEG8)
+endif ()
+if (TARGET CONAN_PKG::lcms)
+    add_definitions(-DUSE_LCMS2)
+endif ()
+if (TARGET CONAN_PKG::jasper)
+    add_definitions(-DUSE_JASPER)
+endif ()
 
 add_library(raw ${headers} ${sources})
 set_property(TARGET raw PROPERTY CXX_STANDARD 11)

--- a/recipes/libraw/all/conanfile.py
+++ b/recipes/libraw/all/conanfile.py
@@ -12,8 +12,20 @@ class LibRawConan(ConanFile):
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
 
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_jpeg": [False, "libjpeg", "libjpeg-turbo"],
+        "with_lcms": [True, False],
+        "with_jasper": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_jpeg": "libjpeg",
+        "with_lcms": True,
+        "with_jasper": True
+    }
 
     _cmake = None
 
@@ -26,9 +38,16 @@ class LibRawConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("libjpeg/9d")
-        self.requires("lcms/2.11")
-        self.requires("jasper/2.0.16")
+        # TODO: RawSpeed dependency (-DUSE_RAWSPEED)
+        # TODO: DNG SDK dependency (-DUSE_DNGSDK)
+        if self.options.with_jpeg == "libjpeg":
+            self.requires("libjpeg/9d")
+        elif self.options.with_jpeg == "libjpeg-turbo":
+            self.requires("libjpeg-turbo/2.1.1")
+        if self.options.with_lcms:
+            self.requires("lcms/2.12")
+        if self.options.with_jasper:
+            self.requires("jasper/2.0.33")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Specify library name and version:  **libraw/0.20.2**

Adds `with_jpeg`, `with_lcms` and `with_jasper` option flags with corresponding updates in bundled 'CMakeLists.txt'.

Main benefit is that it is possible to switch between libjpeg and libjpeg-turbo dependencies. Also the `-DUSE_LCMS2` flag was missing for LCMS dependency.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
