### PR TITLE
(#7107) sdl: Add requires for libunwind

### DIFF
--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -312,7 +312,7 @@ class SDLConan(ConanFile):
                 self.cpp_info.components["libsdl2"].requires.append("wayland::wayland")
                 self.cpp_info.components["libsdl2"].requires.append("xkbcommon::xkbcommon")
                 self.cpp_info.components["libsdl2"].requires.append("egl::egl")
-            if self.options.get_safe("libunwind"):
+            if self.options.libunwind:
                 self.cpp_info.components["libsdl2"].requires.append("libunwind::libunwind")
         elif tools.is_apple_os(self.settings.os):
             self.cpp_info.components["libsdl2"].frameworks = [

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -141,7 +141,7 @@ class SDLConan(ConanFile):
                 self.requires("egl/system")
             if self.options.directfb:
                 raise ConanInvalidConfiguration("Package for 'directfb' is not available (yet)")
-            if self.options.get_safe("libunwind", False):
+            if self.options.libunwind:
                 self.requires("libunwind/1.5.0")
 
     def validate(self):
@@ -235,10 +235,10 @@ class SDLConan(ConanFile):
 
                 self._cmake.definitions["VIDEO_DIRECTFB"] = self.options.directfb
                 self._cmake.definitions["VIDEO_RPI"] = self.options.video_rpi
+                self._cmake.definitions["HAVE_LIBUNWIND_H"] = self.options.libunwind
             elif self.settings.os == "Windows":
                 self._cmake.definitions["DIRECTX"] = self.options.directx
 
-            self._cmake.definitions["HAVE_LIBUNWIND_H"] = self.options.get_safe("libunwind")
 
             # Add extra information collected from the deps
             self._cmake.definitions["EXTRA_LDFLAGS"] = " ".join(cmake_extra_ldflags)


### PR DESCRIPTION
Specify library name and version:  sdl/2.0.16

Fix to bug #7107, SDL2 cannot build without the libunwind package, so I added the option for SDL2 to properly build! This is my first contribution to Conan packages so let me know if anything needs to be changed :)! I'm not the author or anything like that, SDL2 just requires libunwind.
close #7107 
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
