### PR TITLE
[rapidcheck] Remove _deprecated_ versions

### DIFF
--- a/recipes/rapidcheck/all/conandata.yml
+++ b/recipes/rapidcheck/all/conandata.yml
@@ -1,10 +1,4 @@
 sources:
-  "20200131":
-    url: "https://github.com/emil-e/rapidcheck/archive/258d907da00a0855f92c963d8f76eef115531716.zip"
-    sha256: "87bfbdceaa09e7aaaf70b2efd0078e93323dd8abdad48c57e9f23bfd84174a75"
-  "20210107":
-    url: "https://github.com/emil-e/rapidcheck/archive/37bcab858dfc398634d409c973363088703ba96e.zip"
-    sha256: "35433d0417fb945abe2b56b720b03d6d92da1188e760c50662c243dac42a6717"
   "cci.20210702":
     url: "https://github.com/emil-e/rapidcheck/archive/33d15a858e3125f5af61a655f390f1cbc2f272ba.zip"
     sha256: "521c9b163f0018ea6379513e0c674d520b9da66fdb8df73a7a98b04ea2358e69"

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -51,9 +51,6 @@ class RapidcheckConan(ConanFile):
         if self.settings.compiler == "Visual Studio" and self.options.shared:
             raise ConanInvalidConfiguration("shared is not supported using Visual Studio")
 
-        if 'cci' not in self.version:
-            self.output.warn("This version has been deprecated in favor of '{}/cci.{}'".format(self.name, self.version))
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -107,11 +107,9 @@ class RapidcheckConan(ConanFile):
         self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
         self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
         self.cpp_info.libs = ["rapidcheck"]
-        # Remove after 9473 is merged.
-        version = self.version
-        if version.startswith("cci."):
-            version = version[4:]
-        if version < "20201218":
+        
+        version = self.version[4:]
+        if tools.Version(version) < "20201218":
             if self.options.enable_rtti:
                 self.cpp_info.defines.append("RC_USE_RTTI")
         else:

--- a/recipes/rapidcheck/config.yml
+++ b/recipes/rapidcheck/config.yml
@@ -1,8 +1,4 @@
 versions:
-  "20200131":
-    folder: all
-  "20210107":
-    folder: all
   "cci.20210702":
     folder: all
   "cci.20210107":


### PR DESCRIPTION
After https://github.com/conan-io/conan-center-index/pull/7037, we can remove versions without `cci.` prefix
