### PR TITLE
rectanglebinpack: add rectanglebinpack/cci.20210901 recipe

### DIFF
--- a/recipes/rectanglebinpack/all/CMakeLists.txt
+++ b/recipes/rectanglebinpack/all/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.4)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+add_subdirectory("source_subfolder")

--- a/recipes/rectanglebinpack/all/CMakeLists.txt
+++ b/recipes/rectanglebinpack/all/CMakeLists.txt
@@ -1,13 +1,8 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.8)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
 conan_basic_setup()
-
-if(NOT "${CMAKE_CXX_STANDARD}")
-    set(CMAKE_CXX_STANDARD 11)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/recipes/rectanglebinpack/all/CMakeLists.txt
+++ b/recipes/rectanglebinpack/all/CMakeLists.txt
@@ -4,6 +4,11 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
+if(NOT "${CMAKE_CXX_STANDARD}")
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_subdirectory("source_subfolder")

--- a/recipes/rectanglebinpack/all/conandata.yml
+++ b/recipes/rectanglebinpack/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "cci.20210829":
+    - url: "https://github.com/juj/RectangleBinPack/archive/d503ea88f110396be948019288bec1f7a2123166.zip"
+      sha256: "3425a111fac110e58f21e588bf770a2d8bad23c2f01a426b5d3f4f77a0dcbe55"
+    - url: "https://unlicense.org/UNLICENSE"
+      sha256: "7e12e5df4bae12cb21581ba157ced20e1986a0508dd10d0e8a4ab9a4cf94e85c"
+patches:
+  "cci.20210829":
+    - patch_file: "patches/0001_fix_win32_build.patch"
+      base_path: "source_subfolder"

--- a/recipes/rectanglebinpack/all/conandata.yml
+++ b/recipes/rectanglebinpack/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
-  "cci.20210829":
-    - url: "https://github.com/juj/RectangleBinPack/archive/d503ea88f110396be948019288bec1f7a2123166.zip"
-      sha256: "3425a111fac110e58f21e588bf770a2d8bad23c2f01a426b5d3f4f77a0dcbe55"
+  "cci.20210901":
+    - url: "https://github.com/juj/RectangleBinPack/archive/a40fcaf3871da57b0f6a080655b3387374840877.zip"
+      sha256: "88cec105ca8d90d09e9e81f9862caa0cc1cdb851560fb701555eb58b29515748"
     - url: "https://unlicense.org/UNLICENSE"
       sha256: "7e12e5df4bae12cb21581ba157ced20e1986a0508dd10d0e8a4ab9a4cf94e85c"
 patches:
-  "cci.20210829":
+  "cci.20210901":
     - patch_file: "patches/0001_fix_win32_build.patch"
       base_path: "source_subfolder"

--- a/recipes/rectanglebinpack/all/conanfile.py
+++ b/recipes/rectanglebinpack/all/conanfile.py
@@ -1,0 +1,74 @@
+from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class RectangleBinPackConan(ConanFile):
+    name = "rectanglebinpack"
+    license = "Unlicense"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/juj/RectangleBinPack"
+    description = "The code can be used to solve the problem of packing a set of 2D rectangles into a larger bin."
+    topics = ("rectangle", "packing", "bin")
+    exports_sources = ["CMakeLists.txt", "patches/**"]
+    generators = "cmake"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version][0],
+                  strip_root=True, destination=self._source_subfolder)
+        tools.download(filename="LICENSE", **self.conan_data["sources"][self.version][1])
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses")
+        self.copy("*.h", dst=os.path.join("include", self.name), src=self._source_subfolder, excludes="old/**")
+        self.copy("*.dll", dst="bin", keep_path=False)
+        self.copy("*.lib", dst="lib", keep_path=False)
+        self.copy("*.so", dst="lib", keep_path=False)
+        self.copy("*.dylib", dst="lib", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.names["cmake_find_package"] = "RectangleBinPack"
+        self.cpp_info.names["cmake_find_package_multi"] = "RectangleBinPack"

--- a/recipes/rectanglebinpack/all/conanfile.py
+++ b/recipes/rectanglebinpack/all/conanfile.py
@@ -41,6 +41,10 @@ class RectangleBinPackConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version][0],
                   strip_root=True, destination=self._source_subfolder)
@@ -69,6 +73,6 @@ class RectangleBinPackConan(ConanFile):
         self.copy("*.a", dst="lib", keep_path=False)
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = ["RectangleBinPack"]
         self.cpp_info.names["cmake_find_package"] = "RectangleBinPack"
         self.cpp_info.names["cmake_find_package_multi"] = "RectangleBinPack"

--- a/recipes/rectanglebinpack/all/patches/0001_fix_win32_build.patch
+++ b/recipes/rectanglebinpack/all/patches/0001_fix_win32_build.patch
@@ -1,0 +1,11 @@
+--- a/test/MaxRectsBinPackTest.cpp
++++ b/test/MaxRectsBinPackTest.cpp
+@@ -24,8 +24,6 @@
+ #if defined(WIN32)
+ 	LARGE_INTEGER ddwTimer;
+ 	BOOL success = QueryPerformanceCounter(&ddwTimer);
+-	assume(success != 0);
+-	MARK_UNUSED(success);
+ 	return ddwTimer.QuadPart;
+ #elif defined(__APPLE__)
+ 	return mach_absolute_time();

--- a/recipes/rectanglebinpack/all/test_package/CMakeLists.txt
+++ b/recipes/rectanglebinpack/all/test_package/CMakeLists.txt
@@ -6,3 +6,4 @@ conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/rectanglebinpack/all/test_package/CMakeLists.txt
+++ b/recipes/rectanglebinpack/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.4)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/rectanglebinpack/all/test_package/conanfile.py
+++ b/recipes/rectanglebinpack/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/rectanglebinpack/all/test_package/conanfile.py
+++ b/recipes/rectanglebinpack/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/rectanglebinpack/all/test_package/test_package.cpp
+++ b/recipes/rectanglebinpack/all/test_package/test_package.cpp
@@ -1,0 +1,47 @@
+/*
+ * Original source code:
+ * https://github.com/juj/RectangleBinPack/blob/29eec60fe2c9aa0df855dddabd8d4d17023b95f3/test/MaxRectsBinPackTest.cpp
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+#include <rectanglebinpack/MaxRectsBinPack.h>
+
+using namespace rbp;
+
+bool AreDisjoint(const Rect &a, const Rect &b)
+{
+	return a.x >= b.x + b.width || a.x + a.width <= b.x ||
+		a.y >= b.y + b.height || a.y + a.height <= b.y;
+}
+
+bool AllRectsDisjoint(std::vector<Rect> &packed)
+{
+	for(size_t i = 0; i < packed.size(); ++i)
+		for(size_t j = i+1; j < packed.size(); ++j)
+		{
+			if (!AreDisjoint(packed[i], packed[j]))
+				return false;
+		}
+	return true;
+}
+
+int main()
+{
+	MaxRectsBinPack pack(256, 256, true);
+
+	std::vector<Rect> packed;
+	srand(12412);
+	for(int i = 1; i < 128; ++i)
+	{
+		int a = (rand() % 128) + 1;
+		int b = (rand() % 128) + 1;
+		Rect r = pack.Insert(a, b, MaxRectsBinPack::RectBestShortSideFit);
+		if (!r.width)
+			break;
+		packed.push_back(r);
+	}
+	printf("Packed %d rectangles. All rects disjoint: %s. Occupancy: %f\n",
+		(int)packed.size(), AllRectsDisjoint(packed) ? "yes" : "NO!", pack.Occupancy());
+}

--- a/recipes/rectanglebinpack/config.yml
+++ b/recipes/rectanglebinpack/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20210829":
+  "cci.20210901":
     folder: "all"

--- a/recipes/rectanglebinpack/config.yml
+++ b/recipes/rectanglebinpack/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20210829":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **rectanglebinpack/cci.20210901**

We use this library as a dependency, so we would like to provide this recipe so anyone can use it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
