### PR TITLE
[json-schema-validator] gcc 4.x

### DIFF
--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -51,7 +51,7 @@ class JsonSchemaValidatorConan(ConanFile):
 
         compilers = {
             "Visual Studio": min_vs_version,
-            "gcc": "5",
+            "gcc": "5" if version < "2.1.0" else "4.9",
             "clang": "4",
             "apple-clang": "9"}
         min_version = compilers.get(str(self.settings.compiler))


### PR DESCRIPTION
Specify library name and version:  **json-schema-validator/2.1.0**

json-schema-validator is intended to support gcc < 4.9, though there are some issues that prevent this without patches in 2.0.0 (see e.g. https://github.com/pboettch/json-schema-validator/issues/76) and supporting gcc 4.8 would add an additional requirement on **boost::regex** (see https://github.com/pboettch/json-schema-validator/issues/131#issuecomment-686507223 and https://github.com/pboettch/json-schema-validator/blob/2.0.0/CMakeLists.txt#L79), so I'm just adding gcc 4.9 support for **json-schema-validator/2.1.0** in this PR.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
