### PR TITLE
bump up quill/1.6.3

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -26,3 +26,6 @@ sources:
   "1.6.2":
     url: "https://github.com/odygrd/quill/archive/v1.6.2.tar.gz"
     sha256: "9c27cd7fdf4459c75d1722dd9f2226b5e82ad96b5dbf58559bc8ba3df6af8839"
+  "1.6.3":
+    url: "https://github.com/odygrd/quill/archive/v1.6.3.tar.gz"
+    sha256: "886120b084db952aafe651c64f459e69fec481b4e189c14daa8c4108afebcba3"

--- a/recipes/quill/all/conanfile.py
+++ b/recipes/quill/all/conanfile.py
@@ -61,7 +61,9 @@ class QuillConan(ConanFile):
             self.output.warn("Quill requires C++14. Your compiler is unknown. Assuming it supports C++14.")
 
     def requirements(self):
-        if tools.Version(self.version) >= "1.3.3":
+        if tools.Version(self.version) >= "1.6.3":
+            self.requires("fmt/8.0.1")
+        elif tools.Version(self.version) >= "1.3.3":
             self.requires("fmt/7.1.2")
         else:
             self.requires("fmt/6.2.1")

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -17,3 +17,5 @@ versions:
     folder: "all"
   "1.6.2":
     folder: "all"
+  "1.6.3":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **quill/1.6.3**

quill  is upgraded to 1.6.3 on 2021-08-31.

---

- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [+] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [+] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
