### PR TITLE
Add with_leak_detection option to cpputest/4.0

### DIFF
--- a/recipes/cpputest/all/conanfile.py
+++ b/recipes/cpputest/all/conanfile.py
@@ -18,10 +18,12 @@ class CppUTestConan(ConanFile):
     options = {
         "fPIC": [True, False],
         "with_extensions": [True, False],
+        "with_leak_detection": [True, False],
     }
     default_options = {
         "fPIC": True,
         "with_extensions": True,
+        "with_leak_detection": True,
     }
 
     _cmake = None
@@ -53,7 +55,7 @@ class CppUTestConan(ConanFile):
         self._cmake.definitions["STD_C"] = "ON"
         self._cmake.definitions["STD_CPP"] = "ON"
         self._cmake.definitions["C++11"] = "ON"
-        self._cmake.definitions["MEMORY_LEAK_DETECTION"] = "ON"
+        self._cmake.definitions["MEMORY_LEAK_DETECTION"] = self.options.with_leak_detection
         self._cmake.definitions["EXTENSIONS"] = self.options.with_extensions
         self._cmake.definitions["LONGLONG"] = "ON"
         self._cmake.definitions["COVERAGE"] = "OFF"


### PR DESCRIPTION
Specify library name and version:  **cpputest/4.0**

Add `with_leak_detection` option. This is an option to the `cpputest` package that has not been exposed through through conan yet.

Resolves #7131 7131
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
