### PR TITLE
Remove apply_conandata_patches from oatpp-postgresql

### DIFF
--- a/recipes/oatpp-postgresql/all/conanfile.py
+++ b/recipes/oatpp-postgresql/all/conanfile.py
@@ -1,6 +1,5 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches
 import os
 
 required_conan_version = ">=1.35.0"
@@ -12,7 +11,7 @@ class OatppPostgresqlConan(ConanFile):
     homepage = "https://github.com/oatpp/oatpp-postgresql"
     url = "https://github.com/conan-io/conan-center-index"
     description = "oat++ PostgreSQL library"
-    topics = ("conan", "oat++", "oatpp", "postgresql")
+    topics = ("oat", "postgresql", "orm", "database")
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
@@ -36,6 +35,8 @@ class OatppPostgresqlConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+
+    def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
 
@@ -63,7 +64,8 @@ class OatppPostgresqlConan(ConanFile):
         return self._cmake
 
     def build(self):
-        apply_conandata_patches(self)
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 


### PR DESCRIPTION
The `apply_conandata_patches` will be changed on Conan 1.40 and should be removed for now.

Specify library name and version:  **oatpp-postgresql/1.2.5**

/cc @lasote

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
