### PR TITLE
Remove apply_conandata_patches from azure-storage-cpp

### DIFF
--- a/recipes/azure-storage-cpp/all/conanfile.py
+++ b/recipes/azure-storage-cpp/all/conanfile.py
@@ -1,9 +1,8 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches
 import os
 
-required_conan_version = ">=1.35.0"
+required_conan_version = ">=1.33.0"
 
 class AzureStorageCppConan(ConanFile):
     name = "azure-storage-cpp"
@@ -105,7 +104,8 @@ class AzureStorageCppConan(ConanFile):
             raise ConanInvalidConfiguration("Visual Studio build for shared library with MT runtime is not supported")
 
     def build(self):
-        apply_conandata_patches(self)
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 


### PR DESCRIPTION
The `apply_conandata_patches` will be changed on Conan 1.40 and should be removed for now.

Specify library name and version:  **azure-storage-cpp/7.5.0**

/cc @lasote

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
