### PR TITLE
[docs] Enforce usage of targets

### DIFF
--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -117,7 +117,7 @@ enforce this generator to align with the upcoming
 and it should help in the migration (and compatibility) with Conan v2.
 
 In ConanCenter we try to mimic the names of the targets and the information provided by CMake's modules and config files that some libraries
-provide. If CMake or the library itself don't enforce any target name, the ones provided by Conan should be recomended. The minimal project
+provide. If CMake or the library itself don't enforce any target name, the ones provided by Conan should be recommended. The minimal project
 in the `test_package` folder should serve as an example of the best way to consume the package, and targets are preferred over raw variables.
 
 This rule applies for the _global_ target and for components ones. The following snippet should serve as example:

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -137,7 +137,7 @@ target_link_libraries(${PROJECT_NAME} package::package)
 ```
 
 We encourage contributors to check that not only the _global_ target works properly, but also the ones for the components. It can be
-done creating and linking different libraries and or executables.
+done creating and linking different libraries and/or executables.
 
 ### Recommended feature options names
 

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -105,20 +105,39 @@ def _configure_cmake(self):
 
 ### Minimalistic Source Code
 
-The contents of `test_package.c` or `test_package.cpp` should be as minimal as possible, including a few headers at most with simple instantiation of objects to ensure linkage
-and dependencies are correct.
+The contents of `test_package.c` or `test_package.cpp` should be as minimal as possible, including a few headers at most with simple
+instantiation of objects to ensure linkage and dependencies are correct. Any build system can be used to test the package, but
+CMake or Meson are usually preferred.
 
-### Verifying Components
+### CMake targets
 
-When components are defined in the `package_info` in `conanfile.py` the following conditions are desired
+When using CMake to test a package, the information should be consumed using the **targets provided by `cmake_find_package_multi` generator**. We
+enforce this generator to align with the upcoming 
+[Conan's new `CMakeDeps` generator](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmakedeps.html?highlight=cmakedeps)
+and it should help in the migration (and compatibility) with Conan v2.
 
-* use `cmake_find_package` if library has an [official](cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules) CMake module emulated in the recipe.
-* use `cmake_find_package_multi` if library provides an official cmake config file emulated in the recipe. If there are more than one target, try to use all of them, or add another executable linking to the global (usually unofficial) target. There may additionally be variables that are emulated by the recipe which should be used as well. There are some ways to identify when to use it:
-    * Usually, project installs its cmake files into `package_folder/lib/cmake`. The folder is removed from package folder by calling `tools.rmdir(os.path.join(self.package_folder), "lib", "cmake")`
-    * Also, the library's CMake scripts can use [install(EXPORT ..)](https://cmake.org/cmake/help/latest/command/install.html#export) and/or may install [package configuration helpers](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html)
-      to indicate an exported CMake config file.
-    * When `self.cpp_info.filenames["cmake_find_package_multi"]`, `self.cpp_info.names["cmake_find_package_multi"]` are declared
-* otherwise, use [cmake generator](https://docs.conan.io/en/latest/reference/generators/cmake.html) to not suggest an unofficial cmake target in test package.
+In ConanCenter we try to mimic the names of the targets and the information provided by CMake's modules and config files that some libraries
+provide. If CMake or the library itself don't enforce any target name, the ones provided by Conan should be recomended. The minimal project
+in the `test_package` folder should serve as an example of the best way to consume the package, and targets are preferred over raw variables.
+
+This rule applies for the _global_ target and for components ones. The following snippet should serve as example:
+
+**CMakeLists.txt**
+```cmake
+cmake_minimum_required(VERSION 3.1.2)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(package REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} package::package)
+```
+
+We encourage contributors to check that not only the _global_ target works properly, but also the ones for the components. It can be
+done creating and linking different libraries and or executables.
 
 ### Recommended feature options names
 

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -139,7 +139,7 @@ target_link_libraries(${PROJECT_NAME} package::package)
 We encourage contributors to check that not only the _global_ target works properly, but also the ones for the components. It can be
 done creating and linking different libraries and/or executables.
 
-### Recommended feature options names
+## Recommended feature options names
 
 It's often needed to add options to toggle specific library features on/off. Regardless of the default, there is a strong preference for using positive naming for options. In order to avoid the fragmentation, we recommend to use the following naming conventions for such options:
 


### PR DESCRIPTION
Conan v2 is approaching fast with radical improvements around build helpers. Most of the new functionality is being backported to Conan v1.x in an effort to provide a baseline of compatible features and syntax that will work with both versions and make the migration path as smooth as possible.

You can read about these new features in the [tribe repository](https://github.com/conan-io/tribe) and in the [Conan documentation](https://docs.conan.io/en/latest/). The [changelog](https://github.com/conan-io/conan/releases) is also a good place to keep updated, there you can find an exhaustive list of new features together with a link to the documentation that was changed related to it.

Regarding `conan-center-index`, one of the main changes will be the deprecation of (the functionality provided by) the `cmake` generator. This functionality will be superseded by a much more convenient approach: CMake toolchains (the new CMake build-helper will take care to inject it and it would be the same if using CMake from CLI). It means that some variables will no longer be accessible, among them it's important to **notice that `CONAN_LIBS` will no longer be available**.

We are already doing a huge effort (thanks to everyone) trying to mimic in our `package_info()` the information provided by the modules offered by CMake and the config files that some libraries provide. We are mimic target names, and thanks to the build-modules we can create aliases and provide extra variables. 

We believe that targets are more convenient for consumers and there is no reason to keep using only the `cmake` generator and raw variables instead of the targets that Conan is already providing. We think that ConanCenter itself **can suggest and enforce** targets when they are not already enforced. 

Following this lead, the mini-project in `test_package` can become **an example of the best practices to consume the library**, and not just a test for the Conan package itself. It will also align with the following releases of Conan and will make it easier to use new Conan versions and, eventually, make it possible to **use the same recipes with Conan v1 and v2**.

Of course, we will keep trying to mimic existing targets when they are already available and spread in the C++ ecosystem, and we will change Conan ones and modify the `cpp_info` information if some library starts to recommend different names and/or targets. 