### PR TITLE
gtk-doc-stub: add gtk-doc-stub/cci.20181216 recipe

### DIFF
--- a/recipes/gtk-doc-stub/all/conandata.yml
+++ b/recipes/gtk-doc-stub/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "cci.20181216":
+    url: "https://gitlab.gnome.org/GNOME/gtk-doc-stub/-/archive/d26c9b8343540661080eccbff393ee5709a673f4/gtk-doc-stub-d26c9b8343540661080eccbff393ee5709a673f4.tar.gz"
+    sha256: "50da38b540d9cf8a865b4c9a10d45f09471d29f7dd946dd63cfc94b44fee8479"
+patches:
+  "cci.20181216":
+    - patch_file: "patches/0001-relocatable-gtkdocize.patch"
+      base_path: "source_subfolder"

--- a/recipes/gtk-doc-stub/all/conanfile.py
+++ b/recipes/gtk-doc-stub/all/conanfile.py
@@ -14,7 +14,7 @@ class GtkDocStubConan(ConanFile):
     topics = ("gtk", "documentation", "gtkdocize")
     settings = "os"
 
-    exports_sources = "patches/*
+    exports_sources = "patches/*"
 
     @property
     def _source_subfolder(self):

--- a/recipes/gtk-doc-stub/all/conanfile.py
+++ b/recipes/gtk-doc-stub/all/conanfile.py
@@ -12,8 +12,9 @@ class GtkDocStubConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     license = "GPL-2.0-or-later"
     topics = ("gtk", "documentation", "gtkdocize")
+    settings = "os"
 
-    exports_sources = "patches/*"
+    exports_sources = "patches/*
 
     @property
     def _source_subfolder(self):

--- a/recipes/gtk-doc-stub/all/conanfile.py
+++ b/recipes/gtk-doc-stub/all/conanfile.py
@@ -7,7 +7,7 @@ required_conan_version = ">=1.33.0"
 class GtkDocStubConan(ConanFile):
     name = "gtk-doc-stub"
     homepage = "https://gitlab.gnome.org/GNOME/gtk-doc-stub"
-    description = "Helper scripts for generating GTK documentaiton"
+    description = "Helper scripts for generating GTK documentation"
     url = "https://github.com/conan-io/conan-center-index"
     license = "GPLv2-or-later"
     topics = ("gtk", "documentation", "gtkdocize")

--- a/recipes/gtk-doc-stub/all/conanfile.py
+++ b/recipes/gtk-doc-stub/all/conanfile.py
@@ -10,7 +10,7 @@ class GtkDocStubConan(ConanFile):
     homepage = "https://gitlab.gnome.org/GNOME/gtk-doc-stub"
     description = "Helper scripts for generating GTK documentation"
     url = "https://github.com/conan-io/conan-center-index"
-    license = "GPLv2-or-later"
+    license = "GPL-2.0-or-later"
     topics = ("gtk", "documentation", "gtkdocize")
     settings = "os"
 

--- a/recipes/gtk-doc-stub/all/conanfile.py
+++ b/recipes/gtk-doc-stub/all/conanfile.py
@@ -12,7 +12,6 @@ class GtkDocStubConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     license = "GPL-2.0-or-later"
     topics = ("gtk", "documentation", "gtkdocize")
-    settings = "os"
 
     exports_sources = "patches/*"
 

--- a/recipes/gtk-doc-stub/all/conanfile.py
+++ b/recipes/gtk-doc-stub/all/conanfile.py
@@ -1,0 +1,67 @@
+from conans import AutoToolsBuildEnvironment, ConanFile, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class GtkDocStubConan(ConanFile):
+    name = "gtk-doc-stub"
+    homepage = "https://gitlab.gnome.org/GNOME/gtk-doc-stub"
+    description = "Helper scripts for generating GTK documentaiton"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "GPLv2-or-later"
+    topics = ("gtk", "documentation", "gtkdocize")
+    settings = "os"
+
+    exports_sources = "patches/*"
+
+    _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def build_requirements(self):
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
+
+    def package_id(self):
+        self.info.header_only()
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        args = [
+            "--datadir={}".format(tools.unix_path(os.path.join(self.package_folder, "res"))),
+            "--datarootdir={}".format(tools.unix_path(os.path.join(self.package_folder, "res"))),
+        ]
+        self._autotools.configure(args=args, configure_dir=self._source_subfolder)
+        return self._autotools
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        autotools = self._configure_autotools()
+        autotools.make()
+
+    def package(self):
+        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
+        autotools = self._configure_autotools()
+        autotools.install()
+
+    def package_info(self):
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = ["res"]
+
+        automake_dir = os.path.join(self.package_folder, "res", "aclocal")
+        self.output.info("Appending AUTOMAKE_CONAN_INCLUDES environment variable: {}".format(automake_dir))
+        self.env_info.AUTOMAKE_CONAN_INCLUDES.append(automake_dir)

--- a/recipes/gtk-doc-stub/all/patches/0001-relocatable-gtkdocize.patch
+++ b/recipes/gtk-doc-stub/all/patches/0001-relocatable-gtkdocize.patch
@@ -1,0 +1,15 @@
+--- gtkdocize.in
++++ gtkdocize.in
+@@ -6,9 +6,9 @@
+ PACKAGE=gtk-doc
+ VERSION=1.1000
+ 
+-prefix=@prefix@
+-datarootdir=@datarootdir@
+-datadir=@datadir@
++SCRIPT_HOME=`dirname $0 | while read a; do cd $a && pwd && break; done`
++datarootdir=$SCRIPT_HOME/../res
++datadir=$datarootdir
+ 
+ # options
+ copy=no

--- a/recipes/gtk-doc-stub/all/test_package/conanfile.py
+++ b/recipes/gtk-doc-stub/all/test_package/conanfile.py
@@ -1,0 +1,33 @@
+from conans import AutoToolsBuildEnvironment, ConanFile, tools
+import os
+import shutil
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    exports_sources = "configure.ac",
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def build_requirements(self):
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
+        self.build_requires("automake/1.16.4")
+
+    def build(self):
+        for src in self.exports_sources:
+            shutil.copy(os.path.join(self.source_folder, src),
+                        os.path.join(self.build_folder, src))
+        # self.run("gtkdocize", run_environment=True, win_bash=tools.os_info.is_windows)
+        self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True, win_bash=tools.os_info.is_windows)
+        autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        args = [
+            "--enable-option-checking=fatal",
+            "--enable-gtk-doc=no",
+        ]
+        autotools.configure(args=args)
+
+    def test(self):
+        self.run("gtkdocize --copy", run_environment=True, win_bash=tools.os_info.is_windows)

--- a/recipes/gtk-doc-stub/all/test_package/conanfile.py
+++ b/recipes/gtk-doc-stub/all/test_package/conanfile.py
@@ -6,6 +6,7 @@ import shutil
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     exports_sources = "configure.ac",
+    test_type = "requires", "build_requires"
 
     @property
     def _settings_build(self):
@@ -20,7 +21,6 @@ class TestPackageConan(ConanFile):
         for src in self.exports_sources:
             shutil.copy(os.path.join(self.source_folder, src),
                         os.path.join(self.build_folder, src))
-        # self.run("gtkdocize", run_environment=True, win_bash=tools.os_info.is_windows)
         self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True, win_bash=tools.os_info.is_windows)
         autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         args = [

--- a/recipes/gtk-doc-stub/all/test_package/configure.ac
+++ b/recipes/gtk-doc-stub/all/test_package/configure.ac
@@ -1,0 +1,9 @@
+AC_INIT([test_package], [1.0])
+
+AC_CONFIG_SRCDIR([configure.ac])
+
+AC_PROG_CC
+
+GTK_DOC_CHECK
+
+AC_OUTPUT

--- a/recipes/gtk-doc-stub/all/test_package/configure.ac
+++ b/recipes/gtk-doc-stub/all/test_package/configure.ac
@@ -2,8 +2,6 @@ AC_INIT([test_package], [1.0])
 
 AC_CONFIG_SRCDIR([configure.ac])
 
-AC_PROG_CC
-
 GTK_DOC_CHECK
 
 AC_OUTPUT

--- a/recipes/gtk-doc-stub/config.yml
+++ b/recipes/gtk-doc-stub/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20181216":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **gtk-doc-stub/cci.201812126**

Needed for running autoreconf on cairo

Depends on :

- [x] https://github.com/conan-io/hooks/pull/343

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
