### PR TITLE
cairo: modernize + add gtk-doc-stub build requirement

### DIFF
--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -7,45 +7,59 @@ import shutil
 class CairoConan(ConanFile):
     name = "cairo"
     description = "Cairo is a 2D graphics library with support for multiple output devices"
-    topics = ("conan", "cairo", "graphics")
+    topics = ("cairo", "graphics")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://cairographics.org/"
     license = ("LGPL-2.1-only", "MPL-1.1")
-    exports_sources = ["patches/*"]
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False],
+    options = {
+        "shared": [True, False],
         "fPIC": [True, False],
         "with_freetype": [True, False],
         "with_fontconfig": [True, False],
         "with_xlib": [True, False],
         "with_xlib_xrender": [True, False],
         "with_xcb": [True, False],
-        "with_glib": [True, False]}
-    default_options = {'shared': False,
-        'fPIC': True,
+        "with_glib": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
         "with_freetype": True,
         "with_fontconfig": True,
         "with_xlib": True,
         "with_xlib_xrender": False,
         "with_xcb": True,
-        "with_glib": True}
+        "with_glib": True,
+    }
+
+    exports_sources = "patches/*"
     generators = "pkg_config"
 
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
+    _autotools = None
 
-    _env_build = None
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
     def config_options(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-        if self.settings.os == 'Windows':
+        if self.settings.os == "Windows":
             del self.options.fPIC
             del self.options.with_fontconfig
         if self._is_msvc:
             del self.options.with_freetype
             del self.options.with_glib
-        if self.settings.os != 'Linux':
+        if self.settings.os != "Linux":
             del self.options.with_xlib
             del self.options.with_xlib_xrender
             del self.options.with_xcb
@@ -56,7 +70,7 @@ class CairoConan(ConanFile):
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
         if self._is_msvc:
-            if self.settings.build_type not in ['Debug', 'Release']:
+            if self.settings.build_type not in ["Debug", "Release"]:
                 raise ConanInvalidConfiguration("MSVC build supports only Debug or Release build type")
 
     def requirements(self):
@@ -64,32 +78,33 @@ class CairoConan(ConanFile):
             self.requires("freetype/2.10.4")
         if self.options.get_safe("with_fontconfig", False):
             self.requires("fontconfig/2.13.93")
-        if self.settings.os == 'Linux':
+        if self.settings.os == "Linux":
             if self.options.with_xlib or self.options.with_xlib_xrender or self.options.with_xcb:
                 self.requires("xorg/system")
         if self.options.get_safe("with_glib", True):
-            self.requires("glib/2.68.1")
+            self.requires("glib/2.69.2")
         self.requires("zlib/1.2.11")
         self.requires("pixman/0.40.0")
         self.requires("libpng/1.6.37")
 
     def build_requirements(self):
-        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires('msys2/cci.latest')
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
         if not self._is_msvc:
             self.build_requires("libtool/2.4.6")
             self.build_requires("pkgconf/1.7.4")
+            self.build_requires("gtk-doc-stub/cci.20181216")
 
     @property
     def _is_msvc(self):
-        return self.settings.compiler == 'Visual Studio'
+        return self.settings.compiler == "Visual Studio"
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
     def build(self):
-        for patch in self.conan_data["patches"][self.version]:
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         if self._is_msvc:
             self._build_msvc()
@@ -99,18 +114,18 @@ class CairoConan(ConanFile):
     def _build_msvc(self):
         with tools.chdir(self._source_subfolder):
             # https://cairographics.org/end_to_end_build_for_win32/
-            win32_common = os.path.join('build', 'Makefile.win32.common')
-            tools.replace_in_file(win32_common, '-MD ', '-%s ' % self.settings.compiler.runtime)
-            tools.replace_in_file(win32_common, '-MDd ', '-%s ' % self.settings.compiler.runtime)
-            tools.replace_in_file(win32_common, '$(ZLIB_PATH)/lib/zlib1.lib',
-                                                self.deps_cpp_info['zlib'].libs[0] + '.lib')
-            tools.replace_in_file(win32_common, '$(LIBPNG_PATH)/lib/libpng16.lib',
-                                                self.deps_cpp_info['libpng'].libs[0] + '.lib')
-            tools.replace_in_file(win32_common, '$(FREETYPE_PATH)/lib/freetype.lib',
-                                                self.deps_cpp_info['freetype'].libs[0] + '.lib')
+            win32_common = os.path.join("build", "Makefile.win32.common")
+            tools.replace_in_file(win32_common, "-MD ", "-%s " % self.settings.compiler.runtime)
+            tools.replace_in_file(win32_common, "-MDd ", "-%s " % self.settings.compiler.runtime)
+            tools.replace_in_file(win32_common, "$(ZLIB_PATH)/lib/zlib1.lib",
+                                                self.deps_cpp_info["zlib"].libs[0] + ".lib")
+            tools.replace_in_file(win32_common, "$(LIBPNG_PATH)/lib/libpng16.lib",
+                                                self.deps_cpp_info["libpng"].libs[0] + ".lib")
+            tools.replace_in_file(win32_common, "$(FREETYPE_PATH)/lib/freetype.lib",
+                                                self.deps_cpp_info["freetype"].libs[0] + ".lib")
             with tools.vcvars(self.settings):
                 env_msvc = VisualStudioBuildEnvironment(self)
-                env_msvc.flags.append('/FS')  # C1041 if multiple CL.EXE write to the same .PDB file, please use /FS
+                env_msvc.flags.append("/FS")  # C1041 if multiple CL.EXE write to the same .PDB file, please use /FS
                 with tools.environment_append(env_msvc.vars):
                     env_build = AutoToolsBuildEnvironment(self)
                     args=[
@@ -119,19 +134,19 @@ class CairoConan(ConanFile):
                         "CAIRO_HAS_FC_FONT=0",
                         "ZLIB_PATH={}".format(self.deps_cpp_info["zlib"].rootpath),
                         "LIBPNG_PATH={}".format(self.deps_cpp_info["libpng"].rootpath),
-                        "PIXMAN_PATH={}".format(self.deps_cpp_info['pixman'].rootpath),
-                        "FREETYPE_PATH={}".format(self.deps_cpp_info['freetype'].rootpath),
-                        "GOBJECT_PATH={}".format(self.deps_cpp_info['glib'].rootpath)
+                        "PIXMAN_PATH={}".format(self.deps_cpp_info["pixman"].rootpath),
+                        "FREETYPE_PATH={}".format(self.deps_cpp_info["freetype"].rootpath),
+                        "GOBJECT_PATH={}".format(self.deps_cpp_info["glib"].rootpath)
                     ]
 
                     env_build.make(args=args)
-                    env_build.make(args=['-C', os.path.join('util', 'cairo-gobject')] + args)
+                    env_build.make(args=["-C", os.path.join("util", "cairo-gobject")] + args)
 
-    def _get_env_build(self):
-        if self._env_build:
-            return self._env_build
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
 
-        self._env_build = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         yes_no = lambda v: "yes" if v else "no"
         configure_args = [
             "--datarootdir={}".format(tools.unix_path(os.path.join(self.package_folder, "res"))),
@@ -143,34 +158,34 @@ class CairoConan(ConanFile):
             "--enable-xcb={}".format(yes_no(self.options.get_safe("xcb"))),
             "--enable-shared={}".format(yes_no(self.options.shared)),
             "--enable-static={}".format(yes_no(not self.options.shared)),
+            "--disable-gtk-doc",
         ]
         if self.settings.compiler in ["gcc", "clang", "apple-clang"]:
-            self._env_build.flags.append("-Wno-enum-conversion")
+            self._autotools.flags.append("-Wno-enum-conversion")
 
         with tools.run_environment(self):
-            self._env_build.configure(args=configure_args)
-        return self._env_build
+            self._autotools.configure(args=configure_args, configure_dir=self._source_subfolder)
+        return self._autotools
 
     def _build_configure(self):
         with tools.chdir(self._source_subfolder):
             # disable build of test suite
-            tools.replace_in_file(os.path.join('test', 'Makefile.am'), 'noinst_PROGRAMS = cairo-test-suite$(EXEEXT)',
-                                  '')
+            tools.replace_in_file(os.path.join("test", "Makefile.am"), "noinst_PROGRAMS = cairo-test-suite$(EXEEXT)",
+                                  "")
             if self.options.with_freetype:
                 tools.replace_in_file(os.path.join(self.source_folder, self._source_subfolder, "src", "cairo-ft-font.c"),
-                                      '#if HAVE_UNISTD_H', '#ifdef HAVE_UNISTD_H')
+                                      "#if HAVE_UNISTD_H", "#ifdef HAVE_UNISTD_H")
 
-            with tools.environment_append({"NOCONFIGURE": "1"}):
-                self.run("./autogen.sh", win_bash=tools.os_info.is_windows, run_environment=True)
-            env_build = self._get_env_build()
-            env_build.make()
+            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows, run_environment=True)
+        autotools = self._configure_autotools()
+        autotools.make()
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
         if self._is_msvc:
-            src = os.path.join(self._source_subfolder, 'src')
-            cairo_gobject = os.path.join(self._source_subfolder, 'util', 'cairo-gobject')
-            inc = os.path.join('include', 'cairo')
+            src = os.path.join(self._source_subfolder, "src")
+            cairo_gobject = os.path.join(self._source_subfolder, "util", "cairo-gobject")
+            inc = os.path.join("include", "cairo")
             self.copy(pattern="cairo-version.h", dst=inc, src=(src if tools.Version(self.version) >= "1.17.4" else self._source_subfolder))
             self.copy(pattern="cairo-features.h", dst=inc, src=src)
             self.copy(pattern="cairo.h", dst=inc, src=src)
@@ -190,12 +205,11 @@ class CairoConan(ConanFile):
             else:
                 self.copy(pattern="*cairo-static.lib", dst="lib", src=src, keep_path=False)
                 self.copy(pattern="*cairo-gobject.lib", dst="lib", src=cairo_gobject, keep_path=False)
-                shutil.move(os.path.join(self.package_folder, 'lib', "cairo-static.lib"),
-                            os.path.join(self.package_folder, 'lib', "cairo.lib"))
+                shutil.move(os.path.join(self.package_folder, "lib", "cairo-static.lib"),
+                            os.path.join(self.package_folder, "lib", "cairo.lib"))
         else:
-            with tools.chdir(self._source_subfolder):
-                env_build = self._get_env_build()
-                env_build.install()
+            autotools = self._configure_autotools()
+            autotools.install()
         tools.remove_files_by_mask(self.package_folder, "*.la")
 
         self.copy("COPYING*", src=self._source_subfolder, dst="licenses", keep_path=False)
@@ -205,15 +219,15 @@ class CairoConan(ConanFile):
     def package_info(self):
         self.cpp_info.components["cairo_"].names["pkg_config"] = "cairo"
         self.cpp_info.components["cairo_"].libs = ["cairo"]
-        self.cpp_info.components["cairo_"].includedirs.insert(0, os.path.join('include', 'cairo'))
+        self.cpp_info.components["cairo_"].includedirs.insert(0, os.path.join("include", "cairo"))
         self.cpp_info.components["cairo_"].requires = ["pixman::pixman", "libpng::libpng", "zlib::zlib"]
         if self.options.get_safe("with_freetype", True):
             self.cpp_info.components["cairo_"].requires.append("freetype::freetype")
 
         if self.settings.os == "Windows":
-            self.cpp_info.components["cairo_"].system_libs.extend(['gdi32','msimg32','user32'])
+            self.cpp_info.components["cairo_"].system_libs.extend(["gdi32", "msimg32", "user32"])
             if not self.options.shared:
-                self.cpp_info.components["cairo_"].defines.append('CAIRO_WIN32_STATIC_BUILD=1')
+                self.cpp_info.components["cairo_"].defines.append("CAIRO_WIN32_STATIC_BUILD=1")
         else:
             if self.options.with_glib:
                 self.cpp_info.components["cairo_"].requires.extend(["glib::gobject-2.0", "glib::glib-2.0"])

--- a/recipes/cairo/all/test_package/CMakeLists.txt
+++ b/recipes/cairo/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1.2)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/cairo/all/test_package/test_package.c
+++ b/recipes/cairo/all/test_package/test_package.c
@@ -1,6 +1,6 @@
-#include <stdio.h>
 #include <cairo.h>
 #include <cairo-version.h>
+#include <stdio.h>
 
 int main()
 {


### PR DESCRIPTION
Specify library name and version:  **cairo/all**

- [x] Depends on #7155 for `gtkdocize`


Fixes #7089

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
