### PR TITLE
Add aws-sdk-cpp BUILD_SHARED_LIBS CMake definition for shared option.

### DIFF
--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -360,6 +360,7 @@ class AwsSdkCppConan(ConanFile):
         self._cmake.definitions["ENABLE_TESTING"] = False
         self._cmake.definitions["AUTORUN_UNIT_TESTS"] = False
 
+        self._cmake.definitions["BUILD_SHARED_LIBS"] = True if self.options.shared else False
         self._cmake.definitions["MINIMIZE_SIZE"] = self.options.min_size
         if self.settings.compiler == "Visual Studio":
             self._cmake.definitions["FORCE_SHARED_CRT"] = "MD" in self.settings.compiler.runtime


### PR DESCRIPTION
aws-sdk-cpp/1.8.130

This uses the "shared" option to specify the BUILD_SHARED_LIBS option, so binaries can be either statically or dynamically linked based on the option. Previously they were always dynamically linked.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
