### PR TITLE
aaf: Use cmake_find_package generator

### DIFF
--- a/recipes/aaf/all/conanfile.py
+++ b/recipes/aaf/all/conanfile.py
@@ -12,7 +12,7 @@ class AafConan(ConanFile):
     topics = ("aaf", "multimedia", "crossplatform")
     license = "AAFSDKPSL-2.0"
     exports_sources = ["CMakeLists.txt", "patches/**"]
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
     settings = "os", "compiler", "build_type", "arch"
     options = {
         "shared": [True, False],

--- a/recipes/aaf/all/patches/0006-remove-expat.patch
+++ b/recipes/aaf/all/patches/0006-remove-expat.patch
@@ -1,6 +1,6 @@
-commit fa629835c7d890d4181dbd5b309c8a8405e9ceb4
+commit a9b8fe86b3d8659e02653a4a502827a6f779e4ba
 Author: Martin Delille <martin@delille.org>
-Date:   Tue Aug 3 11:49:46 2021 +0200
+Date:   Thu Sep 2 16:38:59 2021 +0200
 
     Remove expat
 
@@ -17,10 +17,10 @@ index b1fe34c52..8f4df30b9 100644
  add_subdirectory(plugins)
  add_subdirectory(src/com-api)
 diff --git a/ref-impl/src/OM/CMakeLists.txt b/ref-impl/src/OM/CMakeLists.txt
-index e0c5be195..1693af987 100644
+index e0c5be195..1210f4d99 100644
 --- a/ref-impl/src/OM/CMakeLists.txt
 +++ b/ref-impl/src/OM/CMakeLists.txt
-@@ -158,9 +158,11 @@ target_include_directories(OM PRIVATE
+@@ -158,9 +158,13 @@ target_include_directories(OM PRIVATE
      # HACK (see OMStructuredStorage.h): Required with OM_USE_SCHEMASOFT_SS and OM_USE_GSF_SS
      ${AAFSDK_ROOT}/ss-impl/ref
      # AAF-XML stored format support requires the expat library which is bundled with the AAF SDK.
@@ -28,7 +28,9 @@ index e0c5be195..1693af987 100644
 +    #${AAFSDK_ROOT}/ref-impl/expat
  )
  
-+target_link_libraries(OM PUBLIC ${CONAN_LIBS})
++find_package(EXPAT REQUIRED)
++
++target_link_libraries(OM PUBLIC EXPAT::EXPAT)
 +
  target_compile_definitions(OM PUBLIC
      XML_STATIC

--- a/recipes/aaf/all/patches/0007-remove-libjpeg.patch
+++ b/recipes/aaf/all/patches/0007-remove-libjpeg.patch
@@ -1,6 +1,6 @@
-commit a13ac7edf3c42de433999a9c2a9a3034ca236fd8
+commit 03d84af50a106955f3af7a8f27b9b2f77fa9ddb7
 Author: Martin Delille <martin@delille.org>
-Date:   Wed Aug 4 12:22:47 2021 +0200
+Date:   Thu Sep 2 16:45:22 2021 +0200
 
     Remove libjpeg
 
@@ -17,21 +17,30 @@ index 8f4df30b9..cdcf808de 100644
  add_subdirectory(src/com-api)
  add_subdirectory(src/impl)
 diff --git a/ref-impl/plugins/CMakeLists.txt b/ref-impl/plugins/CMakeLists.txt
-index a9ed0163f..512814263 100644
+index a9ed0163f..0570e0b98 100644
 --- a/ref-impl/plugins/CMakeLists.txt
 +++ b/ref-impl/plugins/CMakeLists.txt
-@@ -79,12 +79,13 @@ target_include_directories(AAFStandardCodecs PUBLIC
+@@ -71,6 +71,8 @@ add_library(AAFStandardCodecs SHARED
+     ../src/OM/utf8.cpp
+ )
+ 
++find_package(JPEG REQUIRED)
++
+ target_include_directories(AAFStandardCodecs PUBLIC
+     .
+     ../include/OM
+@@ -79,12 +81,13 @@ target_include_directories(AAFStandardCodecs PUBLIC
      ../src/impl
      ../src/OM
      ../../Utilities/Include
-+    ${CONAN_RES_DIRS_LIBJPEG}
++    ${JPEG_RES_DIRS}
  )
  
  target_link_libraries(AAFStandardCodecs PRIVATE
      AAFIID
      AAFLIB
 -    libjpeg
-+    ${CONAN_LIBS_LIBJPEG}
++    JPEG::JPEG
  )
  
  if(MSVC)


### PR DESCRIPTION
Specify library name and version:  **aaf/1.2.0**

After @jgsogo [comment](https://github.com/conan-io/conan-center-index/pull/5998#pullrequestreview-742511252) I improved `libjpeg` and `expat` dependencies.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
