### PR TITLE
Add recipe for collier

### DIFF
--- a/recipes/collier/all/CMakeLists.txt
+++ b/recipes/collier/all/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.4)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+if(MSVC AND BUILD_SHARED_LIBS)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+add_subdirectory("source_subfolder")

--- a/recipes/collier/all/conandata.yml
+++ b/recipes/collier/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "1.2.0":
-    url: "https://collier.hepforge.org/downloads/collier-1.2.0.tar.gz"
-    sha256: "e5b2def953d7f9f4f2cacd4616aa65c77e2b9adf7eed2ca3531b993e529fbafd"
   "1.2.1":
     url: "https://collier.hepforge.org/downloads/collier-1.2.1.tar.gz"
     sha256: "7f5bc81a00de071e2451ba3e11cad726df0ae18bd973dba4aeba165897d48c2d"

--- a/recipes/collier/all/conandata.yml
+++ b/recipes/collier/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.2.5":
+    url: "https://collier.hepforge.org/downloads/collier-1.2.5.tar.gz"
+    sha256: "3ec58a975ff0c3b1ca870bc38973476c923ff78fd3dd5850e296037852b94a8b"

--- a/recipes/collier/all/conandata.yml
+++ b/recipes/collier/all/conandata.yml
@@ -1,4 +1,19 @@
 sources:
+  "1.2.0":
+    url: "https://collier.hepforge.org/downloads/collier-1.2.0.tar.gz"
+    sha256: "e5b2def953d7f9f4f2cacd4616aa65c77e2b9adf7eed2ca3531b993e529fbafd"
+  "1.2.1":
+    url: "https://collier.hepforge.org/downloads/collier-1.2.1.tar.gz"
+    sha256: "7f5bc81a00de071e2451ba3e11cad726df0ae18bd973dba4aeba165897d48c2d"
+  "1.2.2":
+    url: "https://collier.hepforge.org/downloads/collier-1.2.2.tar.gz"
+    sha256: "140029e36635565262719124dcda2fa7d66fd468442cb268f6da16d4cbbab29a"
+  "1.2.3":
+    url: "https://collier.hepforge.org/downloads/collier-1.2.3.tar.gz"
+    sha256: "e6f72df223654df59113b0067a4bebe9f8c20227bb81371d3193e1557bdf56fb"
+  "1.2.4":
+    url: "https://collier.hepforge.org/downloads/collier-1.2.4.tar.gz"
+    sha256: "92ae8f61461b232fbd47a6d8e832e1a726d504f9390b7edc49a68fceedff8857"
   "1.2.5":
     url: "https://collier.hepforge.org/downloads/collier-1.2.5.tar.gz"
     sha256: "3ec58a975ff0c3b1ca870bc38973476c923ff78fd3dd5850e296037852b94a8b"

--- a/recipes/collier/all/conanfile.py
+++ b/recipes/collier/all/conanfile.py
@@ -38,9 +38,6 @@ class Gm2calcConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
-    def requirements(self):
-        self.requires("gfortran/10.2")
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("COLLIER-{}".format(self.version), self._source_subfolder)

--- a/recipes/collier/all/conanfile.py
+++ b/recipes/collier/all/conanfile.py
@@ -38,6 +38,9 @@ class Gm2calcConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    def requirements(self):
+        self.requires("gfortran/10.2")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename("COLLIER-{}".format(self.version), self._source_subfolder)

--- a/recipes/collier/all/conanfile.py
+++ b/recipes/collier/all/conanfile.py
@@ -65,4 +65,6 @@ class Gm2calcConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "COLLIER"
         self.cpp_info.names["cmake_find_package_multi"] = "COLLIER"
         self.cpp_info.names["pkg_config"] = "collier"
-        self.cpp_info.libs = ["collier"]
+        self.cpp_info.libs = ["collier", "gfortran"]
+        if self.settings.os == "Linux":
+            self.cpp_info.libs.append("m")

--- a/recipes/collier/all/conanfile.py
+++ b/recipes/collier/all/conanfile.py
@@ -1,0 +1,71 @@
+import os
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.30.0"
+
+
+class Gm2calcConan(ConanFile):
+    name = "collier"
+    license = "GPL-3.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://collier.hepforge.org/"
+    description = "Fortran library for the numerical evaluation of one-loop scalar and tensor integrals in perturbative relativistic quantum field theory"
+    topics = ("conan", "high-energy", "physics", "hep", "one-loop", "integrals")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake", "cmake_find_package"
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+        if self.options.shared:
+            del self.options.fPIC
+
+    def requirements(self):
+        self.requires("gfortran/10.2")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("COLLIER-{}".format(self.version), self._source_subfolder)
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["static"] = "OFF" if self.options.shared else "ON"
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def package(self):
+        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.remove_files_by_mask(self.package_folder, "*Config*.cmake")
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "COLLIER"
+        self.cpp_info.names["cmake_find_package_multi"] = "COLLIER"
+        self.cpp_info.names["pkg_config"] = "collier"
+        self.cpp_info.libs = ["collier"]

--- a/recipes/collier/all/test_package/CMakeLists.txt
+++ b/recipes/collier/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest C Fortran)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(test_package test_package.f90)
+target_link_libraries(test_package CONAN_PKG::collier)

--- a/recipes/collier/all/test_package/CMakeLists.txt
+++ b/recipes/collier/all/test_package/CMakeLists.txt
@@ -6,3 +6,6 @@ conan_basic_setup(TARGETS)
 
 add_executable(test_package test_package.f90)
 target_link_libraries(test_package CONAN_PKG::collier)
+
+add_executable(test_package_c test_package.c)
+target_link_libraries(test_package_c CONAN_PKG::collier)

--- a/recipes/collier/all/test_package/conanfile.py
+++ b/recipes/collier/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class Gm2calcTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.run(os.path.join("bin", "test_package"), run_environment=True)

--- a/recipes/collier/all/test_package/conanfile.py
+++ b/recipes/collier/all/test_package/conanfile.py
@@ -15,3 +15,4 @@ class Gm2calcTestConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             self.run(os.path.join("bin", "test_package"), run_environment=True)
+            self.run(os.path.join("bin", "test_package_c"), run_environment=True)

--- a/recipes/collier/all/test_package/test_package.c
+++ b/recipes/collier/all/test_package/test_package.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+void __collier_init_MOD_getversionnumber_cll(char[5]);
+
+int main()
+{
+   char version[6];
+   __collier_init_MOD_getversionnumber_cll(version);
+   version[5] = '\0';
+
+   printf("COLLIER (version %s)\n", version);
+
+   return 0;
+}

--- a/recipes/collier/all/test_package/test_package.f90
+++ b/recipes/collier/all/test_package/test_package.f90
@@ -1,0 +1,12 @@
+
+program example
+  use COLLIER
+  implicit none
+
+  character(len=5) :: version
+
+  call GetVersionNumber_cll(version)
+
+  write(*, *) "COLLIER (version ", version, ")"
+
+end program example

--- a/recipes/collier/config.yml
+++ b/recipes/collier/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.2.5":
+    folder: all

--- a/recipes/collier/config.yml
+++ b/recipes/collier/config.yml
@@ -1,3 +1,13 @@
 versions:
+  "1.2.0":
+    folder: all
+  "1.2.1":
+    folder: all
+  "1.2.2":
+    folder: all
+  "1.2.3":
+    folder: all
+  "1.2.4":
+    folder: all
   "1.2.5":
     folder: all

--- a/recipes/collier/config.yml
+++ b/recipes/collier/config.yml
@@ -1,6 +1,4 @@
 versions:
-  "1.2.0":
-    folder: all
   "1.2.1":
     folder: all
   "1.2.2":


### PR DESCRIPTION
**COLLIER/1.2.5**

**COLLIER** is a library for the numerical calculation of one-loop integrals in high-energy physics. It is a basic building block for all kinds of quantum field theory loop calculations, written by experts in the field. Since it is such a fundamental library, needed by many high-energy physics programs, I think it is best to create a conan package for it.

This PR is a re-opened version of the closed PR #5375 (closed due to inactivity). The recipe has been modified to remove the dependency on the (broken) package `gfortran/10.2`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
