### PR TITLE
opengl: link to OpenGLES framework on iOS & tvOS

### DIFF
--- a/recipes/opengl/all/conanfile.py
+++ b/recipes/opengl/all/conanfile.py
@@ -74,6 +74,8 @@ class SysConfigOpenGLConan(ConanFile):
         if self.settings.os == "Macos":
             self.cpp_info.defines.append("GL_SILENCE_DEPRECATION=1")
             self.cpp_info.frameworks.append("OpenGL")
+        elif self.settings.os in ["iOS", "tvOS"]:
+            self.cpp_info.frameworks.append("OpenGLES")
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs = ["opengl32"]
         elif self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/opengl/all/test_package/conanfile.py
+++ b/recipes/opengl/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

On iOS & tvOS, we have to link to OpenGLES framework.
See https://developer.apple.com/documentation/opengles?language=objc

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
