### PR TITLE
Added wise_enum header only recipe

### DIFF
--- a/recipes/wise_enum/all/conandata.yml
+++ b/recipes/wise_enum/all/conandata.yml
@@ -1,0 +1,4 @@
+sources: 
+  "3.0.0":
+    url: "https://github.com/quicknir/wise_enum/archive/refs/tags/3.0.0.tar.gz"
+    sha256: "6e0d62855854ea755dd4277e74a599d1f4e7eec95562baf751151cc2e4df5eb8"

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -38,6 +38,10 @@ class WiseEnumConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
+        if self.settings.compiler == "Visual Studio":
+            with tools.chdir(self._source_subfolder):
+                self.run("{} create_generated.py 125  wise_enum_generated.h".format(self._python_executable))
+        
 
     def package(self):
         self.copy("*.h", dst="include", src=self._source_subfolder)

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -1,0 +1,43 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+class WiseEnumConan(ConanFile):
+    name = "wise_enum"
+    description = "Header-only C++11/14/17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code."
+    topics = (
+        "conan",
+        "cplusplus",
+        "enum-to-string",
+        "string-to-enum"
+        "serialization",
+        "reflection",
+        "header-only",
+        "compile-time"
+    )
+    url = "https://github.com/quicknir/wise_enum"
+    homepage = url
+    license = "BPL"
+    settings = "compiler"
+    no_copy_source = True
+    
+    @property
+    def _source_subfolder(self):
+        return "src"
+    
+   
+
+    def configure(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, "11")
+    def package_id(self):
+        self.info.header_only()
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        self.copy("*.h", dst="include", src=self._source_subfolder)
+        self.copy("LICENSE", dst="licenses" , src=self._source_subfolder)

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -43,3 +43,7 @@ class WiseEnumConan(ConanFile):
     def package(self):
         self.copy("*.h", dst="include", src=self._source_subfolder)
         self.copy("LICENSE", dst="licenses" , src=self._source_subfolder)
+        
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "wise_enum"
+        self.cpp_info.names["cmake_find_package_multi"] = "wise_enum"

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -36,9 +36,8 @@ class WiseEnumConan(ConanFile):
         self.info.header_only()
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy("*.h", dst="include", src=self._source_subfolder)

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
+import sys
 
 required_conan_version = ">=1.33.0"
 
@@ -24,7 +25,15 @@ class WiseEnumConan(ConanFile):
     
     @property
     def _source_subfolder(self):
-        return "source_subfolder"    
+        return "source_subfolder"  
+    @property
+    def _python_executable(self):
+        """
+        obtain full path to the python interpreter executable
+        :return: path to the python interpreter executable, either set by option, or system default
+        """
+        exe = sys.executable
+        return str(exe).replace('\\', '/')  
    
 
     def validate(self):
@@ -50,6 +59,9 @@ class WiseEnumConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
+        if self.settings.compiler == "Visual Studio":
+            with tools.chdir(self._source_subfolder):
+                self.run("{} create_generated.py 125  wise_enum_generated.h".format(self._python_executable))
           
 
     def package(self):

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class WiseEnumConan(ConanFile):
     name = "wise_enum"
-    description = "Header-only C++11/14/17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code."
+    description = "Header-only C++11/14/17 library provides static reflection for enums, work with any enum type without any boilerplate code."
     topics = (
         "conan",
         "cplusplus",

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -65,5 +65,5 @@ class WiseEnumConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "WiseEnum"
         self.cpp_info.names["pkg_config"] = "WiseEnum"
         self.cpp_info.components["_wise_enum"].names["cmake_find_package"] = "wise_enum"
-        self.cpp_info.components["_wise_enum"].names["cmake_find_package"] = "wise_enum"
+        self.cpp_info.components["_wise_enum"].names["cmake_find_package_multi"] = "wise_enum"
         self.cpp_info.components["_wise_enum"].names["pkg_config"] = "WiseEnum"

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -27,16 +27,6 @@ class WiseEnumConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
-    @property
-    def _python_executable(self):
-        """
-        obtain full path to the python interpreter executable
-        :return: path to the python interpreter executable, either set by option, or system default
-        """
-        exe = sys.executable
-        return str(exe).replace('\\', '/')  
-   
-
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "11")

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.33.0"
+
 class WiseEnumConan(ConanFile):
     name = "wise_enum"
     description = "Header-only C++11/14/17 library provides static reflection for enums, work with any enum type without any boilerplate code."

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -25,7 +25,8 @@ class WiseEnumConan(ConanFile):
     
     @property
     def _source_subfolder(self):
-        return "source_subfolder"  
+        return "source_subfolder"
+
     @property
     def _python_executable(self):
         """

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -40,7 +40,7 @@ class WiseEnumConan(ConanFile):
         unsupported = {"Visual Studio"}
         if compiler in unsupported:
             raise ConanInvalidConfiguration(
-                "{} doe not support  {} compiler".format(self.name, compiler)
+                "{} does not support  {} compiler".format(self.name, compiler)
             )
 
         if compiler in minimal_version and compiler_version < minimal_version[compiler]:

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -61,6 +61,9 @@ class WiseEnumConan(ConanFile):
         self.copy("LICENSE", dst="licenses" , src=self._source_subfolder)
         
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "wise_enum"
-        self.cpp_info.names["cmake_find_package_multi"] = "wise_enum"
-
+        self.cpp_info.names["cmake_find_package"] = "WiseEnum"
+        self.cpp_info.names["cmake_find_package_multi"] = "WiseEnum"
+        self.cpp_info.names["pkg_config"] = "WiseEnum"
+        self.cpp_info.components["_wise_enum"].names["cmake_find_package"] = "wise_enum"
+        self.cpp_info.components["_wise_enum"].names["cmake_find_package"] = "wise_enum"
+        self.cpp_info.components["_wise_enum"].names["pkg_config"] = "WiseEnum"

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -44,14 +44,19 @@ class WiseEnumConan(ConanFile):
         compiler_version = tools.Version(self.settings.compiler.version)
 
         minimal_version = {
-            "Visual Studio": "16",
-            "gcc": "5"
+           "gcc": "5"
         }
+        unsupported = {"Visual Studio"}
+        if compiler in unsupported:
+            raise ConanInvalidConfiguration(
+                "{} doe not support  {} compiler".format(self.name, compiler)
+            )
 
         if compiler in minimal_version and compiler_version < minimal_version[compiler]:
             raise ConanInvalidConfiguration(
                 "{} requires {} compiler {} or newer [is: {}]".format(self.name, compiler, minimal_version[compiler], compiler_version)
             )
+        
 
     def package_id(self):
         self.info.header_only()
@@ -59,11 +64,7 @@ class WiseEnumConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
-        if self.settings.compiler == "Visual Studio":
-            with tools.chdir(self._source_subfolder):
-                self.run("{} create_generated.py 125  wise_enum_generated.h".format(self._python_executable))
-          
-
+        
     def package(self):
         self.copy("*.h", dst="include", src=self._source_subfolder)
         self.copy("LICENSE", dst="licenses" , src=self._source_subfolder)

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -16,7 +16,8 @@ class WiseEnumConan(ConanFile):
         "header-only",
         "compile-time"
     )
-    url = "https://github.com/quicknir/wise_enum"
+    homepage = "https://github.com/quicknir/wise_enum"
+    url = "https://github.com/conan-io/conan-center-index/"
     homepage = url
     license = "BPL"
     settings = "compiler"

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -30,6 +30,19 @@ class WiseEnumConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "11")
+        
+        compiler = str(self.settings.compiler)
+        compiler_version = tools.Version(self.settings.compiler.version)
+
+        minimal_version = {
+            "Visual Studio": "16",
+            "gcc": "5"
+        }
+
+        if compiler in minimal_version and compiler_version < minimal_version[compiler]:
+            raise ConanInvalidConfiguration(
+                "{} requires {} compiler {} or newer [is: {}]".format(self.name, compiler, minimal_version[compiler], compiler_version)
+            )
 
     def package_id(self):
         self.info.header_only()
@@ -37,10 +50,7 @@ class WiseEnumConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
-        if self.settings.compiler == "Visual Studio":
-            with tools.chdir(self._source_subfolder):
-                self.run("{} create_generated.py 125  wise_enum_generated.h".format(self._python_executable))
-        
+          
 
     def package(self):
         self.copy("*.h", dst="include", src=self._source_subfolder)

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -19,7 +19,7 @@ class WiseEnumConan(ConanFile):
     homepage = "https://github.com/quicknir/wise_enum"
     url = "https://github.com/conan-io/conan-center-index/"
     homepage = url
-    license = "BPL"
+    license = "BSL-1.0"
     settings = "compiler"
     no_copy_source = True
     

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -8,7 +8,6 @@ class WiseEnumConan(ConanFile):
     name = "wise_enum"
     description = "Header-only C++11/14/17 library provides static reflection for enums, work with any enum type without any boilerplate code."
     topics = (
-        "conan",
         "cplusplus",
         "enum-to-string",
         "string-to-enum"

--- a/recipes/wise_enum/all/conanfile.py
+++ b/recipes/wise_enum/all/conanfile.py
@@ -25,13 +25,13 @@ class WiseEnumConan(ConanFile):
     
     @property
     def _source_subfolder(self):
-        return "src"
-    
+        return "source_subfolder"    
    
 
     def configure(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "11")
+
     def package_id(self):
         self.info.header_only()
 

--- a/recipes/wise_enum/all/test_package/CMakeLists.txt
+++ b/recipes/wise_enum/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package)
+project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)

--- a/recipes/wise_enum/all/test_package/CMakeLists.txt
+++ b/recipes/wise_enum/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(wise_enum REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} wise_enum::wise_enum)

--- a/recipes/wise_enum/all/test_package/CMakeLists.txt
+++ b/recipes/wise_enum/all/test_package/CMakeLists.txt
@@ -4,8 +4,8 @@ project(test_package CXX)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(wise_enum REQUIRED CONFIG)
+find_package(WiseEnum REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
-target_link_libraries(${PROJECT_NAME} wise_enum::wise_enum)
+target_link_libraries(${PROJECT_NAME} WiseEnum::wise_enum)

--- a/recipes/wise_enum/all/test_package/conanfile.py
+++ b/recipes/wise_enum/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/wise_enum/all/test_package/conanfile.py
+++ b/recipes/wise_enum/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/wise_enum/all/test_package/test_package.cpp
+++ b/recipes/wise_enum/all/test_package/test_package.cpp
@@ -1,0 +1,79 @@
+#include <wise_enum.h>
+
+#include <cassert>
+#include <iostream>
+
+// Equivalent to enum Color {GREEN = 2, RED};
+namespace my_lib {
+WISE_ENUM(Color, (GREEN, 2), RED)
+}
+
+// Equivalent to enum class MoreColor : int64_t {BLUE, BLACK = 1};
+WISE_ENUM_CLASS((MoreColor, int64_t), BLUE, (BLACK, 1))
+
+// Inside a class, must use a different macro, but still works
+struct Bar {
+  WISE_ENUM_MEMBER(Foo, BUZ)
+};
+
+// Adapt an existing enum you don't control so it works with generic code
+namespace another_lib {
+enum class SomebodyElse { FIRST, SECOND };
+}
+WISE_ENUM_ADAPT(another_lib::SomebodyElse, FIRST, SECOND)
+
+struct Blub {
+    struct Flub {
+
+        int x = 0;
+
+    };
+};
+
+int main() {
+
+  // Number of enumerations:
+  static_assert(wise_enum::enumerators<my_lib::Color>::size == 2, "");
+  std::cerr << "Number of enumerators: "
+            << wise_enum::enumerators<my_lib::Color>::size << "\n";
+
+  // Iterate over enums
+  std::cerr << "Enum values and names:\n";
+  for (auto e : wise_enum::enumerators<my_lib::Color>::range) {
+    std::cerr << static_cast<int>(e.value) << " " << e.name << "\n";
+  }
+  std::cerr << "\n";
+
+  // Convert any enum to a string
+  std::cerr << wise_enum::to_string(my_lib::Color::RED) << "\n";
+
+  // Convert any string to an optional enum
+  auto x1 = wise_enum::from_string<my_lib::Color>("GREEN");
+  auto x2 = wise_enum::from_string<my_lib::Color>("Greeeeeeen");
+
+  assert(x1.value() == my_lib::Color::GREEN);
+  assert(!x2);
+
+  // Everything is constexpr, and a type trait is made available for easy use in
+  // enable_if/tag dispatch
+  static_assert(wise_enum::is_wise_enum<my_lib::Color>::value, "");
+  static_assert(!wise_enum::is_wise_enum<int>::value, "");
+  enum flub { blub, glub };
+  static_assert(!wise_enum::is_wise_enum<flub>::value, "");
+  // We made a regular enum wise!
+  static_assert(wise_enum::is_wise_enum<another_lib::SomebodyElse>::value, "");
+
+  // Assert underlying type
+  static_assert(
+      std::is_same<int64_t,
+                   typename std::underlying_type<MoreColor>::type>::value,
+      "");
+
+  // Full API available for adapted wise enums
+  for (auto e : wise_enum::enumerators<another_lib::SomebodyElse>::range) {
+    std::cerr << static_cast<int>(e.value) << " "
+              << wise_enum::to_string(e.value) << "\n";
+  }
+
+  return 0;
+}

--- a/recipes/wise_enum/config.yml
+++ b/recipes/wise_enum/config.yml
@@ -1,0 +1,3 @@
+versions:
+   "3.0.0":
+    folder: all


### PR DESCRIPTION
Closes #7172
Package Details
Package Name/Version: wise_enum/3.0.0
Website: https://github.com/quicknir/wise_enum#readme
Source code: *https://github.com/quicknir/wise_enum
Description Of The Library / Tool
A small header-only c++ library for reflective enum. similar to magic enum, but supports C++ 14/11
I am not the author of the library, but I would like to use it for the project that already uses conan

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
