### PR TITLE
Update changelog 6-September-2021

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 6-September-2021 - 11:15 CEST
+
+- [feature] Display useful CI status notifications in Github pull requests.
+- [feature] Upgrade Conan client version to 1.38.0.
+- [feature] Move the Conan and Artifactory configuration out of the Jenkins library.
+- [feature] Use separated files for the different profile configurations.
+
 ### 3-August-2021 - 13:29 CEST
 
 - [feature] BuildSingleReference: Create packages for apple-clang armv8 (Apple M1) in pull-requests' builds.


### PR DESCRIPTION
In this new deployment we are releasing some improvements in the build service that will directly improve the user experience of contributors 👏 :

- 🔔 **GitHub status notifications:** Sometimes, the feedback received in the PRs about the status of the CI is a bit slow due to building times and contributors don't know if the builds are running or not until the bot posts the final comment. Now, each package reference and set of profiles configurations will be split into several statuses under the GitHub CI notification mechanism for pull requests. This gives early feedback to contributors, separates the builds into multiple stages and the result (package tables) can be checked for each configuration.
![image](https://user-images.githubusercontent.com/10808592/132194571-5e3afaa7-549e-4db0-8bfb-f1f476e4e5ca.png)
⚠️  **Important:** This is our first experience using custom GitHub CI notifications status, so there might be some glitches (e.g. when running jobs in parallel). We will monitor this new feature and improve it for future releases. Note that **bot notifications are still present** with a link to the result of the build aggregating all the packages built (or not) for all the configurations (same behavior until now).

- 📄 **Header-only packages tested in different platforms:** As a consequence of splitting the profiles into different sets, the package ID computation for each reference is calculated in each stage, meaning that for header-only libraries we will generate the package once (for the first set of profiles) and then run the test_package for the rest. So now, header-only packages are tested in different platforms as well (Linux, macOS, windows at least).
![](https://user-images.githubusercontent.com/1406456/131973860-43b6edfd-5e6c-4260-b113-b83544122847.png)