### PR TITLE
[mdnsresponder] Fix the most egregious of Apple's remaining compile warnings on Windows

### DIFF
--- a/recipes/mdnsresponder/all/conandata.yml
+++ b/recipes/mdnsresponder/all/conandata.yml
@@ -11,6 +11,10 @@ patches:
       patch_file: "patches/878.200.35/DLLStub.c.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/878.200.35/mDNSResponder.sln.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/878.200.35/mDNSWin32.c.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/878.200.35/Service.c.patch"
   "878.200.35-opt":
     - base_path: "source_subfolder"
       patch_file: "patches/878.200.35/opt/permit-over-long-service-types.patch"

--- a/recipes/mdnsresponder/all/patches/878.200.35/Service.c.patch
+++ b/recipes/mdnsresponder/all/patches/878.200.35/Service.c.patch
@@ -1,6 +1,26 @@
 --- mDNSWindows/SystemService/Service.c
-+++ mDNSWindows/SystemService/Service.new.c
-@@ -2127,9 +2127,8 @@
++++ mDNSWindows/SystemService/Service.c
+@@ -1075,9 +1075,6 @@
+ 	BOOL			initialized;
+ 	BOOL			ok;
+ 	
+-	DEBUG_UNUSED( argc );
+-	DEBUG_UNUSED( argv );
+-	
+ 	initialized = FALSE;
+ 	
+ 	// <rdar://problem/5727548> Make the service as running before we call ServiceSpecificInitialize. We've
+@@ -1197,9 +1194,6 @@
+ {
+ 	OSStatus err;
+ 	
+-	DEBUG_UNUSED( argc );
+-	DEBUG_UNUSED( argv );
+-	
+ 	mDNSPlatformMemZero( &gMDNSRecord, sizeof gMDNSRecord);
+ 	mDNSPlatformMemZero( &gPlatformStorage, sizeof gPlatformStorage);
+ 
+@@ -2127,9 +2121,8 @@
  }
  
  
@@ -11,3 +31,12 @@
  	(void)delay;
  	// No-op, for now
  	}
+@@ -2340,8 +2333,6 @@
+ {
+ 	OSStatus err = kNoErr;
+ 
+-	DEBUG_UNUSED( inMDNS );
+-
+ 	//
+ 	// <rdar://problem/4096464> Don't call SetLLRoute on loopback
+ 	// <rdar://problem/6885843> Default route on Windows 7 breaks network connectivity

--- a/recipes/mdnsresponder/all/patches/878.200.35/Service.c.patch
+++ b/recipes/mdnsresponder/all/patches/878.200.35/Service.c.patch
@@ -1,0 +1,13 @@
+--- mDNSWindows/SystemService/Service.c
++++ mDNSWindows/SystemService/Service.new.c
+@@ -2127,9 +2127,8 @@
+ }
+ 
+ 
+-mDNSexport void RecordUpdatedNiceLabel(mDNS *const m, mDNSs32 delay)
++mDNSexport void RecordUpdatedNiceLabel(mDNSs32 delay)
+ 	{
+-	(void)m;
+ 	(void)delay;
+ 	// No-op, for now
+ 	}

--- a/recipes/mdnsresponder/all/patches/878.200.35/mDNSWin32.c.patch
+++ b/recipes/mdnsresponder/all/patches/878.200.35/mDNSWin32.c.patch
@@ -85,7 +85,17 @@
          if (!err) break;
  	}
  
-@@ -1464,15 +1462,13 @@
+@@ -1398,8 +1396,7 @@
+ 	struct sockaddr_storage		addr;
+ 	int							n;
+ 	
+-	DEBUG_USE_ONLY( inMDNS );
+-	DEBUG_USE_ONLY( useBackgroundTrafficClass );
++	DEBUG_UNUSED( useBackgroundTrafficClass );
+ 	
+ 	n = (int)( inMsgEnd - ( (const mDNSu8 * const) inMsg ) );
+ 	check( inMDNS );
+@@ -1464,15 +1461,13 @@
  	return( err );
  }
  
@@ -103,7 +113,7 @@
  	DEBUG_UNUSED( allowSleep );
  	DEBUG_UNUSED( reason );
  	}
-@@ -1481,7 +1477,7 @@
+@@ -1481,7 +1476,7 @@
  //	mDNSPlatformSendRawPacket
  //===========================================================================================================================
  
@@ -112,7 +122,7 @@
  {
  	unsigned char			mac[ 6 ];
  	unsigned char			buf[ 102 ];
-@@ -1518,7 +1514,7 @@
+@@ -1518,7 +1513,7 @@
  
  	info = ( MulticastWakeupStruct* ) malloc( sizeof( MulticastWakeupStruct ) );
  	require_action( info, exit, err = mStatus_NoMemoryErr );
@@ -121,7 +131,7 @@
  	memset( &info->addr, 0, sizeof( info->addr ) );
  	info->addr.sin_family = AF_INET;
  	info->addr.sin_addr.s_addr = AllDNSLinkGroup_v4.ip.v4.NotAnInteger;
-@@ -1566,9 +1562,8 @@
+@@ -1566,9 +1561,8 @@
  	if (bufsize) buf[0] = 0;
  	}
  
@@ -132,7 +142,7 @@
  	DEBUG_UNUSED( tpa );
  	DEBUG_UNUSED( tha );
  	DEBUG_UNUSED( InterfaceID );
-@@ -1595,7 +1590,6 @@
+@@ -1595,7 +1589,6 @@
  
  mDNSexport void mDNSPlatformWriteLogMsg( const char * ident, const char * msg, mDNSLogLevel_t loglevel )
  	{
@@ -140,7 +150,7 @@
  	int type;
  	
  	DEBUG_UNUSED( ident );
-@@ -1650,11 +1644,11 @@
+@@ -1650,11 +1643,11 @@
  mDNSlocal void SetDNSServers( mDNS *const m );
  mDNSlocal void SetSearchDomainList( void );
  
@@ -154,7 +164,7 @@
  	if (setsearch) SetSearchDomainList();
  	
  	if ( fqdn )
-@@ -2033,7 +2027,7 @@
+@@ -2033,7 +2026,7 @@
  //===========================================================================================================================
  
  mDNSexport mStatus
@@ -163,7 +173,7 @@
  {
  	IP_ADAPTER_INFO *	pAdapterInfo;
  	IP_ADAPTER_INFO *	pAdapter;
-@@ -2043,8 +2037,6 @@
+@@ -2043,8 +2036,6 @@
  	DWORD				index;
  	mStatus				err = mStatus_NoError;
  
@@ -172,7 +182,7 @@
  	*v6 = zeroAddr;
  
  	pAdapterInfo	= NULL;
-@@ -2080,9 +2072,9 @@
+@@ -2080,9 +2071,9 @@
  		{
  			// Found one that will work
  
@@ -184,7 +194,7 @@
  			}
  
  			found = TRUE;
-@@ -2111,9 +2103,8 @@
+@@ -2111,9 +2102,8 @@
  	(void) win;		// Unused
  }
  
@@ -195,7 +205,7 @@
  	(void) raddr;	// Unused
  
  	return mStatus_UnsupportedErr;
-@@ -2140,9 +2131,8 @@
+@@ -2140,9 +2130,8 @@
  	return mStatus_UnsupportedErr;
  }
  

--- a/recipes/mdnsresponder/all/patches/878.200.35/mDNSWin32.c.patch
+++ b/recipes/mdnsresponder/all/patches/878.200.35/mDNSWin32.c.patch
@@ -1,0 +1,208 @@
+--- mDNSWindows/mDNSWin32.c
++++ mDNSWindows/mDNSWin32.c
+@@ -55,6 +55,8 @@
+ #include    "dnssec.h"
+ #include    "nsec.h"
+ 
++extern mDNS mDNSStorage;
++
+ #if 0
+ #pragma mark == Constants ==
+ #endif
+@@ -718,16 +720,14 @@
+     return ptr;
+ }
+ 
+-mDNSexport void DNSProxyInit(mDNS *const m, mDNSu32 IpIfArr[], mDNSu32 OpIf)
++mDNSexport void DNSProxyInit(mDNSu32 IpIfArr[], mDNSu32 OpIf)
+ {
+-    (void) m;
+     (void) IpIfArr;
+     (void) OpIf;
+ }
+ 
+-mDNSexport void DNSProxyTerminate(mDNS *const m)
++mDNSexport void DNSProxyTerminate(void)
+ {
+-    (void) m;
+ }
+ 
+ //===========================================================================================================================
+@@ -972,7 +972,6 @@
+ TCPSocket *
+ mDNSPlatformTCPSocket
+ 	(
+-	mDNS			* const m,
+ 	TCPSocketFlags		flags,
+ 	mDNSIPPort			*	port, 
+ 	mDNSBool			useBackgroundTrafficClass
+@@ -984,7 +983,6 @@
+ 	int					len;
+ 	mStatus				err		= mStatus_NoError;
+ 
+-	DEBUG_UNUSED( m );
+ 	DEBUG_UNUSED( useBackgroundTrafficClass );
+ 
+ 	require_action( flags == 0, exit, err = mStatus_UnsupportedErr );
+@@ -996,7 +994,7 @@
+ 	mDNSPlatformMemZero( sock, sizeof( TCPSocket ) );
+ 	sock->fd		= INVALID_SOCKET;
+ 	sock->flags		= flags;
+-	sock->m			= m;
++	sock->m			= &mDNSStorage;
+ 
+ 	mDNSPlatformMemZero(&saddr, sizeof(saddr));
+ 	saddr.sin_family		= AF_INET;
+@@ -1269,7 +1267,7 @@
+ //	mDNSPlatformUDPSocket
+ //===========================================================================================================================
+ 
+-mDNSexport UDPSocket* mDNSPlatformUDPSocket(mDNS *const m, const mDNSIPPort requestedport)
++mDNSexport UDPSocket* mDNSPlatformUDPSocket(const mDNSIPPort requestedport)
+ {
+ 	UDPSocket*	sock	= NULL;
+ 	mDNSIPPort	port	= requestedport;
+@@ -1285,10 +1283,10 @@
+ 	// Create the socket
+ 
+ 	sock->fd			= INVALID_SOCKET;
+-	sock->recvMsgPtr	= m->p->unicastSock4.recvMsgPtr;
+-	sock->addr			= m->p->unicastSock4.addr;
++	sock->recvMsgPtr	= mDNSStorage.p->unicastSock4.recvMsgPtr;
++	sock->addr			= mDNSStorage.p->unicastSock4.addr;
+ 	sock->ifd			= NULL;
+-	sock->m				= m;
++	sock->m				= &mDNSStorage;
+ 
+ 	// Try at most 10000 times to get a unique random port
+ 
+@@ -1309,7 +1307,7 @@
+ 
+ 		saddr.sin_port = port.NotAnInteger;
+ 
+-        err = SetupSocket(m, ( struct sockaddr* ) &saddr, port, &sock->fd );
++        err = SetupSocket(sock->m, ( struct sockaddr* ) &saddr, port, &sock->fd );
+         if (!err) break;
+ 	}
+ 
+@@ -1464,15 +1462,13 @@
+ 	return( err );
+ }
+ 
+-mDNSexport void mDNSPlatformUpdateProxyList(mDNS *const m, const mDNSInterfaceID InterfaceID)
++mDNSexport void mDNSPlatformUpdateProxyList(const mDNSInterfaceID InterfaceID)
+ 	{
+-	DEBUG_UNUSED( m );
+ 	DEBUG_UNUSED( InterfaceID );
+ 	}
+ 
+-mDNSexport void mDNSPlatformSetAllowSleep(mDNS *const m, mDNSBool allowSleep, const char *reason)
++mDNSexport void mDNSPlatformSetAllowSleep(mDNSBool allowSleep, const char *reason)
+ 	{
+-	DEBUG_UNUSED( m );
+ 	DEBUG_UNUSED( allowSleep );
+ 	DEBUG_UNUSED( reason );
+ 	}
+@@ -1481,7 +1477,7 @@
+ //	mDNSPlatformSendRawPacket
+ //===========================================================================================================================
+ 
+-mDNSexport void mDNSPlatformSendWakeupPacket(mDNS *const m, mDNSInterfaceID InterfaceID, char *ethaddr, char *ipaddr, int iteration)
++mDNSexport void mDNSPlatformSendWakeupPacket(mDNSInterfaceID InterfaceID, char *ethaddr, char *ipaddr, int iteration)
+ {
+ 	unsigned char			mac[ 6 ];
+ 	unsigned char			buf[ 102 ];
+@@ -1518,7 +1514,7 @@
+ 
+ 	info = ( MulticastWakeupStruct* ) malloc( sizeof( MulticastWakeupStruct ) );
+ 	require_action( info, exit, err = mStatus_NoMemoryErr );
+-	info->inMDNS = m;
++	info->inMDNS = &mDNSStorage;
+ 	memset( &info->addr, 0, sizeof( info->addr ) );
+ 	info->addr.sin_family = AF_INET;
+ 	info->addr.sin_addr.s_addr = AllDNSLinkGroup_v4.ip.v4.NotAnInteger;
+@@ -1566,9 +1562,8 @@
+ 	if (bufsize) buf[0] = 0;
+ 	}
+ 
+-mDNSexport void mDNSPlatformSetLocalAddressCacheEntry(mDNS *const m, const mDNSAddr *const tpa, const mDNSEthAddr *const tha, mDNSInterfaceID InterfaceID)
++mDNSexport void mDNSPlatformSetLocalAddressCacheEntry(const mDNSAddr *const tpa, const mDNSEthAddr *const tha, mDNSInterfaceID InterfaceID)
+ 	{
+-	DEBUG_UNUSED( m );
+ 	DEBUG_UNUSED( tpa );
+ 	DEBUG_UNUSED( tha );
+ 	DEBUG_UNUSED( InterfaceID );
+@@ -1595,7 +1590,6 @@
+ 
+ mDNSexport void mDNSPlatformWriteLogMsg( const char * ident, const char * msg, mDNSLogLevel_t loglevel )
+ 	{
+-	extern mDNS mDNSStorage;
+ 	int type;
+ 	
+ 	DEBUG_UNUSED( ident );
+@@ -1650,11 +1644,11 @@
+ mDNSlocal void SetDNSServers( mDNS *const m );
+ mDNSlocal void SetSearchDomainList( void );
+ 
+-mDNSexport mDNSBool mDNSPlatformSetDNSConfig(mDNS *const m, mDNSBool setservers, mDNSBool setsearch, domainname *const fqdn, DNameListElem **regDomains, DNameListElem **browseDomains, mDNSBool ackConfig)
++mDNSexport mDNSBool mDNSPlatformSetDNSConfig(mDNSBool setservers, mDNSBool setsearch, domainname *const fqdn, DNameListElem **regDomains, DNameListElem **browseDomains, mDNSBool ackConfig)
+ {
+ 	(void) ackConfig;
+ 
+-	if (setservers) SetDNSServers(m);
++	if (setservers) SetDNSServers(&mDNSStorage);
+ 	if (setsearch) SetSearchDomainList();
+ 	
+ 	if ( fqdn )
+@@ -2033,7 +2027,7 @@
+ //===========================================================================================================================
+ 
+ mDNSexport mStatus
+-mDNSPlatformGetPrimaryInterface( mDNS * const m, mDNSAddr * v4, mDNSAddr * v6, mDNSAddr * router )
++mDNSPlatformGetPrimaryInterface( mDNSAddr * v4, mDNSAddr * v6, mDNSAddr * router )
+ {
+ 	IP_ADAPTER_INFO *	pAdapterInfo;
+ 	IP_ADAPTER_INFO *	pAdapter;
+@@ -2043,8 +2037,6 @@
+ 	DWORD				index;
+ 	mStatus				err = mStatus_NoError;
+ 
+-	DEBUG_UNUSED( m );
+-
+ 	*v6 = zeroAddr;
+ 
+ 	pAdapterInfo	= NULL;
+@@ -2080,9 +2072,9 @@
+ 		{
+ 			// Found one that will work
+ 
+-			if ( pAdapter->AddressLength == sizeof( m->PrimaryMAC ) )
++			if ( pAdapter->AddressLength == sizeof( mDNSStorage.PrimaryMAC ) )
+ 			{
+-				memcpy( &m->PrimaryMAC, pAdapter->Address, pAdapter->AddressLength );
++				memcpy( &mDNSStorage.PrimaryMAC, pAdapter->Address, pAdapter->AddressLength );
+ 			}
+ 
+ 			found = TRUE;
+@@ -2111,9 +2103,8 @@
+ 	(void) win;		// Unused
+ }
+ 
+-mDNSexport mStatus mDNSPlatformGetRemoteMacAddr(mDNS *const m, mDNSAddr *raddr)
++mDNSexport mStatus mDNSPlatformGetRemoteMacAddr(mDNSAddr *raddr)
+ {
+-	(void) m;		// Unused
+ 	(void) raddr;	// Unused
+ 
+ 	return mStatus_UnsupportedErr;
+@@ -2140,9 +2131,8 @@
+ 	return mStatus_UnsupportedErr;
+ }
+ 
+-mDNSexport mStatus mDNSPlatformRetrieveTCPInfo(mDNS *const m, mDNSAddr *laddr, mDNSIPPort *lport, mDNSAddr *raddr, mDNSIPPort *rport, mDNSTCPInfo *mti)
++mDNSexport mStatus mDNSPlatformRetrieveTCPInfo(mDNSAddr *laddr, mDNSIPPort *lport, mDNSAddr *raddr, mDNSIPPort *rport, mDNSTCPInfo *mti)
+ {
+-	(void) m;       // Unused
+ 	(void) laddr; 	// Unused
+ 	(void) raddr; 	// Unused
+ 	(void) lport; 	// Unused


### PR DESCRIPTION
Specify library name and version:  **mdnsresponder/878.200.35**

As can be seen in the build logs for #6930, e.g. Windows, Visual Studio 16, `MDd`, [here](https://c3i.jfrog.io/c3i/misc/logs/pr/6930/26-production/mdnsresponder/878.200.35//d057732059ea44a47760900cb5e4855d2bea8714-build.txt), there are a lot of compiler warnings, some of which are serious:

```
warning C4028: formal parameter N different from declaration
warning C4029: declared formal parameter list different from definition
```

Diffs between the 765.x.x and 878.x.x [tarballs](https://opensource.apple.com/tarballs/mDNSResponder/), show that Apple changed the `mDNSPlatformXxxx` API, updated the "mDNSMacOSX" and "mDNSPosix" implementations to match but failed to do so for the "mDNSWindows" one. This patch fixes that.

Of course, I'd love Apple to merge these patches upstream, but they have repeatedly failed to respond to bug/patch submissions about mDNSResponder.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
