### PR TITLE
[docs] Remove some configurations

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 7-September-2021 - TBD
+### 7-September-2021 - 16:49 CEST
 
 - [configs] Remove Visual Studio 2015
 - [configs] Remove Macos apple-clang 10

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 - [configs] Remove Macos apple-clang 10
 - [configs] Remove Linux GCC 4.9
 - [configs] Linux Clang: keep only latest versions 10 and 11
+- [feature] Rename EAP to Access Request.
+- [feature] Display merge error in pull-requests.
 
 ### 6-September-2021 - 11:15 CEST
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 7-September-2021 - TBD
+
+- [configs] Remove Visual Studio 2015
+- [configs] Remove Macos apple-clang 10
+- [configs] Remove Linux GCC 4.9
+- [configs] Linux Clang: keep only latest versions 10 and 11
+
 ### 6-September-2021 - 11:15 CEST
 
 - [feature] Display useful CI status notifications in Github pull requests.


### PR DESCRIPTION
Following https://github.com/conan-io/conan-center-index/issues/4761, the next step is to actually remove the configurations.

 This release will remove:
  * **VS 2015** and **apple-clang 10**. They are almost not used: https://github.com/conan-io/conan-center-index/issues/4761#issuecomment-904520393.
  * **Linux GCC 4.9** and **clang <10**: They won't be available if using the [new docker images](https://github.com/conan-io/conan-docker-tools/tree/master/modern).
  
 ---
 
 We are currently preparing these changes, but we wanted to notify them before merging. A more comprehensive rationale can be read in #4761, together with the next steps and considerations we are taking into account. 