### PR TITLE
Add ruy recipe

### DIFF
--- a/recipes/ruy/all/CMakeLists.txt
+++ b/recipes/ruy/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/ruy/all/CMakeLists.txt
+++ b/recipes/ruy/all/CMakeLists.txt
@@ -1,7 +1,9 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.4)
 project(cmake_wrapper)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_subdirectory(source_subfolder)

--- a/recipes/ruy/all/conandata.yml
+++ b/recipes/ruy/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20210622":
+    url: "https://github.com/google/ruy/archive/9c56af3fce210a8a103eda19bd6f47c08a9e3d90.tar.gz"
+    sha256: "8895874cfbf7263b028a6ec55b4b1737af0ea2b7bfedac90fd14d0b0a654f2dc"

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -31,6 +31,26 @@ class RuyConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _minimum_compilers_version(self):
+        return {
+            "Visual Studio": "15",
+            "gcc": "5",
+            "clang": "3.4",
+            "apple-clang": "5.1",
+        }
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, 14)
+
+        minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
+        if not minimum_version:
+            self.output.warn("Compiler is unknown. Assuming it supports C++14.")
+        elif tools.Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration("Build requires support for C++14. Minimum version for {} is {}"
+                .format(str(self.settings.compiler), minimum_version))
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -53,6 +73,7 @@ class RuyConan(ConanFile):
         self._cmake.definitions["RUY_MINIMAL_BUILD"] = True
         self._cmake.configure()
         return self._cmake
+
 
     def build(self):
         # 1. Allow Shared builds

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -36,7 +36,7 @@ class RuyConan(ConanFile):
         return {
             "Visual Studio": "15",
             "gcc": "5",
-            "clang": "3.4",
+            "clang": "5",
             "apple-clang": "5.1",
         }
 
@@ -73,7 +73,6 @@ class RuyConan(ConanFile):
         self._cmake.definitions["RUY_MINIMAL_BUILD"] = True
         self._cmake.configure()
         return self._cmake
-
 
     def build(self):
         # 1. Allow Shared builds

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -36,7 +36,7 @@ class RuyConan(ConanFile):
         return {
             "Visual Studio": "15",
             "gcc": "5",
-            "clang": "5",
+            "clang": "3.4",
             "apple-clang": "5.1",
         }
 
@@ -73,6 +73,7 @@ class RuyConan(ConanFile):
         self._cmake.definitions["RUY_MINIMAL_BUILD"] = True
         self._cmake.configure()
         return self._cmake
+
 
     def build(self):
         # 1. Allow Shared builds

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -84,10 +84,14 @@ class RuyConan(ConanFile):
                               "add_library(${_NAME} STATIC",
                               "add_library(${_NAME}"
                               )
-        # 2. Shared builds fail with undefined symbols without this. clog is a library from the cpuinfo
+
+        # 2. Shared builds fail with undefined symbols without this fix.
+        # This is because ruy only links to 'cpuinfo' but it also needs 'clog' (from the same package)
+        cpuinfoLibs = self.deps_cpp_info["cpuinfo"].libs + self.deps_cpp_info["cpuinfo"].system_libs
+        libsListAsString = ";".join(cpuinfoLibs)
         tools.replace_in_file(os.path.join(self._source_subfolder, "ruy", "CMakeLists.txt"),
                               "set(ruy_6_cpuinfo \"cpuinfo\")",
-                              "set(ruy_6_cpuinfo \"cpuinfo;clog\")"
+                              f"set(ruy_6_cpuinfo \"{libsListAsString}\")"
                               )
         cmake = self._configure_cmake()
         cmake.build()

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -95,8 +95,6 @@ class RuyConan(ConanFile):
         self.copy(pattern="*", dst="lib", src="lib")
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "ruy"
-        self.cpp_info.names["cmake_find_package_multi"] = "ruy"
         self.cpp_info.libs = ["ruy_frontend",
                             "ruy_context",
                             "ruy_trmul",

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -51,6 +51,9 @@ class RuyConan(ConanFile):
             raise ConanInvalidConfiguration("Build requires support for C++14. Minimum version for {} is {}"
                 .format(str(self.settings.compiler), minimum_version))
 
+        if str(self.settings.compiler) == "clang" and tools.Version(self.settings.compiler.version) <= 5 and self.settings.build_type == "Debug":
+            raise ConanInvalidConfiguration("Debug builds are not supported on older versions of Clang (<=5)")
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -98,6 +98,8 @@ class RuyConan(ConanFile):
         self.copy(pattern="*", dst="lib", src="lib")
         self.copy(pattern="*", dst="bin", src="bin")
 
+        tools.remove_files_by_mask(self.package_folder, "*.pdb")
+
     def package_info(self):
         self.cpp_info.libs = ["ruy_frontend",
                             "ruy_context",

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -132,3 +132,5 @@ class RuyConan(ConanFile):
                             "ruy_profiler_instrumentation",
                             "ruy_profiler_profiler"
                             ]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -96,6 +96,7 @@ class RuyConan(ConanFile):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         self.copy(pattern="*.h", dst=os.path.join("include", "ruy"), src=os.path.join(self._source_subfolder, "ruy"))
         self.copy(pattern="*", dst="lib", src="lib")
+        self.copy(pattern="*", dst="bin", src="bin")
 
     def package_info(self):
         self.cpp_info.libs = ["ruy_frontend",

--- a/recipes/ruy/all/test_package/CMakeLists.txt
+++ b/recipes/ruy/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(ruy REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ruy::ruy)

--- a/recipes/ruy/all/test_package/CMakeLists.txt
+++ b/recipes/ruy/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(ruy REQUIRED)
 

--- a/recipes/ruy/all/test_package/CMakeLists.txt
+++ b/recipes/ruy/all/test_package/CMakeLists.txt
@@ -8,3 +8,4 @@ find_package(ruy REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ruy::ruy)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/ruy/all/test_package/conanfile.py
+++ b/recipes/ruy/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        pass
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/ruy/all/test_package/conanfile.py
+++ b/recipes/ruy/all/test_package/conanfile.py
@@ -12,7 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        pass
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/ruy/all/test_package/test_package.cpp
+++ b/recipes/ruy/all/test_package/test_package.cpp
@@ -1,0 +1,161 @@
+/* Copyright 2019 Google LLC. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <iostream>
+
+#include "ruy/ruy.h"
+
+void ExampleMulFloat(ruy::Context *context) {
+  const float lhs_data[] = {1, 2, 3, 4};
+  const float rhs_data[] = {1, 2, 3, 4};
+  float dst_data[4];
+
+  ruy::Matrix<float> lhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
+  lhs.set_data(lhs_data);
+  ruy::Matrix<float> rhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
+  rhs.set_data(rhs_data);
+  ruy::Matrix<float> dst;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
+  dst.set_data(dst_data);
+
+  ruy::MulParams<float, float> mul_params;
+  ruy::Mul(lhs, rhs, mul_params, context, &dst);
+
+  std::cout << "Example Mul, float:\n";
+  std::cout << "LHS:\n" << lhs;
+  std::cout << "RHS:\n" << rhs;
+  std::cout << "Result:\n" << dst << "\n";
+}
+
+void ExampleMulFloatWithBiasAddAndClamp(ruy::Context *context) {
+  const float lhs_data[] = {1, 2, 3, 4};
+  const float rhs_data[] = {1, 2, 3, 4};
+  const float bias_data[] = {1, 0};
+  float dst_data[4];
+
+  ruy::Matrix<float> lhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
+  lhs.set_data(lhs_data);
+  ruy::Matrix<float> rhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
+  rhs.set_data(rhs_data);
+  ruy::Matrix<float> dst;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
+  dst.set_data(dst_data);
+
+  ruy::MulParams<float, float> mul_params;
+  mul_params.set_bias(bias_data);
+  mul_params.set_clamp_min(0);
+  mul_params.set_clamp_max(15);
+  ruy::Mul(lhs, rhs, mul_params, context, &dst);
+
+  std::cout << "Example Mul, float with bias addition and clamp:\n";
+  std::cout << "LHS:\n" << lhs;
+  std::cout << "RHS:\n" << rhs;
+  std::cout << "Result:\n" << dst << "\n";
+}
+
+void ExampleMulUint8AsymmetricQuantized(ruy::Context *context) {
+  const std::uint8_t lhs_data[] = {124, 125, 126, 127};
+  const std::uint8_t rhs_data[] = {129, 130, 131, 132};
+  std::uint8_t dst_data[4];
+
+  ruy::Matrix<std::uint8_t> lhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
+  lhs.set_data(lhs_data);
+  lhs.set_zero_point(125);
+  ruy::Matrix<std::uint8_t> rhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
+  rhs.set_data(rhs_data);
+  rhs.set_zero_point(132);
+  ruy::Matrix<std::uint8_t> dst;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
+  dst.set_data(dst_data);
+  dst.set_zero_point(129);
+
+  ruy::MulParams<std::int32_t, std::uint8_t> mul_params;
+  mul_params.set_multiplier_fixedpoint(1 << 30);
+
+  mul_params.set_multiplier_exponent(0);
+  ruy::Mul(lhs, rhs, mul_params, context, &dst);
+
+  std::cout << "Example Mul, uint8 quantized with asymmetric zero points:\n";
+  std::cout << "LHS:\n" << lhs;
+  std::cout << "RHS:\n" << rhs;
+  std::cout << "Result:\n" << dst << "\n";
+}
+void ExampleMulInt8PerChannelQuantized(ruy::Context *context) {
+  const std::int8_t lhs_data[] = {1, 2, 3, 4};
+  const std::int8_t rhs_data[] = {1, 2, 3, 4};
+  const std::int32_t multiplier_data[] = {3 << 28, 5 << 28};
+  const int exponent_data[] = {1, -2};
+  std::int8_t dst_data[4];
+
+  ruy::Matrix<std::int8_t> lhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
+  lhs.set_data(lhs_data);
+  ruy::Matrix<std::int8_t> rhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
+  rhs.set_data(rhs_data);
+  ruy::Matrix<std::int8_t> dst;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
+  dst.set_data(dst_data);
+
+  ruy::MulParams<std::int32_t, std::int8_t> mul_params;
+  mul_params.set_multiplier_fixedpoint_perchannel(multiplier_data);
+  mul_params.set_multiplier_exponent_perchannel(exponent_data);
+  ruy::Mul(lhs, rhs, mul_params, context, &dst);
+
+  std::cout << "Example Mul, int8 quantized with per-channel multipliers\n";
+  std::cout << "LHS:\n" << lhs;
+  std::cout << "RHS:\n" << rhs;
+  std::cout << "Result:\n" << dst << "\n";
+}
+void ExampleMulInt8GetRawAccumulators(ruy::Context *context) {
+  const std::int8_t lhs_data[] = {1, 2, 3, 4};
+  const std::int8_t rhs_data[] = {1, 2, 3, 4};
+  std::int32_t dst_data[4];
+
+  ruy::Matrix<std::int8_t> lhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
+  lhs.set_data(lhs_data);
+  ruy::Matrix<std::int8_t> rhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
+  rhs.set_data(rhs_data);
+  ruy::Matrix<std::int32_t> dst;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
+  dst.set_data(dst_data);
+
+  // When Dst is int32, mul_params is unused.
+  ruy::MulParams<std::int32_t, std::int32_t> mul_params;
+  ruy::Mul(lhs, rhs, mul_params, context, &dst);
+
+  std::cout << "Example Mul, returning raw int32 accumulators:\n";
+  std::cout << "LHS:\n" << lhs;
+  std::cout << "RHS:\n" << rhs;
+  std::cout << "Result:\n" << dst << "\n";
+}
+
+int main() {
+  ruy::Context context;
+  ExampleMulFloat(&context);
+  ExampleMulFloatWithBiasAddAndClamp(&context);
+  ExampleMulUint8AsymmetricQuantized(&context);
+  ExampleMulInt8PerChannelQuantized(&context);
+  ExampleMulInt8GetRawAccumulators(&context);
+}

--- a/recipes/ruy/all/test_package/test_package.cpp
+++ b/recipes/ruy/all/test_package/test_package.cpp
@@ -1,161 +1,27 @@
-/* Copyright 2019 Google LLC. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-==============================================================================*/
-
 #include <cstdint>
 #include <iostream>
 
 #include "ruy/ruy.h"
 
-void ExampleMulFloat(ruy::Context *context) {
-  const float lhs_data[] = {1, 2, 3, 4};
-  const float rhs_data[] = {1, 2, 3, 4};
-  float dst_data[4];
-
-  ruy::Matrix<float> lhs;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
-  lhs.set_data(lhs_data);
-  ruy::Matrix<float> rhs;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
-  rhs.set_data(rhs_data);
-  ruy::Matrix<float> dst;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
-  dst.set_data(dst_data);
-
-  ruy::MulParams<float, float> mul_params;
-  ruy::Mul(lhs, rhs, mul_params, context, &dst);
-
-  std::cout << "Example Mul, float:\n";
-  std::cout << "LHS:\n" << lhs;
-  std::cout << "RHS:\n" << rhs;
-  std::cout << "Result:\n" << dst << "\n";
-}
-
-void ExampleMulFloatWithBiasAddAndClamp(ruy::Context *context) {
-  const float lhs_data[] = {1, 2, 3, 4};
-  const float rhs_data[] = {1, 2, 3, 4};
-  const float bias_data[] = {1, 0};
-  float dst_data[4];
-
-  ruy::Matrix<float> lhs;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
-  lhs.set_data(lhs_data);
-  ruy::Matrix<float> rhs;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
-  rhs.set_data(rhs_data);
-  ruy::Matrix<float> dst;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
-  dst.set_data(dst_data);
-
-  ruy::MulParams<float, float> mul_params;
-  mul_params.set_bias(bias_data);
-  mul_params.set_clamp_min(0);
-  mul_params.set_clamp_max(15);
-  ruy::Mul(lhs, rhs, mul_params, context, &dst);
-
-  std::cout << "Example Mul, float with bias addition and clamp:\n";
-  std::cout << "LHS:\n" << lhs;
-  std::cout << "RHS:\n" << rhs;
-  std::cout << "Result:\n" << dst << "\n";
-}
-
-void ExampleMulUint8AsymmetricQuantized(ruy::Context *context) {
-  const std::uint8_t lhs_data[] = {124, 125, 126, 127};
-  const std::uint8_t rhs_data[] = {129, 130, 131, 132};
-  std::uint8_t dst_data[4];
-
-  ruy::Matrix<std::uint8_t> lhs;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
-  lhs.set_data(lhs_data);
-  lhs.set_zero_point(125);
-  ruy::Matrix<std::uint8_t> rhs;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
-  rhs.set_data(rhs_data);
-  rhs.set_zero_point(132);
-  ruy::Matrix<std::uint8_t> dst;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
-  dst.set_data(dst_data);
-  dst.set_zero_point(129);
-
-  ruy::MulParams<std::int32_t, std::uint8_t> mul_params;
-  mul_params.set_multiplier_fixedpoint(1 << 30);
-
-  mul_params.set_multiplier_exponent(0);
-  ruy::Mul(lhs, rhs, mul_params, context, &dst);
-
-  std::cout << "Example Mul, uint8 quantized with asymmetric zero points:\n";
-  std::cout << "LHS:\n" << lhs;
-  std::cout << "RHS:\n" << rhs;
-  std::cout << "Result:\n" << dst << "\n";
-}
-void ExampleMulInt8PerChannelQuantized(ruy::Context *context) {
-  const std::int8_t lhs_data[] = {1, 2, 3, 4};
-  const std::int8_t rhs_data[] = {1, 2, 3, 4};
-  const std::int32_t multiplier_data[] = {3 << 28, 5 << 28};
-  const int exponent_data[] = {1, -2};
-  std::int8_t dst_data[4];
-
-  ruy::Matrix<std::int8_t> lhs;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
-  lhs.set_data(lhs_data);
-  ruy::Matrix<std::int8_t> rhs;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
-  rhs.set_data(rhs_data);
-  ruy::Matrix<std::int8_t> dst;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
-  dst.set_data(dst_data);
-
-  ruy::MulParams<std::int32_t, std::int8_t> mul_params;
-  mul_params.set_multiplier_fixedpoint_perchannel(multiplier_data);
-  mul_params.set_multiplier_exponent_perchannel(exponent_data);
-  ruy::Mul(lhs, rhs, mul_params, context, &dst);
-
-  std::cout << "Example Mul, int8 quantized with per-channel multipliers\n";
-  std::cout << "LHS:\n" << lhs;
-  std::cout << "RHS:\n" << rhs;
-  std::cout << "Result:\n" << dst << "\n";
-}
-void ExampleMulInt8GetRawAccumulators(ruy::Context *context) {
-  const std::int8_t lhs_data[] = {1, 2, 3, 4};
-  const std::int8_t rhs_data[] = {1, 2, 3, 4};
-  std::int32_t dst_data[4];
-
-  ruy::Matrix<std::int8_t> lhs;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
-  lhs.set_data(lhs_data);
-  ruy::Matrix<std::int8_t> rhs;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
-  rhs.set_data(rhs_data);
-  ruy::Matrix<std::int32_t> dst;
-  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
-  dst.set_data(dst_data);
-
-  // When Dst is int32, mul_params is unused.
-  ruy::MulParams<std::int32_t, std::int32_t> mul_params;
-  ruy::Mul(lhs, rhs, mul_params, context, &dst);
-
-  std::cout << "Example Mul, returning raw int32 accumulators:\n";
-  std::cout << "LHS:\n" << lhs;
-  std::cout << "RHS:\n" << rhs;
-  std::cout << "Result:\n" << dst << "\n";
-}
-
 int main() {
+
   ruy::Context context;
-  ExampleMulFloat(&context);
-  ExampleMulFloatWithBiasAddAndClamp(&context);
-  ExampleMulUint8AsymmetricQuantized(&context);
-  ExampleMulInt8PerChannelQuantized(&context);
-  ExampleMulInt8GetRawAccumulators(&context);
+  const float lhs_data[] = {1, 2, 3, 4};
+  const float rhs_data[] = {1, 2, 3, 4};
+  float dst_data[4];
+
+  ruy::Matrix<float> lhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kRowMajor, lhs.mutable_layout());
+  lhs.set_data(lhs_data);
+  ruy::Matrix<float> rhs;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, rhs.mutable_layout());
+  rhs.set_data(rhs_data);
+  ruy::Matrix<float> dst;
+  ruy::MakeSimpleLayout(2, 2, ruy::Order::kColMajor, dst.mutable_layout());
+  dst.set_data(dst_data);
+
+  ruy::MulParams<float, float> mul_params;
+  ruy::Mul(lhs, rhs, mul_params, &context, &dst);
+
+  std::cout << "ruy's test_package ran successfully \n";
 }

--- a/recipes/ruy/config.yml
+++ b/recipes/ruy/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20210622":
+    folder: all


### PR DESCRIPTION
First step into tensorflow-lite https://github.com/conan-io/conan-center-index/issues/7165

By default this library only supports static builds. I've patched it to support shared, but even though all the binaries are `.so` (Linux) `ldd` stil reports some as statically linked.

```
ldd libruy_have_built_path_for_avx2_fma.so 
	statically linked
```

Should I remove that patch and keep it static only as designed?

I've chosen the order of `cpp_info.libs` to avoid linking errors to the best of my knowledge. 
This is a google library and, as usual, it is full of non-standard things on the build system.
