### PR TITLE
wasmtime: need to download binaries in `build`

### DIFF
--- a/recipes/wasmtime/all/conanfile.py
+++ b/recipes/wasmtime/all/conanfile.py
@@ -79,6 +79,7 @@ class WasmtimeConan(ConanFile):
             self.info.settings.compiler = "gcc"
 
     def build(self):
+        # This is packaging binaries so the download needs to be in build
         tools.get(**self.conan_data["sources"][self.version][self._sources_os_key][str(self.settings.arch)],
                   destination=self.source_folder, strip_root=True)
 

--- a/recipes/wasmtime/all/conanfile.py
+++ b/recipes/wasmtime/all/conanfile.py
@@ -73,6 +73,9 @@ class WasmtimeConan(ConanFile):
             # FIXME: https://github.com/bytecodealliance/wasmtime/issues/3168
             raise ConanInvalidConfiguration("Shared mingw is currently not possible")
 
+    def package_id(self):
+        del self.info.settings.compiler.version
+
     def build(self):
         tools.get(**self.conan_data["sources"][self.version][self._sources_os_key][str(self.settings.arch)],
                   destination=self.source_folder, strip_root=True)

--- a/recipes/wasmtime/all/conanfile.py
+++ b/recipes/wasmtime/all/conanfile.py
@@ -75,6 +75,8 @@ class WasmtimeConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.compiler.version
+        if self.settings.compiler == "clang":
+            self.info.settings.compiler = "gcc"
 
     def build(self):
         tools.get(**self.conan_data["sources"][self.version][self._sources_os_key][str(self.settings.arch)],

--- a/recipes/wasmtime/all/conanfile.py
+++ b/recipes/wasmtime/all/conanfile.py
@@ -1,20 +1,25 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration, ConanException
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 import shutil
 
 required_conan_version = ">=1.33.0"
 
+
 class WasmtimeConan(ConanFile):
-    name = 'wasmtime'
-    homepage = 'https://github.com/bytecodealliance/wasmtime'
-    license = 'Apache-2.0'
-    url = 'https://github.com/conan-io/conan-center-index'
+    name = "wasmtime"
+    homepage = "https://github.com/bytecodealliance/wasmtime"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
     description = "Standalone JIT-style runtime for WebAssembly, using Cranelift"
     topics = ("webassembly", "wasm", "wasi")
-    settings = "os", "compiler", "arch"
-    options = { "shared": [True, False] }
-    default_options = { 'shared': False }
+    settings = "os", "arch", "compiler"
+    options = {
+        "shared": [True, False],
+    }
+    default_options = {
+        "shared": False,
+    }
     no_copy_source = True
 
     @property
@@ -31,7 +36,7 @@ class WasmtimeConan(ConanFile):
         }
 
     @property
-    def _sources_key(self):
+    def _sources_os_key(self):
         if self.settings.compiler == "Visual Studio":
             return "Windows"
         elif self.settings.os == "Windows" and self.settings.compiler == "gcc":
@@ -60,16 +65,17 @@ class WasmtimeConan(ConanFile):
             self.output.warn(msg)
 
         try:
-            self.conan_data["sources"][self.version][self._sources_key][str(self.settings.arch)]
+            self.conan_data["sources"][self.version][self._sources_os_key][str(self.settings.arch)]
         except KeyError:
-            raise ConanInvalidConfiguration("Binaries for this combination of architecture/version/os not available")
+            raise ConanInvalidConfiguration("Binaries for this combination of architecture/version/os are not available")
 
         if (self.settings.compiler, self.settings.os) == ("gcc", "Windows") and self.options.shared:
             # FIXME: https://github.com/bytecodealliance/wasmtime/issues/3168
             raise ConanInvalidConfiguration("Shared mingw is currently not possible")
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version][self._sources_key][str(self.settings.arch)], destination=self.source_folder, strip_root=True)
+    def build(self):
+        tools.get(**self.conan_data["sources"][self.version][self._sources_os_key][str(self.settings.arch)],
+                  destination=self.source_folder, strip_root=True)
 
     def package(self):
         shutil.copytree(os.path.join(self.source_folder, "include"),
@@ -86,7 +92,7 @@ class WasmtimeConan(ConanFile):
             self.copy("wasmtime.lib", src=srclibdir, dst="lib", keep_path=False)
             self.copy("libwasmtime.a", src=srclibdir, dst="lib", keep_path=False)
 
-        self.copy('LICENSE', dst='licenses', src=self.source_folder)
+        self.copy("LICENSE", dst="licenses", src=self.source_folder)
 
     def package_info(self):
         if self.options.shared:
@@ -96,10 +102,10 @@ class WasmtimeConan(ConanFile):
                 self.cpp_info.libs = ["wasmtime"]
         else:
             if self.settings.os == "Windows":
-                self.cpp_info.defines= ["/DWASM_API_EXTERN=", "/DWASI_API_EXTERN="]
+                self.cpp_info.defines = ["WASM_API_EXTERN=", "WASI_API_EXTERN="]
             self.cpp_info.libs = ["wasmtime"]
 
-        if self.settings.os == 'Windows':
-            self.cpp_info.system_libs = ['ws2_32', 'bcrypt', 'advapi32', 'userenv', 'ntdll', 'shell32', 'ole32']
-        elif self.settings.os == 'Linux':
-            self.cpp_info.system_libs = ['pthread', 'dl', 'm']
+            if self.settings.os == "Windows":
+                self.cpp_info.system_libs = ["ws2_32", "bcrypt", "advapi32", "userenv", "ntdll", "shell32", "ole32"]
+            elif self.settings.os == "Linux":
+                self.cpp_info.system_libs = ["pthread", "dl", "m"]

--- a/recipes/wasmtime/all/test_package/CMakeLists.txt
+++ b/recipes/wasmtime/all/test_package/CMakeLists.txt
@@ -1,13 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
-project(PackageTest C)
-
-set(CMAKE_C_STANDARD 11)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-find_package(wasmtime REQUIRED)
+find_package(wasmtime REQUIRED CONFIG)
 
-add_executable(example example.c)
-target_link_libraries(example PRIVATE wasmtime::wasmtime)
-target_compile_options(example PRIVATE ${CONAN_COMPILE_DEFINITIONS_WASMTIME})
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE wasmtime::wasmtime)
+set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 11)

--- a/recipes/wasmtime/all/test_package/conanfile.py
+++ b/recipes/wasmtime/all/test_package/conanfile.py
@@ -2,9 +2,9 @@ from conans import ConanFile, CMake, tools
 import os
 
 
-class WasmtimeTestConan(ConanFile):
-    settings = 'os', 'compiler', 'build_type', 'arch'
-    generators = 'cmake', 'cmake_find_package'
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -13,5 +13,5 @@ class WasmtimeTestConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self):
-            bin_path = os.path.join('bin', 'example')
+            bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/wasmtime/all/test_package/example.c
+++ b/recipes/wasmtime/all/test_package/example.c
@@ -1,8 +1,0 @@
-#include <wasmtime.h>
-
-int main() {
-  char* wat = "";
-  wasm_byte_vec_t ret;
-  wasmtime_error_t *error = wasmtime_wat2wasm(wat, sizeof(wat), &ret);
-  return 0;
-}

--- a/recipes/wasmtime/all/test_package/test_package.c
+++ b/recipes/wasmtime/all/test_package/test_package.c
@@ -16,6 +16,7 @@ int main() {
         fprintf(stderr, "wasmtime_wat2wasm failed:\n");
         wasm_name_t message;
         wasmtime_error_message(error, &message);
+        wasmtime_error_delete(error);
         fprintf(stderr, "%s\n", message.data);
         wasm_byte_vec_delete(&message);
         return EXIT_FAILURE;

--- a/recipes/wasmtime/all/test_package/test_package.c
+++ b/recipes/wasmtime/all/test_package/test_package.c
@@ -12,7 +12,15 @@ int main() {
                    "\t\ti32.add))";
     wasm_byte_vec_t ret;
     wasmtime_error_t *error = wasmtime_wat2wasm(wat, strlen(wat), &ret);
-    printf("wasm:\n%s\n", wat);
+    if (error != NULL) {
+        fprintf(stderr, "wasmtime_wat2wasm failed:\n");
+        wasm_name_t message;
+        wasmtime_error_message(error, &message);
+        fprintf(stderr, "%s\n", message.data);
+        wasm_byte_vec_delete(&message);
+        return EXIT_FAILURE;
+    }
+    printf("wasm text:\n%s\n", wat);
     puts("assembly:");
     for(size_t i = 0; i < ret.size; ++i) {
         printf(" 0x%02x", ret.data[i]);
@@ -21,5 +29,6 @@ int main() {
         }
     }
     puts("");
+    wasm_byte_vec_delete(&ret);
     return EXIT_SUCCESS;
 }

--- a/recipes/wasmtime/all/test_package/test_package.c
+++ b/recipes/wasmtime/all/test_package/test_package.c
@@ -1,0 +1,25 @@
+#include <wasmtime.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main() {
+    char *wat = "(module\n"
+                   "\t(func (param $lhs i32) (param $rhs i32) (result i32)\n"
+                   "\t\tlocal.get $lhs\n"
+                   "\t\tlocal.get $rhs\n"
+                   "\t\ti32.add))";
+    wasm_byte_vec_t ret;
+    wasmtime_error_t *error = wasmtime_wat2wasm(wat, strlen(wat), &ret);
+    printf("wasm:\n%s\n", wat);
+    puts("assembly:");
+    for(size_t i = 0; i < ret.size; ++i) {
+        printf(" 0x%02x", ret.data[i]);
+        if (i%8 == 7) {
+            puts("");
+        }
+    }
+    puts("");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Specify library name and version:  **wasmtime/all**

wasmtime is packaging binaries, so we need to download the binaries in the `build` method.

@redradist
This is an important fix for wasmtime.
I also could remove the use of `CONAN_COMPILE_DEFINITIONS_WASMTIME` in the test package.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
