### PR TITLE
harfbuzz: add version 2.9.1

### DIFF
--- a/recipes/harfbuzz/all/conandata.yml
+++ b/recipes/harfbuzz/all/conandata.yml
@@ -26,6 +26,9 @@ sources:
   "2.9.0":
     url: "https://github.com/harfbuzz/harfbuzz/releases/download/2.9.0/harfbuzz-2.9.0.tar.xz"
     sha256: "3e1c2e1d2c65d56364fd16d1c41a06b2a35795496f78dfff635c2b7414b54c5a"
+  "2.9.1":
+    url: "https://github.com/harfbuzz/harfbuzz/archive/2.9.1.tar.gz"
+    sha256: "f997abd0e3b90647408bfb01af2383b5fc9557af20137e7c2deaf2fa13705dc8"
 patches:
   "2.6.8":
     - patch_file: "patches/icu.patch"
@@ -52,5 +55,8 @@ patches:
     - patch_file: "patches/icu-2.8.x.patch"
       base_path: "source_subfolder"
   "2.9.0":
+    - patch_file: "patches/icu-2.8.x.patch"
+      base_path: "source_subfolder"
+  "2.9.1":
     - patch_file: "patches/icu-2.8.x.patch"
       base_path: "source_subfolder"

--- a/recipes/harfbuzz/config.yml
+++ b/recipes/harfbuzz/config.yml
@@ -17,3 +17,5 @@ versions:
     folder: all
   "2.9.0":
     folder: all
+  "2.9.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **harfbuzz:/2.9.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
