### PR TITLE
[docs] Rename EAP to Access Request

### DIFF
--- a/docs/how_to_add_packages.md
+++ b/docs/how_to_add_packages.md
@@ -20,13 +20,13 @@ When pull requests are merged, the CI will upload the generated packages to the 
     * [Updating conan hooks on your machine](#updating-conan-hooks-on-your-machine)
   * [Debugging failed builds](#debugging-failed-builds)<!-- endToc -->
 
-## Join the Early Access Program
+## Request access
 
-:one: The first step in adding packages to ConanCenter is requesting access to the **Early Access Program**. To enroll in EAP, please write a comment
-requesting access in this GitHub [issue](https://github.com/conan-io/conan-center-index/issues/4). The EAP was designed to onboard authors
-to the new process.
+:one: The first step in adding packages to ConanCenter is requesting access. To enroll in ConanCenter repository, please write a comment
+requesting access in this GitHub [issue](https://github.com/conan-io/conan-center-index/issues/4). Feel free to introduce yourself and
+your motivation to join ConanCenter.
 
-All EAP requests are reviewed and approved (or denied) every week, thus your request can take one week to be approved, so don't worry. This
+All requests are reviewed and approved every week, please be patient, the process is not automated and it won't be. This
 process helps conan-center-index against spam and malicious code.
 
 ## Submitting a Package
@@ -48,7 +48,7 @@ The **build service** associated to this repo will generate binary packages auto
 
 > ⚠️ **Note**: This not a testing service, it is a binary building service for package **releases**. Unit tests shouldn't be built nor run in recipes by default. Before submitting a pull request, please ensure that it works locally for some configurations.
 
-- The CI bot will start a new build only after being approved in EAP. Your PR may be reviewed in the mean time, but is not guaranteed.
+- The CI bot will start a new build only after the author is approved. Your PR may be reviewed in the mean time, but is not guaranteed.
 - The CI system will also report with messages in the PR any error in the process, even linking to the logs to see more details and debug.
 
 The pipeline will report errors and build logs by creating a comment in the pull-request after every commit. The message will include links to the logs for inspecting.

--- a/docs/review_process.md
+++ b/docs/review_process.md
@@ -28,7 +28,7 @@ conan-center-index tries to make the process as smooth and simple as possible fo
 
 In general, reviews are driven by the automated [bot](https://github.com/conan-center-bot). The bot is responsible for:
 
-- Adding or removing labels (such as [No Beta User](https://github.com/conan-io/conan-center-index/pulls?q=is%3Apr+is%3Aopen+label%3A%22No+Beta+user%22) or [Docs](https://github.com/conan-io/conan-center-index/pulls?q=is%3Apr+is%3Aopen+label%3ADocs)).
+- Adding or removing labels (such as [Bump version](https://github.com/conan-io/conan-center-index/pulls?q=is%3Apr+is%3Aopen+label%3A%22Bump+version%22) or [Docs](https://github.com/conan-io/conan-center-index/pulls?q=is%3Apr+is%3Aopen+label%3ADocs)).
 - Writing comments (most of the time, it's a build status, either failure with logs or success).
 - Merging pull requests.
 - Closing issues (after merging pull requests with GitHub keywords).
@@ -51,7 +51,7 @@ If you struggle to fix build errors yourself, you may want to ask for help from 
 ### Unexpected error
 
 Sometimes, build fails with `Unexpected error` message. This indicates an infrastructure problem, and usually it's unrelated to the changes within PR itself.
-Keep in mind conan-center-index is still in "early access program", and there are still some instabilities. Especially, as we're using lots of external services,
+Keep in mind conan-center-index is still _under development_, and there can be some instabilities. Especially, as we're using lots of external services,
 which might be inaccessible (GitHub API, docker hub, etc.) and may result in intermittent failures.
 So, what to do once `Unexpected error` was encountered? You may consider re-running the build by closing your pull request, waiting 15 seconds, and then re-opening it again.
 
@@ -125,7 +125,7 @@ It doesn't always mean accepting all the suggestions, but at least providing a r
 The bot runs Automatic Merges every 30 minutes. Currently, it can only merge a single PR in this timeframe, so there is a theoretical limit of 48 PRs merged per day (in practice, it's even less for reasons listed below).
 PR is selected for the merge only if:
 
-- Author is an added [beta user](https://github.com/conan-io/conan-center-index/issues/4).
+- Author is already [approved](https://github.com/conan-io/conan-center-index/issues/4).
 - Author has signed CLA.
 - PR is not a Draft or WIP.
 - PR has a green status (successful build).


### PR DESCRIPTION
After merging changes in https://github.com/conan-io/conan-center-index/pull/7182, the bot should not use `EAP` again, but _access request_ or similar. 

There are still some fringes, like the `"No Beta user"` label that will be changed in the following days. 