### PR TITLE
ffmpeg/all: Fix postproc and test_package.c bugs.

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -269,7 +269,7 @@ class FFMpegConan(ConanFile):
             "--disable-cuvid",  # FIXME: CUVID support
             # Licenses
             opt_enable_disable("nonfree", self.options.with_libfdk_aac),
-            opt_enable_disable("gpl", self.options.with_libx264 or self.options.with_libx265 or self.options.with_postproc)
+            opt_enable_disable("gpl", self.options.with_libx264 or self.options.with_libx265 or self.options.postproc)
         ]
         if self._arch:
             args.append("--arch={}".format(self._arch))
@@ -332,7 +332,7 @@ class FFMpegConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.components["avdevice"].libs = ["avdevice"]
-        self.cpp_info.components["avdevice"].requires = ["avfilter", "swscale", "postproc", "avformat", "avcodec", "swresample", "avutil"]
+        self.cpp_info.components["avdevice"].requires = ["avfilter", "swscale", "avformat", "avcodec", "swresample", "avutil"]
         self.cpp_info.components["avdevice"].names["pkg_config"] = "libavdevice"
 
         self.cpp_info.components["avfilter"].libs = ["avfilter"]

--- a/recipes/ffmpeg/all/test_package/test_package.c
+++ b/recipes/ffmpeg/all/test_package/test_package.c
@@ -9,14 +9,18 @@
 #include <stdio.h>
 
 int main() {
-    avcodec_register_all();
-    av_register_all();
-    avfilter_register_all();
     avdevice_register_all();
-    swresample_version();
-    swscale_version();
-    if (avcodec_find_encoder_by_name("libx264") == NULL) {
-        printf("Unable to find libx264 encoder\n");
+
+    printf("configuration: %s\n", avcodec_configuration());
+
+    printf("avcodec version: %d.%d.%d\n", AV_VERSION_MAJOR(avcodec_version()), AV_VERSION_MINOR(avcodec_version()), AV_VERSION_MICRO(avcodec_version()));
+    printf("avfilter version: %d.%d.%d\n", AV_VERSION_MAJOR(avfilter_version()), AV_VERSION_MINOR(avfilter_version()), AV_VERSION_MICRO(avfilter_version()));
+    printf("avdevice version: %d.%d.%d\n", AV_VERSION_MAJOR(avdevice_version()), AV_VERSION_MINOR(avdevice_version()), AV_VERSION_MICRO(avdevice_version()));
+    printf("swresample version: %d.%d.%d\n", AV_VERSION_MAJOR(swresample_version()), AV_VERSION_MINOR(swresample_version()), AV_VERSION_MICRO(swresample_version()));
+    printf("swscale version: %d.%d.%d\n", AV_VERSION_MAJOR(swscale_version()), AV_VERSION_MINOR(swscale_version()), AV_VERSION_MICRO(swscale_version()));
+
+    if (avcodec_find_encoder_by_name("rawvideo") == NULL) {
+        printf("Unable to find rawvideo encoder\n");
         return -1;
     }
     return 0;


### PR DESCRIPTION
Specify library name and version:  **ffmpeg/4.2.1**

Conanfile changes:
* Changed invalid `with_postproc` flag usage to correct `postproc`.
* Removed `postproc` dependency from `avdevice` requires list. Actually the `postproc` dependency is already correctly handled few lines down in `if self.options.postproc` block.

Test changes:
* Functions `avcodec_register_all`, `av_register_all` and `avfilter_register_all` are deprecated and are should not be used since version 4.0. Hence they were removed.
* Instead print out FFmpeg configuration string and module version numbers.
* Replace `libx264` encoder search with `rawvideo` encoder. The reason is that when `with_libx264` is False then the encoder cannot be found. The `rawvideo` should always be found if FFmpeg is compiled correctly.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
