### PR TITLE
gnu-config: bump + don't use tools.os_info in build_requirements

### DIFF
--- a/recipes/gnu-config/all/conandata.yml
+++ b/recipes/gnu-config/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20210814":
+    url: "http://git.savannah.gnu.org/cgit/config.git/snapshot/config-191bcb948f7191c36eefe634336f5fc5c0c4c2be.tar.gz"
+    sha256: "302e5e7f3c4996976c58efde8b2f28f71d51357e784330eeed738e129300dc33"
   "cci.20201022":
     url: "http://git.savannah.gnu.org/cgit/config.git/snapshot/config-1c4398015583eb77bc043234f5734be055e64bea.tar.gz"
     sha256: "339eb64757bf5af9e23ca15daa136acdd9d778753377190ce17fba7e1b222aff"

--- a/recipes/gnu-config/all/conanfile.py
+++ b/recipes/gnu-config/all/conanfile.py
@@ -1,7 +1,8 @@
 from conans import ConanFile, tools
 from conans.errors import ConanException
-import glob
 import os
+
+required_conan_version = ">=1.33.0"
 
 
 class GnuConfigConan(ConanFile):
@@ -9,7 +10,7 @@ class GnuConfigConan(ConanFile):
     description = "The GNU config.guess and config.sub scripts"
     homepage = "https://savannah.gnu.org/projects/config/"
     url = "https://github.com/conan-io/conan-center-index"
-    topics = ("conan", "gnu", "config", "autotools", "canonical", "host", "build", "target", "triplet")
+    topics = ("gnu", "config", "autotools", "canonical", "host", "build", "target", "triplet")
     license = "GPL-3.0-or-later", "autoconf-special-exception"
     no_copy_source = True
 
@@ -17,9 +18,12 @@ class GnuConfigConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    def package_id(self):
+        self.info.header_only()
+
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(glob.glob("config*")[0], self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _extract_license(self):
         txt_lines = tools.load(os.path.join(self.source_folder, self._source_subfolder, "config.guess")).splitlines()
@@ -40,9 +44,6 @@ class GnuConfigConan(ConanFile):
         tools.save(os.path.join(self.package_folder, "licenses", "COPYING"), self._extract_license())
         self.copy("config.guess", src=self._source_subfolder, dst="bin")
         self.copy("config.sub", src=self._source_subfolder, dst="bin")
-
-    def package_id(self):
-        self.info.header_only()
 
     def package_info(self):
         bin_path = os.path.join(self.package_folder, "bin")

--- a/recipes/gnu-config/all/test_package/conanfile.py
+++ b/recipes/gnu-config/all/test_package/conanfile.py
@@ -2,12 +2,16 @@ from conans import ConanFile, tools
 from conans.errors import ConanException
 
 
-class TestConan(ConanFile):
+class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
 
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
     def build_requirements(self):
-        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires("msys2/20190524")
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
 
     def test(self):
         triplet = tools.get_gnu_triplet(str(self.settings.os), str(self.settings.arch), str(self.settings.compiler))

--- a/recipes/gnu-config/config.yml
+++ b/recipes/gnu-config/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "cci.20210814":
+    folder: "all"
   "cci.20201022":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **gnu-config/all**

- Bump
- For https://github.com/conan-io/hooks/pull/320

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
