### PR TITLE
libsafec: modernize + dont't use tools.os_info in build_requirements

### DIFF
--- a/recipes/libsafec/all/conanfile.py
+++ b/recipes/libsafec/all/conanfile.py
@@ -12,22 +12,44 @@ class LibSafeCConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/rurban/safeclib"
     license = "MIT"
-    topics = ("conan", "safec", "libc")
+    topics = ("safec", "libc", "bounds-checking")
 
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
 
     exports_sources = "patches/*"
+
     _autotools = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def build_requirements(self):
+        self.build_requires("libtool/2.4.6")
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
 
     @property
     def _supported_compiler(self):
@@ -39,20 +61,11 @@ class LibSafeCConan(ConanFile):
             return False
         return True
 
-    def configure(self):
+    def validate(self):
         if not self._supported_compiler:
             raise ConanInvalidConfiguration(
                 "libsafec doesn't support {}/{}".format(
                     self.settings.compiler, self.settings.compiler.version))
-        if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
-
-    def build_requirements(self):
-        self.build_requires("libtool/2.4.6")
-        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires("msys2/cci.latest")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -62,14 +75,15 @@ class LibSafeCConan(ConanFile):
         if self._autotools:
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        if self.options.shared:
-            args = ["--enable-shared", "--disable-static"]
-        else:
-            args = ["--disable-shared", "--enable-static"]
-        args.extend(["--disable-doc", "--disable-Werror"])
-        if self.settings.build_type in ("Debug", "RelWithDebInfo"):
-            args.append("--enable-debug")
-        self._autotools.configure(configure_dir=self._source_subfolder, args=args)
+        yes_no = lambda v: "yes" if v else "no"
+        args = [
+            "--enable-shared={}".format(yes_no(self.options.shared)),
+            "--enable-static={}".format(yes_no(not self.options.shared)),
+            "--enable-debug={}".format(yes_no(self.settings.build_type == "Debug")),
+            "--disable-doc",
+            "--disable-Werror",
+        ]
+        self._autotools.configure(args=args, configure_dir=self._source_subfolder)
         return self._autotools
 
     def build(self):

--- a/recipes/libsafec/all/conanfile.py
+++ b/recipes/libsafec/all/conanfile.py
@@ -62,6 +62,8 @@ class LibSafeCConan(ConanFile):
         return True
 
     def validate(self):
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            raise ConanInvalidConfiguration("This platform is not yet supported by libsafec (os=Macos arch=armv8)")
         if not self._supported_compiler:
             raise ConanInvalidConfiguration(
                 "libsafec doesn't support {}/{}".format(

--- a/recipes/libsafec/all/test_package/conanfile.py
+++ b/recipes/libsafec/all/test_package/conanfile.py
@@ -1,6 +1,5 @@
-import os
-
 from conans import CMake, ConanFile, tools
+import os
 
 
 class TestPackageConan(ConanFile):
@@ -13,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **libsafec/all**

For https://github.com/conan-io/hooks/pull/320

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
