### PR TITLE
gnulib: modernize + no `tools.os_info` in `build_requirements`

### DIFF
--- a/recipes/gnulib/all/conanfile.py
+++ b/recipes/gnulib/all/conanfile.py
@@ -44,6 +44,8 @@ class GnuLibConanFile(ConanFile):
                 shutil.copy(src, dst)
 
     def package_info(self):
+        self.cpp_info.libdirs = []
+
         binpath = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment var: {}".format(binpath))
         self.env_info.PATH.append(binpath)

--- a/recipes/gnulib/all/conanfile.py
+++ b/recipes/gnulib/all/conanfile.py
@@ -1,7 +1,8 @@
 from conans import ConanFile, tools
 import os
-import re
 import shutil
+
+required_conan_version = ">=1.33.0"
 
 
 class GnuLibConanFile(ConanFile):
@@ -9,20 +10,19 @@ class GnuLibConanFile(ConanFile):
     description = "Gnulib is a central location for common GNU code, intended to be shared among GNU packages."
     homepage =  "https://www.gnu.org/software/gnulib/"
     url = "https://github.com/conan-io/conan-center-index"
-    topics = ("conan", "gnulib", "library", "gnu")
+    topics = ("gnulib", "library", "gnu")
     license = ("GPL-3.0-or-later", "LGPL-3.0-or-later", "Unlicense")
-    no_copy_source = True
 
-    # Added to test on CI
-    settings = "os_build", "arch_build"
+    no_copy_source = True
 
     _source_subfolder = "source_subfolder"
 
+    def package_id(self):
+        self.info.header_only()
+
     def source(self):
-        hash = re.search(r"h=([0-9a-f]*)", self.conan_data["sources"][self.version]["url"]).group(1)
-        dirname = "{}-{}".format(self.name, hash[:7])
-        tools.get(**self.conan_data["sources"][self.version], filename="gnulib-{}.tar.gz".format(dirname))
-        os.rename(dirname, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True, filename="gnulib.tar.gz")
 
     def package(self):
         self.copy("COPYING", src=self._source_subfolder, dst="licenses")
@@ -42,9 +42,6 @@ class GnuLibConanFile(ConanFile):
                 src = os.path.join(root, file)
                 dst = os.path.join(dstdir, file)
                 shutil.copy(src, dst)
-
-    def package_id(self):
-        self.info.include_build_settings()
 
     def package_info(self):
         binpath = os.path.join(self.package_folder, "bin")

--- a/recipes/gnulib/all/test_package/conanfile.py
+++ b/recipes/gnulib/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
 from conans import ConanFile, tools, AutoToolsBuildEnvironment
-from contextlib import contextmanager
+import contextlib
 import os
 import shutil
 
@@ -8,16 +8,19 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     exports_sources = "configure.ac", "Makefile.am", "test_package.c"
 
-    def build_requirements(self):
-        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH") and \
-                tools.os_info.detect_windows_subsystem() != "msys2":
-            self.build_requires("msys2/20190524")
-        self.build_requires("automake/1.16.1")
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
-    @contextmanager
+    def build_requirements(self):
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
+        self.build_requires("automake/1.16.4")
+
+    @contextlib.contextmanager
     def _build_context(self):
         if self.settings.compiler == "Visual Studio":
-            with tools.vcvars(self.settings):
+            with tools.vcvars(self):
                 env = {
                     "AR": "{} lib".format(tools.unix_path(os.path.join(self.build_folder, "build-aux", "ar-lib"))),
                     "CC": "cl -nologo",
@@ -49,6 +52,6 @@ class TestPackageConan(ConanFile):
                 autotools.make()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join(".", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/gnulib/all/test_package/conanfile.py
+++ b/recipes/gnulib/all/test_package/conanfile.py
@@ -43,9 +43,9 @@ class TestPackageConan(ConanFile):
             for fn in ("COPYING", "NEWS", "INSTALL", "README", "AUTHORS", "ChangeLog"):
                 tools.save(fn, "\n")
             with tools.run_environment(self):
-                self.run("gnulib-tool --list", win_bash=tools.os_info.is_windows)
-                self.run("gnulib-tool --import getopt-posix", win_bash=tools.os_info.is_windows)
-            self.run("{} -ifv".format(os.environ["AUTORECONF"]), win_bash=tools.os_info.is_windows)
+                self.run("gnulib-tool --list", win_bash=tools.os_info.is_windows, run_environment=True)
+                self.run("gnulib-tool --import getopt-posix", win_bash=tools.os_info.is_windows, run_environment=True)
+            self.run("{} -fiv".format(os.environ["AUTORECONF"]), win_bash=tools.os_info.is_windows, run_environment=True)
 
             with self._build_context():
                 autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)

--- a/recipes/gnulib/all/test_package/conanfile.py
+++ b/recipes/gnulib/all/test_package/conanfile.py
@@ -45,7 +45,9 @@ class TestPackageConan(ConanFile):
             with tools.run_environment(self):
                 self.run("gnulib-tool --list", win_bash=tools.os_info.is_windows, run_environment=True)
                 self.run("gnulib-tool --import getopt-posix", win_bash=tools.os_info.is_windows, run_environment=True)
-            self.run("{} -fiv".format(os.environ["AUTORECONF"]), win_bash=tools.os_info.is_windows, run_environment=True)
+            # m4 built with Visual Studio does not support executing *nix utils (e.g. `test`)
+            with tools.environment_append({"M4":None}) if self.settings.os == "Windows" else tools.no_op():
+                self.run("{} -fiv".format(os.environ["AUTORECONF"]), win_bash=tools.os_info.is_windows, run_environment=True)
 
             with self._build_context():
                 autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)

--- a/recipes/gnulib/all/test_package/conanfile.py
+++ b/recipes/gnulib/all/test_package/conanfile.py
@@ -42,8 +42,9 @@ class TestPackageConan(ConanFile):
         with tools.chdir(self.build_folder):
             for fn in ("COPYING", "NEWS", "INSTALL", "README", "AUTHORS", "ChangeLog"):
                 tools.save(fn, "\n")
-            self.run("gnulib-tool --list", win_bash=tools.os_info.is_windows)
-            self.run("gnulib-tool --import getopt-posix", win_bash=tools.os_info.is_windows)
+            with tools.run_environment(self):
+                self.run("gnulib-tool --list", win_bash=tools.os_info.is_windows)
+                self.run("gnulib-tool --import getopt-posix", win_bash=tools.os_info.is_windows)
             self.run("{} -ifv".format(os.environ["AUTORECONF"]), win_bash=tools.os_info.is_windows)
 
             with self._build_context():


### PR DESCRIPTION
Specify library name and version:  **gnulib/all**

For https://github.com/conan-io/hooks/pull/320

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
