### PR TITLE
bison: no `tools.os_info` in `build_requirements`

### DIFF
--- a/recipes/bison/all/conanfile.py
+++ b/recipes/bison/all/conanfile.py
@@ -47,7 +47,7 @@ class BisonConan(ConanFile):
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
         if self.settings.compiler == "Visual Studio":
-            self.build_requires("automake/1.16.3")
+            self.build_requires("automake/1.16.4")
         if self.settings.os != "Windows":
             self.build_requires("flex/2.6.4")
 

--- a/recipes/bison/all/test_package/conanfile.py
+++ b/recipes/bison/all/test_package/conanfile.py
@@ -3,20 +3,23 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
 
-    def build_requirements(self):
-        if tools.os_info.is_windows and not tools.get_env("CONAN_BASH_PATH") and \
-                tools.os_info.detect_windows_subsystem() != "msys2":
-            self.build_requires("msys2/20190524")
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
-    @ property
+    def build_requirements(self):
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
+
+    @property
     def _mc_parser_source(self):
         return os.path.join(self.source_folder, "mc_parser.yy")
 
     def build(self):
-        if not tools.cross_building(self.settings, skip_x64_x86=True):
+        if not tools.cross_building(self, skip_x64_x86=True):
             # verify bison may run
             self.run("bison --version", run_environment=True)
             # verify yacc may run
@@ -30,7 +33,7 @@ class TestPackageConan(ConanFile):
             cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings, skip_x64_x86=True):
+        if not tools.cross_building(self, skip_x64_x86=True):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)
 

--- a/recipes/bison/all/test_package/mc_parser.yy
+++ b/recipes/bison/all/test_package/mc_parser.yy
@@ -37,6 +37,6 @@ factor: NUM           { $$ = $1; }
 %%
 int main()
 {
-  yyparse();
-  return 0;
+    yyparse();
+    return 0;
 }

--- a/recipes/bison/all/test_package/test_package.cpp
+++ b/recipes/bison/all/test_package/test_package.cpp
@@ -2,12 +2,12 @@
 
 extern "C"
 {
-    int yyerror(char *);
+    int yyerror(const char *);
 }
 
 int main()
 {
-    char error[] = "Bincrafters";
+    char error[] = "conan-center-index";
     std::cout << yyerror(error) << std::endl;
     return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **bison/all**

For https://github.com/conan-io/hooks/pull/320

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
