### PR TITLE
spirv-tools: fix CMake imported targets + drop maintenance of v prefixed versions + modernize

### DIFF
--- a/recipes/spirv-tools/all/CMakeLists.txt
+++ b/recipes/spirv-tools/all/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
-if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-  include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-else()
-  include(conanbuildinfo.cmake)
-endif()
+include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_subdirectory("source_subfolder")

--- a/recipes/spirv-tools/all/conandata.yml
+++ b/recipes/spirv-tools/all/conandata.yml
@@ -5,25 +5,13 @@ sources:
   "2020.5":
     url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.5.tar.gz"
     sha256: "947ee994ba416380bd7ccc1c6377ac28a4802a55ca81ccc06796c28e84c00b71"
-  "v2020.5":
-    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.5.tar.gz"
-    sha256: "947ee994ba416380bd7ccc1c6377ac28a4802a55ca81ccc06796c28e84c00b71"
   "2020.3":
-    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.3.tar.gz"
-    sha256: "8b538a1cb2a4275ef9617abcb047d54e8292f975ac1d93323d5dd1e19c85280b"
-  "v2020.3":
     url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.3.tar.gz"
     sha256: "8b538a1cb2a4275ef9617abcb047d54e8292f975ac1d93323d5dd1e19c85280b"
   "2019.2":
     url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2019.2.tar.gz"
     sha256: "1fde9d2a0df920a401441cd77253fc7b3b9ab0578eabda8caaaceaa6c7638440"
-  "v2019.2":
-    url: "https://github.com/KhronosGroup/SPIRV-Tools/archive/v2019.2.tar.gz"
-    sha256: "1fde9d2a0df920a401441cd77253fc7b3b9ab0578eabda8caaaceaa6c7638440"
 patches:
   "2020.5":
-    - patch_file: "patches/support-SPV_KHR_fragment_shading_rate.patch"
-      base_path: "source_subfolder"
-  "v2020.5":
     - patch_file: "patches/support-SPV_KHR_fragment_shading_rate.patch"
       base_path: "source_subfolder"

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -37,12 +37,6 @@ class SpirvtoolsConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
-    @property
-    def _version(self):
-        if self.version[0] == "v":
-            return self.version[1:]
-        return self.version
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -63,7 +57,7 @@ class SpirvtoolsConan(ConanFile):
             "2020.5": "1.5.4",
             "2020.3": "1.5.3",
             "2019.2": "1.5.1",
-        }.get(str(self._version), False)
+        }.get(str(self.version), False)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -72,7 +66,7 @@ class SpirvtoolsConan(ConanFile):
     def _validate_dependency_graph(self):
         if self.deps_cpp_info["spirv-headers"].version != self._get_compatible_spirv_headers_version:
             raise ConanInvalidConfiguration("spirv-tools {0} requires spirv-headers {1}"
-                                            .format(self._version, self._get_compatible_spirv_headers_version))
+                                            .format(self.version, self._get_compatible_spirv_headers_version))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -84,10 +78,10 @@ class SpirvtoolsConan(ConanFile):
 
         cmake = CMake(self)
 
-        # - Before v2020.5, the shared lib is always built, but static libs might be built as shared
+        # - Before 2020.5, the shared lib is always built, but static libs might be built as shared
         #   with BUILD_SHARED_LIBS injection (which doesn't work due to symbols visibility, at least for msvc)
-        # - From v2020.5, static and shared libs are fully controlled by upstream CMakeLists.txt
-        if tools.Version(self._version) < "2020.5":
+        # - From 2020.5, static and shared libs are fully controlled by upstream CMakeLists.txt
+        if tools.Version(self.version) < "2020.5":
             cmake.definitions["BUILD_SHARED_LIBS"] = False
 
         # Required by the project's CMakeLists.txt

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -187,7 +187,7 @@ class SpirvtoolsConan(ConanFile):
         if self.options.shared:
             self.cpp_info.components["spirv-tools-core"].defines = ["SPIRV_TOOLS_SHAREDLIB"]
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["spirv-tools-core"].system_libs.append("rt")
+            self.cpp_info.components["spirv-tools-core"].system_libs.extend(["m", "rt"])
         if not self.options.shared and tools.stdcpp_library(self):
             self.cpp_info.components["spirv-tools-core"].system_libs.append(tools.stdcpp_library(self))
 

--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, tools, CMake
 from conans.errors import ConanInvalidConfiguration
 import os
+import textwrap
 
 required_conan_version = ">=1.33.0"
 
@@ -134,45 +135,88 @@ class SpirvtoolsConan(ConanFile):
             tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*SPIRV-Tools-shared.dll")
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*SPIRV-Tools-shared*")
 
+        if self.options.shared:
+            targets = {"SPIRV-Tools-shared": "spirv-tools::SPIRV-Tools"}
+        else:
+            targets = {
+                "SPIRV-Tools": "spirv-tools::SPIRV-Tools", # before 2020.5, kept for conveniency
+                "SPIRV-Tools-static": "spirv-tools::SPIRV-Tools",
+                "SPIRV-Tools-opt": "spirv-tools::SPIRV-Tools-opt",
+                "SPIRV-Tools-link": "spirv-tools::SPIRV-Tools-link",
+                "SPIRV-Tools-reduce": "spirv-tools::SPIRV-Tools-reduce",
+            }
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            targets,
+        )
+
+    @staticmethod
+    def _create_cmake_module_alias_targets(module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent("""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """.format(alias=alias, aliased=aliased))
+        tools.save(module_file, content)
+
+    @property
+    def _module_subfolder(self):
+        return os.path.join("lib", "cmake")
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join(self._module_subfolder,
+                            "conan-official-{}-targets.cmake".format(self.name))
+
     def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "SPIRV-Tools"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "SPIRV-Tools"
         self.cpp_info.names["pkg_config"] = "SPIRV-Tools-shared" if self.options.shared else "SPIRV-Tools"
-        # FIXME: official CMake imported targets are not namespaced
+
         # SPIRV-Tools
         self.cpp_info.components["spirv-tools-core"].names["cmake_find_package"] = "SPIRV-Tools"
         self.cpp_info.components["spirv-tools-core"].names["cmake_find_package_multi"] = "SPIRV-Tools"
+        self.cpp_info.components["spirv-tools-core"].builddirs.append(self._module_subfolder)
+        self.cpp_info.components["spirv-tools-core"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.components["spirv-tools-core"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
         self.cpp_info.components["spirv-tools-core"].libs = ["SPIRV-Tools-shared" if self.options.shared else "SPIRV-Tools"]
         self.cpp_info.components["spirv-tools-core"].requires = ["spirv-headers::spirv-headers"]
         if self.options.shared:
             self.cpp_info.components["spirv-tools-core"].defines = ["SPIRV_TOOLS_SHAREDLIB"]
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["spirv-tools-core"].system_libs.append("rt")
         if not self.options.shared and tools.stdcpp_library(self):
             self.cpp_info.components["spirv-tools-core"].system_libs.append(tools.stdcpp_library(self))
-
-        # Also provide official CMake imported target names for SPIRV-Tools lib:
-        # - if shared: SPIRV-Tools-shared
-        # - if static: SPIRV-Tools-static if version >= 2020.5 else SPIRV-Tools
-        spirv_tools_target = "SPIRV-Tools-shared" if self.options.shared else "SPIRV-Tools-static"
-        self.cpp_info.components["spirv-tools-core-alias"].names["cmake_find_package"] = spirv_tools_target
-        self.cpp_info.components["spirv-tools-core-alias"].names["cmake_find_package_multi"] = spirv_tools_target
 
         # FIXME: others components should have their own CMake config file
         if not self.options.shared:
             # SPIRV-Tools-opt
             self.cpp_info.components["spirv-tools-opt"].names["cmake_find_package"] = "SPIRV-Tools-opt"
             self.cpp_info.components["spirv-tools-opt"].names["cmake_find_package_multi"] = "SPIRV-Tools-opt"
+            self.cpp_info.components["spirv-tools-opt"].builddirs.append(self._module_subfolder)
+            self.cpp_info.components["spirv-tools-opt"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+            self.cpp_info.components["spirv-tools-opt"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
             self.cpp_info.components["spirv-tools-opt"].libs = ["SPIRV-Tools-opt"]
             self.cpp_info.components["spirv-tools-opt"].requires = ["spirv-tools-core", "spirv-headers::spirv-headers"]
-            if self.settings.os == "Linux":
+            if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["spirv-tools-opt"].system_libs.append("m")
             # SPIRV-Tools-link
             self.cpp_info.components["spirv-tools-link"].names["cmake_find_package"] = "SPIRV-Tools-link"
             self.cpp_info.components["spirv-tools-link"].names["cmake_find_package_multi"] = "SPIRV-Tools-link"
+            self.cpp_info.components["spirv-tools-link"].builddirs.append(self._module_subfolder)
+            self.cpp_info.components["spirv-tools-link"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+            self.cpp_info.components["spirv-tools-link"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
             self.cpp_info.components["spirv-tools-link"].libs = ["SPIRV-Tools-link"]
             self.cpp_info.components["spirv-tools-link"].requires = ["spirv-tools-core", "spirv-tools-opt"]
             # SPIRV-Tools-reduce
             self.cpp_info.components["spirv-tools-reduce"].names["cmake_find_package"] = "SPIRV-Tools-reduce"
             self.cpp_info.components["spirv-tools-reduce"].names["cmake_find_package_multi"] = "SPIRV-Tools-reduce"
+            self.cpp_info.components["spirv-tools-reduce"].builddirs.append(self._module_subfolder)
+            self.cpp_info.components["spirv-tools-reduce"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+            self.cpp_info.components["spirv-tools-reduce"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
             self.cpp_info.components["spirv-tools-reduce"].libs = ["SPIRV-Tools-reduce"]
             self.cpp_info.components["spirv-tools-reduce"].requires = ["spirv-tools-core", "spirv-tools-opt"]
 

--- a/recipes/spirv-tools/all/test_package/CMakeLists.txt
+++ b/recipes/spirv-tools/all/test_package/CMakeLists.txt
@@ -2,13 +2,22 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(SPIRV-Tools REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME}_c test_package.c)
-target_link_libraries(${PROJECT_NAME}_c ${CONAN_LIBS})
+if(TARGET SPIRV-Tools-shared)
+    target_link_libraries(${PROJECT_NAME}_c SPIRV-Tools-shared)
+elseif(TARGET SPIRV-Tools-static)
+    target_link_libraries(${PROJECT_NAME}_c SPIRV-Tools-static)
+else()
+    target_link_libraries(${PROJECT_NAME}_c SPIRV-Tools)
+endif()
 
-if(SPIRV_TOOLS_STATIC)
-  add_executable(${PROJECT_NAME}_cpp test_package.cpp)
-  target_link_libraries(${PROJECT_NAME}_cpp ${CONAN_LIBS})
-  set_property(TARGET ${PROJECT_NAME}_cpp PROPERTY CXX_STANDARD 11)
+# TODO: we should call find_package(SPIRV-Tools-opt REQUIRED CONFIG), but not modeled right now
+if(TARGET SPIRV-Tools-opt)
+    add_executable(${PROJECT_NAME}_cpp test_package.cpp)
+    target_link_libraries(${PROJECT_NAME}_cpp SPIRV-Tools-opt)
+    set_property(TARGET ${PROJECT_NAME}_cpp PROPERTY CXX_STANDARD 11)
 endif()

--- a/recipes/spirv-tools/all/test_package/conanfile.py
+++ b/recipes/spirv-tools/all/test_package/conanfile.py
@@ -4,11 +4,10 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["SPIRV_TOOLS_STATIC"] = not self.options["spirv-tools"].shared
         cmake.configure()
         cmake.build()
 

--- a/recipes/spirv-tools/all/test_package/conanfile.py
+++ b/recipes/spirv-tools/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
 
     def build(self):
@@ -13,7 +13,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path_c = os.path.join("bin", "test_package_c")
             self.run(bin_path_c, run_environment=True)
             if not self.options["spirv-tools"].shared:

--- a/recipes/spirv-tools/config.yml
+++ b/recipes/spirv-tools/config.yml
@@ -3,13 +3,7 @@ versions:
     folder: all
   "2020.5":
     folder: all
-  "v2020.5":
-    folder: all
   "2020.3":
     folder: all
-  "v2020.3":
-    folder: all
   "2019.2":
-    folder: all
-  "v2019.2":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

CMake imported targets of SPIRV-Tools are not namespaced.
Moreover, each of them comes from a specific config file, but it can't be modeled right now. So I've decided to only model SPIRV-ToolsConfig.cmake, and put all the targets in this config file until implementation of https://github.com/conan-io/conan/issues/9000 in conan client.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
