### PR TITLE
opencolorio/all: Use external tinyxml, fix OIIO, bump dependencies.

### DIFF
--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -45,8 +45,6 @@ class OpenColorIOConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, 11)
-        if not self.options["tinyxml"].with_stl:
-            raise ConanInvalidConfiguration("tinyxml option 'with_stl' has to be enabled to build opencolorio!")
 
     def requirements(self):
         # TODO: add GLUT (needed for ociodisplay tool)
@@ -71,6 +69,7 @@ class OpenColorIOConan(ConanFile):
         self._cmake.definitions["OCIO_BUILD_DOCS"] = False
         self._cmake.definitions["OCIO_BUILD_TESTS"] = False
         self._cmake.definitions["OCIO_BUILD_PYGLUE"] = False
+        self._cmake.definitions["OCIO_USE_BOOST_PTR"] = False
 
         self._cmake.definitions["USE_EXTERNAL_YAML"] = True
         self._cmake.definitions["USE_EXTERNAL_TINYXML"] = True

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -42,13 +42,17 @@ class OpenColorIOConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, "11")
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+        if not self.options["tinyxml"].with_stl:
+            raise ConanInvalidConfiguration("tinyxml option 'with_stl' has to be enabled to build opencolorio!")
 
     def requirements(self):
         # TODO: add GLUT (needed for ociodisplay tool)
-        self.requires("lcms/2.11")
-        self.requires("yaml-cpp/0.6.3")
+        self.requires("lcms/2.12")
+        self.requires("yaml-cpp/0.7.0")
+        self.requires("tinyxml/2.6.2")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -67,12 +71,10 @@ class OpenColorIOConan(ConanFile):
         self._cmake.definitions["OCIO_BUILD_DOCS"] = False
         self._cmake.definitions["OCIO_BUILD_TESTS"] = False
         self._cmake.definitions["OCIO_BUILD_PYGLUE"] = False
-        self._cmake.definitions["USE_EXTERNAL_YAML"] = True
-        self._cmake.definitions["USE_EXTERNAL_LCMS"] = True
 
-        # FIXME: OpenColorIO uses old TinyXML which doesn't have Conan package.
-        self._cmake.definitions["USE_EXTERNAL_TINYXML"] = False
-        self._cmake.definitions["TINYXML_OBJECT_LIB_EMBEDDED"] = True
+        self._cmake.definitions["USE_EXTERNAL_YAML"] = True
+        self._cmake.definitions["USE_EXTERNAL_TINYXML"] = True
+        self._cmake.definitions["USE_EXTERNAL_LCMS"] = True
 
         self._cmake.configure()
         return self._cmake

--- a/recipes/opencolorio/all/patches/1.1.1.patch
+++ b/recipes/opencolorio/all/patches/1.1.1.patch
@@ -190,15 +190,19 @@ index 4955f4db..14b5017f 100644
      )
  
 diff --git a/src/core/CDLTransform.cpp b/src/core/CDLTransform.cpp
-index 8b05debc..37f8d1cd 100644
+index 8b05debc..a7d6031f 100644
 --- a/src/core/CDLTransform.cpp
 +++ b/src/core/CDLTransform.cpp
-@@ -126,7 +126,7 @@ OCIO_NAMESPACE_ENTER
+@@ -126,7 +126,11 @@ OCIO_NAMESPACE_ENTER
              TiXmlPrinter printer;
              printer.SetStreamPrinting();
              doc.Accept( &printer );
 -            return printer.Str();
-+            return printer.CStr();
++            #ifdef TIXML_USE_STL
++                return printer.Str();
++            #else
++                return printer.CStr();
++            #endif
          }
      }
      

--- a/recipes/opencolorio/all/patches/1.1.1.patch
+++ b/recipes/opencolorio/all/patches/1.1.1.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e4f3119..1f7f77c 100644
+index e4f31196..b4f2f2f0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -4,11 +4,13 @@ set(OCIO_VERSION_MINOR 1)
@@ -31,28 +31,92 @@ index e4f3119..1f7f77c 100644
  set(EXTDIST_BINPATH ${EXTDIST_ROOT}/bin)
  if(PYTHON_OK)
      set(EXTDIST_PYTHONPATH ${EXTDIST_ROOT}/${PYTHON_VARIANT_PATH})
-@@ -189,9 +191,9 @@ else(USE_EXTERNAL_TINYXML)
-         set(TINYXML_CMAKE_ARGS ${TINYXML_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
-     endif()
-     set(TINYXML_CMAKE_ARGS ${TINYXML_CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+@@ -168,204 +170,20 @@ messageonce("Setting EXTDIST_PYTHONPATH: ${EXTDIST_PYTHONPATH}")
+ ### tinyxml ###
+ ##TODO: yaml and tinyxml : when there are not USE_EXTERNAL_TINYXML, use the same cmake schema/instructions => maybe refactorize in a cmake functions/macros ?
+ 
+-if(USE_EXTERNAL_TINYXML)
+-    set(TINYXML_VERSION_MIN "2.6.1")
+-    find_package(TinyXML)
+-    if(TINYXML_FOUND)
+-        if(TINYXML_VERSION VERSION_EQUAL ${TINYXML_VERSION_MIN} OR
+-           TINYXML_VERSION VERSION_GREATER ${TINYXML_VERSION_MIN})
+-            message(STATUS "External TinyXML will be used.")
+-        else()
+-            message(FATAL_ERROR "ERROR: ${TINYXML_VERSION} found, but ${TINYXML_VERSION_MIN} or newer is required.")
+-        endif()
+-    else(TINYXML_FOUND)
+-        message(STATUS "TinyXML was not found. Perhaps you forgot to install the development package?")
+-    endif(TINYXML_FOUND)
+-
+-else(USE_EXTERNAL_TINYXML)
+-    set(TINYXML_VERSION 2_6_1)
+-    set(TINYXML_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/ext/dist -DOCIO_INLINES_HIDDEN:BOOL=${OCIO_INLINES_HIDDEN})
+-    if(CMAKE_TOOLCHAIN_FILE)
+-        set(TINYXML_CMAKE_ARGS ${TINYXML_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
+-    endif()
+-    set(TINYXML_CMAKE_ARGS ${TINYXML_CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 -    set(TINYXML_ZIPFILE     "${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.tar.gz")
 -    set(TINYXML_PATCHFILE   "${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.patch")
 -    set(TINYXML_SOURCE_DIR  "${CMAKE_BINARY_DIR}/ext")
-+    set(TINYXML_ZIPFILE     "${PROJECT_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.tar.gz")
-+    set(TINYXML_PATCHFILE   "${PROJECT_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.patch")
-+    set(TINYXML_SOURCE_DIR  "${PROJECT_BINARY_DIR}/ext")
-     ## Create our TINYXML_LIB target
-     if(CMAKE_VERSION VERSION_GREATER "2.8.7")
-         option(TINYXML_OBJECT_LIB_EMBEDDED ${OCIO_BUILD_STATIC} "directly embedded tinyxml 3rdParty object lib into our resulting static lib, no link needed anymore")
-@@ -204,6 +206,7 @@ else(USE_EXTERNAL_TINYXML)
-         set(tinyxml_sources ${TINYXML_SOURCE_DIR}/tinyxml/tinystr.cpp       ${TINYXML_SOURCE_DIR}/tinyxml/tinyxml.cpp 
-                             ${TINYXML_SOURCE_DIR}/tinyxml/tinyxmlerror.cpp  ${TINYXML_SOURCE_DIR}/tinyxml/tinyxmlparser.cpp )
-         set(tinyxml_headers ${TINYXML_SOURCE_DIR}/tinyxml/tinystr.h         ${TINYXML_SOURCE_DIR}/tinyxml/tinyxml.h )
-+        file(MAKE_DIRECTORY "${TINYXML_SOURCE_DIR}")
-         add_custom_command(                                 ## will be done at build time
-             OUTPUT ${tinyxml_sources} ${tinyxml_headers}    ## expected output files
-             COMMAND ${CMAKE_COMMAND} -E tar xzf ${TINYXML_ZIPFILE}
-@@ -248,124 +251,12 @@ endif(USE_EXTERNAL_TINYXML)
+-    ## Create our TINYXML_LIB target
+-    if(CMAKE_VERSION VERSION_GREATER "2.8.7")
+-        option(TINYXML_OBJECT_LIB_EMBEDDED ${OCIO_BUILD_STATIC} "directly embedded tinyxml 3rdParty object lib into our resulting static lib, no link needed anymore")
+-    else()
+-        set(TINYXML_OBJECT_LIB_EMBEDDED OFF CACHE BOOL "directly embedded tinyxml 3rdParty object lib into our resulting static lib, no link needed anymore" FORCE)
+-        message("Force disable TINYXML_OBJECT_LIB_EMBEDDED feature due to CMake Version less than 2.8.8")
+-    endif()
+-    mark_as_advanced(TINYXML_OBJECT_LIB_EMBEDDED) ## two way to build with tinyxml (objects embedded or static transitive link)
+-    if(TINYXML_OBJECT_LIB_EMBEDDED)
+-        set(tinyxml_sources ${TINYXML_SOURCE_DIR}/tinyxml/tinystr.cpp       ${TINYXML_SOURCE_DIR}/tinyxml/tinyxml.cpp 
+-                            ${TINYXML_SOURCE_DIR}/tinyxml/tinyxmlerror.cpp  ${TINYXML_SOURCE_DIR}/tinyxml/tinyxmlparser.cpp )
+-        set(tinyxml_headers ${TINYXML_SOURCE_DIR}/tinyxml/tinystr.h         ${TINYXML_SOURCE_DIR}/tinyxml/tinyxml.h )
+-        add_custom_command(                                 ## will be done at build time
+-            OUTPUT ${tinyxml_sources} ${tinyxml_headers}    ## expected output files
+-            COMMAND ${CMAKE_COMMAND} -E tar xzf ${TINYXML_ZIPFILE}
+-            DEPENDS ${TINYXML_ZIPFILE}
+-            WORKING_DIRECTORY ${TINYXML_SOURCE_DIR}
+-            COMMENT "Unpacking ${TINYXML_ZIPFILE} to ${TINYXML_SOURCE_DIR}"
+-            VERBATIM
+-        )
+-        include_directories(BEFORE ${TINYXML_SOURCE_DIR}/tinyxml) ## needed to build correctly
+-        add_library(TINYXML_LIB OBJECT ${tinyxml_sources})
+-        ## embedded tinyxml objects files (no static link needed anymore) 
+-        ## => great news when build staticaly since we do not want another client project have to link also with tinyxml when he want to use this project
+-        ## => could be problematic if the client project use another version of tinyxml... In this case build tinyxml as shared lib with all projects could be a solution
+-        ## => TODO: so maybe provide a simple cmake way to build 3rdParty as shared and auto install with this project ?
+-        set_target_properties(TINYXML_LIB PROPERTIES COMPILE_FLAGS "-DTIXML_USE_STL -fPIC -fvisibility-inlines-hidden -fvisibility=hidden")
+-        add_definitions(-DTIXML_USE_STL) ## needed to build correctly, and also need to be propagated in child projects (client projects)
+-        list(APPEND EXTERNAL_OBJECTS $<TARGET_OBJECTS:TINYXML_LIB>)
+-    else()
+-        find_package(Git REQUIRED) ## in order to apply patch (for crossplateform compatibility)
+-        ExternalProject_Add(tinyxml
+-            URL             ${TINYXML_ZIPFILE}
+-            SOURCE_DIR      ${TINYXML_SOURCE_DIR}/tinyxml
+-            PATCH_COMMAND   ${GIT_EXECUTABLE} apply --ignore-whitespace ${TINYXML_PATCHFILE}
+-            BINARY_DIR      ext/build/tinyxml
+-            INSTALL_DIR     ext/dist
+-            CMAKE_ARGS      ${TINYXML_CMAKE_ARGS}
+-        )
+-        if(WIN32)
+-            set(TINYXML_STATIC_LIBRARIES  ${PROJECT_BINARY_DIR}/ext/dist/lib/tinyxml.lib)
+-        else()
+-            set(TINYXML_STATIC_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/libtinyxml.a)
+-        endif()
+-        add_library(TINYXML_LIB STATIC IMPORTED)
+-        ## static is the .lib location, shared is the .dll/.so location (see IMPORTED_IMPLIB for the associated .lib archive location on windows)
+-        set_property(TARGET TINYXML_LIB PROPERTY IMPORTED_LOCATION ${TINYXML_STATIC_LIBRARIES})
+-        add_dependencies(TINYXML_LIB tinyxml)
+-        list(APPEND EXTERNAL_LIBRARIES TINYXML_LIB)
+-    endif()
+-    set_target_properties(TINYXML_LIB PROPERTIES FOLDER External)
+-endif(USE_EXTERNAL_TINYXML)
+-    
++find_package(TinyXML REQUIRED)
++
++set(TINYXML_LIBRARIES TinyXML::TinyXML)
++list(APPEND EXTERNAL_LIBRARIES ${TINYXML_LIBRARIES})
++
  ###############################################################################
  ### YAML ###
  
@@ -72,7 +136,8 @@ index e4f3119..1f7f77c 100644
 -    if(YAML_CPP_VERSION VERSION_LESS ${YAML_VERSION_MIN})
 -        message(FATAL_ERROR "ERROR: yaml-cpp ${YAML_VERSION_MIN} or greater is required.")
 -    endif()
--
++find_package(yaml-cpp)
+ 
 -    find_package_handle_standard_args(yaml-cpp
 -                                      REQUIRED_VARS YAML_CPP_LIBRARIES YAML_CPP_INCLUDE_DIRS )
 -    set(YAML_CPP_FOUND ${YAML-CPP_FOUND})
@@ -170,8 +235,7 @@ index e4f3119..1f7f77c 100644
 -    endif()
 -    set_target_properties(YAML_CPP_LIB PROPERTIES FOLDER External)
 -endif(USE_EXTERNAL_YAML)
-+find_package(yaml-cpp)
- 
+-
 -if(YAML_CPP_VERSION VERSION_LESS "0.5.0")
 -    set(YAML_CPP_COMPILE_FLAGS "-DOLDYAML")
 -endif()
@@ -182,7 +246,16 @@ index e4f3119..1f7f77c 100644
  
  ###############################################################################
  ### Externals ###
-@@ -528,7 +419,7 @@ endif()
+@@ -460,7 +278,7 @@ endif()
+ if(OCIO_BUILD_APPS AND (OCIO_BUILD_STATIC OR OCIO_BUILD_SHARED) )
+ 
+     # Try to find OpenImageIO (OIIO) and OpenGL stuff
+-    OCIOFindOpenImageIO()
++    #OCIOFindOpenImageIO()
+     
+     if(OIIO_FOUND)
+         add_subdirectory(src/apps/ocioconvert)
+@@ -528,7 +346,7 @@ endif()
  
  ###############################################################################
  ### Configure env script ###
@@ -191,7 +264,7 @@ index e4f3119..1f7f77c 100644
      ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/setup_ocio.sh @ONLY)
  
  INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/setup_ocio.sh DESTINATION share/ocio/)
-@@ -597,7 +488,7 @@ if(TARGET OpenColorIO_STATIC)
+@@ -597,7 +415,7 @@ if(TARGET OpenColorIO_STATIC)
      endif()
  endif()
  install(EXPORT OpenColorIO DESTINATION cmake)
@@ -200,14 +273,14 @@ index e4f3119..1f7f77c 100644
      "
      get_filename_component(OpenColorIO_DIR \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)
      
-@@ -646,4 +537,4 @@ file(WRITE "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake"
+@@ -646,4 +464,4 @@ file(WRITE "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake"
      message(STATUS OPENCOLORIO_FOUND=\${OPENCOLORIO_FOUND})
      "
  )
 -install(FILES "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake" DESTINATION .)
 +install(FILES "${PROJECT_BINARY_DIR}/OpenColorIOConfig.cmake" DESTINATION .)
 diff --git a/share/cmake/OCIOMacros.cmake b/share/cmake/OCIOMacros.cmake
-index b9fb239..b1a206e 100644
+index b9fb2393..b1a206e7 100644
 --- a/share/cmake/OCIOMacros.cmake
 +++ b/share/cmake/OCIOMacros.cmake
 @@ -356,9 +356,9 @@ ENDMACRO()
@@ -235,7 +308,7 @@ index b9fb239..b1a206e 100644
        COMMENT "Extracting reStructuredText from ${INFILE}"
     )
 diff --git a/src/apps/ociobakelut/CMakeLists.txt b/src/apps/ociobakelut/CMakeLists.txt
-index d31b4e3..efebda6 100644
+index d31b4e34..efebda66 100644
 --- a/src/apps/ociobakelut/CMakeLists.txt
 +++ b/src/apps/ociobakelut/CMakeLists.txt
 @@ -1,6 +1,10 @@
@@ -287,7 +360,7 @@ index d31b4e3..efebda6 100644
      ${Boost_INCLUDE_DIR}
  )
 diff --git a/src/apps/ociocheck/CMakeLists.txt b/src/apps/ociocheck/CMakeLists.txt
-index 4955f4d..14b5017 100644
+index 4955f4db..14b5017f 100644
 --- a/src/apps/ociocheck/CMakeLists.txt
 +++ b/src/apps/ociocheck/CMakeLists.txt
 @@ -1,9 +1,9 @@
@@ -305,7 +378,7 @@ index 4955f4d..14b5017 100644
      )
  
 diff --git a/src/core/CMakeLists.txt b/src/core/CMakeLists.txt
-index 1eb691b..a2f099a 100644
+index 1eb691b6..a2f099ab 100644
 --- a/src/core/CMakeLists.txt
 +++ b/src/core/CMakeLists.txt
 @@ -2,29 +2,29 @@
@@ -366,3 +439,16 @@ index 1eb691b..a2f099a 100644
      ${CMAKE_CURRENT_BINARY_DIR}/OpenColorIO.pc @ONLY)
  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenColorIO.pc
      DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib${LIB_SUFFIX}/pkgconfig/)
+diff --git a/src/core/OCIOYaml.cpp b/src/core/OCIOYaml.cpp
+index 68fcef60..a1c1c1d8 100644
+--- a/src/core/OCIOYaml.cpp
++++ b/src/core/OCIOYaml.cpp
+@@ -1442,7 +1442,7 @@ OCIO_NAMESPACE_ENTER
+ #ifdef OLDYAML
+             if(node.FindValue("ocio_profile_version") == NULL)
+ #else
+-            if(node["ocio_profile_version"] == NULL)
++            if(node["ocio_profile_version"].IsNull())
+ #endif
+             {
+                 std::ostringstream os;

--- a/recipes/opencolorio/all/patches/1.1.1.patch
+++ b/recipes/opencolorio/all/patches/1.1.1.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e4f31196..b4f2f2f0 100644
+index e4f31196..b73396b4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -4,11 +4,13 @@ set(OCIO_VERSION_MINOR 1)
@@ -31,222 +31,52 @@ index e4f31196..b4f2f2f0 100644
  set(EXTDIST_BINPATH ${EXTDIST_ROOT}/bin)
  if(PYTHON_OK)
      set(EXTDIST_PYTHONPATH ${EXTDIST_ROOT}/${PYTHON_VARIANT_PATH})
-@@ -168,204 +170,20 @@ messageonce("Setting EXTDIST_PYTHONPATH: ${EXTDIST_PYTHONPATH}")
- ### tinyxml ###
- ##TODO: yaml and tinyxml : when there are not USE_EXTERNAL_TINYXML, use the same cmake schema/instructions => maybe refactorize in a cmake functions/macros ?
+@@ -170,7 +172,12 @@ messageonce("Setting EXTDIST_PYTHONPATH: ${EXTDIST_PYTHONPATH}")
  
--if(USE_EXTERNAL_TINYXML)
--    set(TINYXML_VERSION_MIN "2.6.1")
+ if(USE_EXTERNAL_TINYXML)
+     set(TINYXML_VERSION_MIN "2.6.1")
 -    find_package(TinyXML)
--    if(TINYXML_FOUND)
--        if(TINYXML_VERSION VERSION_EQUAL ${TINYXML_VERSION_MIN} OR
--           TINYXML_VERSION VERSION_GREATER ${TINYXML_VERSION_MIN})
--            message(STATUS "External TinyXML will be used.")
--        else()
--            message(FATAL_ERROR "ERROR: ${TINYXML_VERSION} found, but ${TINYXML_VERSION_MIN} or newer is required.")
--        endif()
--    else(TINYXML_FOUND)
--        message(STATUS "TinyXML was not found. Perhaps you forgot to install the development package?")
--    endif(TINYXML_FOUND)
--
--else(USE_EXTERNAL_TINYXML)
--    set(TINYXML_VERSION 2_6_1)
--    set(TINYXML_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/ext/dist -DOCIO_INLINES_HIDDEN:BOOL=${OCIO_INLINES_HIDDEN})
--    if(CMAKE_TOOLCHAIN_FILE)
--        set(TINYXML_CMAKE_ARGS ${TINYXML_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
--    endif()
--    set(TINYXML_CMAKE_ARGS ${TINYXML_CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
--    set(TINYXML_ZIPFILE     "${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.tar.gz")
--    set(TINYXML_PATCHFILE   "${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.patch")
--    set(TINYXML_SOURCE_DIR  "${CMAKE_BINARY_DIR}/ext")
--    ## Create our TINYXML_LIB target
--    if(CMAKE_VERSION VERSION_GREATER "2.8.7")
--        option(TINYXML_OBJECT_LIB_EMBEDDED ${OCIO_BUILD_STATIC} "directly embedded tinyxml 3rdParty object lib into our resulting static lib, no link needed anymore")
--    else()
--        set(TINYXML_OBJECT_LIB_EMBEDDED OFF CACHE BOOL "directly embedded tinyxml 3rdParty object lib into our resulting static lib, no link needed anymore" FORCE)
--        message("Force disable TINYXML_OBJECT_LIB_EMBEDDED feature due to CMake Version less than 2.8.8")
--    endif()
--    mark_as_advanced(TINYXML_OBJECT_LIB_EMBEDDED) ## two way to build with tinyxml (objects embedded or static transitive link)
--    if(TINYXML_OBJECT_LIB_EMBEDDED)
--        set(tinyxml_sources ${TINYXML_SOURCE_DIR}/tinyxml/tinystr.cpp       ${TINYXML_SOURCE_DIR}/tinyxml/tinyxml.cpp 
--                            ${TINYXML_SOURCE_DIR}/tinyxml/tinyxmlerror.cpp  ${TINYXML_SOURCE_DIR}/tinyxml/tinyxmlparser.cpp )
--        set(tinyxml_headers ${TINYXML_SOURCE_DIR}/tinyxml/tinystr.h         ${TINYXML_SOURCE_DIR}/tinyxml/tinyxml.h )
--        add_custom_command(                                 ## will be done at build time
--            OUTPUT ${tinyxml_sources} ${tinyxml_headers}    ## expected output files
--            COMMAND ${CMAKE_COMMAND} -E tar xzf ${TINYXML_ZIPFILE}
--            DEPENDS ${TINYXML_ZIPFILE}
--            WORKING_DIRECTORY ${TINYXML_SOURCE_DIR}
--            COMMENT "Unpacking ${TINYXML_ZIPFILE} to ${TINYXML_SOURCE_DIR}"
--            VERBATIM
--        )
--        include_directories(BEFORE ${TINYXML_SOURCE_DIR}/tinyxml) ## needed to build correctly
--        add_library(TINYXML_LIB OBJECT ${tinyxml_sources})
--        ## embedded tinyxml objects files (no static link needed anymore) 
--        ## => great news when build staticaly since we do not want another client project have to link also with tinyxml when he want to use this project
--        ## => could be problematic if the client project use another version of tinyxml... In this case build tinyxml as shared lib with all projects could be a solution
--        ## => TODO: so maybe provide a simple cmake way to build 3rdParty as shared and auto install with this project ?
--        set_target_properties(TINYXML_LIB PROPERTIES COMPILE_FLAGS "-DTIXML_USE_STL -fPIC -fvisibility-inlines-hidden -fvisibility=hidden")
--        add_definitions(-DTIXML_USE_STL) ## needed to build correctly, and also need to be propagated in child projects (client projects)
--        list(APPEND EXTERNAL_OBJECTS $<TARGET_OBJECTS:TINYXML_LIB>)
--    else()
--        find_package(Git REQUIRED) ## in order to apply patch (for crossplateform compatibility)
--        ExternalProject_Add(tinyxml
--            URL             ${TINYXML_ZIPFILE}
--            SOURCE_DIR      ${TINYXML_SOURCE_DIR}/tinyxml
--            PATCH_COMMAND   ${GIT_EXECUTABLE} apply --ignore-whitespace ${TINYXML_PATCHFILE}
--            BINARY_DIR      ext/build/tinyxml
--            INSTALL_DIR     ext/dist
--            CMAKE_ARGS      ${TINYXML_CMAKE_ARGS}
--        )
--        if(WIN32)
--            set(TINYXML_STATIC_LIBRARIES  ${PROJECT_BINARY_DIR}/ext/dist/lib/tinyxml.lib)
--        else()
--            set(TINYXML_STATIC_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/libtinyxml.a)
--        endif()
--        add_library(TINYXML_LIB STATIC IMPORTED)
--        ## static is the .lib location, shared is the .dll/.so location (see IMPORTED_IMPLIB for the associated .lib archive location on windows)
--        set_property(TARGET TINYXML_LIB PROPERTY IMPORTED_LOCATION ${TINYXML_STATIC_LIBRARIES})
--        add_dependencies(TINYXML_LIB tinyxml)
--        list(APPEND EXTERNAL_LIBRARIES TINYXML_LIB)
--    endif()
--    set_target_properties(TINYXML_LIB PROPERTIES FOLDER External)
--endif(USE_EXTERNAL_TINYXML)
--    
-+find_package(TinyXML REQUIRED)
++    find_package(TinyXML REQUIRED)
++    set(TINYXML_FOUND ${TinyXML_FOUND})
++    set(TINYXML_LIBRARIES TinyXML::TinyXML)
++    set(TINYXML_VERSION "${TinyXML_VERSION}")
++    list(APPEND EXTERNAL_LIBRARIES ${TINYXML_LIBRARIES})
 +
-+set(TINYXML_LIBRARIES TinyXML::TinyXML)
-+list(APPEND EXTERNAL_LIBRARIES ${TINYXML_LIBRARIES})
+     if(TINYXML_FOUND)
+         if(TINYXML_VERSION VERSION_EQUAL ${TINYXML_VERSION_MIN} OR
+            TINYXML_VERSION VERSION_GREATER ${TINYXML_VERSION_MIN})
+@@ -251,6 +258,13 @@ endif(USE_EXTERNAL_TINYXML)
+ if(USE_EXTERNAL_YAML)
+     # Set minimum yaml version for non-patched sources.
+     set(YAML_VERSION_MIN "0.3.0")
++    find_package(yaml-cpp REQUIRED)
++    set(YAML_CPP_INCLUDE_DIRS "${CONAN_INCLUDE_DIRS_YAML-CPP}")
++    set(YAML_CPP_LIBRARIES yaml-cpp::yaml-cpp)
++    set(YAML_CPP_VERSION "${yaml-cpp_VERSION}")
++    list(APPEND EXTERNAL_LIBRARIES ${YAML_CPP_LIBRARIES})
 +
- ###############################################################################
- ### YAML ###
++    if(0)
+     include(FindPkgConfig)
+     pkg_check_modules(PC_YAML_CPP REQUIRED QUIET yaml-cpp)
+     find_path(YAML_CPP_INCLUDE_DIR yaml-cpp/yaml.h
+@@ -293,6 +307,7 @@ if(USE_EXTERNAL_YAML)
+     else(YAML_CPP_FOUND)
+         message(FATAL_ERROR "ERROR: System yaml-cpp library was not found. Make sure the library is installed and the pkg-config file exists.")
+     endif(YAML_CPP_FOUND)
++    endif()
+ else(USE_EXTERNAL_YAML) ## provide 2 ways to build this dependency
+     set(YAML_CPP_VERSION 0.3.0)
+     set(YAML_CPP_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/ext/dist -DYAML_CPP_BUILD_TOOLS:BOOL=FALSE -DOCIO_INLINES_HIDDEN:BOOL=${OCIO_INLINES_HIDDEN})
+@@ -384,7 +399,7 @@ else()
+     set(OCIO_INLINES_HIDDEN OFF)
+ endif()
  
--if(USE_EXTERNAL_YAML)
--    # Set minimum yaml version for non-patched sources.
--    set(YAML_VERSION_MIN "0.3.0")
--    include(FindPkgConfig)
--    pkg_check_modules(PC_YAML_CPP REQUIRED QUIET yaml-cpp)
--    find_path(YAML_CPP_INCLUDE_DIR yaml-cpp/yaml.h
--        HINTS  ${PC_YAML_CPP_INCLUDEDIR} ${PC_YAML_CPP_INCLUDE_DIRS} )
--    find_library(YAML_CPP_LIBRARY LIBRARY_NAMES yaml-cpp libyaml-cpp
--        HINTS ${PC_YAML_CPP_LIBRARY_DIRS} )
--    set(YAML_CPP_LIBRARIES ${YAML_CPP_LIBRARY})
--    set(YAML_CPP_INCLUDE_DIRS ${YAML_CPP_INCLUDE_DIR})
--    set(YAML_CPP_VERSION ${PC_YAML_CPP_VERSION})
--
--    if(YAML_CPP_VERSION VERSION_LESS ${YAML_VERSION_MIN})
--        message(FATAL_ERROR "ERROR: yaml-cpp ${YAML_VERSION_MIN} or greater is required.")
--    endif()
-+find_package(yaml-cpp)
+-set(EXTERNAL_COMPILE_FLAGS "-DTIXML_USE_STL ${YAML_CPP_COMPILE_FLAGS} ${GCC_COMPILE_FLAGS}")
++set(EXTERNAL_COMPILE_FLAGS "${YAML_CPP_COMPILE_FLAGS} ${GCC_COMPILE_FLAGS}")
  
--    find_package_handle_standard_args(yaml-cpp
--                                      REQUIRED_VARS YAML_CPP_LIBRARIES YAML_CPP_INCLUDE_DIRS )
--    set(YAML_CPP_FOUND ${YAML-CPP_FOUND})
--    mark_as_advanced(YAML_CPP_INCLUDE_DIR YAML_CPP_LIBRARY YAML-CPP_FOUND)
--
--    if(YAML_CPP_FOUND)
--        if(YAML_CPP_VERSION VERSION_GREATER "0.5.0")
--            # Need to also get the boost headers here, as yaml-cpp 0.5.0+ requires them.
--            # Don't bother doing this step if we are already including the boost headers for shared_ptr
--            if(NOT OCIO_USE_BOOST_PTR)
--                set(Boost_ADDITIONAL_VERSIONS "1.49" "1.45" "1.44" "1.43" "1.43.0" "1.42"
--                                              "1.42.0" "1.41" "1.41.0" "1.40"
--                                              "1.40.0" "1.39" "1.39.0" "1.38"
--                                              "1.38.0" "1.37" "1.37.0" "1.34.1"
--                                              "1_34_1")
--                set(Boost_USE_MULTITHREADED ON)
--                find_package(Boost 1.34)
--                if(NOT Boost_FOUND)
--                    message(FATAL_ERROR "Error: Detected system yaml-cpp version ${YAML_CPP_VERSION} is greater than 0.5.0, and therefore requires boost, but a boost installation could not be found.")
--                endif()
--
--                set(EXTERNAL_INCLUDE_DIRS ${EXTERNAL_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
--            endif()
--        endif()
--        set(EXTERNAL_INCLUDE_DIRS ${EXTERNAL_INCLUDE_DIRS} ${YAML_CPP_INCLUDE_DIRS})
--    else(YAML_CPP_FOUND)
--        message(FATAL_ERROR "ERROR: System yaml-cpp library was not found. Make sure the library is installed and the pkg-config file exists.")
--    endif(YAML_CPP_FOUND)
--else(USE_EXTERNAL_YAML) ## provide 2 ways to build this dependency
--    set(YAML_CPP_VERSION 0.3.0)
--    set(YAML_CPP_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/ext/dist -DYAML_CPP_BUILD_TOOLS:BOOL=FALSE -DOCIO_INLINES_HIDDEN:BOOL=${OCIO_INLINES_HIDDEN})
--    if(CMAKE_TOOLCHAIN_FILE)
--        set(YAML_CPP_CMAKE_ARGS ${YAML_CPP_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
--    endif()
--    set(YAML_CPP_CMAKE_ARGS ${YAML_CPP_CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
--    set(YAML_CPP_ZIPFILE        "${CMAKE_SOURCE_DIR}/ext/yaml-cpp-${YAML_CPP_VERSION}.tar.gz")
--    set(YAML_CPP_SOURCE_DIR     "${CMAKE_BINARY_DIR}/ext")
--    set(YAML_CPP_PATCHFILE      "${CMAKE_SOURCE_DIR}/ext/yaml-cpp-${YAML_CPP_VERSION}.patch")
--    set(YAML_CPP_SRCLISTFILE    "${CMAKE_SOURCE_DIR}/ext/yaml-cpp-${YAML_CPP_VERSION}-sourcesList.txt") ## see cmd line for this generated file bellow
--    ## Create our YAML_CPP_LIB target
--    if(CMAKE_VERSION VERSION_GREATER "2.8.7")
--        option(YAML_CPP_OBJECT_LIB_EMBEDDED ${OCIO_BUILD_STATIC} "directly embedded yaml-cpp 3rdParty lib into our resulting static lib, no link needed anymore")
--    else()
--        set(YAML_CPP_OBJECT_LIB_EMBEDDED OFF CACHE BOOL "directly embedded yaml-cpp 3rdParty object lib into our resulting static lib, no link needed anymore" FORCE)
--        message("Force disable YAML_CPP_OBJECT_LIB_EMBEDDED feature due to CMake Version less than 2.8.8")
--    endif()
--    mark_as_advanced(YAML_CPP_OBJECT_LIB_EMBEDDED)
--    if(YAML_CPP_OBJECT_LIB_EMBEDDED)        
--        ## generated at extraction level dir, with (use git bash or cygwin under windows): 
--        ## find yaml-cpp -type f \( -name "*.h" -o -name "*.cpp" \) -not \( -path "*/test/*" -o -path "*/util/*" \) > yaml-cpp-sourcesList.txt
--        ## this will exclude test and util paths since we want YAML_CPP_BUILD_TOOLS:BOOL=OFF (see externalProject cmake args)
--        file(STRINGS ${YAML_CPP_SRCLISTFILE} YAML_CPP_SRCLISTFILE_CONTENT)
--        foreach(yamlsrc ${YAML_CPP_SRCLISTFILE_CONTENT})
--            list(APPEND yamlcpp_sources ${YAML_CPP_SOURCE_DIR}/${yamlsrc})  ## get absolute filepath
--        endforeach()
--        include_directories(BEFORE ${YAML_CPP_SOURCE_DIR}/yaml-cpp/include) ## needed to build correctly
--        add_custom_command(             ## will be done at build time
--            OUTPUT ${yamlcpp_sources}   ## expected output files
--            COMMAND ${CMAKE_COMMAND} -E tar xzf ${YAML_CPP_ZIPFILE}
--            DEPENDS ${YAML_CPP_ZIPFILE}
--            WORKING_DIRECTORY ${YAML_CPP_SOURCE_DIR}
--            COMMENT "Unpacking ${YAML_CPP_ZIPFILE} to ${YAML_CPP_SOURCE_DIR}"
--            VERBATIM
--        )
--        add_library(YAML_CPP_LIB OBJECT ${yamlcpp_sources})
--        ## embedded yaml-cpp objects files (no static link needed anymore)
--        ## => great news when build statically since we do not want another client project have to link also with yaml-cpp when he want to use this project
--        ## => could be problematic if the client project use another version of yaml-cpp... In this case build yaml-cpp as shared lib with all projects could be a solution 
--        ## => TODO: so maybe provide a simple cmake way to build 3rdParty as shared and auto install with this project ?
--        list(APPEND EXTERNAL_OBJECTS $<TARGET_OBJECTS:YAML_CPP_LIB>) 
--    else()
--        find_package(Git REQUIRED) ## in order to apply patch (for crossplateform compatibility)
--        ExternalProject_Add(YAML_CPP_LOCAL
--            URL             ${YAML_CPP_ZIPFILE}
--            SOURCE_DIR      ${YAML_CPP_SOURCE_DIR}/yaml-cpp
--            PATCH_COMMAND   ${GIT_EXECUTABLE} apply --ignore-whitespace ${YAML_CPP_PATCHFILE}
--            BINARY_DIR      ext/build/yaml-cpp
--            INSTALL_DIR     ext/dist
--            CMAKE_ARGS      ${YAML_CPP_CMAKE_ARGS}
--        )
--        set(YAML_CPP_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ext/dist/include)
--        set(YAML_CPP_LIBRARY_DIRS ${PROJECT_BINARY_DIR}/ext/dist/lib)
--        add_library(YAML_CPP_LIB STATIC IMPORTED)
--        if(WIN32)
--            set(YAML_CPP_STATIC_DEBUG_LIBRARIES     ${PROJECT_BINARY_DIR}/ext/dist/lib/libyaml-cppmdd.lib)
--            set(YAML_CPP_STATIC_OPTIMIZED_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/libyaml-cppmd.lib)
--            set_property(TARGET YAML_CPP_LIB PROPERTY IMPORTED_LOCATION_DEBUG   ${YAML_CPP_STATIC_DEBUG_LIBRARIES})
--            set_property(TARGET YAML_CPP_LIB PROPERTY IMPORTED_LOCATION_RELEASE ${YAML_CPP_STATIC_OPTIMIZED_LIBRARIES})
--        else()
--            set(YAML_CPP_STATIC_GENERAL_LIBRARIES           ${PROJECT_BINARY_DIR}/ext/dist/lib/libyaml-cpp.a)
--            set_property(TARGET YAML_CPP_LIB PROPERTY IMPORTED_LOCATION ${YAML_CPP_STATIC_GENERAL_LIBRARIES})
--        endif()
--        add_dependencies(YAML_CPP_LIB  YAML_CPP_LOCAL)
--        list(APPEND EXTERNAL_LIBRARIES YAML_CPP_LIB)
--    endif()
--    set_target_properties(YAML_CPP_LIB PROPERTIES FOLDER External)
--endif(USE_EXTERNAL_YAML)
--
--if(YAML_CPP_VERSION VERSION_LESS "0.5.0")
--    set(YAML_CPP_COMPILE_FLAGS "-DOLDYAML")
--endif()
-+set(YAML_CPP_INCLUDE_DIRS "${CONAN_INCLUDE_DIRS_YAML-CPP}")
-+set(YAML_CPP_LIBRARIES yaml-cpp::yaml-cpp)
-+set(YAML_CPP_VERSION "${yaml-cpp_VERSION}")
-+list(APPEND EXTERNAL_LIBRARIES ${YAML_CPP_LIBRARIES})
- 
- ###############################################################################
- ### Externals ###
-@@ -460,7 +278,7 @@ endif()
+ set(EXTERNAL_LINK_FLAGS "")
+ set(EXTERNAL_LIBRARY_DIRS ${PROJECT_BINARY_DIR}/ext/dist/lib)
+@@ -460,7 +475,7 @@ endif()
  if(OCIO_BUILD_APPS AND (OCIO_BUILD_STATIC OR OCIO_BUILD_SHARED) )
  
      # Try to find OpenImageIO (OIIO) and OpenGL stuff
@@ -255,7 +85,7 @@ index e4f31196..b4f2f2f0 100644
      
      if(OIIO_FOUND)
          add_subdirectory(src/apps/ocioconvert)
-@@ -528,7 +346,7 @@ endif()
+@@ -528,7 +543,7 @@ endif()
  
  ###############################################################################
  ### Configure env script ###
@@ -264,7 +94,7 @@ index e4f31196..b4f2f2f0 100644
      ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/setup_ocio.sh @ONLY)
  
  INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/setup_ocio.sh DESTINATION share/ocio/)
-@@ -597,7 +415,7 @@ if(TARGET OpenColorIO_STATIC)
+@@ -597,7 +612,7 @@ if(TARGET OpenColorIO_STATIC)
      endif()
  endif()
  install(EXPORT OpenColorIO DESTINATION cmake)
@@ -273,7 +103,7 @@ index e4f31196..b4f2f2f0 100644
      "
      get_filename_component(OpenColorIO_DIR \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)
      
-@@ -646,4 +464,4 @@ file(WRITE "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake"
+@@ -646,4 +661,4 @@ file(WRITE "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake"
      message(STATUS OPENCOLORIO_FOUND=\${OPENCOLORIO_FOUND})
      "
  )
@@ -308,14 +138,14 @@ index b9fb2393..b1a206e7 100644
        COMMENT "Extracting reStructuredText from ${INFILE}"
     )
 diff --git a/src/apps/ociobakelut/CMakeLists.txt b/src/apps/ociobakelut/CMakeLists.txt
-index d31b4e34..efebda66 100644
+index d31b4e34..4aa1efb2 100644
 --- a/src/apps/ociobakelut/CMakeLists.txt
 +++ b/src/apps/ociobakelut/CMakeLists.txt
 @@ -1,6 +1,10 @@
  # LCMS
 -include(FindPkgConfig FindPackageMessage)
 -pkg_check_modules(LCMS QUIET lcms2)
-+find_package(lcms)
++find_package(lcms REQUIRED)
 +set(LCMS_FOUND ${lcms_FOUND})
 +set(LCMS_VERSION ${lcms_VERSION})
 +set(LCMS_LIBRARIES ${lcms_LIBRARIES})
@@ -324,24 +154,6 @@ index d31b4e34..efebda66 100644
  if(LCMS_FOUND AND (LCMS_VERSION VERSION_EQUAL 2.1 OR LCMS_VERSION VERSION_GREATER 2.1))
      FIND_PACKAGE_MESSAGE(LCMS "Found lcms: ${LCMS_LIBRARIES}"
          "${LCMS_INCLUDE_DIR}")
-@@ -15,12 +19,12 @@ else()
-     if(CMAKE_TOOLCHAIN_FILE)
-         set(LCMS_CMAKE_ARGS ${LCMS_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
-     endif()
--    set(LCMS_INSTALL_DIR ${CMAKE_BINARY_DIR}/ext/dist)
-+    set(LCMS_INSTALL_DIR ${PROJECT_BINARY_DIR}/ext/dist)
-     ExternalProject_Add(LCMS
--        PREFIX         ${CMAKE_BINARY_DIR}/lcms2-prefix
--        URL            ${CMAKE_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.tar.gz
--        PATCH_COMMAND  ${GIT_EXECUTABLE} apply ${CMAKE_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.patch
--        BINARY_DIR     ${CMAKE_BINARY_DIR}/ext/build/lcms2
-+        PREFIX         ${PROJECT_BINARY_DIR}/lcms2-prefix
-+        URL            ${PROJECT_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.tar.gz
-+        PATCH_COMMAND  ${GIT_EXECUTABLE} apply ${PROJECT_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.patch
-+        BINARY_DIR     ${PROJECT_BINARY_DIR}/ext/build/lcms2
-         INSTALL_DIR    ${LCMS_INSTALL_DIR}
-         CMAKE_ARGS     ${LCMS_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${LCMS_INSTALL_DIR} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-     )
 @@ -29,12 +33,12 @@ else()
      set(LCMS_LIBRARIES 		${PROJECT_BINARY_DIR}/ext/dist/lib/${CMAKE_STATIC_LIBRARY_PREFIX}lcms2${CMAKE_STATIC_LIBRARY_SUFFIX})
  endif()
@@ -377,6 +189,19 @@ index 4955f4db..14b5017f 100644
      ${Boost_INCLUDE_DIR}
      )
  
+diff --git a/src/core/CDLTransform.cpp b/src/core/CDLTransform.cpp
+index 8b05debc..37f8d1cd 100644
+--- a/src/core/CDLTransform.cpp
++++ b/src/core/CDLTransform.cpp
+@@ -126,7 +126,7 @@ OCIO_NAMESPACE_ENTER
+             TiXmlPrinter printer;
+             printer.SetStreamPrinting();
+             doc.Accept( &printer );
+-            return printer.Str();
++            return printer.CStr();
+         }
+     }
+     
 diff --git a/src/core/CMakeLists.txt b/src/core/CMakeLists.txt
 index 1eb691b6..a2f099ab 100644
 --- a/src/core/CMakeLists.txt


### PR DESCRIPTION
Specify library name and version:  **opencolorio/1.1.1**

* Now that tinyxml package is in Conan, use that instead of bundled version. However, the tinyxml option `with_stl` has to be enabled.
* One-line bug fix to 'OCIOYaml.cpp' to use latest yaml-cpp version.
* Properly disabled OpenImageIO detection as it found system OIIO instead. OIIO is only used in OCIO applications and there is a circular dependency with OIIO so no attempt was made to fix building with OIIO.
* Moved C++11 check to `validate()`.
* Updated dependency versions.

The biggest issue is tinyxml dependency `with_stl` option that should be turned on which is off by default. Without it there seem to be linker errors when using MSVC. Questions:

* Currently I throw error if the tinyxml option `with_stl` is off in `validate` function. Is that ok? Haven't seen anyone do that.
* Would it be possible to do `"tinyxml:with_stl": True`in `default_options`? Again I haven't seen it being done.
* Perhaps tinyxml `with_stl` can be switched on by default?

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
