### PR TITLE
Workaround for conan qmake generator bug which causes failure to build QWT dll

### DIFF
--- a/recipes/qwt/all/conanfile.py
+++ b/recipes/qwt/all/conanfile.py
@@ -90,8 +90,8 @@ class QwtConan(ConanFile):
     def _patch_qmake_generator_files(self):
         # Work around the qmake generator bug (https://github.com/conan-io/conan/pull/9568) which
         # causes exe linker flags to be set on DLL, causing link failure.
-        if self.settings.compiler == "Visual Studio" and self.options.shared == True:
-            tools.replace_in_file(os.path.join(self.build_folder, "conanbuildinfo.pri"), "CONAN_QMAKE_LFLAGS += -ENTRY:mainCRTStartup", "")
+        if self.settings.compiler == "Visual Studio":
+            tools.replace_in_file(os.path.join(self.build_folder, "conanbuildinfo.pri"), "CONAN_QMAKE_LFLAGS += -ENTRY:mainCRTStartup", "", strict=False)
 
     def build(self):
         self._patch_qwt_config_files()

--- a/recipes/qwt/all/conanfile.py
+++ b/recipes/qwt/all/conanfile.py
@@ -87,8 +87,15 @@ class QwtConan(ConanFile):
             qwtbuild += "CONFIG += force_debug_info\n"
         tools.save(qwtbuild_path, qwtbuild)
 
+    def _patch_qmake_generator_files(self):
+        # Work around the qmake generator bug (https://github.com/conan-io/conan/pull/9568) which
+        # causes exe linker flags to be set on DLL, causing link failure.
+        if self.settings.compiler == "Visual Studio" and self.options.shared == True:
+            tools.replace_in_file(os.path.join(self.build_folder, "conanbuildinfo.pri"), "CONAN_QMAKE_LFLAGS += -ENTRY:mainCRTStartup", "")
+
     def build(self):
         self._patch_qwt_config_files()
+        self._patch_qmake_generator_files()
 
         if self.settings.compiler == "Visual Studio":
             vcvars = tools.vcvars_command(self.settings)


### PR DESCRIPTION
Specify library name and version:  **qwt/6.1.6**

Fixes bug that prevents building shared/DLL library on Window with Visual Studio.
When the conan PR https://github.com/conan-io/conan/pull/9568 is landed, this change will still be compatible with the latest conan version, and also allow the recipe to be useful for earlier conan versions.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
