### PR TITLE
Build m4 using sources from a .tar.gz file instead of a .tar.bz2 file.

### DIFF
--- a/recipes/m4/all/conandata.yml
+++ b/recipes/m4/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.4.18":
-    url: "https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.bz2"
-    sha256: "6640d76b043bc658139c8903e293d5978309bf0f408107146505eca701e67cf6"
+    url: "https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.gz"
+    sha256: "ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab"
 patches:
   "1.4.18":
     - patch_file: "patches/0001-fflush-adjust-to-glibc-2.28-libio.h-removal.patch"


### PR DESCRIPTION
Specify library name and version:  m4/1.4.18

On AIX, Conan fails to extract the .tar.bz2 file used for the m4 source.
https://github.com/conan-io/conan/issues/9577

Instead of using .tar.bz2, we can use the .tar.gz file type which works fine.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
