### PR TITLE
tl-expected: don't set CMAKE_CXX_STANDARD

### DIFF
--- a/recipes/tl-expected/all/conanfile.py
+++ b/recipes/tl-expected/all/conanfile.py
@@ -13,6 +13,7 @@ class TlExpectedConan(ConanFile):
     topics = ("cpp11", "cpp14", "cpp17", "expected")
     license = "CC0-1.0"
     no_copy_source = True
+    settings = "compiler"
 
     @property
     def _source_subfolder(self):
@@ -28,6 +29,10 @@ class TlExpectedConan(ConanFile):
         ]
         return expected_dirs[0].name
 
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, "11")
+    
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         os.rename(self._archive_dir, self._source_subfolder)

--- a/recipes/tl-expected/all/test_package/CMakeLists.txt
+++ b/recipes/tl-expected/all/test_package/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
-set(CMAKE_CXX_STANDARD 11)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()


### PR DESCRIPTION
this must be handled by conan_basic_setup

Specify library name and version:  **tl-expected/***

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
