### PR TITLE
feat: add mono-msbuild

### DIFF
--- a/recipes/mono-msbuild/all/conanfile.py
+++ b/recipes/mono-msbuild/all/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=1.33.0"
 class MonoConan(ConanFile):
     name = "mono-msbuild"
     description = "The Microsoft Build Engine (MSBuild) is the build platform for .NET and Visual Studio."
-    url = "https://github.com/mono/mono"
+    url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/mono/msbuild"
     license = "MIT, BSD"
     exports_sources = "patches/**"

--- a/recipes/mono-msbuild/all/conanfile.py
+++ b/recipes/mono-msbuild/all/conanfile.py
@@ -1,0 +1,69 @@
+from conans import AutoToolsBuildEnvironment, ConanFile, CMake, tools, RunEnvironment
+from conans.errors import ConanInvalidConfiguration
+import glob
+import os
+import yaml
+
+required_conan_version = ">=1.33.0"
+
+
+class MonoConan(ConanFile):
+    name = "mono-msbuild"
+    description = "The Microsoft Build Engine (MSBuild) is the build platform for .NET and Visual Studio."
+    url = "https://github.com/mono/mono"
+    homepage = "https://github.com/mono/msbuild"
+    license = "MIT, BSD"
+    exports_sources = "patches/**"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "pkg_config"
+    topics = "mono", "dotnet"
+
+    requires = ["mono/6.12.0.122"]
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        os.mkdir(self._source_subfolder)
+        with tools.chdir(self._source_subfolder):
+            git = tools.Git()
+            git.clone(url="https://github.com/mono/msbuild.git")
+            # latest commit on xplat-master as of 10Sep2021 (corresponds to version 16.10.1)
+            git.checkout("63458bd6cb3a98b5a062bb18bd51ffdea4aa3001")
+
+    def build(self):
+        env_build = RunEnvironment(self)
+        env_build.vars["HOME"] = os.path.join(self.build_folder, "homedir")
+        with tools.environment_append(env_build.vars):
+            with tools.chdir(self._source_subfolder):
+                # Got some ideas from here:
+                # https://github.com/mono/linux-packaging-msbuild/blob/main/debian/rules
+                self.run("./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests /p:DisableNerdbankVersioning=true")
+                self.run("/bin/bash ./stage1/mono-msbuild/msbuild mono/build/install.proj /p:MonoInstallPrefix={} /p:Configuration=Release-MONO /p:IgnoreDiffFailure=true".format(
+                    os.path.join(self.build_folder, "tmp", "usr")))
+
+    def package(self):
+        # replace absolute path for mono in msbuild script with empty string to use the mono binary from conan package
+        self.output.info('sed -i "s@{0}/tmp/usr/bin/@@g" {0}/tmp/usr/bin/msbuild'.format(self.build_folder))
+        self.run('sed -i "s@{0}/tmp/usr/bin/@@g" {0}/tmp/usr/bin/msbuild'.format(self.build_folder))
+        # replace absolute path to libs in msbuild with MSBUILD_ROOT_DIR environment variable
+        self.output.info('sed -i "s@{0}/tmp/usr/lib@{1}/lib@g" {0}/tmp/usr/bin/msbuild'.format(self.build_folder, "\\${MSBUILD_ROOT_DIR}"))
+        self.run('sed -i "s@{0}/tmp/usr/lib@{1}/lib@g" {0}/tmp/usr/bin/msbuild'.format(self.build_folder, "\\${MSBUILD_ROOT_DIR}"))
+        tools.remove_files_by_mask(os.path.join(self.build_folder,"tmp", "usr", "lib", "mono"), "Microsoft.DiaSymReader.Native.*dll")
+        tools.remove_files_by_mask(os.path.join(self.build_folder,"tmp", "usr", "lib", "mono"), "System.Reflection.Metadata.dll")
+        tools.remove_files_by_mask(os.path.join(self.build_folder,"tmp", "usr", "lib", "mono"), "*.dylib")
+        tools.remove_files_by_mask(os.path.join(self.build_folder,"tmp", "usr", "lib", "mono"), "*.so")
+        tools.remove_files_by_mask(os.path.join(self.build_folder,"tmp", "usr", "lib", "mono"), "*.so")
+        # See https://github.com/mono/linux-packaging-msbuild/blob/main/debian/msbuild.install
+        self.copy("*", dst="bin", src=os.path.join("tmp", "usr", "bin"))
+        self.copy("*", dst=os.path.join("lib", "mono"), src=os.path.join("tmp", "usr", "lib", "mono"))
+
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "msbuild"
+        self.cpp_info.names["cmake_find_package_multi"] = "msbuild"
+        self.cpp_info.names["pkg_config"] = "msbuild"
+        self.cpp_info.libs = tools.collect_libs(self)
+        self.env_info.MSBUILD_ROOT_DIR = self.package_folder
+

--- a/recipes/mono-msbuild/all/conanfile.py
+++ b/recipes/mono-msbuild/all/conanfile.py
@@ -33,8 +33,6 @@ class MonoConan(ConanFile):
     def validate(self):
         if self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration("This recipe does not support Visual Studio builds")
-
-    def configure(self):
         # C++ minimum standard required
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, 11)

--- a/recipes/mono-msbuild/all/conanfile.py
+++ b/recipes/mono-msbuild/all/conanfile.py
@@ -7,7 +7,7 @@ import yaml
 required_conan_version = ">=1.33.0"
 
 
-class MonoConan(ConanFile):
+class MonoMsbuildConan(ConanFile):
     name = "mono-msbuild"
     description = "The Microsoft Build Engine (MSBuild) is the build platform for .NET and Visual Studio."
     url = "https://github.com/conan-io/conan-center-index"
@@ -15,7 +15,6 @@ class MonoConan(ConanFile):
     license = "MIT, BSD"
     exports_sources = "patches/**"
     settings = "os", "compiler", "build_type", "arch"
-    generators = "pkg_config"
     topics = "mono", "dotnet"
 
     requires = ["mono/6.12.0.122"]
@@ -83,9 +82,6 @@ class MonoConan(ConanFile):
 
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "msbuild"
-        self.cpp_info.names["cmake_find_package_multi"] = "msbuild"
-        self.cpp_info.names["pkg_config"] = "msbuild"
         self.cpp_info.libs = tools.collect_libs(self)
         self.env_info.MSBUILD_ROOT_DIR = self.package_folder
 

--- a/recipes/mono-msbuild/all/conanfile.py
+++ b/recipes/mono-msbuild/all/conanfile.py
@@ -21,6 +21,30 @@ class MonoConan(ConanFile):
     requires = ["mono/6.12.0.122"]
 
     @property
+    def _minimum_compilers_version(self):
+        # requires C++11
+        return {
+            "gcc": "7",
+            "clang": "6",
+            "apple-clang": "9"
+        }
+
+
+    def validate(self):
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration("mono cannot be built on Windows")
+
+    def configure(self):
+        # C++ minimum standard required
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+        minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
+        if not minimum_version:
+            self.output.warn("C++11 support required. Your compiler is unknown. Assuming it supports C++11.")
+        elif tools.Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration("C++11 support required, which your compiler does not support.")
+
+    @property
     def _source_subfolder(self):
         return "source_subfolder"
 

--- a/recipes/mono-msbuild/all/conanfile.py
+++ b/recipes/mono-msbuild/all/conanfile.py
@@ -31,8 +31,8 @@ class MonoConan(ConanFile):
 
 
     def validate(self):
-        if self.settings.os == "Windows":
-            raise ConanInvalidConfiguration("mono cannot be built on Windows")
+        if self.settings.compiler == "Visual Studio":
+            raise ConanInvalidConfiguration("This recipe does not support Visual Studio builds")
 
     def configure(self):
         # C++ minimum standard required

--- a/recipes/mono-msbuild/all/test_package/conanfile.py
+++ b/recipes/mono-msbuild/all/test_package/conanfile.py
@@ -10,6 +10,5 @@ class TestPackageConan(ConanFile):
         pass
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            self.output.info("Version:")
+        if not tools.cross_building(self):
             self.run("msbuild --version", run_environment=True)

--- a/recipes/mono-msbuild/all/test_package/conanfile.py
+++ b/recipes/mono-msbuild/all/test_package/conanfile.py
@@ -1,0 +1,15 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanException
+import os
+
+
+class TestPackageConan(ConanFile):
+    #generators = "cmake"
+
+    def build(self):
+        pass
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            self.output.info("Version:")
+            self.run("msbuild --version", run_environment=True)

--- a/recipes/mono-msbuild/config.yml
+++ b/recipes/mono-msbuild/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "16.10.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **mono-msbuild/16.10.1**

msbuild for mono is required to build .NET applications on linux.

Depends on #7239

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
