### PR TITLE
#7244 numa option is deleted if Boost fibre is disabled

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -291,7 +291,9 @@ class BoostConan(ConanFile):
 
         if self.settings.compiler == "Visual Studio":
             # Shared builds of numa do not link on Visual Studio due to missing symbols
-            self.options.numa = False
+            numa_value = self.options.get_safe("numa", default=False)
+            if numa_value:
+                self.options.numa = False
 
         if tools.Version(self.version) >= "1.76.0":
             # Starting from 1.76.0, Boost.Math requires a c++11 capable compiler


### PR DESCRIPTION
Specify library name and version:  **boost/1.77.0**

Resolves #7244.

When option `without_fiber` is set to True, option `numa` is deleted in the recipe. But currently the recipe still tries to change it value without checking if the option exists.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
