### PR TITLE
libcap/2.57: Bump version

### DIFF
--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -11,3 +11,25 @@ sources:
   "2.50":
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.50.tar.xz"
     sha256: "47a57b8bd238b84c93c921a9b4ff82337551dbcb0cca071316aadf3e23b19261"
+
+patches:
+  "2.45":
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
+  "2.46":
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
+  "2.48":
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
+  "2.50":
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"

--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -11,6 +11,9 @@ sources:
   "2.50":
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.50.tar.xz"
     sha256: "47a57b8bd238b84c93c921a9b4ff82337551dbcb0cca071316aadf3e23b19261"
+  "2.57":
+    url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.57.tar.xz"
+    sha256: "750221e347689e779a0ce2b22746ee9987d229712da934acb81b2d280684b7ab"
 
 patches:
   "2.45":
@@ -33,3 +36,8 @@ patches:
       patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
+  "2.57":
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"

--- a/recipes/libcap/all/conanfile.py
+++ b/recipes/libcap/all/conanfile.py
@@ -3,6 +3,8 @@ import os
 from conans import ConanFile, tools, AutoToolsBuildEnvironment
 from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.33.0"
+
 
 class LibcapConan(ConanFile):
     name = "libcap"
@@ -23,6 +25,8 @@ class LibcapConan(ConanFile):
         "fPIC": True,
         "psx_syscals": False,
     }
+    exports_sources = "patches/**"
+
     _autotools = None
     _autotools_env = None
 
@@ -39,9 +43,8 @@ class LibcapConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        src_folder = "{}-{}".format(self.name, self.version)
-        os.rename(src_folder, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_autotools(self):
         if self._autotools:
@@ -64,24 +67,12 @@ class LibcapConan(ConanFile):
 
         return self._autotools, self._autotools_env
 
+    def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
     def build(self):
-        make_rules = os.path.join(self._source_subfolder, "Make.Rules")
-        tools.replace_in_file(
-            make_rules,
-            "IPATH += -fPIC -I$(KERNEL_HEADERS) -I$(topdir)/libcap/include",
-            "IPATH += -I$(KERNEL_HEADERS) -I$(topdir)/libcap/include")
-        tools.replace_in_file(
-            make_rules,
-            "CC := $(CROSS_COMPILE)gcc",
-            "CC ?= $(CROSS_COMPILE)gcc")
-        tools.replace_in_file(
-            make_rules,
-            "AR := $(CROSS_COMPILE)ar",
-            "AR ?= $(CROSS_COMPILE)ar")
-        tools.replace_in_file(
-            make_rules,
-            "RANLIB := $(CROSS_COMPILE)ranlib",
-            "RANLIB ?= $(CROSS_COMPILE)ranlib")
+        self._patch_sources()
 
         with tools.chdir(os.path.join(self._source_subfolder, self.name)):
             env_build, env_build_vars = self._configure_autotools()

--- a/recipes/libcap/all/patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch
+++ b/recipes/libcap/all/patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch
@@ -1,0 +1,26 @@
+From bb2c4e80928e8221a31c3631f5a802c7b022aebd Mon Sep 17 00:00:00 2001
+From: Sergey Bobrenok <bobrofon@gmail.com>
+Date: Sun, 29 Aug 2021 12:02:23 +0300
+Subject: [PATCH 1/2] Make.Rules: Remove hardcoded -fPIC
+
+Signed-off-by: Sergey Bobrenok <bobrofon@gmail.com>
+---
+ Make.Rules | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Make.Rules b/Make.Rules
+index cc6f95b..91099c6 100644
+--- a/Make.Rules
++++ b/Make.Rules
+@@ -52,7 +52,7 @@ GOMAJOR=0
+ # Compilation specifics
+ 
+ KERNEL_HEADERS := $(topdir)/libcap/include/uapi
+-IPATH += -fPIC -I$(KERNEL_HEADERS) -I$(topdir)/libcap/include
++IPATH += -I$(KERNEL_HEADERS) -I$(topdir)/libcap/include
+ 
+ CC := $(CROSS_COMPILE)gcc
+ DEFINES := -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+-- 
+2.31.1
+

--- a/recipes/libcap/all/patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch
+++ b/recipes/libcap/all/patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch
@@ -1,0 +1,36 @@
+From 76e637ad20faa811f4091a8a08af4b29c528697b Mon Sep 17 00:00:00 2001
+From: Sergey Bobrenok <bobrofon@gmail.com>
+Date: Sun, 29 Aug 2021 12:06:18 +0300
+Subject: [PATCH 2/2] Make.Rules: Make compile tools configurable
+
+Signed-off-by: Sergey Bobrenok <bobrofon@gmail.com>
+---
+ Make.Rules | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Make.Rules b/Make.Rules
+index 91099c6..cd25495 100644
+--- a/Make.Rules
++++ b/Make.Rules
+@@ -54,15 +54,15 @@ GOMAJOR=0
+ KERNEL_HEADERS := $(topdir)/libcap/include/uapi
+ IPATH += -I$(KERNEL_HEADERS) -I$(topdir)/libcap/include
+ 
+-CC := $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ DEFINES := -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+ COPTS ?= -O2
+ CFLAGS ?= $(COPTS) $(DEFINES)
+ BUILD_CC ?= $(CC)
+ BUILD_COPTS ?= -O2
+ BUILD_CFLAGS ?= $(BUILD_COPTS) $(DEFINES) $(IPATH)
+-AR := $(CROSS_COMPILE)ar
+-RANLIB := $(CROSS_COMPILE)ranlib
++AR ?= $(CROSS_COMPILE)ar
++RANLIB ?= $(CROSS_COMPILE)ranlib
+ DEBUG = -g #-DDEBUG
+ WARNINGS=-Wall -Wwrite-strings \
+         -Wpointer-arith -Wcast-qual -Wcast-align \
+-- 
+2.31.1
+

--- a/recipes/libcap/all/patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch
+++ b/recipes/libcap/all/patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch
@@ -1,0 +1,27 @@
+From b70454fccba1816b14d50813b1715e9a50d7cca0 Mon Sep 17 00:00:00 2001
+From: Sergey Bobrenok <bobrofon@gmail.com>
+Date: Sat, 11 Sep 2021 20:39:49 +0300
+Subject: [PATCH 1/2] libcap: Remove hardcoded -fPIC
+
+Signed-off-by: Sergey Bobrenok <bobrofon@gmail.com>
+---
+ libcap/Makefile | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/libcap/Makefile b/libcap/Makefile
+index 7706063..1b52eb9 100644
+--- a/libcap/Makefile
++++ b/libcap/Makefile
+@@ -18,9 +18,6 @@ CAPMAGICOBJ=cap_magic.o
+ PSXFILES=../psx/psx
+ PSXMAGICOBJ=psx_magic.o
+ 
+-# Always build libcap sources this way:
+-CFLAGS += -fPIC
+-
+ # The linker magic needed to build a dynamic library as independently
+ # executable
+ MAGIC=-Wl,-e,__so_start
+-- 
+2.31.1
+

--- a/recipes/libcap/all/patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch
+++ b/recipes/libcap/all/patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch
@@ -1,0 +1,33 @@
+From a38f5a330d65cc877fcc1da02836526d11ead4f0 Mon Sep 17 00:00:00 2001
+From: Sergey Bobrenok <bobrofon@gmail.com>
+Date: Sat, 11 Sep 2021 20:44:07 +0300
+Subject: [PATCH 2/2] Make.Rules: Make compile tools configurable
+
+Signed-off-by: Sergey Bobrenok <bobrofon@gmail.com>
+---
+ Make.Rules | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Make.Rules b/Make.Rules
+index 00f2a03..34831ae 100644
+--- a/Make.Rules
++++ b/Make.Rules
+@@ -66,11 +66,11 @@ DEFINES := -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+ SYSTEM_HEADERS = /usr/include
+ 
+ SUDO := sudo
+-CC := $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ LD := $(CC) -Wl,-x -shared
+-AR := $(CROSS_COMPILE)ar
+-RANLIB := $(CROSS_COMPILE)ranlib
+-OBJCOPY := $(CROSS_COMPILE)objcopy
++AR ?= $(CROSS_COMPILE)ar
++RANLIB ?= $(CROSS_COMPILE)ranlib
++OBJCOPY ?= $(CROSS_COMPILE)objcopy
+ 
+ # Reference:
+ #   CPPFLAGS used for building .o files from .c & .h files
+-- 
+2.31.1
+

--- a/recipes/libcap/config.yml
+++ b/recipes/libcap/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "2.50":
     folder: all
+  "2.57":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libcap/2.57**

Added new version of libcap. Also made some recipe cleanup to make it easy to apply different patches to different library versions.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
