### PR TITLE
ffmpeg/4.2.1: Handle Macos os.version setting

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -287,6 +287,9 @@ class FFMpegConan(ConanFile):
             args.append("--cc={}".format(tools.get_env("CC")))
         if tools.get_env("CXX"):
             args.append("--cxx=".format(tools.get_env("CXX")))
+        if self.settings.os == "Macos":
+            print("os.version:" + self.settings.os.version)
+        raise ConanInvalidConfiguration("securetransport is only available on Apple")
         if self.settings.compiler == "Visual Studio":
             args.append("--pkg-config={}".format(tools.get_env("PKG_CONFIG")))
             args.append("--toolchain=msvc")

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -287,9 +287,8 @@ class FFMpegConan(ConanFile):
             args.append("--cc={}".format(tools.get_env("CC")))
         if tools.get_env("CXX"):
             args.append("--cxx=".format(tools.get_env("CXX")))
-        if self.settings.os == "Macos":
-            print("os.version:" + self.settings.os.version)
-        raise ConanInvalidConfiguration("securetransport is only available on Apple")
+        if self.settings.os == "Macos" and self.settings.os.version:
+            args.append("--extra-ldflags={}".format(tools.apple_deployment_target_flag(self.settings.os, self.settings.os.version)))
         if self.settings.compiler == "Visual Studio":
             args.append("--pkg-config={}".format(tools.get_env("PKG_CONFIG")))
             args.append("--toolchain=msvc")


### PR DESCRIPTION
Specify library name and version:  **ffmpeg/4.2.1**

Since ffmpeg doesn't use vanilla autotools, I had to explicitely set the apple deployement target flag.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
