### PR TITLE
openimageio/all: Add new versions and many new dependencies.

### DIFF
--- a/recipes/openimageio/all/CMakeLists.txt
+++ b/recipes/openimageio/all/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
-include("${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake")
+include("conanbuildinfo.cmake")
 conan_basic_setup()
 
 include_directories(

--- a/recipes/openimageio/all/conandata.yml
+++ b/recipes/openimageio/all/conandata.yml
@@ -2,7 +2,19 @@ sources:
   "2.2.7.0":
     url: "https://github.com/OpenImageIO/oiio/archive/Release-2.2.7.0.tar.gz"
     sha256: "857ac83798d6d2bda5d4d11a90618ff19486da2e5a4c4ff022c5976b5746fe8c"
+  "2.2.18.0":
+    url: "https://github.com/OpenImageIO/oiio/archive/refs/tags/v2.2.18.0.tar.gz"
+    sha256: "72597619f09b60cc2afc18f378b40fbec62701112957f43cff162dd9a52a26ce"
+  "2.3.7.2":
+    url: "https://github.com/OpenImageIO/oiio/archive/refs/tags/v2.3.7.2.tar.gz"
+    sha256: "829c05d17610f1156c2a777310f4709b81f3a302fd11e3999ea4a865a5b4a5d3"
 patches:
   "2.2.7.0":
     - patch_file: "patches/2.2.7.0-cmake-targets.patch"
+      base_path: "source_subfolder"
+  "2.2.18.0":
+    - patch_file: "patches/2.2.18.0-cmake-targets.patch"
+      base_path: "source_subfolder"
+  "2.3.7.2":
+    - patch_file: "patches/2.3.7.2-cmake-targets.patch"
       base_path: "source_subfolder"

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -143,13 +143,13 @@ class OpenImageIOConan(ConanFile):
         if self.options.with_libpng:
             self.requires("libpng/1.6.37")
         if self.options.with_freetype:
-            self.requires("freetype/2.10.4")
+            self.requires("freetype/2.11.0")
         if self.options.with_hdf5:
             self.requires("hdf5/1.12.0")
         if self.options.with_opencolorio:
             self.requires("opencolorio/1.1.1")
         if self.options.with_opencv:
-            self.requires("opencv/4.5.2")
+            self.requires("opencv/4.5.3")
         if self.options.with_tbb:
             self.requires("tbb/2020.3")
         if self.options.with_dicom:
@@ -170,7 +170,7 @@ class OpenImageIOConan(ConanFile):
         if self.options.with_ptex:
             self.requires("ptex/2.4.0")
         if self.options.with_libwebp:
-            self.requires("libwebp/1.2.0")
+            self.requires("libwebp/1.2.1")
         # TODO: R3DSDK dependency
         # TODO: Nuke dependency
 

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -124,12 +124,6 @@ class OpenImageIOConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        # Override dependencies
-        self.requires("zstd/1.5.0", override=True)
-        self.requires("lcms/2.12", override=True)
-        self.requires("jasper/2.0.33", override=True)
-        self.requires("openssl/1.1.1l", override=True)
-
         # Required libraries
         self.requires("zlib/1.2.11")
         self.requires("boost/1.76.0")

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -1,11 +1,12 @@
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 import os, shutil
 
 class OpenImageIOConan(ConanFile):
     name = "openimageio"
     description = "OpenImageIO is a library for reading and writing images, and a bunch of related classes, utilities, and applications." \
                   "There is a particular emphasis on formats and functionality used in professional, large-scale animation and visual effects work for film."
-    topics = ("conan", "vfx", "image", "picture")
+    topics = ("vfx", "image", "picture")
     license = "BSD-3-Clause"
     homepage = "http://www.openimageio.org/"
     url = "https://github.com/conan-io/conan-center-index"
@@ -17,15 +18,43 @@ class OpenImageIOConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_libjpeg": ["libjpeg", "libjpeg-turbo"],
+        "with_libpng": [True, False],
+        "with_freetype": [True, False],
+        "with_hdf5": [True, False],
+        "with_opencolorio": [True, False],
+        "with_opencv": [True, False],
+        "with_tbb": [True, False],
         "with_dicom": [True, False],
-        "with_raw": [True, False]
+        "with_ffmpeg": [True, False],
+        "with_giflib": [True, False],
+        "with_libheif": [True, False],
+        "with_raw": [True, False],
+        "with_openjpeg": [True, False],
+        "with_openvdb": [True, False],
+        "with_ptex": [True, False],
+        "with_libwebp": [True, False],
     }
 
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_libjpeg": "libjpeg",
+        "with_libpng": True,
+        "with_freetype": True,
+        "with_hdf5": True,
+        "with_opencolorio": True,
+        "with_opencv": True,
+        "with_tbb": True,
         "with_dicom": False, # Heavy dependency, disabled by default
-        "with_raw": False # libraw is available under CDDL-1.0 or LGPL-2.1, for this reason it is disabled by default
+        "with_ffmpeg": True,
+        "with_giflib": True,
+        "with_libheif": True,
+        "with_raw": False, # libraw is available under CDDL-1.0 or LGPL-2.1, for this reason it is disabled by default
+        "with_openjpeg": True,
+        "with_openvdb": False, # FIXME: broken on M1
+        "with_ptex": True,
+        "with_libwebp": True,
     }
 
     _cmake = None
@@ -34,6 +63,10 @@ class OpenImageIOConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake
@@ -41,6 +74,7 @@ class OpenImageIOConan(ConanFile):
         self._cmake = CMake(self)
 
         # CMake options
+        self._cmake.definitions["CMAKE_DEBUG_POSTFIX"] = "" # Needed for 2.3.x.x+ versions
         self._cmake.definitions["OIIO_BUILD_TOOLS"] = True
         self._cmake.definitions["OIIO_BUILD_TESTS"] = False
         self._cmake.definitions["BUILD_DOCS"] = False
@@ -51,31 +85,34 @@ class OpenImageIOConan(ConanFile):
         self._cmake.definitions["USE_PYTHON"] = False
         self._cmake.definitions["USE_EXTERNAL_PUGIXML"] = True
 
-        # Set "USE_<PKG>" variables for disabled plugins to False.
-        # If these variables are not set, the package will be built
-        # when required library is found, even if it is not provided
-        # by Conan.
-        self._cmake.definitions["USE_JPEGTURBO"] = False
-        self._cmake.definitions["USE_JPEG"] = True
-        self._cmake.definitions["USE_HDF5"] = False
-        self._cmake.definitions["USE_OPENCOLORIO"] = True
-        self._cmake.definitions["USE_OPENCV"] = False
-        self._cmake.definitions["USE_TBB"] = False
+        # OIIO CMake files are patched to check USE_* flags to require or not use dependencies
+        self._cmake.definitions["USE_JPEGTURBO"] = self.options.with_libjpeg == "libjpeg-turbo"
+        self._cmake.definitions["USE_JPEG"] = True # Needed for jpeg.imageio plugin, libjpeg/libjpeg-turbo selection still works
+        self._cmake.definitions["USE_HDF5"] = self.options.with_hdf5
+        self._cmake.definitions["USE_OPENCOLORIO"] = self.options.with_opencolorio
+        self._cmake.definitions["USE_OPENCV"] = self.options.with_opencv
+        self._cmake.definitions["USE_TBB"] = self.options.with_tbb
         self._cmake.definitions["USE_DCMTK"] = self.options.with_dicom
-        self._cmake.definitions["USE_FFMPEG"] = False
+        self._cmake.definitions["USE_FFMPEG"] = self.options.with_ffmpeg
         self._cmake.definitions["USE_FIELD3D"] = False
-        self._cmake.definitions["USE_GIF"] = True
-        self._cmake.definitions["USE_LIBHEIF"] = False
+        self._cmake.definitions["USE_GIF"] = self.options.with_giflib
+        self._cmake.definitions["USE_LIBHEIF"] = self.options.with_libheif
         self._cmake.definitions["USE_LIBRAW"] = self.options.with_raw
-        self._cmake.definitions["USE_OPENVDB"] = False
-        self._cmake.definitions["USE_PTEX"] = False
+        self._cmake.definitions["USE_OPENVDB"] = self.options.with_openvdb
+        self._cmake.definitions["USE_PTEX"] = self.options.with_ptex
         self._cmake.definitions["USE_R3DSDK"] = False
         self._cmake.definitions["USE_NUKE"] = False
         self._cmake.definitions["USE_OPENGL"] = False
         self._cmake.definitions["USE_QT"] = False
-        self._cmake.definitions["USE_QT5"] = False
-        
-        self._cmake.configure()
+        self._cmake.definitions["USE_LIBPNG"] = self.options.with_libpng
+        self._cmake.definitions["USE_FREETYPE"] = self.options.with_freetype
+        self._cmake.definitions["USE_LIBWEBP"] = self.options.with_libwebp
+        self._cmake.definitions["USE_OPENJPEG"] = self.options.with_openjpeg
+
+        if self.options.with_openvdb:
+            self._cmake.definitions["CMAKE_CXX_STANDARD"] = 14
+
+        self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
     def config_options(self):
@@ -87,30 +124,73 @@ class OpenImageIOConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("openexr/2.5.2")
-        self.requires("libtiff/4.1.0")
-        self.requires("fmt/7.0.3")
-        self.requires("boost/1.74.0")
-        self.requires("tsl-robin-map/0.6.3")
-        self.requires("pugixml/1.10")
-        self.requires("libsquish/1.15")
-        self.requires("libpng/1.6.37")
-        self.requires("libwebp/1.1.0")
-        self.requires("openjpeg/2.3.1")
-        self.requires("giflib/5.2.1")
-        self.requires("freetype/2.10.2")
-        self.requires("opencolorio/1.1.1")
-        self.requires("libjpeg/9d")
-    
-        if self.options.with_dicom:
-            self.requires("dcmtk/3.6.5")
+        # Override dependencies
+        self.requires("zstd/1.5.0", override=True)
+        self.requires("lcms/2.12", override=True)
+        self.requires("jasper/2.0.33", override=True)
+        self.requires("openssl/1.1.1l", override=True)
 
+        # Required libraries
+        self.requires("zlib/1.2.11")
+        self.requires("boost/1.76.0")
+        self.requires("libtiff/4.3.0")
+        self.requires("openexr/2.5.7")
+        if self.options.with_libjpeg == "libjpeg":
+            self.requires("libjpeg/9d")
+        elif self.options.with_libjpeg == "libjpeg-turbo":
+            self.requires("libjpeg-turbo/2.1.1")
+        self.requires("pugixml/1.11")
+        self.requires("libsquish/1.15")
+        self.requires("tsl-robin-map/0.6.3")
+        self.requires("libsquish/1.15")
+        self.requires("fmt/8.0.1")
+
+        # Optional libraries
+        if self.options.with_libpng:
+            self.requires("libpng/1.6.37")
+        if self.options.with_freetype:
+            self.requires("freetype/2.10.4")
+        if self.options.with_hdf5:
+            self.requires("hdf5/1.12.0")
+        if self.options.with_opencolorio:
+            self.requires("opencolorio/1.1.1")
+        if self.options.with_opencv:
+            self.requires("opencv/4.5.2")
+        if self.options.with_tbb:
+            self.requires("tbb/2020.3")
+        if self.options.with_dicom:
+            self.requires("dcmtk/3.6.6")
+        if self.options.with_ffmpeg:
+            self.requires("ffmpeg/4.2.1")
+        # TODO: Field3D dependency
+        if self.options.with_giflib:
+            self.requires("giflib/5.2.1")
+        if self.options.with_libheif:
+            self.requires("libheif/1.12.0")
         if self.options.with_raw:
-            self.requires("libraw/0.20.0")
-        
+            self.requires("libraw/0.20.2")
+        if self.options.with_openjpeg:
+            self.requires("openjpeg/2.4.0")
+        if self.options.with_openvdb:
+            self.requires("openvdb/8.0.1")
+        if self.options.with_ptex:
+            self.requires("ptex/2.4.0")
+        if self.options.with_libwebp:
+            self.requires("libwebp/1.2.0")
+        # TODO: R3DSDK dependency
+        # TODO: Nuke dependency
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            if tools.Version(self.version) >= "2.3.0.0" or self.options.with_openvdb:
+                tools.check_min_cppstd(self, 14)
+            else:
+                tools.check_min_cppstd(self, 11)
+        if self.settings.compiler == "Visual Studio" and self.settings.compiler.get_safe("runtime", "").startswith("MT") and self.options.shared:
+            raise ConanInvalidConfiguration("Building shared library with static runtime is not supported!")
+
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("oiio-Release-{}".format(self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def _patch_sources(self):
          for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -118,7 +198,7 @@ class OpenImageIOConan(ConanFile):
 
     def build(self):
         self._patch_sources()
-        
+
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -126,7 +206,6 @@ class OpenImageIOConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
 
-        tools.rmdir(os.path.join(self.package_folder, "include", "OpenImageIO", "fmt"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
@@ -136,12 +215,53 @@ class OpenImageIOConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "OpenImageIO"
         self.cpp_info.names["cmake_find_package_multi"] = "OpenImageIO"
-        self.cpp_info.names['pkg_config'] = 'OpenImageIO'
 
-        self.cpp_info.libs = tools.collect_libs(self)
-
+        self.cpp_info.components["util"].libs = ["OpenImageIO_Util"]
+        self.cpp_info.components["util"].requires = ["boost::filesystem", "boost::thread", "boost::system", "boost::regex", "openexr::openexr"]
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs.append("dl")
+            self.cpp_info.components["util"].system_libs.extend(["dl", "m", "pthread"])
+
+        self.cpp_info.components["main"].libs = ["OpenImageIO"]
+        self.cpp_info.components["main"].requires = [
+            "util", "zlib::zlib", "boost::thread", "boost::system", "boost::container", "boost::regex", "libtiff::libtiff", "openexr::openexr",
+            "pugixml::pugixml", "tsl-robin-map::tsl-robin-map", "libsquish::libsquish", "fmt::fmt"]
+        if self.options.with_libjpeg == "libjpeg":
+            self.cpp_info.components["main"].requires.append("libjpeg::libjpeg")
+        elif self.options.with_libjpeg == "libjpeg-turbo":
+            self.cpp_info.components["main"].requires.append("libjpeg-turbo::libjpeg-turbo")
+        if self.options.with_libpng:
+            self.cpp_info.components["main"].requires.append("libpng::libpng")
+        if self.options.with_freetype:
+            self.cpp_info.components["main"].requires.append("freetype::freetype")
+        if self.options.with_hdf5:
+            self.cpp_info.components["main"].requires.append("hdf5::hdf5")
+        if self.options.with_opencolorio:
+            self.cpp_info.components["main"].requires.append("opencolorio::opencolorio")
+        if self.options.with_opencv:
+            self.cpp_info.components["main"].requires.append("opencv::opencv")
+        if self.options.with_tbb:
+            self.cpp_info.components["main"].requires.append("tbb::tbb")
+        if self.options.with_dicom:
+            self.cpp_info.components["main"].requires.append("dcmtk::dcmtk")
+        if self.options.with_ffmpeg:
+            self.cpp_info.components["main"].requires.append("ffmpeg::ffmpeg")
+        if self.options.with_giflib:
+            self.cpp_info.components["main"].requires.append("giflib::giflib")
+        if self.options.with_libheif:
+            self.cpp_info.components["main"].requires.append("libheif::libheif")
+        if self.options.with_raw:
+            self.cpp_info.components["main"].requires.append("libraw::libraw")
+        if self.options.with_openjpeg:
+            self.cpp_info.components["main"].requires.append("openjpeg::openjpeg")
+        if self.options.with_openvdb:
+            self.cpp_info.components["main"].requires.append("openvdb::openvdb")
+        if self.options.with_ptex:
+            self.cpp_info.components["main"].requires.append("ptex::ptex")
+        if self.options.with_libwebp:
+            self.cpp_info.components["main"].requires.append("libwebp::libwebp")
+        if self.settings.os == "Linux":
+            self.cpp_info.components["main"].system_libs.extend(["dl", "m", "pthread"])
+        self.cpp_info.components["main"].names["pkg_config"] = "OpenImageIO"
 
         if not self.options.shared:
-            self.cpp_info.defines.append("OIIO_STATIC_DEFINE")
+            self.cpp_info.components["main"].defines.append("OIIO_STATIC_DEFINE")

--- a/recipes/openimageio/all/patches/2.2.18.0-cmake-targets.patch
+++ b/recipes/openimageio/all/patches/2.2.18.0-cmake-targets.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 447c6170..702fb50b 100644
+index ccda926b..24b26b8f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -99,7 +99,7 @@ message(STATUS "Setting Namespace to: ${PROJ_NAMESPACE_V}")
@@ -11,50 +11,57 @@ index 447c6170..702fb50b 100644
        "${PROJECT_SOURCE_DIR}/src/cmake")
  
  include (GNUInstallDirs)
-@@ -172,7 +172,7 @@ if (OIIO_BUILD_TOOLS AND NOT BUILD_OIIOUTIL_ONLY)
+@@ -179,7 +179,7 @@ if (OIIO_BUILD_TOOLS AND NOT BUILD_OIIOUTIL_ONLY)
      add_subdirectory (src/iinfo)
      add_subdirectory (src/maketx)
      add_subdirectory (src/oiiotool)
 -    add_subdirectory (src/testtex)
-+    #add_subdirectory (src/testtex)
++    # add_subdirectory (src/testtex)
      add_subdirectory (src/iv)
  endif ()
  
 diff --git a/src/cmake/compiler.cmake b/src/cmake/compiler.cmake
-index 12a8e819..46c1d0f8 100644
+index 8747f506..503e2a55 100644
 --- a/src/cmake/compiler.cmake
 +++ b/src/cmake/compiler.cmake
-@@ -88,7 +88,7 @@ if (NOT MSVC)
+@@ -92,7 +92,7 @@ if (NOT MSVC)
          add_compile_options ("-Wextra")
      endif ()
      if (STOP_ON_WARNING OR DEFINED ENV{CI})
 -        add_compile_options ("-Werror")
 +        # add_compile_options ("-Werror")
-         # N.B. Force CI builds (Travis defines $CI) to use -Werror, even if
-         # STOP_ON_WARNING has been switched off by default, which we may do
-         # in release branches.
+         # N.B. Force CI builds to use -Werror, even if STOP_ON_WARNING has
+         # been switched off by default, which we may do in release
+         # branches.
 diff --git a/src/cmake/externalpackages.cmake b/src/cmake/externalpackages.cmake
-index 03d521dc..9fe73388 100644
+index 21e18b53..605d247a 100644
 --- a/src/cmake/externalpackages.cmake
 +++ b/src/cmake/externalpackages.cmake
-@@ -39,7 +39,7 @@ if (LINKSTATIC)
-     endif ()
- else ()
-     if (MSVC)
+@@ -46,7 +46,7 @@ endif ()
+ if (MSVC)
+     # Not linking Boost as static libraries: either an explicit setting or LINKSTATIC is FALSE:
+     if (NOT Boost_USE_STATIC_LIBS)
 -        add_definitions (-DBOOST_ALL_DYN_LINK=1)
 +        # add_definitions (-DBOOST_ALL_DYN_LINK=1)
      endif ()
  endif ()
- if (BOOST_CUSTOM)
-@@ -89,23 +89,27 @@ checked_find_package (OpenEXR 2.0 REQUIRED
-                       RECOMMEND_MIN 2.2
-                       RECOMMEND_MIN_REASON "for DWA compression")
- # We use Imath so commonly, may as well include it everywhere.
--include_directories ("${OPENEXR_INCLUDES}" "${ILMBASE_INCLUDES}"
--                     "${ILMBASE_INCLUDES}/OpenEXR")
+ 
+@@ -55,7 +55,7 @@ if (BOOST_CUSTOM)
+     # N.B. For a custom version, the caller had better set up the variables
+     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
+ else ()
+-    set (Boost_COMPONENTS filesystem system thread)
++    set (Boost_COMPONENTS filesystem system thread container)
+     if (NOT USE_STD_REGEX)
+         list (APPEND Boost_COMPONENTS regex)
+     endif ()
+@@ -106,16 +106,16 @@ checked_find_package (OpenEXR REQUIRED
+ # library. This shoudn't be necessary, except for the common case of people
+ # building against Imath/OpenEXR 3.x when there is still a system-level
+ # install version of 2.x.
+-include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})
 -if (CMAKE_COMPILER_IS_CLANG AND OPENEXR_VERSION VERSION_LESS 2.3)
-+# include_directories ("${OPENEXR_INCLUDES}" "${ILMBASE_INCLUDES}"
-+#                      "${ILMBASE_INCLUDES}/OpenEXR")
++# include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})
 +if (CMAKE_COMPILER_IS_CLANG AND OpenEXR_VERSION VERSION_LESS 2.3)
      # clang C++ >= 11 doesn't like 'register' keyword in old exr headers
      add_compile_options (-Wno-deprecated-register)
@@ -64,13 +71,21 @@ index 03d521dc..9fe73388 100644
 +    # add_definitions (-DOPENEXR_DLL) # Is this needed for new versions?
  endif ()
  
+-if (OPENEXR_VERSION VERSION_GREATER_EQUAL 2.5.99)
++if (OpenEXR_VERSION VERSION_GREATER_EQUAL 2.5.99)
+     set (OIIO_USING_IMATH 3)
+ else ()
+     set (OIIO_USING_IMATH 2)
+@@ -123,12 +123,15 @@ endif ()
+ 
  
  # JPEG -- prefer Turbo-JPEG to regular libjpeg
 -checked_find_package (JPEGTurbo
 +if (USE_JPEGTURBO)
 +    checked_find_package (libjpeg-turbo REQUIRED
                        DEFINITIONS -DUSE_JPEG_TURBO=1
--                      PRINT       JPEG_INCLUDES JPEG_LIBRARIES)
+-                      PRINT       JPEG_INCLUDES JPEG_INCLUDE_DIRS
+-                                  JPEG_LIBRARIES)
 -if (NOT JPEG_FOUND) # Try to find the non-turbo version
 +                      PRINT       libjpeg-turbo_INCLUDES libjpeg-turbo_LIBRARIES)
 +    add_library(JPEG::JPEG ALIAS libjpeg-turbo::libjpeg-turbo)
@@ -81,7 +96,15 @@ index 03d521dc..9fe73388 100644
  endif ()
  
  # Pugixml setup.  Normally we just use the version bundled with oiio, but
-@@ -123,56 +127,93 @@ endif()
+@@ -144,60 +147,83 @@ else ()
+ endif()
+ 
+ # From pythonutils.cmake
+-find_python()
++# find_python()
+ 
+ 
+ ###########################################################################
  # Dependencies for optional formats and features. If these are not found,
  # we will continue building, but the related functionality will be disabled.
  
@@ -126,56 +149,94 @@ index 03d521dc..9fe73388 100644
 -checked_find_package (TBB 2017
 +if (USE_TBB)
 +    checked_find_package (TBB 2017 REQUIRED
-                    DEFINITIONS  -DUSE_TBB=1
-                    ISDEPOF      OpenVDB)
+                       DEFINITIONS  -DUSE_TBB=1
+                       PREFER_CONFIG)
 +endif ()
  
--checked_find_package (DCMTK 3.6.1)  # For DICOM images
--checked_find_package (FFmpeg 2.6)
+-checked_find_package (DCMTK VERSION_MIN 3.6.1)  # For DICOM images
+-checked_find_package (FFmpeg VERSION_MIN 2.6)
 -checked_find_package (Field3D
 +if (USE_DCMTK)
-+    checked_find_package (DCMTK 3.6.1 REQUIRED)  # For DICOM images
++    checked_find_package (DCMTK REQUIRED VERSION_MIN 3.6.1)  # For DICOM images
 +endif ()
 +if (USE_FFMPEG)
-+    checked_find_package (ffmpeg 2.6 REQUIRED)
++    checked_find_package (ffmpeg REQUIRED VERSION_MIN 2.6)
 +endif ()
 +if (USE_FIELD3D)
 +    checked_find_package (Field3D REQUIRED
                     DEPS         HDF5
                     DEFINITIONS  -DUSE_FIELD3D=1)
--checked_find_package (GIF 4
+-checked_find_package (GIF
 +endif ()
 +if (USE_GIF)
-+    checked_find_package (GIF 4 REQUIRED
++    checked_find_package (GIF REQUIRED
+                       VERSION_MIN 4
                        RECOMMEND_MIN 5.0
                        RECOMMEND_MIN_REASON "for stability and thread safety")
--checked_find_package (Libheif 1.3)  # For HEIF/HEIC format
--checked_find_package (LibRaw
--                      PRINT LibRaw_r_LIBRARIES
 +endif ()
+ 
+ # For HEIF/HEIC/AVIF formats
+-checked_find_package (Libheif VERSION_MIN 1.3
 +if (USE_LIBHEIF)
-+    checked_find_package (libheif 1.3 REQUIRED)  # For HEIF/HEIC format
++    checked_find_package (libheif REQUIRED VERSION_MIN 1.3
+                       RECOMMEND_MIN 1.7
+                       RECOMMEND_MIN_REASON "for AVIF support")
+-if (APPLE AND LIBHEIF_VERSION VERSION_GREATER_EQUAL 1.10 AND LIBHEIF_VERSION VERSION_LESS 1.11)
 +endif ()
++if (0)
+     message (WARNING "Libheif 1.10 on Apple is known to be broken, disabling libheif support")
+     set (Libheif_FOUND 0)
+ endif ()
+ 
+-checked_find_package (LibRaw
 +if (USE_LIBRAW)
 +    checked_find_package (libraw REQUIRED
                        RECOMMEND_MIN 0.18
-                       RECOMMEND_MIN_REASON "for ACES support")
--checked_find_package (OpenJpeg 2.0)
--checked_find_package (OpenVDB 5.0
+-                      RECOMMEND_MIN_REASON "for ACES support and better camera metadata"
+-                      PRINT LibRaw_r_LIBRARIES)
+-if (LibRaw_FOUND AND LibRaw_VERSION VERSION_LESS 0.20 AND CMAKE_CXX_STANDARD VERSION_GREATER_EQUAL 17)
++                      RECOMMEND_MIN_REASON "for ACES support and better camera metadata")
 +endif ()
++if (0)
+     message (STATUS "${ColorYellow}WARNING When building for C++17, LibRaw should be 0.20 or higher (found ${LibRaw_VERSION}). You may get errors, depending on the compiler.${ColorReset}")
+     # Currently, we issue the above warning and let them take their chances.
+     # If we wish to disable the LibRaw<0.20/C++17 combination that may fail,
+@@ -206,12 +232,15 @@ if (LibRaw_FOUND AND LibRaw_VERSION VERSION_LESS 0.20 AND CMAKE_CXX_STANDARD VER
+     # set (LIBRAW_FOUND 0)
+ endif ()
+ 
+-checked_find_package (OpenJPEG VERSION_MIN 2.0)
+-
+-checked_find_package (OpenVDB
 +if (USE_OPENJPEG)
-+    checked_find_package (OpenJPEG 2.0 REQUIRED)
++    checked_find_package (OpenJPEG REQUIRED VERSION_MIN 2.0)
 +endif ()
 +if (USE_OPENVDB)
-+    checked_find_package (OpenVDB 5.0 REQUIRED
-                    DEPS         TBB
-                    DEFINITIONS  -DUSE_OPENVDB=1)
--checked_find_package (PTex)
--checked_find_package (Webp)
++    checked_find_package (OpenVDB REQUIRED
+                       VERSION_MIN 5.0
+                       DEPS         TBB
+                       DEFINITIONS  -DUSE_OPENVDB=1)
 +endif ()
+ if (OpenVDB_FOUND AND OpenVDB_VERSION VERSION_GREATER_EQUAL 8.0
+         AND CMAKE_CXX_STANDARD VERSION_LESS 14)
+     set (OpenVDB_FOUND OFF)
+@@ -225,23 +254,32 @@ if (OpenVDB_FOUND AND OpenVDB_VERSION VERSION_GREATER_EQUAL 8.0
+     message (STATUS "${ColorRed}Not using OpenVDB -- OpenVDB ${OpenVDB_VERSION} requires C++14 or later. ${ColorReset}")
+ endif ()
+ 
+-checked_find_package (Ptex PREFER_CONFIG)
+-if (NOT Ptex_FOUND OR NOT Ptex_VERSION)
 +if (USE_PTEX)
-+    checked_find_package (ptex REQUIRED)
++    checked_find_package (ptex REQUIRED PREFER_CONFIG)
 +endif ()
++if (0)
+     # Fallback for inadequate Ptex exported configs. This will eventually
+     # disappear when we can 100% trust Ptex's exports.
+     unset (Ptex_FOUND)
+     checked_find_package (Ptex)
+ endif ()
+-
+-checked_find_package (WebP)
 +if (USE_LIBWEBP)
 +    checked_find_package (WebP REQUIRED)
 +endif ()
@@ -199,7 +260,7 @@ index 03d521dc..9fe73388 100644
  
  # Qt -- used for iv
  set (qt5_modules Core Gui Widgets)
-@@ -180,7 +221,9 @@ if (OPENGL_FOUND)
+@@ -249,7 +287,9 @@ if (OPENGL_FOUND)
      list (APPEND qt5_modules OpenGL)
  endif ()
  option (USE_QT "Use Qt if found" ON)
@@ -210,7 +271,7 @@ index 03d521dc..9fe73388 100644
  if (USE_QT AND NOT Qt5_FOUND AND APPLE)
      message (STATUS "  If you think you installed qt5 with Homebrew and it still doesn't work,")
      message (STATUS "  try:   export PATH=/usr/local/opt/qt5/bin:$PATH")
-@@ -201,13 +244,13 @@ macro (find_or_download_robin_map)
+@@ -270,13 +310,13 @@ macro (find_or_download_robin_map)
      # for an installed version. Still prefer a copy that seems to be
      # locally installed in this tree.
      if (NOT BUILD_ROBINMAP_FORCE)
@@ -226,7 +287,7 @@ index 03d521dc..9fe73388 100644
          message (STATUS "Downloading local Tessil/robin-map")
          set (ROBINMAP_INSTALL_DIR "${PROJECT_SOURCE_DIR}/ext/robin-map")
          set (ROBINMAP_GIT_REPOSITORY "https://github.com/Tessil/robin-map")
-@@ -225,7 +268,7 @@ macro (find_or_download_robin_map)
+@@ -294,7 +334,7 @@ macro (find_or_download_robin_map)
          endif ()
          set (ROBINMAP_INCLUDE_DIR "${ROBINMAP_INSTALL_DIR}/include")
      endif ()
@@ -235,22 +296,16 @@ index 03d521dc..9fe73388 100644
  endmacro()
  
  
-@@ -235,7 +278,7 @@ endmacro()
+@@ -304,7 +344,7 @@ endmacro()
  option (USE_EMBEDDED_LIBSQUISH
          "Force use of embedded Libsquish, even if external is found" OFF)
  if (NOT USE_EMBEDDED_LIBSQUISH)
 -    checked_find_package (Libsquish)
-+    checked_find_package (libsquish REQUIRED)
++    checked_find_package (libsquish)
  endif ()
  
  
-@@ -251,12 +294,12 @@ macro (find_or_download_fmt)
-     # for an installed version. Still prefer a copy that seems to be
-     # locally installed in this tree.
-     if (NOT BUILD_FMT_FORCE)
--        find_package (fmt QUIET)
-+        find_package (fmt REQUIRED)
-     endif ()
+@@ -325,7 +365,7 @@ macro (find_or_download_fmt)
      # If an external copy wasn't found and we requested that missing
      # packages be built, or we we are forcing a local copy to be built, then
      # download and build it.
@@ -291,23 +346,13 @@ index ddd72044..3603eaa3 100644
                       DEFINITIONS "-DUSE_DCMTK=1")
  else ()
      message (WARNING "DICOM plugin will not be built, no DCMTK")
-diff --git a/src/dpx.imageio/CMakeLists.txt b/src/dpx.imageio/CMakeLists.txt
-index 858beb9d..dd169af4 100644
---- a/src/dpx.imageio/CMakeLists.txt
-+++ b/src/dpx.imageio/CMakeLists.txt
-@@ -6,4 +6,4 @@ add_oiio_plugin (dpxinput.cpp dpxoutput.cpp
-   libdpx/DPX.cpp libdpx/OutStream.cpp libdpx/RunLengthEncoding.cpp
-   libdpx/Codec.cpp libdpx/Reader.cpp libdpx/Writer.cpp libdpx/DPXHeader.cpp
-   libdpx/ElementReadStream.cpp libdpx/InStream.cpp libdpx/DPXColorConverter.cpp
--  LINK_LIBRARIES ${OPENEXR_LIBRARIES})
-+  LINK_LIBRARIES OpenEXR::OpenEXR)
 diff --git a/src/ffmpeg.imageio/CMakeLists.txt b/src/ffmpeg.imageio/CMakeLists.txt
-index 6cf07636..d3bb5f61 100644
+index 614b8843..0df87825 100644
 --- a/src/ffmpeg.imageio/CMakeLists.txt
 +++ b/src/ffmpeg.imageio/CMakeLists.txt
-@@ -11,11 +11,11 @@ if (NOT MSVC)
-                              PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
- endif()
+@@ -2,13 +2,13 @@
+ # SPDX-License-Identifier: BSD-3-Clause
+ # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
  
 -if (FFmpeg_FOUND)
 +if (ffmpeg_FOUND)
@@ -317,10 +362,13 @@ index 6cf07636..d3bb5f61 100644
 -                                    ${BZIP2_LIBRARIES}
 +                     # INCLUDE_DIRS ${FFMPEG_INCLUDES}
 +                     LINK_LIBRARIES ffmpeg::avcodec ffmpeg::avformat ffmpeg::swscale
-+                     #                ${BZIP2_LIBRARIES}
-                      DEFINITIONS "-DUSE_FFMPEG")
++                     #               ${BZIP2_LIBRARIES}
+                      DEFINITIONS "-DUSE_FFMPEG"
+-                                 "-DOIIO_FFMPEG_VERSION=\"${FFMPEG_VERSION}\"")
++                                 "-DOIIO_FFMPEG_VERSION=\"${ffmpeg_VERSION}\"")
  else()
      message (STATUS "FFmpeg not found: ffmpeg plugin will not be built")
+ endif()
 diff --git a/src/gif.imageio/CMakeLists.txt b/src/gif.imageio/CMakeLists.txt
 index c9e7392c..eda8b482 100644
 --- a/src/gif.imageio/CMakeLists.txt
@@ -352,21 +400,6 @@ index fed80015..2593f585 100644
                       DEFINITIONS "-DUSE_HEIF=1")
  else ()
      message (WARNING "heif plugin will not be built")
-diff --git a/src/ico.imageio/CMakeLists.txt b/src/ico.imageio/CMakeLists.txt
-index 5a46174d..a8919f63 100644
---- a/src/ico.imageio/CMakeLists.txt
-+++ b/src/ico.imageio/CMakeLists.txt
-@@ -4,8 +4,8 @@
- 
- if (PNG_FOUND)
-     add_oiio_plugin (icoinput.cpp icooutput.cpp
--                     INCLUDE_DIRS ${PNG_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS}
--                     LINK_LIBRARIES ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
-+                     # INCLUDE_DIRS ${PNG_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS}
-+                     LINK_LIBRARIES PNG::PNG ZLIB::ZLIB)
- else ()
-     message (WARNING "libpng not found, so ICO support will not work")
-     set (format_plugin_definitions ${format_plugin_definitions} DISABLE_ICO=1 PARENT_SCOPE)
 diff --git a/src/igrep/CMakeLists.txt b/src/igrep/CMakeLists.txt
 index 3fde566a..adaac8bd 100644
 --- a/src/igrep/CMakeLists.txt
@@ -390,11 +423,11 @@ index 3fde566a..adaac8bd 100644
 +                                     Boost::regex # because regex
                        )
 diff --git a/src/include/CMakeLists.txt b/src/include/CMakeLists.txt
-index a60b3b21..050911c8 100644
+index 1ea81b64..248e8a25 100644
 --- a/src/include/CMakeLists.txt
 +++ b/src/include/CMakeLists.txt
-@@ -44,17 +44,20 @@ install (FILES ${public_headers}
-          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+@@ -56,17 +56,20 @@ install (FILES ${detail_headers}
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/detail
           COMPONENT developer)
  
 +set(FMT_INCLUDES "${fmt_INCLUDE_DIR}")
@@ -415,10 +448,10 @@ index a60b3b21..050911c8 100644
  if (NOT USE_EXTERNAL_PUGIXML)
      set (pugixml_headers
 diff --git a/src/include/OpenImageIO/strutil.h b/src/include/OpenImageIO/strutil.h
-index db356f03..003df7f8 100644
+index ed68af14..34b83220 100644
 --- a/src/include/OpenImageIO/strutil.h
 +++ b/src/include/OpenImageIO/strutil.h
-@@ -39,9 +39,9 @@
+@@ -41,9 +41,9 @@
  #ifndef FMT_USE_GRISU
  #    define FMT_USE_GRISU 1
  #endif
@@ -432,16 +465,16 @@ index db356f03..003df7f8 100644
  #    pragma GCC diagnostic pop
  #endif
 diff --git a/src/jpeg.imageio/CMakeLists.txt b/src/jpeg.imageio/CMakeLists.txt
-index 548faeb7..95e4feb5 100644
+index 15d50cad..83830cd2 100644
 --- a/src/jpeg.imageio/CMakeLists.txt
 +++ b/src/jpeg.imageio/CMakeLists.txt
 @@ -3,5 +3,5 @@
  # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
  
  add_oiio_plugin (jpeginput.cpp jpegoutput.cpp
--                 INCLUDE_DIRS ${JPEG_INCLUDE_DIR}
+-                 INCLUDE_DIRS ${JPEG_INCLUDE_DIRS}
 -                 LINK_LIBRARIES ${JPEG_LIBRARIES})
-+                 # INCLUDE_DIRS ${JPEG_INCLUDE_DIR}
++                 # INCLUDE_DIRS ${JPEG_INCLUDE_DIRS}
 +                 LINK_LIBRARIES JPEG::JPEG)
 diff --git a/src/jpeg2000.imageio/CMakeLists.txt b/src/jpeg2000.imageio/CMakeLists.txt
 index 575ed0b7..5644bcf3 100644
@@ -462,96 +495,132 @@ index 575ed0b7..5644bcf3 100644
  else()
      message (WARNING "Jpeg-2000 plugin will not be built")
 diff --git a/src/libOpenImageIO/CMakeLists.txt b/src/libOpenImageIO/CMakeLists.txt
-index fe39cdd4..b877cc4d 100644
+index 29923b60..77035aa7 100644
 --- a/src/libOpenImageIO/CMakeLists.txt
 +++ b/src/libOpenImageIO/CMakeLists.txt
-@@ -135,31 +135,33 @@ endif ()
- 
+@@ -136,37 +136,42 @@ endif ()
  target_link_libraries (OpenImageIO
          PUBLIC
+             # For OpenEXR/Imath 3.x:
+-            $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+-            $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
++            # $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
++            # $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+             # For OpenEXR >= 2.4/2.5 with reliable exported targets
+-            $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+-            $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
++            # $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
++            # $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+             # For OpenEXR <= 2.3:
 -            ${ILMBASE_LIBRARIES}
--            ${OPENEXR_LIBRARIES}
--            ${OpenCV_LIBRARIES}
 +            OpenEXR::OpenEXR
-+            $<$<BOOL:${OpenColorIO_FOUND}>:OpenColorIO::OpenColorIO>
              ${GCC_ATOMIC_LIBRARIES}
          PRIVATE
+             # For OpenEXR/Imath 3.x:
+-            $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
++            # $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+             # For OpenEXR >= 2.4/2.5 with reliable exported targets
+-            $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+-            $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+-            $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
++            # $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
++            # $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
++            # $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
+             # For OpenEXR <= 2.3:
+-            ${OPENEXR_LIBRARIES}
+-            ${OpenCV_LIBRARIES}
++            # ${OPENEXR_LIBRARIES}
++            # ${OpenCV_LIBRARIES}
              ${SANITIZE_LIBRARIES}
              ${format_plugin_libs} # Add all the target link libraries from the plugins
--            $<$<BOOL:${OpenColorIO_FOUND}>:OpenColorIO::OpenColorIO>
--            ${BZIP2_LIBRARIES}
--            ${ZLIB_LIBRARIES}
--            ${Boost_LIBRARIES}
 +            tsl::robin_map
-+            ZLIB::ZLIB
-+            Boost::Boost
+             $<$<TARGET_EXISTS:OpenColorIO::OpenColorIO>:OpenColorIO::OpenColorIO>
+-            $<$<TARGET_EXISTS:OpenColorIO::OpenColorIOHeaders>:OpenColorIO::OpenColorIOHeaders>
++            # $<$<TARGET_EXISTS:OpenColorIO::OpenColorIOHeaders>:OpenColorIO::OpenColorIOHeaders>
+             $<$<BOOL:${pugixml_FOUND}>:pugixml::pugixml>
+-            ${BZIP2_LIBRARIES}
++            # ${BZIP2_LIBRARIES}
+             ZLIB::ZLIB
+-            ${Boost_LIBRARIES}
++            Boost::filesystem Boost::thread Boost::system Boost::container
              ${CMAKE_DL_LIBS}
          )
  
+-if (FREETYPE_FOUND)
+-    target_link_libraries (OpenImageIO PRIVATE ${FREETYPE_LIBRARIES})
 +if (OpenCV_FOUND)
 +    target_link_libraries (OpenImageIO PUBLIC opencv::opencv_core opencv::opencv_imgproc opencv::opencv_videoio)
 +endif ()
 +
- if (USE_EXTERNAL_PUGIXML)
--    if(TARGET pugixml)
--        target_link_libraries (OpenImageIO PRIVATE pugixml)
-+    if(pugixml_FOUND)
-+        target_link_libraries (OpenImageIO PRIVATE pugixml::pugixml)
-     else()
-         target_include_directories (OpenImageIO PRIVATE ${PUGIXML_INCLUDES})
-         target_link_libraries (OpenImageIO PRIVATE ${PUGIXML_LIBRARIES})
-     endif()
- endif()
- 
--if (FREETYPE_FOUND)
--    target_link_libraries (OpenImageIO PRIVATE ${FREETYPE_LIBRARIES})
 +if (Freetype_FOUND)
 +    target_link_libraries (OpenImageIO PRIVATE Freetype::Freetype)
  endif()
  
  if (WIN32)
 diff --git a/src/libutil/CMakeLists.txt b/src/libutil/CMakeLists.txt
-index 083b077c..4cdd4e6b 100644
+index 25d76e5c..c1950e81 100644
 --- a/src/libutil/CMakeLists.txt
 +++ b/src/libutil/CMakeLists.txt
-@@ -13,11 +13,11 @@ target_include_directories (OpenImageIO_Util
-         )
+@@ -14,19 +14,19 @@ target_include_directories (OpenImageIO_Util
  target_link_libraries (OpenImageIO_Util
          PUBLIC
+             # For OpenEXR/Imath 3.x:
+-            $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+-            $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
++            # $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
++            # $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+             # For OpenEXR >= 2.4/2.5 with reliable exported targets
+-            $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+-            $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+-            $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+-            $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
++            # $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
++            # $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
++            # $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
++            # $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
+             # For OpenEXR <= 2.3:
 -            ${ILMBASE_LIBRARIES}
 +            OpenEXR::OpenEXR
              ${GCC_ATOMIC_LIBRARIES}
          PRIVATE
              ${SANITIZE_LIBRARIES}
 -            ${Boost_LIBRARIES}
-+            Boost::Boost
++            Boost::filesystem Boost::thread Boost::system Boost::regex
              ${CMAKE_DL_LIBS}
          )
  
 diff --git a/src/oiiotool/CMakeLists.txt b/src/oiiotool/CMakeLists.txt
-index 3fde566a..adaac8bd 100644
+index e281d3f8..0fb1b425 100644
 --- a/src/oiiotool/CMakeLists.txt
 +++ b/src/oiiotool/CMakeLists.txt
-@@ -3,5 +3,5 @@
- # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+@@ -4,8 +4,8 @@
  
- fancy_add_executable (LINK_LIBRARIES OpenImageIO
--                                     ${Boost_LIBRARIES} # because regex
-+                                     Boost::regex # because regex
+ fancy_add_executable (LINK_LIBRARIES
+                         OpenImageIO
+-                        ${Boost_LIBRARIES} # because regex
+-                        $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+-                        $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+-                        ${OPENEXR_LIBRARIES}
++                        Boost::regex # because regex
++                        # $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
++                        # $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
++                        OpenEXR::OpenEXR
                        )
 diff --git a/src/openexr.imageio/CMakeLists.txt b/src/openexr.imageio/CMakeLists.txt
-index 3226eb13..bf8e0358 100644
+index 30758836..1a4d2077 100644
 --- a/src/openexr.imageio/CMakeLists.txt
 +++ b/src/openexr.imageio/CMakeLists.txt
-@@ -3,5 +3,5 @@
+@@ -3,6 +3,6 @@
  # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
  
  add_oiio_plugin (exrinput.cpp exroutput.cpp
+-                 INCLUDE_DIRS ${OPENEXR_INCLUDES} ${IMATH_INCLUDE_DIR}/OpenEXR
 -                 LINK_LIBRARIES ${OPENEXR_LIBRARIES})
++                 # INCLUDE_DIRS ${OPENEXR_INCLUDES} ${IMATH_INCLUDE_DIR}/OpenEXR
 +                 LINK_LIBRARIES OpenEXR::OpenEXR)
  
 diff --git a/src/openvdb.imageio/CMakeLists.txt b/src/openvdb.imageio/CMakeLists.txt
-index 57a0f625..61dc2459 100644
+index 57a0f625..34866390 100644
 --- a/src/openvdb.imageio/CMakeLists.txt
 +++ b/src/openvdb.imageio/CMakeLists.txt
 @@ -2,8 +2,8 @@
@@ -564,23 +633,8 @@ index 57a0f625..61dc2459 100644
 -                     INCLUDE_DIRS ${TBB_INCLUDE_DIRS}
 -                     LINK_LIBRARIES OpenVDB::OpenVDB ${TBB_tbb_LIBRARY} ${BOOST_LIBRARIES})
 +                     # INCLUDE_DIRS ${TBB_INCLUDE_DIRS}
-+                     LINK_LIBRARIES OpenVDB::OpenVDB TBB::TBB Boost::Boost)
++                     LINK_LIBRARIES OpenVDB::OpenVDB TBB::TBB)
  endif()
-diff --git a/src/png.imageio/CMakeLists.txt b/src/png.imageio/CMakeLists.txt
-index be2724f2..ac16da21 100644
---- a/src/png.imageio/CMakeLists.txt
-+++ b/src/png.imageio/CMakeLists.txt
-@@ -4,8 +4,8 @@
- 
- if (PNG_FOUND)
-     add_oiio_plugin (pnginput.cpp pngoutput.cpp
--                     INCLUDE_DIRS ${PNG_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS}
--                     LINK_LIBRARIES ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
-+                     # INCLUDE_DIRS ${PNG_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS}
-+                     LINK_LIBRARIES PNG::PNG ZLIB::ZLIB)
- else ()
-     message (WARNING "libpng not found, so PNG support will not work")
-     set (format_plugin_definitions ${format_plugin_definitions} DISABLE_PNG=1 PARENT_SCOPE)
 diff --git a/src/psd.imageio/CMakeLists.txt b/src/psd.imageio/CMakeLists.txt
 index 48bf24fb..7e1d9257 100644
 --- a/src/psd.imageio/CMakeLists.txt
@@ -595,27 +649,25 @@ index 48bf24fb..7e1d9257 100644
 +                 LINK_LIBRARIES JPEG::JPEG)
  
 diff --git a/src/ptex.imageio/CMakeLists.txt b/src/ptex.imageio/CMakeLists.txt
-index 912081b1..6039fc58 100644
+index 2f47527a..1c3c9800 100644
 --- a/src/ptex.imageio/CMakeLists.txt
 +++ b/src/ptex.imageio/CMakeLists.txt
-@@ -2,9 +2,9 @@
+@@ -2,8 +2,8 @@
  # SPDX-License-Identifier: BSD-3-Clause
  # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
  
--if (PTEX_FOUND)
+-if (Ptex_FOUND)
 +if (PTex_FOUND)
      add_oiio_plugin (ptexinput.cpp
--                     INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS} ${PTEX_INCLUDE_DIR}
--                     LINK_LIBRARIES ${PTEX_LIBRARIES} ${ZLIB_LIBRARIES}
-+                     # INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS} ${PTEX_INCLUDE_DIR}
+-                     LINK_LIBRARIES Ptex::Ptex_dynamic ZLIB::ZLIB
 +                     LINK_LIBRARIES PTex::PTex ZLIB::ZLIB
                       DEFINITIONS "-DUSE_PTEX")
  endif ()
 diff --git a/src/raw.imageio/CMakeLists.txt b/src/raw.imageio/CMakeLists.txt
-index 81a0ff54..ae229e31 100644
+index d235fd9d..ae229e31 100644
 --- a/src/raw.imageio/CMakeLists.txt
 +++ b/src/raw.imageio/CMakeLists.txt
-@@ -2,10 +2,10 @@
+@@ -2,11 +2,11 @@
  # SPDX-License-Identifier: BSD-3-Clause
  # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
  
@@ -624,50 +676,36 @@ index 81a0ff54..ae229e31 100644
      add_oiio_plugin (rawinput.cpp
 -                     INCLUDE_DIRS ${LibRaw_INCLUDE_DIR}
 -                     LINK_LIBRARIES ${LibRaw_r_LIBRARIES}
+-                     DEFINITIONS "-DUSE_LIBRAW=1" ${LibRaw_r_DEFINITIONS})
 +                     # INCLUDE_DIRS ${LibRaw_INCLUDE_DIR}
 +                     LINK_LIBRARIES libraw::libraw
-                      DEFINITIONS "-DUSE_LIBRAW=1")
++                     DEFINITIONS "-DUSE_LIBRAW=1")
  else ()
      message (WARNING "Raw plugin will not be built")
+ endif ()
 diff --git a/src/tiff.imageio/CMakeLists.txt b/src/tiff.imageio/CMakeLists.txt
-index f6d648c8..385607c9 100644
+index ab94d56d..05820e8f 100644
 --- a/src/tiff.imageio/CMakeLists.txt
 +++ b/src/tiff.imageio/CMakeLists.txt
 @@ -3,6 +3,6 @@
  # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
  
  add_oiio_plugin (tiffinput.cpp tiffoutput.cpp
--                 INCLUDE_DIRS ${TIFF_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS}
+-                 INCLUDE_DIRS ${TIFF_INCLUDE_DIR}
 -                 LINK_LIBRARIES ${TIFF_LIBRARIES} ${JPEG_LIBRARIES}
--                                ${ZLIB_LIBRARIES})
-+                 # INCLUDE_DIRS ${TIFF_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS}
++                 # INCLUDE_DIRS ${TIFF_INCLUDE_DIR}
 +                 LINK_LIBRARIES TIFF::TIFF JPEG::JPEG
-+                                ZLIB::ZLIB)
+                                 ZLIB::ZLIB)
 diff --git a/src/webp.imageio/CMakeLists.txt b/src/webp.imageio/CMakeLists.txt
-index 9e01bd7f..78fe1a58 100644
+index 44462c49..78fe1a58 100644
 --- a/src/webp.imageio/CMakeLists.txt
 +++ b/src/webp.imageio/CMakeLists.txt
-@@ -2,9 +2,9 @@
- # SPDX-License-Identifier: BSD-3-Clause
- # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+@@ -4,7 +4,7 @@
  
--if (Webp_FOUND)
-+if (WebP_FOUND)
+ if (WebP_FOUND)
      add_oiio_plugin (webpinput.cpp webpoutput.cpp
--                     LINK_LIBRARIES Webp::Webp
+-                     LINK_LIBRARIES WebP::WebP WebP::WebPDemux
 +                     LINK_LIBRARIES WebP::WebP
                       DEFINITIONS "-DUSE_WEBP=1")
  else ()
      message (STATUS "WebP plugin will not be built")
-diff --git a/src/zfile.imageio/CMakeLists.txt b/src/zfile.imageio/CMakeLists.txt
-index 36a7ad99..c8fd99d3 100644
---- a/src/zfile.imageio/CMakeLists.txt
-+++ b/src/zfile.imageio/CMakeLists.txt
-@@ -3,5 +3,5 @@
- # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
- 
- add_oiio_plugin (zfile.cpp
--                 INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS}
--                 LINK_LIBRARIES ${ZLIB_LIBRARIES})
-+                 # INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS}
-+                 LINK_LIBRARIES ZLIB::ZLIB)

--- a/recipes/openimageio/all/patches/2.3.7.2-cmake-targets.patch
+++ b/recipes/openimageio/all/patches/2.3.7.2-cmake-targets.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 447c6170..702fb50b 100644
+index 54fe7d9c..97a1b8e4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -99,7 +99,7 @@ message(STATUS "Setting Namespace to: ${PROJ_NAMESPACE_V}")
+@@ -111,7 +111,7 @@ message(STATUS "Setting Namespace to: ${PROJ_NAMESPACE_V}")
  
  
  list (APPEND CMAKE_MODULE_PATH
@@ -11,7 +11,7 @@ index 447c6170..702fb50b 100644
        "${PROJECT_SOURCE_DIR}/src/cmake")
  
  include (GNUInstallDirs)
-@@ -172,7 +172,7 @@ if (OIIO_BUILD_TOOLS AND NOT BUILD_OIIOUTIL_ONLY)
+@@ -191,7 +191,7 @@ if (OIIO_BUILD_TOOLS AND NOT BUILD_OIIOUTIL_ONLY)
      add_subdirectory (src/iinfo)
      add_subdirectory (src/maketx)
      add_subdirectory (src/oiiotool)
@@ -21,40 +21,47 @@ index 447c6170..702fb50b 100644
  endif ()
  
 diff --git a/src/cmake/compiler.cmake b/src/cmake/compiler.cmake
-index 12a8e819..46c1d0f8 100644
+index 2a513f58..13568140 100644
 --- a/src/cmake/compiler.cmake
 +++ b/src/cmake/compiler.cmake
-@@ -88,7 +88,7 @@ if (NOT MSVC)
+@@ -92,7 +92,7 @@ if (NOT MSVC)
          add_compile_options ("-Wextra")
      endif ()
      if (STOP_ON_WARNING OR DEFINED ENV{CI})
 -        add_compile_options ("-Werror")
-+        # add_compile_options ("-Werror")
-         # N.B. Force CI builds (Travis defines $CI) to use -Werror, even if
-         # STOP_ON_WARNING has been switched off by default, which we may do
-         # in release branches.
++        #add_compile_options ("-Werror")
+         # N.B. Force CI builds to use -Werror, even if STOP_ON_WARNING has
+         # been switched off by default, which we may do in release
+         # branches.
 diff --git a/src/cmake/externalpackages.cmake b/src/cmake/externalpackages.cmake
-index 03d521dc..9fe73388 100644
+index 957abe34..885becbf 100644
 --- a/src/cmake/externalpackages.cmake
 +++ b/src/cmake/externalpackages.cmake
-@@ -39,7 +39,7 @@ if (LINKSTATIC)
-     endif ()
- else ()
-     if (MSVC)
+@@ -46,7 +46,7 @@ endif ()
+ if (MSVC)
+     # Not linking Boost as static libraries: either an explicit setting or LINKSTATIC is FALSE:
+     if (NOT Boost_USE_STATIC_LIBS)
 -        add_definitions (-DBOOST_ALL_DYN_LINK=1)
 +        # add_definitions (-DBOOST_ALL_DYN_LINK=1)
      endif ()
  endif ()
- if (BOOST_CUSTOM)
-@@ -89,23 +89,27 @@ checked_find_package (OpenEXR 2.0 REQUIRED
-                       RECOMMEND_MIN 2.2
-                       RECOMMEND_MIN_REASON "for DWA compression")
- # We use Imath so commonly, may as well include it everywhere.
--include_directories ("${OPENEXR_INCLUDES}" "${ILMBASE_INCLUDES}"
--                     "${ILMBASE_INCLUDES}/OpenEXR")
+ 
+@@ -55,7 +55,7 @@ if (BOOST_CUSTOM)
+     # N.B. For a custom version, the caller had better set up the variables
+     # Boost_VERSION, Boost_INCLUDE_DIRS, Boost_LIBRARY_DIRS, Boost_LIBRARIES.
+ else ()
+-    set (Boost_COMPONENTS filesystem system thread)
++    set (Boost_COMPONENTS filesystem system thread container)
+     # The FindBoost.cmake interface is broken if it uses boost's installed
+     # cmake output (e.g. boost 1.70.0, cmake <= 3.14). Specifically it fails
+     # to set the expected variables printed below. So until that's fixed
+@@ -103,16 +103,16 @@ checked_find_package (OpenEXR REQUIRED
+ # library. This shoudn't be necessary, except for the common case of people
+ # building against Imath/OpenEXR 3.x when there is still a system-level
+ # install version of 2.x.
+-include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})
 -if (CMAKE_COMPILER_IS_CLANG AND OPENEXR_VERSION VERSION_LESS 2.3)
-+# include_directories ("${OPENEXR_INCLUDES}" "${ILMBASE_INCLUDES}"
-+#                      "${ILMBASE_INCLUDES}/OpenEXR")
++# include_directories(BEFORE ${IMATH_INCLUDES} ${OPENEXR_INCLUDES})
 +if (CMAKE_COMPILER_IS_CLANG AND OpenEXR_VERSION VERSION_LESS 2.3)
      # clang C++ >= 11 doesn't like 'register' keyword in old exr headers
      add_compile_options (-Wno-deprecated-register)
@@ -64,13 +71,21 @@ index 03d521dc..9fe73388 100644
 +    # add_definitions (-DOPENEXR_DLL) # Is this needed for new versions?
  endif ()
  
+-if (OPENEXR_VERSION VERSION_GREATER_EQUAL 2.5.99)
++if (OpenEXR_VERSION VERSION_GREATER_EQUAL 2.5.99)
+     set (OIIO_USING_IMATH 3)
+ else ()
+     set (OIIO_USING_IMATH 2)
+@@ -120,12 +120,15 @@ endif ()
+ 
  
  # JPEG -- prefer Turbo-JPEG to regular libjpeg
 -checked_find_package (JPEGTurbo
 +if (USE_JPEGTURBO)
 +    checked_find_package (libjpeg-turbo REQUIRED
                        DEFINITIONS -DUSE_JPEG_TURBO=1
--                      PRINT       JPEG_INCLUDES JPEG_LIBRARIES)
+-                      PRINT       JPEG_INCLUDES JPEG_INCLUDE_DIRS
+-                                  JPEG_LIBRARIES)
 -if (NOT JPEG_FOUND) # Try to find the non-turbo version
 +                      PRINT       libjpeg-turbo_INCLUDES libjpeg-turbo_LIBRARIES)
 +    add_library(JPEG::JPEG ALIAS libjpeg-turbo::libjpeg-turbo)
@@ -81,7 +96,15 @@ index 03d521dc..9fe73388 100644
  endif ()
  
  # Pugixml setup.  Normally we just use the version bundled with oiio, but
-@@ -123,56 +127,93 @@ endif()
+@@ -141,62 +144,85 @@ else ()
+ endif()
+ 
+ # From pythonutils.cmake
+-find_python()
++# find_python()
+ 
+ 
+ ###########################################################################
  # Dependencies for optional formats and features. If these are not found,
  # we will continue building, but the related functionality will be disabled.
  
@@ -113,11 +136,13 @@ index 03d521dc..9fe73388 100644
 +endif ()
 +if (USE_OPENCOLORIO)
 +    checked_find_package (OpenColorIO REQUIRED
-                    DEFINITIONS  -DUSE_OCIO=1 -DUSE_OPENCOLORIO=1)
--checked_find_package (OpenCV
+                       DEFINITIONS  -DUSE_OCIO=1 -DUSE_OPENCOLORIO=1
+                       # PREFER_CONFIG
+                       )
+-checked_find_package (OpenCV 3.0
 +endif ()
 +if (USE_OPENCV)
-+    checked_find_package (OpenCV REQUIRED
++    checked_find_package (OpenCV 3.0 REQUIRED
                     DEFINITIONS  -DUSE_OPENCV=1)
 +endif ()
  
@@ -126,56 +151,88 @@ index 03d521dc..9fe73388 100644
 -checked_find_package (TBB 2017
 +if (USE_TBB)
 +    checked_find_package (TBB 2017 REQUIRED
-                    DEFINITIONS  -DUSE_TBB=1
-                    ISDEPOF      OpenVDB)
+                       DEFINITIONS  -DUSE_TBB=1
+                       PREFER_CONFIG)
 +endif ()
  
--checked_find_package (DCMTK 3.6.1)  # For DICOM images
--checked_find_package (FFmpeg 2.6)
+-checked_find_package (DCMTK VERSION_MIN 3.6.1)  # For DICOM images
+-checked_find_package (FFmpeg VERSION_MIN 3.0)
 -checked_find_package (Field3D
 +if (USE_DCMTK)
-+    checked_find_package (DCMTK 3.6.1 REQUIRED)  # For DICOM images
++    checked_find_package (DCMTK REQUIRED VERSION_MIN 3.6.1)  # For DICOM images
 +endif ()
 +if (USE_FFMPEG)
-+    checked_find_package (ffmpeg 2.6 REQUIRED)
++    checked_find_package (ffmpeg REQUIRED VERSION_MIN 3.0)
 +endif ()
 +if (USE_FIELD3D)
 +    checked_find_package (Field3D REQUIRED
                     DEPS         HDF5
                     DEFINITIONS  -DUSE_FIELD3D=1)
--checked_find_package (GIF 4
+-checked_find_package (GIF
 +endif ()
 +if (USE_GIF)
-+    checked_find_package (GIF 4 REQUIRED
++    checked_find_package (GIF REQUIRED
+                       VERSION_MIN 4
                        RECOMMEND_MIN 5.0
                        RECOMMEND_MIN_REASON "for stability and thread safety")
--checked_find_package (Libheif 1.3)  # For HEIF/HEIC format
--checked_find_package (LibRaw
--                      PRINT LibRaw_r_LIBRARIES
 +endif ()
+ 
+ # For HEIF/HEIC/AVIF formats
+-checked_find_package (Libheif VERSION_MIN 1.3
 +if (USE_LIBHEIF)
-+    checked_find_package (libheif 1.3 REQUIRED)  # For HEIF/HEIC format
++    checked_find_package (libheif REQUIRED VERSION_MIN 1.3
+                       RECOMMEND_MIN 1.7
+                       RECOMMEND_MIN_REASON "for AVIF support")
+-if (APPLE AND LIBHEIF_VERSION VERSION_GREATER_EQUAL 1.10 AND LIBHEIF_VERSION VERSION_LESS 1.11)
 +endif ()
++if (0)
+     message (WARNING "Libheif 1.10 on Apple is known to be broken, disabling libheif support")
+     set (Libheif_FOUND 0)
+ endif ()
+ 
+-checked_find_package (LibRaw
 +if (USE_LIBRAW)
 +    checked_find_package (libraw REQUIRED
                        RECOMMEND_MIN 0.18
-                       RECOMMEND_MIN_REASON "for ACES support")
--checked_find_package (OpenJpeg 2.0)
--checked_find_package (OpenVDB 5.0
+-                      RECOMMEND_MIN_REASON "for ACES support and better camera metadata"
+-                      PRINT LibRaw_r_LIBRARIES)
+-if (LibRaw_FOUND AND LibRaw_VERSION VERSION_LESS 0.20 AND CMAKE_CXX_STANDARD VERSION_GREATER_EQUAL 17)
++                      RECOMMEND_MIN_REASON "for ACES support and better camera metadata")
 +endif ()
++if (0)
+     message (STATUS "${ColorYellow}WARNING When building for C++17, LibRaw should be 0.20 or higher (found ${LibRaw_VERSION}). You may get errors, depending on the compiler.${ColorReset}")
+     # Currently, we issue the above warning and let them take their chances.
+     # If we wish to disable the LibRaw<0.20/C++17 combination that may fail,
+@@ -205,30 +231,43 @@ if (LibRaw_FOUND AND LibRaw_VERSION VERSION_LESS 0.20 AND CMAKE_CXX_STANDARD VER
+     # set (LIBRAW_FOUND 0)
+ endif ()
+ 
+-checked_find_package (OpenJPEG VERSION_MIN 2.0)
+-
+-checked_find_package (OpenVDB
 +if (USE_OPENJPEG)
-+    checked_find_package (OpenJPEG 2.0 REQUIRED)
++    checked_find_package (OpenJPEG REQUIRED VERSION_MIN 2.0)
 +endif ()
 +if (USE_OPENVDB)
-+    checked_find_package (OpenVDB 5.0 REQUIRED
-                    DEPS         TBB
-                    DEFINITIONS  -DUSE_OPENVDB=1)
--checked_find_package (PTex)
--checked_find_package (Webp)
++    checked_find_package (OpenVDB REQUIRED
+                       VERSION_MIN 5.0
+                       DEPS         TBB
+                       DEFINITIONS  -DUSE_OPENVDB=1)
 +endif ()
+ 
+-checked_find_package (Ptex PREFER_CONFIG)
+-if (NOT Ptex_FOUND OR NOT Ptex_VERSION)
 +if (USE_PTEX)
-+    checked_find_package (ptex REQUIRED)
++    checked_find_package (ptex REQUIRED PREFER_CONFIG)
 +endif ()
++if (0)
+     # Fallback for inadequate Ptex exported configs. This will eventually
+     # disappear when we can 100% trust Ptex's exports.
+     unset (Ptex_FOUND)
+     checked_find_package (Ptex)
+ endif ()
+ 
+-checked_find_package (WebP)
 +if (USE_LIBWEBP)
 +    checked_find_package (WebP REQUIRED)
 +endif ()
@@ -199,7 +256,7 @@ index 03d521dc..9fe73388 100644
  
  # Qt -- used for iv
  set (qt5_modules Core Gui Widgets)
-@@ -180,7 +221,9 @@ if (OPENGL_FOUND)
+@@ -236,7 +275,9 @@ if (OPENGL_FOUND)
      list (APPEND qt5_modules OpenGL)
  endif ()
  option (USE_QT "Use Qt if found" ON)
@@ -210,7 +267,7 @@ index 03d521dc..9fe73388 100644
  if (USE_QT AND NOT Qt5_FOUND AND APPLE)
      message (STATUS "  If you think you installed qt5 with Homebrew and it still doesn't work,")
      message (STATUS "  try:   export PATH=/usr/local/opt/qt5/bin:$PATH")
-@@ -201,13 +244,13 @@ macro (find_or_download_robin_map)
+@@ -257,13 +298,13 @@ macro (find_or_download_robin_map)
      # for an installed version. Still prefer a copy that seems to be
      # locally installed in this tree.
      if (NOT BUILD_ROBINMAP_FORCE)
@@ -226,7 +283,7 @@ index 03d521dc..9fe73388 100644
          message (STATUS "Downloading local Tessil/robin-map")
          set (ROBINMAP_INSTALL_DIR "${PROJECT_SOURCE_DIR}/ext/robin-map")
          set (ROBINMAP_GIT_REPOSITORY "https://github.com/Tessil/robin-map")
-@@ -225,7 +268,7 @@ macro (find_or_download_robin_map)
+@@ -281,7 +322,7 @@ macro (find_or_download_robin_map)
          endif ()
          set (ROBINMAP_INCLUDE_DIR "${ROBINMAP_INSTALL_DIR}/include")
      endif ()
@@ -235,7 +292,7 @@ index 03d521dc..9fe73388 100644
  endmacro()
  
  
-@@ -235,7 +278,7 @@ endmacro()
+@@ -291,7 +332,7 @@ endmacro()
  option (USE_EMBEDDED_LIBSQUISH
          "Force use of embedded Libsquish, even if external is found" OFF)
  if (NOT USE_EMBEDDED_LIBSQUISH)
@@ -244,7 +301,7 @@ index 03d521dc..9fe73388 100644
  endif ()
  
  
-@@ -251,12 +294,12 @@ macro (find_or_download_fmt)
+@@ -307,12 +348,12 @@ macro (find_or_download_fmt)
      # for an installed version. Still prefer a copy that seems to be
      # locally installed in this tree.
      if (NOT BUILD_FMT_FORCE)
@@ -291,23 +348,13 @@ index ddd72044..3603eaa3 100644
                       DEFINITIONS "-DUSE_DCMTK=1")
  else ()
      message (WARNING "DICOM plugin will not be built, no DCMTK")
-diff --git a/src/dpx.imageio/CMakeLists.txt b/src/dpx.imageio/CMakeLists.txt
-index 858beb9d..dd169af4 100644
---- a/src/dpx.imageio/CMakeLists.txt
-+++ b/src/dpx.imageio/CMakeLists.txt
-@@ -6,4 +6,4 @@ add_oiio_plugin (dpxinput.cpp dpxoutput.cpp
-   libdpx/DPX.cpp libdpx/OutStream.cpp libdpx/RunLengthEncoding.cpp
-   libdpx/Codec.cpp libdpx/Reader.cpp libdpx/Writer.cpp libdpx/DPXHeader.cpp
-   libdpx/ElementReadStream.cpp libdpx/InStream.cpp libdpx/DPXColorConverter.cpp
--  LINK_LIBRARIES ${OPENEXR_LIBRARIES})
-+  LINK_LIBRARIES OpenEXR::OpenEXR)
 diff --git a/src/ffmpeg.imageio/CMakeLists.txt b/src/ffmpeg.imageio/CMakeLists.txt
-index 6cf07636..d3bb5f61 100644
+index 614b8843..0df87825 100644
 --- a/src/ffmpeg.imageio/CMakeLists.txt
 +++ b/src/ffmpeg.imageio/CMakeLists.txt
-@@ -11,11 +11,11 @@ if (NOT MSVC)
-                              PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
- endif()
+@@ -2,13 +2,13 @@
+ # SPDX-License-Identifier: BSD-3-Clause
+ # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
  
 -if (FFmpeg_FOUND)
 +if (ffmpeg_FOUND)
@@ -317,10 +364,13 @@ index 6cf07636..d3bb5f61 100644
 -                                    ${BZIP2_LIBRARIES}
 +                     # INCLUDE_DIRS ${FFMPEG_INCLUDES}
 +                     LINK_LIBRARIES ffmpeg::avcodec ffmpeg::avformat ffmpeg::swscale
-+                     #                ${BZIP2_LIBRARIES}
-                      DEFINITIONS "-DUSE_FFMPEG")
++                     #               ${BZIP2_LIBRARIES}
+                      DEFINITIONS "-DUSE_FFMPEG"
+-                                 "-DOIIO_FFMPEG_VERSION=\"${FFMPEG_VERSION}\"")
++                                 "-DOIIO_FFMPEG_VERSION=\"${ffmpeg_VERSION}\"")
  else()
      message (STATUS "FFmpeg not found: ffmpeg plugin will not be built")
+ endif()
 diff --git a/src/gif.imageio/CMakeLists.txt b/src/gif.imageio/CMakeLists.txt
 index c9e7392c..eda8b482 100644
 --- a/src/gif.imageio/CMakeLists.txt
@@ -352,23 +402,8 @@ index fed80015..2593f585 100644
                       DEFINITIONS "-DUSE_HEIF=1")
  else ()
      message (WARNING "heif plugin will not be built")
-diff --git a/src/ico.imageio/CMakeLists.txt b/src/ico.imageio/CMakeLists.txt
-index 5a46174d..a8919f63 100644
---- a/src/ico.imageio/CMakeLists.txt
-+++ b/src/ico.imageio/CMakeLists.txt
-@@ -4,8 +4,8 @@
- 
- if (PNG_FOUND)
-     add_oiio_plugin (icoinput.cpp icooutput.cpp
--                     INCLUDE_DIRS ${PNG_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS}
--                     LINK_LIBRARIES ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
-+                     # INCLUDE_DIRS ${PNG_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS}
-+                     LINK_LIBRARIES PNG::PNG ZLIB::ZLIB)
- else ()
-     message (WARNING "libpng not found, so ICO support will not work")
-     set (format_plugin_definitions ${format_plugin_definitions} DISABLE_ICO=1 PARENT_SCOPE)
 diff --git a/src/igrep/CMakeLists.txt b/src/igrep/CMakeLists.txt
-index 3fde566a..adaac8bd 100644
+index 3fde566a..49f063a8 100644
 --- a/src/igrep/CMakeLists.txt
 +++ b/src/igrep/CMakeLists.txt
 @@ -3,5 +3,5 @@
@@ -376,10 +411,10 @@ index 3fde566a..adaac8bd 100644
  
  fancy_add_executable (LINK_LIBRARIES OpenImageIO
 -                                     ${Boost_LIBRARIES} # because regex
-+                                     Boost::regex # because regex
++                                     #${Boost_LIBRARIES} # because regex
                        )
 diff --git a/src/iinfo/CMakeLists.txt b/src/iinfo/CMakeLists.txt
-index 3fde566a..adaac8bd 100644
+index 3fde566a..49f063a8 100644
 --- a/src/iinfo/CMakeLists.txt
 +++ b/src/iinfo/CMakeLists.txt
 @@ -3,5 +3,5 @@
@@ -387,14 +422,14 @@ index 3fde566a..adaac8bd 100644
  
  fancy_add_executable (LINK_LIBRARIES OpenImageIO
 -                                     ${Boost_LIBRARIES} # because regex
-+                                     Boost::regex # because regex
++                                     #${Boost_LIBRARIES} # because regex
                        )
 diff --git a/src/include/CMakeLists.txt b/src/include/CMakeLists.txt
-index a60b3b21..050911c8 100644
+index 1ea81b64..248e8a25 100644
 --- a/src/include/CMakeLists.txt
 +++ b/src/include/CMakeLists.txt
-@@ -44,17 +44,20 @@ install (FILES ${public_headers}
-          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+@@ -56,17 +56,20 @@ install (FILES ${detail_headers}
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/detail
           COMPONENT developer)
  
 +set(FMT_INCLUDES "${fmt_INCLUDE_DIR}")
@@ -415,10 +450,10 @@ index a60b3b21..050911c8 100644
  if (NOT USE_EXTERNAL_PUGIXML)
      set (pugixml_headers
 diff --git a/src/include/OpenImageIO/strutil.h b/src/include/OpenImageIO/strutil.h
-index db356f03..003df7f8 100644
+index 030d80a9..d6e768a3 100644
 --- a/src/include/OpenImageIO/strutil.h
 +++ b/src/include/OpenImageIO/strutil.h
-@@ -39,9 +39,9 @@
+@@ -41,9 +41,9 @@
  #ifndef FMT_USE_GRISU
  #    define FMT_USE_GRISU 1
  #endif
@@ -432,16 +467,16 @@ index db356f03..003df7f8 100644
  #    pragma GCC diagnostic pop
  #endif
 diff --git a/src/jpeg.imageio/CMakeLists.txt b/src/jpeg.imageio/CMakeLists.txt
-index 548faeb7..95e4feb5 100644
+index 15d50cad..83830cd2 100644
 --- a/src/jpeg.imageio/CMakeLists.txt
 +++ b/src/jpeg.imageio/CMakeLists.txt
 @@ -3,5 +3,5 @@
  # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
  
  add_oiio_plugin (jpeginput.cpp jpegoutput.cpp
--                 INCLUDE_DIRS ${JPEG_INCLUDE_DIR}
+-                 INCLUDE_DIRS ${JPEG_INCLUDE_DIRS}
 -                 LINK_LIBRARIES ${JPEG_LIBRARIES})
-+                 # INCLUDE_DIRS ${JPEG_INCLUDE_DIR}
++                 # INCLUDE_DIRS ${JPEG_INCLUDE_DIRS}
 +                 LINK_LIBRARIES JPEG::JPEG)
 diff --git a/src/jpeg2000.imageio/CMakeLists.txt b/src/jpeg2000.imageio/CMakeLists.txt
 index 575ed0b7..5644bcf3 100644
@@ -462,96 +497,133 @@ index 575ed0b7..5644bcf3 100644
  else()
      message (WARNING "Jpeg-2000 plugin will not be built")
 diff --git a/src/libOpenImageIO/CMakeLists.txt b/src/libOpenImageIO/CMakeLists.txt
-index fe39cdd4..b877cc4d 100644
+index 1e34593d..103c89de 100644
 --- a/src/libOpenImageIO/CMakeLists.txt
 +++ b/src/libOpenImageIO/CMakeLists.txt
-@@ -135,31 +135,33 @@ endif ()
- 
- target_link_libraries (OpenImageIO
+@@ -123,37 +123,42 @@ target_link_libraries (OpenImageIO
          PUBLIC
+             OpenImageIO_Util
+             # For OpenEXR/Imath 3.x:
+-            $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+-            $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
++            # $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
++            # $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+             # For OpenEXR >= 2.4/2.5 with reliable exported targets
+-            $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+-            $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
++            # $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
++            # $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+             # For OpenEXR <= 2.3:
 -            ${ILMBASE_LIBRARIES}
--            ${OPENEXR_LIBRARIES}
--            ${OpenCV_LIBRARIES}
 +            OpenEXR::OpenEXR
-+            $<$<BOOL:${OpenColorIO_FOUND}>:OpenColorIO::OpenColorIO>
              ${GCC_ATOMIC_LIBRARIES}
          PRIVATE
+             # For OpenEXR/Imath 3.x:
+-            $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
++            # $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+             # For OpenEXR >= 2.4/2.5 with reliable exported targets
+-            $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+-            $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+-            $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
++            # $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
++            # $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
++            # $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
+             # For OpenEXR <= 2.3:
+-            ${OPENEXR_LIBRARIES}
+-            ${OpenCV_LIBRARIES}
++            # ${OPENEXR_LIBRARIES}
++            # ${OpenCV_LIBRARIES}
              ${SANITIZE_LIBRARIES}
              ${format_plugin_libs} # Add all the target link libraries from the plugins
--            $<$<BOOL:${OpenColorIO_FOUND}>:OpenColorIO::OpenColorIO>
--            ${BZIP2_LIBRARIES}
--            ${ZLIB_LIBRARIES}
--            ${Boost_LIBRARIES}
 +            tsl::robin_map
-+            ZLIB::ZLIB
-+            Boost::Boost
+             $<$<TARGET_EXISTS:OpenColorIO::OpenColorIO>:OpenColorIO::OpenColorIO>
+-            $<$<TARGET_EXISTS:OpenColorIO::OpenColorIOHeaders>:OpenColorIO::OpenColorIOHeaders>
++            # $<$<TARGET_EXISTS:OpenColorIO::OpenColorIOHeaders>:OpenColorIO::OpenColorIOHeaders>
+             $<$<BOOL:${pugixml_FOUND}>:pugixml::pugixml>
+-            ${BZIP2_LIBRARIES}
++            # ${BZIP2_LIBRARIES}
+             ZLIB::ZLIB
+-            ${Boost_LIBRARIES}
++            Boost::filesystem Boost::thread Boost::system Boost::container
              ${CMAKE_DL_LIBS}
          )
  
+-if (FREETYPE_FOUND)
+-    target_link_libraries (OpenImageIO PRIVATE ${FREETYPE_LIBRARIES})
 +if (OpenCV_FOUND)
 +    target_link_libraries (OpenImageIO PUBLIC opencv::opencv_core opencv::opencv_imgproc opencv::opencv_videoio)
 +endif ()
 +
- if (USE_EXTERNAL_PUGIXML)
--    if(TARGET pugixml)
--        target_link_libraries (OpenImageIO PRIVATE pugixml)
-+    if(pugixml_FOUND)
-+        target_link_libraries (OpenImageIO PRIVATE pugixml::pugixml)
-     else()
-         target_include_directories (OpenImageIO PRIVATE ${PUGIXML_INCLUDES})
-         target_link_libraries (OpenImageIO PRIVATE ${PUGIXML_LIBRARIES})
-     endif()
- endif()
- 
--if (FREETYPE_FOUND)
--    target_link_libraries (OpenImageIO PRIVATE ${FREETYPE_LIBRARIES})
 +if (Freetype_FOUND)
 +    target_link_libraries (OpenImageIO PRIVATE Freetype::Freetype)
  endif()
  
  if (WIN32)
 diff --git a/src/libutil/CMakeLists.txt b/src/libutil/CMakeLists.txt
-index 083b077c..4cdd4e6b 100644
+index 7de38836..3e1609ad 100644
 --- a/src/libutil/CMakeLists.txt
 +++ b/src/libutil/CMakeLists.txt
-@@ -13,11 +13,11 @@ target_include_directories (OpenImageIO_Util
-         )
+@@ -14,19 +14,19 @@ target_include_directories (OpenImageIO_Util
  target_link_libraries (OpenImageIO_Util
          PUBLIC
+             # For OpenEXR/Imath 3.x:
+-            $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+-            $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
++            # $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
++            # $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+             # For OpenEXR >= 2.4/2.5 with reliable exported targets
+-            $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+-            $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+-            $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+-            $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
++            # $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
++            # $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
++            # $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
++            # $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
+             # For OpenEXR <= 2.3:
 -            ${ILMBASE_LIBRARIES}
 +            OpenEXR::OpenEXR
              ${GCC_ATOMIC_LIBRARIES}
          PRIVATE
              ${SANITIZE_LIBRARIES}
 -            ${Boost_LIBRARIES}
-+            Boost::Boost
++            Boost::filesystem Boost::thread Boost::system
              ${CMAKE_DL_LIBS}
          )
  
 diff --git a/src/oiiotool/CMakeLists.txt b/src/oiiotool/CMakeLists.txt
-index 3fde566a..adaac8bd 100644
+index e281d3f8..4ee92aad 100644
 --- a/src/oiiotool/CMakeLists.txt
 +++ b/src/oiiotool/CMakeLists.txt
-@@ -3,5 +3,5 @@
- # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+@@ -4,8 +4,8 @@
  
- fancy_add_executable (LINK_LIBRARIES OpenImageIO
--                                     ${Boost_LIBRARIES} # because regex
-+                                     Boost::regex # because regex
+ fancy_add_executable (LINK_LIBRARIES
+                         OpenImageIO
+-                        ${Boost_LIBRARIES} # because regex
+-                        $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+-                        $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+-                        ${OPENEXR_LIBRARIES}
++                        Boost::container
++                        # $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
++                        # $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
++                        OpenEXR::OpenEXR
                        )
 diff --git a/src/openexr.imageio/CMakeLists.txt b/src/openexr.imageio/CMakeLists.txt
-index 3226eb13..bf8e0358 100644
+index d4772880..9f5f8998 100644
 --- a/src/openexr.imageio/CMakeLists.txt
 +++ b/src/openexr.imageio/CMakeLists.txt
-@@ -3,5 +3,5 @@
- # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
- 
- add_oiio_plugin (exrinput.cpp exroutput.cpp
--                 LINK_LIBRARIES ${OPENEXR_LIBRARIES})
-+                 LINK_LIBRARIES OpenEXR::OpenEXR)
+@@ -12,7 +12,7 @@ if (OIIO_USE_EXR_C_API)
+     LINK_LIBRARIES OpenEXR::OpenEXRCore)
+ else()
+   add_oiio_plugin (exrinput.cpp exroutput.cpp
+-    INCLUDE_DIRS ${OPENEXR_INCLUDES} ${IMATH_INCLUDE_DIR}/OpenEXR
+-    LINK_LIBRARIES ${OPENEXR_LIBRARIES})
++    #INCLUDE_DIRS ${OPENEXR_INCLUDES} ${IMATH_INCLUDE_DIR}/OpenEXR
++    LINK_LIBRARIES OpenEXR::OpenEXR)
+ endif()
  
 diff --git a/src/openvdb.imageio/CMakeLists.txt b/src/openvdb.imageio/CMakeLists.txt
-index 57a0f625..61dc2459 100644
+index 57a0f625..986f9c21 100644
 --- a/src/openvdb.imageio/CMakeLists.txt
 +++ b/src/openvdb.imageio/CMakeLists.txt
 @@ -2,8 +2,8 @@
@@ -561,28 +633,12 @@ index 57a0f625..61dc2459 100644
 -if (OpenVDB_FOUND)
 +if (OpenVDB_FOUND AND TBB_FOUND)
      add_oiio_plugin (openvdbinput.cpp
--                     INCLUDE_DIRS ${TBB_INCLUDE_DIRS}
+                      INCLUDE_DIRS ${TBB_INCLUDE_DIRS}
 -                     LINK_LIBRARIES OpenVDB::OpenVDB ${TBB_tbb_LIBRARY} ${BOOST_LIBRARIES})
-+                     # INCLUDE_DIRS ${TBB_INCLUDE_DIRS}
-+                     LINK_LIBRARIES OpenVDB::OpenVDB TBB::TBB Boost::Boost)
++                     LINK_LIBRARIES OpenVDB::OpenVDB TBB::TBB)
  endif()
-diff --git a/src/png.imageio/CMakeLists.txt b/src/png.imageio/CMakeLists.txt
-index be2724f2..ac16da21 100644
---- a/src/png.imageio/CMakeLists.txt
-+++ b/src/png.imageio/CMakeLists.txt
-@@ -4,8 +4,8 @@
- 
- if (PNG_FOUND)
-     add_oiio_plugin (pnginput.cpp pngoutput.cpp
--                     INCLUDE_DIRS ${PNG_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS}
--                     LINK_LIBRARIES ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
-+                     # INCLUDE_DIRS ${PNG_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS}
-+                     LINK_LIBRARIES PNG::PNG ZLIB::ZLIB)
- else ()
-     message (WARNING "libpng not found, so PNG support will not work")
-     set (format_plugin_definitions ${format_plugin_definitions} DISABLE_PNG=1 PARENT_SCOPE)
 diff --git a/src/psd.imageio/CMakeLists.txt b/src/psd.imageio/CMakeLists.txt
-index 48bf24fb..7e1d9257 100644
+index 48bf24fb..a5acecfd 100644
 --- a/src/psd.imageio/CMakeLists.txt
 +++ b/src/psd.imageio/CMakeLists.txt
 @@ -3,6 +3,6 @@
@@ -591,83 +647,64 @@ index 48bf24fb..7e1d9257 100644
  add_oiio_plugin (psdinput.cpp jpeg_memory_src.cpp
 -                 INCLUDE_DIRS ${JPEG_INCLUDE_DIR}
 -                 LINK_LIBRARIES ${JPEG_LIBRARIES})
-+                 # INCLUDE_DIRS ${JPEG_INCLUDE_DIR}
++                 #INCLUDE_DIRS ${JPEG_INCLUDE_DIR}
 +                 LINK_LIBRARIES JPEG::JPEG)
  
 diff --git a/src/ptex.imageio/CMakeLists.txt b/src/ptex.imageio/CMakeLists.txt
-index 912081b1..6039fc58 100644
+index 2f47527a..1c3c9800 100644
 --- a/src/ptex.imageio/CMakeLists.txt
 +++ b/src/ptex.imageio/CMakeLists.txt
-@@ -2,9 +2,9 @@
+@@ -2,8 +2,8 @@
  # SPDX-License-Identifier: BSD-3-Clause
  # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
  
--if (PTEX_FOUND)
+-if (Ptex_FOUND)
 +if (PTex_FOUND)
      add_oiio_plugin (ptexinput.cpp
--                     INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS} ${PTEX_INCLUDE_DIR}
--                     LINK_LIBRARIES ${PTEX_LIBRARIES} ${ZLIB_LIBRARIES}
-+                     # INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS} ${PTEX_INCLUDE_DIR}
+-                     LINK_LIBRARIES Ptex::Ptex_dynamic ZLIB::ZLIB
 +                     LINK_LIBRARIES PTex::PTex ZLIB::ZLIB
                       DEFINITIONS "-DUSE_PTEX")
  endif ()
 diff --git a/src/raw.imageio/CMakeLists.txt b/src/raw.imageio/CMakeLists.txt
-index 81a0ff54..ae229e31 100644
+index d235fd9d..6661a2a8 100644
 --- a/src/raw.imageio/CMakeLists.txt
 +++ b/src/raw.imageio/CMakeLists.txt
-@@ -2,10 +2,10 @@
- # SPDX-License-Identifier: BSD-3-Clause
- # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+@@ -4,9 +4,9 @@
  
--if (LIBRAW_FOUND)
-+if (libraw_FOUND)
+ if (LIBRAW_FOUND)
      add_oiio_plugin (rawinput.cpp
 -                     INCLUDE_DIRS ${LibRaw_INCLUDE_DIR}
 -                     LINK_LIBRARIES ${LibRaw_r_LIBRARIES}
-+                     # INCLUDE_DIRS ${LibRaw_INCLUDE_DIR}
+-                     DEFINITIONS "-DUSE_LIBRAW=1" ${LibRaw_r_DEFINITIONS})
++                     #INCLUDE_DIRS ${LibRaw_INCLUDE_DIR}
 +                     LINK_LIBRARIES libraw::libraw
-                      DEFINITIONS "-DUSE_LIBRAW=1")
++                     DEFINITIONS "-DUSE_LIBRAW=1")
  else ()
      message (WARNING "Raw plugin will not be built")
+ endif ()
 diff --git a/src/tiff.imageio/CMakeLists.txt b/src/tiff.imageio/CMakeLists.txt
-index f6d648c8..385607c9 100644
+index ab94d56d..99ee19ae 100644
 --- a/src/tiff.imageio/CMakeLists.txt
 +++ b/src/tiff.imageio/CMakeLists.txt
 @@ -3,6 +3,6 @@
  # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
  
  add_oiio_plugin (tiffinput.cpp tiffoutput.cpp
--                 INCLUDE_DIRS ${TIFF_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS}
+-                 INCLUDE_DIRS ${TIFF_INCLUDE_DIR}
 -                 LINK_LIBRARIES ${TIFF_LIBRARIES} ${JPEG_LIBRARIES}
--                                ${ZLIB_LIBRARIES})
-+                 # INCLUDE_DIRS ${TIFF_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS}
++                 #INCLUDE_DIRS ${TIFF_INCLUDE_DIR}
 +                 LINK_LIBRARIES TIFF::TIFF JPEG::JPEG
-+                                ZLIB::ZLIB)
+                                 ZLIB::ZLIB)
 diff --git a/src/webp.imageio/CMakeLists.txt b/src/webp.imageio/CMakeLists.txt
-index 9e01bd7f..78fe1a58 100644
+index 44462c49..78fe1a58 100644
 --- a/src/webp.imageio/CMakeLists.txt
 +++ b/src/webp.imageio/CMakeLists.txt
-@@ -2,9 +2,9 @@
- # SPDX-License-Identifier: BSD-3-Clause
- # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
+@@ -4,7 +4,7 @@
  
--if (Webp_FOUND)
-+if (WebP_FOUND)
+ if (WebP_FOUND)
      add_oiio_plugin (webpinput.cpp webpoutput.cpp
--                     LINK_LIBRARIES Webp::Webp
+-                     LINK_LIBRARIES WebP::WebP WebP::WebPDemux
 +                     LINK_LIBRARIES WebP::WebP
                       DEFINITIONS "-DUSE_WEBP=1")
  else ()
      message (STATUS "WebP plugin will not be built")
-diff --git a/src/zfile.imageio/CMakeLists.txt b/src/zfile.imageio/CMakeLists.txt
-index 36a7ad99..c8fd99d3 100644
---- a/src/zfile.imageio/CMakeLists.txt
-+++ b/src/zfile.imageio/CMakeLists.txt
-@@ -3,5 +3,5 @@
- # https://github.com/OpenImageIO/oiio/blob/master/LICENSE.md
- 
- add_oiio_plugin (zfile.cpp
--                 INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS}
--                 LINK_LIBRARIES ${ZLIB_LIBRARIES})
-+                 # INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS}
-+                 LINK_LIBRARIES ZLIB::ZLIB)

--- a/recipes/openimageio/all/test_package/CMakeLists.txt
+++ b/recipes/openimageio/all/test_package/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(OpenImageIO REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} OpenImageIO::OpenImageIO)

--- a/recipes/openimageio/all/test_package/CMakeLists.txt
+++ b/recipes/openimageio/all/test_package/CMakeLists.txt
@@ -6,4 +6,3 @@ conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/openimageio/all/test_package/conanfile.py
+++ b/recipes/openimageio/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         version = tools.Version(self.deps_cpp_info["openimageio"].version)

--- a/recipes/openimageio/all/test_package/conanfile.py
+++ b/recipes/openimageio/all/test_package/conanfile.py
@@ -6,11 +6,13 @@ class TestPackageConan(ConanFile):
     generators = "cmake"
 
     def build(self):
+        version = tools.Version(self.deps_cpp_info["openimageio"].version)
         cmake = CMake(self)
+        cmake.definitions["CMAKE_CXX_STANDARD"] = 14 if version >= "2.3.0.0" else 11
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/openimageio/config.yml
+++ b/recipes/openimageio/config.yml
@@ -1,3 +1,7 @@
 versions:
   "2.2.7.0":
     folder: all
+  "2.2.18.0":
+    folder: all
+  "2.3.7.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **openimageio/2.2.7.0**, **openimageio/2.2.18.0**, **openimageio/2.3.7.2**

Adds many new dependency libraries which are now available in Conan. The `with_dicom` and `with_raw` flag names and default values were left as-is to preserve compatibility.

Each version requires their own patch due to changes in CMake scripts.

There are some diamond dependency conflicts. I currently handle them by using `requires` with `override=True`. As far as I know this is has not been done in any conan center packages. So how do I handle this situation?

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
