### PR TITLE
winflexbison: modernize + add mingw support

### DIFF
--- a/recipes/winflexbison/all/conandata.yml
+++ b/recipes/winflexbison/all/conandata.yml
@@ -1,7 +1,14 @@
 sources:
-  "2.5.22":
-    url: "https://github.com/lexxmark/winflexbison/archive/v2.5.22.tar.gz"
-    sha256: "697c2c4af3308625605b75498bd63a9a294660f8e43a4c35452cf4334fa4a530"
   "2.5.24":
     url: "https://github.com/lexxmark/winflexbison/archive/v2.5.24.tar.gz"
     sha256: "a49d6e310636e3487e1e066e411d908cfeae2d5b5fde1f3cf74fe1d6d4301062"
+  "2.5.22":
+    url: "https://github.com/lexxmark/winflexbison/archive/v2.5.22.tar.gz"
+    sha256: "697c2c4af3308625605b75498bd63a9a294660f8e43a4c35452cf4334fa4a530"
+patches:
+  "2.5.24":
+    - patch_file: "patches/0001-2.5.24-mingw-support.patch"
+      base_path: "source_subfolder"
+  "2.5.22":
+    - patch_file: "patches/0001-2.5.22-mingw-support.patch"
+      base_path: "source_subfolder"

--- a/recipes/winflexbison/all/conanfile.py
+++ b/recipes/winflexbison/all/conanfile.py
@@ -1,41 +1,45 @@
-import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import functools
+import os
+
+required_conan_version = ">= 1.33.0"
+
 
 class WinflexbisonConan(ConanFile):
     name = "winflexbison"
     description = "Flex and Bison for Windows"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/lexxmark/winflexbison"
-    topics = ("conan", "winflexbison", "flex", "bison")
-
+    topics = ("flex", "bison")
     generators = "cmake"
     license = "GPL-3.0-or-later"
-    exports_sources = ["CMakeLists.txt"]
+    settings = "os", "arch", "compiler", "build_type"
 
-    settings = "os", "build_type", "arch", "compiler"
+    exports_sources = "CMakeLists.txt", "patches/*"
 
-    _source_subfolder = "source_subfolder"
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
-    _cmake = None
-
-    def config_options(self):
+    def validate(self):
         if self.settings.os != "Windows":
             raise ConanInvalidConfiguration("winflexbison is only supported on Windows.")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.configure()
-        return self._cmake
+        cmake = CMake(self)
+        cmake.verbose = True
+        cmake.configure()
+        return cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -50,19 +54,19 @@ class WinflexbisonConan(ConanFile):
     def package(self):
         if self.settings.build_type in ("Release", "Debug") and tools.Version(self.version) < "2.5.23":
             actual_build_path = "{0}/bin/{1}".format(self._source_subfolder, self.settings.build_type)
-            self.copy(pattern="*.exe", dst="bin", src=actual_build_path, keep_path=False)
+            self.copy("*.exe", src=actual_build_path, dst="bin", keep_path=False)
         else:
-            self.copy(pattern="*.exe", dst="bin", src="bin", keep_path=False)
-        self.copy(pattern="data/*", dst="bin", src="{}/bison".format(self._source_subfolder), keep_path=True)
-        self.copy(pattern="FlexLexer.h", dst="include", src=os.path.join(self._source_subfolder, "flex", "src"), keep_path=False)
+            self.copy("*.exe", src="bin", dst="bin", keep_path=False)
+        self.copy("data/*", src="{}/bison".format(self._source_subfolder), dst="bin", keep_path=True)
+        self.copy("FlexLexer.h", src=os.path.join(self._source_subfolder, "flex", "src"), dst="include", keep_path=False)
 
         # Copy licenses
         self._extract_license()
-        self.copy(pattern="COPYING.GPL3", dst="licenses")
-        self.copy(pattern="COPYING", dst="licenses", src=os.path.join(self._source_subfolder, "flex", "src"), keep_path=False)
-        os.rename(os.path.join(self.package_folder, "licenses", "COPYING"), os.path.join(self.package_folder, "licenses", "bison-license"))
-        self.copy(pattern="COPYING", dst="licenses", src=os.path.join(self._source_subfolder, "bison", "src"), keep_path=False)
-        os.rename(os.path.join(self.package_folder, "licenses", "COPYING"), os.path.join(self.package_folder, "licenses", "flex-license"))
+        self.copy("COPYING.GPL3", dst="licenses")
+        self.copy("COPYING", src=os.path.join(self._source_subfolder, "flex", "src"), dst="licenses", keep_path=False)
+        tools.rename(os.path.join(self.package_folder, "licenses", "COPYING"), os.path.join(self.package_folder, "licenses", "bison-license"))
+        self.copy("COPYING", src=os.path.join(self._source_subfolder, "bison", "src"), dst="licenses", keep_path=False)
+        tools.rename(os.path.join(self.package_folder, "licenses", "COPYING"), os.path.join(self.package_folder, "licenses", "flex-license"))
 
     def package_info(self):
         bindir = os.path.join(self.package_folder, "bin")

--- a/recipes/winflexbison/all/conanfile.py
+++ b/recipes/winflexbison/all/conanfile.py
@@ -33,7 +33,6 @@ class WinflexbisonConan(ConanFile):
     @functools.lru_cache(1)
     def _configure_cmake(self):
         cmake = CMake(self)
-        cmake.verbose = True
         cmake.configure()
         return cmake
 

--- a/recipes/winflexbison/all/patches/0001-2.5.22-mingw-support.patch
+++ b/recipes/winflexbison/all/patches/0001-2.5.22-mingw-support.patch
@@ -1,0 +1,207 @@
+--- bison/src/config.h
++++ bison/src/config.h
+@@ -1,3 +1,4 @@
++#pragma once
+ #define PACKAGE_BUGREPORT "http://sourceforge.net/p/winflexbison/tickets"
+ #define VERSION "3.5.0"
+ #define PACKAGE_COPYRIGHT_YEAR 2019
+--- bison/src/conflicts.c
++++ bison/src/conflicts.c
+@@ -29,7 +29,7 @@
+ #include "getargs.h"
+ #include "gram.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "print-xml.h"
+ #include "reader.h"
+ #include "state.h"
+--- bison/src/lalr.c
++++ bison/src/lalr.c
+@@ -33,7 +33,7 @@
+ #include "getargs.h"
+ #include "gram.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "muscle-tab.h"
+ #include "nullable.h"
+ #include "reader.h"
+--- bison/src/LR0.c
++++ bison/src/LR0.c
+@@ -32,7 +32,7 @@
+ #include "getargs.h"
+ #include "gram.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "reader.h"
+ #include "reduce.h"
+ #include "state.h"
+--- bison/src/main.c
++++ bison/src/main.c
+@@ -40,7 +40,7 @@
+ #include "gram.h"
+ #include "ielr.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "muscle-tab.h"
+ #include "nullable.h"
+ #include "output.h"
+--- bison/src/print.c
++++ bison/src/print.c
+@@ -29,7 +29,7 @@
+ #include "getargs.h"
+ #include "gram.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "muscle-tab.h"
+ #include "print.h"
+ #include "reader.h"
+--- bison/src/print-graph.c
++++ bison/src/print-graph.c
+@@ -31,7 +31,7 @@
+ #include "gram.h"
+ #include "graphviz.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "reader.h"
+ #include "state.h"
+ #include "symtab.h"
+--- bison/src/print-xml.c
++++ bison/src/print-xml.c
+@@ -32,7 +32,7 @@
+ #include "getargs.h"
+ #include "gram.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "print.h"
+ #include "reader.h"
+ #include "reduce.h"
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -3,24 +3,24 @@
+ project (winflexbison)
+ 
+ if(NOT MSVC)
+-   message( FATAL_ERROR "Visual Studio Build supported only" )
++#   message( FATAL_ERROR "Visual Studio Build supported only" )
+ endif()
+ 
+ # Output Variables
+ set(OUTPUT_DEBUG "${CMAKE_CURRENT_LIST_DIR}/bin/Debug")
+ set(OUTPUT_RELEASE "${CMAKE_CURRENT_LIST_DIR}/bin/Release")
+-
++if(MSVC)
+ add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+-
++endif()
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${OUTPUT_DEBUG}")
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${OUTPUT_RELEASE}")
+ 
+ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+   add_definitions(-D_DEBUG)
+ endif()
+ 
+-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /W3 /MD /Od /Zi /EHsc")
+-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /GL /Od /Oi /Gy /Zi /EHsc")
++#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /W3 /MD /Od /Zi /EHsc")
++#set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /GL /Od /Oi /Gy /Zi /EHsc")
+ 
+ # Define Release by default.
+ if(NOT CMAKE_BUILD_TYPE)
+--- common/CMakeLists.txt
++++ common/CMakeLists.txt
+@@ -4,6 +4,12 @@
+ 
+ project(${PROJECT_NAME} C)
+ 
++include(CheckSymbolExists)
++check_symbol_exists(nanouptime "sys/time.h" HAVE_NANOUPTIME)
++check_symbol_exists(clock_gettime "time.h" HAVE_CLOCK_GETTIME)
++check_symbol_exists(microuptime "sys/time.h" HAVE_MICROUPTIME)
++check_symbol_exists(timespec_get "time.h" HAVE_TIMESPEC_GET)
++
+ # Definition of Macros
+ add_definitions(-D_LIB)
+ 
+@@ -27,6 +33,12 @@
+ add_library(${PROJECT_NAME} STATIC
+    ${SOURCE_FILES}
+ )
++target_compile_definitions(${PROJECT_NAME} PRIVATE
++    $<$<BOOL:${HAVE_NANOUPTIME}>:HAVE_NANOUPTIME=1>
++    $<$<BOOL:${HAVE_CLOCK_GETTIME}>:HAVE_CLOCK_GETTIME=1>
++    $<$<BOOL:${HAVE_MICROUPTIME}>:HAVE_MICROUPTIME=1>
++    $<$<BOOL:${HAVE_TIMESPEC_GET}>:HAVE_TIMESPEC_GET=1>
++)
+ 
+ target_include_directories(${PROJECT_NAME} PUBLIC "misc")
+ target_include_directories(${PROJECT_NAME} PUBLIC "m4")
+--- common/m4/lib/clean-temp.h
++++ common/m4/lib/clean-temp.h
+@@ -107,7 +107,7 @@
+    Return 0 upon success, or -1 if there was some problem.  */
+ extern int cleanup_temp_dir (struct temp_dir *dir);
+-
+-typedef int mode_t;
+-
++#if defined _MSC_VER
++typedef int mode_t;
++#endif
+ /* Open a temporary file in a temporary directory.
+    Registers the resulting file descriptor to be closed.  */
+--- common/misc/gethrxtime.c
++++ common/misc/gethrxtime.c
+@@ -27,6 +27,6 @@
+-//#include <sys/time.h>
+ #include "timespec.h"
+-
++#if HAVE_CLOCK_GETTIME
++#include <pthread_time.h>
++#endif
+ /* Get the current time, as a count of the number of nanoseconds since
+    an arbitrary epoch (e.g., the system boot time).  Prefer a
+-   high-resolution clock that is not subject to resetting or
+@@ -49,8 +49,8 @@
+     if (clock_gettime (CLOCK_MONOTONIC, &ts) == 0)
+       return xtime_make (ts.tv_sec, ts.tv_nsec);
+   }
+-#  endif
+-
++#  
++#  else
+ #  if HAVE_MICROUPTIME
+   {
+     struct timeval tv;
+@@ -69,6 +69,6 @@
+   }
+ #  endif
+ # endif
++# endif
+ }
+-
+ #endif
+--- flex/CMakeLists.txt
++++ flex/CMakeLists.txt
+@@ -22,4 +22,4 @@
+ 
+ target_include_directories(${PROJECT_NAME} PRIVATE "src")
+ 
+-target_link_libraries(${PROJECT_NAME} common_lib kernel32.lib user32.lib Ws2_32.lib)
++target_link_libraries(${PROJECT_NAME} common_lib kernel32 user32 ws2_32)
+--- flex/src/tables.c
++++ flex/src/tables.c
+@@ -36,7 +36,7 @@
+ #include "flexdef.h"
+ #include "tables.h"
+ 
+-#include <Winsock2.h>
++#include <winsock2.h>
+ 
+ /** Convert size_t to t_flag.
+  *  @param n in {1,2,4}

--- a/recipes/winflexbison/all/patches/0001-2.5.24-mingw-support.patch
+++ b/recipes/winflexbison/all/patches/0001-2.5.24-mingw-support.patch
@@ -1,0 +1,201 @@
+--- bison/src/config.h
++++ bison/src/config.h
+@@ -1,3 +1,4 @@
++#pragma once
+ #define PACKAGE_BUGREPORT "https://github.com/lexxmark/winflexbison/issues"
+ #define VERSION "3.7.4"
+ #define PACKAGE_COPYRIGHT_YEAR 2020
+--- bison/src/conflicts.c
++++ bison/src/conflicts.c
+@@ -30,7 +30,7 @@
+ #include "getargs.h"
+ #include "gram.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "print-xml.h"
+ #include "reader.h"
+ #include "state.h"
+--- bison/src/lalr.c
++++ bison/src/lalr.c
+@@ -33,7 +33,7 @@
+ #include "getargs.h"
+ #include "gram.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "muscle-tab.h"
+ #include "nullable.h"
+ #include "reader.h"
+--- bison/src/LR0.c
++++ bison/src/LR0.c
+@@ -32,7 +32,7 @@
+ #include "getargs.h"
+ #include "gram.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "reader.h"
+ #include "reduce.h"
+ #include "state.h"
+--- bison/src/main.c
++++ bison/src/main.c
+@@ -45,7 +45,7 @@
+ #include "gram.h"
+ #include "ielr.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "muscle-tab.h"
+ #include "nullable.h"
+ #include "output.h"
+--- bison/src/print.c
++++ bison/src/print.c
+@@ -35,7 +35,7 @@
+ #include "getargs.h"
+ #include "gram.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "muscle-tab.h"
+ #include "reader.h"
+ #include "reduce.h"
+--- bison/src/print-graph.c
++++ bison/src/print-graph.c
+@@ -31,7 +31,7 @@
+ #include "gram.h"
+ #include "graphviz.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "reader.h"
+ #include "state.h"
+ #include "symtab.h"
+--- bison/src/print-xml.c
++++ bison/src/print-xml.c
+@@ -32,7 +32,7 @@
+ #include "getargs.h"
+ #include "gram.h"
+ #include "lalr.h"
+-#include "lr0.h"
++#include "LR0.h"
+ #include "print.h"
+ #include "reader.h"
+ #include "reduce.h"
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -2,18 +2,18 @@
+ 
+ project (winflexbison)
+ 
+-if(NOT MSVC)
+-   message( FATAL_ERROR "Visual Studio Build supported only" )
++if(MSVC)
++  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+ endif()
+ 
+-add_definitions(-D_CRT_SECURE_NO_WARNINGS)
++
+ 
+ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+   add_definitions(-D_DEBUG)
+ endif()
+ 
+-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /W3 /MD /Od /Zi /EHsc")
+-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /GL /Od /Oi /Gy /Zi /EHsc")
++#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /W3 /MD /Od /Zi /EHsc")
++#set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /W3 /GL /Od /Oi /Gy /Zi /EHsc")
+ 
+ # Define Release by default.
+ if(NOT CMAKE_BUILD_TYPE)
+--- common/CMakeLists.txt
++++ common/CMakeLists.txt
+@@ -4,6 +4,12 @@
+ 
+ project(${PROJECT_NAME} C)
+ 
++include(CheckSymbolExists)
++check_symbol_exists(nanouptime "sys/time.h" HAVE_NANOUPTIME)
++check_symbol_exists(clock_gettime "time.h" HAVE_CLOCK_GETTIME)
++check_symbol_exists(microuptime "sys/time.h" HAVE_MICROUPTIME)
++check_symbol_exists(timespec_get "time.h" HAVE_TIMESPEC_GET)
++
+ # Definition of Macros
+ add_definitions(-D_LIB)
+ 
+@@ -27,6 +33,12 @@
+ add_library(${PROJECT_NAME} STATIC
+    ${SOURCE_FILES}
+ )
++target_compile_definitions(${PROJECT_NAME} PRIVATE
++    $<$<BOOL:${HAVE_NANOUPTIME}>:HAVE_NANOUPTIME=1>
++    $<$<BOOL:${HAVE_CLOCK_GETTIME}>:HAVE_CLOCK_GETTIME=1>
++    $<$<BOOL:${HAVE_MICROUPTIME}>:HAVE_MICROUPTIME=1>
++    $<$<BOOL:${HAVE_TIMESPEC_GET}>:HAVE_TIMESPEC_GET=1>
++)
+ 
+ target_include_directories(${PROJECT_NAME} PUBLIC "misc")
+ target_include_directories(${PROJECT_NAME} PUBLIC "m4")
+--- common/m4/lib/clean-temp.h
++++ common/m4/lib/clean-temp.h
+@@ -107,7 +107,7 @@
+    Return 0 upon success, or -1 if there was some problem.  */
+ extern int cleanup_temp_dir (struct temp_dir *dir);
+-
+-typedef int mode_t;
+-
++#if defined _MSC_VER
++typedef int mode_t;
++#endif
+ /* Open a temporary file in a temporary directory.
+    Registers the resulting file descriptor to be closed.  */
+--- common/misc/gethrxtime.c
++++ common/misc/gethrxtime.c
+@@ -27,6 +27,6 @@
+-//#include <sys/time.h>
+ #include "timespec.h"
+-
++#if HAVE_CLOCK_GETTIME
++#include <pthread_time.h>
++#endif
+ /* Get the current time, as a count of the number of nanoseconds since
+    an arbitrary epoch (e.g., the system boot time).  Prefer a
+-   high-resolution clock that is not subject to resetting or
+@@ -49,8 +49,8 @@
+     if (clock_gettime (CLOCK_MONOTONIC, &ts) == 0)
+       return xtime_make (ts.tv_sec, ts.tv_nsec);
+   }
+-#  endif
+-
++#  
++#  else
+ #  if HAVE_MICROUPTIME
+   {
+     struct timeval tv;
+@@ -69,6 +69,6 @@
+   }
+ #  endif
+ # endif
++# endif
+ }
+-
+ #endif
+--- flex/CMakeLists.txt
++++ flex/CMakeLists.txt
+@@ -22,4 +22,4 @@
+ 
+ target_include_directories(${PROJECT_NAME} PRIVATE "src")
+ 
+-target_link_libraries(${PROJECT_NAME} winflexbison_common kernel32.lib user32.lib Ws2_32.lib)
++target_link_libraries(${PROJECT_NAME} winflexbison_common kernel32 user32 ws2_32)
+--- flex/src/tables.c
++++ flex/src/tables.c
+@@ -36,7 +36,7 @@
+ #include "flexdef.h"
+ #include "tables.h"
+ 
+-#include <Winsock2.h>
++#include <winsock2.h>
+ 
+ /** Convert size_t to t_flag.
+  *  @param n in {1,2,4}

--- a/recipes/winflexbison/all/test_package/CMakeLists.txt
+++ b/recipes/winflexbison/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(test_package)
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 # Flex
 
@@ -11,7 +11,7 @@ if(MSVC)
     set(FLEX_TARGET_COMPILE_FLAGS "--wincompat")
 endif()
 
-find_package(FLEX)
+find_package(FLEX REQUIRED)
 set(FLEX_VARS
     FLEX_FOUND
     FLEX_EXECUTABLE
@@ -49,6 +49,6 @@ endforeach()
 
 bison_target(bison_parser_target mc_parser.yy "${CMAKE_CURRENT_BINARY_DIR}/mc_parser.cpp")
 
-add_executable(bison_test_package "${CMAKE_CURRENT_BINARY_DIR}/mc_parser.cpp" dummy_lex.cpp)
+add_executable(bison_test_package "${CMAKE_CURRENT_BINARY_DIR}/mc_parser.cpp" dummy_lex.c)
 set_property(TARGET bison_test_package PROPERTY CXX_STANDARD 11)
 target_include_directories(bison_test_package PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")

--- a/recipes/winflexbison/all/test_package/conanfile.py
+++ b/recipes/winflexbison/all/test_package/conanfile.py
@@ -18,6 +18,5 @@ class TestPackageConan(ConanFile):
             self.run("win_flex --version", run_environment=True)
             self.run("win_bison --version", run_environment=True)
 
-            if not tools.cross_building(self.settings):
-                self.run(os.path.join("bin", "bison_test_package"), run_environment=True)
-                self.run("{} {}".format(os.path.join("bin", "flex_test_package"), os.path.join(self.source_folder, "basic_nr.txt")), run_environment=True)
+            self.run(os.path.join("bin", "bison_test_package"), run_environment=True)
+            self.run("{} {}".format(os.path.join("bin", "flex_test_package"), os.path.join(self.source_folder, "basic_nr.txt")), run_environment=True)

--- a/recipes/winflexbison/all/test_package/conanfile.py
+++ b/recipes/winflexbison/all/test_package/conanfile.py
@@ -7,14 +7,17 @@ class TestPackageConan(ConanFile):
     generators = "cmake"
 
     def build(self):
-        cmake = CMake(self)
-        cmake.configure()
-        cmake.build()
+        if not tools.cross_building(self, skip_x64_x86=True):
+            with tools.run_environment(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
 
     def test(self):
-        self.run("win_flex --version", run_environment=True)
-        self.run("win_bison --version", run_environment=True)
+        if not tools.cross_building(self, skip_x64_x86=True):
+            self.run("win_flex --version", run_environment=True)
+            self.run("win_bison --version", run_environment=True)
 
-        if not tools.cross_building(self.settings):
-            self.run(os.path.join("bin", "bison_test_package"), run_environment=True)
-            self.run("{} {}".format(os.path.join("bin", "flex_test_package"), os.path.join(self.source_folder, "basic_nr.txt")), run_environment=True)
+            if not tools.cross_building(self.settings):
+                self.run(os.path.join("bin", "bison_test_package"), run_environment=True)
+                self.run("{} {}".format(os.path.join("bin", "flex_test_package"), os.path.join(self.source_folder, "basic_nr.txt")), run_environment=True)

--- a/recipes/winflexbison/all/test_package/dummy_lex.c
+++ b/recipes/winflexbison/all/test_package/dummy_lex.c
@@ -1,14 +1,12 @@
 #include "mc_parser.hpp"
 
-namespace {
-    const int VARS[] = {
-        NUM,
-        OPA,
-        NUM,
-        STOP,
-        0,
-    };
-}
+static const int VARS[] = {
+    NUM,
+    OPA,
+    NUM,
+    STOP,
+    0,
+};
 
 int yylex() {
     static unsigned pos = 0;

--- a/recipes/winflexbison/all/test_package/mc_parser.yy
+++ b/recipes/winflexbison/all/test_package/mc_parser.yy
@@ -5,7 +5,9 @@
 #include <cstdlib> //-- I need this for atoi
 using namespace std;
 
+extern "C" {
 int yylex();
+}
 int yyerror(const char *p) { cerr << "Error: " << p << endl; return 0; }
 %}
 

--- a/recipes/winflexbison/config.yml
+++ b/recipes/winflexbison/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.5.22":
-    folder: all
   "2.5.24":
+    folder: all
+  "2.5.22":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **winflexbison/all**

Needed when using mingw@Linux

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
