### PR TITLE
ffmpeg/all: Fix vaapi and vdpau library linking.

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -164,7 +164,7 @@ class FFMpegConan(ConanFile):
             self.requires("openssl/1.1.1l")
         if self.options.get_safe("with_libalsa"):
             self.requires("libalsa/1.2.5.1")
-        if self.options.get_safe("with_xcb"):
+        if self.options.get_safe("with_xcb") or self.options.get_safe("with_vaapi"):
             self.requires("xorg/system")
         if self.options.get_safe("with_pulse"):
             self.requires("pulseaudio/14.2")
@@ -367,7 +367,7 @@ class FFMpegConan(ConanFile):
         self.cpp_info.components["avutil"].names["pkg_config"] = "libavutil"
 
         if self.settings.os in ("FreeBSD", "Linux"):
-            self.cpp_info.components["avutil"].system_libs = ["pthread"]
+            self.cpp_info.components["avutil"].system_libs = ["pthread", "m", "dl"]
             self.cpp_info.components["swresample"].system_libs = ["m"]
             self.cpp_info.components["swscale"].system_libs = ["m"]
             if self.options.postproc:
@@ -450,10 +450,10 @@ class FFMpegConan(ConanFile):
             self.cpp_info.components["avformat"].frameworks.append("Security")
 
         if self.options.get_safe("with_vaapi"):
-            self.cpp_info.components["avcodec"].requires.append("vaapi::vaapi")
+            self.cpp_info.components["avutil"].requires.extend(["vaapi::vaapi", "xorg::x11"])
 
         if self.options.get_safe("with_vdpau"):
-            self.cpp_info.components["avcodec"].requires.append("vdpau::vdpau")
+            self.cpp_info.components["avutil"].requires.append("vdpau::vdpau")
 
         if self.options.get_safe("with_appkit"):
             self.cpp_info.components["avdevice"].frameworks.append("AppKit")
@@ -463,7 +463,7 @@ class FFMpegConan(ConanFile):
             self.cpp_info.components["avdevice"].frameworks.append("AVFoundation")
 
         if self.options.get_safe("with_coreimage"):
-            self.cpp_info.components["avfilter"].frameworks = ["CoreImage"]
+            self.cpp_info.components["avfilter"].frameworks.append("CoreImage")
 
         if self.options.get_safe("with_audiotoolbox"):
             self.cpp_info.components["avcodec"].frameworks.append("AudioToolbox")


### PR DESCRIPTION
Specify library name and version:  **ffmpeg/4.2.1**

Both vaapi and vdpau are used from avutil instead of avcodec so fix the component requirements accordingly.

In case of vaapi there is another issue. The libva library can be compiled with and without X11 support. When FFmpeg detects that libva has X11 support then it uses some libX11 functions directly. Hence it needs to be linked with `xorg::x11`. In theory if we could detect whether the system vaapi was compiled with X11 (e.g. has libva-x11) we could conditionally include `xorg::x11`, but I don't think there is a simple way to do that right now.

Additionally fixed `CoreImage` framework issue where existing list of frameworks were overwritten by a new list instead of appending. I have little experience with MacOS so please review this too.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
