### PR TITLE
fix argparse after tag changed

### DIFF
--- a/recipes/argparse/all/conandata.yml
+++ b/recipes/argparse/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2.1":
     url: "https://github.com/p-ranav/argparse/archive/v2.1.tar.gz"
-    sha256: "0a82f464b568b8ee6650fc837f371eb9c81417e2ef9fb3b51f65ad50fa3b8662"
+    sha256: "44f40a5b9908e722a419973f676bfad4f34d904bf23f89351c477988bc5c4044"

--- a/recipes/argparse/all/conanfile.py
+++ b/recipes/argparse/all/conanfile.py
@@ -40,10 +40,7 @@ class ArgparseConan(ConanFile):
 
     def package(self):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        self.copy("*.hpp", src=os.path.join(self._source_subfolder, "include"), dst=os.path.join("include", "argparse"))
+        self.copy("*.hpp", src=os.path.join(self._source_subfolder, "include"), dst="include")
 
     def package_id(self):
         self.info.header_only()
-
-    def package_info(self):
-        self.cpp_info.includedirs.append(os.path.join("include", "argparse"))

--- a/recipes/argparse/all/test_package/test_package.cpp
+++ b/recipes/argparse/all/test_package/test_package.cpp
@@ -1,4 +1,4 @@
-#include <argparse.hpp>
+#include <argparse/argparse.hpp>
 
 #include <iostream>
 


### PR DESCRIPTION
Specify library name and version:  **argparse/2.1**

Fix https://github.com/conan-io/conan-center-index/issues/7253. Apparently, the library author changed the release tag, breaking the package. The issue has been reported, but if it is not going to be fixed, this PR should fix the Conan package.

That would also imply to use ``<argparse/argparse.hpp>`` for including the header.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
