### PR TITLE
[libtiff] remove jbig if it's disabled

### DIFF
--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -105,15 +105,19 @@ class LibtiffConan(ConanFile):
                   destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
         # Rename the generated Findjbig.cmake and Findzstd.cmake to avoid case insensitive conflicts with FindJBIG.cmake and FindZSTD.cmake on Windows
         if self.options.jbig:
             tools.rename(os.path.join(self.build_folder, "Findjbig.cmake"),
                          os.path.join(self.build_folder, "ConanFindjbig.cmake"))
+        else:
+            os.remove(os.path.join(self.build_folder, self._source_subfolder, "cmake", "FindJBIG.cmake"))
         if self.options.get_safe("zstd"):
             tools.rename(os.path.join(self.build_folder, "Findzstd.cmake"),
                          os.path.join(self.build_folder, "ConanFindzstd.cmake"))
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+
         if self.options.shared and self.settings.compiler == "Visual Studio":
             # https://github.com/Microsoft/vcpkg/blob/master/ports/tiff/fix-cxx-shared-libs.patch
             tools.replace_in_file(os.path.join(self._source_subfolder, "libtiff", "CMakeLists.txt"),

--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -114,9 +114,12 @@ class LibtiffConan(ConanFile):
                          os.path.join(self.build_folder, "ConanFindjbig.cmake"))
         else:
             os.remove(os.path.join(self.build_folder, self._source_subfolder, "cmake", "FindJBIG.cmake"))
-        if self.options.get_safe("zstd"):
-            tools.rename(os.path.join(self.build_folder, "Findzstd.cmake"),
-                         os.path.join(self.build_folder, "ConanFindzstd.cmake"))
+        if self._has_zstd_option:
+            if self.options.zstd:
+                tools.rename(os.path.join(self.build_folder, "Findzstd.cmake"),
+                             os.path.join(self.build_folder, "ConanFindzstd.cmake"))
+            else:
+                os.remove(os.path.join(self.build_folder, self._source_subfolder, "cmake", "FindZSTD.cmake"))
 
         if self.options.shared and self.settings.compiler == "Visual Studio":
             # https://github.com/Microsoft/vcpkg/blob/master/ports/tiff/fix-cxx-shared-libs.patch


### PR DESCRIPTION
Specify library name and version:  **libtiff/4.3.0**

libtiff will fail to build with jbig disabled, this removes the FindJBIG.cmake file if jbig is disabled so that libtiff will not find it.

fixes #7276

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
