### PR TITLE
boost: fixed stacktrace_windbg* components, improved stacktrace test.

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1565,10 +1565,10 @@ class BoostConan(ConanFile):
                 self.cpp_info.components["stacktrace_noop"].defines.append("BOOST_STACKTRACE_USE_NOOP")
 
                 if self.settings.os == "Windows":
-                    self.cpp_info.components["stacktrace_windb"].defines.append("BOOST_STACKTRACE_USE_WINDBG")
-                    self.cpp_info.components["stacktrace_windb"].system_libs.extend(["ole32", "dbgeng"])
-                    self.cpp_info.components["stacktrace_windb_cached"].defines.append("BOOST_STACKTRACE_USE_WINDBG_CACHED")
-                    self.cpp_info.components["stacktrace_windb_cached"].system_libs.extend(["ole32", "dbgeng"])
+                    self.cpp_info.components["stacktrace_windbg"].defines.append("BOOST_STACKTRACE_USE_WINDBG")
+                    self.cpp_info.components["stacktrace_windbg"].system_libs.extend(["ole32", "dbgeng"])
+                    self.cpp_info.components["stacktrace_windbg_cached"].defines.append("BOOST_STACKTRACE_USE_WINDBG_CACHED")
+                    self.cpp_info.components["stacktrace_windbg_cached"].system_libs.extend(["ole32", "dbgeng"])
                 elif tools.is_apple_os(self.settings.os) or self.settings.os == "FreeBSD":
                     self.cpp_info.components["stacktrace"].defines.append("BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED")
 

--- a/recipes/boost/all/test_package/stacktrace.cpp
+++ b/recipes/boost/all/test_package/stacktrace.cpp
@@ -34,6 +34,82 @@ static const char *stacktrace_impls[] = {
     "windbg_cached",
 };
 
+bool check_used_defined()
+{
+    bool success = true;
+#if TEST_STACKTRACE_IMPL == TEST_STACKTRACE_ADDR2LINE
+#   if !defined(BOOST_STACKTRACE_USE_ADDR2LINE)
+        std::cerr << "testing stacktrace_addr2line but BOOST_STACKTRACE_USE_ADDR2LINE not defined\n";
+        success = false;
+#   endif
+#endif
+#if TEST_STACKTRACE_IMPL == TEST_STACKTRACE_BACKTRACE
+#   if !defined(BOOST_STACKTRACE_USE_BACKTRACE)
+        std::cerr << "testing stacktrace_backtrace but BOOST_STACKTRACE_USE_BACKTRACE not defined\n";
+        success = false;
+#   endif
+#endif
+#if TEST_STACKTRACE_IMPL == TEST_STACKTRACE_NOOP
+#   if !defined(BOOST_STACKTRACE_USE_NOOP)
+        std::cerr << "testing stacktrace_noop but BOOST_STACKTRACE_USE_NOOP not defined\n";
+        success = false;
+#   endif
+#endif
+#if TEST_STACKTRACE_IMPL == TEST_STACKTRACE_WINDBG
+#   if !defined(BOOST_STACKTRACE_USE_WINDBG)
+        std::cerr << "testing stacktrace_windbg but BOOST_STACKTRACE_USE_WINDBG not defined\n";
+        success = false;
+#   endif
+#endif
+#if TEST_STACKTRACE_IMPL == TEST_STACKTRACE_WINDBG_CACHED
+#   if !defined(BOOST_STACKTRACE_USE_WINDBG_CACHED)
+        std::cerr << "testing stacktrace_windbg_cached but BOOST_STACKTRACE_USE_WINDBG_CACHED not defined\n";
+        success = false;
+#   endif
+#endif
+    return success;
+}
+
+bool check_unused_undefined()
+{
+    bool success = true;
+#   if defined(BOOST_STACKTRACE_USE_ADDR2LINE)
+#       if TEST_STACKTRACE_IMPL != TEST_STACKTRACE_ADDR2LINE
+            std::cerr << "BOOST_STACKTRACE_USE_ADDR2LINE defined but not testing stacktrace_addr2line\n";
+            success = false;
+#       endif
+#       if !defined(BOOST_STACKTRACE_ADDR2LINE_LOCATION)
+            std::cerr << "error: BOOST_STACKTRACE_ADDR2LINE_LOCATION not defined\n";
+            success = false;
+#       endif
+#   endif
+#   if defined(BOOST_STACKTRACE_USE_BACKTRACE)
+#       if TEST_STACKTRACE_IMPL != TEST_STACKTRACE_BACKTRACE
+            std::cerr << "BOOST_STACKTRACE_USE_BACKTRACE defined but not testing stacktrace_backtrace\n";
+            success = false;
+#       endif
+#   endif
+#   if defined(BOOST_STACKTRACE_USE_NOOP)
+#       if TEST_STACKTRACE_IMPL != TEST_STACKTRACE_NOOP
+            std::cerr << "BOOST_STACKTRACE_USE_NOOP defined but not testing stacktrace_noop\n";
+            success = false;
+#       endif
+#   endif
+#   if defined(BOOST_STACKTRACE_USE_WINDBG)
+#       if TEST_STACKTRACE_IMPL != TEST_STACKTRACE_WINDBG
+            std::cerr << "BOOST_STACKTRACE_USE_WINDBG defined but not testing stacktrace_windbg\n";
+            success = false;
+#       endif
+#   endif
+#   if defined(BOOST_STACKTRACE_USE_WINDBG_CACHED)
+#       if TEST_STACKTRACE_IMPL != TEST_STACKTRACE_WINDBG_CACHED
+            std::cerr << "BOOST_STACKTRACE_USE_WINDBG_CACHED defined but not testing stacktrace_windbg_cached\n";
+            success = false;
+#       endif
+#   endif
+    return success;
+}
+
 int main() {
     int res = 0;
 
@@ -42,40 +118,12 @@ int main() {
     res = 1;
 #else
     std::cerr << "Testing stacktrace_" << stacktrace_impls[TEST_STACKTRACE_IMPL-1] << "...\n";
-#   if defined(BOOST_STACKTRACE_USE_ADDR2LINE)
-#       if TEST_STACKTRACE_IMPL != TEST_STACKTRACE_ADDR2LINE
-            std::cerr << "BOOST_STACKTRACE_USE_ADDR2LINE defined but not testing stacktrace_addr2line\n";
-            res = 1;
-#       endif
-#       if !defined(BOOST_STACKTRACE_ADDR2LINE_LOCATION)
-            std::cerr << "error: BOOST_STACKTRACE_ADDR2LINE_LOCATION not defined\n";
-            res = 1;
-#       endif
-#   endif
-#   if defined(BOOST_STACKTRACE_USE_BACKTRACE)
-#       if TEST_STACKTRACE_IMPL != TEST_STACKTRACE_BACKTRACE
-            std::cerr << "BOOST_STACKTRACE_USE_BACKTRACE defined but not testing stacktrace_backtrace\n";
-            res = 1;
-#       endif
-#   endif
-#   if defined(BOOST_STACKTRACE_USE_NOOP)
-#       if TEST_STACKTRACE_IMPL != TEST_STACKTRACE_NOOP
-            std::cerr << "BOOST_STACKTRACE_USE_NOOP defined but not testing stacktrace_noop\n";
-            res = 1;
-#       endif
-#   endif
-#   if defined(BOOST_STACKTRACE_USE_WINDBG)
-#       if TEST_STACKTRACE_IMPL != TEST_STACKTRACE_WINDBG
-            std::cerr << "BOOST_STACKTRACE_USE_WINDBG defined but not testing stacktrace_windbg\n";
-            res = 1;
-#       endif
-#   endif
-#   if defined(BOOST_STACKTRACE_USE_WINDBG_CACHED)
-#       if TEST_STACKTRACE_IMPL != TEST_STACKTRACE_WINDBG_CACHED
-            std::cerr << "BOOST_STACKTRACE_USE_WINDBG_CACHED defined but not testing stacktrace_windbg_cached\n";
-            res = 1;
-#       endif
-#   endif
+    if (!check_unused_undefined()) {
+        res = 1;
+    }
+    if (!check_used_defined()) {
+        res = 1;
+    }
 #endif
     f1();
     return res;


### PR DESCRIPTION
Specify library name and version:  **boost/1.77.0**

The proper component is `stacktrace_windbg` (or `stacktrace_windbg_cached`) but when setting extra component info it was misspelled `stacktrace_windb`/`stacktrace_windb_cached`, leaving the aforementioned components unusably broken.

The stacktrace test only checked for spurious defines that shouldn't be there ("if X is defined, I should be testing X"). It never checked for the ones which ought to be defined ("if I am testing X, X should be defined"), meaning if nothing was defined at all (as was the case before this patch), it would happily pass. I added a complementary set of checks to cover that.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
