### PR TITLE
s2n/1.0.11: Bump openssl version to 1.1.1l

### DIFF
--- a/recipes/s2n/all/conanfile.py
+++ b/recipes/s2n/all/conanfile.py
@@ -36,7 +36,7 @@ class S2n(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("openssl/1.1.1k")
+        self.requires("openssl/1.1.1l")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],


### PR DESCRIPTION
Specify library name and version:  **s2n/1.0.11**

closes #7285

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
