### PR TITLE
Revert "pcre: fix link issue with bzip2"

### DIFF
--- a/recipes/pcre/all/conanfile.py
+++ b/recipes/pcre/all/conanfile.py
@@ -108,8 +108,6 @@ class PCREConan(ConanFile):
         # Avoid CMP0006 error (macos bundle)
         tools.replace_in_file(
             cmake_file, "RUNTIME DESTINATION bin", "RUNTIME DESTINATION bin\n        BUNDLE DESTINATION bin")
-        tools.replace_in_file(
-            cmake_file, "BZIP2_LIBRARIES", "BZip2_LIBRARIES")
 
     def _configure_cmake(self):
         if self._cmake:


### PR DESCRIPTION
This reverts commit 05de5a305b694f2219083302f039f03343881599.

Old commit fixes the problem in the wrong place. Fixed the behavior by rebuilding an outdated recipe.
See: https://github.com/conan-io/conan-center-index/pull/7282

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
