### PR TITLE
Define boost::system as header-only component

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1513,6 +1513,13 @@ class BoostConan(ConanFile):
                 if set(module_libraries).difference(all_detected_libraries):
                     incomplete_components.append(module)
 
+                # Starting v1.69.0 Boost.System is header-only. A stub library is
+                # still built for compatibility, but linking to it is no longer
+                # necessary.
+                # https://www.boost.org/doc/libs/1_75_0/libs/system/doc/html/system.html#changes_in_boost_1_69
+                if module == "system":
+                    module_libraries = []
+
                 self.cpp_info.components[module].libs = module_libraries
 
                 self.cpp_info.components[module].requires = self._dependencies["dependencies"][module] + ["_libboost"]


### PR DESCRIPTION
Specify library name and version:  **boost/1.77.0**

Use boost_system as header-only library

Starting v1.69.0 Boost.System is header-only. A stub library is still built for compatibility, but linking to it is no longer necessary.
https://www.boost.org/doc/libs/1_75_0/libs/system/doc/html/system.html#changes_in_boost_1_69

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
