### PR TITLE
bump up fast_float 3.1.0

### DIFF
--- a/recipes/fast_float/all/conandata.yml
+++ b/recipes/fast_float/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "3.1.0":
+    url: "https://github.com/fastfloat/fast_float/archive/v3.1.0.tar.gz"
+    sha256: "755ee0bdde8ee0cc10ae16e1f283c2833d9cfa7ea114950ab807dc7ee108f722"
+  "2.0.0":
+    url: "https://github.com/fastfloat/fast_float/archive/v2.0.0.tar.gz"
+    sha256: "5d528ec20811577c5f2b2873528c085c500fdcd2b2c0901450509a71de5f1fa4"
   "1.1.2":
     url: "https://github.com/fastfloat/fast_float/archive/v1.1.2.tar.gz"
     sha256: "580655a9ad2aeac7507de4433dcf985d8699ae8128b97c2cabc0962aa5beb513"

--- a/recipes/fast_float/config.yml
+++ b/recipes/fast_float/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "3.1.0":
+    folder: all
+  "2.0.0":
+    folder: all
   "1.1.2":
     folder: all
   "1.1.1":


### PR DESCRIPTION
Specify library name and version:  **fast_float/3.1.0**

fast_float bumps up 3.1.0.
There are no breaking changes since 1.1.2.

---

- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [+] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [+] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
