### PR TITLE
Create MacExtras module for qtmacextras option

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1130,6 +1130,9 @@ Examples = bin/datadir/examples""")
         if self.options.qtwinextras:
             _create_module("WinExtras")
 
+        if self.options.qtmacextras:
+            _create_module("MacExtras")
+
         if self.options.qtxmlpatterns:
              _create_module("XmlPatterns", ["Network"])
 


### PR DESCRIPTION
Specify library name and version:  **qt/5.15.2**

Without this patch it is impossible to add `Qt5::MacExtras` to `target_link_libraries` in `CMakeLists.txt` and use it in a project.

---

- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [+] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
