### PR TITLE
[openblas] Force compile failure when fortran compiler not found and build_lapack=True

### DIFF
--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -52,10 +52,26 @@ class OpenblasConan(ConanFile):
             strip_root=True,
             destination=self._source_subfolder
         )
+
+        if tools.Version(self.version) >= "0.3.12":
+            search = """message(STATUS "No Fortran compiler found, can build only BLAS but not LAPACK")"""
+            replace = """message(FATAL_ERROR "No Fortran compiler found. Cannot build with LAPACK.")"""
+        else:
+            search = "enable_language(Fortran)"
+            replace = """include(CheckLanguage)
+check_language(Fortran)
+if(CMAKE_Fortran_COMPILER)
+  enable_language(Fortran)
+else()
+  message(FATAL_ERROR "No Fortran compiler found. Cannot build with LAPACK.")
+  set (NOFORTRAN 1)
+  set (NO_LAPACK 1)
+endif()"""
+
         tools.replace_in_file(
             os.path.join(self._source_subfolder, "cmake", "f_check.cmake"),
-            """message(STATUS "No Fortran compiler found, can build only BLAS but not LAPACK")""",
-            """message(FATAL_ERROR "No Fortran compiler found. Cannot build with LAPACK.")""",
+            search,
+            replace,
         )
 
     def _configure_cmake(self):


### PR DESCRIPTION
* Force compilation failure when fortran compiler can't be found and
  build_lapack option is True. This prevents a silent failure in the
  capabilities of the package.
* Apply Black reformatting for readability and maintainability

Fixes #7294

Specify library name and version:  **openblas/0.3.17**

Currently if CMake can't find a fortran compiler whilst `build_lapack=True`, the lapack build will fail silently and only BLAS will be built. This pull request will cause a fatal error if the fortran compiler can't be found, making the compilation fail loudly. This rectifies issues with downstream consumers that rely on lapack being built correctly. Specifically, this is an issue when packaging armadillo in #6754.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
