### PR TITLE
FAQ and Reviewing - Removing old project versions

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -209,7 +209,7 @@ This is for historical reasons, when older versions were permitted the overwhelm
 
 Keeping many older versions can be a problem, as over time they may become incompatible with newer versions of the package's Python code and/or dependencies. They also become downloaded less often than newer versions, and yet continue to consume CI resources during Pull Requests.
 
-Given a technical limitations and/or incompatibilities emerging from infrastructure changes, removing older versions from `config.yml` and `conandata.yml` may be permitted. The respective binary packages will not be removed from Conan Center, but they will not receive new updates, as they are not listed to be built.
+Given a technical limitations and/or incompatibilities emerging from infrastructure changes, removing older versions from `config.yml` and `conandata.yml` may be permitted. The respective recipes and binary packages will not be removed from Conan Center, but they will not receive new updates, as they are not listed to be built.
 
 There is no strict rule for keeping older versions, but we recommend keeping only the latest version of each old major release. For the latest major version available, the last patch version of each minor version should be available. As example, we can list the [CMake](https://github.com/conan-io/conan-center-index/blob/master/recipes/cmake/config.yml) package.
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -24,6 +24,7 @@ This section gathers the most common questions from the community related to pac
   * [What license should I use for Public Domain?](#what-license-should-i-use-for-public-domain)
   * [Why is a `tools.check_min_cppstd` call not enough?](#why-is-a-toolscheck_min_cppstd-call-not-enough)
   * [What is the policy for adding older versions of a package?](#what-is-the-policy-for-adding-older-versions-of-a-package)
+  * [What is the policy for removing older versions of a package?](#what-is-the-policy-for-removing-older-versions-of-a-package)
   * [Can I install packages from the system package manager?](#can-i-install-packages-from-the-system-package-manager)
   * [Why ConanCenter does not build and execute tests in recipes](#why-conancenter-does-not-build-and-execute-tests-in-recipes)
   * [What is the policy for supported python versions?](#what-is-the-policy-for-supported-python-versions)<!-- endToc -->
@@ -203,6 +204,12 @@ As a result, all calls to `tools.check_min_cppstd` must be guarded by a check fo
 
 We defer adding older versions without a direct requirement. We love to hear why in the opening description of the PR.
 This is for historical reasons, when older versions were permitted the overwhelming majority received zero downloads and were never used by the community while still increasing the burden on the build system.
+
+## What is the policy for removing older versions of a package?
+
+Keeping older versions can be a problem as longer they become incompatible, less downloaded and consumes CI resources. Thus, removing older versions from
+`config.yml` and `conandata.yml` is totally fine. The respective binary packages will not be from Conan Center, but they will not receive new updates, as
+they are not listed to be built. There is no strict rule for keeping older versions, but we recommend keeping only the latest version of each old major release. For the latest major version available, the last patch version of each minor version should be available. As example, we can list the [CMake](https://github.com/conan-io/conan-center-index/blob/master/recipes/cmake/config.yml) package.
 
 ## Can I install packages from the system package manager?
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -207,9 +207,13 @@ This is for historical reasons, when older versions were permitted the overwhelm
 
 ## What is the policy for removing older versions of a package?
 
-Keeping older versions can be a problem as longer they become incompatible, less downloaded and consumes CI resources. Thus, removing older versions from
-`config.yml` and `conandata.yml` is totally fine. The respective binary packages will not be from Conan Center, but they will not receive new updates, as
-they are not listed to be built. There is no strict rule for keeping older versions, but we recommend keeping only the latest version of each old major release. For the latest major version available, the last patch version of each minor version should be available. As example, we can list the [CMake](https://github.com/conan-io/conan-center-index/blob/master/recipes/cmake/config.yml) package.
+Keeping many older versions can be a problem, as over time they may become incompatible with newer versions of the package's Python code and/or dependencies. They also become downloaded less often than newer versions, and yet continue to consume CI resources during Pull Requests.
+
+Thus, removing older versions from
+`config.yml` and `conandata.yml` is totally fine. The respective binary packages will not be removed from Conan Center, but they will not receive new updates, as
+they are not listed to be built.
+
+There is no strict rule for keeping older versions, but we recommend keeping only the latest version of each old major release. For the latest major version available, the last patch version of each minor version should be available. As example, we can list the [CMake](https://github.com/conan-io/conan-center-index/blob/master/recipes/cmake/config.yml) package.
 
 ## Can I install packages from the system package manager?
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -209,9 +209,7 @@ This is for historical reasons, when older versions were permitted the overwhelm
 
 Keeping many older versions can be a problem, as over time they may become incompatible with newer versions of the package's Python code and/or dependencies. They also become downloaded less often than newer versions, and yet continue to consume CI resources during Pull Requests.
 
-Thus, removing older versions from
-`config.yml` and `conandata.yml` is totally fine. The respective binary packages will not be removed from Conan Center, but they will not receive new updates, as
-they are not listed to be built.
+Given a technical limitations and/or incompatibilities emerging from infrastructure changes, removing older versions from `config.yml` and `conandata.yml` may be permitted. The respective binary packages will not be removed from Conan Center, but they will not receive new updates, as they are not listed to be built.
 
 There is no strict rule for keeping older versions, but we recommend keeping only the latest version of each old major release. For the latest major version available, the last patch version of each minor version should be available. As example, we can list the [CMake](https://github.com/conan-io/conan-center-index/blob/master/recipes/cmake/config.yml) package.
 

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -17,7 +17,8 @@ The following policies are preferred during the review, but not mandatory:
   * [Test Package](#test-package)
     * [Minimalistic Source Code](#minimalistic-source-code)
     * [CMake targets](#cmake-targets)
-  * [Recommended feature options names](#recommended-feature-options-names)<!-- endToc -->
+  * [Recommended feature options names](#recommended-feature-options-names)
+  * [Supported Versions](#supported-versions)<!-- endToc -->
 
 ## Trailing white-spaces
 
@@ -112,7 +113,7 @@ CMake or Meson are usually preferred.
 ### CMake targets
 
 When using CMake to test a package, the information should be consumed using the **targets provided by `cmake_find_package_multi` generator**. We
-enforce this generator to align with the upcoming 
+enforce this generator to align with the upcoming
 [Conan's new `CMakeDeps` generator](https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmakedeps.html?highlight=cmakedeps)
 and it should help in the migration (and compatibility) with Conan v2.
 
@@ -165,3 +166,12 @@ the actual recipe code then may look like:
 ```
 
 having the same naming conventions for the options may help consumers, e.g. they will be able to specify options with wildcards: `-o *:with_threads=True`, therefore, `with_threads` options will be enabled for all packages in the graph that support it.
+
+## Supported Versions
+
+Keeping older versions is needed due users which are still using legacy versions and can not update their packages. However, some points should be considered:
+- Adding older versions should allowed only strict cases when required by an user. The committer should express he/she needs on the PR.
+- Removing older versions is allowed, since it keeps at least one version for each older major release available. For the latest major version, at least,
+  three last versions should be available.
+
+Also, consider these FAQs: [What is the policy for adding older versions of a package?](faqs.md#what-is-the-policy-for-adding-older-versions-of-a-package)  and [What is the policy for removing older versions of a package?](faqs.md#what-is-the-policy-for-removing-older-versions-of-a-package)

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -175,4 +175,6 @@ Keeping older versions is needed due to users who are still using legacy version
   - for each older major release available, at least one version
   - for the latest major version, at least three last versions should be available (if there are more than three such versions).
 
-Also, consider these FAQs: [What is the policy for adding older versions of a package?](faqs.md#what-is-the-policy-for-adding-older-versions-of-a-package)  and [What is the policy for removing older versions of a package?](faqs.md#what-is-the-policy-for-removing-older-versions-of-a-package)
+Also, consider these FAQs:
+- [What is the policy for adding older versions of a package?](faqs.md#what-is-the-policy-for-adding-older-versions-of-a-package)
+- [What is the policy for removing older versions of a package?](faqs.md#what-is-the-policy-for-removing-older-versions-of-a-package)

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -169,9 +169,10 @@ having the same naming conventions for the options may help consumers, e.g. they
 
 ## Supported Versions
 
-Keeping older versions is needed due users which are still using legacy versions and can not update their packages. However, some points should be considered:
-- Adding older versions should allowed only strict cases when required by an user. The committer should express he/she needs on the PR.
-- Removing older versions is allowed, since it keeps at least one version for each older major release available. For the latest major version, at least,
-  three last versions should be available.
+Keeping older versions is needed due to users who are still using legacy versions and can not update their packages. However, some points should be considered:
+- Adding older versions should be allowed only in strict cases, when required by a user. The committer should express their needs on the PR.
+- Removing older versions is allowed, so long as it keeps:
+  - for each older major release available, at least one version
+  - for the latest major version, at least three last versions should be available (if there are more than three such versions).
 
 Also, consider these FAQs: [What is the policy for adding older versions of a package?](faqs.md#what-is-the-policy-for-adding-older-versions-of-a-package)  and [What is the policy for removing older versions of a package?](faqs.md#what-is-the-policy-for-removing-older-versions-of-a-package)


### PR DESCRIPTION
We still don't have a documented advice about removing older versions, but we have some practice on it (CMake for instance).

My suggestion is removing the excess of patches versions available and keeping at least 3 last versions available. Major versions should be preserved.

/cc @Croydon @SpaceIm @madebr @prince-chrismc 

This question came from @claremacrae and is related to PR #7213 

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
