### PR TITLE
Update libcurl to version 7.79.0

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.79.0":
+    sha256: aff0c7c4a526d7ecc429d2f96263a85fa73e709877054d593d8af3d136858074
+    url: https://curl.se/download/curl-7.79.0.tar.gz
   "7.78.0":
     sha256: ed936c0b02c06d42cf84b39dd12bb14b62d77c7c4e875ade022280df5dcc81d7
     url: https://curl.se/download/curl-7.78.0.tar.gz

--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -48,6 +48,9 @@ sources:
     sha256: 432d3f466644b9416bc5b649d344116a753aeaa520c8beaf024a90cba9d3d35d
     url: https://curl.haxx.se/download/curl-7.64.1.tar.gz
 patches:
+  "7.79.0":
+    - patch_file: "patches/004-no-checksrc.patch"
+      base_path: "source_subfolder"
   "7.72.0":
     - patch_file: "patches/002-add-missing-file-FindZstd.patch"
       base_path: "source_subfolder"

--- a/recipes/libcurl/all/patches/004-no-checksrc.patch
+++ b/recipes/libcurl/all/patches/004-no-checksrc.patch
@@ -1,0 +1,12 @@
+diff -ruN a/lib/Makefile.am b/lib/Makefile.am
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -138,8 +138,6 @@
+ CS_ = $(CS_0)
+ 
+ checksrc:
+-	$(CHECKSRC)(@PERL@ $(srcdir)/checksrc.pl -D$(srcdir) -W$(srcdir)/curl_config.h \
+-	$(srcdir)/*.[ch] $(srcdir)/vauth/*.[ch] $(srcdir)/vtls/*.[ch] $(srcdir)/vquic/*.[ch] $(srcdir)/vssh/*.[ch])
+ 
+ if CURLDEBUG
+ # for debug builds, we scan the sources on all regular make invokes

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.79.0":
+    folder: all
   "7.78.0":
     folder: all
   "7.77.0":


### PR DESCRIPTION
Specify library name and version:  **libcurl/7.79.0**

Add libcurl version 7.79.0

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Closes #7310 