### PR TITLE
sentry-crashpad/0.2.6: Invalidate armv8 arch

### DIFF
--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -54,7 +54,7 @@ class SentryCrashpadConan(ConanFile):
     def requirements(self):
         self.requires("zlib/1.2.11")
         if self.options.get_safe("with_tls"):
-            self.requires("openssl/1.1.1k")
+            self.requires("openssl/1.1.1l")
 
     def validate(self):
         if self.settings.compiler.cppstd:
@@ -68,6 +68,8 @@ class SentryCrashpadConan(ConanFile):
         elif tools.Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("Build requires support for C++14. Minimum version for {} is {}"
                 .format(str(self.settings.compiler), minimum_version))
+        if tools.Version(self.version) < "0.4" and self.settings.os == "Macos" and self.settings.arch == "armv8":
+            raise ConanInvalidConfiguration("This version doesn't support ARM compilation".format(self.version))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)


### PR DESCRIPTION
Specify library name and version:  **sentry-crashpad/0.2.6**

https://github.com/conan-io/conan-center-index/pull/7274#issuecomment-918409298 is failing because of missing binaries for sentry-crashpad/0.2.6 with armv8 arch. Since it doesn't seems to build, I invalidate this arch for macos.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
