### PR TITLE
(#7329) Support Gandiva in Arrow 2.0.0

### DIFF
--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -24,3 +24,10 @@ patches:
       patch_file: "patches/2.0.0-0003-fix-shared-msvc.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/1.0.0-0004-mallctl-takes-size_t.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.0.0-0005-gandiva-engine.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.0.0-0006-gandiva-llvm-re2.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.0.0-0007-fix-protoc-cmake.patch"
+

--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -239,7 +239,7 @@ class ArrowConan(ConanFile):
         if self.options.with_json:
             self.requires("rapidjson/1.1.0")
         if self._with_llvm():
-            raise ConanInvalidConfiguration("CCI has no llvm recipe (yet)")
+            self.requires("llvm-core/12.0.0")
         if self._with_openssl():
             self.requires("openssl/1.1.1l")
         if self.options.with_s3:
@@ -353,8 +353,7 @@ class ArrowConan(ConanFile):
             self._cmake.definitions["ARROW_USE_STATIC_CRT"] = "MT" in str(self.settings.compiler.runtime)
 
         if self._with_llvm():
-            self._cmake.definitions["LLVM_DIR"] = self.deps_cpp_info["llvm"].rootpath.replace("\\", "/")
-
+            self._cmake.definitions["LLVM_DIR"] = self.deps_cpp_info["llvm-core"].rootpath.replace("\\", "/")
         self._cmake.configure()
         return self._cmake
 
@@ -458,15 +457,14 @@ class ArrowConan(ConanFile):
             self.cpp_info.components["libarrow"].requires.append("jemalloc::jemalloc")
         if self._with_re2():
             self.cpp_info.components["libgandiva"].requires.append("re2::re2")
+        if self._with_llvm():
+            self.cpp_info.components["libgandiva"].requires.append("llvm-core::llvm-core")
         if self._with_protobuf():
             self.cpp_info.components["libarrow"].requires.append("protobuf::protobuf")
         if self._with_utf8proc():
             self.cpp_info.components["libarrow"].requires.append("uff8proc::uff8proc")
-        if self._with_llvm():
-            self.cpp_info.components["libarrow"].requires.append("llvm::llvm")
         if self._with_thrift():
             self.cpp_info.components["libarrow"].requires.append("thrift::thrift")
-
         if self.options.with_backtrace:
             self.cpp_info.components["libarrow"].requires.append("backtrace::backtrace")
         if self.options.with_cuda:

--- a/recipes/arrow/all/patches/2.0.0-0005-gandiva-engine.patch
+++ b/recipes/arrow/all/patches/2.0.0-0005-gandiva-engine.patch
@@ -1,0 +1,13 @@
+--- cpp/src/gandiva/engine.cc
++++ cpp/src/gandiva/engine.cc
+@@ -64,6 +64,10 @@
+ #include <llvm/Transforms/Utils.h>
+ #include <llvm/Transforms/Vectorize.h>
+ 
++#if GANDIVA_LLVM_VERSION >= 11
++#include <llvm/Support/Host.h>
++#endif
++
+ #if defined(_MSC_VER)
+ #pragma warning(pop)
+ #endif

--- a/recipes/arrow/all/patches/2.0.0-0006-gandiva-llvm-re2.patch
+++ b/recipes/arrow/all/patches/2.0.0-0006-gandiva-llvm-re2.patch
@@ -1,0 +1,78 @@
+--- cpp/CMakeLists.txt
++++ cpp/CMakeLists.txt
+@@ -109,7 +109,7 @@ set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
+ set(ARROW_CMAKE_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+ set(ARROW_DOC_DIR "share/doc/${PROJECT_NAME}")
+ 
+-set(ARROW_LLVM_VERSIONS "10" "9" "8" "7")
++set(ARROW_LLVM_VERSIONS "12" "11" "10" "9" "8" "7")
+ list(GET ARROW_LLVM_VERSIONS 0 ARROW_LLVM_VERSION_PRIMARY)
+ string(REGEX
+        REPLACE "^([0-9]+)(\\..+)?" "\\1" ARROW_LLVM_VERSION_PRIMARY_MAJOR
+
+--- cpp/cmake_modules/ThirdpartyToolchain.cmake
++++ cpp/cmake_modules/ThirdpartyToolchain.cmake
+@@ -2092,10 +2092,11 @@ macro(build_re2)
+ endmacro()
+ 
+ if(ARROW_GANDIVA)
+-  resolve_dependency(RE2)
++  find_package(re2 REQUIRED)
++  resolve_dependency(re2)
+ 
+   # TODO: Don't use global includes but rather target_include_directories
+-  get_target_property(RE2_INCLUDE_DIR RE2::re2 INTERFACE_INCLUDE_DIRECTORIES)
++  get_target_property(RE2_INCLUDE_DIR re2::re2 INTERFACE_INCLUDE_DIRECTORIES)
+   include_directories(SYSTEM ${RE2_INCLUDE_DIR})
+ endif()
+ 
+--- cpp/src/gandiva/CMakeLists.txt
++++ cpp/src/gandiva/CMakeLists.txt
+@@ -25,8 +25,14 @@ add_custom_target(gandiva-benchmarks)
+ 
+ add_dependencies(gandiva-all gandiva gandiva-tests gandiva-benchmarks)
+ 
++# Now LLVMAlt is only for finding clang/llvm-link
+ find_package(LLVMAlt REQUIRED)
+ 
++find_package(llvm-core REQUIRED)
++
++string(REPLACE "." ";" VERSION_LIST ${llvm-core_VERSION})
++list(GET VERSION_LIST 0 LLVM_VERSION_MAJOR)
++
+ if(LLVM_VERSION_MAJOR LESS "10")
+   set(GANDIVA_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+ else()
+@@ -88,9 +94,9 @@ set(SRC_FILES
+     random_generator_holder.cc
+     ${GANDIVA_PRECOMPILED_CC_PATH})
+ 
+-set(GANDIVA_SHARED_PRIVATE_LINK_LIBS arrow_shared LLVM::LLVM_INTERFACE RE2::re2)
++set(GANDIVA_SHARED_PRIVATE_LINK_LIBS arrow_shared llvm-core::llvm-core re2::re2)
+ 
+-set(GANDIVA_STATIC_LINK_LIBS arrow_static LLVM::LLVM_INTERFACE RE2::re2)
++set(GANDIVA_STATIC_LINK_LIBS arrow_static llvm-core::llvm-core re2::re2)
+ 
+ if(ARROW_GANDIVA_STATIC_LIBSTDCPP
+    AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX))
+@@ -131,7 +137,7 @@ add_arrow_lib(gandiva
+               arrow_dependencies
+               precompiled
+               EXTRA_INCLUDES
+-              $<TARGET_PROPERTY:LLVM::LLVM_INTERFACE,INTERFACE_INCLUDE_DIRECTORIES>
++              ${llvm-core_INCLUDE_DIRS}
+               SHARED_LINK_FLAGS
+               ${GANDIVA_SHARED_LINK_FLAGS}
+               SHARED_LINK_LIBS
+@@ -225,9 +231,9 @@ add_gandiva_test(internals-test
+                  decimal_type_util_test.cc
+                  random_generator_holder_test.cc
+                  EXTRA_DEPENDENCIES
+-                 LLVM::LLVM_INTERFACE
++                 llvm-core::llvm-core
+                  EXTRA_INCLUDES
+-                 $<TARGET_PROPERTY:LLVM::LLVM_INTERFACE,INTERFACE_INCLUDE_DIRECTORIES>
++                 ${llvm-core_INCLUDE_DIRS}
+                  ${GANDIVA_INTERNALS_TEST_ARGUMENTS})
+ 
+ if(ARROW_GANDIVA_JAVA)

--- a/recipes/arrow/all/patches/2.0.0-0006-gandiva-llvm-re2.patch
+++ b/recipes/arrow/all/patches/2.0.0-0006-gandiva-llvm-re2.patch
@@ -60,7 +60,7 @@
                precompiled
                EXTRA_INCLUDES
 -              $<TARGET_PROPERTY:LLVM::LLVM_INTERFACE,INTERFACE_INCLUDE_DIRECTORIES>
-+              ${llvm-core_INCLUDE_DIRS}
++              $<TARGET_PROPERTY:llvm-core::core,INTERFACE_INCLUDE_DIRECTORIES>
                SHARED_LINK_FLAGS
                ${GANDIVA_SHARED_LINK_FLAGS}
                SHARED_LINK_LIBS
@@ -72,7 +72,7 @@
 +                 llvm-core::llvm-core
                   EXTRA_INCLUDES
 -                 $<TARGET_PROPERTY:LLVM::LLVM_INTERFACE,INTERFACE_INCLUDE_DIRECTORIES>
-+                 ${llvm-core_INCLUDE_DIRS}
++                 $<TARGET_PROPERTY:llvm-core::core,INTERFACE_INCLUDE_DIRECTORIES>
                   ${GANDIVA_INTERNALS_TEST_ARGUMENTS})
  
  if(ARROW_GANDIVA_JAVA)

--- a/recipes/arrow/all/patches/2.0.0-0007-fix-protoc-cmake.patch
+++ b/recipes/arrow/all/patches/2.0.0-0007-fix-protoc-cmake.patch
@@ -1,0 +1,11 @@
+--- cpp/cmake_modules/ThirdpartyToolchain.cmake
++++ cpp/cmake_modules/ThirdpartyToolchain.cmake
+@@ -1452,7 +1452,7 @@ if(ARROW_WITH_PROTOBUF)
+   message(STATUS "Found protoc: ${PROTOBUF_PROTOC_EXECUTABLE}")
+   # Protobuf_PROTOC_LIBRARY is set by all versions of FindProtobuf.cmake
+   message(STATUS "Found libprotoc: ${Protobuf_PROTOC_LIBRARY}")
+-  get_target_property(PROTOBUF_LIBRARY ${ARROW_PROTOBUF_LIBPROTOBUF} IMPORTED_LOCATION)
++  # get_target_property(PROTOBUF_LIBRARY ${ARROW_PROTOBUF_LIBPROTOBUF} IMPORTED_LOCATION)
+   message(STATUS "Found libprotobuf: ${PROTOBUF_LIBRARY}")
+   message(STATUS "Found protobuf headers: ${PROTOBUF_INCLUDE_DIR}")
+ endif()


### PR DESCRIPTION
* fix protobuf, re2 and llvm dependencies
* fix compile error since the llvm api changed.

Specify library name and version:  **arrow/2.0.0**

In arrow 2.0.0,  CCI does not support gandiva component since gandiva depends on llvm. Since CCI has llvm recipe now.
Turn on gandiva component support, and fix some compiling errors.

Tested on
MacOS / Clang 12
Debian / GCC 9.3

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
