### PR TITLE
libcap/2.58: Bump version

### DIFF
--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -14,6 +14,9 @@ sources:
   "2.57":
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.57.tar.xz"
     sha256: "750221e347689e779a0ce2b22746ee9987d229712da934acb81b2d280684b7ab"
+  "2.58":
+    url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.58.tar.xz"
+    sha256: "41399a7d77497d348d20475dc9b2046f53e6b9755bf858ec78cc235101a11d4b"
 
 patches:
   "2.45":
@@ -37,6 +40,11 @@ patches:
     - base_path: "source_subfolder"
       patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
   "2.57":
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
+  "2.58":
     - base_path: "source_subfolder"
       patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
     - base_path: "source_subfolder"

--- a/recipes/libcap/config.yml
+++ b/recipes/libcap/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "2.57":
     folder: all
+  "2.58":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libcap/2.58**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
