### PR TITLE
Recipe/armadillo

### DIFF
--- a/recipes/armadillo/all/CMakeLists.txt
+++ b/recipes/armadillo/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/armadillo/all/conandata.yml
+++ b/recipes/armadillo/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "10.6.1":
+    url: "http://sourceforge.net/projects/arma/files/armadillo-10.6.1.tar.xz"
+    sha256: "1d06c3237d65c7bc461ea12f4fdfd8b5a69b6a965b4900ae70960ce92088179f"

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -161,7 +161,7 @@ class ArmadilloConan(ConanFile):
             self.options.USE_OPENBLAS = False
             self.options.ARMA_USE_ACCELERATE = True
         if self.settings.os != "Macos":
-            del self.options.ARMA_USE_ACCELERATE
+            self.options.ARMA_USE_ACCELERATE = False
 
     def configure(self):
         if self.options.shared:

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -1,0 +1,442 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class ArmadilloConan(ConanFile):
+    name = "armadillo"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://arma.sourceforge.net"
+    description = "Armadillo is a high quality C++ library for linear algebra and scientific computing, aiming towards a good balance between speed and ease of use."
+    topics = (
+        "linear algebra",
+        "scientific computing",
+        "matrix",
+        "vector",
+        "math",
+        "blas",
+        "lapack",
+        "mkl",
+        "hdf5",
+    )
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        # These are options exposed by armadillo_bits/config.hpp
+        "ARMA_USE_LAPACK": [True, False],
+        "ARMA_USE_BLAS": [True, False],
+        "ARMA_USE_ATLAS": [True, False],
+        "ARMA_USE_HDF5": [True, False],
+        "ARMA_USE_ARPACK": [True, False],
+        "ARMA_USE_EXTERN_RNG": [True, False],
+        "ARMA_USE_SUPERLU": [True, False],
+        "ARMA_USE_WRAPPER": [True, False],
+        # These are the options that the armadillo CMakeLists exposes
+        "ALLOW_FLEXIBLAS_LINUX": [True, False],
+        "ALLOW_OPENBLAS_MACOS": [True, False],
+        "ALLOW_BLAS_LAPACK_MACOS": [True, False],
+        # These are options unique to this recipe
+        # Optional dependencies
+        "USE_OPENBLAS": [True, False],  # Use conan OpenBLAS package
+        # System dependency overrides
+        "USE_SYSTEM_LAPACK": [True, False],
+        "USE_SYSTEM_BLAS": [True, False],
+        "USE_SYSTEM_ATLAS": [True, False],
+        "USE_SYSTEM_HDF5": [True, False],
+        "USE_SYSTEM_ARPACK": [True, False],
+        "USE_SYSTEM_SUPERLU": [True, False],
+        "USE_SYSTEM_OPENBLAS": [True, False],
+        "USE_SYSTEM_FLEXIBLAS": [True, False],
+        "USE_SYSTEM_MKL": [True, False],
+        "MKL_LIBRARY_PATH": "ANY",
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        # These are options exposed by armadillo_bits/config.hpp
+        "ARMA_USE_LAPACK": True,
+        "ARMA_USE_BLAS": True,
+        "ARMA_USE_ATLAS": False,
+        "ARMA_USE_HDF5": True,
+        "ARMA_USE_ARPACK": False,
+        "ARMA_USE_EXTERN_RNG": False,
+        "ARMA_USE_SUPERLU": False,
+        "ARMA_USE_WRAPPER": False,
+        # These are the options that the armadillo CMakeLists exposes
+        "ALLOW_FLEXIBLAS_LINUX": False,
+        "ALLOW_OPENBLAS_MACOS": False,
+        "ALLOW_BLAS_LAPACK_MACOS": False,
+        # These are options unique to this recipe
+        # Optional dependencies
+        "USE_OPENBLAS": True,  # Use conan OpenBLAS package
+        # System dependency overrides
+        "USE_SYSTEM_LAPACK": False,
+        "USE_SYSTEM_BLAS": False,
+        "USE_SYSTEM_ATLAS": False,
+        "USE_SYSTEM_HDF5": False,
+        "USE_SYSTEM_ARPACK": False,
+        "USE_SYSTEM_SUPERLU": False,
+        "USE_SYSTEM_OPENBLAS": False,
+        "USE_SYSTEM_FLEXIBLAS": False,
+        "USE_SYSTEM_MKL": False,
+        "MKL_LIBRARY_PATH": "",
+    }
+    # Options that have a dependency on a specific operating system
+    os_dependencies = {
+        "ALLOW_FLEXIBLAS_LINUX": "Linux",
+        "ALLOW_BLAS_LAPACK_MACOS": "Macos",
+        "ALLOW_OPENBLAS_MACOS": "Macos",
+    }
+    # Options that require another option to be set to be valid
+    opt_dependencies = {
+        "ARMA_USE_LAPACK": "ARMA_USE_BLAS",
+        "USE_SYSTEM_LAPACK": "ARMA_USE_LAPACK",
+        "USE_SYSTEM_BLAS": "ARMA_USE_BLAS",
+        "USE_SYSTEM_ATLAS": "ARMA_USE_ATLAS",
+        "USE_SYSTEM_ARPACK": "ARMA_USE_ARPACK",
+        "USE_SYSTEM_SUPERLU": "ARMA_USE_SUPERLU",
+        "USE_SYSTEM_HDF5": "ARMA_USE_HDF5",
+        "MKL_LIBRARY_PATH": "USE_SYSTEM_MKL",
+    }
+    # Options that are mutually exclusive
+    exclusions = {
+        "blas": [
+            "USE_OPENBLAS",
+            "USE_SYSTEM_OPENBLAS",
+            "USE_SYSTEM_MKL",
+            "USE_SYSTEM_FLEXIBLAS",
+            "USE_SYSTEM_BLAS",
+        ],
+        "lapack": ["USE_SYSTEM_LAPACK", "USE_SYSTEM_ATLAS"],
+    }
+    exports_sources = "CMakeLists.txt"
+    generators = (
+        "cmake",
+        "cmake_find_package",
+    )
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+        # Use default MKL path or throw error if no default path exists
+        if self.options.USE_SYSTEM_MKL and not self.options.MKL_LIBRARY_PATH:
+            if self.settings.os == "Linux":
+                self.options.MKL_LIBRARY_PATH = "/opt/intel/mkl/lib/intel64"
+            elif self.settings.os == "Windows":
+                self.options.MKL_LIBRARY_PATH = (
+                    "C:/IntelSWTools/compilers_and_libraries/windows/mkl/lib/intel64"
+                )
+            else:
+                raise ConanInvalidConfiguration(
+                    f"A default MKL_LIBRARY_PATH value for your operating system is not available. Please specify a value for MKL_LIBRARY_PATH"
+                )
+        # If no BLAS package has been specified, OpenBLAS will be the default
+        if (
+            self.options.ARMA_USE_BLAS
+            and not self.options.USE_OPENBLAS
+            and not self.options.USE_SYSTEM_OPENBLAS
+            and not self.options.USE_SYSTEM_BLAS
+        ):
+            blas_conflicts = [
+                x for x in self.exclusions["blas"] if getattr(self.options, x)
+            ]
+            if (
+                (
+                    (
+                        self.settings.os == "Macos"
+                        and self.ALLOW_BLAS_LAPACK_MACOS
+                        and self.options.ALLOW_OPENBLAS_MACOS
+                    )
+                    or self.settings.os != "Macos"
+                )
+                and self.options.ARMA_USE_BLAS
+                and not blas_conflicts
+            ):
+                self.options.USE_OPENBLAS = True
+
+    def validate(self):
+        # Do validation stuff here to make sure options are valid
+        # Iterate over dependency maps to confirm requirements are met
+        for option, dependency in self.os_dependencies.items():
+            if getattr(self.options, option) and self.settings.os != dependency:
+                raise ConanInvalidConfiguration(
+                    f"Option {option} can only be enabled on {dependency} operating systems"
+                )
+
+        for option, dependency in self.opt_dependencies.items():
+            if getattr(self.options, option) and not getattr(self.options, dependency):
+                raise ConanInvalidConfiguration(
+                    f"Option {option} cannot be enabled without enabling {dependency}"
+                )
+
+        for category, incompatible_opts in self.exclusions.items():
+            conflicts = [x for x in incompatible_opts if getattr(self.options, x)]
+            if len(conflicts) > 1:
+                raise ConanInvalidConfiguration(
+                    "The following options are in conflict: {conflict}. Resolve this conflict by ensuring only one of these options is enabled and try again.".format(
+                        conflict=", ".join(conflicts)
+                    )
+                )
+
+        if self.settings.compiler == "Visual Studio" and self.options.shared:
+            self.output.warn(
+                "Building a shared library with MSVC is not supported. This may not be successful."
+            )
+
+    def requirements(self):
+        # Optional requirements
+        openblas = "openblas/[>=0.3.10]"
+        hdf5 = "hdf5/[>=1.12.0]"
+        # atlas = "atlas/3.10.3" # Pending https://github.com/conan-io/conan-center-index/issues/6757
+        # superlu = "superlu/5.2.2" # Pending https://github.com/conan-io/conan-center-index/issues/6756
+        # arpack = "arpack/1.0" # Pending https://github.com/conan-io/conan-center-index/issues/6755
+        # flexiblas = "flexiblas/3.0.4" # Pending https://github.com/conan-io/conan-center-index/issues/6827
+
+        if self.options.ARMA_USE_HDF5 and not self.options.USE_SYSTEM_HDF5:
+            # Use the conan dependency if the system lib isn't being used
+            self.requires(hdf5)
+            self.options["hdf5"].shared = self.options.shared
+
+        if self.options.USE_OPENBLAS:
+            self.requires(openblas)
+            # Note that if you're relying on this to build LAPACK, you _must_ have
+            # gfortran installed. If you don't, OpenBLAS will build successfully but
+            # without LAPACK support, which isn't obvious.
+            self.options["openblas"].build_lapack = (
+                self.options.ARMA_USE_LAPACK and not self.options.USE_SYSTEM_LAPACK
+            )
+            self.options["openblas"].shared = self.options.shared
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["ARMA_USE_LAPACK"] = self.options.ARMA_USE_LAPACK
+        self._cmake.definitions["ARMA_USE_BLAS"] = self.options.ARMA_USE_BLAS
+        self._cmake.definitions["ARMA_USE_ATLAS"] = self.options.ARMA_USE_ATLAS
+        self._cmake.definitions["ARMA_USE_HDF5"] = self.options.ARMA_USE_HDF5
+        self._cmake.definitions["ARMA_USE_ARPACK"] = self.options.ARMA_USE_ARPACK
+        self._cmake.definitions[
+            "ARMA_USE_EXTERN_RNG"
+        ] = self.options.ARMA_USE_EXTERN_RNG
+        self._cmake.definitions["ARMA_USE_SUPERLU"] = self.options.ARMA_USE_SUPERLU
+        self._cmake.definitions["ARMA_USE_WRAPPER"] = self.options.ARMA_USE_WRAPPER
+        self._cmake.definitions["DETECT_HDF5"] = self.options.ARMA_USE_HDF5
+        self._cmake.definitions["USE_OPENBLAS"] = self.options.USE_OPENBLAS
+        self._cmake.definitions["USE_SYSTEM_LAPACK"] = self.options.USE_SYSTEM_LAPACK
+        self._cmake.definitions["USE_SYSTEM_BLAS"] = self.options.USE_SYSTEM_BLAS
+        self._cmake.definitions["USE_SYSTEM_ATLAS"] = self.options.USE_SYSTEM_ATLAS
+        self._cmake.definitions["USE_SYSTEM_HDF5"] = self.options.USE_SYSTEM_HDF5
+        self._cmake.definitions["USE_SYSTEM_ARPACK"] = self.options.USE_SYSTEM_ARPACK
+        self._cmake.definitions["USE_SYSTEM_SUPERLU"] = self.options.USE_SYSTEM_SUPERLU
+        self._cmake.definitions[
+            "USE_SYSTEM_OPENBLAS"
+        ] = self.options.USE_SYSTEM_OPENBLAS
+        self._cmake.definitions[
+            "USE_SYSTEM_FLEXIBLAS"
+        ] = self.options.USE_SYSTEM_FLEXIBLAS
+        self._cmake.definitions["USE_SYSTEM_MKL"] = self.options.USE_SYSTEM_MKL
+        self._cmake.definitions[
+            "ALLOW_FLEXIBLAS_LINUX"
+        ] = self.options.ALLOW_FLEXIBLAS_LINUX
+        self._cmake.definitions[
+            "ALLOW_OPENBLAS_MACOS"
+        ] = self.options.ALLOW_OPENBLAS_MACOS
+        self._cmake.definitions[
+            "ALLOW_BLAS_LAPACK_MACOS"
+        ] = self.options.ALLOW_BLAS_LAPACK_MACOS
+        self._cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def source(self):
+        tools.get(
+            **self.conan_data["sources"][self.version],
+            strip_root=True,
+            destination=self._source_subfolder,
+            filename="{name}-{version}.tar.xz".format(
+                name=self.name, version=self.version
+            ),
+        )
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            "include(ARMA_FindBLAS)",
+            """
+if(USE_SYSTEM_BLAS)
+  include(ARMA_FindBLAS)
+else()
+  set(BLAS_FOUND NO)
+endif()""",
+        )
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            "include(ARMA_FindOpenBLAS)",
+            """
+if(USE_SYSTEM_OPENBLAS)
+  include(ARMA_FindOpenBLAS)
+elseif(USE_OPENBLAS)
+  find_package(OpenBLAS)
+else()
+  set(OpenBLAS_FOUND NO)
+endif()""",
+        )
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            "include(ARMA_FindFlexiBLAS)",
+            """
+if(USE_SYSTEM_FLEXIBLAS)
+  include(ARMA_FindFlexiBLAS)
+else()
+  set(FlexiBLAS_FOUND NO)
+endif()""",
+        )
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            "include(ARMA_FindMKL)",
+            """
+if(USE_SYSTEM_MKL)
+  include(ARMA_FindMKL)
+else()
+  set(MKL_FOUND NO)
+endif()""",
+        )
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            "include(ARMA_FindLAPACK)",
+            """
+if(USE_SYSTEM_LAPACK)
+  include(ARMA_FindLAPACK)
+else()
+  set(LAPACK_FOUND NO)
+endif()""",
+        )
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            "include(ARMA_FindARPACK)",
+            """
+if(USE_SYSTEM_ARPACK)
+  include(ARMA_FindARPACK)
+else()
+  set(ARPACK_FOUND NO)
+endif()""",
+        )
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            "include(ARMA_FindSuperLU5)",
+            """
+if(USE_SYSTEM_SUPERLU)
+  include(ARMA_FindSuperLU5)
+else()
+  set(SuperLU_FOUND NO)
+endif()""",
+        )
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            "include(ARMA_FindATLAS)",
+            """
+if(USE_SYSTEM_ATLAS)
+  include(ARMA_FindATLAS)
+else()
+  set(ATLAS_FOUND NO)
+endif()""",
+        )
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            "list(GET HDF5_INCLUDE_DIRS 0 ARMA_HDF5_INCLUDE_DIR)",
+            """
+if(NOT USE_SYSTEM_HDF5)
+  list(GET HDF5_INCLUDE_DIRS 1 ARMA_HDF5_INCLUDE_DIR)
+else()
+  list(GET HDF5_INCLUDE_DIRS 0 ARMA_HDF5_INCLUDE_DIR)
+endif()""",
+        )
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE.txt", dst="licenses", src=self._source_subfolder)
+        self.copy("NOTICE.txt", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["armadillo"]
+        self.cpp_info.names["pkg_config"] = "armadillo"
+
+        if self.options.USE_SYSTEM_MKL:
+            self.cpp_info.libs.extend(["mkl_rt"])
+            self.cpp_info.libdirs.append(str(self.options.MKL_LIBRARY_PATH))
+
+        if self.settings.build_type == "Release":
+            self.cpp_info.defines.append("ARMA_NO_DEBUG")
+
+        # The wrapper library links everything together. If disabled, system libs must be
+        # linked manually
+        if not self.options.ARMA_USE_WRAPPER:
+            self.cpp_info.defines.append("ARMA_DONT_USE_WRAPPER")
+            if self.settings.os == "Macos" and not self.options.ALLOW_BLAS_LAPACK_MACOS:
+                self.cpp_info.frameworks.append("Accelerate")
+
+        if self.options.ARMA_USE_HDF5:
+            self.cpp_info.defines.append("ARMA_USE_HDF5")
+            if self.options.USE_SYSTEM_HDF5 and not self.options.ARMA_USE_WRAPPER:
+                self.cpp_info.system_libs.extend(
+                    ["hdf5", "hdf5_cpp", "hdf5_hl", "hdf5_hl_cpp"]
+                )
+        else:
+            self.cpp_info.defines.append("ARMA_DONT_USE_HDF5")
+
+        if self.options.ARMA_USE_BLAS:
+            self.cpp_info.defines.append("ARMA_USE_BLAS")
+            if self.options.USE_SYSTEM_BLAS and not self.options.ARMA_USE_WRAPPER:
+                self.cpp_info.system_libs.extend(["blas"])
+        else:
+            self.cpp_info.defines.append("ARMA_DONT_USE_BLAS")
+
+        if self.options.ARMA_USE_LAPACK:
+            self.cpp_info.defines.append("ARMA_USE_LAPACK")
+            if self.options.USE_SYSTEM_LAPACK and not self.options.ARMA_USE_WRAPPER:
+                self.cpp_info.system_libs.extend(["lapack"])
+        else:
+            self.cpp_info.defines.append("ARMA_DONT_USE_LAPACK")
+
+        if self.options.ARMA_USE_ARPACK:
+            self.cpp_info.defines.append("ARMA_USE_ARPACK")
+            if self.options.USE_SYSTEM_ARPACK and not self.options.ARMA_USE_WRAPPER:
+                self.cpp_info.system_libs.extend(["arpack"])
+        else:
+            self.cpp_info.defines.append("ARMA_DONT_USE_ARPACK")
+
+        if self.options.ARMA_USE_SUPERLU:
+            self.cpp_info.defines.append("ARMA_USE_SUPERLU")
+            if self.options.USE_SYSTEM_SUPERLU and not self.options.ARMA_USE_WRAPPER:
+                self.cpp_info.system_libs.extend(["superlu"])
+        else:
+            self.cpp_info.defines.append("ARMA_DONT_USE_SUPERLU")
+
+        if self.options.ARMA_USE_ATLAS:
+            self.cpp_info.defines.append("ARMA_USE_ATLAS")
+            if self.options.USE_SYSTEM_ATLAS and not self.options.ARMA_USE_WRAPPER:
+                self.cpp_info.system_libs.extend(["atlas"])
+        else:
+            self.cpp_info.defines.append("ARMA_DONT_USE_ATLAS")

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -216,8 +216,9 @@ class ArmadilloConan(ConanFile):
         if self.options.USE_OPENBLAS:
             self.requires(openblas)
             # Note that if you're relying on this to build LAPACK, you _must_ have
-            # gfortran installed. If you don't, OpenBLAS will build successfully but
+            # a fortran compiler installed. If you don't, OpenBLAS will build successfully but
             # without LAPACK support, which isn't obvious.
+            # This can be achieved by setting the FC environment variable in your conan profile
             self.options["openblas"].build_lapack = (
                 self.options.ARMA_USE_LAPACK and not self.options.USE_SYSTEM_LAPACK
             )

--- a/recipes/armadillo/all/test_package/CMakeLists.txt
+++ b/recipes/armadillo/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.6)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})

--- a/recipes/armadillo/all/test_package/conanfile.py
+++ b/recipes/armadillo/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class ArmadilloTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/armadillo/all/test_package/example.cpp
+++ b/recipes/armadillo/all/test_package/example.cpp
@@ -1,0 +1,155 @@
+#include <iostream>
+#include <armadillo>
+
+using namespace std;
+using namespace arma;
+
+// Armadillo documentation is available at:
+// http://arma.sourceforge.net/docs.html
+
+// NOTE: the C++11 "auto" keyword is not recommended for use with Armadillo objects and functions
+
+int
+main(int argc, char** argv)
+  {
+  cout << "Armadillo version: " << arma_version::as_string() << endl;
+  
+  // construct a matrix according to given size and form of element initialisation
+  mat A(2,3,fill::zeros);
+  
+  // .n_rows and .n_cols are read only
+  cout << "A.n_rows: " << A.n_rows << endl;
+  cout << "A.n_cols: " << A.n_cols << endl;
+  
+  A(1,2) = 456.0;  // access an element (indexing starts at 0)
+  A.print("A:");
+  
+  A = 5.0;         // scalars are treated as a 1x1 matrix
+  A.print("A:");
+  
+  A.set_size(4,5); // change the size (data is not preserved)
+  
+  A.fill(5.0);     // set all elements to a specific value
+  A.print("A:");
+  
+  A = { { 0.165300, 0.454037, 0.995795, 0.124098, 0.047084 },
+        { 0.688782, 0.036549, 0.552848, 0.937664, 0.866401 },
+        { 0.348740, 0.479388, 0.506228, 0.145673, 0.491547 },
+        { 0.148678, 0.682258, 0.571154, 0.874724, 0.444632 },
+        { 0.245726, 0.595218, 0.409327, 0.367827, 0.385736 } };
+        
+  A.print("A:");
+  
+  // determinant
+  cout << "det(A): " << det(A) << endl;
+  
+  // inverse
+  cout << "inv(A): " << endl << inv(A) << endl;
+  
+  // save matrix as a text file
+  A.save("A.txt", raw_ascii);
+  
+  // load from file
+  mat B;
+  B.load("A.txt");
+  
+  // submatrices
+  cout << "B( span(0,2), span(3,4) ):" << endl << B( span(0,2), span(3,4) ) << endl;
+  
+  cout << "B( 0,3, size(3,2) ):" << endl << B( 0,3, size(3,2) ) << endl;
+  
+  cout << "B.row(0): " << endl << B.row(0) << endl;
+  
+  cout << "B.col(1): " << endl << B.col(1) << endl;
+  
+  // transpose
+  cout << "B.t(): " << endl << B.t() << endl;
+  
+  // maximum from each column (traverse along rows)
+  cout << "max(B): " << endl << max(B) << endl;
+  
+  // maximum from each row (traverse along columns)
+  cout << "max(B,1): " << endl << max(B,1) << endl;
+  
+  // maximum value in B
+  cout << "max(max(B)) = " << max(max(B)) << endl;
+  
+  // sum of each column (traverse along rows)
+  cout << "sum(B): " << endl << sum(B) << endl;
+  
+  // sum of each row (traverse along columns)
+  cout << "sum(B,1) =" << endl << sum(B,1) << endl;
+  
+  // sum of all elements
+  cout << "accu(B): " << accu(B) << endl;
+  
+  // trace = sum along diagonal
+  cout << "trace(B): " << trace(B) << endl;
+  
+  // generate the identity matrix
+  mat C = eye<mat>(4,4);
+  
+  // random matrix with values uniformly distributed in the [0,1] interval
+  mat D = randu<mat>(4,4);
+  D.print("D:");
+  
+  // row vectors are treated like a matrix with one row
+  rowvec r = { 0.59119, 0.77321, 0.60275, 0.35887, 0.51683 };
+  r.print("r:");
+  
+  // column vectors are treated like a matrix with one column
+  vec q = { 0.14333, 0.59478, 0.14481, 0.58558, 0.60809 };
+  q.print("q:");
+  
+  // convert matrix to vector; data in matrices is stored column-by-column
+  vec v = vectorise(A);
+  v.print("v:");
+  
+  // dot or inner product
+  cout << "as_scalar(r*q): " << as_scalar(r*q) << endl;
+  
+  // outer product
+  cout << "q*r: " << endl << q*r << endl;
+  
+  // multiply-and-accumulate operation (no temporary matrices are created)
+  cout << "accu(A % B) = " << accu(A % B) << endl;
+  
+  // example of a compound operation
+  B += 2.0 * A.t();
+  B.print("B:");
+  
+  // imat specifies an integer matrix
+  imat AA = { { 1, 2, 3 },
+              { 4, 5, 6 },
+              { 7, 8, 9 } };
+  
+  imat BB = { { 3, 2, 1 }, 
+              { 6, 5, 4 },
+              { 9, 8, 7 } };
+  
+  // comparison of matrices (element-wise); output of a relational operator is a umat
+  umat ZZ = (AA >= BB);
+  ZZ.print("ZZ:");
+  
+  // cubes ("3D matrices")
+  cube Q( B.n_rows, B.n_cols, 2 );
+  
+  Q.slice(0) = B;
+  Q.slice(1) = 2.0 * B;
+  
+  Q.print("Q:");
+  
+  // 2D field of matrices; 3D fields are also supported
+  field<mat> F(4,3); 
+  
+  for(uword col=0; col < F.n_cols; ++col)
+      for(uword row=0; row < F.n_rows; ++row)
+        {
+        F(row,col) = randu<mat>(2,3);  // each element in field<mat> is a matrix
+        }
+  
+  F.print("F:");
+  
+  return 0;
+  }
+

--- a/recipes/armadillo/config.yml
+++ b/recipes/armadillo/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "10.6.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **armadillo/10.6.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

Armadillo is a math library that I'd like to use. From a quick survey it's a dependency of the following packages:
* gdal - https://github.com/conan-io/conan-center-index/issues/1023
* mlpack: https://github.com/conan-io/wishlist/issues/106
* ensmallen: https://github.com/conan-io/conan-center-index/issues/6797

It's also on the list of most relevant c++ libraries not already packaged:
* https://github.com/conan-io/conan-center-index/issues/621

This recipe is designed to be as true to the original packaging as it feasibly could. Of note, this means:
* Option names match the configuration settings exposed by armadillo
* Retains the ability to search for system libraries if specified - specifically, it can be configured to use libraries that aren't currently packaged by conan as system dependencies (these are optional, though, and not used by default):
    * ATLAS - https://github.com/conan-io/conan-center-index/issues/6757
    * SuperLU - https://github.com/conan-io/conan-center-index/issues/6756
    * ARPACK - https://github.com/conan-io/conan-center-index/issues/6755
    * MKL - https://github.com/conan-io/conan-center-index/issues/6801
    * FlexiBLAS - https://github.com/conan-io/conan-center-index/issues/6827
    * LAPACK - https://github.com/conan-io/conan-center-index/issues/4509

By default, this package utilises OpenBLAS to fulfill its BLAS and LAPACK requirements. It uses OpenBLAS by default on Linux and Windows operating systems, and configures it to build with LAPACK support. On Macos, it's configured to use the Accelerate framework by default. This usage of OpenBLAS introduces an upstream system dependency on a fortran compiler in order to provide LAPACK support.

Armadillo _is_ capable of running _without_ LAPACK support, however it only runs with a subset of features and the provided example code will fail with an error indicating LAPACK functionality needs to be provided when attempting to execute a command that requires it.

Of note, this build will currently fail if the usage of lapack is not disabled and a fortran compiler is not present on the system. This is because OpenBLAS will continue to build when configured to build with LAPACK, even when it can't find a fortran compiler. In this case, it will build with BLAS support only, and defer this problem downstream to the consumer. Armadillo will also build successfully, however it will have linked against the LAPACK symbols, and so any consumer usage of the resulting library will result in unresolved symbol errors. I've raised #7294 to address this issue and trigger a failure if a fortran compiler is not found.

I'm looking for some feedback on this recipe, specifically:
* Are we happy to accept the ability to toggle on usage of system libraries?
    * My thoughts are that this will be good in the mid-term until the above libraries can be packaged in conan. The only system requirement imposed currently is fortran, which is really a requirement of the upstream OpenBLAS recipe so it should be possible for users to use this recipe in its default configuration if they have a fortran compiler. If they don't BLAS or LAPACK functionality can be turned off to provide whatever functionality is required, or augmented with system libraries as required.
* I've got a number of `replace_in_file` calls in the recipe - are these better placed as patches?
* Is there a better way of managing co-dependent/mutually exclusive options than what I've done here?
* Are there any other improvements that can be made?

I'm not the author of this library.
---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
