### PR TITLE
bump up leveldb 1.23

### DIFF
--- a/recipes/leveldb/all/conandata.yml
+++ b/recipes/leveldb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.23":
+    sha256: 9a37f8a6174f09bd622bc723b55881dc541cd50747cbd08831c2a82d620f6d76
+    url: https://github.com/google/leveldb/archive/1.23.tar.gz
   "1.22":
     sha256: 55423cac9e3306f4a9502c738a001e4a339d1a38ffbee7572d4a07d5d63949b2
     url: https://github.com/google/leveldb/archive/1.22.tar.gz

--- a/recipes/leveldb/all/conanfile.py
+++ b/recipes/leveldb/all/conanfile.py
@@ -35,6 +35,10 @@ class LevelDBCppConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
     # FIXME: crc32, tcmalloc are also conditionally included in leveldb, but
     # there are no "official" conan packages yet; when those are available, we
     # can add similar with options for those

--- a/recipes/leveldb/config.yml
+++ b/recipes/leveldb/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.23":
+    folder: "all"
   "1.22":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **leveldb/1.23**

leveldb bumps up 1.23.
This release included a lot of bug fixes.
But I couldn't find breaking changes.

---

- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [+] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [+] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
