### PR TITLE
[cppcheck] Add cppcheck-htmlreport script

### DIFF
--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -18,15 +18,25 @@ patches:
   "2.5":
     - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0002-htmlreport-python3.patch"
+      base_path: "source_subfolder"
   "2.4.1":
     - patch_file: "patches/0001-cmake-source-dir.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-htmlreport-python3.patch"
       base_path: "source_subfolder"
   "2.4":
     - patch_file: "patches/0001-cmake-source-dir.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0002-htmlreport-python3.patch"
+      base_path: "source_subfolder"
   "2.3":
     - patch_file: "patches/0001-cmake-source-dir.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0002-htmlreport-python3.patch"
+      base_path: "source_subfolder"
   "2.2":
     - patch_file: "patches/0001-cmake-source-dir.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-htmlreport-python3.patch"
       base_path: "source_subfolder"

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -72,3 +72,5 @@ class CppcheckConan(ConanFile):
         bin_folder = os.path.join(self.package_folder, "bin")
         self.output.info("Append %s to environment variable PATH" % bin_folder)
         self.env_info.PATH.append(bin_folder)
+        # This is required to run the python script on windows, as we cannot simply add it to the PATH
+        self.env_info.CPPCHECK_HTMLREPORT = os.path.join(bin_folder, "cppcheck-htmlreport")

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -63,6 +63,7 @@ class CppcheckConan(ConanFile):
     def package(self):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)
         self.copy("*", dst=os.path.join("bin","cfg"), src=os.path.join(self._source_subfolder,"cfg"))
+        self.copy("cppcheck-htmlreport", dst=os.path.join("bin"), src=os.path.join(self._source_subfolder,"htmlreport"))
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "share"))

--- a/recipes/cppcheck/all/patches/0002-htmlreport-python3.patch
+++ b/recipes/cppcheck/all/patches/0002-htmlreport-python3.patch
@@ -1,0 +1,10 @@
+diff --git a/htmlreport/cppcheck-htmlreport b/htmlreport/cppcheck-htmlreport
+index 97a3af50d..b45cebf31 100755
+--- a/htmlreport/cppcheck-htmlreport
++++ b/htmlreport/cppcheck-htmlreport
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ from __future__ import unicode_literals
+ 

--- a/recipes/cppcheck/all/test_package/conanfile.py
+++ b/recipes/cppcheck/all/test_package/conanfile.py
@@ -7,4 +7,8 @@ class TestPackageConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             self.run("cppcheck --version", run_environment=True)
-            self.run("cppcheck-htmlreport -h", run_environment=True)
+            # On windows we need to explicitly use python to run the python script
+            if self.settings.os == 'Windows':
+                self.run("python3 $CPPCHECK_HTMLREPORT -h", run_environment=True)
+            else:
+                self.run("cppcheck-htmlreport -h", run_environment=True)

--- a/recipes/cppcheck/all/test_package/conanfile.py
+++ b/recipes/cppcheck/all/test_package/conanfile.py
@@ -8,7 +8,8 @@ class TestPackageConan(ConanFile):
         if not tools.cross_building(self.settings):
             self.run("cppcheck --version", run_environment=True)
             # On windows we need to explicitly use python to run the python script
-            if self.settings.os == 'Windows' and tools.which("python3"):
-                self.run("python3 $CPPCHECK_HTMLREPORT -h", run_environment=True)
+            if self.settings.os == 'Windows':
+                if tools.which("python3"):
+                    self.run("python3 $CPPCHECK_HTMLREPORT -h", run_environment=True)
             else:
                 self.run("cppcheck-htmlreport -h", run_environment=True)

--- a/recipes/cppcheck/all/test_package/conanfile.py
+++ b/recipes/cppcheck/all/test_package/conanfile.py
@@ -7,3 +7,4 @@ class TestPackageConan(ConanFile):
     def test(self):
         if not tools.cross_building(self.settings):
             self.run("cppcheck --version", run_environment=True)
+            self.run("cppcheck-htmlreport -h", run_environment=True)

--- a/recipes/cppcheck/all/test_package/conanfile.py
+++ b/recipes/cppcheck/all/test_package/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools
+import sys
 
 
 class TestPackageConan(ConanFile):
@@ -9,7 +10,6 @@ class TestPackageConan(ConanFile):
             self.run("cppcheck --version", run_environment=True)
             # On windows we need to explicitly use python to run the python script
             if self.settings.os == 'Windows':
-                if tools.which("python3"):
-                    self.run("python3 $CPPCHECK_HTMLREPORT -h", run_environment=True)
+                self.run("{} {} -h".format(sys.executable, tools.get_env("CPPCHECK_HTMLREPORT")))
             else:
                 self.run("cppcheck-htmlreport -h", run_environment=True)

--- a/recipes/cppcheck/all/test_package/conanfile.py
+++ b/recipes/cppcheck/all/test_package/conanfile.py
@@ -8,7 +8,7 @@ class TestPackageConan(ConanFile):
         if not tools.cross_building(self.settings):
             self.run("cppcheck --version", run_environment=True)
             # On windows we need to explicitly use python to run the python script
-            if self.settings.os == 'Windows':
+            if self.settings.os == 'Windows' and tools.which("python3"):
                 self.run("python3 $CPPCHECK_HTMLREPORT -h", run_environment=True)
             else:
                 self.run("cppcheck-htmlreport -h", run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **cppcheck** (any version)

This PR adds the cppcheck-htmlreport script which is included in the cppcheck repo, but was not yet copied to the conan package.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
