### PR TITLE
bump up cimg 2.9.9

### DIFF
--- a/recipes/cimg/all/conandata.yml
+++ b/recipes/cimg/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.9.9":
+    url: "https://cimg.eu/files/CImg_2.9.9.zip"
+    sha256: "c94412f26800ea318fa79410c58da1cf3df71771d07e515c39b16ee743f68e92"
   "2.9.4":
     url: "https://cimg.eu/files/CImg_2.9.4.zip"
     sha256: "455945dc035d50bbc042450e2dc81b2ca19ea74cd3bc38b46ac623df6997dfff"

--- a/recipes/cimg/config.yml
+++ b/recipes/cimg/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.9.9":
+    folder: all
   "2.9.4":
     folder: all
   "2.9.2":


### PR DESCRIPTION
Specify library name and version:  **cimg/2.9.9**

There are a lot of bugfixes from cimg/2.9.4.

---

- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [+] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [+] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
