### PR TITLE
opencl-icd-loader: Add disable_openclon12 option to avoid Windows SDK

### DIFF
--- a/recipes/opencl-icd-loader/all/conanfile.py
+++ b/recipes/opencl-icd-loader/all/conanfile.py
@@ -26,6 +26,8 @@ class OpenclIcdLoaderConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        else:
+            del self.options.disable_openclon12
 
     def configure(self):
         if self.options.shared:
@@ -48,7 +50,8 @@ class OpenclIcdLoaderConan(ConanFile):
             self._cmake.definitions["USE_DYNAMIC_VCXX_RUNTIME"] = str(self.settings.compiler.runtime).startswith("MD")
         self._cmake.definitions["OPENCL_ICD_LOADER_PIC"] = self.options.get_safe("fPIC", True)
         self._cmake.definitions["OPENCL_ICD_LOADER_BUILD_TESTING"] = False
-        self._cmake.definitions["OPENCL_ICD_LOADER_DISABLE_OPENCLON12"] = self.options.disable_openclon12
+        if self.settings.os == "Windows":
+            self._cmake.definitions["OPENCL_ICD_LOADER_DISABLE_OPENCLON12"] = self.options.disable_openclon12
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/opencl-icd-loader/all/conanfile.py
+++ b/recipes/opencl-icd-loader/all/conanfile.py
@@ -36,8 +36,7 @@ class OpenclIcdLoaderConan(ConanFile):
         self.requires("opencl-headers/{}".format(self.version))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        tools.rename("OpenCL-ICD-Loader-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/opencl-icd-loader/all/conanfile.py
+++ b/recipes/opencl-icd-loader/all/conanfile.py
@@ -48,7 +48,7 @@ class OpenclIcdLoaderConan(ConanFile):
             self._cmake.definitions["USE_DYNAMIC_VCXX_RUNTIME"] = str(self.settings.compiler.runtime).startswith("MD")
         self._cmake.definitions["OPENCL_ICD_LOADER_PIC"] = self.options.get_safe("fPIC", True)
         self._cmake.definitions["OPENCL_ICD_LOADER_BUILD_TESTING"] = False
-        self._cmake.definitions["OPENCL_ICD_LOADER_DISABLE_OPENCLON12"] = self.options.get_safe("disable_openclon12", False)
+        self._cmake.definitions["OPENCL_ICD_LOADER_DISABLE_OPENCLON12"] = self.options.disable_openclon12
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/opencl-icd-loader/all/conanfile.py
+++ b/recipes/opencl-icd-loader/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
+required_conan_version = ">=1.33.0" 
 
 class OpenclIcdLoaderConan(ConanFile):
     name = "opencl-icd-loader"

--- a/recipes/opencl-icd-loader/all/conanfile.py
+++ b/recipes/opencl-icd-loader/all/conanfile.py
@@ -11,8 +11,8 @@ class OpenclIcdLoaderConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
 
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "disable_openclon12": [True, False]}
+    default_options = {"shared": False, "fPIC": True, "disable_openclon12": False}
 
     exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake"
@@ -48,6 +48,7 @@ class OpenclIcdLoaderConan(ConanFile):
             self._cmake.definitions["USE_DYNAMIC_VCXX_RUNTIME"] = str(self.settings.compiler.runtime).startswith("MD")
         self._cmake.definitions["OPENCL_ICD_LOADER_PIC"] = self.options.get_safe("fPIC", True)
         self._cmake.definitions["OPENCL_ICD_LOADER_BUILD_TESTING"] = False
+        self._cmake.definitions["OPENCL_ICD_LOADER_DISABLE_OPENCLON12"] = True
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/opencl-icd-loader/all/conanfile.py
+++ b/recipes/opencl-icd-loader/all/conanfile.py
@@ -48,7 +48,7 @@ class OpenclIcdLoaderConan(ConanFile):
             self._cmake.definitions["USE_DYNAMIC_VCXX_RUNTIME"] = str(self.settings.compiler.runtime).startswith("MD")
         self._cmake.definitions["OPENCL_ICD_LOADER_PIC"] = self.options.get_safe("fPIC", True)
         self._cmake.definitions["OPENCL_ICD_LOADER_BUILD_TESTING"] = False
-        self._cmake.definitions["OPENCL_ICD_LOADER_DISABLE_OPENCLON12"] = True
+        self._cmake.definitions["OPENCL_ICD_LOADER_DISABLE_OPENCLON12"] = self.options.get_safe("disable_openclon12", False)
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/opencl-icd-loader/all/conanfile.py
+++ b/recipes/opencl-icd-loader/all/conanfile.py
@@ -6,7 +6,7 @@ class OpenclIcdLoaderConan(ConanFile):
     name = "opencl-icd-loader"
     description = "OpenCL ICD Loader."
     license = "Apache-2.0"
-    topics = ("conan", "opencl-icd-loader", "opencl", "khronos", "parallel", "icd-loader")
+    topics = ("opencl-icd-loader", "opencl", "khronos", "parallel", "icd-loader")
     homepage = "https://github.com/KhronosGroup/OpenCL-ICD-Loader"
     url = "https://github.com/conan-io/conan-center-index"
 
@@ -37,7 +37,7 @@ class OpenclIcdLoaderConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        os.rename("OpenCL-ICD-Loader-" + self.version, self._source_subfolder)
+        tools.rename("OpenCL-ICD-Loader-" + self.version, self._source_subfolder)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/opencl-icd-loader/all/test_package/conanfile.py
+++ b/recipes/opencl-icd-loader/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **opencl-icd-loader/2021.04.29**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
