### PR TITLE
[magnum] Plugins can also be used as regular libraries

### DIFF
--- a/recipes/magnum/all/cmake/conan-bugfix-global-target.cmake
+++ b/recipes/magnum/all/cmake/conan-bugfix-global-target.cmake
@@ -1,0 +1,24 @@
+# If using 'cmake_find_package', all the components are being added to the global
+# target unconditionally. See generated FindMagnum.cmake file:
+# 
+# if(NOT ${CMAKE_VERSION} VERSION_LESS "3.0")
+#     if(NOT TARGET Magnum::Magnum)
+#         add_library(Magnum::Magnum INTERFACE IMPORTED)
+#     endif()
+#     set_property(TARGET Magnum::Magnum APPEND PROPERTY
+#                  INTERFACE_LINK_LIBRARIES "${Magnum_COMPONENTS}")
+# endif()
+# 
+# but it doesn't add the library directories and the linker will fail.
+# 
+# Here we fix this bug (breaking change) for this recipe, we just override
+# the list of targets again.
+# 
+
+
+if(NOT ${CMAKE_VERSION} VERSION_LESS "3.0")
+    if(TARGET Magnum::Magnum)
+        set_target_properties(Magnum::Magnum PROPERTIES INTERFACE_LINK_LIBRARIES
+            "${Magnum_Magnum_LINK_LIBS};${Magnum_Magnum_LINKER_FLAGS_LIST}")
+    endif()
+endif()

--- a/recipes/magnum/all/conanfile.py
+++ b/recipes/magnum/all/conanfile.py
@@ -623,95 +623,81 @@ class MagnumConan(ConanFile):
 
 
         ######## PLUGINS ########
-        # If shared, there are no libraries to link with
         if self.options.any_audio_importer:
             self.cpp_info.components["any_audio_importer"].names["cmake_find_package"] = "AnyAudioConverter"
             self.cpp_info.components["any_audio_importer"].names["cmake_find_package_multi"] = "AnyAudioConverter"
-            if not self.options.shared_plugins:
-                self.cpp_info.components["any_audio_importer"].libs = ["AnyAudioConverter"]
-                self.cpp_info.components["any_audio_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'audioimporters')]
+            self.cpp_info.components["any_audio_importer"].libs = ["AnyAudioConverter"]
+            self.cpp_info.components["any_audio_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'audioimporters')]
             self.cpp_info.components["any_audio_importer"].requires = ["magnum_main", "audio"]
 
         if self.options.any_image_converter:
             self.cpp_info.components["any_image_converter"].names["cmake_find_package"] = "AnyImageConverter"
             self.cpp_info.components["any_image_converter"].names["cmake_find_package_multi"] = "AnyImageConverter"
-            if not self.options.shared_plugins:
-                self.cpp_info.components["any_image_converter"].libs = ["AnyImageConverter"]
-                self.cpp_info.components["any_image_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'imageconverters')]
+            self.cpp_info.components["any_image_converter"].libs = ["AnyImageConverter"]
+            self.cpp_info.components["any_image_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'imageconverters')]
             self.cpp_info.components["any_image_converter"].requires = ["trade"]
 
         if self.options.any_image_importer:
             self.cpp_info.components["any_image_importer"].names["cmake_find_package"] = "AnyImageImporter"
             self.cpp_info.components["any_image_importer"].names["cmake_find_package_multi"] = "AnyImageImporter"
-            if not self.options.shared_plugins:
-                self.cpp_info.components["any_image_importer"].libs = ["AnyImageImporter"]
-                self.cpp_info.components["any_image_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
+            self.cpp_info.components["any_image_importer"].libs = ["AnyImageImporter"]
+            self.cpp_info.components["any_image_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
             self.cpp_info.components["any_image_importer"].requires = ["trade"]
 
         if self.options.any_scene_converter:
             self.cpp_info.components["any_scene_converter"].names["cmake_find_package"] = "AnySceneConverter"
             self.cpp_info.components["any_scene_converter"].names["cmake_find_package_multi"] = "AnySceneConverter"
-            if not self.options.shared_plugins:
-                self.cpp_info.components["any_scene_converter"].libs = ["AnySceneConverter"]
-                self.cpp_info.components["any_scene_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'sceneconverters')]
+            self.cpp_info.components["any_scene_converter"].libs = ["AnySceneConverter"]
+            self.cpp_info.components["any_scene_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'sceneconverters')]
             self.cpp_info.components["any_scene_converter"].requires = ["trade"]
 
         if self.options.any_scene_importer:
             self.cpp_info.components["any_scene_importer"].names["cmake_find_package"] = "AnySceneImporter"
             self.cpp_info.components["any_scene_importer"].names["cmake_find_package_multi"] = "AnySceneImporter"
-            if not self.options.shared_plugins:
-                self.cpp_info.components["any_scene_importer"].libs = ["AnySceneImporter"]
-                self.cpp_info.components["any_scene_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
+            self.cpp_info.components["any_scene_importer"].libs = ["AnySceneImporter"]
+            self.cpp_info.components["any_scene_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
             self.cpp_info.components["any_scene_importer"].requires = ["trade"]
 
         if self.options.magnum_font:
             self.cpp_info.components["magnum_font"].names["cmake_find_package"] = "MagnumFont"
             self.cpp_info.components["magnum_font"].names["cmake_find_package_multi"] = "MagnumFont"
-            if not self.options.shared_plugins:
-                self.cpp_info.components["magnum_font"].libs = ["MagnumFont"]
-                self.cpp_info.components["magnum_font"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'fonts')]
+            self.cpp_info.components["magnum_font"].libs = ["MagnumFont"]
+            self.cpp_info.components["magnum_font"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'fonts')]
             self.cpp_info.components["magnum_font"].requires = ["magnum_main", "trade", "text"]
 
         if self.options.magnum_font_converter:
             self.cpp_info.components["magnum_font_converter"].names["cmake_find_package"] = "MagnumFontConverter"
             self.cpp_info.components["magnum_font_converter"].names["cmake_find_package_multi"] = "MagnumFontConverter"
-            if not self.options.shared_plugins:
-                self.cpp_info.components["magnum_font_converter"].libs = ["MagnumFontConverter"]
-                self.cpp_info.components["magnum_font_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'fontconverters')]
-            self.cpp_info.components["magnum_font_converter"].requires = ["magnum_main", "trade", "text"]
-            if not self.options.shared_plugins:
-                self.cpp_info.components["magnum_font_converter"].requires += ["tga_image_converter"]
+            self.cpp_info.components["magnum_font_converter"].libs = ["MagnumFontConverter"]
+            self.cpp_info.components["magnum_font_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'fontconverters')]
+            self.cpp_info.components["magnum_font_converter"].requires = ["magnum_main", "trade", "text", "tga_image_converter"]
 
         if self.options.obj_importer:
             self.cpp_info.components["obj_importer"].names["cmake_find_package"] = "ObjImporter"
             self.cpp_info.components["obj_importer"].names["cmake_find_package_multi"] = "ObjImporter"
-            if not self.options.shared_plugins:
-                self.cpp_info.components["obj_importer"].libs = ["ObjImporter"]
-                self.cpp_info.components["obj_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
+            self.cpp_info.components["obj_importer"].libs = ["ObjImporter"]
+            self.cpp_info.components["obj_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
             self.cpp_info.components["obj_importer"].requires = ["trade", "mesh_tools"]
 
         if self.options.tga_importer:
             self.cpp_info.components["tga_importer"].names["cmake_find_package"] = "TgaImporter"
             self.cpp_info.components["tga_importer"].names["cmake_find_package_multi"] = "TgaImporter"
-            if not self.options.shared_plugins:
-                self.cpp_info.components["tga_importer"].libs = ["TgaImporter"]
-                self.cpp_info.components["tga_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
+            self.cpp_info.components["tga_importer"].libs = ["TgaImporter"]
+            self.cpp_info.components["tga_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
             self.cpp_info.components["tga_importer"].requires = ["trade"]
 
         if self.options.tga_image_converter:
             self.cpp_info.components["tga_image_converter"].names["cmake_find_package"] = "TgaImageConverter"
             self.cpp_info.components["tga_image_converter"].names["cmake_find_package_multi"] = "TgaImageConverter"
-            if not self.options.shared_plugins:
-                self.cpp_info.components["tga_image_converter"].libs = ["TgaImageConverter"]
-                self.cpp_info.components["tga_image_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'imageconverters')]
+            self.cpp_info.components["tga_image_converter"].libs = ["TgaImageConverter"]
+            self.cpp_info.components["tga_image_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'imageconverters')]
             self.cpp_info.components["tga_image_converter"].requires = ["trade"]
 
         if self.options.wav_audio_importer:
             self.cpp_info.components["wav_audio_importer"].names["cmake_find_package"] = "WavAudioConverter"
             self.cpp_info.components["wav_audio_importer"].names["cmake_find_package_multi"] = "WavAudioConverter"
-            if not self.options.shared_plugins:
-                self.cpp_info.components["wav_audio_importer"].libs = ["WavAudioConverter"]
-                self.cpp_info.components["wav_audio_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'audioimporters')]
+            self.cpp_info.components["wav_audio_importer"].libs = ["WavAudioConverter"]
+            self.cpp_info.components["wav_audio_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'audioimporters')]
             self.cpp_info.components["wav_audio_importer"].requires = ["magnum_main", "audio"]
 
         #### EXECUTABLES ####

--- a/recipes/magnum/all/conanfile.py
+++ b/recipes/magnum/all/conanfile.py
@@ -439,6 +439,7 @@ class MagnumConan(ConanFile):
         self.cpp_info.components["magnum_main"].names["cmake_find_package_multi"] = "Magnum"
         self.cpp_info.components["magnum_main"].libs = ["Magnum{}".format(lib_suffix)]
         self.cpp_info.components["magnum_main"].requires = ["_magnum", "corrade::utility"]
+        self.cpp_info.components["magnum_main"].build_modules["cmake_find_package"].append(os.path.join("lib", "cmake", "conan-bugfix-global-target.cmake"))
 
         # Audio
         if self.options.audio:
@@ -624,9 +625,9 @@ class MagnumConan(ConanFile):
 
         ######## PLUGINS ########
         if self.options.any_audio_importer:
-            self.cpp_info.components["any_audio_importer"].names["cmake_find_package"] = "AnyAudioConverter"
-            self.cpp_info.components["any_audio_importer"].names["cmake_find_package_multi"] = "AnyAudioConverter"
-            self.cpp_info.components["any_audio_importer"].libs = ["AnyAudioConverter"]
+            self.cpp_info.components["any_audio_importer"].names["cmake_find_package"] = "AnyAudioImporter"
+            self.cpp_info.components["any_audio_importer"].names["cmake_find_package_multi"] = "AnyAudioImporter"
+            self.cpp_info.components["any_audio_importer"].libs = ["AnyAudioImporter"]
             self.cpp_info.components["any_audio_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'audioimporters')]
             self.cpp_info.components["any_audio_importer"].requires = ["magnum_main", "audio"]
 
@@ -694,9 +695,9 @@ class MagnumConan(ConanFile):
             self.cpp_info.components["tga_image_converter"].requires = ["trade"]
 
         if self.options.wav_audio_importer:
-            self.cpp_info.components["wav_audio_importer"].names["cmake_find_package"] = "WavAudioConverter"
-            self.cpp_info.components["wav_audio_importer"].names["cmake_find_package_multi"] = "WavAudioConverter"
-            self.cpp_info.components["wav_audio_importer"].libs = ["WavAudioConverter"]
+            self.cpp_info.components["wav_audio_importer"].names["cmake_find_package"] = "WavAudioImporter"
+            self.cpp_info.components["wav_audio_importer"].names["cmake_find_package_multi"] = "WavAudioImporter"
+            self.cpp_info.components["wav_audio_importer"].libs = ["WavAudioImporter"]
             self.cpp_info.components["wav_audio_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'audioimporters')]
             self.cpp_info.components["wav_audio_importer"].requires = ["magnum_main", "audio"]
 


### PR DESCRIPTION
Even if they are plugins, they might be used like regular libraries by some consumers (like https://github.com/conan-io/conan-center-index/pull/7272), so the targets need their corresponding libraries and so on.

This PR is also adding a workaround (bugfix) for `cmake_find_package` generator (please read the comment in the `.cmake` file added in this PR): it guarantees that the main target that is overridden will link only to the components defined in the `package_info()` (related: https://github.com/conan-io/conan-center-index/issues/6605#issuecomment-902601082).