### PR TITLE
[openblas] Set default build_lapack option to true

### DIFF
--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -25,7 +25,7 @@ class OpenblasConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "build_lapack": False,
+        "build_lapack": True,
         "use_thread": True,
         "dynamic_arch": False
     }


### PR DESCRIPTION
* Set default value for build_lapack option to true. This will enable
  other packages depending on lapack to be packaged to CCI as recipes
  can only depend on the default options of other packages.

Closes #7361

Specify library name and version:  **openblas/0.3.17**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

This PR updates the default build lapack option to `build_lapack=True`. This is in support of https://github.com/conan-io/conan-center-index/pull/7334 and closes #7361. This will also support future packages that require lapack as a default option to include as a dependency to be hosted through CCI.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
