### PR TITLE
freetype: make available libtool version using user_info variable

### DIFF
--- a/recipes/freetype/all/test_package/CMakeLists.txt
+++ b/recipes/freetype/all/test_package/CMakeLists.txt
@@ -4,9 +4,6 @@ project(test_package C)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/OpenSans-Bold.ttf
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-
 find_package(Freetype REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.c)

--- a/recipes/freetype/all/test_package/conanfile.py
+++ b/recipes/freetype/all/test_package/conanfile.py
@@ -14,4 +14,5 @@ class TestPackageConan(ConanFile):
     def test(self):
         if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+            font_path = os.path.join(self.source_folder, "OpenSans-Bold.ttf")
+            self.run("{} {}".format(bin_path, font_path), run_environment=True)

--- a/recipes/freetype/all/test_package/test_package.c
+++ b/recipes/freetype/all/test_package/test_package.c
@@ -3,14 +3,14 @@
 /* This small program shows how to print a rotated string with the */
 /* FreeType 2 library.                                             */
 
+#include "ft2build.h"
+#include FT_FREETYPE_H
 
 #include <stdio.h>
 #include <stddef.h>
 #include <string.h>
 #include <math.h>
 
-#include "ft2build.h"
-#include FT_FREETYPE_H
 
 
 #define WIDTH   640
@@ -69,9 +69,13 @@ main( int     argc,
   int           target_height;
   size_t        n, num_chars;
 
+  if (argv < 2) {
+    fprintf(stderr, "Usage: %s FONT\n", argv[0]);
+    return EXIT_FAILURE;
+  }
 
-  filename      = "OpenSans-Bold.ttf";
-  text          = "Bincrafters";
+  filename      = argv[1];
+  text          = "conan-center-index";
   num_chars     = strlen( text );
   angle         = ( 25.0 / 360 ) * 3.14159 * 2;      /* use 25 degrees     */
   target_height = HEIGHT;


### PR DESCRIPTION
Specify library name and version:  **freetypeall**

Make available pkg_config version using environment variable.
(Needed for fontconfig)

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
