### PR TITLE
[libsecret] add gcrypt option

### DIFF
--- a/recipes/libsecret/all/conanfile.py
+++ b/recipes/libsecret/all/conanfile.py
@@ -4,6 +4,7 @@ import os
 
 required_conan_version = ">=1.32.0"
 
+
 class LibsecretConan(ConanFile):
     name = "libsecret"
     description = "A library for storing and retrieving passwords and other secrets"
@@ -14,8 +15,16 @@ class LibsecretConan(ConanFile):
     generators = "pkg_config"
 
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_libgcrypt": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_libgcrypt": True,
+    }
 
     @property
     def _source_subfolder(self):
@@ -24,6 +33,10 @@ class LibsecretConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    @property
+    def _use_gcrypt(self):
+        return self.options.get_safe("with_libgcrypt", False)
 
     def validate(self):
         if self.settings.os == "Windows":
@@ -38,11 +51,21 @@ class LibsecretConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+
+        if self.options.with_libgcrypt and self.settings.os != "Linux":
+            self.output.warn(
+                "gcrypt is only available on Linux. Option will be ignored."
+            )
+            del self.options.with_libgcrypt
+
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
+
     def requirements(self):
         self.requires("glib/2.67.2")
+        if self._use_gcrypt:
+            self.requires("libgcrypt/1.8.4")
 
     def build_requirements(self):
         self.build_requires("meson/0.56.2")
@@ -55,10 +78,10 @@ class LibsecretConan(ConanFile):
     def _configure_meson(self):
         meson = Meson(self)
         defs = {}
-        defs["introspection"] = "false"
-        defs["manpage"] = "false"
-        defs["gtk_doc"] = "false"
-        defs["gcrypt"] = "false"
+        defs["introspection"] = False
+        defs["manpage"] = False
+        defs["gtk_doc"] = False
+        defs["gcrypt"] = self._use_gcrypt
         meson.configure(
             defs=defs,
             build_folder=self._build_subfolder,
@@ -83,5 +106,7 @@ class LibsecretConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["pkg_config"] = "libsecret-1"
         self.cpp_info.requires = ["glib::glib-2.0", "glib::gobject-2.0"]
+        if self._use_gcrypt:
+            self.cpp_info.requires.append("libgcrypt::gcrypt")
         self.cpp_info.includedirs = [os.path.join("include", "libsecret-1")]
         self.cpp_info.libs = ["secret-1"]

--- a/recipes/libsecret/all/conanfile.py
+++ b/recipes/libsecret/all/conanfile.py
@@ -52,10 +52,8 @@ class LibsecretConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
-        if self.options.with_libgcrypt and self.settings.os != "Linux":
-            self.output.warn(
-                "gcrypt is only available on Linux. Option will be ignored."
-            )
+        if self.settings.os != "Linux":
+            # libgcrypt recipe is currently only available on Linux
             del self.options.with_libgcrypt
 
         del self.settings.compiler.libcxx


### PR DESCRIPTION
Specify library name and version:  **libsecret/0.20.4**

Add support for using gcrypt on Linux. The libgcrypt recipe is unfortunately not available on other platforms at this time.

Note that the option is set to true by default, so this **changes the behavior of the recipe**. This does reflect the original default behavior of libsecret though (and it's safer to use gcrypt).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
