### PR TITLE
bump indicators to 2.2

### DIFF
--- a/recipes/indicators/all/conandata.yml
+++ b/recipes/indicators/all/conandata.yml
@@ -5,4 +5,7 @@ sources:
   "2.0":
     url: "https://github.com/p-ranav/indicators/archive/v2.0.tar.gz"
     sha256: "ef296fa614edcd798db0ac6c3c0f2990682cae8b83724a4db34eed17521c75f7"
+  "2.2":
+    url: "https://github.com/p-ranav/indicators/archive/v2.2.tar.gz"
+    sha256: "b768f1b7ca64a413503f72d5460cc617c1458c17fb7a8c0ee503d753e1f20d03"
 

--- a/recipes/indicators/config.yml
+++ b/recipes/indicators/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: "all"
   "2.0":
     folder: "all"
+  "2.2":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **indicators/2.2**

Fix compilation problems in some compile environments.

---

- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [+] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [+] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
