### PR TITLE
Adds rapidcheck gtest/catch integrations

### DIFF
--- a/recipes/rapidcheck/all/conandata.yml
+++ b/recipes/rapidcheck/all/conandata.yml
@@ -13,8 +13,8 @@ patches:
     - patch_file: "patches/0001-gtest-catch-integration.patch"
       base_path: "source_subfolder"
   "cci.20210107":
-    - patch_file: "patches/0001-gtest-catch-integration.patch"
+    - patch_file: "patches/0001-gtest-catch-integration-20210107.patch"
       base_path: "source_subfolder"
   "cci.20200131":
-    - patch_file: "patches/0001-gtest-catch-integration.patch"
+    - patch_file: "patches/0001-gtest-catch-integration-20200131.patch"
       base_path: "source_subfolder"

--- a/recipes/rapidcheck/all/conandata.yml
+++ b/recipes/rapidcheck/all/conandata.yml
@@ -8,3 +8,13 @@ sources:
   "cci.20200131":
     url: "https://github.com/emil-e/rapidcheck/archive/258d907da00a0855f92c963d8f76eef115531716.zip"
     sha256: "87bfbdceaa09e7aaaf70b2efd0078e93323dd8abdad48c57e9f23bfd84174a75"
+patches:
+  "cci.20210702":
+    - patch_file: "patches/0001-gtest-catch-integration.patch"
+      base_path: "source_subfolder"
+  "cci.20210107":
+    - patch_file: "patches/0001-gtest-catch-integration.patch"
+      base_path: "source_subfolder"
+  "cci.20200131":
+    - patch_file: "patches/0001-gtest-catch-integration.patch"
+      base_path: "source_subfolder"

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -94,9 +94,9 @@ class RapidcheckConan(ConanFile):
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),
             {"rapidcheck": "rapidcheck::rapidcheck", 
-             "rapidcheck_catch":"rapidcheck::catch", 
-             "rapidcheck_gmock": "rapidcheck::gmock", 
-             "rapidcheck_gtest": "rapidcheck::gtest"}
+             "rapidcheck_catch":"rapidcheck::rapidcheck_catch", 
+             "rapidcheck_gmock": "rapidcheck::rapidcheck_gmock", 
+             "rapidcheck_gtest": "rapidcheck::rapidcheck_gtest"}
         )
 
     @staticmethod
@@ -137,12 +137,9 @@ class RapidcheckConan(ConanFile):
                 self.cpp_info.components["core"].defines.append("RC_DONT_USE_RTTI")
                 
         if self.options.enable_catch:
-            self.cpp_info.components["core"].requires.append("catch2::catch2")
-            self.cpp_info.components["catch"].requires = ["core", "catch2::catch2"]
+            self.cpp_info.components["rapidcheck_catch"].requires = ["core", "catch2::catch2"]
         if self.options.enable_gmock:
-            self.cpp_info.components["core"].requires.append("gtest::gtest")
-            self.cpp_info.components["gmock"].requires = ["core"]
+            self.cpp_info.components["rapidcheck_gmock"].requires = ["core", "gtest::gtest"]
         if self.options.enable_gtest:
-            self.cpp_info.components["core"].requires.append("gtest::gtest")
-            self.cpp_info.components["gtest"].requires = ["core"]
+            self.cpp_info.components["rapidcheck_gtest"].requires = ["core", "gtest::gtest"]
         

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -129,7 +129,14 @@ class RapidcheckConan(ConanFile):
         self.cpp_info.components["core"].set_property("cmake_build_modules", [self._module_file_rel_path])
         self.cpp_info.components["core"].libs = ["rapidcheck"]
         self.cpp_info.components["core"].includedirs  = ["include"]
-        
+        version = self.version[4:]
+        if tools.Version(version) < "20201218":
+            if self.options.enable_rtti:
+                self.cpp_info.components["core"].defines.append("RC_USE_RTTI")
+        else:
+            if not self.options.enable_rtti:
+                self.cpp_info.components["core"].defines.append("RC_DONT_USE_RTTI")
+                
         if(self.options.enable_catch):
             self.cpp_info.components["catch"].requires = ["core"]
             self.cpp_info.components["catch"].includedirs  = ["include"]
@@ -146,10 +153,3 @@ class RapidcheckConan(ConanFile):
             self.cpp_info.components["boost_test"].requires = ["core"]
             self.cpp_info.components["boost_test"].includedirs  = ["include"]
         
-        version = self.version[4:]
-        if tools.Version(version) < "20201218":
-            if self.options.enable_rtti:
-                self.cpp_info.defines.append("RC_USE_RTTI")
-        else:
-            if not self.options.enable_rtti:
-                self.cpp_info.defines.append("RC_DONT_USE_RTTI")

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -121,8 +121,8 @@ class RapidcheckConan(ConanFile):
                             "conan-official-{}-targets.cmake".format(self.name))
 
     def package_info(self):
-        cpp_info.names["cmake_find_package"] = "rapidcheck"
-        cpp_info.names["cmake_find_package_multi"] = "rapidcheck"
+        self.cpp_info.names["cmake_find_package"] = "rapidcheck"
+        self.cpp_info.names["cmake_find_package_multi"] = "rapidcheck"
         
         self.cpp_info.components["core"].set_property("cmake_target_name", "rapidcheck")
         self.cpp_info.components["core"].builddirs.append(self._module_subfolder)

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -92,11 +92,11 @@ class RapidcheckConan(ConanFile):
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),
             {"rapidcheck": "rapidcheck::rapidcheck", 
-             "rapidcheck::catch": "rapidcheck_catch", 
-             "rapidcheck::gmock": "rapidcheck_gmock", 
-             "rapidcheck::gtest": "rapidcheck_gtest", 
-             "rapidcheck::boost": "rapidcheck_boost", 
-             "rapidcheck::boost_test": "rapidcheck_boost_test"}
+             "rapidcheck_catch":"rapidcheck::catch", 
+             "rapidcheck_gmock": "rapidcheck::gmock", 
+             "rapidcheck_gtest": "rapidcheck::gtest", 
+             "rapidcheck_boost": "rapidcheck::boost", 
+             "rapidcheck_boost_test": "rapidcheck::boost_test"}
         )
 
     @staticmethod

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -81,6 +81,8 @@ class RapidcheckConan(ConanFile):
         return self._cmake
 
     def build(self):
+        if self.options.enable_gmock and not self.deps_cpp_info["gtest"].build_gmock:
+            raise ConanInvalidConfiguration("The option `rapidcheck:enable_gmock` requires gtest:build_gmock=True`")
         for patch in self.conan_data["patches"][self.version]:
             tools.patch(**patch)
         cmake = self._configure_cmake()

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -20,11 +20,21 @@ class RapidcheckConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "enable_rtti": [True, False],
+        "enable_catch": [True, False],
+        "enable_gmock": [True, False],
+        "enable_gtest": [True, False],
+        "enable_boost": [True, False],
+        "enable_boost_test": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "enable_rtti": True,
+        "enable_catch": False,
+        "enable_gmock": False,
+        "enable_gtest": False,
+        "enable_boost": False,
+        "enable_boost_test": False
     }
 
     _cmake = None
@@ -62,6 +72,11 @@ class RapidcheckConan(ConanFile):
         self._cmake.definitions["RC_ENABLE_RTTI"] = self.options.enable_rtti
         self._cmake.definitions["RC_ENABLE_TESTS"] = False
         self._cmake.definitions["RC_ENABLE_EXAMPLES"] = False
+        self._cmake.definitions["RC_ENABLE_CATCH"] = self.options.enable_catch
+        self._cmake.definitions["RC_ENABLE_GMOCK"] = self.options.enable_gmock
+        self._cmake.definitions["RC_ENABLE_GTEST"] = self.options.enable_gtest
+        self._cmake.definitions["RC_ENABLE_BOOST"] = self.options.enable_boost
+        self._cmake.definitions["RC_ENABLE_BOOST_TEST"] = self.options.enable_boost_test
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
@@ -76,7 +91,12 @@ class RapidcheckConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),
-            {"rapidcheck": "rapidcheck::rapidcheck"}
+            {"rapidcheck": "rapidcheck::rapidcheck", 
+             "rapidcheck::catch": "rapidcheck_catch", 
+             "rapidcheck::gmock": "rapidcheck_gmock", 
+             "rapidcheck::gtest": "rapidcheck_gtest", 
+             "rapidcheck::boost": "rapidcheck_boost", 
+             "rapidcheck::boost_test": "rapidcheck_boost_test"}
         )
 
     @staticmethod
@@ -101,12 +121,29 @@ class RapidcheckConan(ConanFile):
                             "conan-official-{}-targets.cmake".format(self.name))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "rapidcheck"
-        self.cpp_info.names["cmake_find_package_multi"] = "rapidcheck"
-        self.cpp_info.builddirs.append(self._module_subfolder)
-        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
-        self.cpp_info.libs = ["rapidcheck"]
+        self.cpp_info.name = "rapidcheck"
+        
+        self.cpp_info.components["core"].set_property("cmake_target_name", "rapidcheck")
+        self.cpp_info.components["core"].builddirs.append(self._module_subfolder)
+        self.cpp_info.components["core"].set_property("cmake_build_modules", [self._module_file_rel_path])
+        self.cpp_info.components["core"].libs = ["rapidcheck"]
+        self.cpp_info.components["core"].includedirs  = ["include"]
+        
+        if(self.options.enable_catch):
+            self.cpp_info.components["catch"].requires = ["core"]
+            self.cpp_info.components["catch"].includedirs  = ["include"]
+        if(self.options.enable_gmock):
+            self.cpp_info.components["gmock"].requires = ["core"]
+            self.cpp_info.components["gmock"].includedirs  = ["include"]
+        if(self.options.enable_gtest):
+            self.cpp_info.components["gtest"].requires = ["core"]
+            self.cpp_info.components["gtest"].includedirs  = ["include"]
+        if(self.options.enable_boost):
+            self.cpp_info.components["boost"].requires = ["core"]
+            self.cpp_info.components["boost"].includedirs  = ["include"]
+        if(self.options.enable_boost_test):
+            self.cpp_info.components["boost_test"].requires = ["core"]
+            self.cpp_info.components["boost_test"].includedirs  = ["include"]
         
         version = self.version[4:]
         if tools.Version(version) < "20201218":

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -121,7 +121,8 @@ class RapidcheckConan(ConanFile):
                             "conan-official-{}-targets.cmake".format(self.name))
 
     def package_info(self):
-        self.cpp_info.name = "rapidcheck"
+        cpp_info.names["cmake_find_package"] = "rapidcheck"
+        cpp_info.names["cmake_find_package_multi"] = "rapidcheck"
         
         self.cpp_info.components["core"].set_property("cmake_target_name", "rapidcheck")
         self.cpp_info.components["core"].builddirs.append(self._module_subfolder)

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -139,17 +139,12 @@ class RapidcheckConan(ConanFile):
                 
         if(self.options.enable_catch):
             self.cpp_info.components["catch"].requires = ["core"]
-            self.cpp_info.components["catch"].includedirs  = ["include"]
         if(self.options.enable_gmock):
             self.cpp_info.components["gmock"].requires = ["core"]
-            self.cpp_info.components["gmock"].includedirs  = ["include"]
         if(self.options.enable_gtest):
             self.cpp_info.components["gtest"].requires = ["core"]
-            self.cpp_info.components["gtest"].includedirs  = ["include"]
         if(self.options.enable_boost):
             self.cpp_info.components["boost"].requires = ["core"]
-            self.cpp_info.components["boost"].includedirs  = ["include"]
         if(self.options.enable_boost_test):
             self.cpp_info.components["boost_test"].requires = ["core"]
-            self.cpp_info.components["boost_test"].includedirs  = ["include"]
         

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -124,22 +124,22 @@ class RapidcheckConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "rapidcheck"
         self.cpp_info.names["cmake_find_package_multi"] = "rapidcheck"
         
-        self.cpp_info.components["core"].set_property("cmake_target_name", "rapidcheck")
-        self.cpp_info.components["core"].builddirs.append(self._module_subfolder)
-        self.cpp_info.components["core"].set_property("cmake_build_modules", [self._module_file_rel_path])
-        self.cpp_info.components["core"].libs = ["rapidcheck"]
+        self.cpp_info.components["rapidcheck_rapidcheck"].set_property("cmake_target_name", "rapidcheck")
+        self.cpp_info.components["rapidcheck_rapidcheck"].builddirs.append(self._module_subfolder)
+        self.cpp_info.components["rapidcheck_rapidcheck"].set_property("cmake_build_modules", [self._module_file_rel_path])
+        self.cpp_info.components["rapidcheck_rapidcheck"].libs = ["rapidcheck"]
         version = self.version[4:]
         if tools.Version(version) < "20201218":
             if self.options.enable_rtti:
-                self.cpp_info.components["core"].defines.append("RC_USE_RTTI")
+                self.cpp_info.components["rapidcheck_rapidcheck"].defines.append("RC_USE_RTTI")
         else:
             if not self.options.enable_rtti:
-                self.cpp_info.components["core"].defines.append("RC_DONT_USE_RTTI")
+                self.cpp_info.components["rapidcheck_rapidcheck"].defines.append("RC_DONT_USE_RTTI")
                 
         if self.options.enable_catch:
-            self.cpp_info.components["rapidcheck_catch"].requires = ["core", "catch2::catch2"]
+            self.cpp_info.components["rapidcheck_catch"].requires = ["rapidcheck_rapidcheck", "catch2::catch2"]
         if self.options.enable_gmock:
-            self.cpp_info.components["rapidcheck_gmock"].requires = ["core", "gtest::gtest"]
+            self.cpp_info.components["rapidcheck_gmock"].requires = ["rapidcheck_rapidcheck", "gtest::gtest"]
         if self.options.enable_gtest:
-            self.cpp_info.components["rapidcheck_gtest"].requires = ["core", "gtest::gtest"]
+            self.cpp_info.components["rapidcheck_gtest"].requires = ["rapidcheck_rapidcheck", "gtest::gtest"]
         

--- a/recipes/rapidcheck/all/patches/0001-gtest-catch-integration-20200131.patch
+++ b/recipes/rapidcheck/all/patches/0001-gtest-catch-integration-20200131.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 92bc63c7df2cb87b5e5672a7651dbb4eafa3aaa7..c57b700157360f4b5a2e280167e821f567bb31ea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -106,8 +106,6 @@ if(RC_ENABLE_RTTI)
+   target_compile_definitions(rapidcheck PUBLIC RC_USE_RTTI)
+ endif()
+ 
+-add_subdirectory(ext)
+-
+ if(RC_ENABLE_TESTS)
+   enable_testing()
+   add_subdirectory(test)
+@@ -117,6 +115,16 @@ if(RC_ENABLE_EXAMPLES)
+   add_subdirectory(examples)
+ endif()
+ 
++if (RC_ENABLE_CATCH)
++	find_package(Catch2 REQUIRED)
++	target_link_libraries(rapidcheck PUBLIC Catch2::Catch2)
++endif()
++
++if (RC_ENABLE_GMOCK OR RC_ENABLE_GTEST)
++	find_package(GTest REQUIRED)
++	target_link_libraries(rapidcheck PUBLIC GTest::GTest)
++endif()
++
+ add_subdirectory(extras)
+ 
+ # Install the export file specifying all the targets for RapidCheck

--- a/recipes/rapidcheck/all/patches/0001-gtest-catch-integration-20200131.patch
+++ b/recipes/rapidcheck/all/patches/0001-gtest-catch-integration-20200131.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 92bc63c7df2cb87b5e5672a7651dbb4eafa3aaa7..c57b700157360f4b5a2e280167e821f567bb31ea 100644
+index 92bc63c7df2cb87b5e5672a7651dbb4eafa3aaa7..14000896cd4e6ebcde3f2154b85caf4f5cca056b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -106,8 +106,6 @@ if(RC_ENABLE_RTTI)
@@ -11,20 +11,3 @@ index 92bc63c7df2cb87b5e5672a7651dbb4eafa3aaa7..c57b700157360f4b5a2e280167e821f5
  if(RC_ENABLE_TESTS)
    enable_testing()
    add_subdirectory(test)
-@@ -117,6 +115,16 @@ if(RC_ENABLE_EXAMPLES)
-   add_subdirectory(examples)
- endif()
- 
-+if (RC_ENABLE_CATCH)
-+	find_package(Catch2 REQUIRED)
-+	target_link_libraries(rapidcheck PUBLIC Catch2::Catch2)
-+endif()
-+
-+if (RC_ENABLE_GMOCK OR RC_ENABLE_GTEST)
-+	find_package(GTest REQUIRED)
-+	target_link_libraries(rapidcheck PUBLIC GTest::GTest)
-+endif()
-+
- add_subdirectory(extras)
- 
- # Install the export file specifying all the targets for RapidCheck

--- a/recipes/rapidcheck/all/patches/0001-gtest-catch-integration-20210107.patch
+++ b/recipes/rapidcheck/all/patches/0001-gtest-catch-integration-20210107.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9f583afc171fab0a6894ffd64a0c787fd806bbaa..da2389500c99e4e4b59c772ee25285e2a9607de5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -106,8 +106,6 @@ if(NOT RC_ENABLE_RTTI)
+   target_compile_definitions(rapidcheck PUBLIC RC_DONT_USE_RTTI)
+ endif()
+ 
+-add_subdirectory(ext)
+-
+ if(RC_ENABLE_TESTS)
+   enable_testing()
+   add_subdirectory(test)
+@@ -116,6 +114,15 @@ endif()
+ if(RC_ENABLE_EXAMPLES)
+   add_subdirectory(examples)
+ endif()
++if (RC_ENABLE_CATCH)
++	find_package(Catch2 REQUIRED)
++	target_link_libraries(rapidcheck PUBLIC Catch2::Catch2)
++endif()
++
++if (RC_ENABLE_GMOCK OR RC_ENABLE_GTEST)
++	find_package(GTest REQUIRED)
++	target_link_libraries(rapidcheck PUBLIC GTest::GTest)
++endif()
+ 
+ add_subdirectory(extras)
+ 

--- a/recipes/rapidcheck/all/patches/0001-gtest-catch-integration-20210107.patch
+++ b/recipes/rapidcheck/all/patches/0001-gtest-catch-integration-20210107.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9f583afc171fab0a6894ffd64a0c787fd806bbaa..da2389500c99e4e4b59c772ee25285e2a9607de5 100644
+index 9f583afc171fab0a6894ffd64a0c787fd806bbaa..ea31145f55fe1010fe36739c17a655309db552f1 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -106,8 +106,6 @@ if(NOT RC_ENABLE_RTTI)
@@ -11,19 +11,3 @@ index 9f583afc171fab0a6894ffd64a0c787fd806bbaa..da2389500c99e4e4b59c772ee25285e2
  if(RC_ENABLE_TESTS)
    enable_testing()
    add_subdirectory(test)
-@@ -116,6 +114,15 @@ endif()
- if(RC_ENABLE_EXAMPLES)
-   add_subdirectory(examples)
- endif()
-+if (RC_ENABLE_CATCH)
-+	find_package(Catch2 REQUIRED)
-+	target_link_libraries(rapidcheck PUBLIC Catch2::Catch2)
-+endif()
-+
-+if (RC_ENABLE_GMOCK OR RC_ENABLE_GTEST)
-+	find_package(GTest REQUIRED)
-+	target_link_libraries(rapidcheck PUBLIC GTest::GTest)
-+endif()
- 
- add_subdirectory(extras)
- 

--- a/recipes/rapidcheck/all/patches/0001-gtest-catch-integration.patch
+++ b/recipes/rapidcheck/all/patches/0001-gtest-catch-integration.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 15c46d01288dce235179b791770187f5a38230ab..0c47308162af09841789ff9791b11839d524f852 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -111,8 +111,6 @@ if(NOT RC_ENABLE_RTTI)
+   target_compile_definitions(rapidcheck PUBLIC RC_DONT_USE_RTTI)
+ endif()
+ 
+-add_subdirectory(ext)
+-
+ if(RC_ENABLE_TESTS)
+   enable_testing()
+   add_subdirectory(test)
+@@ -122,6 +120,16 @@ if(RC_ENABLE_EXAMPLES)
+   add_subdirectory(examples)
+ endif()
+ 
++if (RC_ENABLE_CATCH)
++	find_package(Catch2 REQUIRED)
++	target_link_libraries(rapidcheck PUBLIC Catch2::Catch2)
++endif()
++
++if (RC_ENABLE_GMOCK OR RC_ENABLE_GTEST)
++	find_package(GTest REQUIRED)
++	target_link_libraries(rapidcheck PUBLIC GTest::GTest)
++endif()
++
+ add_subdirectory(extras)
+ 
+ # Install the export file specifying all the targets for RapidCheck

--- a/recipes/rapidcheck/all/patches/0001-gtest-catch-integration.patch
+++ b/recipes/rapidcheck/all/patches/0001-gtest-catch-integration.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 15c46d01288dce235179b791770187f5a38230ab..0c47308162af09841789ff9791b11839d524f852 100644
+index 15c46d01288dce235179b791770187f5a38230ab..1805354a744931086622c41fa5a640c283142adc 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -111,8 +111,6 @@ if(NOT RC_ENABLE_RTTI)
@@ -11,20 +11,3 @@ index 15c46d01288dce235179b791770187f5a38230ab..0c47308162af09841789ff9791b11839
  if(RC_ENABLE_TESTS)
    enable_testing()
    add_subdirectory(test)
-@@ -122,6 +120,16 @@ if(RC_ENABLE_EXAMPLES)
-   add_subdirectory(examples)
- endif()
- 
-+if (RC_ENABLE_CATCH)
-+	find_package(Catch2 REQUIRED)
-+	target_link_libraries(rapidcheck PUBLIC Catch2::Catch2)
-+endif()
-+
-+if (RC_ENABLE_GMOCK OR RC_ENABLE_GTEST)
-+	find_package(GTest REQUIRED)
-+	target_link_libraries(rapidcheck PUBLIC GTest::GTest)
-+endif()
-+
- add_subdirectory(extras)
- 
- # Install the export file specifying all the targets for RapidCheck

--- a/recipes/rapidcheck/all/test_package/conanfile.py
+++ b/recipes/rapidcheck/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **rapidcheck**

Rapidcheck provides integration with multiple unit test frameworks. This enables those integrations within the conan package

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
