### PR TITLE
bump numcpp to 2.5.1 and add package options

### DIFF
--- a/recipes/numcpp/all/conandata.yml
+++ b/recipes/numcpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.1":
+    url: "https://github.com/dpilger26/NumCpp/archive/Version_2.5.1.tar.gz"
+    sha256: "0677907a90e96a468a9ea4e702940833570c2419d9a822724ee708dddd3c422e"
   "2.4.2":
     url: "https://github.com/dpilger26/NumCpp/archive/Version_2.4.2.tar.gz"
     sha256: "8da0494552796b76e5e9ef691176fa7cb27bc52fec4019da20bfd8fb7ba00b91"

--- a/recipes/numcpp/all/conanfile.py
+++ b/recipes/numcpp/all/conanfile.py
@@ -75,9 +75,9 @@ class NumCppConan(ConanFile):
             self.cpp_info.cxxflags.append("-DNUMCPP_NO_USE_BOOST")
 
         if tools.Version(self.version) < "2.5.0" and self.options.threads == False:
-            self.cpp_info.cxxflags.append("-DNO_MULTITHREAD")
+            self.cpp_info.defines.append("NO_MULTITHREAD")
         if tools.Version(self.version) >= "2.5.0" and self.options.threads == True:
-            self.cpp_info.cxxflags.append("-DNUMCPP_USE_MULTITHREAD")
+            self.cpp_info.defines.append("NUMCPP_USE_MULTITHREAD")
 
         self.cpp_info.names["cmake_find_package"] = "NumCpp"
         self.cpp_info.names["cmake_find_package_multi"] = "NumCpp"

--- a/recipes/numcpp/all/conanfile.py
+++ b/recipes/numcpp/all/conanfile.py
@@ -12,12 +12,12 @@ class NumCppConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/dpilger26/NumCpp"
     options = {
-        "use_boost" : [True, False],
-        "use_thread" : [True, False],
+        "with_boost" : [True, False],
+        "threads" : [True, False],
     }
     default_options = {
-        "use_boost" : True,
-        "use_thread" : False,
+        "with_boost" : True,
+        "threads" : False,
     }
     license = "MIT"
     no_copy_source = True
@@ -49,13 +49,13 @@ class NumCppConan(ConanFile):
             raise ConanInvalidConfiguration("%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
 
     def requirements(self):
-        if tools.Version(self.version) < "2.5.0" or self.options.use_boost:
+        if tools.Version(self.version) < "2.5.0" or self.options.with_boost:
             self.requires("boost/1.75.0")
 
     def config_options(self):
         if tools.Version(self.version) < "2.5.0":
-            del self.options.use_boost
-            self.default_options["use_thread"] = True
+            del self.options.with_boost
+            self.options.threads = True
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -71,12 +71,12 @@ class NumCppConan(ConanFile):
         self.info.header_only()
         
     def package_info(self):
-        if tools.Version(self.version) >= "2.5.0" and self.options.use_boost == False:
+        if not self.options.get_safe("with_boost", False):
             self.cpp_info.cxxflags.append("-DNUMCPP_NO_USE_BOOST")
 
-        if tools.Version(self.version) < "2.5.0" and self.options.use_thread == False:
+        if tools.Version(self.version) < "2.5.0" and self.options.threads == False:
             self.cpp_info.cxxflags.append("-DNO_MULTITHREAD")
-        if tools.Version(self.version) >= "2.5.0" and self.options.use_thread == True:
+        if tools.Version(self.version) >= "2.5.0" and self.options.threads == True:
             self.cpp_info.cxxflags.append("-DNUMCPP_USE_MULTITHREAD")
 
         self.cpp_info.names["cmake_find_package"] = "NumCpp"

--- a/recipes/numcpp/config.yml
+++ b/recipes/numcpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.1":
+    folder: "all"
   "2.4.2":
     folder: "all"
   "2.4.1":


### PR DESCRIPTION
Specify library name and version:  **numcpp/2.5.1**

bump up and add two package options:
- use_boost : before 2.5.0, use_boost is disabled because we can't compile numcpp without boost. (probably bug in 2.4.2)
- use_thread : before 2.5.0,  multi thread is default. after 2.5.0, single thread is default.

---

- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [+] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [+] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
