### PR TITLE
Bump Taocpp JSON + request pegtl

### DIFF
--- a/recipes/taocpp-json/all/conandata.yml
+++ b/recipes/taocpp-json/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.0.0-beta.13":
+    sha256: 2513b32d1883277f78071ff1cc55d4f35a979fffdaddf6412d3cb67852ce68b5
+    url: https://github.com/taocpp/json/archive/1.0.0-beta.13.tar.gz
+  "1.0.0-beta.12":
+    sha256: 92692225b0b6b217948ee7f3bf176f5a2a168b9a616d09c080ea571b9dfbd4a7
+    url: https://github.com/taocpp/json/archive/1.0.0-beta.12.tar.gz
   "1.0.0-beta.11":
     sha256: d27f5d02cf62e7fea997abd6f540bdf05fdf36a952807db289dbdda0598de106
     url: https://github.com/taocpp/json/archive/1.0.0-beta.11.tar.gz

--- a/recipes/taocpp-json/all/conanfile.py
+++ b/recipes/taocpp-json/all/conanfile.py
@@ -34,6 +34,10 @@ class TaoCPPJSONConan(ConanFile):
     def _min_cppstd_required(self):
         return "11" if tools.Version(self.version) < "1.0.0-beta.11" else "17"
 
+    @property
+    def _requires_pegtl(self):
+        return tools.Version(self.version) >= "1.0.0-beta.13"
+
     def configure(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, self._min_cppstd_required)
@@ -44,6 +48,10 @@ class TaoCPPJSONConan(ConanFile):
                     raise ConanInvalidConfiguration("taocpp-json requires C++17, which your compiler does not support.")
             else:
                 self.output.warn("taocpp-json requires C++17. Your compiler is unknown. Assuming it supports C++17.")
+
+    def requirements(self):
+        if self._requires_pegtl:
+            self.requires("taocpp-pegtl/3.2.1")
 
     def package_id(self):
         self.info.header_only()
@@ -61,5 +69,7 @@ class TaoCPPJSONConan(ConanFile):
         self.cpp_info.filenames["cmake_find_package_multi"] = "taocpp-json"
         self.cpp_info.names["cmake_find_package"] = "taocpp"
         self.cpp_info.names["cmake_find_package_multi"] = "taocpp"
-        self.cpp_info.components["_taocpp-json"].names["cmake_find_package"] = "json"
-        self.cpp_info.components["_taocpp-json"].names["cmake_find_package_multi"] = "json"
+        self.cpp_info.components["json"].names["cmake_find_package"] = "json"
+        self.cpp_info.components["json"].names["cmake_find_package_multi"] = "json"
+        if self._requires_pegtl:
+            self.cpp_info.components["json"].requires = ["taocpp-pegtl::taocpp-pegtl"]

--- a/recipes/taocpp-json/all/test_package/CMakeLists.txt
+++ b/recipes/taocpp-json/all/test_package/CMakeLists.txt
@@ -8,4 +8,4 @@ find_package(taocpp-json REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} taocpp::json)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/recipes/taocpp-json/all/test_package/conanfile.py
+++ b/recipes/taocpp-json/all/test_package/conanfile.py
@@ -13,6 +13,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/taocpp-json/config.yml
+++ b/recipes/taocpp-json/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "1.0.0-beta.13":
+    folder: all
+  "1.0.0-beta.12":
+    folder: all
   "1.0.0-beta.11":
     folder: all
   "1.0.0-beta.10":


### PR DESCRIPTION
Specify library name and version:  **taocpp-json/1.0.0-beta.13**

Since Taocpp JSON 1.0.0-beta.13, the project Taocpp PEGTL is required. Here we are using PEGTL 3.2.1

Related to https://github.com/taocpp/json/issues/107

/cc @d-frey @ColinH 

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
