### PR TITLE
[abseil] include C++ standard in package settings

### DIFF
--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -21,7 +21,7 @@ class ConanRecipe(ConanFile):
     generators = "cmake"
     short_paths = True
 
-    settings = "os", "arch", "compiler", "build_type"
+    settings = "os", "arch", "compiler", "build_type", "cppstd"
     options = {"fPIC": [True, False]}
     default_options = {"fPIC": True}
 

--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -21,7 +21,7 @@ class ConanRecipe(ConanFile):
     generators = "cmake"
     short_paths = True
 
-    settings = "os", "arch", "compiler", "build_type", "cppstd"
+    settings = "os", "arch", "compiler", "build_type"
     options = {"fPIC": [True, False]}
     default_options = {"fPIC": True}
 
@@ -30,6 +30,10 @@ class ConanRecipe(ConanFile):
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def package_id(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            self.info.settings.cppstd = self.settings.compiler.get_safe("cppstd")
 
     def config_options(self):
         if self.settings.os == "Windows":


### PR DESCRIPTION
**abseil/all**

Abseil's ABI depends on the C++ standard. When compiled with C++11
Abseil provides its own definition of `absl::optional`, `absl::variant`,
and `absl::string_view`. When compiled (or used!) with C++17 it uses the
versions from `std::*`. Effectively this means an Abseil library
compiled with C++11 cannot be used from C++17 and vice-versa.

I am not one of the authors of Abseil, but remember offices?  I used to sit next to some
of them.

Fixes #7249 thought it uses a different approach than what I was thinking about when I wrote that issue.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
