### PR TITLE
Add valijson v0.6

### DIFF
--- a/recipes/valijson/all/conandata.yml
+++ b/recipes/valijson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6":
+    url: "https://github.com/tristanpenman/valijson/archive/v0.6.zip"
+    sha256: d655dd7ca502978238e72a4febcd064cb1ffaece18cd5d78c7f17df420387b59
   "0.3":
     url: "https://github.com/tristanpenman/valijson/archive/v0.3.zip"
     sha256: 76f1ad4800fb730b258a6272dfe738b0695101cbbb4e72f9ab75e33b2a90262e

--- a/recipes/valijson/config.yml
+++ b/recipes/valijson/config.yml
@@ -1,3 +1,5 @@
 versions:
   "0.3":
     folder: "all"
+  "0.6":
+    folder: "all"


### PR DESCRIPTION
**valijson/0.6**

Valijson v0.6 was recently released (https://github.com/tristanpenman/valijson/releases), this is an update for the recipe.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] ~~I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.~~ This change doesn't touch .py files.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
