### PR TITLE
openssl/3.0.0 Build and copy fips module. Fix no-fips option.

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -404,6 +404,9 @@ class OpenSSLConan(ConanFile):
                 args.append("-DOPENSSL_CAPIENG_DIALOG=1")
         else:
             args.append("-fPIC" if self.options.get_safe("fPIC", True) else "no-pic")
+
+        args.append("no-fips" if self.options.get_safe("no_fips", True) else "enable-fips")
+
         if self.settings.os == "Neutrino":
             args.append("no-asm -lsocket -latomic")
 
@@ -431,7 +434,7 @@ class OpenSSLConan(ConanFile):
             ])
 
         for option_name in self.options.values.fields:
-            if self.options.get_safe(option_name, False) and option_name not in ("shared", "fPIC", "openssldir", "capieng_dialog", "enable_capieng", "zlib"):
+            if self.options.get_safe(option_name, False) and option_name not in ("shared", "fPIC", "openssldir", "capieng_dialog", "enable_capieng", "zlib", "no_fips"):
                 self.output.info(f"Activated option: {option_name}")
                 args.append(option_name.replace("_", "-"))
         return args
@@ -649,6 +652,11 @@ class OpenSSLConan(ConanFile):
                     continue
                 if file.endswith(".a"):
                     os.unlink(os.path.join(libdir, file))
+
+
+        if not self.options.no_fips:
+            provdir = os.path.join(self._source_subfolder, "providers")
+            self.copy("fips.so", src=provdir,dst="lib/ossl-modules")
 
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -656,7 +656,12 @@ class OpenSSLConan(ConanFile):
 
         if not self.options.no_fips:
             provdir = os.path.join(self._source_subfolder, "providers")
-            self.copy("fips.so", src=provdir,dst="lib/ossl-modules")
+            if self.settings.os == "Macos":
+                self.copy("fips.dylib", src=provdir,dst="lib/ossl-modules")
+            elif self.settings.os == "Windows":
+                self.copy("fips.dll", src=provdir,dst="lib/ossl-modules")
+            else:
+                self.copy("fips.so", src=provdir,dst="lib/ossl-modules")
 
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 


### PR DESCRIPTION
Specify library name and version:  **openssl/3.0.0**

Build and copy fips module. Fix no-fips option.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
