### PR TITLE
[magnum] handle `shared_plugins=False`, add test_package using `ObjImporter` plugin

### DIFF
--- a/recipes/magnum/all/conanfile.py
+++ b/recipes/magnum/all/conanfile.py
@@ -645,6 +645,8 @@ class MagnumConan(ConanFile):
             self.cpp_info.components[component].requires = deps
             if not self.options.shared_plugins:
                 self.cpp_info.components[component].build_modules.append(os.path.join("lib", "cmake", "conan-magnum-plugins-{}.cmake".format(component)))
+        plugin_dir = "bin" if self.settings.os == "Windows" else "lib"
+        self.user_info.plugins_basepath = os.path.join(self.package_folder, plugin_dir, magnum_plugin_libdir)
 
         #### EXECUTABLES ####
         bindir = os.path.join(self.package_folder, "bin")

--- a/recipes/magnum/all/conanfile.py
+++ b/recipes/magnum/all/conanfile.py
@@ -70,7 +70,7 @@ class MagnumConan(ConanFile):
         "image_converter": [True, False],
         "scene_converter": [True, False],
 
-        # Options related to plugins
+        # Plugins
         "any_audio_importer": [True, False],
         "any_image_converter": [True, False],
         "any_image_importer": [True, False],
@@ -129,7 +129,7 @@ class MagnumConan(ConanFile):
         "image_converter": True,
         "scene_converter": True,
 
-        # Related to plugins
+        # Plugins
         "any_audio_importer": True,
         "any_image_converter": True,
         "any_image_importer": True,
@@ -420,6 +420,19 @@ class MagnumConan(ConanFile):
                     endif()
                 """.format(exec=executable)))
 
+        if not self.options.shared_plugins:
+            for component, target, library, folder, deps in self._plugins:
+                build_module_path = os.path.join(build_modules_folder, "conan-magnum-plugins-{}.cmake".format(component))
+                with open(build_module_path, "w+") as f:
+                    f.write(textwrap.dedent("""\
+                        if(NOT ${{CMAKE_VERSION}} VERSION_LESS "3.0")
+                            if(TARGET Magnum::{target})
+                                set_target_properties(Magnum::{target} PROPERTIES INTERFACE_SOURCES 
+                                                    "${{CMAKE_CURRENT_LIST_DIR}}/../../include/MagnumPlugins/{library}/importStaticPlugin.cpp")
+                            endif()
+                        endif()
+                    """.format(target=target, library=library)))
+
         tools.rmdir(os.path.join(self.package_folder, "share"))
         self.copy("*.cmake", src=os.path.join(self.source_folder, "cmake"), dst=os.path.join("lib", "cmake"))
         self.copy("COPYING", src=self._source_subfolder, dst="licenses")
@@ -624,82 +637,14 @@ class MagnumConan(ConanFile):
 
 
         ######## PLUGINS ########
-        if self.options.any_audio_importer:
-            self.cpp_info.components["any_audio_importer"].names["cmake_find_package"] = "AnyAudioImporter"
-            self.cpp_info.components["any_audio_importer"].names["cmake_find_package_multi"] = "AnyAudioImporter"
-            self.cpp_info.components["any_audio_importer"].libs = ["AnyAudioImporter"]
-            self.cpp_info.components["any_audio_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'audioimporters')]
-            self.cpp_info.components["any_audio_importer"].requires = ["magnum_main", "audio"]
-
-        if self.options.any_image_converter:
-            self.cpp_info.components["any_image_converter"].names["cmake_find_package"] = "AnyImageConverter"
-            self.cpp_info.components["any_image_converter"].names["cmake_find_package_multi"] = "AnyImageConverter"
-            self.cpp_info.components["any_image_converter"].libs = ["AnyImageConverter"]
-            self.cpp_info.components["any_image_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'imageconverters')]
-            self.cpp_info.components["any_image_converter"].requires = ["trade"]
-
-        if self.options.any_image_importer:
-            self.cpp_info.components["any_image_importer"].names["cmake_find_package"] = "AnyImageImporter"
-            self.cpp_info.components["any_image_importer"].names["cmake_find_package_multi"] = "AnyImageImporter"
-            self.cpp_info.components["any_image_importer"].libs = ["AnyImageImporter"]
-            self.cpp_info.components["any_image_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
-            self.cpp_info.components["any_image_importer"].requires = ["trade"]
-
-        if self.options.any_scene_converter:
-            self.cpp_info.components["any_scene_converter"].names["cmake_find_package"] = "AnySceneConverter"
-            self.cpp_info.components["any_scene_converter"].names["cmake_find_package_multi"] = "AnySceneConverter"
-            self.cpp_info.components["any_scene_converter"].libs = ["AnySceneConverter"]
-            self.cpp_info.components["any_scene_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'sceneconverters')]
-            self.cpp_info.components["any_scene_converter"].requires = ["trade"]
-
-        if self.options.any_scene_importer:
-            self.cpp_info.components["any_scene_importer"].names["cmake_find_package"] = "AnySceneImporter"
-            self.cpp_info.components["any_scene_importer"].names["cmake_find_package_multi"] = "AnySceneImporter"
-            self.cpp_info.components["any_scene_importer"].libs = ["AnySceneImporter"]
-            self.cpp_info.components["any_scene_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
-            self.cpp_info.components["any_scene_importer"].requires = ["trade"]
-
-        if self.options.magnum_font:
-            self.cpp_info.components["magnum_font"].names["cmake_find_package"] = "MagnumFont"
-            self.cpp_info.components["magnum_font"].names["cmake_find_package_multi"] = "MagnumFont"
-            self.cpp_info.components["magnum_font"].libs = ["MagnumFont"]
-            self.cpp_info.components["magnum_font"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'fonts')]
-            self.cpp_info.components["magnum_font"].requires = ["magnum_main", "trade", "text"]
-
-        if self.options.magnum_font_converter:
-            self.cpp_info.components["magnum_font_converter"].names["cmake_find_package"] = "MagnumFontConverter"
-            self.cpp_info.components["magnum_font_converter"].names["cmake_find_package_multi"] = "MagnumFontConverter"
-            self.cpp_info.components["magnum_font_converter"].libs = ["MagnumFontConverter"]
-            self.cpp_info.components["magnum_font_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'fontconverters')]
-            self.cpp_info.components["magnum_font_converter"].requires = ["magnum_main", "trade", "text", "tga_image_converter"]
-
-        if self.options.obj_importer:
-            self.cpp_info.components["obj_importer"].names["cmake_find_package"] = "ObjImporter"
-            self.cpp_info.components["obj_importer"].names["cmake_find_package_multi"] = "ObjImporter"
-            self.cpp_info.components["obj_importer"].libs = ["ObjImporter"]
-            self.cpp_info.components["obj_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
-            self.cpp_info.components["obj_importer"].requires = ["trade", "mesh_tools"]
-
-        if self.options.tga_importer:
-            self.cpp_info.components["tga_importer"].names["cmake_find_package"] = "TgaImporter"
-            self.cpp_info.components["tga_importer"].names["cmake_find_package_multi"] = "TgaImporter"
-            self.cpp_info.components["tga_importer"].libs = ["TgaImporter"]
-            self.cpp_info.components["tga_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'importers')]
-            self.cpp_info.components["tga_importer"].requires = ["trade"]
-
-        if self.options.tga_image_converter:
-            self.cpp_info.components["tga_image_converter"].names["cmake_find_package"] = "TgaImageConverter"
-            self.cpp_info.components["tga_image_converter"].names["cmake_find_package_multi"] = "TgaImageConverter"
-            self.cpp_info.components["tga_image_converter"].libs = ["TgaImageConverter"]
-            self.cpp_info.components["tga_image_converter"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'imageconverters')]
-            self.cpp_info.components["tga_image_converter"].requires = ["trade"]
-
-        if self.options.wav_audio_importer:
-            self.cpp_info.components["wav_audio_importer"].names["cmake_find_package"] = "WavAudioImporter"
-            self.cpp_info.components["wav_audio_importer"].names["cmake_find_package_multi"] = "WavAudioImporter"
-            self.cpp_info.components["wav_audio_importer"].libs = ["WavAudioImporter"]
-            self.cpp_info.components["wav_audio_importer"].libdirs = [os.path.join(self.package_folder, 'lib', magnum_plugin_libdir, 'audioimporters')]
-            self.cpp_info.components["wav_audio_importer"].requires = ["magnum_main", "audio"]
+        for component, target, library, folder, deps in self._plugins:
+            self.cpp_info.components[component].names["cmake_find_package"] = target
+            self.cpp_info.components[component].names["cmake_find_package_multi"] = target
+            self.cpp_info.components[component].libs = [library]
+            self.cpp_info.components[component].libdirs = [os.path.join(self.package_folder, "lib", magnum_plugin_libdir, folder)]
+            self.cpp_info.components[component].requires = deps
+            if not self.options.shared_plugins:
+                self.cpp_info.components[component].build_modules.append(os.path.join("lib", "cmake", "conan-magnum-plugins-{}.cmake".format(component)))
 
         #### EXECUTABLES ####
         bindir = os.path.join(self.package_folder, "bin")
@@ -708,3 +653,21 @@ class MagnumConan(ConanFile):
 
         for executable in self._executables:
             self.cpp_info.components["_magnum"].build_modules.append(os.path.join("lib", "cmake", "conan-magnum-{}.cmake".format(executable)))
+
+    @property
+    def _plugins(self):
+        #   (opt_name, (component, target, library, folder, deps))
+        all_plugins = (
+            ("any_audio_importer", ("any_audio_importer", "AnyAudioImporter", "AnyAudioImporter", "audioimporters", ["magnum_main", "audio"])), 
+            ("any_image_converter", ("any_image_converter", "AnyImageConverter", "AnyImageConverter", "imageconverters", ["trade"])), 
+            ("any_image_importer", ("any_image_importer", "AnyImageImporter", "AnyImageImporter", "importers", ["trade"])), 
+            ("any_scene_converter", ("any_scene_converter", "AnySceneConverter", "AnySceneConverter", "sceneconverters", ["trade"])), 
+            ("any_scene_importer", ("any_scene_importer", "AnySceneImporter", "AnySceneImporter", "importers", ["trade"])), 
+            ("magnum_font", ("magnum_font", "MagnumFont", "MagnumFont", "fonts", ["magnum_main", "trade", "text"])), 
+            ("magnum_font_converter", ("magnum_font_converter", "MagnumFontConverter", "MagnumFontConverter", "fontconverters", ["magnum_main", "trade", "text", "tga_image_converter"])), 
+            ("obj_importer", ("obj_importer", "ObjImporter", "ObjImporter", "importers", ["trade", "mesh_tools"])), 
+            ("tga_importer", ("tga_importer", "TgaImporter", "TgaImporter", "importers", ["trade"])), 
+            ("tga_image_converter", ("tga_image_converter", "TgaImageConverter", "TgaImageConverter", "imageconverters", ["trade"])), 
+            ("wav_audio_importer", ("wav_audio_importer", "WavAudioImporter", "WavAudioImporter", "audioimporters", ["magnum_main", "audio"])), 
+            )
+        return [plugin for opt_name, plugin in all_plugins if self.options.get_safe(opt_name)]

--- a/recipes/magnum/all/test_package/CMakeLists.txt
+++ b/recipes/magnum/all/test_package/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
-set(CONAN_CMAKE_SILENT_OUTPUT 1 )
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 

--- a/recipes/magnum/all/test_package/CMakeLists.txt
+++ b/recipes/magnum/all/test_package/CMakeLists.txt
@@ -1,13 +1,26 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
+set(CONAN_CMAKE_SILENT_OUTPUT 1 )
+
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(Magnum REQUIRED)
+if(SHARED_PLUGINS)
+    find_package(Magnum REQUIRED)
+else()
+    find_package(Magnum REQUIRED ObjImporter)
+endif()
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/configure.h)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} Magnum::Magnum)
+target_link_libraries(${PROJECT_NAME} PRIVATE Magnum::Magnum Magnum::Trade)
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+if(NOT SHARED_PLUGINS)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Magnum::ObjImporter)
+endif()
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
         CXX_STANDARD 11

--- a/recipes/magnum/all/test_package/conanfile.py
+++ b/recipes/magnum/all/test_package/conanfile.py
@@ -25,10 +25,18 @@ class TestPackageConan(ConanFile):
                 pass
         return available
 
+    def _importer_plugins_folder(self):
+        magnum_plugin_libdir = "magnum-d" if self.settings.build_type == "Debug" else "magnum"
+        pkg_dir = "bin" if self.settings.os == "Windows" else "lib"
+        return os.path.join(self.deps_cpp_info["magnum"].rootpath, pkg_dir, magnum_plugin_libdir, "importers")
+
     def build(self):
         cmake = CMake(self)
         for exec in self._executables:
             cmake.definitions["EXEC_{}".format(exec.replace("-", "_")).upper()] = True
+        cmake.definitions["IMPORTER_PLUGINS_FOLDER"] = self._importer_plugins_folder().replace("\\", "/")
+        cmake.definitions["OBJ_FILE"] = os.path.join(os.path.dirname(__file__), "triangleMesh.obj").replace("\\", "/")
+        cmake.definitions["SHARED_PLUGINS"] = self.options["magnum"].shared_plugins
         cmake.configure()
         cmake.build()
 

--- a/recipes/magnum/all/test_package/conanfile.py
+++ b/recipes/magnum/all/test_package/conanfile.py
@@ -25,17 +25,12 @@ class TestPackageConan(ConanFile):
                 pass
         return available
 
-    def _importer_plugins_folder(self):
-        magnum_plugin_libdir = "magnum-d" if self.settings.build_type == "Debug" else "magnum"
-        pkg_dir = "bin" if self.settings.os == "Windows" else "lib"
-        return os.path.join(self.deps_cpp_info["magnum"].rootpath, pkg_dir, magnum_plugin_libdir, "importers")
-
     def build(self):
         cmake = CMake(self)
         for exec in self._executables:
             cmake.definitions["EXEC_{}".format(exec.replace("-", "_")).upper()] = True
-        cmake.definitions["IMPORTER_PLUGINS_FOLDER"] = self._importer_plugins_folder().replace("\\", "/")
-        cmake.definitions["OBJ_FILE"] = os.path.join(os.path.dirname(__file__), "triangleMesh.obj").replace("\\", "/")
+        cmake.definitions["IMPORTER_PLUGINS_FOLDER"] = os.path.join(self.deps_user_info["magnum"].plugins_basepath, "importers").replace("\\", "/")
+        cmake.definitions["OBJ_FILE"] = os.path.join(self.source_folder, "triangleMesh.obj").replace("\\", "/")
         cmake.definitions["SHARED_PLUGINS"] = self.options["magnum"].shared_plugins
         cmake.configure()
         cmake.build()

--- a/recipes/magnum/all/test_package/configure.h.in
+++ b/recipes/magnum/all/test_package/configure.h.in
@@ -1,0 +1,3 @@
+
+#cmakedefine IMPORTER_PLUGINS_FOLDER "${IMPORTER_PLUGINS_FOLDER}"
+#cmakedefine OBJ_FILE "${OBJ_FILE}"

--- a/recipes/magnum/all/test_package/test_package.cpp
+++ b/recipes/magnum/all/test_package/test_package.cpp
@@ -27,7 +27,7 @@ int main() {
     // Test some plugin
     Corrade::PluginManager::Manager<Magnum::Trade::AbstractImporter> manager{IMPORTER_PLUGINS_FOLDER};
     manager.load("ObjImporter");
-    Corrade::Containers::Pointer<Magnum::Trade::AbstractImporter> importer = manager.instantiate("ObjImporter");
+    auto importer = manager.instantiate("ObjImporter");
 
     if(!importer) Magnum::Fatal{} << "Cannot load the ObjImporter plugin";
 

--- a/recipes/magnum/all/test_package/test_package.cpp
+++ b/recipes/magnum/all/test_package/test_package.cpp
@@ -1,6 +1,10 @@
 #include <iostream>
 #include "Magnum/Math/Vector.h"
 #include "Magnum/Math/StrictWeakOrdering.h"
+#include <Corrade/PluginManager/Manager.h>
+#include <Magnum/Trade/AbstractImporter.h>
+
+#include "configure.h"
 
 /*
     I would like to use some windowless application to test, like
@@ -10,12 +14,24 @@
 */
 
 int main() {
+    // Test some basic Magnum
     const Magnum::Math::Vector<2, Magnum::Float> v2a{1.0f, 2.0f};
     const Magnum::Math::Vector<2, Magnum::Float> v2b{2.0f, 3.0f};
     const Magnum::Math::Vector<2, Magnum::Float> v2c{1.0f, 3.0f};
 
     Magnum::Math::StrictWeakOrdering o;
     if (o(v2a, v2b)) {
-        std::cout << "Magnum working\n";
+        std::cout << "Basic Magnum working\n";
     }
+
+    // Test some plugin
+    Corrade::PluginManager::Manager<Magnum::Trade::AbstractImporter> manager{IMPORTER_PLUGINS_FOLDER};
+    manager.load("ObjImporter");
+    Corrade::Containers::Pointer<Magnum::Trade::AbstractImporter> importer = manager.instantiate("ObjImporter");
+
+    if(!importer) Magnum::Fatal{} << "Cannot load the ObjImporter plugin";
+
+    importer->openFile(OBJ_FILE);
+    std::cout << "Mesh count: " << importer->meshCount() << "\n";
+    return 0;
 }

--- a/recipes/magnum/all/test_package/triangleMesh.obj
+++ b/recipes/magnum/all/test_package/triangleMesh.obj
@@ -1,0 +1,9 @@
+# Positions
+v 0.5 2 3
+v 0 1.5 1
+v 2 3 5.0
+v 2.5 0 1
+
+# Triangles
+f 1 2 3
+f 4 2 1


### PR DESCRIPTION
Following the same approach proposed here: https://github.com/conan-io/conan-center-index/pull/7272, if `shared_plugins=False` the target needs to inject some `importStaticPlugin.cpp` to consumers so the plugin is registered automatically and is available to use.

