### PR TITLE
Bump openssl dependency of minizip-ng to latest version

### DIFF
--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -80,7 +80,7 @@ class MinizipNgConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/1.4.8")
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1k")
+            self.requires("openssl/1.1.1l")
         if self.settings.os != "Windows":
             if self.options.get_safe("with_iconv"):
                 self.requires("libiconv/1.16")


### PR DESCRIPTION
Specify library name and version:  **minizip-ng/3.0.2**

Bump openssl dependency of minizip-ng to latest version

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
