### PR TITLE
aws-sdk-cpp: turn monitoring on

### DIFF
--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -295,6 +295,7 @@ class AwsSdkCppConan(ConanFile):
     default_options["transfer"] = True
     default_options["s3-encryption"] = True
     default_options["text-to-speech"] = True
+    default_options["monitoring"] = True
     _internal_requirements = {
             "access-management": ["iam", "cognito-identity"],
             "identity-management": ["cognito-identity", "sts"],
@@ -363,7 +364,7 @@ class AwsSdkCppConan(ConanFile):
         self._cmake.definitions["MINIMIZE_SIZE"] = self.options.min_size
         if self.settings.compiler == "Visual Studio":
             self._cmake.definitions["FORCE_SHARED_CRT"] = "MD" in self.settings.compiler.runtime
-            
+
         if tools.cross_building(self):
             self._cmake.definitions["CURL_HAS_H2_EXITCODE"] = "0"
             self._cmake.definitions["CURL_HAS_H2_EXITCODE__TRYRUN_OUTPUT"] = ""

--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -288,14 +288,14 @@ class AwsSdkCppConan(ConanFile):
                 }
             }
     default_options = {key: False for key in options.keys()}
-    default_options["fPIC"] = True
     default_options["access-management"] = True
+    default_options["fPIC"] = True
     default_options["identity-management"] = True
-    default_options["queues"] = True
-    default_options["transfer"] = True
-    default_options["s3-encryption"] = True
-    default_options["text-to-speech"] = True
     default_options["monitoring"] = True
+    default_options["queues"] = True
+    default_options["s3-encryption"] = True
+    default_options["transfer"] = True
+    default_options["text-to-speech"] = True
     _internal_requirements = {
             "access-management": ["iam", "cognito-identity"],
             "identity-management": ["cognito-identity", "sts"],


### PR DESCRIPTION
Specify library name and version:  **aws-sdk-cpp/1.8.130**

aws-cdi-sdk package requires monitoring to be on.
see https://github.com/conan-io/conan-center-index/pull/7407#issuecomment-927251719

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
