### PR TITLE
copy missing header file in 1.0.5

### DIFF
--- a/recipes/readerwriterqueue/all/conanfile.py
+++ b/recipes/readerwriterqueue/all/conanfile.py
@@ -24,6 +24,9 @@ class ReaderWriterQueue(ConanFile):
     def package(self):
         self.copy("atomicops.h", src=self._source_subfolder, dst=os.path.join("include", "readerwriterqueue"))
         self.copy("readerwriterqueue.h", src=self._source_subfolder, dst=os.path.join("include", "readerwriterqueue"))
+        if tools.Version(self.version) >= "1.0.5":
+            self.copy("readerwritercircularbuffer.h", src=self._source_subfolder, dst=os.path.join("include", "readerwriterqueue"))
+
         self.copy("LICENSE.md", src=self._source_subfolder, dst="licenses")
 
     def package_id(self):


### PR DESCRIPTION
Specify library name and version:  **readerwriterqueue/1.0.5**

Although readerwritercircularbuffer.h is added in 1.0.5, 
recipe doesn't care about it.

---
- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [+] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [+] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
