### PR TITLE
Add libcurl 7.79.1 support

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.79.1":
+    sha256: 370b11201349816287fb0ccc995e420277fbfcaf76206e309b3f60f0eda090c2
+    url: https://curl.se/download/curl-7.79.1.tar.gz
   "7.79.0":
     sha256: aff0c7c4a526d7ecc429d2f96263a85fa73e709877054d593d8af3d136858074
     url: https://curl.se/download/curl-7.79.0.tar.gz

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.79.1":
+    folder: all
   "7.79.0":
     folder: all
   "7.78.0":


### PR DESCRIPTION
Specify library name and version:  **libcurl/7.79.0**

Library update. Closes #7433 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
