### PR TITLE
bump ImGuizmo to 1.83

### DIFF
--- a/recipes/imguizmo/all/conandata.yml
+++ b/recipes/imguizmo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.83":
+    url: "https://github.com/CedricGuillemet/ImGuizmo/archive/refs/tags/1.83.tar.gz"
+    sha256: "e6d05c5ebde802df7f6c342a06bc675bd2aa1c754d2d96755399a182187098a8"
   "cci.20210223":
     url: "https://github.com/CedricGuillemet/ImGuizmo/archive/f7bbbe39971d9d45816417a70e9b53a0f698c56e.tar.gz"
     sha256: "77e618cd7cd6f8d6b3a1426ac90dbbc5b4dcdd674e0fe5e5dec2c158eb54acb5"

--- a/recipes/imguizmo/all/conanfile.py
+++ b/recipes/imguizmo/all/conanfile.py
@@ -14,7 +14,6 @@ class ImGuizmoConan(ConanFile):
 
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
-    requires = "imgui/1.82"
 
     options = {
         "shared": [True, False],
@@ -43,6 +42,12 @@ class ImGuizmoConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = glob.glob("ImGuizmo-*/")[0]
         os.rename(extracted_dir, self._source_subfolder)
+
+    def requirements(self):
+        if self.version == "cci.20210223":
+            self.requires("imgui/1.82")
+        else:
+            self.requires("imgui/1.83")
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/imguizmo/config.yml
+++ b/recipes/imguizmo/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.83":
+    folder: "all"
   "cci.20210223":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **imguizmo/1.83**

Bump ImGuizmo to 1.83.
Because imguizmo/1.83 depends on imgui/1.83, 
requirements in conanfile.py was modified to function.

fixes #7392

---

- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [+] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [+] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
