### PR TITLE
[OpenCV]Make the protobuf version a property

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -99,6 +99,10 @@ class OpenCVConan(ConanFile):
     def _has_with_tiff_option(self):
         return self.settings.os != "iOS"
 
+    @property
+    def _protobuf_version(self):
+        return "protobuf/3.17.1"
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -163,7 +167,7 @@ class OpenCVConan(ConanFile):
         if self.options.get_safe("with_gtk"):
             self.requires("gtk/system")
         if self.options.dnn:
-            self.requires("protobuf/3.17.1")
+            self.requires(self._protobuf_version)
         if self.options.with_ade:
             self.requires("ade/0.1.1f")
 
@@ -178,7 +182,7 @@ class OpenCVConan(ConanFile):
 
     def build_requirements(self):
         if self.options.dnn and hasattr(self, "settings_build"):
-            self.build_requires("protobuf/3.17.1")
+            self.build_requires(self._protobuf_version)
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version][0],


### PR DESCRIPTION
I'm using a custom version of protobuf. I spent a bunch of time trying to debug a build error, turns out  my protobuf versions were not in sync.
I can see this happening again when someone updates the version here. Current implementation is error prone.

By making the version a property we ensure that both the requirement and the build_requierement are in sync. 

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
