### PR TITLE
Add unity recipe

### DIFF
--- a/recipes/unity/all/CMakeLists.txt
+++ b/recipes/unity/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/unity/all/conandata.yml
+++ b/recipes/unity/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.5.2":
+    url: "https://github.com/ThrowTheSwitch/Unity/archive/refs/tags/v2.5.2.tar.gz"
+    sha256: "3786de6c8f389be3894feae4f7d8680a02e70ed4dbcce36109c8f8646da2671a"

--- a/recipes/unity/all/conanfile.py
+++ b/recipes/unity/all/conanfile.py
@@ -1,0 +1,67 @@
+from conans import ConanFile, CMake
+from conans import tools
+import os
+
+class UnityConan(ConanFile):
+    name = "unity"
+    license = "MIT"
+    url = "https://github.com/ThrowTheSwitch/Unity"
+    description = "Conan wrap around unity"
+    topics = ("todo")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+    generators = ["make", "cmake"]
+    exports_sources = ["*"]
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["UNITY_EXTENSION_FIXTURE"] = "ON"
+        self._cmake.definitions["UNITY_EXTENSION_MEMORY"] = "ON"
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        # TODO - check if we can remove this.
+        self.copy("*.h", dst="include", src=(self._source_subfolder + "/src"))
+        self.copy("*.h", dst="include", src=(self._source_subfolder + "/extras/fixture/src"))
+        self.copy("*.h", dst="include", src=(self._source_subfolder + "/extras/memory/src"))
+        self.copy("*.rb", dst="auto", src=(self._source_subfolder + "/auto"))
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.names["cmake_find_package"] = "unity"
+        self.cpp_info.names["cmake_find_package_multi"] = "unity"
+        self.cpp_info.bindirs = ['auto']

--- a/recipes/unity/all/conanfile.py
+++ b/recipes/unity/all/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, CMake
 from conans import tools
-import os
+
 
 class UnityConan(ConanFile):
     name = "unity"
@@ -35,7 +35,8 @@ class UnityConan(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True,
+                  destination=self._source_subfolder)
 
     def build(self):
         cmake = self._configure_cmake()
@@ -51,17 +52,20 @@ class UnityConan(ConanFile):
         return self._cmake
 
     def package(self):
-        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        self.copy("LICENSE.txt", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        # TODO - check if we can remove this.
+        # need to add these manually, since otherwise includes within other
+        # tools like cmock or cexception won't be able to find them properly.
         self.copy("*.h", dst="include", src=(self._source_subfolder + "/src"))
-        self.copy("*.h", dst="include", src=(self._source_subfolder + "/extras/fixture/src"))
-        self.copy("*.h", dst="include", src=(self._source_subfolder + "/extras/memory/src"))
-        self.copy("*.rb", dst="auto", src=(self._source_subfolder + "/auto"))
+        self.copy("*.h", dst="include",
+                  src=(self._source_subfolder + "/extras/fixture/src"))
+        self.copy("*.h", dst="include",
+                  src=(self._source_subfolder + "/extras/memory/src"))
+        self.copy("*.rb", dst="bin", src=(self._source_subfolder + "/auto"))
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
         self.cpp_info.names["cmake_find_package"] = "unity"
         self.cpp_info.names["cmake_find_package_multi"] = "unity"
-        self.cpp_info.bindirs = ['auto']
+        self.cpp_info.bindirs = ['bin']

--- a/recipes/unity/config.yml
+++ b/recipes/unity/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.5.2":
+    folder: all


### PR DESCRIPTION
Adds a recipe for **unity/2.5.2**

This PR is being submitted so that a different project I am working on may use `conan` to pull in the `unity` package, which enables quick and efficient unit testing aimed specifically at embedded c applications. I am not the author of `unity`, that would be the good folks over at [ThrowTheSwitch](https://github.com/ThrowTheSwitch)

---

- [x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
