### PR TITLE
abseil: pin ABI at compile-time

### DIFF
--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -56,9 +56,39 @@ class ConanRecipe(ConanFile):
         self._cmake.configure()
         return self._cmake
 
+    @property
+    def _abseil_abi_macros(self):
+        return [
+            "ABSL_OPTION_USE_STD_ANY",
+            "ABSL_OPTION_USE_STD_OPTIONAL",
+            "ABSL_OPTION_USE_STD_STRING_VIEW",
+            "ABSL_OPTION_USE_STD_VARIANT",
+        ]
+
+    def _abseil_abi_config(self):
+        """Determine the Abseil ABI for polyfills (absl::any, absl::optional, absl::string_view, and absl::variant)"""
+        if self.settings.compiler.get_safe("cppstd"):
+            if self.settings.compiler.get_safe("cppstd") >= "17":
+                return "1"
+            return "0"
+        # As-of 2021-09-27 only GCC-11 defaults to C++17.
+        if (
+            self.settings.compiler == "gcc"
+            and tools.Version(self.settings.compiler.version) >= "11"
+        ):
+            return "1"
+        return "0"
+
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
+        absl_option = self._abseil_abi_config()
+        for macro in self._abseil_abi_macros:
+            tools.replace_in_file(
+                os.path.join(self._source_subfolder, "absl", "base", "options.h"),
+                "#define {} 2".format(macro),
+                "#define {} {}".format(macro, absl_option),
+            )
         cmake = self._configure_cmake()
         cmake.build()
 


### PR DESCRIPTION
**abseil/all**

As discussed in https://github.com/conan-io/conan-center-index/pull/7400#discussion_r716048204 Abseil cannot be compiled with C++11 and used from C++17, not without first "pinning" its ABI via some patches to `absl/base/options.h`.  This PR changes the recipe to make these changes when the code is built.

Fixes #7249.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
