### PR TITLE
Benchmark 1.6.0

### DIFF
--- a/recipes/benchmark/all/conandata.yml
+++ b/recipes/benchmark/all/conandata.yml
@@ -17,3 +17,6 @@ sources:
   "1.5.6":
     url: "https://github.com/google/benchmark/archive/v1.5.6.tar.gz"
     sha256: "789f85b4810d13ff803834ea75999e41b326405d83d6a538baf01499eda96102"
+  "1.6.0":
+    url: "https://github.com/google/benchmark/archive/v1.6.0.tar.gz"
+    sha256: "1f71c72ce08d2c1310011ea6436b31e39ccab8c2db94186d26657d41747c85d6"

--- a/recipes/benchmark/all/conanfile.py
+++ b/recipes/benchmark/all/conanfile.py
@@ -87,6 +87,7 @@ class BenchmarkConan(ConanFile):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
         tools.rmdir(os.path.join(self.package_folder, 'lib', 'pkgconfig'))
         tools.rmdir(os.path.join(self.package_folder, 'lib', 'cmake'))
+        tools.rmdir(os.path.join(self.package_folder, 'share'))
 
     def package_info(self):
         self.cpp_info.libs = ["benchmark", "benchmark_main"]

--- a/recipes/benchmark/config.yml
+++ b/recipes/benchmark/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: all
   "1.5.6":
     folder: all
+  "1.6.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **benchmark/1.6.0**

In 1.6.0, cmake places docs into share directory when installing library.
So conanfile.py becomes to delete it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
