### PR TITLE
[magnum] fPIC true when shared

### DIFF
--- a/recipes/magnum/all/conanfile.py
+++ b/recipes/magnum/all/conanfile.py
@@ -282,7 +282,7 @@ class MagnumConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["BUILD_DEPRECATED"] = False
         self._cmake.definitions["BUILD_STATIC"] = not self.options.shared
-        self._cmake.definitions["BUILD_STATIC_PIC"] = self.options.get_safe("fPIC", False)
+        self._cmake.definitions["BUILD_STATIC_PIC"] = self.options.get_safe("fPIC", True)
         # self._cmake.definitions["BUILD_STATIC_UNIQUE_GLOBALS"]
         self._cmake.definitions["BUILD_PLUGINS_STATIC"] = not self.options.shared_plugins
         self._cmake.definitions["LIB_SUFFIX"] = ""


### PR DESCRIPTION
From https://github.com/conan-io/conan-center-index/pull/7419#discussion_r717715869
When `shared` we remove the `fPIC` option, and we want it to be `True` for those scenarios (shared)
