### PR TITLE
add build_requires for cmake to geographiclib

### DIFF
--- a/recipes/geographiclib/all/conanfile.py
+++ b/recipes/geographiclib/all/conanfile.py
@@ -27,6 +27,8 @@ class GeographiclibConan(ConanFile):
         "tools": True
     }
 
+    build_requires = ["cmake/3.21.3"]
+
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
     _cmake = None


### PR DESCRIPTION
Specify library name and version:  **geographiclib/all**

Geographiclib will fail to build without cmake installed, this adds a build_requires for cmake so that the build will succeed even without cmake installed.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
