### PR TITLE
Update package to v2.2

### DIFF
--- a/recipes/argparse/all/conandata.yml
+++ b/recipes/argparse/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "2.1":
-    url: "https://github.com/p-ranav/argparse/archive/v2.1.tar.gz"
-    sha256: "0a82f464b568b8ee6650fc837f371eb9c81417e2ef9fb3b51f65ad50fa3b8662"
+  "2.2":
+    url: "https://github.com/p-ranav/argparse/archive/v2.2.tar.gz"
+    sha256: "f0fc6ab7e70ac24856c160f44ebb0dd79dc1f7f4a614ee2810d42bb73799872b"

--- a/recipes/argparse/all/conanfile.py
+++ b/recipes/argparse/all/conanfile.py
@@ -40,10 +40,12 @@ class ArgparseConan(ConanFile):
 
     def package(self):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        self.copy("*.hpp", src=os.path.join(self._source_subfolder, "include"), dst=os.path.join("include", "argparse"))
+        self.copy("*.hpp", src=os.path.join(self._source_subfolder, "include"), dst="include")
 
     def package_id(self):
         self.info.header_only()
 
     def package_info(self):
-        self.cpp_info.includedirs.append(os.path.join("include", "argparse"))
+        self.cpp_info.names["cmake_find_package"] = "argparse"
+        self.cpp_info.names["cmake_find_package_multi"] = "argparse"
+        self.cpp_info.names["pkg_config"] = "argparse"

--- a/recipes/argparse/all/test_package/test_package.cpp
+++ b/recipes/argparse/all/test_package/test_package.cpp
@@ -1,4 +1,4 @@
-#include <argparse.hpp>
+#include <include/argparse.hpp>
 
 #include <iostream>
 

--- a/recipes/argparse/config.yml
+++ b/recipes/argparse/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "2.1":
+  "2.2":
     folder: all


### PR DESCRIPTION
Update conandata.yml to point to v2.2 and update sha256.

conanfile.py dst is include and not include/argparse

package_info update to include missing attributes
like cmake_find_package cmake_find_package_multi pkg_config

config.yml updated to be 2.2

test_package changed to use include/argparse.hpp

Library: argparse/2.2

I'm not the author but I'd like to promote v2.2 to the index.

Question to the reviewer - What are the steps to test 2.2 on my local workspace?