### PR TITLE
gst-plugins-base/all: Add dependencies and component definitions.

### DIFF
--- a/recipes/gst-plugins-base/all/conanfile.py
+++ b/recipes/gst-plugins-base/all/conanfile.py
@@ -18,14 +18,36 @@ class GStPluginsBaseConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_libalsa": [True, False],
+        "with_libpng": [True, False],
+        "with_libjpeg": [False, "libjpeg", "libjpeg-turbo"],
+        "with_graphene": [True, False],
+        "with_pango": [True, False],
+        "with_ogg": [True, False],
+        "with_opus": [True, False],
+        "with_theora": [True, False],
+        "with_vorbis": [True, False],
         "with_gl": [True, False],
+        "with_egl": [True, False],
+        "with_wayland": [True, False],
+        "with_xorg": [True, False],
         "with_introspection": [True, False],
         }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_libalsa": True,
-        "with_gl": False,
+        "with_libpng": True,
+        "with_libjpeg": "libjpeg",
+        "with_graphene": True,
+        "with_pango": True,
+        "with_ogg": True,
+        "with_opus": True,
+        "with_theora": True,
+        "with_vorbis": True,
+        "with_gl": True,
+        "with_egl": True,
+        "with_wayland": True,
+        "with_xorg": True,
         "with_introspection": False,
         }
     _source_subfolder = "source_subfolder"
@@ -62,12 +84,43 @@ class GStPluginsBaseConan(ConanFile):
             del self.options.fPIC
         if self.settings.os != "Linux":
             del self.options.with_libalsa
+            del self.options.with_wayland
+        if self.settings.os not in ["Linux", "FreeBSD"]:
+            del self.options.with_egl
+            del self.options.with_xorg
 
     def requirements(self):
+        self.requires("zlib/1.2.11")
+        self.requires("glib/2.70.0")
         self.requires("gstreamer/1.19.1")
-        if self.settings.os == "Linux":
-            if self.options.with_libalsa:
-                self.requires("libalsa/1.1.9")
+        if self.options.get_safe("with_libalsa"):
+            self.requires("libalsa/1.1.9")
+        if self.options.get_safe("with_xorg"):
+            self.requires("xorg/system")
+        if self.options.with_gl:
+            self.requires("opengl/system")
+            if self.options.get_safe("with_egl"):
+                self.requires("egl/system")
+            if self.options.get_safe("with_wayland"):
+                self.requires("wayland/1.19.0")
+            if self.options.with_graphene:
+                self.requires("graphene/1.10.6")
+            if self.options.with_libpng:
+                self.requires("libpng/1.6.37")
+            if self.options.with_libjpeg == "libjpeg":
+                self.requires("libjpeg/9d")
+            elif self.options.with_libjpeg == "libjpeg-turbo":
+                self.requires("libjpeg-turbo/2.1.1")
+        if self.options.with_ogg:
+            self.requires("ogg/1.3.4")
+        if self.options.with_opus:
+            self.requires("opus/1.3.1")
+        if self.options.with_theora:
+            self.requires("theora/1.1.1")
+        if self.options.with_vorbis:
+            self.requires("vorbis/1.3.7")
+        if self.options.with_pango:
+            self.requires("pango/1.49.1")
 
     def build_requirements(self):
         self.build_requires("meson/0.54.2")
@@ -112,11 +165,26 @@ class GStPluginsBaseConan(ConanFile):
             defs["b_vscrt"] = str(self.settings.compiler.runtime).lower()
         defs["tools"] = "disabled"
         defs["examples"] = "disabled"
-        defs["benchmarks"] = "disabled"
         defs["tests"] = "disabled"
         defs["wrap_mode"] = "nofallback"
         defs["introspection"] = "enabled" if self.options.with_introspection else "disabled"
+        defs["orc"] = "disabled" # TODO: orc
         defs["gl"] = "enabled" if self.options.with_gl else "disabled"
+        defs["gl-graphene"] = "enabled" if self.options.with_gl and self.options.with_graphene else "disabled"
+        defs["gl-png"] = "enabled" if self.options.with_gl and self.options.with_libpng else "disabled"
+        defs["gl-jpeg"] = "enabled" if self.options.with_gl and self.options.with_libjpeg else "disabled"
+        defs["alsa"] = "enabled" if self.options.get_safe("with_libalsa") else "disabled"
+        defs["cdparanoia"] = "disabled" # "enabled" if self.options.with_cdparanoia else "disabled" # TODO: cdparanoia
+        defs["libvisual"] = "disabled" # "enabled" if self.options.with_libvisual else "disabled" # TODO: libvisual
+        defs["ogg"] = "enabled" if self.options.with_ogg else "disabled"
+        defs["opus"] = "enabled" if self.options.with_opus else "disabled"
+        defs["pango"] = "enabled" if self.options.with_pango else "disabled"
+        defs["theora"] = "enabled" if self.options.with_theora else "disabled"
+        defs["tremor"] = "disabled" # "enabled" if self.options.with_tremor else "disabled" # TODO: tremor - only useful on machines without floating-point support
+        defs["vorbis"] = "enabled" if self.options.with_vorbis else "disabled"
+        defs["x11"] = "enabled" if self.options.get_safe("with_xorg") else "disabled"
+        defs["xshm"] = "enabled" if self.options.get_safe("with_xorg") else "disabled"
+        defs["xvideo"] = "enabled" if self.options.get_safe("with_xorg") else "disabled"
         meson.configure(build_folder=self._build_subfolder,
                         source_folder=self._source_subfolder,
                         defs=defs)
@@ -153,50 +221,350 @@ class GStPluginsBaseConan(ConanFile):
         tools.remove_files_by_mask(self.package_folder, "*.pdb")
 
     def package_info(self):
+        gst_plugins = []
         gst_plugin_path = os.path.join(self.package_folder, "lib", "gstreamer-1.0")
+        gst_include_path = os.path.join(self.package_folder, "include", "gstreamer-1.0")
+
         if self.options.shared:
             self.output.info("Appending GST_PLUGIN_PATH env var : %s" % gst_plugin_path)
             self.env_info.GST_PLUGIN_PATH.append(gst_plugin_path)
-        else:
-            self.cpp_info.defines.append("GST_PLUGINS_BASE_STATIC")
-            self.cpp_info.libdirs.append(gst_plugin_path)
-            self.cpp_info.libs.extend(["gstaudiotestsrc",
-                                       "gstaudioconvert",
-                                       "gstaudiomixer",
-                                       "gstaudiorate",
-                                       "gstaudioresample",
-                                       "gstvideotestsrc",
-                                       "gstvideoconvert",
-                                       "gstvideorate",
-                                       "gstvideoscale",
-                                       "gstadder",
-                                       "gstapp",
-                                       "gstcompositor",
-                                       "gstencoding",
-                                       "gstgio",
-                                       "gstopengl",
-                                       "gstoverlaycomposition",
-                                       "gstpbtypes",
-                                       "gstplayback",
-                                       "gstrawparse",
-                                       "gstsubparse",
-                                       "gsttcp",
-                                       "gsttypefindfunctions",
-                                       "gstvolume"])
-            if not self.options.with_gl:
-                self.cpp_info.libs.remove("gstopengl")
-        self.cpp_info.libs.extend(["gstallocators-1.0",
-                                   "gstapp-1.0",
-                                   "gstaudio-1.0",
-                                   "gstfft-1.0",
-                                   "gstpbutils-1.0",
-                                   "gstriff-1.0",
-                                   "gstrtp-1.0",
-                                   "gstrtsp-1.0",
-                                   "gstsdp-1.0",
-                                   "gsttag-1.0",
-                                   "gstvideo-1.0",
-                                   "gstgl-1.0"])
-        if not self.options.with_gl:
-            self.cpp_info.libs.remove("gstgl-1.0")
-        self.cpp_info.includedirs = ["include", os.path.join("include", "gstreamer-1.0")]
+
+        # Plugins ('gst')
+        self.cpp_info.components["gstadder"].libs = ["gstadder"]
+        self.cpp_info.components["gstadder"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstadder"].requires = ["gstreamer-audio-1.0"] # TODO: orc
+        gst_plugins.append("gstadder")
+
+        self.cpp_info.components["gstapp"].libs = ["gstapp"]
+        self.cpp_info.components["gstapp"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstapp"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-app-1.0", "gstreamer-tag-1.0"]
+        gst_plugins.append("gstapp")
+
+        self.cpp_info.components["gstaudioconvert"].libs = ["gstaudioconvert"]
+        self.cpp_info.components["gstaudioconvert"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstaudioconvert"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"]
+        gst_plugins.append("gstaudioconvert")
+
+        self.cpp_info.components["gstaudiomixer"].libs = ["gstaudiomixer"]
+        self.cpp_info.components["gstaudiomixer"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstaudiomixer"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"] # TODO: orc
+        gst_plugins.append("gstaudiomixer")
+
+        self.cpp_info.components["gstaudiorate"].libs = ["gstaudiorate"]
+        self.cpp_info.components["gstaudiorate"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstaudiorate"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"]
+        gst_plugins.append("gstaudiorate")
+
+        self.cpp_info.components["gstaudioresample"].libs = ["gstaudioresample"]
+        self.cpp_info.components["gstaudioresample"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstaudioresample"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"]
+        if self.settings.os == "Linux":
+            self.cpp_info.components["gstaudioresample"].system_libs = ["m"]
+        gst_plugins.append("gstaudioresample")
+
+        self.cpp_info.components["gstaudiotestsrc"].libs = ["gstaudiotestsrc"]
+        self.cpp_info.components["gstaudiotestsrc"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstaudiotestsrc"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"]
+        if self.settings.os == "Linux":
+            self.cpp_info.components["gstaudiotestsrc"].system_libs = ["m"]
+        gst_plugins.append("gstaudiotestsrc")
+
+        self.cpp_info.components["gstcompositor"].libs = ["gstcompositor"]
+        self.cpp_info.components["gstcompositor"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstcompositor"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0"] # TODO: orc
+        if self.settings.os == "Linux":
+            self.cpp_info.components["gstcompositor"].system_libs = ["m"]
+        gst_plugins.append("gstcompositor")
+
+        self.cpp_info.components["gstencoding"].libs = ["gstencoding"]
+        self.cpp_info.components["gstencoding"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstencoding"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0", "gstreamer-pbutils-1.0"]
+        gst_plugins.append("gstencoding")
+
+        self.cpp_info.components["gstgio"].libs = ["gstgio"]
+        self.cpp_info.components["gstgio"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstgio"].requires = ["gstreamer::gstreamer-base-1.0", "glib::gio-2.0"]
+        gst_plugins.append("gstgio")
+
+        self.cpp_info.components["gstoverlaycomposition"].libs = ["gstoverlaycomposition"]
+        self.cpp_info.components["gstoverlaycomposition"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstoverlaycomposition"].requires = ["gstreamer-video-1.0"]
+        gst_plugins.append("gstoverlaycomposition")
+
+        self.cpp_info.components["gstpbtypes"].libs = ["gstpbtypes"]
+        self.cpp_info.components["gstpbtypes"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstpbtypes"].requires = ["gstreamer-video-1.0"]
+        gst_plugins.append("gstpbtypes")
+
+        self.cpp_info.components["gstplayback"].libs = ["gstplayback"]
+        self.cpp_info.components["gstplayback"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstplayback"].requires = ["gstreamer-audio-1.0", "gstreamer-video-1.0", "gstreamer-pbutils-1.0", "gstreamer-tag-1.0"]
+        gst_plugins.append("gstplayback")
+
+        self.cpp_info.components["gstrawparse"].libs = ["gstrawparse"]
+        self.cpp_info.components["gstrawparse"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstrawparse"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0", "gstreamer-video-1.0"]
+        gst_plugins.append("gstrawparse")
+
+        self.cpp_info.components["gstsubparse"].libs = ["gstsubparse"]
+        self.cpp_info.components["gstsubparse"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstsubparse"].requires = ["gstreamer::gstreamer-base-1.0"]
+        gst_plugins.append("gstsubparse")
+
+        self.cpp_info.components["gsttcp"].libs = ["gsttcp"]
+        self.cpp_info.components["gsttcp"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gsttcp"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer::gstreamer-net-1.0", "glib::gio-2.0"]
+        gst_plugins.append("gsttcp")
+
+        self.cpp_info.components["gsttypefindfunctions"].libs = ["gsttypefindfunctions"]
+        self.cpp_info.components["gsttypefindfunctions"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gsttypefindfunctions"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-pbutils-1.0", "glib::gio-2.0"]
+        gst_plugins.append("gsttypefindfunctions")
+
+        self.cpp_info.components["gstvideoconvert"].libs = ["gstvideoconvert"]
+        self.cpp_info.components["gstvideoconvert"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstvideoconvert"].requires = ["gstreamer-video-1.0"]
+        gst_plugins.append("gstvideoconvert")
+
+        self.cpp_info.components["gstvideorate"].libs = ["gstvideorate"]
+        self.cpp_info.components["gstvideorate"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstvideorate"].requires = ["gstreamer-video-1.0"]
+        gst_plugins.append("gstvideorate")
+
+        self.cpp_info.components["gstvideoscale"].libs = ["gstvideoscale"]
+        self.cpp_info.components["gstvideoscale"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstvideoscale"].requires = [
+            "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+            "gstreamer-video-1.0", "glib::glib-2.0", "glib::gobject-2.0"]
+        gst_plugins.append("gstvideoscale")
+
+        self.cpp_info.components["gstvideotestsrc"].libs = ["gstvideotestsrc"]
+        self.cpp_info.components["gstvideotestsrc"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstvideotestsrc"].requires = [
+            "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+            "gstreamer-video-1.0", "glib::glib-2.0", "glib::gobject-2.0"] # TODO: orc
+        if self.settings.os == "Linux":
+            self.cpp_info.components["gstvideotestsrc"].system_libs = ["m"]
+        gst_plugins.append("gstvideotestsrc")
+
+        self.cpp_info.components["gstvolume"].libs = ["gstvolume"]
+        self.cpp_info.components["gstvolume"].libdirs.append(gst_plugin_path)
+        self.cpp_info.components["gstvolume"].requires = [
+            "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+            "gstreamer-audio-1.0", "glib::glib-2.0", "glib::gobject-2.0"] # TODO: orc
+        gst_plugins.append("gstvolume")
+
+        # Plugins ('ext')
+        if self.options.get_safe("with_libalsa"):
+            self.cpp_info.components["gstalsa"].libs = ["gstalsa"]
+            self.cpp_info.components["gstalsa"].libdirs.append(gst_plugin_path)
+            self.cpp_info.components["gstalsa"].requires = [
+                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+                "gstreamer-audio-1.0", "gstreamer-tag-1.0",
+                "libalsa::libalsa", "glib::glib-2.0", "glib::gobject-2.0"]
+            gst_plugins.append("gstalsa")
+
+        # if self.options.with_cdparanoia: # TODO: cdparanoia
+        #     self.cpp_info.components["gstcdparanoia"].libs = ["gstcdparanoia"]
+        #     self.cpp_info.components["gstcdparanoia"].libdirs.append(gst_plugin_path)
+        #     self.cpp_info.components["gstcdparanoia"].requires = [
+        #         "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0",
+        #         "cdparanoia::cdparanoia", "glib::glib-2.0", "glib::gobject-2.0"]
+        #     gst_plugins.append("gstcdparanoia")
+
+        if self.options.with_gl:
+            self.cpp_info.components["gstopengl"].libs = ["gstopengl"]
+            self.cpp_info.components["gstopengl"].libdirs.append(gst_plugin_path)
+            self.cpp_info.components["gstopengl"].requires = [
+                "gstreamer::gstreamer-base-1.0", "gstreamer::gstreamer-controller-1.0",
+                "gstreamer-video-1.0", "gstreamer-allocators-1.0", "opengl::opengl"] # TODO: bcm, nvbuf_utils
+            if self.settings.os == "Macos":
+                self.cpp_info.components["gstopengl"].frameworks = ["CoreFoundation", "Foundation", "QuartzCore"]
+            if self.options.with_graphene:
+                self.cpp_info.components["gstopengl"].requires.append("graphene::graphene-gobject-1.0")
+            if self.options.with_libpng:
+                self.cpp_info.components["gstopengl"].requires.append("libpng::libpng")
+            if self.options.with_libjpeg == "libjpeg":
+                self.cpp_info.components["gstopengl"].requires.append("libjpeg::libjpeg")
+            elif self.options.with_libjpeg == "libjpeg-turbo":
+                self.cpp_info.components["gstopengl"].requires.append("libjpeg-turbo::libjpeg-turbo")
+            if self.options.get_safe("with_xorg"):
+                self.cpp_info.components["gstopengl"].requires.append("xorg::x11")
+            if self.settings.os == "Linux":
+                self.cpp_info.components["gstopengl"].system_libs = ["m"]
+            gst_plugins.append("gstopengl")
+
+        # if self.options.with_libvisual: # TODO: libvisual
+        #     self.cpp_info.components["gstlibvisual"].libs = ["gstlibvisual"]
+        #     self.cpp_info.components["gstlibvisual"].libdirs.append(gst_plugin_path)
+        #     self.cpp_info.components["gstlibvisual"].requires = [
+        #         "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+        #         "gstreamer-audio-1.0", "gstreamer-video-1.0", "gstreamer-pbutils-1.0",
+        #         "libvisual::libvisual", "glib::glib-2.0", "glib::gobject-2.0"]
+        #     gst_plugins.append("gstlibvisual")
+
+        if self.options.with_ogg:
+            self.cpp_info.components["gstogg"].libs = ["gstogg"]
+            self.cpp_info.components["gstogg"].libdirs.append(gst_plugin_path)
+            self.cpp_info.components["gstogg"].requires = [
+                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+                "gstreamer-audio-1.0", "gstreamer-pbutils-1.0", "gstreamer-tag-1.0", "gstreamer-riff-1.0",
+                "ogg::ogglib", "glib::glib-2.0", "glib::gobject-2.0"]
+            gst_plugins.append("gstogg")
+
+        if self.options.with_opus:
+            self.cpp_info.components["gstopus"].libs = ["gstopus"]
+            self.cpp_info.components["gstopus"].libdirs.append(gst_plugin_path)
+            self.cpp_info.components["gstopus"].requires = [
+                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+                "gstreamer-audio-1.0", "gstreamer-pbutils-1.0", "gstreamer-tag-1.0",
+                "opus::libopus", "glib::glib-2.0", "glib::gobject-2.0"]
+            if self.settings.os == "Linux":
+                self.cpp_info.components["gstopus"].system_libs = ["m"]
+            gst_plugins.append("gstopus")
+
+        if self.options.with_pango:
+            self.cpp_info.components["gstpango"].libs = ["gstpango"]
+            self.cpp_info.components["gstpango"].libdirs.append(gst_plugin_path)
+            self.cpp_info.components["gstpango"].requires = [
+                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+                "gstreamer-video-1.0",
+                "pango::pangocairo", "glib::glib-2.0", "glib::gobject-2.0"]
+            if self.settings.os == "Linux":
+                self.cpp_info.components["gstpango"].system_libs = ["m"]
+            gst_plugins.append("gstpango")
+
+        if self.options.with_theora:
+            self.cpp_info.components["gsttheora"].libs = ["gsttheora"]
+            self.cpp_info.components["gsttheora"].libdirs.append(gst_plugin_path)
+            self.cpp_info.components["gsttheora"].requires = [
+                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+                "gstreamer-video-1.0", "gstreamer-tag-1.0",
+                "theora::theoraenc", "theora::theoradec", "glib::glib-2.0", "glib::gobject-2.0"]
+            gst_plugins.append("gsttheora")
+
+        if self.options.with_vorbis:
+            self.cpp_info.components["gstvorbis"].libs = ["gstvorbis"]
+            self.cpp_info.components["gstvorbis"].libdirs.append(gst_plugin_path)
+            self.cpp_info.components["gstvorbis"].requires = [
+                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+                "gstreamer-audio-1.0", "gstreamer-tag-1.0",
+                "vorbis::vorbismain", "vorbis::vorbisenc", "glib::glib-2.0", "glib::gobject-2.0"]
+            gst_plugins.append("gstvorbis")
+
+        # if self.options.with_tremor: # TODO: tremor
+        #     self.cpp_info.components["gstivorbisdec"].libs = ["gstivorbisdec"]
+        #     self.cpp_info.components["gstivorbisdec"].libdirs.append(gst_plugin_path)
+        #     self.cpp_info.components["gstivorbisdec"].requires = [
+        #         "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+        #         "gstreamer-audio-1.0", "gstreamer-tag-1.0",
+        #         "tremor::tremor", "glib::glib-2.0", "glib::gobject-2.0"]
+        #     gst_plugins.append("gstivorbisdec")
+
+        # Plugins ('sys')
+        if self.options.get_safe("with_xorg"):
+            self.cpp_info.components["gstximagesink"].libs = ["gstximagesink"]
+            self.cpp_info.components["gstximagesink"].libdirs.append(gst_plugin_path)
+            self.cpp_info.components["gstximagesink"].requires = [
+                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+                "gstreamer-video-1.0",
+                "xorg::x11", "xorg::xext", "glib::glib-2.0", "glib::gobject-2.0"]
+            gst_plugins.append("gstximagesink")
+
+            self.cpp_info.components["gstxvimagesink"].libs = ["gstxvimagesink"]
+            self.cpp_info.components["gstxvimagesink"].libdirs.append(gst_plugin_path)
+            self.cpp_info.components["gstxvimagesink"].requires = [
+                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+                "gstreamer-video-1.0",
+                "xorg::x11", "xorg::xext", "xorg::xv", "glib::glib-2.0", "glib::gobject-2.0"]
+            if self.settings.os == "Linux":
+                self.cpp_info.components["gstxvimagesink"].system_libs = ["m"]
+            gst_plugins.append("gstxvimagesink")
+
+        # Libraries
+        self.cpp_info.components["gstreamer-plugins-base-1.0"].names["pkg_config"] = "gstreamer-plugins-base-1.0"
+        self.cpp_info.components["gstreamer-plugins-base-1.0"].requires = ["gstreamer::gstreamer-1.0"]
+        self.cpp_info.components["gstreamer-plugins-base-1.0"].includedirs = [gst_include_path]
+        if not self.options.shared:
+            self.cpp_info.components["gstreamer-plugins-base-1.0"].defines.append("GST_PLUGINS_BASE_STATIC")
+            self.cpp_info.components["gstreamer-plugins-base-1.0"].requires.extend(gst_plugins)
+
+        self.cpp_info.components["gstreamer-allocators-1.0"].names["pkg_config"] = "gstreamer-allocators-1.0"
+        self.cpp_info.components["gstreamer-allocators-1.0"].libs = ["gstallocators-1.0"]
+        self.cpp_info.components["gstreamer-allocators-1.0"].requires = ["gstreamer::gstreamer-1.0"]
+        self.cpp_info.components["gstreamer-allocators-1.0"].includedirs = [gst_include_path]
+
+        self.cpp_info.components["gstreamer-app-1.0"].names["pkg_config"] = "gstreamer-app-1.0"
+        self.cpp_info.components["gstreamer-app-1.0"].libs = ["gstapp-1.0"]
+        self.cpp_info.components["gstreamer-app-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0"]
+        self.cpp_info.components["gstreamer-app-1.0"].includedirs = [gst_include_path]
+
+        self.cpp_info.components["gstreamer-audio-1.0"].names["pkg_config"] = "gstreamer-audio-1.0"
+        self.cpp_info.components["gstreamer-audio-1.0"].libs = ["gstaudio-1.0"]
+        self.cpp_info.components["gstreamer-audio-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-tag-1.0"] # TODO: orc
+        self.cpp_info.components["gstreamer-audio-1.0"].includedirs = [gst_include_path]
+
+        self.cpp_info.components["gstreamer-fft-1.0"].names["pkg_config"] = "gstreamer-fft-1.0"
+        self.cpp_info.components["gstreamer-fft-1.0"].libs = ["gstfft-1.0"]
+        self.cpp_info.components["gstreamer-fft-1.0"].requires = ["gstreamer::gstreamer-1.0"]
+        self.cpp_info.components["gstreamer-fft-1.0"].includedirs = [gst_include_path]
+        if self.settings.os == "Linux":
+            self.cpp_info.components["gstreamer-fft-1.0"].system_libs = ["m"]
+
+        if self.options.with_gl:
+            self.cpp_info.components["gstreamer-gl-1.0"].names["pkg_config"] = "gstreamer-gl-1.0"
+            self.cpp_info.components["gstreamer-gl-1.0"].libs = ["gstgl-1.0"]
+            self.cpp_info.components["gstreamer-gl-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0"]
+            self.cpp_info.components["gstreamer-gl-1.0"].includedirs = [os.path.join(self.package_folder, "include"), gst_include_path]
+
+            self.cpp_info.components["gstreamer-gl-prototypes-1.0"].names["pkg_config"] = "gstreamer-gl-prototypes-1.0"
+            self.cpp_info.components["gstreamer-gl-prototypes-1.0"].requires = ["gstreamer-gl-1.0", "opengl::opengl"]
+
+            if self.options.get_safe("with_egl"):
+                self.cpp_info.components["gstreamer-gl-egl-1.0"].names["pkg_config"] = "gstreamer-gl-egl-1.0"
+                self.cpp_info.components["gstreamer-gl-egl-1.0"].requires = ["gstreamer-gl-1.0", "egl::egl"]
+
+            if self.options.get_safe("with_wayland"):
+                self.cpp_info.components["gstreamer-gl-wayland-1.0"].names["pkg_config"] = "gstreamer-gl-wayland-1.0"
+                self.cpp_info.components["gstreamer-gl-wayland-1.0"].requires = ["gstreamer-gl-1.0", "wayland::wayland-client", "wayland::wayland-egl"]
+
+            if self.options.get_safe("with_xorg"):
+                self.cpp_info.components["gstreamer-gl-x11-1.0"].names["pkg_config"] = "gstreamer-gl-x11-1.0"
+                self.cpp_info.components["gstreamer-gl-x11-1.0"].requires = ["gstreamer-gl-1.0", "xorg::x11-xcb"]
+
+        self.cpp_info.components["gstreamer-pbutils-1.0"].names["pkg_config"] = "gstreamer-pbutils-1.0"
+        self.cpp_info.components["gstreamer-pbutils-1.0"].libs = ["gstpbutils-1.0"]
+        self.cpp_info.components["gstreamer-pbutils-1.0"].requires = [
+            "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
+            "gstreamer-audio-1.0", "gstreamer-video-1.0", "gstreamer-tag-1.0"]
+        self.cpp_info.components["gstreamer-pbutils-1.0"].includedirs = [gst_include_path]
+
+        self.cpp_info.components["gstreamer-riff-1.0"].names["pkg_config"] = "gstreamer-riff-1.0"
+        self.cpp_info.components["gstreamer-riff-1.0"].libs = ["gstriff-1.0"]
+        self.cpp_info.components["gstreamer-riff-1.0"].requires = ["gstreamer::gstreamer-1.0"]
+        self.cpp_info.components["gstreamer-riff-1.0"].includedirs = [gst_include_path]
+
+        self.cpp_info.components["gstreamer-rtp-1.0"].names["pkg_config"] = "gstreamer-rtp-1.0"
+        self.cpp_info.components["gstreamer-rtp-1.0"].libs = ["gstrtp-1.0"]
+        self.cpp_info.components["gstreamer-rtp-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0"]
+        self.cpp_info.components["gstreamer-rtp-1.0"].includedirs = [gst_include_path]
+
+        self.cpp_info.components["gstreamer-rtsp-1.0"].names["pkg_config"] = "gstreamer-rtsp-1.0"
+        self.cpp_info.components["gstreamer-rtsp-1.0"].libs = ["gstrtsp-1.0"]
+        self.cpp_info.components["gstreamer-rtsp-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer-sdp-1.0", "glib::gio-2.0"]
+        self.cpp_info.components["gstreamer-rtsp-1.0"].includedirs = [gst_include_path]
+
+        self.cpp_info.components["gstreamer-sdp-1.0"].names["pkg_config"] = "gstreamer-sdp-1.0"
+        self.cpp_info.components["gstreamer-sdp-1.0"].libs = ["gstsdp-1.0"]
+        self.cpp_info.components["gstreamer-sdp-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer-rtp-1.0", "glib::glib-2.0", "glib::gio-2.0"]
+        self.cpp_info.components["gstreamer-sdp-1.0"].includedirs = [gst_include_path]
+
+        self.cpp_info.components["gstreamer-tag-1.0"].names["pkg_config"] = "gstreamer-tag-1.0"
+        self.cpp_info.components["gstreamer-tag-1.0"].libs = ["gsttag-1.0"]
+        self.cpp_info.components["gstreamer-tag-1.0"].requires = ["gstreamer::gstreamer-1.0", "zlib::zlib"]
+        self.cpp_info.components["gstreamer-tag-1.0"].includedirs = [gst_include_path]
+
+        self.cpp_info.components["gstreamer-video-1.0"].names["pkg_config"] = "gstreamer-video-1.0"
+        self.cpp_info.components["gstreamer-video-1.0"].libs = ["gstvideo-1.0"]
+        self.cpp_info.components["gstreamer-video-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0"] # TODO: orc
+        self.cpp_info.components["gstreamer-video-1.0"].includedirs = [gst_include_path]

--- a/recipes/gst-plugins-base/all/conanfile.py
+++ b/recipes/gst-plugins-base/all/conanfile.py
@@ -560,7 +560,9 @@ class GStPluginsBaseConan(ConanFile):
             if self.options.get_safe("with_xorg"):
                 self.cpp_info.components["gstreamer-gl-1.0"].requires.extend(["xorg::x11", "xorg::x11-xcb"])
             if self.options.get_safe("with_wayland"):
-                self.cpp_info.components["gstreamer-gl-1.0"].requires.extend(["wayland::wayland-client", "wayland::wayland-cursor", "wayland::wayland-egl"])
+                self.cpp_info.components["gstreamer-gl-1.0"].requires.extend([
+                    "wayland::wayland-client", "wayland::wayland-cursor", "wayland::wayland-egl",
+                    "wayland-protocols::wayland-protocols"])
             if self.settings.os == "Windows":
                 self.cpp_info.components["gstreamer-gl-1.0"].system_libs = ["gdi32"]
             if self.settings.os in ["Macos", "iOS", "tvOS", "watchOS"]:
@@ -578,7 +580,9 @@ class GStPluginsBaseConan(ConanFile):
 
             if self.options.get_safe("with_wayland"):
                 self.cpp_info.components["gstreamer-gl-wayland-1.0"].names["pkg_config"] = "gstreamer-gl-wayland-1.0"
-                self.cpp_info.components["gstreamer-gl-wayland-1.0"].requires = ["gstreamer-gl-1.0", "wayland::wayland-client", "wayland::wayland-egl"]
+                self.cpp_info.components["gstreamer-gl-wayland-1.0"].requires = [
+                    "gstreamer-gl-1.0", "wayland::wayland-client", "wayland::wayland-egl",
+                    "wayland-protocols::wayland-protocols"]
 
             if self.options.get_safe("with_xorg"):
                 self.cpp_info.components["gstreamer-gl-x11-1.0"].names["pkg_config"] = "gstreamer-gl-x11-1.0"

--- a/recipes/gst-plugins-base/all/conanfile.py
+++ b/recipes/gst-plugins-base/all/conanfile.py
@@ -105,6 +105,7 @@ class GStPluginsBaseConan(ConanFile):
                 self.requires("egl/system")
             if self.options.get_safe("with_wayland"):
                 self.requires("wayland/1.19.0")
+                self.requires("wayland-protocols/1.23")
             if self.options.with_graphene:
                 self.requires("graphene/1.10.6")
             if self.options.with_libpng:

--- a/recipes/gst-plugins-base/all/test_package/CMakeLists.txt
+++ b/recipes/gst-plugins-base/all/test_package/CMakeLists.txt
@@ -8,4 +8,4 @@ conan_basic_setup(TARGETS)
 find_package(gst-plugins-base CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} gst-plugins-base::gst-plugins-base)
+target_link_libraries(${PROJECT_NAME} gst-plugins-base::gstreamer-plugins-base-1.0)


### PR DESCRIPTION
Specify library name and version:  **gst-plugins-base/1.19.1**

Thanks to @SSE4 we now have gst-plugins-base package which I have been looking forward to having in Conan for some time. This PR adds lots of dependencies and creates all possible components. The plugins need to be defined as components as well for static linking to properly work.

Also turns `with_gl` flag on by default. Let me know if there was a reason for this flag being off.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
