### PR TITLE
bump aws-c-common to 0.6.9

### DIFF
--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.9":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.6.9.tar.gz"
+    sha256: "928a3e36f24d1ee46f9eec360ec5cebfe8b9b8994fe39d4fa74ff51aebb12717"
   "0.6.8":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.6.8.tar.gz"
     sha256: "2997e851ed690a614507a43f4c393f45a198614d94da1660ecdf9b5a729535fc"

--- a/recipes/aws-c-common/config.yml
+++ b/recipes/aws-c-common/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.9":
+    folder: all
   "0.6.8":
     folder: all
   "0.6.7":


### PR DESCRIPTION
Specify library name and version:  **aws-c-common/0.6.9**

Nothing special. added some constant value.
It is required to bump aws-c-http to 0.6.7.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
