### PR TITLE
bump numcpp to 2.6.2

### DIFF
--- a/recipes/numcpp/all/conandata.yml
+++ b/recipes/numcpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.2":
+    url: "https://github.com/dpilger26/NumCpp/archive/Version_2.6.2.tar.gz"
+    sha256: "6c32dd72cc2ccaf7efbba394305c7a3e2ccf1b763d3688de7e253f9ca9b3cf4a"
   "2.5.1":
     url: "https://github.com/dpilger26/NumCpp/archive/Version_2.5.1.tar.gz"
     sha256: "0677907a90e96a468a9ea4e702940833570c2419d9a822724ee708dddd3c422e"

--- a/recipes/numcpp/config.yml
+++ b/recipes/numcpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.2":
+    folder: "all"
   "2.5.1":
     folder: "all"
   "2.4.2":


### PR DESCRIPTION
Specify library name and version:  **numcpp/2.6.2**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
