### PR TITLE
aws-c-compression/all: Update dependencies

### DIFF
--- a/recipes/aws-c-compression/all/conanfile.py
+++ b/recipes/aws-c-compression/all/conanfile.py
@@ -39,7 +39,7 @@ class AwsCCompression(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.7")
+        self.requires("aws-c-common/0.6.9")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],


### PR DESCRIPTION
Specify library name and version:  **aws-c-compression/all**

update dependencies:
  - aws-c-common 0.6.7 -> 0.6.9

I'm trying to upgrade aws-c-s3, but it depends on definitions added to latest aws-c-common and aws-c-http. So I am going to update other dependent packages that depend on these packages.

---
- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
