### PR TITLE
aws-c-common/0.6.9: Use STATIC_CRT cmake definitions

### DIFF
--- a/recipes/aws-c-common/all/conanfile.py
+++ b/recipes/aws-c-common/all/conanfile.py
@@ -1,5 +1,6 @@
 import os
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.33.0"
 
@@ -37,6 +38,10 @@ class AwsCCommon(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
+
+    def validate(self):
+        if self.settings.compiler == "Visual Studio" and self.options.shared and "MT" in self.settings.compiler.runtime:
+            raise ConanInvalidConfiguration("Static runtime + shared is not working for more recent releases")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/aws-c-common/all/conanfile.py
+++ b/recipes/aws-c-common/all/conanfile.py
@@ -47,6 +47,8 @@ class AwsCCommon(ConanFile):
             return self._cmake
         self._cmake = CMake(self)
         self._cmake.definitions["BUILD_TESTING"] = False
+        if self.settings.compiler == "Visual Studio":
+            self._cmake.definitions["STATIC_CRT"] = "MT" in self.settings.compiler.runtime
         self._cmake.configure()
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **aws-c-common/0.6.9**

Trying to fix https://github.com/conan-io/conan-center-index/pull/7257

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
