### PR TITLE
abseil: fix old releases

### DIFF
--- a/recipes/abseil/all/conandata.yml
+++ b/recipes/abseil/all/conandata.yml
@@ -1,41 +1,56 @@
 sources:
-  "20200205":
-    sha256: 3c554df4909c5c55a6d251f6eadc2c78ff20db5ad4471fd9cbf8085c51b76797
-    url: https://github.com/abseil/abseil-cpp/archive/08a7e7bf972c8451855a5022f2faf3d3655db015.tar.gz
-  "20200225.2":
-    url: "https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz"
-    sha256: "f41868f7a938605c92936230081175d1eae87f6ea2c248f41077c8f88316f111"
-  "20200225.3":
-    url: "https://github.com/abseil/abseil-cpp/archive/20200225.3.tar.gz"
-    sha256: "66d4d009050f39c104b03f79bdca9d930c4964016f74bf24867a43fbdbd00d23"
-  "20200923":
-    url: "https://github.com/abseil/abseil-cpp/archive/20200923.tar.gz"
-    sha256: "b3744a4f7a249d5eaf2309daad597631ce77ea62e0fc6abffbab4b4c3dc0fc08"
-  "20200923.1":
-    url: "https://github.com/abseil/abseil-cpp/archive/20200923.1.tar.gz"
-    sha256: "808350c4d7238315717749bab0067a1acd208023d41eaf0c7360f29cc8bc8f21"
-  "20200923.2":
-    url: "https://github.com/abseil/abseil-cpp/archive/20200923.2.tar.gz"
-    sha256: "bf3f13b13a0095d926b25640e060f7e13881bd8a792705dd9e161f3c2b9aa976"
-  "20200923.3":
-    url: "https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz"
-    sha256: "ebe2ad1480d27383e4bf4211e2ca2ef312d5e6a09eba869fd2e8a5c5d553ded2"
-  "20210324.0":
-    url: "https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.0.tar.gz"
-    sha256: "dd7db6815204c2a62a2160e32c55e97113b0a0178b2f090d6bab5ce36111db4b"
-  "20210324.1":
-    url: "https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.1.tar.gz"
-    sha256: "441db7c09a0565376ecacf0085b2d4c2bbedde6115d7773551bc116212c2a8d6"
   "20210324.2":
     url: "https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz"
     sha256: "59b862f50e710277f8ede96f083a5bb8d7c9595376146838b9580be90374ee1f"
-patches:
-  "20200205":
-    - patch_file: "patches/cmake-install.patch"
-      base_path: "source_subfolder"
+  "20210324.1":
+    url: "https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.1.tar.gz"
+    sha256: "441db7c09a0565376ecacf0085b2d4c2bbedde6115d7773551bc116212c2a8d6"
+  "20210324.0":
+    url: "https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.0.tar.gz"
+    sha256: "dd7db6815204c2a62a2160e32c55e97113b0a0178b2f090d6bab5ce36111db4b"
+  "20200923.3":
+    url: "https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz"
+    sha256: "ebe2ad1480d27383e4bf4211e2ca2ef312d5e6a09eba869fd2e8a5c5d553ded2"
+  "20200923.2":
+    url: "https://github.com/abseil/abseil-cpp/archive/20200923.2.tar.gz"
+    sha256: "bf3f13b13a0095d926b25640e060f7e13881bd8a792705dd9e161f3c2b9aa976"
+  "20200923.1":
+    url: "https://github.com/abseil/abseil-cpp/archive/20200923.1.tar.gz"
+    sha256: "808350c4d7238315717749bab0067a1acd208023d41eaf0c7360f29cc8bc8f21"
+  "20200923":
+    url: "https://github.com/abseil/abseil-cpp/archive/20200923.tar.gz"
+    sha256: "b3744a4f7a249d5eaf2309daad597631ce77ea62e0fc6abffbab4b4c3dc0fc08"
+  "20200225.3":
+    url: "https://github.com/abseil/abseil-cpp/archive/20200225.3.tar.gz"
+    sha256: "66d4d009050f39c104b03f79bdca9d930c4964016f74bf24867a43fbdbd00d23"
   "20200225.2":
-    - patch_file: "patches/cmake-install.patch"
+    url: "https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz"
+    sha256: "f41868f7a938605c92936230081175d1eae87f6ea2c248f41077c8f88316f111"
+  "20200205":
+    url: "https://github.com/abseil/abseil-cpp/archive/08a7e7bf972c8451855a5022f2faf3d3655db015.tar.gz"
+    sha256: 3c554df4909c5c55a6d251f6eadc2c78ff20db5ad4471fd9cbf8085c51b76797
+patches:
+  "20200923.2":
+    - patch_file: "patches/20200205-missing-numeric_limits.h.patch"
+      base_path: "source_subfolder"
+  "20200923.1":
+    - patch_file: "patches/20200205-missing-numeric_limits.h.patch"
+      base_path: "source_subfolder"
+  "20200923":
+    - patch_file: "patches/20200205-missing-numeric_limits.h.patch"
       base_path: "source_subfolder"
   "20200225.3":
-    - patch_file: "patches/cmake-install.patch"
+    - patch_file: "patches/20200205-cmake-install.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/20200205-missing-numeric_limits.h.patch"
+      base_path: "source_subfolder"
+  "20200225.2":
+    - patch_file: "patches/20200205-cmake-install.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/20200205-missing-numeric_limits.h.patch"
+      base_path: "source_subfolder"
+  "20200205":
+    - patch_file: "patches/20200205-cmake-install.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/20200205-missing-numeric_limits.h.patch"
       base_path: "source_subfolder"

--- a/recipes/abseil/all/patches/20200205-cmake-install.patch
+++ b/recipes/abseil/all/patches/20200205-cmake-install.patch
@@ -1,6 +1,6 @@
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -41,9 +41,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -41,9 +41,9 @@
  # when absl is included as subproject (i.e. using add_subdirectory(abseil-cpp))
  # in the source tree of a project that uses it, install rules are disabled.
  if(NOT "^${CMAKE_SOURCE_DIR}$" STREQUAL "^${PROJECT_SOURCE_DIR}$")

--- a/recipes/abseil/all/patches/20200205-missing-numeric_limits.h.patch
+++ b/recipes/abseil/all/patches/20200205-missing-numeric_limits.h.patch
@@ -1,0 +1,11 @@
+--- absl/synchronization/internal/graphcycles.cc
++++ absl/synchronization/internal/graphcycles.cc
+@@ -34,7 +34,7 @@
+ #ifndef ABSL_LOW_LEVEL_ALLOC_MISSING
+ 
+ #include "absl/synchronization/internal/graphcycles.h"
+-
++#include <limits>
+ #include <algorithm>
+ #include <array>
+ #include "absl/base/internal/hide_ptr.h"

--- a/recipes/abseil/config.yml
+++ b/recipes/abseil/config.yml
@@ -1,21 +1,21 @@
 versions:
-  "20200205":
-    folder: all
-  "20200225.2":
-    folder: all
-  "20200225.3":
-    folder: all
-  "20200923":
-    folder: all
-  "20200923.1":
-    folder: all
-  "20200923.2":
-    folder: all
-  "20200923.3":
-    folder: all
-  "20210324.0":
+  "20210324.2":
     folder: all
   "20210324.1":
     folder: all
-  "20210324.2":
+  "20210324.0":
+    folder: all
+  "20200923.3":
+    folder: all
+  "20200923.2":
+    folder: all
+  "20200923.1":
+    folder: all
+  "20200923":
+    folder: all
+  "20200225.3":
+    folder: all
+  "20200225.2":
+    folder: all
+  "20200205":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **abseil/all**

Missing header broke older releases

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
