### PR TITLE
android-ndk: set CONAN_CMAKE_SYSTEM_PROCESSOR

### DIFF
--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -2,55 +2,70 @@ sources:
   "r23":
     url:
       "Windows":
-        url: "https://dl.google.com/android/repository/android-ndk-r23-windows.zip"
-        sha256: "40325b5bfdb7f6de016ea3efee0468a7d306eda55a6f80966a501645ba01fbfa"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r23-windows.zip"
+          sha256: "40325b5bfdb7f6de016ea3efee0468a7d306eda55a6f80966a501645ba01fbfa"
       "Linux":
-        url: "https://dl.google.com/android/repository/android-ndk-r23-linux.zip"
-        sha256: "e3eacf80016b91d4cd2c8ca9f34eebd32df912bb799c859cc5450b6b19277b4f"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r23-linux.zip"
+          sha256: "e3eacf80016b91d4cd2c8ca9f34eebd32df912bb799c859cc5450b6b19277b4f"
       "Macos":
-        url: " https://dl.google.com/android/repository/android-ndk-r23-darwin.zip"
-        sha256: "163ff3bb72306ffa814de35c49819bccae9df10855a4e3fbba52ad4111fcccae"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r23-darwin.zip"
+          sha256: "163ff3bb72306ffa814de35c49819bccae9df10855a4e3fbba52ad4111fcccae"
   "r22b":
     url:
       "Windows":
-        url: "https://dl.google.com/android/repository/android-ndk-r22b-windows-x86_64.zip"
-        sha256: "6d2fe8dbba8342634e88ecbaf321bcbfc07e579b6281f426639002dd35046d03"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r22b-windows-x86_64.zip"
+          sha256: "6d2fe8dbba8342634e88ecbaf321bcbfc07e579b6281f426639002dd35046d03"
       "Linux":
-        url: "https://dl.google.com/android/repository/android-ndk-r22b-linux-x86_64.zip"
-        sha256: "ac3a0421e76f71dd330d0cd55f9d99b9ac864c4c034fc67e0d671d022d4e806b"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r22b-linux-x86_64.zip"
+          sha256: "ac3a0421e76f71dd330d0cd55f9d99b9ac864c4c034fc67e0d671d022d4e806b"
       "Macos":
-        url: "https://dl.google.com/android/repository/android-ndk-r22b-darwin-x86_64.zip"
-        sha256: "b05d2087a6346d66cd26a1dc89fcc877b59e49feab6269b665aa67c784a81512"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r22b-darwin-x86_64.zip"
+          sha256: "b05d2087a6346d66cd26a1dc89fcc877b59e49feab6269b665aa67c784a81512"
   "r22":
     url:
       "Windows":
-        url: "https://dl.google.com/android/repository/android-ndk-r22-windows-x86_64.zip"
-        sha256: "5a0eafa83c8bba3c76e8427aa3d83d169215f62963a277b1914a3651aa47f751"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r22-windows-x86_64.zip"
+          sha256: "5a0eafa83c8bba3c76e8427aa3d83d169215f62963a277b1914a3651aa47f751"
       "Linux":
-        url: "https://dl.google.com/android/repository/android-ndk-r22-linux-x86_64.zip"
-        sha256: "d37fc69cd81e5660234a686e20adef39bc0244086e4d66525a40af771c020718"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r22-linux-x86_64.zip"
+          sha256: "d37fc69cd81e5660234a686e20adef39bc0244086e4d66525a40af771c020718"
       "Macos":
-        url: "https://dl.google.com/android/repository/android-ndk-r22-darwin-x86_64.zip"
-        sha256: "14fce4dea7fb3facbc0e3d20270007bffec3ba383aec02e8b0e0dad8d8782892"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r22-darwin-x86_64.zip"
+          sha256: "14fce4dea7fb3facbc0e3d20270007bffec3ba383aec02e8b0e0dad8d8782892"
   "r21e":
     url:
       "Windows":
-        url: "https://dl.google.com/android/repository/android-ndk-r21e-windows-x86_64.zip"
-        sha256: "f71307c5c572e2c163d602b3704b8bc024bec0c43ba2800de36bd10f3a21492b"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r21e-windows-x86_64.zip"
+          sha256: "f71307c5c572e2c163d602b3704b8bc024bec0c43ba2800de36bd10f3a21492b"
       "Linux":
-        url: "https://dl.google.com/android/repository/android-ndk-r21e-linux-x86_64.zip"
-        sha256: "ad7ce5467e18d40050dc51b8e7affc3e635c85bd8c59be62de32352328ed467e"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r21e-linux-x86_64.zip"
+          sha256: "ad7ce5467e18d40050dc51b8e7affc3e635c85bd8c59be62de32352328ed467e"
       "Macos":
-        url: "https://dl.google.com/android/repository/android-ndk-r21e-darwin-x86_64.zip"
-        sha256: "437278103a3db12632c05b1be5c41bbb8522791a67e415cc54411a65366f499d"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r21e-darwin-x86_64.zip"
+          sha256: "437278103a3db12632c05b1be5c41bbb8522791a67e415cc54411a65366f499d"
   "r21d":
     url:
       "Windows":
-        url: "https://dl.google.com/android/repository/android-ndk-r21d-windows-x86_64.zip"
-        sha256: "18335e57f8acab5a4acf6a2204130e64f99153015d55eb2667f8c28d4724d927"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r21d-windows-x86_64.zip"
+          sha256: "18335e57f8acab5a4acf6a2204130e64f99153015d55eb2667f8c28d4724d927"
       "Linux":
-        url: "https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip"
-        sha256: "dd6dc090b6e2580206c64bcee499bc16509a5d017c6952dcd2bed9072af67cbd"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip"
+          sha256: "dd6dc090b6e2580206c64bcee499bc16509a5d017c6952dcd2bed9072af67cbd"
       "Macos":
-        url: "https://dl.google.com/android/repository/android-ndk-r21d-darwin-x86_64.zip"
-        sha256: "5851115c6fc4cce26bc320295b52da240665d7ff89bda2f5d5af1887582f5c48"
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r21d-darwin-x86_64.zip"
+          sha256: "5851115c6fc4cce26bc320295b52da240665d7ff89bda2f5d5af1887582f5c48"

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -3,88 +3,106 @@ from conans.errors import ConanInvalidConfiguration
 import os
 
 
-class AndroidNDKInstallerConan(ConanFile):
+class AndroidNDKConan(ConanFile):
     name = "android-ndk"
     description = "The Android NDK is a toolset that lets you implement parts of your app in " \
                   "native code, using languages such as C and C++"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://developer.android.com/ndk/"
-    topics = ("NDK", "android", "toolchain", "compiler")
+    topics = ("android", "NDK", "toolchain", "compiler")
     license = "Apache-2.0"
-    short_paths = True
-    no_copy_source = True
-    exports_sources = ["cmake-wrapper.cmd", "cmake-wrapper"]
 
-    settings = {"os": ["Windows", "Linux", "Macos"],
-                "arch": ["x86_64"]}
+    settings = "os", "arch"
+
+    short_paths = True
+    exports_sources = "cmake-wrapper.cmd", "cmake-wrapper"
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
-    def configure(self):
-        if self.settings.arch != 'x86_64':
-            raise ConanInvalidConfiguration("No binaries available for other than 'x86_64' architectures")
+    def _settings_os_supported(self):
+        try:
+            self.conan_data["sources"][self.version][str(self.settings.os)]
+            return True
+        except KeyError:
+            return False
 
-    def source(self):
-        tarballs = self.conan_data["sources"][self.version]["url"]
-        tools.get(**tarballs[str(self.settings.os)])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+    def _settings_arch_supported(self):
+        try:
+            self.conan_data["sources"][self.version][str(self.settings.os)][str(self.settings.arch)]
+            return True
+        except KeyError:
+            return False
+
+    def validate(self):
+        if not self._settings_os_supported():
+            raise ConanInvalidConfiguration(f"os={self.settings.os} is not supported by {self.name} (no binaries are available)")
+        if not self._settings_arch_supported():
+            raise ConanInvalidConfiguration(f"os,arch={self.settings.os},{self.settings.arch} is not supported by {self.name} (no binaries are available)")
 
     def build(self):
-        pass # no build, but please also no warnings
+        tools.get(**self.conan_data["sources"][self.version]["url"][str(self.settings.os)][str(self.settings.arch)],
+            destination=self._source_subfolder, strip_root=True)
 
-    # from here on, everything is assumed to run in 2 profile mode, when using the ndk as a build requirement
+    # from here on, everything is assumed to run in 2 profile mode, using this android-ndk recipe as a build requirement
 
     @property
     def _platform(self):
-        return {"Windows": "windows",
-                "Macos": "darwin",
-                "Linux": "linux"}.get(str(self.settings_build.os))
+        return {
+            "Linux": "linux",
+            "Macos": "darwin",
+            "Windows": "windows",
+        }.get(str(self.settings_build.os))
 
     @property
     def _android_abi(self):
-        return {"x86": "x86",
-                "x86_64": "x86_64",
-                "armv7": "armeabi-v7a",
-                "armv8": "arm64-v8a"}.get(str(self.settings_target.arch))
+        return {
+            "armv7": "armeabi-v7a",
+            "armv8": "arm64-v8a",
+            "x86": "x86",
+            "x86_64": "x86_64",
+        }.get(str(self.settings_target.arch))
 
     @property
     def _llvm_triplet(self):
-        arch = {'armv7': 'arm',
-                'armv8': 'aarch64',
-                'x86': 'i686',
-                'x86_64': 'x86_64'}.get(str(self.settings_target.arch))
-        abi = 'androideabi' if self.settings_target.arch == 'armv7' else 'android'
-        return '%s-linux-%s' % (arch, abi)
+        arch = {
+            "armv7": "arm",
+            "armv8": "aarch64",
+            "x86": "i686",
+            "x86_64": "x86_64",
+        }.get(str(self.settings_target.arch))
+        abi = "androideabi" if self.settings_target.arch == "armv7" else "android"
+        return f"{arch}-linux-{abi}"
 
     @property
     def _clang_triplet(self):
-        arch = {'armv7': 'armv7a',
-                'armv8': 'aarch64',
-                'x86': 'i686',
-                'x86_64': 'x86_64'}.get(str(self.settings_target.arch))
-        abi = 'androideabi' if self.settings_target.arch == 'armv7' else 'android'
-        return '%s-linux-%s' % (arch, abi)
+        arch = {
+            "armv7": "armv7a",
+            "armv8": "aarch64",
+            "x86": "i686",
+            "x86_64": "x86_64",
+        }.get(str(self.settings_target.arch))
+        abi = "androideabi" if self.settings_target.arch == "armv7" else "android"
+        return f"{arch}-linux-{abi}"
 
     def _fix_permissions(self):
-        if os.name != 'posix':
+        if os.name != "posix":
             return
         for root, _, files in os.walk(self.package_folder):
             for filename in files:
                 filename = os.path.join(root, filename)
-                with open(filename, 'rb') as f:
+                with open(filename, "rb") as f:
                     sig = f.read(4)
                     if type(sig) is str:
                         sig = [ord(s) for s in sig]
                     else:
                         sig = [s for s in sig]
                     if len(sig) > 2 and sig[0] == 0x23 and sig[1] == 0x21:
-                        self.output.info('chmod on script file: "%s"' % filename)
+                        self.output.info(f"chmod on script file: '{filename}'")
                         self._chmod_plus_x(filename)
                     elif sig == [0x7F, 0x45, 0x4C, 0x46]:
-                        self.output.info('chmod on ELF file: "%s"' % filename)
+                        self.output.info(f"chmod on ELF file: '{filename}'")
                         self._chmod_plus_x(filename)
                     elif sig == [0xCA, 0xFE, 0xBA, 0xBE] or \
                          sig == [0xBE, 0xBA, 0xFE, 0xCA] or \
@@ -92,76 +110,35 @@ class AndroidNDKInstallerConan(ConanFile):
                          sig == [0xCF, 0xFA, 0xED, 0xFE] or \
                          sig == [0xFE, 0xEF, 0xFA, 0xCE] or \
                          sig == [0xCE, 0xFA, 0xED, 0xFE]:
-                        self.output.info('chmod on Mach-O file: "%s"' % filename)
+                        self.output.info(f"chmod on Mach-O file: '{filename}'")
                         self._chmod_plus_x(filename)
 
     def package(self):
-        self.copy(pattern="*", dst=".", src=self._source_subfolder, keep_path=True, symlinks=True)
-        self.copy(pattern="*NOTICE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="*NOTICE.toolchain", dst="licenses", src=self._source_subfolder)
+        self.copy("*", src=self._source_subfolder, dst=".", keep_path=True, symlinks=True)
+        self.copy("*NOTICE", src=self._source_subfolder, dst="licenses")
+        self.copy("*NOTICE.toolchain", src=self._source_subfolder, dst="licenses")
         self.copy("cmake-wrapper.cmd")
         self.copy("cmake-wrapper")
         self._fix_permissions()
 
     @property
     def _host(self):
-        return self._platform + "-x86_64"
+        return f"{self._platform}_{self.settings.arch}"
 
     @property
     def _ndk_root(self):
         return os.path.join(self.package_folder, "toolchains", "llvm", "prebuilt", self._host)
 
     def _tool_name(self, tool):
-        if 'clang' in tool:
-            suffix = '.cmd' if self.settings_build.os == 'Windows' else ''
-            return '%s%s-%s%s' % (self._clang_triplet, self.settings_target.os.api_level, tool, suffix)
+        if "clang" in tool:
+            suffix = ".cmd" if self.settings_build.os == "Windows" else ""
+            return f"{self._clang_triplet}{self.settings_target.os.api_level}-{tool}{suffix}"
         else:
-            suffix = '.exe' if self.settings_build.os == 'Windows' else ''
-            return '%s-%s%s' % (self._llvm_triplet, tool, suffix)
+            suffix = ".exe" if self.settings_build.os == "Windows" else ""
+            return f"{self._llvm_triplet}-{tool}{suffix}"
 
-    def _define_tool_var(self, name, value):
-        ndk_bin = os.path.join(self._ndk_root, 'bin')
-        path = os.path.join(ndk_bin, self._tool_name(value))
-        self.output.info('Creating %s environment variable: %s' % (name, path))
-        return path
-
-    # def package_id(self):
-    #     self.info.include_build_settings()
-    #     del self.info.settings.arch
-    #     del self.info.settings.os.api_level
-
-    @staticmethod
-    def _chmod_plus_x(filename):
-        if os.name == 'posix':
-            os.chmod(filename, os.stat(filename).st_mode | 0o111)
-
-    def package_info(self):
-        # test shall pass, so this runs also in the build as build requirement context
-        # ndk-build: https://developer.android.com/ndk/guides/ndk-build
-        self.env_info.PATH.append(self.package_folder)
-
-        # You should use the ANDROID_NDK_ROOT environment variable to indicate where the NDK is located.
-        # That's what most NDK-related scripts use (inside the NDK, and outside of it).
-        # https://groups.google.com/g/android-ndk/c/qZjhOaynHXc
-        self.output.info('Creating ANDROID_NDK_ROOT environment variable: %s' % self.package_folder)
-        self.env_info.ANDROID_NDK_ROOT = self.package_folder
-
-        self.output.info('Creating ANDROID_NDK_HOME environment variable: %s' % self.package_folder)
-        self.env_info.ANDROID_NDK_HOME = self.package_folder
-
-        #  this is not enough, I can kill that .....
-        if not hasattr(self, 'settings_target'):
-            return
-
-        # interestingly I can reach that with
-        # conan test --profile:build nsdk-default --profile:host default /Users/a4z/elux/conan/myrecipes/android-ndk/all/test_package android-ndk/r21d@
-        if  self.settings_target is None:
-            return
-
-        # And if we are not building for Android, why bother at all
-        if not self.settings_target.os == "Android":
-            return
-
+    @property
+    def _cmake_system_processor(self):
         cmake_system_processor = {
             "x86_64": "x86_64",
             "x86": "i686",
@@ -176,60 +153,102 @@ class AndroidNDKInstallerConan(ConanFile):
             cmake_system_processor = "armv6"
         elif "armv5" in str(self.settings.arch):
             cmake_system_processor = "armv5te"
+        return cmake_system_processor
+
+    def _define_tool_var(self, name, value):
+        ndk_bin = os.path.join(self._ndk_root, "bin")
+        path = os.path.join(ndk_bin, self._tool_name(value))
+        self.output.info(f"Creating {name} environment variable: {path}")
+        return path
+
+    @staticmethod
+    def _chmod_plus_x(filename):
+        if os.name == "posix":
+            os.chmod(filename, os.stat(filename).st_mode | 0o111)
+
+    def package_info(self):
+        # test shall pass, so this runs also in the build as build requirement context
+        # ndk-build: https://developer.android.com/ndk/guides/ndk-build
+        self.env_info.PATH.append(self.package_folder)
+
+        # You should use the ANDROID_NDK_ROOT environment variable to indicate where the NDK is located.
+        # That's what most NDK-related scripts use (inside the NDK, and outside of it).
+        # https://groups.google.com/g/android-ndk/c/qZjhOaynHXc
+        self.output.info(f"Creating ANDROID_NDK_ROOT environment variable: {self.package_folder}")
+        self.env_info.ANDROID_NDK_ROOT = self.package_folder
+
+        self.output.info(f"Creating ANDROID_NDK_HOME environment variable: {self.package_folder}")
+        self.env_info.ANDROID_NDK_HOME = self.package_folder
+
+        #  this is not enough, I can kill that .....
+        if not hasattr(self, "settings_target"):
+            return
+
+        # interestingly I can reach that with
+        # conan test --profile:build nsdk-default --profile:host default /Users/a4z/elux/conan/myrecipes/android-ndk/all/test_package android-ndk/r21d@
+        if self.settings_target is None:
+            return
+
+        # And if we are not building for Android, why bother at all
+        if not self.settings_target.os == "Android":
+            self.output.warn(f"You've added {self.name}/{self.version} as a build requirement, while os={self.settings_targe.os} != Android")
+            return
+
+        cmake_system_processor = self._cmake_system_processor
         if cmake_system_processor:
-            self.output.info('Creating CONAN_CMAKE_SYSTEM_PROCESSOR environment variable: %s' % cmake_system_processor)
+            self.output.info(f"Creating CONAN_CMAKE_SYSTEM_PROCESSOR environment variable: {cmake_system_processor}")
             self.env_info.CONAN_CMAKE_SYSTEM_PROCESSOR = cmake_system_processor
         else:
             self.output.warn("Could not find a valid CMAKE_SYSTEM_PROCESSOR variable, supported by CMake")
 
-        self.output.info('Creating NDK_ROOT environment variable: %s' % self._ndk_root)
+        self.output.info(f"Creating NDK_ROOT environment variable: {self._ndk_root}")
         self.env_info.NDK_ROOT = self._ndk_root
 
-        self.output.info('Creating CHOST environment variable: %s' % self._llvm_triplet)
+        self.output.info(f"Creating CHOST environment variable: {self._llvm_triplet}")
         self.env_info.CHOST = self._llvm_triplet
 
-        ndk_sysroot = os.path.join(self._ndk_root, 'sysroot')
-        self.output.info('Creating CONAN_CMAKE_FIND_ROOT_PATH environment variable: %s' % ndk_sysroot)
+        ndk_sysroot = os.path.join(self._ndk_root, "sysroot")
+        self.output.info(f"Creating CONAN_CMAKE_FIND_ROOT_PATH environment variable: {ndk_sysroot}")
         self.env_info.CONAN_CMAKE_FIND_ROOT_PATH = ndk_sysroot
 
-        self.output.info('Creating SYSROOT environment variable: %s' % ndk_sysroot)
+        self.output.info(f"Creating SYSROOT environment variable: {ndk_sysroot}")
         self.env_info.SYSROOT = ndk_sysroot
 
-        self.output.info('Creating self.cpp_info.sysroot: %s' % ndk_sysroot)
+        self.output.info(f"Creating self.cpp_info.sysroot: {ndk_sysroot}")
         self.cpp_info.sysroot = ndk_sysroot
 
-        self.output.info('Creating ANDROID_NATIVE_API_LEVEL environment variable: %s' % self.settings_target.os.api_level)
+        self.output.info(f"Creating ANDROID_NATIVE_API_LEVEL environment variable: {self.settings_target.os.api_level}")
         self.env_info.ANDROID_NATIVE_API_LEVEL = str(self.settings_target.os.api_level)
 
         self._chmod_plus_x(os.path.join(self.package_folder, "cmake-wrapper"))
         cmake_wrapper = "cmake-wrapper.cmd" if self.settings.os == "Windows" else "cmake-wrapper"
         cmake_wrapper = os.path.join(self.package_folder, cmake_wrapper)
-        self.output.info('Creating CONAN_CMAKE_PROGRAM environment variable: %s' % cmake_wrapper)
+        self.output.info(f"Creating CONAN_CMAKE_PROGRAM environment variable: {cmake_wrapper}")
         self.env_info.CONAN_CMAKE_PROGRAM = cmake_wrapper
 
         toolchain = os.path.join(self.package_folder, "build", "cmake", "android.toolchain.cmake")
-        self.output.info('Creating CONAN_CMAKE_TOOLCHAIN_FILE environment variable: %s' % toolchain)
+        self.output.info(f"Creating CONAN_CMAKE_TOOLCHAIN_FILE environment variable: {toolchain}")
         self.env_info.CONAN_CMAKE_TOOLCHAIN_FILE = toolchain
 
-        self.env_info.CC = self._define_tool_var('CC', 'clang')
-        self.env_info.CXX = self._define_tool_var('CXX', 'clang++')
-        self.env_info.LD = self._define_tool_var('LD', 'ld')
-        self.env_info.AR = self._define_tool_var('AR', 'ar')
-        self.env_info.AS = self._define_tool_var('AS', 'as')
-        self.env_info.RANLIB = self._define_tool_var('RANLIB', 'ranlib')
-        self.env_info.STRIP = self._define_tool_var('STRIP', 'strip')
-        self.env_info.ADDR2LINE = self._define_tool_var('ADDR2LINE', 'addr2line')
-        self.env_info.NM = self._define_tool_var('NM', 'nm')
-        self.env_info.OBJCOPY = self._define_tool_var('OBJCOPY', 'objcopy')
-        self.env_info.OBJDUMP = self._define_tool_var('OBJDUMP', 'objdump')
-        self.env_info.READELF = self._define_tool_var('READELF', 'readelf')
-        self.env_info.ELFEDIT = self._define_tool_var('ELFEDIT', 'elfedit')
+        self.env_info.CC = self._define_tool_var("CC", "clang")
+        self.env_info.CXX = self._define_tool_var("CXX", "clang++")
+        self.env_info.LD = self._define_tool_var("LD", "ld")
+        self.env_info.AR = self._define_tool_var("AR", "ar")
+        self.env_info.AS = self._define_tool_var("AS", "as")
+        self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib")
+        self.env_info.STRIP = self._define_tool_var("STRIP", "strip")
+        self.env_info.ADDR2LINE = self._define_tool_var("ADDR2LINE", "addr2line")
+        self.env_info.NM = self._define_tool_var("NM", "nm")
+        self.env_info.OBJCOPY = self._define_tool_var("OBJCOPY", "objcopy")
+        self.env_info.OBJDUMP = self._define_tool_var("OBJDUMP", "objdump")
+        self.env_info.READELF = self._define_tool_var("READELF", "readelf")
+        self.env_info.ELFEDIT = self._define_tool_var("ELFEDIT", "elfedit")
 
-        self.env_info.ANDROID_PLATFORM = "android-%s" % self.settings_target.os.api_level
+        self.env_info.ANDROID_PLATFORM = f"android-{self.settings_target.os.api_level}"
         self.env_info.ANDROID_TOOLCHAIN = "clang"
         self.env_info.ANDROID_ABI = self._android_abi
         libcxx_str = str(self.settings_target.compiler.libcxx)
-        self.env_info.ANDROID_STL = libcxx_str if libcxx_str.startswith('c++_') else 'c++_shared'
+        self.env_info.ANDROID_STL = libcxx_str if libcxx_str.startswith("c++_") else "c++_shared"
 
         self.env_info.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
         self.env_info.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = "BOTH"

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -24,10 +24,10 @@ class AndroidNDKConan(ConanFile):
         return "source_subfolder"
 
     def _settings_os_supported(self):
-        return self.conan_data["sources"][self.version].get(str(self.settings.os)) is not None
+        return self.conan_data["sources"][self.version]["url"].get(str(self.settings.os)) is not None
 
     def _settings_arch_supported(self):
-        return self.conan_data["sources"][self.version].get(str(self.settings.os), {}).get(str(self.settings.arch)) is not None
+        return self.conan_data["sources"][self.version]["url"].get(str(self.settings.os), {}).get(str(self.settings.arch)) is not None
 
     def validate(self):
         if not self._settings_os_supported():

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -140,7 +140,7 @@ class AndroidNDKInstallerConan(ConanFile):
         # ndk-build: https://developer.android.com/ndk/guides/ndk-build
         self.env_info.PATH.append(self.package_folder)
 
-        # You should use the ANDROID_NDK_ROOT environment variable to indicate where the NDK is located. 
+        # You should use the ANDROID_NDK_ROOT environment variable to indicate where the NDK is located.
         # That's what most NDK-related scripts use (inside the NDK, and outside of it).
         # https://groups.google.com/g/android-ndk/c/qZjhOaynHXc
         self.output.info('Creating ANDROID_NDK_ROOT environment variable: %s' % self.package_folder)
@@ -162,9 +162,29 @@ class AndroidNDKInstallerConan(ConanFile):
         if not self.settings_target.os == "Android":
             return
 
+        cmake_system_processor = {
+            "x86_64": "x86_64",
+            "x86": "i686",
+            "mips": "mips",
+            "mips64": "mips64",
+        }.get(str(self.settings.arch))
+        if self.settings_target.arch == "armv8":
+            cmake_system_processor = "aarch64"
+        elif "armv7" in str(self.settings.arch):
+            cmake_system_processor = "armv7-a"
+        elif "armv6" in str(self.settings.arch):
+            cmake_system_processor = "armv6"
+        elif "armv5" in str(self.settings.arch):
+            cmake_system_processor = "armv5te"
+        if cmake_system_processor:
+            self.output.info('Creating CONAN_CMAKE_SYSTEM_PROCESSOR environment variable: %s' % cmake_system_processor)
+            self.env_info.CONAN_CMAKE_SYSTEM_PROCESSOR = cmake_system_processor
+        else:
+            self.output.warn("Could not find a valid CMAKE_SYSTEM_PROCESSOR variable, supported by CMake")
+
         self.output.info('Creating NDK_ROOT environment variable: %s' % self._ndk_root)
         self.env_info.NDK_ROOT = self._ndk_root
-        
+
         self.output.info('Creating CHOST environment variable: %s' % self._llvm_triplet)
         self.env_info.CHOST = self._llvm_triplet
 

--- a/recipes/android-ndk/all/test_package/conanfile.py
+++ b/recipes/android-ndk/all/test_package/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, tools
 
+
 class TestPackgeConan(ConanFile):
     settings = "os", "arch"
 


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

When cross building to armv8 android, we need to set `CMAKE_SYSTEM_PROCESSOR=aarch64` explicitly.

[These are the available values](https://github.com/Kitware/CMake/blob/89d134c61d4cc78bfb9585c80144ce2acae14cfa/Modules/Platform/Android-Determine.cmake#L346-L353)

Without this pr, [this error is shown](https://github.com/Kitware/CMake/blob/89d134c61d4cc78bfb9585c80144ce2acae14cfa/Modules/Platform/Android-Determine.cmake#L368)

[(This is where I encountered it)](https://github.com/madebr/pdfium-cmake/runs/3761926813?check_suite_focus=true#step:8:453)


Also,
- I've reformatted the recipe to use double quotes + f-strings
- encoded the valid os/arch in conandata.yml. If the recipe cannot find sources in the conandata.yml, then it's not supported
- Also moved the download from source to build. android-ndk is a package of a binary artifact, and is different for each os/arch.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
