### PR TITLE
jemalloc: add jeprof and other tools to the package

### DIFF
--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -203,6 +203,7 @@ class JemallocConan(ConanFile):
             # Use install_lib_XXX and install_include to avoid mixing binaries and dll's
             autotools.make(target="install_lib_shared" if self.options.shared else "install_lib_static")
             autotools.make(target="install_include")
+            autotools.make(target="install_bin")
             if self.settings.os == "Windows" and self.settings.compiler == "gcc":
                 tools.rename(os.path.join(self.package_folder, "lib", "{}.lib".format(self._library_name)),
                              os.path.join(self.package_folder, "lib", "lib{}.a".format(self._library_name)))

--- a/recipes/jemalloc/all/test_package/conanfile.py
+++ b/recipes/jemalloc/all/test_package/conanfile.py
@@ -15,3 +15,4 @@ class TestPackageConan(ConanFile):
         if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)
+            self.run("jeprof --version", run_environment=True)


### PR DESCRIPTION
jemalloc includes the tools:
- jemalloc-config - compiler flags, similar to pkg-config
- jemalloc.sh - LD_PRELOAD wrapper
- jeprof - profile post-processing and visualization tool

Library name and version:  **jemalloc/5.2.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
