### PR TITLE
bump aws-c-io to 0.10.9 with update dependencies

### DIFF
--- a/recipes/aws-c-io/all/conandata.yml
+++ b/recipes/aws-c-io/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10.9":
+    url: "https://github.com/awslabs/aws-c-io/archive/v0.10.9.tar.gz"
+    sha256: "c64464152abe8b7e23f10bc026ed54a15eaf0ec0aae625d28e2caf4489090327"
   "0.10.5":
     url: "https://github.com/awslabs/aws-c-io/archive/v0.10.5.tar.gz"
     sha256: "59abd4606661790cc0b777807938f3134cce77c03383015781498cfbfd191811"

--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -41,10 +41,7 @@ class AwsCIO(ConanFile):
     def requirements(self):
         self.requires("aws-c-cal/0.5.12")
         if self.settings.os in ["Linux", "FreeBSD", "Android"]:
-            if tools.Version(self.version) <=  "0.10.6":
-                self.requires("s2n/1.0.11")
-            else:
-                self.requires("s2n/1.1.0")
+            self.requires("s2n/1.1.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -39,9 +39,12 @@ class AwsCIO(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-c-cal/0.5.11")
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.requires("s2n/1.0.11")
+        self.requires("aws-c-cal/0.5.12")
+        if self.settings.os in ["Linux", "FreeBSD", "Android"]:
+            if tools.Version(self.version) <=  "0.10.6":
+                self.requires("s2n/1.0.11")
+            else:
+                self.requires("s2n/1.1.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/aws-c-io/config.yml
+++ b/recipes/aws-c-io/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.10.9":
+    folder: all
   "0.10.5":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **aws-c-io/0.10.9**

update dependencies:
  - aws-c-cal : 0.5.11 -> 0.5.12 (with aws-c-common update)
  - s2n: 1.0.11 -> 1.1.0 (aws-c-io >= 0.10.7 requires s2n's new function)

---
- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
