### PR TITLE
boost: Adds with_stacktrace_noop option

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -98,6 +98,7 @@ class BoostConan(ConanFile):
         "visibility": ["global", "protected", "hidden"],
         "addr2line_location": "ANY",
         "with_stacktrace_backtrace": [True, False],
+        "with_stacktrace_noop": [True, False],
         "buildid": "ANY",
         "python_buildid": "ANY",
     }
@@ -134,6 +135,7 @@ class BoostConan(ConanFile):
         "visibility": "hidden",
         "addr2line_location": "/usr/bin/addr2line",
         "with_stacktrace_backtrace": True,
+        "with_stacktrace_noop": True,
         "buildid": None,
         "python_buildid": None,
     }
@@ -1567,7 +1569,8 @@ class BoostConan(ConanFile):
                     self.cpp_info.components["stacktrace_backtrace"].defines.append("BOOST_STACKTRACE_USE_BACKTRACE")
                     self.cpp_info.components["stacktrace_backtrace"].requires.append("libbacktrace::libbacktrace")
 
-                self.cpp_info.components["stacktrace_noop"].defines.append("BOOST_STACKTRACE_USE_NOOP")
+                if self.options.with_stacktrace_noop:
+                    self.cpp_info.components["stacktrace_noop"].defines.append("BOOST_STACKTRACE_USE_NOOP")
 
                 if self.settings.os == "Windows":
                     self.cpp_info.components["stacktrace_windbg"].defines.append("BOOST_STACKTRACE_USE_WINDBG")

--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -82,8 +82,13 @@ if(NOT HEADER_ONLY)
     if(WITH_STACKTRACE)
         find_package(Boost COMPONENTS stacktrace REQUIRED)
 
-        add_executable(stacktrace_noop_exe stacktrace.cpp)
-        target_compile_definitions(stacktrace_noop_exe PRIVATE TEST_STACKTRACE_IMPL=4)
+	add_executable(stacktrace_noop_exe stacktrace.cpp)
+	if(WITH_STACKTRACE_NOOP)
+	  target_compile_definitions(stacktrace_noop_exe PRIVATE TEST_STACKTRACE_IMPL=4)
+	else()
+	  # BOOST_STACKTRACE_USE_NOOP is not defined in this case, so we set it here only for this target
+	  target_compile_definitions(stacktrace_noop_exe PRIVATE TEST_STACKTRACE_IMPL=4 PRIVATE BOOST_STACKTRACE_USE_NOOP)
+	endif()
         target_link_libraries(stacktrace_noop_exe PRIVATE Boost::stacktrace_noop)
 
         if(WIN32)


### PR DESCRIPTION
Specify library name and version:  **boost/all**

This is to add a **with_stacktrace_noop** option to **boost::stacktrace**. Currently, the **BOOST_STACKTRACE_USE_NOOP** define is set always and there isn't a way to disable it without modifying downstream generated build configs.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
