### PR TITLE
upx: add upx/3.96 recipe

### DIFF
--- a/recipes/upx/all/CMakeLists.txt
+++ b/recipes/upx/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/upx/all/conandata.yml
+++ b/recipes/upx/all/conandata.yml
@@ -1,0 +1,25 @@
+sources:
+  "3.96":
+    "Linux":
+      "x86_64":
+        url: "https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz"
+        sha256: "ac75f5172c1c530d1b5ce7215ca9e94586c07b675a26af3b97f8421b8b8d413d"
+      "armv8":
+        url: "https://github.com/upx/upx/releases/download/v3.96/upx-3.96-arm64_linux.tar.xz"
+        sha256: "a075eccc7fd84ed46dff50692e1869e42b1bd6fc25a81f651b9a13c1146476fc"
+      "armv7":
+        url: "https://github.com/upx/upx/releases/download/v3.96/upx-3.96-arm_linux.tar.xz"
+        sha256: "7c568b9ef05a0a129f3f4da3c825ffa8968b1ec5a31f3ce21485a87c61748c96"
+      "ppc32":
+        url: "https://github.com/upx/upx/releases/download/v3.96/upx-3.96-powerpc_linux.tar.xz"
+        sha256: "5096b2b2ecfedd7aef8b3b108de4f6526a4d051336f1eedecccc90f90f1f5af7"
+      "ppc64le":
+        url: "https://github.com/upx/upx/releases/download/v3.96/upx-3.96-powerpc64le_linux.tar.xz"
+        sha256: "df854565df1b37299d1b0f0eee2bdd6588bf98638f8be9fe3776d4e5dd89746f"
+    "Windows":
+      "x86":
+        url: "https://github.com/upx/upx/releases/download/v3.96/upx-3.96-win32.zip"
+        sha256: "014912ea363e2d491587534c1e7efd5bc516520d8f2cdb76bb0aaf915c5db961"
+      "x86_64":
+        url: "https://github.com/upx/upx/releases/download/v3.96/upx-3.96-win64.zip"
+        sha256: "a2655c66a547e2274474e54d7a373f1c28e96ded162c51b34651873691022184"

--- a/recipes/upx/all/conanfile.py
+++ b/recipes/upx/all/conanfile.py
@@ -1,0 +1,53 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class UPXConan(ConanFile):
+    name = "upx"
+    description = "UPX - the Ultimate Packer for eXecutables "
+    license = "GPL-2.0-or-later", "special-exception-for-compressed-executables"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://upx.github.io/"
+    topics = ("packer", "executable", "compression", "size", "reduction", "small", "footprintt")
+    no_copy_source = True
+    settings = "os", "arch"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def _conan_data_sources(self):
+        # Don't surround this with try/catch to catch unknown versions
+        conandata_version = self.conan_data["sources"][self.version]
+        try:
+            return conandata_version[str(self.settings.os)][str(self.settings.arch)]
+        except KeyError:
+            return None
+
+    def validate(self):
+        if not self._conan_data_sources():
+            raise ConanInvalidConfiguration(f"This recipe has no upx binary for os/arch={self.settings.os}/{self.settings.arch}")
+
+    def build(self):
+        tools.get(**self._conan_data_sources(),
+                  destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
+        self.copy("upx.exe", src=self._source_subfolder, dst="bin")
+        self.copy("upx", src=self._source_subfolder, dst="bin")
+
+    def package_info(self):
+        self.cpp_info.libdirs = []
+
+        bin_path = os.path.join(self.package_folder, "bin")
+        self.output.info(f"Appending PATH environment variable: {bin_path}")
+        self.env_info.PATH.append(bin_path)
+
+        bin_ext = ".exe" if self.settings.os == "Windows" else ""
+        upx = os.path.join(bin_path, f"upx{bin_ext}")
+        self.user_info.upx = upx

--- a/recipes/upx/all/conanfile.py
+++ b/recipes/upx/all/conanfile.py
@@ -38,8 +38,10 @@ class UPXConan(ConanFile):
     def package(self):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
         self.copy("COPYING", src=self._source_subfolder, dst="licenses")
-        self.copy("upx.exe", src=self._source_subfolder, dst="bin")
-        self.copy("upx", src=self._source_subfolder, dst="bin")
+        if self.settings.os == "Windows":
+            self.copy("upx.exe", src=self._source_subfolder, dst="bin")
+        else:
+            self.copy("upx", src=self._source_subfolder, dst="bin")
 
     def package_info(self):
         self.cpp_info.libdirs = []

--- a/recipes/upx/all/test_package/CMakeLists.txt
+++ b/recipes/upx/all/test_package/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
+if(CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang|GNU")
+    add_link_options(-static)
+endif()
+
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 

--- a/recipes/upx/all/test_package/CMakeLists.txt
+++ b/recipes/upx/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${PROJECT_NAME} test_package.c)

--- a/recipes/upx/all/test_package/conanfile.py
+++ b/recipes/upx/all/test_package/conanfile.py
@@ -1,0 +1,32 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self, skip_x64_x86=True):
+            bin_ext = ".exe" if self.settings.os == "Windows" else ""
+            bin_path = os.path.join("bin", f"test_package{bin_ext}")
+
+            upx_bin = self.deps_user_info["upx"].upx
+            self.run(f"{upx_bin} --help", run_environment=True)
+
+            original_size = os.stat(bin_path).st_size
+
+            self.run(f"{upx_bin} {bin_path}", run_environment=True)
+
+            packed_size = os.stat(bin_path).st_size
+
+            self.output.info(f"File: {bin_path}")
+            self.output.info(f"Original size: {original_size:>9}")
+            self.output.info(f"Packed size:   {packed_size:>9}")
+            self.output.info(f"               ---------")
+            self.output.info(f"Size diff:     {original_size-packed_size:>9}")

--- a/recipes/upx/all/test_package/conanfile.py
+++ b/recipes/upx/all/test_package/conanfile.py
@@ -25,6 +25,9 @@ class TestPackageConan(ConanFile):
 
             packed_size = os.stat(bin_path).st_size
 
+            # Run the packed executable to see whether it still works
+            self.run(bin_path, run_environment=True)
+
             self.output.info(f"File: {bin_path}")
             self.output.info(f"Original size: {original_size:>9}")
             self.output.info(f"Packed size:   {packed_size:>9}")

--- a/recipes/upx/all/test_package/test_package.c
+++ b/recipes/upx/all/test_package/test_package.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello world!\n");
+    return 0;
+}

--- a/recipes/upx/all/test_package/test_package.c
+++ b/recipes/upx/all/test_package/test_package.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-int main() {
-    printf("Hello world!\n");
+int main(int argc, char *argv[]) {
+    puts("Hello world!");
     return 0;
 }

--- a/recipes/upx/config.yml
+++ b/recipes/upx/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.96":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **upx/3.96**

I think building upx from source is a bit too ambitious for current conan.

The CI of upx:
- downloads [`upx-stubtools`](https://github.com/upx/upx-stubtools/releases/download/v20210104/bin-upx-20210104.tar.xz) that contains binary toolchains for all targets (powerpc/powerpc64/mips/aarch64)
- creates the stubs for all os'es on Linux using the stub tools downloaded above
- then builds upx for each os/arch (Visual Studio is not supported, it builds with mingw@Linux)

It's possible to build from source, but not from the constrained conan environment.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
