### PR TITLE
bump uSockets to 0.8.1 with eventloop option

### DIFF
--- a/recipes/usockets/all/conandata.yml
+++ b/recipes/usockets/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "0.7.1":
     url: "https://github.com/uNetworking/uSockets/archive/v0.7.1.tar.gz"
     sha256: "1fdc5376e5ef9acf4fb673fcd5fd191da9b8d59a319e9ec7922872070a3dd21c"
+  "0.8.1":
+    url: "https://github.com/uNetworking/uSockets/archive/v0.8.1.tar.gz"
+    sha256: "3b33b5924a92577854e2326b3e2d393849ec00beb865a1271bf24c0f210cc1d6"
 patches:
   "0.4.0":
     - patch_file: "patches/0001-makefile.patch"
@@ -23,4 +26,9 @@ patches:
     - patch_file: "patches/0001-makefile_0.6.0.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0002-vcxproj.patch"
+      base_path: "source_subfolder"
+  "0.8.1":
+    - patch_file: "patches/0001-makefile_0.8.1.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-vcxproj_0.8.1.patch"
       base_path: "source_subfolder"

--- a/recipes/usockets/all/conanfile.py
+++ b/recipes/usockets/all/conanfile.py
@@ -14,9 +14,11 @@ class UsocketsConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {"fPIC": [True, False],
                "with_ssl": [False, "openssl", "wolfssl"],
+               "with_libuv": [True, False, "deprecated"],
                "eventloop": ["syscall", "libuv", "gcd", "boost"]}
     default_options = {"fPIC": True,
                        "with_ssl": False,
+                       "with_libuv": "deprecated",
                        "eventloop": "syscall"}
     exports_sources = "patches/**"
 
@@ -91,6 +93,13 @@ class UsocketsConan(ConanFile):
             del self.settings.compiler.cppstd
             del self.settings.compiler.libcxx
 
+        if self.options.with_libuv != "deprecated":
+            self.output.warn("with_libuv is deprecated, do not use anymore.")
+            if self.options.with_libuv == True:
+                self.options.eventloop = "libuv"
+            else:
+                self.options.eventloop = "syscall"
+
     def requirements(self):
         if self.options.with_ssl == "openssl":
             self.requires("openssl/1.1.1l")
@@ -154,6 +163,10 @@ class UsocketsConan(ConanFile):
         self.copy(pattern="*.lib", src=self._source_subfolder, dst="lib", keep_path=False)
         # drop internal headers
         tools.rmdir(os.path.join(self.package_folder, "include", "internal"))
+
+    def package_id(self):
+        # Deprecated options
+        del self.info.options.with_libuv
 
     def package_info(self):
         self.cpp_info.libs = ["uSockets"]

--- a/recipes/usockets/all/conanfile.py
+++ b/recipes/usockets/all/conanfile.py
@@ -66,7 +66,7 @@ class UsocketsConan(ConanFile):
             raise ConanInvalidConfiguration("asio eventloop is only supported on uSockets >= 0.8.0")
 
         cppstd = self._cppstd
-        if cppstd == False:
+        if not cppstd:
             return
         cppstd = str(cppstd)
 

--- a/recipes/usockets/all/conanfile.py
+++ b/recipes/usockets/all/conanfile.py
@@ -98,6 +98,8 @@ class UsocketsConan(ConanFile):
             if self.options.with_libuv == True:
                 self.options.eventloop = "libuv"
             else:
+                if self.settings.os == "Windows":
+                    raise ConanInvalidConfiguration("uSockets in Windows uses libuv by default. After 0.8.0, you can choose boost.asio by eventloop option.")
                 self.options.eventloop = "syscall"
 
     def requirements(self):

--- a/recipes/usockets/all/conanfile.py
+++ b/recipes/usockets/all/conanfile.py
@@ -94,7 +94,7 @@ class UsocketsConan(ConanFile):
             del self.settings.compiler.libcxx
 
         if self.options.with_libuv != "deprecated":
-            self.output.warn("with_libuv is deprecated, do not use anymore.")
+            self.output.warn("with_libuv is deprecated, use 'eventloop' instead.")
             if self.options.with_libuv == True:
                 self.options.eventloop = "libuv"
             else:

--- a/recipes/usockets/all/patches/0001-makefile_0.8.1.patch
+++ b/recipes/usockets/all/patches/0001-makefile_0.8.1.patch
@@ -1,0 +1,26 @@
+diff --git a/Makefile b/Makefile
+index b809ac0..454301b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -46,17 +46,17 @@ override LDFLAGS += uSockets.a
+ # By default we build the uSockets.a static library
+ default:
+ 	rm -f *.o
+-	$(CC) $(CFLAGS) -flto -O3 -c src/*.c src/eventing/*.c src/crypto/*.c
++	$(CC) $(CFLAGS) $(CPPFLAGS) -O3 -c src/*.c src/eventing/*.c src/crypto/*.c
+ # Also link in Boost Asio support
+ ifeq ($(WITH_ASIO),1)
+-	$(CXX) $(CXXFLAGS) -Isrc -std=c++14 -flto -O3 -c src/eventing/asio.cpp
++	$(CXX) $(CXXFLAGS) -Isrc -std=c++14 $(CPPFLAGS) -O3 -c src/eventing/asio.cpp
+ endif
+
+ # For now we do rely on C++17 for OpenSSL support but we will be porting this work to C11
+ ifeq ($(WITH_OPENSSL),1)
+-	$(CXX) $(CXXFLAGS) -std=c++17 -flto -O3 -c src/crypto/*.cpp
++	$(CXX) $(CXXFLAGS) -std=c++17 $(CPPFLAGS) -O3 -c src/crypto/*.cpp
+ endif
+-	$(AR) rvs uSockets.a *.o
++	$(AR) rvs libuSockets.a *.o
+
+ # Builds all examples
+ .PHONY: examples

--- a/recipes/usockets/all/patches/0002-vcxproj_0.8.1.patch
+++ b/recipes/usockets/all/patches/0002-vcxproj_0.8.1.patch
@@ -1,0 +1,17 @@
+diff --git a/uSockets.vcxproj b/uSockets.vcxproj
+index 87cbb85..e3871f3 100644
+--- a/uSockets.vcxproj
++++ b/uSockets.vcxproj
+@@ -19,11 +19,10 @@
+   </ItemGroup>
+   <PropertyGroup Label="Globals">
+     <ProjectGuid>{39D08679-782E-41AC-BDE0-06A462568EFF}</ProjectGuid>
+-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.default.props" />
+   <PropertyGroup>
+-    <ConfigurationType>DynamicLibrary</ConfigurationType>
++    <ConfigurationType>StaticLibrary</ConfigurationType>
+     <PlatformToolset>v141</PlatformToolset>
+     <ProjectName>uSockets</ProjectName>
+   </PropertyGroup>

--- a/recipes/usockets/config.yml
+++ b/recipes/usockets/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "0.7.1":
     folder: all
+  "0.8.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **usockets/0.8.1**

uSockets/0.8.0 begins to support boost.asio as event loop library. 
So I add 'eventloop' option instead of 'with_libuv'.

I'm afraid package options is breaked compatibility.
But I suggest to delete 'with_libuv'. 
Because libuv is one of the event loop implementations in usockets. 
(others are epolll, kqueue, gcd, asio.)

I add compiler version check too.
usockets uses C++14 with 'asio' options.
usockets uses C++17 with 'openssl' options. (It may change future release)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
