### PR TITLE
[jpcre2] Added jpcre2 header-only library to cci

### DIFF
--- a/recipes/jpcre2/all/conandata.yml
+++ b/recipes/jpcre2/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "10.32.01":
+    sha256: 668cbc6d2c0a065bb6abe8494d5a1bb3549a14cd956a44a2df9095045623ea47
+    url: https://github.com/jpcre2/jpcre2/archive/refs/tags/10.32.01.tar.gz

--- a/recipes/jpcre2/all/conanfile.py
+++ b/recipes/jpcre2/all/conanfile.py
@@ -26,9 +26,8 @@ class TomlPlusPlusConan(ConanFile):
         pass
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)

--- a/recipes/jpcre2/all/conanfile.py
+++ b/recipes/jpcre2/all/conanfile.py
@@ -5,7 +5,7 @@ import os
 required_conan_version = ">=1.33.0"
 
 
-class TomlPlusPlusConan(ConanFile):
+class Jpcre2Conan(ConanFile):
     name = "jpcre2"
     homepage = "https://github.com/jpcre2/jpcre2"
     description = "Header-only C++ wrapper for PCRE2 library."

--- a/recipes/jpcre2/all/conanfile.py
+++ b/recipes/jpcre2/all/conanfile.py
@@ -7,12 +7,10 @@ class TomlPlusPlusConan(ConanFile):
     name = "jpcre2"
     homepage = "https://github.com/jpcre2/jpcre2"
     description = "Header-only C++ wrapper for PCRE2 library."
-    topics = ("conan", "regex", "pcre2", "header-only", "single-header")
+    topics = ("regex", "pcre2", "header-only", "single-header")
     url = "https://github.com/conan-io/conan-center-index"
-    license = "BSD"
-    settings = list()
-    options = {}
-    default_options = {}
+    license = "BSD-3-Clause"
+
     no_copy_source = True
 
     @property

--- a/recipes/jpcre2/all/conanfile.py
+++ b/recipes/jpcre2/all/conanfile.py
@@ -20,10 +20,7 @@ class TomlPlusPlusConan(ConanFile):
         return "source_subfolder"
 
     def requirements(self):
-        self.requires("pcre2/[>=10.21]")
-
-    def configure(self):
-        pass
+        self.requires("pcre2/10.37")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/jpcre2/all/conanfile.py
+++ b/recipes/jpcre2/all/conanfile.py
@@ -1,0 +1,42 @@
+from conans import ConanFile, tools, CMake
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class TomlPlusPlusConan(ConanFile):
+    name = "jpcre2"
+    homepage = "https://github.com/jpcre2/jpcre2"
+    description = "Header-only C++ wrapper for PCRE2 library."
+    topics = ("conan", "regex", "pcre2", "header-only", "single-header")
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "BSD"
+    settings = list()
+    options = {}
+    default_options = {}
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def requirements(self):
+        self.requires("pcre2/[>=10.21]")
+
+    def configure(self):
+        pass
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        self.copy("jpcre2.hpp", dst="include", src=os.path.join(self._source_subfolder, "src"))
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "jpcre2"
+        self.cpp_info.names["cmake_find_package_multi"] = "jpcre2"

--- a/recipes/jpcre2/all/conanfile.py
+++ b/recipes/jpcre2/all/conanfile.py
@@ -1,5 +1,4 @@
-from conans import ConanFile, tools, CMake
-from conans.errors import ConanInvalidConfiguration
+from conans import ConanFile, tools
 import os
 
 required_conan_version = ">=1.33.0"

--- a/recipes/jpcre2/all/conanfile.py
+++ b/recipes/jpcre2/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, tools, CMake
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.33.0"
+
 
 class TomlPlusPlusConan(ConanFile):
     name = "jpcre2"

--- a/recipes/jpcre2/all/conanfile.py
+++ b/recipes/jpcre2/all/conanfile.py
@@ -32,7 +32,3 @@ class TomlPlusPlusConan(ConanFile):
 
     def package_id(self):
         self.info.header_only()
-
-    def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "jpcre2"
-        self.cpp_info.names["cmake_find_package_multi"] = "jpcre2"

--- a/recipes/jpcre2/all/test_package/CMakeLists.txt
+++ b/recipes/jpcre2/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(jpcre2 REQUIRED)
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE jpcre2::jpcre2)

--- a/recipes/jpcre2/all/test_package/CMakeLists.txt
+++ b/recipes/jpcre2/all/test_package/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(jpcre2 REQUIRED)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE jpcre2::jpcre2)

--- a/recipes/jpcre2/all/test_package/conanfile.py
+++ b/recipes/jpcre2/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/jpcre2/all/test_package/conanfile.py
+++ b/recipes/jpcre2/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    # settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "cmake_find_package"
 
     def build(self):

--- a/recipes/jpcre2/all/test_package/conanfile.py
+++ b/recipes/jpcre2/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    # settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/jpcre2/all/test_package/test_package.cpp
+++ b/recipes/jpcre2/all/test_package/test_package.cpp
@@ -1,0 +1,15 @@
+#include <jpcre2.hpp>
+
+typedef jpcre2::select<char> jp;
+
+int main(int, char**)
+{
+    jp::Regex re;
+    re.setPattern("Hello (\\S+?)").compile();
+    if (!re.match("Hello conan-center-index"))
+    {
+        return 1;
+    }
+
+    return 0;
+}

--- a/recipes/jpcre2/config.yml
+++ b/recipes/jpcre2/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "10.32.01":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **jpcre2/10.32.01**

Added recipe for [jpcre2/10.32.01](https://github.com/jpcre2/jpcre2/releases/tag/10.32.01). This is a header-only wrapper for [pcre2](https://conan.io/center/pcre2) library.

I have checked compilation on Windows (MSVC 16) and linux (gcc 11).

I have several questions about best practices:
1. Should I use specific versions of dependencies like ```pcre2/[>=10.21]``` or always use latest like ```pcre2/10.37```?
2. Should I specify any ```settings``` for header-only library? 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
