### PR TITLE
libatomic_ops: add version 7.6.12

### DIFF
--- a/recipes/libatomic_ops/all/conandata.yml
+++ b/recipes/libatomic_ops/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "7.6.10":
     url: "https://github.com/ivmai/libatomic_ops/releases/download/v7.6.10/libatomic_ops-7.6.10.tar.gz"
     sha256: "587edf60817f56daf1e1ab38a4b3c729b8e846ff67b4f62a6157183708f099af"
+  "7.6.12":
+    url: "https://github.com/ivmai/libatomic_ops/releases/download/v7.6.12/libatomic_ops-7.6.12.tar.gz"
+    sha256: "f0ab566e25fce08b560e1feab6a3db01db4a38e5bc687804334ef3920c549f3e"

--- a/recipes/libatomic_ops/config.yml
+++ b/recipes/libatomic_ops/config.yml
@@ -1,3 +1,5 @@
 versions:
   "7.6.10":
     folder: all
+  "7.6.12":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libatomic_ops/7.6.12**

I'm maintainer of libatomic_ops; v7.6.12 has been released recently.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
