### PR TITLE
bump aws-c-http to 0.6.7 with update dependencies

### DIFF
--- a/recipes/aws-c-http/all/conandata.yml
+++ b/recipes/aws-c-http/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.7":
+    url: "https://github.com/awslabs/aws-c-http/archive/v0.6.7.tar.gz"
+    sha256: "2244d1e26ce5b5f40f96e570b1c4332a07c645ef744644d5b90b089d3695ec3b"
   "0.6.5":
     url: "https://github.com/awslabs/aws-c-http/archive/v0.6.5.tar.gz"
     sha256: "9cb82f1cfe1342f4bbd58f51b74beaeb6a544fb6792c48f9b0d3967619b33221"

--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -39,8 +39,8 @@ class AwsCHttp(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-c-compression/0.2.13")
-        self.requires("aws-c-io/0.10.5")
+        self.requires("aws-c-compression/0.2.14")
+        self.requires("aws-c-io/0.10.9")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/aws-c-http/config.yml
+++ b/recipes/aws-c-http/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.6.7":
+    folder: all
   "0.6.5":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **aws-c-http/0.6.7**

---

- [x] I've read the [guidelines](https://github.\com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
