### PR TITLE
bump aws-c-auth to 0.6.4 with update dependencies

### DIFF
--- a/recipes/aws-c-auth/all/conandata.yml
+++ b/recipes/aws-c-auth/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.4":
+    url: "https://github.com/awslabs/aws-c-auth/archive/v0.6.4.tar.gz"
+    sha256: "119cec67e85b01af8c01b11d962c610d8e9b183cde96fee77db669cccaa19ac9"
   "0.6.0":
     url: "https://github.com/awslabs/aws-c-auth/archive/v0.6.0.tar.gz"
     sha256: "5f5fff63110c3e8f619385ca563f77886bc101d3e054987eecbb87586e27b651"

--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -40,10 +40,10 @@ class AwsCAuth(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.7")
-        self.requires("aws-c-cal/0.5.11")
-        self.requires("aws-c-io/0.10.5")
-        self.requires("aws-c-http/0.6.5")
+        self.requires("aws-c-common/0.6.9")
+        self.requires("aws-c-cal/0.5.12")
+        self.requires("aws-c-io/0.10.9")
+        self.requires("aws-c-http/0.6.7")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/aws-c-auth/config.yml
+++ b/recipes/aws-c-auth/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.6.4":
+    folder: all
   "0.6.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **aws-c-auth/0.6.4**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
