### PR TITLE
sqlite3: rely on SQLITE_API to export/import symbols

### DIFF
--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -37,9 +37,14 @@ set(MAX_BLOB_SIZE CACHE STRING "Set the maximum number of bytes in a string or B
 option(DISABLE_DEFAULT_VFS "Disable default VFS implementation")
 
 add_library(${PROJECT_NAME} source_subfolder/sqlite3.c)
-if (WIN32 AND MSVC AND BUILD_SHARED_LIBS)
-    set_target_properties(${PROJECT_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-endif(MSVC AND BUILD_SHARED_LIBS)
+set_target_properties(${PROJECT_NAME} PROPERTIES C_VISIBILITY_PRESET hidden)
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(${PROJECT_NAME}
+        PRIVATE $<$<BOOL:${WIN32}>:"SQLITE_API=__declspec(dllexport)">
+        INTERFACE $<$<BOOL:${WIN32}>:"SQLITE_API=__declspec(dllimport)">
+        PUBLIC $<$<NOT:$<BOOL:${WIN32}>>:"SQLITE_API=__attribute__((visibility(\"default\")))">
+    )
+endif()
 if(ENABLE_JSON1)
     target_compile_definitions(${PROJECT_NAME} PRIVATE SQLITE_ENABLE_JSON1)
 endif()

--- a/recipes/sqlite3/all/conanfile.py
+++ b/recipes/sqlite3/all/conanfile.py
@@ -177,7 +177,7 @@ class ConanSqlite3(ConanFile):
         self.cpp_info.components["sqlite"].names["cmake_find_package_multi"] = "SQLite3"
         self.cpp_info.components["sqlite"].builddirs.append(self._module_subfolder)
         self.cpp_info.components["sqlite"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.components["sqlite"].libs = tools.collect_libs(self)
+        self.cpp_info.components["sqlite"].libs = ["sqlite3"]
         if self.options.omit_load_extension:
             self.cpp_info.components["sqlite"].defines.append("SQLITE_OMIT_LOAD_EXTENSION")
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/sqlite3/all/conanfile.py
+++ b/recipes/sqlite3/all/conanfile.py
@@ -187,6 +187,9 @@ class ConanSqlite3(ConanFile):
                 self.cpp_info.components["sqlite"].system_libs.append("dl")
             if self.options.enable_fts5 or self.options.get_safe("enable_math_functions"):
                 self.cpp_info.components["sqlite"].system_libs.append("m")
+        elif self.settings.os == "Windows":
+            if self.options.shared:
+                self.cpp_info.components["sqlite"].defines.append("SQLITE_API=__declspec(dllimport)")
 
         if self.options.build_executable:
             bin_path = os.path.join(self.package_folder, "bin")

--- a/recipes/sqlite3/all/test_package/CMakeLists.txt
+++ b/recipes/sqlite3/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 option(USE_EMPTY_VFS "Using empty SQLite OS interface")
 

--- a/recipes/sqlite3/all/test_package/conanfile.py
+++ b/recipes/sqlite3/all/test_package/conanfile.py
@@ -13,6 +13,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

There are 3 global variables in sqlite3: `sqlite3_version`, `sqlite3_temp_directory` and `sqlite3_data_directory`. `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` is not sufficient in this case.
Therefore I think it's better to rely on `SQLITE_API` definition to properly hide private symbols and export public ones.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
