### PR TITLE
aws-c-http: requires aws-c-common explicitely

### DIFF
--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -39,6 +39,7 @@ class AwsCHttp(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
+        self.requires("aws-c-common/0.6.9")
         self.requires("aws-c-compression/0.2.14")
         self.requires("aws-c-io/0.10.9")
 
@@ -72,4 +73,8 @@ class AwsCHttp(ConanFile):
         self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package"] = "aws-c-http"
         self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package_multi"] = "aws-c-http"
         self.cpp_info.components["aws-c-http-lib"].libs = ["aws-c-http"]
-        self.cpp_info.components["aws-c-http-lib"].requires = ["aws-c-compression::aws-c-compression-lib", "aws-c-io::aws-c-io-lib"]
+        self.cpp_info.components["aws-c-http-lib"].requires = [
+            "aws-c-common::aws-c-common-lib",
+            "aws-c-compression::aws-c-compression-lib",
+            "aws-c-io::aws-c-io-lib"
+        ]


### PR DESCRIPTION
Specify library name and version:  **aws-c-http/0.6.5**

ref #7505

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
