### PR TITLE
[android-ndk] Fix broken symlinks

### DIFF
--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -46,6 +46,7 @@ class AndroidNDKConan(ConanFile):
         self.copy("cmake-wrapper.cmd")
         self.copy("cmake-wrapper")
         self._fix_permissions()
+        self._fix_broken_symlinks()
 
     # from here on, everything is assumed to run in 2 profile mode, using this android-ndk recipe as a build requirement
 
@@ -115,9 +116,18 @@ class AndroidNDKConan(ConanFile):
                         self.output.info(f"chmod on Mach-O file: '{filename}'")
                         self._chmod_plus_x(filename)
 
+    def _fix_broken_symlinks(self):
+         if self.version == "r23":
+            ndk_bin = os.path.join(self._ndk_root, "bin")
+            src, dst, dst1 = (os.path.join(ndk_bin, "clang-12"), os.path.join(ndk_bin, "clang"), os.path.join(ndk_bin, "clang++"))
+            os.remove(dst)
+            os.remove(dst1)
+            os.link(src, dst)
+            os.link(src, dst1)
+
     @property
     def _host(self):
-        return f"{self._platform}_{self.settings.arch}"
+        return f"{self._platform}-{self.settings.arch}"
 
     @property
     def _ndk_root(self):


### PR DESCRIPTION
Specify library name and version:  **android-ndk/r23**

The NDK r23 zip file contains the symlinks now, but tools.get() can't extract the links properly.
https://github.com/conan-io/conan/issues/9469
 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
