### PR TITLE
bump aws-c-s3 to 0.1.27 with dependency packages update

### DIFF
--- a/recipes/aws-c-s3/all/conandata.yml
+++ b/recipes/aws-c-s3/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.27":
+    url: "https://github.com/awslabs/aws-c-s3/archive/v0.1.27.tar.gz"
+    sha256: "8fccbf967c3b29f0feaa1ba3de158b7ead805c3b4302c45b7cad3429f045920c"
   "0.1.19":
     url: "https://github.com/awslabs/aws-c-s3/archive/v0.1.19.tar.gz"
     sha256: "30e17e31eed18e8d621cd3d3978b2e6eeeee5557bfc3a9d701d0d3e1c4a8a74d"

--- a/recipes/aws-c-s3/all/conanfile.py
+++ b/recipes/aws-c-s3/all/conanfile.py
@@ -39,10 +39,10 @@ class AwsCS3(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.7")
-        self.requires("aws-c-io/0.10.5")
-        self.requires("aws-c-http/0.6.5")
-        self.requires("aws-c-auth/0.6.0")
+        self.requires("aws-c-common/0.6.9")
+        self.requires("aws-c-io/0.10.9")
+        self.requires("aws-c-http/0.6.7")
+        self.requires("aws-c-auth/0.6.4")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/aws-c-s3/config.yml
+++ b/recipes/aws-c-s3/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.1.27":
+    folder: all
   "0.1.19":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **aws-c-s3/0.1.27**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
