### PR TITLE
aws-c-auth: bump dependencies

### DIFF
--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -40,8 +40,8 @@ class AwsCAuth(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.7")
-        self.requires("aws-c-cal/0.5.11")
+        self.requires("aws-c-common/0.6.9")
+        self.requires("aws-c-cal/0.5.12")
         self.requires("aws-c-io/0.10.5")
         self.requires("aws-c-http/0.6.5")
 


### PR DESCRIPTION
Specify library name and version:  **aws-c-auth/0.6.0**

ref #7505

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
