### PR TITLE
ffmpeg/4.4: Upgrade and properly handle component versioning

### DIFF
--- a/recipes/ffmpeg/all/conandata.yml
+++ b/recipes/ffmpeg/all/conandata.yml
@@ -2,3 +2,16 @@ sources:
   "4.2.1":
     url: "https://ffmpeg.org/releases/ffmpeg-4.2.1.tar.bz2"
     sha256: "682a9fa3f6864d7f0dbf224f86b129e337bc60286e0d00dffcd710998d521624"
+  "4.4":
+    url: "https://ffmpeg.org/releases/ffmpeg-4.4.tar.bz2"
+    sha256: "42093549751b582cf0f338a21a3664f52e0a9fbe0d238d3c992005e493607d0e"
+component_versions:
+  "4.4":
+      avutil: "56.70.100"
+      avcodec: "58.134.100"
+      avformat: "58.76.100"
+      avdevice: "58.13.100"
+      avfilter: "7.110.100"
+      swscale: "5.9.100"
+      swresample: "3.9.100"
+      postproc: "55.9.100"

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -355,37 +355,53 @@ class FFMpegConan(ConanFile):
         self.cpp_info.components["avdevice"].libs = ["avdevice"]
         self.cpp_info.components["avdevice"].requires = ["avfilter", "swscale", "avformat", "avcodec", "swresample", "avutil"]
         self.cpp_info.components["avdevice"].names["pkg_config"] = "libavdevice"
+        if self.conan_data["component_versions"][self.version] is not None:
+            self.cpp_info.components["avdevice"].version = self.conan_data["component_versions"][self.version]["avdevice"]
 
         self.cpp_info.components["avfilter"].libs = ["avfilter"]
         self.cpp_info.components["avfilter"].requires = ["swscale", "avformat", "avcodec", "swresample", "avutil"]
         self.cpp_info.components["avfilter"].names["pkg_config"] = "libavfilter"
+        if self.conan_data["component_versions"][self.version] is not None:
+            self.cpp_info.components["avfilter"].version = self.conan_data["component_versions"][self.version]["avfilter"]
 
         self.cpp_info.components["avformat"].libs = ["avformat"]
         self.cpp_info.components["avformat"].requires = ["avcodec", "swresample", "avutil"]
         self.cpp_info.components["avformat"].names["pkg_config"] = "libavformat"
+        if self.conan_data["component_versions"][self.version] is not None:
+            self.cpp_info.components["avformat"].version = self.conan_data["component_versions"][self.version]["avformat"]
 
         self.cpp_info.components["avcodec"].libs = ["avcodec"]
         self.cpp_info.components["avcodec"].requires = ["swresample", "avutil"]
         self.cpp_info.components["avcodec"].names["pkg_config"] = "libavcodec"
+        if self.conan_data["component_versions"][self.version] is not None:
+            self.cpp_info.components["avcodec"].version = self.conan_data["component_versions"][self.version]["avcodec"]
 
         self.cpp_info.components["swscale"].libs = ["swscale"]
         self.cpp_info.components["swscale"].requires = ["avutil"]
         self.cpp_info.components["swscale"].names["pkg_config"] = "libswscale"
+        if self.conan_data["component_versions"][self.version] is not None:
+            self.cpp_info.components["swscale"].version = self.conan_data["component_versions"][self.version]["swscale"]
 
         self.cpp_info.components["swresample"].libs = ["swresample"]
         self.cpp_info.components["swresample"].names["pkg_config"] = "libswresample"
         self.cpp_info.components["swresample"].requires = ["avutil"]
+        if self.conan_data["component_versions"][self.version] is not None:
+            self.cpp_info.components["swresample"].version = self.conan_data["component_versions"][self.version]["swresample"]
 
         if self.options.postproc:
             self.cpp_info.components["postproc"].libs = ["postproc"]
             self.cpp_info.components["postproc"].requires = ["avutil"]
             self.cpp_info.components["postproc"].names["pkg_config"] = "libpostproc"
+            if self.conan_data["component_versions"][self.version] is not None:
+                self.cpp_info.components["postproc"].version = self.conan_data["component_versions"][self.version]["postproc"]
 
             self.cpp_info.components["avfilter"].requires.append("postproc")
             self.cpp_info.components["avdevice"].requires.append("postproc")
 
         self.cpp_info.components["avutil"].libs = ["avutil"]
         self.cpp_info.components["avutil"].names["pkg_config"] = "libavutil"
+        if self.conan_data["component_versions"][self.version] is not None:
+            self.cpp_info.components["avutil"].version = self.conan_data["component_versions"][self.version]["avutil"]
 
         if self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.components["avutil"].system_libs = ["pthread", "m", "dl"]

--- a/recipes/ffmpeg/config.yml
+++ b/recipes/ffmpeg/config.yml
@@ -1,3 +1,5 @@
 versions:
   "4.2.1":
     folder: "all"
+  "4.4":
+    folder: "all"


### PR DESCRIPTION
This merge request upgrades ffmpeg/4.4 and adds support for component versioning.
ffmpeg is composed of several libraries. The release page shows versions of all libraries the ffmpeg package contain.

This MR proposes to propagate those versions to the corresponding conan components, so that consumers that check for components version work without modification. I came to this when working on installing gstreamer with conan (I will open a serparate MR for this).

Note that the component version are written in the source folder, in libXXX/version.h. I was not sure how to reliably extract those, so I copied them in conandata.yml. Is that OK? has anybody a better solution?

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
