### PR TITLE
Add OpenCV 3.4.3

### DIFF
--- a/recipes/opencv/3.x/conandata.yml
+++ b/recipes/opencv/3.x/conandata.yml
@@ -4,3 +4,8 @@ sources:
       url: https://github.com/opencv/opencv/archive/3.4.12.tar.gz
     - sha256: b207024589674dd2efc7c25740ef192ee4f3e0783e773e2d49a198c37e3e7570
       url: https://github.com/opencv/opencv_contrib/archive/3.4.12.tar.gz
+  "3.4.3":
+    - sha256: 4eef85759d5450b183459ff216b4c0fa43e87a4f6aa92c8af649f89336f002ec
+      url: https://github.com/opencv/opencv/archive/3.4.3.tar.gz
+    - sha256: 6dfb51326f3dfeb659128df952edecd45683626a965aa4a8e1e9c970c40fb636
+      url: https://github.com/opencv/opencv_contrib/archive/3.4.3.tar.gz

--- a/recipes/opencv/config.yml
+++ b/recipes/opencv/config.yml
@@ -1,6 +1,8 @@
 versions:
   "2.4.13.7":
     folder: "2.x"
+  "3.4.3":
+    folder: "3.x"
   "3.4.12":
     folder: "3.x"
   "4.1.2":


### PR DESCRIPTION
Specify library name and version:  **opencv/3.4.3**

OpenCV 3.4.12 crashes on specific images. 
This causes the need for an older, working version.

---

- [/] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [/] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [/] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [/] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
