### PR TITLE
cpp-httplib: add version 0.9.5

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.5":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.9.5.tar.gz"
+    sha256: "0c27090e77635589b4406e6597c50d4bf89cb9079025733faefb2a5168a58c60"
   "0.9.4":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.9.4.tar.gz"
     sha256: "0ff62e28eb0f6e563178d44b77c94dddb8702141d83dd34b83cb046399c2b1d5"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.5":
+    folder: all
   "0.9.4":
     folder: all
   "0.9.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cpp-httplib/0.9.5**

Update cpp-httplib to 0.9.5 for my own project. 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
