### PR TITLE
Remove compiler from package_id

### DIFF
--- a/recipes/patchelf/all/conanfile.py
+++ b/recipes/patchelf/all/conanfile.py
@@ -48,6 +48,9 @@ class PatchElfConan(ConanFile):
         autotools.install()
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
+    def package_id(self):
+        del self.info.settings.compiler
+
     def package_info(self):
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bin_path))


### PR DESCRIPTION
Specify library name and version:  **patchelf/**

This package contains a tool so we don't care about the `compiler` used to build it.
https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#why-installer-packages-remove-some-settings-from-their-package-id

https://github.com/conan-io/conan-center-index/issues/7558

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
