### PR TITLE
bump aws-c-common to 0.6.11 with cpu_extensions option.

### DIFF
--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.11":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.6.11.tar.gz"
+    sha256: "86159bd1128eee2813f705c275d319e14d1b77017fab46f6ca5dafcc66edaea9"
   "0.6.9":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.6.9.tar.gz"
     sha256: "928a3e36f24d1ee46f9eec360ec5cebfe8b9b8994fe39d4fa74ff51aebb12717"

--- a/recipes/aws-c-common/all/conanfile.py
+++ b/recipes/aws-c-common/all/conanfile.py
@@ -17,10 +17,12 @@ class AwsCCommon(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "cpu_extensions": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "cpu_extensions": True,
     }
 
     _cmake = None
@@ -32,6 +34,8 @@ class AwsCCommon(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if tools.Version(self.version) < "0.6.11":
+            del self.options.cpu_extensions
 
     def configure(self):
         if self.options.shared:
@@ -54,6 +58,7 @@ class AwsCCommon(ConanFile):
         self._cmake.definitions["BUILD_TESTING"] = False
         if self.settings.compiler == "Visual Studio":
             self._cmake.definitions["STATIC_CRT"] = "MT" in self.settings.compiler.runtime
+        self._cmake.definitions["USE_CPU_EXTENSIONS"] = self.options.get_safe("cpu_extensions", False)
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/aws-c-common/config.yml
+++ b/recipes/aws-c-common/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.11":
+    folder: all
   "0.6.9":
     folder: all
   "0.6.8":


### PR DESCRIPTION
Specify library name and version:  **aws-c-common/0.6.11**

aws-c-common/0.6.11 added new option named "cpu_extensions".

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
