### PR TITLE
[docs] Give more visibility for contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To contribute follow the next steps:
 
 1. Comment in the corresponding issue that you want to contribute the package/fix proposed. If there is no open issue, we strongly suggest
    to open one to gather feedback.
-2. Check the [how_to_add_packages.md](how_to_add_packages.md) if are
+2. Check the [how_to_add_packages.md](docs/how_to_add_packages.md) if are
    contributing for a new package.
 3. Fork the [CCI repository](https://github.com/conan-io/conan-center-index) and create a `package/xxx` branch from the `master` branch and develop
    your fix/packages as discussed in previous step.


### PR DESCRIPTION
Usually, `CONTRIBUTING.md` file is located on root level and its file name is all uppercase. It's a common pattern, and may help users to find documentation even easier.

https://github.com/search?q=CONTRIBUTING.md&type=repositories

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
