### PR TITLE
libsvm: add version 325

### DIFF
--- a/recipes/libsvm/all/conandata.yml
+++ b/recipes/libsvm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "325":
+    url: "https://github.com/cjlin1/libsvm/archive/v325.tar.gz"
+    sha256: "1f587ec0df6fd422dfe50f942f8836ac179b0723b768fe9d2fabdfd1601a0963"
   "324":
     url: "https://github.com/cjlin1/libsvm/archive/v324.tar.gz"
     sha256: "3ba1ac74ee08c4dd57d3a9e4a861ffb57dab88c6a33fd53eac472fc84fbb2a8f"

--- a/recipes/libsvm/config.yml
+++ b/recipes/libsvm/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "325":
+    folder: all
   "324":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libsvm/325**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
