### PR TITLE
mongo-cxx-driver: add version 3.6.6

### DIFF
--- a/recipes/mongo-cxx-driver/all/conandata.yml
+++ b/recipes/mongo-cxx-driver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.6":
+    url: "https://github.com/mongodb/mongo-cxx-driver/archive/r3.6.6.tar.gz"
+    sha256: "f989c371800458ae45ef69f6d9566e010f9420435a01bf5eb14db77fc024662e"
   "3.6.2":
     url: "https://github.com/mongodb/mongo-cxx-driver/archive/r3.6.2.tar.gz"
     sha256: "f50a1acb98a473f0850e2766dc7e84c05415dc63b1a2f851b77b12629ac14d62"
@@ -6,6 +9,13 @@ sources:
     url: https://github.com/mongodb/mongo-cxx-driver/archive/r3.6.1.tar.gz
     sha256: c6d1b307f7b074d178c4a815d8739195fb4d7870701064bdad6f1f2360ae0af9
 patches:
+  "3.6.6":
+    - patch_file: "patches/dirs_and_tests.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/link_conan_boost.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/poly_use_std_define.patch"
+      base_path: "source_subfolder"
   "3.6.2":
     - patch_file: "patches/dirs_and_tests.patch"
       base_path: "source_subfolder"

--- a/recipes/mongo-cxx-driver/config.yml
+++ b/recipes/mongo-cxx-driver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.6":
+    folder: all
   "3.6.2":
     folder: all
   "3.6.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
