### PR TITLE
khrplatform: New package to provide EGL header 'khrplatform.h'.

### DIFF
--- a/recipes/khrplatform/all/conandata.yml
+++ b/recipes/khrplatform/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20200529":
+    url: "https://github.com/KhronosGroup/EGL-Registry/raw/f636b23410dd4db5055dffbe499f4754013759d5/api/KHR/khrplatform.h"
+    sha256: "e206a6931f98ffe1c5c7ece69c4f94bbe1c9279243f40cbe7782848a0d3fa2de"

--- a/recipes/khrplatform/all/conanfile.py
+++ b/recipes/khrplatform/all/conanfile.py
@@ -1,0 +1,31 @@
+import os
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+
+
+required_conan_version = ">=1.37.0"
+
+class KhrplatformConan(ConanFile):
+    name = "khrplatform"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.khronos.org/registry/EGL/"
+    description = "Khronos EGL platform interfaces"
+    topics = ("opengl", "gl", "egl", "khr", "khronos")
+    no_copy_source = True
+
+    def source(self):
+        tools.download(filename="khrplatform.h", **self.conan_data["sources"][self.version])
+
+    def package(self):
+        self.copy(pattern="khrplatform.h", dst=os.path.join("include", "KHR"))
+        license_data = tools.load(os.path.join(self.source_folder, "khrplatform.h"))
+        begin = license_data.find("/*") + len("/*")
+        end = license_data.find("*/")
+        license_data = license_data[begin:end]
+        license_data = license_data.replace("**", "")
+        tools.save("LICENSE", license_data)
+        self.copy("LICENSE", dst="licenses")
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/khrplatform/all/test_package/CMakeLists.txt
+++ b/recipes/khrplatform/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(khrplatform REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE khrplatform::khrplatform)

--- a/recipes/khrplatform/all/test_package/conanfile.py
+++ b/recipes/khrplatform/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/khrplatform/all/test_package/test_package.c
+++ b/recipes/khrplatform/all/test_package/test_package.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <KHR/khrplatform.h>
+
+int main()
+{
+    khronos_int32_t value = KHRONOS_TRUE;
+    printf("KHRONOS_TRUE: %d\n", value);
+    return EXIT_SUCCESS;
+}

--- a/recipes/khrplatform/config.yml
+++ b/recipes/khrplatform/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20200529":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **khrplatform/cci.20200529**

We need more OpenGL headers to support gst-plugins-base on Windows (PR #7454). This is basically a copy of previous `wglext` package PR #7550.

After this I will also submit `glext` package PR to provide `glext.h`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
