### PR TITLE
imgui: add version 1.85

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -35,3 +35,6 @@ sources:
   "1.84.2":
     url: "https://github.com/ocornut/imgui/archive/v1.84.2.tar.gz"
     sha256: "35cb5ca0fb42cb77604d4f908553f6ef3346ceec4fcd0189675bdfb764f62b9b"
+  "1.85":
+    url: "https://github.com/ocornut/imgui/archive/v1.85.tar.gz"
+    sha256: "7ed49d1f4573004fa725a70642aaddd3e06bb57fcfe1c1a49ac6574a3e895a77"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -23,3 +23,5 @@ versions:
     folder: all
   "1.84.2":
     folder: all
+  "1.85":
+    folder: all


### PR DESCRIPTION
Specify library name and version: imgui/1.85

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
