### PR TITLE
[doc] fix sample code in deprecated options in FAQ

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -155,7 +155,7 @@ default_options = {"foobar": "deprecated"}
 
 def configure(self):
     if self.options.foobar != "deprecated":
-        self.out.warn("foobar option is deprecated, do not use anymore.")
+        self.output.warn("foobar option is deprecated, do not use anymore.")
 
 def package_id(self):
     del self.info.options.foobar


### PR DESCRIPTION
I found small mistake in sample code.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
