### PR TITLE
bump uvw to 2.10.0

### DIFF
--- a/recipes/uvw/all/conandata.yml
+++ b/recipes/uvw/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "2.9.0":
     url: "https://github.com/skypjack/uvw/archive/v2.9.0_libuv_v1.41.tar.gz"
     sha256: "dd610cb1626b8a7779ed251584bcc0362fb98fcee13e699680f61828a1ba55de"
+  "2.10.0":
+    url: "https://github.com/skypjack/uvw/archive/v2.10.0_libuv_v1.42.tar.gz"
+    sha256: "30b0ba97a94d5e652490c6b1b32c95e608263f21cf3bc606308d09b3e3a114bf"

--- a/recipes/uvw/config.yml
+++ b/recipes/uvw/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: "all"
   "2.9.0":
     folder: "all"
+  "2.10.0":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **uvw/2.10.0**

This is a simple update.
The uvw version is strongly tied to the libuv version.
Now that "libuv/1.42.0" has been added, "uvw/2.10.0" is ready to add.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
