### PR TITLE
Don't delete settings in the configure method of the fmt Conanfile

### DIFF
--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -119,7 +119,3 @@ class FmtConan(ConanFile):
                 self.cpp_info.defines.append("FMT_STRING_ALIAS=1")
             if self.options.shared:
                 self.cpp_info.defines.append("FMT_SHARED")
-
-    def package_id(self):
-        if self.options.header_only:
-            self.info.header_only()


### PR DESCRIPTION
Specify library name and version:  **fmt/8.0.1**

The fmt Conanfile deletes all settings as part of the `configure` method when building the library header-only.
This operation is unsafe and causes problems with the new CMakeToolchain and CMakeDeps generators.
This PR just removes the troublesome line of code.

Fixes conan-io/conan#9802.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
