### PR TITLE
feat: update librdkafka to openssl 1.1.1l

### DIFF
--- a/recipes/librdkafka/all/conanfile.py
+++ b/recipes/librdkafka/all/conanfile.py
@@ -54,7 +54,7 @@ class LibrdkafkaConan(ConanFile):
         if self.options.zstd:
             self.requires("zstd/1.5.0")
         if self.options.ssl:
-            self.requires("openssl/1.1.1k")
+            self.requires("openssl/1.1.1l")
         if self.options.sasl and self.settings.os != "Windows":
             self.requires("cyrus-sasl/2.1.27")
 


### PR DESCRIPTION
Specify library name and version:  **librdkafka/all**

Updates librdkafka to use latest openssl 1.1.1l package

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
