### PR TITLE
gst-plugins-base: add version 1.19.2

### DIFF
--- a/recipes/gst-plugins-base/all/conandata.yml
+++ b/recipes/gst-plugins-base/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.19.2":
+    url: "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/archive/1.19.2/gst-plugins-base-1.19.2.tar.gz"
+    sha256: "567b3bf2d08ed6602fb56b7aa9debbd5ff4b5957eb8fbb1f945b491695bc8198"
   "1.19.1":
     url: "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/archive/1.19.1/gst-plugins-base-1.19.1.tar.bz2"
-    sha256 : "b39338e306502570b49043a9b9df5704043e02c8a2ccba3a5a4f1f6ea410d4b1"
+    sha256: "b39338e306502570b49043a9b9df5704043e02c8a2ccba3a5a4f1f6ea410d4b1"

--- a/recipes/gst-plugins-base/config.yml
+++ b/recipes/gst-plugins-base/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.19.2":
+    folder: all
   "1.19.1":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **gst-plugins-base/1.19.2**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
