### PR TITLE
[darknet] Remove obsolete settings

### DIFF
--- a/recipes/darknet/all/conandata.yml
+++ b/recipes/darknet/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   cci.20180914:
-    url: "https://github.com/pjreddie/darknet/archive/61c9d02ec461e30d55762ec7669d6a1d3c356fb2.zip"
-    sha256: "ab4f1eb87aa12025a37fb0992ede1d951b1846157373ad8592dba6e1552c265b"
+    url: "https://github.com/pjreddie/darknet/archive/61c9d02ec461e30d55762ec7669d6a1d3c356fb2.tar.gz"
+    sha256: "a1993ba2628b1be81ab14f8ef81de6c00a298b316c64ca96bebef2b0f40c3967"
 patches:
   cci.20180914:
     - patch_file: "patches/include_conan_flags.patch"

--- a/recipes/darknet/all/conanfile.py
+++ b/recipes/darknet/all/conanfile.py
@@ -68,7 +68,7 @@ class DarknetConan(ConanFile):
 
     def requirements(self):
         if self.options.with_opencv:
-            self.requires("opencv/4.5.3")
+            self.requires("opencv/2.4.13.7")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder,

--- a/recipes/darknet/all/conanfile.py
+++ b/recipes/darknet/all/conanfile.py
@@ -19,7 +19,7 @@ class DarknetConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_opencv": False,
+        "with_opencv": True,
     }
     exports_sources = ['patches/*']
     generators = "pkg_config"

--- a/recipes/darknet/all/conanfile.py
+++ b/recipes/darknet/all/conanfile.py
@@ -19,7 +19,7 @@ class DarknetConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_opencv": True,
+        "with_opencv": False,
     }
     exports_sources = ['patches/*']
     generators = "pkg_config"

--- a/recipes/darknet/all/conanfile.py
+++ b/recipes/darknet/all/conanfile.py
@@ -77,9 +77,10 @@ class DarknetConan(ConanFile):
     def build(self):
         self._patch_sources()
         with tools.chdir(self._source_subfolder):
-            args = ["OPENCV={}".format("1" if self.options.with_opencv else "0")]
-            env_build = AutoToolsBuildEnvironment(self)
-            env_build.make(args=args)
+            with tools.environment_append({"PKG_CONFIG_PATH": self.build_folder}):
+                args = ["OPENCV={}".format("1" if self.options.with_opencv else "0")]
+                env_build = AutoToolsBuildEnvironment(self)
+                env_build.make(args=args)
 
     def package(self):
         self.copy("LICENSE*", dst="licenses", src=self._source_subfolder)

--- a/recipes/darknet/all/conanfile.py
+++ b/recipes/darknet/all/conanfile.py
@@ -57,6 +57,8 @@ class DarknetConan(ConanFile):
         )
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 

--- a/recipes/darknet/all/conanfile.py
+++ b/recipes/darknet/all/conanfile.py
@@ -10,7 +10,7 @@ class DarknetConan(ConanFile):
     homepage = "http://pjreddie.com/darknet/"
     description = "Darknet is a neural network frameworks written in C"
     topics = ("darknet", "neural network", "deep learning")
-    settings = "os", "compiler", "build_type", "arch", "arch_build"
+    settings = "os", "compiler", "build_type", "arch"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -22,15 +22,11 @@ class DarknetConan(ConanFile):
         "with_opencv": False,
     }
     exports_sources = ['patches/*']
+    generators = "pkg_config"
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
-
-    @property
-    def _commit(self):
-        url = self.conan_data["sources"][self.version]["url"]
-        return url[url.rfind("/")+1:url.rfind(".")]
 
     @property
     def _lib_to_compile(self):
@@ -49,7 +45,6 @@ class DarknetConan(ConanFile):
     def _patch_sources(self):
         for patch in self.conan_data["patches"].get(self.version, []):
             tools.patch(**patch)
-        tools.replace_in_file(os.path.join(self._source_subfolder, "Makefile"), "OPENCV=0", "OPENCV={}".format("1" if self.options.with_opencv else "0"))
         tools.replace_in_file(
             os.path.join(self._source_subfolder, "Makefile"),
             "SLIB=libdarknet.so",
@@ -62,26 +57,27 @@ class DarknetConan(ConanFile):
         )
 
     def configure(self):
-        if self.settings.os == "Windows":
-            raise ConanInvalidConfiguration("This library is not compatible with Windows")
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
+    def validate(self):
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration("This library is not compatible with Windows")
+
     def requirements(self):
         if self.options.with_opencv:
-            # FIXME: opencv recipe is missing on CCI
-            raise ConanInvalidConfiguration("opencv recipe is not (yet) available on CCI")
+            self.requires("opencv/4.5.3")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_folder = self.name + "-" + self._commit
-        os.rename(extracted_folder, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder,
+                  strip_root=True)
 
     def build(self):
         self._patch_sources()
         with tools.chdir(self._source_subfolder):
+            args = ["OPENCV={}".format("1" if self.options.with_opencv else "0")]
             env_build = AutoToolsBuildEnvironment(self)
-            env_build.make()
+            env_build.make(args=args)
 
     def package(self):
         self.copy("LICENSE*", dst="licenses", src=self._source_subfolder)

--- a/recipes/darknet/all/conanfile.py
+++ b/recipes/darknet/all/conanfile.py
@@ -80,6 +80,7 @@ class DarknetConan(ConanFile):
             with tools.environment_append({"PKG_CONFIG_PATH": self.build_folder}):
                 args = ["OPENCV={}".format("1" if self.options.with_opencv else "0")]
                 env_build = AutoToolsBuildEnvironment(self)
+                env_build.fpic = self.options.get_safe("fPIC", True)
                 env_build.make(args=args)
 
     def package(self):

--- a/recipes/darknet/all/test_package/CMakeLists.txt
+++ b/recipes/darknet/all/test_package/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
-project(PackageTest CXX)
+project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
 find_package(darknet CONFIG REQUIRED)
 
-add_executable(example example.cpp)
-target_link_libraries(example darknet::darknet)
+add_executable(${PROJECT_NAME} example.cpp)
+target_link_libraries(${PROJECT_NAME} darknet::darknet)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/darknet/all/test_package/CMakeLists.txt
+++ b/recipes/darknet/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(darknet CONFIG REQUIRED)
 
 add_executable(example example.cpp)
-target_link_libraries(example ${CONAN_LIBS})
+target_link_libraries(example darknet::darknet)

--- a/recipes/darknet/all/test_package/conanfile.py
+++ b/recipes/darknet/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 
 class DarknetTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class DarknetTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "example")
             self.run(bin_path, run_environment=True)

--- a/recipes/darknet/all/test_package/conanfile.py
+++ b/recipes/darknet/all/test_package/conanfile.py
@@ -5,6 +5,7 @@ from conans import ConanFile, CMake, tools
 class DarknetTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "cmake_find_package_multi"
+    
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/darknet/all/test_package/conanfile.py
+++ b/recipes/darknet/all/test_package/conanfile.py
@@ -13,5 +13,5 @@ class DarknetTestConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "example")
+            bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/darknet/all/test_package/example.cpp
+++ b/recipes/darknet/all/test_package/example.cpp
@@ -5,4 +5,5 @@
 int main() {
     image image = make_image(2, 3, 1);
     free_image(image);
+    return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **darknet/cci.20180914**

arch_build and os_build are no longer required.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
