### PR TITLE
gst-plugins-base: add include path

### DIFF
--- a/recipes/gst-plugins-base/all/conanfile.py
+++ b/recipes/gst-plugins-base/all/conanfile.py
@@ -133,7 +133,7 @@ class GStPluginsBaseConan(ConanFile):
             self.requires("pango/1.49.1")
 
     def build_requirements(self):
-        self.build_requires("meson/0.54.2")
+        self.build_requires("meson/0.59.0")
         if not tools.which("pkg-config"):
             self.build_requires("pkgconf/1.7.4")
         if self.settings.os == 'Windows':


### PR DESCRIPTION
https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/blob/master/gst-libs/gst/gl/meson.build#L1068
related to conan-io/conan-center-index#7579

Specify library name and version:  **gst-plugins-base/***

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
