### PR TITLE
aws-c-common: add version 0.6.14

### DIFF
--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.14":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.6.14.tar.gz"
+    sha256: "1691c9dad5a0d236c2a0e351cc972231b176947e454c61d1c4b3ea4ab42f32e7"
   "0.6.11":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.6.11.tar.gz"
     sha256: "86159bd1128eee2813f705c275d319e14d1b77017fab46f6ca5dafcc66edaea9"

--- a/recipes/aws-c-common/config.yml
+++ b/recipes/aws-c-common/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.14":
+    folder: all
   "0.6.11":
     folder: all
   "0.6.9":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **aws-c-common/0.6.14**

It seems to be simple update without additonal options.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
