### PR TITLE
libarchive: add version 3.5.2

### DIFF
--- a/recipes/libarchive/all/conandata.yml
+++ b/recipes/libarchive/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.5.2":
+    url: "https://github.com/libarchive/libarchive/archive/v3.5.2.tar.gz"
+    sha256: "126058cb4cf50e36bcf83307f5d987bde2ecebabcae985b6a153116362d25b7b"
   "3.5.1":
     url: "https://github.com/libarchive/libarchive/releases/download/3.5.1/libarchive-3.5.1.tar.gz"
     sha256: "9015d109ec00bb9ae1a384b172bf2fc1dff41e2c66e5a9eeddf933af9db37f5a"

--- a/recipes/libarchive/config.yml
+++ b/recipes/libarchive/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.5.2":
+    folder: all
   "3.5.1":
     folder: all
   "3.4.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libarchive/3.5.2**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
