### PR TITLE
hidapi: add version 0.11.0

### DIFF
--- a/recipes/hidapi/all/conandata.yml
+++ b/recipes/hidapi/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.0":
+    url: "https://github.com/libusb/hidapi/archive/hidapi-0.11.0.tar.gz"
+    sha256: "391d8e52f2d6a5cf76e2b0c079cfefe25497ba1d4659131297081fc0cd744632"
   "0.10.1":
     url: "https://github.com/libusb/hidapi/archive/refs/tags/hidapi-0.10.1.tar.gz"
     sha256: "f71dd8a1f46979c17ee521bc2117573872bbf040f8a4750e492271fc141f2644"

--- a/recipes/hidapi/config.yml
+++ b/recipes/hidapi/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.11.0":
+    folder: all
   "0.10.1":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **hidapi/0.11.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
