### PR TITLE
bitmagic: add version 7.6.0

### DIFF
--- a/recipes/bitmagic/all/conandata.yml
+++ b/recipes/bitmagic/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.6.0":
+    url: "https://github.com/tlk00/BitMagic/archive/v7.6.0.tar.gz"
+    sha256: "eebe39e15fc7c14d2c5aad5f07bf2c8ddf79bffafef2e748470f35d3555cf6a9"
   "7.5.0":
     url: "https://github.com/tlk00/BitMagic/archive/refs/tags/v7.5.0.tar.gz"
     sha256: "dec7d316baf3be9cb058d9da302a7e4cb694ac429d4bd29138c24b1b0157a9e8"

--- a/recipes/bitmagic/config.yml
+++ b/recipes/bitmagic/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.6.0":
+    folder: all
   "7.5.0":
     folder: all
   "7.4.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **bitmagic/7.6.0**

regression bug fixed and performance tuning.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
