### PR TITLE
godot_headers: add version 3.3.4

### DIFF
--- a/recipes/godot_headers/all/conandata.yml
+++ b/recipes/godot_headers/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "3.3.2":
     url: "https://github.com/godotengine/godot-headers/archive/refs/tags/godot-3.3.2-stable.zip"
     sha256: "0297aa9d0eb4374ecb82eb844f588343c6efbc39028473b96de12ca703aa1834"
+  "3.3.4":
+    url: "https://github.com/godotengine/godot-headers/archive/godot-3.3.4-stable.tar.gz"
+    sha256: "14cff754199cc48dcf29b326ad4758c0bc71613acea9942de780815903a0d5a5"

--- a/recipes/godot_headers/config.yml
+++ b/recipes/godot_headers/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "3.3.2":
     folder: all
+  "3.3.4":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **godot_headers/3.3.4**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
