### PR TITLE
[nmos-cpp] Latest upstream

### DIFF
--- a/recipes/nmos-cpp/all/conandata.yml
+++ b/recipes/nmos-cpp/all/conandata.yml
@@ -3,3 +3,6 @@ sources:
   "cci.20210902":
     url: "https://github.com/sony/nmos-cpp/archive/d3a8c7935f80ce5de6d4727c307ddcef667b5d57.tar.gz"
     sha256: "f5bd0b96542810ac1ed3ebaf7237d7471f3c42e68d966ae8b2d39db2601a38f9"
+  "cci.20211015":
+    url: "https://github.com/sony/nmos-cpp/archive/d115866f8f1d2c1c55bb64d05d34aa7d61c039e3.tar.gz"
+    sha256: "74e48497d6d7cc76a97b5a6331f88a58b2c96ce2f24b78176d3631051caceb6a"

--- a/recipes/nmos-cpp/config.yml
+++ b/recipes/nmos-cpp/config.yml
@@ -1,3 +1,5 @@
 versions:
   "cci.20210902":
     folder: all
+  "cci.20211015":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **nmos-cpp/cci.20211015**

Bug fixes and backward-compatible enhancements.

Questions:
* What is the policy on bumping dependencies?
  * Is it necessary to bump Boost from 1.76.0 to 1.77.0 in this PR?
  * Is it necessary to bump CMake from 3.21.2 to 3.21.3 in this PR?
* Do we have a policy on maintaining previous **cci.YYYYMMDD** versions?
  * Is it necessary to maintain the previous **cci.20210902** version? This one is source-code compatible. I'm not sure exactly how [FAQs - What is the policy for removing older versions of a package?](https://github.com/conan-io/conan-center-index/blob/master/docs/faqs.md#what-is-the-policy-for-removing-older-versions-of-a-package) would apply to **cci.** versions.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
