### PR TITLE
Clear the exported include directories for the wayland-protocols package

### DIFF
--- a/recipes/wayland-protocols/all/conanfile.py
+++ b/recipes/wayland-protocols/all/conanfile.py
@@ -77,3 +77,4 @@ class WaylandProtocolsConan(ConanFile):
         self.cpp_info.set_property(
             "pkg_config_custom_content",
             "\n".join("%s=%s" % (key, value) for key,value in pkgconfig_variables.items()))
+        self.cpp_info.includedirs = []


### PR DESCRIPTION
Specify library name and version:  **wayland-protocols/1.21**

The `wayland-protocols` package doesn't provide any includes for consumers but still defines the default include directories.
Consumers using the `CMakeDeps` generator to include this package won't be able to build because the include directory for the package is not available, since one does not actually exist.
This commit just clears the default `cpp_info.includedirs` attribute so that the default include directory is not defined.

Fixes #7750

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
