### PR TITLE
bump aws-c-io to 0.10.12 with adding aws-c-common as dependant packages

### DIFF
--- a/recipes/aws-c-io/all/conandata.yml
+++ b/recipes/aws-c-io/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10.12":
+    url: "https://github.com/awslabs/aws-c-io/archive/v0.10.12.tar.gz"
+    sha256: "0954cab5c14ee4e1ae686faaca44c2de7fbaf9440d1d4cc507eff9b15a8c6f13"
   "0.10.9":
     url: "https://github.com/awslabs/aws-c-io/archive/v0.10.9.tar.gz"
     sha256: "c64464152abe8b7e23f10bc026ed54a15eaf0ec0aae625d28e2caf4489090327"

--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -40,6 +40,10 @@ class AwsCIO(ConanFile):
 
     def requirements(self):
         self.requires("aws-c-cal/0.5.12")
+        if tools.Version(self.version) < "0.10.10":
+            self.requires("aws-c-common/0.6.11")
+        else:
+            self.requires("aws-c-common/0.6.14")
         if self.settings.os in ["Linux", "FreeBSD", "Android"]:
             self.requires("s2n/1.1.0")
 
@@ -73,7 +77,7 @@ class AwsCIO(ConanFile):
         self.cpp_info.components["aws-c-io-lib"].names["cmake_find_package"] = "aws-c-io"
         self.cpp_info.components["aws-c-io-lib"].names["cmake_find_package_multi"] = "aws-c-io"
         self.cpp_info.components["aws-c-io-lib"].libs = ["aws-c-io"]
-        self.cpp_info.components["aws-c-io-lib"].requires = ["aws-c-cal::aws-c-cal-lib"]
+        self.cpp_info.components["aws-c-io-lib"].requires = ["aws-c-common::aws-c-common-lib", "aws-c-cal::aws-c-cal-lib"]
 
         if self.settings.os == "Macos":
             self.cpp_info.components["aws-c-io-lib"].frameworks.append("Security")

--- a/recipes/aws-c-io/config.yml
+++ b/recipes/aws-c-io/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.10.12":
+    folder: all
   "0.10.9":
     folder: all
   "0.10.5":


### PR DESCRIPTION
Specify library name and version:  **aws-c-io/0.10.12**

Add aws-c-common to requirements because aws-c-io directly uses aws-c-common features.

In aws-c-io/0.10.10, some functions have moved from aws-c-io to aws-c-common,
For this reason, the versions of aws-c-io and aws-c-common have been tied.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
