### PR TITLE
Update glew to set/get property model

### DIFF
--- a/recipes/glew/all/conanfile.py
+++ b/recipes/glew/all/conanfile.py
@@ -82,6 +82,7 @@ class GlewConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "GLEW", "cmake_find_package")
+        self.cpp_info.set_property("cmake_file_name", "glew", "cmake_find_package_multi")
         self.cpp_info.set_property("cmake_target_name", "GLEW")
         self.cpp_info.components["glewlib"].set_property("cmake_target_name", "GLEW", "cmake_find_package")
         glewlib_target_name = "glew" if self.options.shared else "glew_s"

--- a/recipes/glew/all/conanfile.py
+++ b/recipes/glew/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 import glob
 from conans import ConanFile, CMake, tools
 
-required_conan_version = ">=1.28.0"
+required_conan_version = ">=1.36.0"
 
 class GlewConan(ConanFile):
     name = "glew"

--- a/recipes/glew/all/conanfile.py
+++ b/recipes/glew/all/conanfile.py
@@ -81,12 +81,11 @@ class GlewConan(ConanFile):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "GLEW"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "glew"
-        self.cpp_info.names["cmake_find_package"] = "GLEW"
-        self.cpp_info.names["cmake_find_package_multi"] = "GLEW"
-        self.cpp_info.components["glewlib"].names["cmake_find_package"] = "GLEW"
-        self.cpp_info.components["glewlib"].names["cmake_find_package_multi"] = "glew" if self.options.shared else "glew_s"
+        self.cpp_info.set_property("cmake_file_name", "GLEW", "cmake_find_package")
+        self.cpp_info.set_property("cmake_target_name", "GLEW")
+        self.cpp_info.components["glewlib"].set_property("cmake_target_name", "GLEW", "cmake_find_package")
+        glewlib_target_name = "glew" if self.options.shared else "glew_s"
+        self.cpp_info.components["glewlib"].set_property("cmake_target_name", glewlib_target_name)
         self.cpp_info.components["glewlib"].libs = tools.collect_libs(self)
         if self.settings.os == "Windows" and not self.options.shared:
             self.cpp_info.components["glewlib"].defines.append("GLEW_STATIC")


### PR DESCRIPTION
This PR updates the `cpp_info.filenames` and `cpp_info.names` to the new model using `get_property` and `set_property`.
See the Conan docs for more information about those methods: https://docs.conan.io/en/latest/reference/conanfile/attributes.html#cpp-info

This would be the first part of the migration for this recipe, as it is planned that `set_property` removes the _generator_ argument in future Conan versions (please check: https://github.com/conan-io/conan/issues/9825). And to make `cmake_find_package` accept `cmake_module_target_name` property to transition smoothly to new generators.

The next step for the migration of this recipe is to use:
 `self.cpp_info.set_property("cmake_module_target_name", "GLEW")`
 instead of 
`self.cpp_info.set_property("cmake_target_name", "GLEW", "cmake_find_package")`
  
When `cmake_find_package` supports this property (probably with Conan 1.42) this can be updated too. 