### PR TITLE
gsl bug fix: removing definition of HAVE_GNUX86_IEEE_INTERFACE when os is linux be…

### DIFF
--- a/recipes/gsl/all/conanfile.py
+++ b/recipes/gsl/all/conanfile.py
@@ -95,6 +95,9 @@ class GslConan(ConanFile):
             if self.options.shared:
                 self._autotools.defines.append("GSL_DLL")
 
+        if self.settings.os == "Linux" and "x86" in self.settings.arch:
+            self._autotools.defines.append("HAVE_GNUX86_IEEE_INTERFACE")
+
         if self.settings.compiler == "Visual Studio":
             self._autotools.flags.append("-FS")
             self._autotools.cxx_flags.append("-EHsc")


### PR DESCRIPTION
…cause you wont always be on x86 when linux...you could be on arm for example

Specify library name and version:  **gsl/2.7**

Fixes issue where build will fail on linux armv7. 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
