### PR TITLE
Icu/custom icu data

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -24,6 +24,7 @@ class ICUBase(ConanFile):
         "with_unit_tests": [True, False],
         "silent": [True, False],
         "with_dyload": [True, False],
+        "dat_package_file": "ANY",
     }
     default_options = {
         "shared": False,
@@ -32,6 +33,7 @@ class ICUBase(ConanFile):
         "with_unit_tests": False,
         "silent": True,
         "with_dyload": True,
+        "dat_package_file": "None",
     }
 
     exports_sources = "patches/*.patch"
@@ -96,6 +98,9 @@ class ICUBase(ConanFile):
     def package_id(self):
         del self.info.options.with_unit_tests  # ICU unit testing shouldn't affect the package's ID
         del self.info.options.silent  # Verbosity doesn't affect package's ID
+        if self.info.options.dat_package_file:
+            dat_package_file_sha256 = tools.sha256sum(str(self.info.options.dat_package_file))
+            self.info.options.dat_package_file = dat_package_file_sha256
 
     @property
     def _settings_build(self):
@@ -110,6 +115,10 @@ class ICUBase(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        if self.options.dat_package_file:
+            dat_package_file = glob.glob(os.path.join(self.source_folder, self._source_subfolder, "source", "data", "in", "*.dat"))
+            if dat_package_file:
+                shutil.copy(str(self.options.dat_package_file), dat_package_file[0])
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -34,7 +34,7 @@ class ICUBase(ConanFile):
         "with_unit_tests": False,
         "silent": True,
         "with_dyload": True,
-        "dat_package_file": "None",
+        "dat_package_file": None,
         "with_icuio": True,
     }
 

--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -25,6 +25,7 @@ class ICUBase(ConanFile):
         "silent": [True, False],
         "with_dyload": [True, False],
         "dat_package_file": "ANY",
+        "with_icuio": [True, False],
     }
     default_options = {
         "shared": False,
@@ -34,6 +35,7 @@ class ICUBase(ConanFile):
         "silent": True,
         "with_dyload": True,
         "dat_package_file": "None",
+        "with_icuio": True,
     }
 
     exports_sources = "patches/*.patch"
@@ -193,6 +195,9 @@ class ICUBase(ConanFile):
 
         if not self._enable_icu_tools:
             args.append("--disable-tools")
+        
+        if not self.options.with_icuio:
+            args.append("--disable-icuio")
 
         env_build = self._configure_autotools()
         if tools.cross_building(self, skip_x64_x86=True):
@@ -338,11 +343,12 @@ class ICUBase(ConanFile):
         self.cpp_info.components["icu-i18n-alias"].requires = ["icu-i18n"]
 
         # icuio
-        self.cpp_info.components["icu-io"].names["cmake_find_package"] = "io"
-        self.cpp_info.components["icu-io"].names["cmake_find_package_multi"] = "io"
-        self.cpp_info.components["icu-io"].names["pkg_config"] = "icu-io"
-        self.cpp_info.components["icu-io"].libs = [self._lib_name("icuio")]
-        self.cpp_info.components["icu-io"].requires = ["icu-i18n", "icu-uc"]
+        if self.options.with_icuio:
+            self.cpp_info.components["icu-io"].names["cmake_find_package"] = "io"
+            self.cpp_info.components["icu-io"].names["cmake_find_package_multi"] = "io"
+            self.cpp_info.components["icu-io"].names["pkg_config"] = "icu-io"
+            self.cpp_info.components["icu-io"].libs = [self._lib_name("icuio")]
+            self.cpp_info.components["icu-io"].requires = ["icu-i18n", "icu-uc"]
 
         if self.settings.os != "Windows" and self.options.data_packaging in ["files", "archive"]:
             data_path = os.path.join(self.package_folder, "res", self._data_filename).replace("\\", "/")

--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -117,14 +117,16 @@ class ICUBase(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
-        if self.options.dat_package_file:
-            dat_package_file = glob.glob(os.path.join(self.source_folder, self._source_subfolder, "source", "data", "in", "*.dat"))
-            if dat_package_file:
-                shutil.copy(str(self.options.dat_package_file), dat_package_file[0])
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
+        
+        if self.options.dat_package_file:
+            dat_package_file = glob.glob(os.path.join(self.source_folder, self._source_subfolder, "source", "data", "in", "*.dat"))
+            if dat_package_file:
+                shutil.copy(str(self.options.dat_package_file), dat_package_file[0])
+        
         if self._is_msvc:
             run_configure_icu_file = os.path.join(self._source_subfolder, "source", "runConfigureICU")
 


### PR DESCRIPTION
**icu**

fixes #7673

Add the possibility the client of the recipe to pass a custom prebuild .dat file that will be used by ICU while building.
Also add a flag to disable building icu io. 
The need for this PR has come while building ICU with conan for iOS(as stated in the opened issue). I did not need all of ICU data. Also I have no need of icu io so I want to disable it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
