### PR TITLE
libusb: Properly handle 'WholeProgramOptimization' flag when using MSVC.

### DIFF
--- a/recipes/libusb/all/conanfile.py
+++ b/recipes/libusb/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, AutoToolsBuildEnvironment, MSBuild, tools
 from conans.errors import ConanInvalidConfiguration
 import os
+import re
 
 required_conan_version = ">=1.33.0"
 
@@ -106,8 +107,12 @@ class LibUSBConan(ConanFile):
 
             solution_file = os.path.join("msvc", "libusb_{}.sln".format(solution_msvc_year))
             platforms = {"x86":"Win32"}
+            properties = {
+                # Enable LTO when CFLAGS contains -GL
+                "WholeProgramOptimization": "true" if any(re.finditer("(^| )[/-]GL($| )", tools.get_env("CFLAGS", ""))) else "false",
+            }
             msbuild = MSBuild(self)
-            msbuild.build(solution_file, platforms=platforms, upgrade_project=False)
+            msbuild.build(solution_file, platforms=platforms, upgrade_project=False, properties=properties)
 
     def _configure_autotools(self):
         if not self._autotools:


### PR DESCRIPTION
Specify library name and version:  **libusb/1.0.24**

MSVC vcxproj files have 'WholeProgramOptimization' flag (aka link time optimization) automatically turned on for Release builds. This patch properly handles LTO flag by copy-pasting a fix already used in lcms and theora recipes.

Perhaps this fix should be incorporated to MSBuild or some helper as it seems that many projects need that?

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
