### PR TITLE
meson: add version 0.59.3

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -77,3 +77,6 @@ sources:
   "0.59.2":
     url: "https://github.com/mesonbuild/meson/archive/0.59.2.tar.gz"
     sha256: "e6d5ccd503d41f938f6cfc4dc9e7326ffe28acabe091b1ff0c6535bdf09732dd"
+  "0.59.3":
+    url: "https://github.com/mesonbuild/meson/archive/0.59.3.tar.gz"
+    sha256: "b2c5bfd5032189a66cf6a32d98ba82d94d7d314577d8efe4d9dc159c4073f282"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -51,3 +51,5 @@ versions:
     folder: all
   "0.59.2":
     folder: all
+  "0.59.3":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/0.59.3**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
