### PR TITLE
meson: add version 0.60.0

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -77,3 +77,6 @@ sources:
   "0.59.2":
     url: "https://github.com/mesonbuild/meson/archive/0.59.2.tar.gz"
     sha256: "e6d5ccd503d41f938f6cfc4dc9e7326ffe28acabe091b1ff0c6535bdf09732dd"
+  "0.60.0":
+    url: "https://github.com/mesonbuild/meson/archive/0.60.0.tar.gz"
+    sha256: "5672a560fc4094c88ca5b8be0487e099fe84357e5045f5aecf1113084800e6fd"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -51,3 +51,5 @@ versions:
     folder: all
   "0.59.2":
     folder: all
+  "0.60.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/0.60.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
