### PR TITLE
add spirv-cross diligent fork version

### DIFF
--- a/recipes/spirv-cross/all/conandata.yml
+++ b/recipes/spirv-cross/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "diligent.2.5.1":
+    url: "https://github.com/DiligentGraphics/SPIRV-Cross/archive/f61a33c8f4bbea37ac6fb3c1710288127dbc7e15.zip"
+    sha256: "00205d618b7367916d9f0486e1d76a0e28a723c78c8021f46b2a31af9edd40f4"
   "cci.20210621":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/9cdeefb5e322fc26b5fed70795fe79725648df1f.tar.gz"
     sha256: "3742c24e7ccc09fce10e9d88c2f9a2e85f5142cc742be6df5cc3ba3f96defa92"

--- a/recipes/spirv-cross/config.yml
+++ b/recipes/spirv-cross/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "diligent.2.5.1":
+    folder: all
   "cci.20210621":
     folder: all
   "20210115":


### PR DESCRIPTION
Specify library name and version:  **spirv-cross/diligent.2.5.1**

this recipe is needed as a dependency of diligent/2.5.1:
relates to https://github.com/conan-io/conan-center-index/pull/7804

Diligent Core has forks of several libs:
https://github.com/DiligentGraphics/DiligentCore/tree/master/ThirdParty
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
