### PR TITLE
gdbm: fix mode parameter of gdbm_open in test_package

### DIFF
--- a/recipes/gdbm/all/test_package/test_package.c
+++ b/recipes/gdbm/all/test_package/test_package.c
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
     gdbm_count_t count;
     datum key, content, fetch;
 
-    file = gdbm_open("test.db", 512, GDBM_WRCREAT, O_RDWR | O_CREAT, NULL);
+    file = gdbm_open("test.db", 512, GDBM_WRCREAT, 0644, NULL);
     if (file == NULL) {
         puts("gdbm_open failed\n");
         return EXIT_FAILURE;


### PR DESCRIPTION
Specify library name and version:  **gdbm/1.19**

closes #7823

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
