### PR TITLE
onnx: fix sha256 of 1.10.2 tarball

### DIFF
--- a/recipes/onnx/all/conandata.yml
+++ b/recipes/onnx/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.10.2":
     url: "https://github.com/onnx/onnx/archive/refs/tags/v1.10.2.tar.gz"
-    sha256: "41367f27d44e599d774c952ca89c87fdea913a312fb785dc429f97be27eb530c"
+    sha256: "520b3aa34272cc215e2eb41385f58adf01750d88858d4722563edca8410c5dc9"
   "1.9.0":
     url: "https://github.com/onnx/onnx/archive/v1.9.0.tar.gz"
     sha256: "61d459a5f30604cabec352574119a6685dfd43bfa757cfbff52be9471d5b8ea0"


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Yesterday, they have moved this tag to the child commit of the previous one, see https://github.com/onnx/onnx/issues/3808

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
