### PR TITLE
[libevent] Make getrandom as optional

### DIFF
--- a/recipes/libevent/all/conanfile.py
+++ b/recipes/libevent/all/conanfile.py
@@ -50,7 +50,7 @@ class LibeventConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-        if self.options.enable_getrandom:
+        if self.options.get_safe("enable_getrandom", False):
             self.output.warn("libevent:enable_getrandom requires glibc >=2.25")
 
     def requirements(self):


### PR DESCRIPTION
Specify library name and version:  **libevent/2.1.12**

Since libevent 2.1.12, `getrandom` from glibc 2.25 can be required. In case its cmake file detects getrandom, it will be defined and required after packaged, which means, if we build this package on a newer distro version and try to run using an older, it will break.

However, when `getrandom` is not detected, libevent uses its own internal implementation.

Disabling it will keep better compatibility, when moving from old docker image to new ones.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
