### PR TITLE
[xnnpack] bump version

### DIFF
--- a/recipes/xnnpack/all/conandata.yml
+++ b/recipes/xnnpack/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "cci.20210310":
     url: "https://github.com/google/XNNPACK/archive/24c2dec2c451b7594eb6ef70c538923899bd541c.zip"
     sha256: "a2869a5be477c47dcb5b3804ce07982da350ac63d4452fa4caa5409c74a848e9"
+  "cci.20211026":
+    url: "https://github.com/google/XNNPACK/archive/ccbaedf11c70a3ff4db0ef17cfeacd710ffc3492.zip"
+    sha256: "4500f1802f6df4daa81222f4d2dada82536d9af50cc013d3a6c75d109de46dc2"

--- a/recipes/xnnpack/all/conandata.yml
+++ b/recipes/xnnpack/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "cci.20210310":
-    url: "https://github.com/google/XNNPACK/archive/24c2dec2c451b7594eb6ef70c538923899bd541c.zip"
-    sha256: "a2869a5be477c47dcb5b3804ce07982da350ac63d4452fa4caa5409c74a848e9"
+    url: "https://github.com/google/XNNPACK/archive/24c2dec2c451b7594eb6ef70c538923899bd541c.tar.gz"
+    sha256: "f049f55d57d6e608dd1125c3d40323763dc842949b31437be7158b7e91687ed8"
   "cci.20211026":
-    url: "https://github.com/google/XNNPACK/archive/ccbaedf11c70a3ff4db0ef17cfeacd710ffc3492.zip"
-    sha256: "4500f1802f6df4daa81222f4d2dada82536d9af50cc013d3a6c75d109de46dc2"
+    url: "https://github.com/google/XNNPACK/archive/ccbaedf11c70a3ff4db0ef17cfeacd710ffc3492.tar.gz"
+    sha256: "9324aea663d21cea4538095c40928572ddb685e0601853f278b7e5ead697fe81"

--- a/recipes/xnnpack/all/conanfile.py
+++ b/recipes/xnnpack/all/conanfile.py
@@ -75,6 +75,9 @@ class XnnpackConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        if self.settings.arch == "armv8":
+            # Not defined by Conan for Apple Silicon. See https://github.com/conan-io/conan/pull/8026
+            self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = "arm64"
         self._cmake.definitions["XNNPACK_LIBRARY_TYPE"] = "default"
         self._cmake.definitions["XNNPACK_ENABLE_ASSEMBLY"] = self.options.assembly
         self._cmake.definitions["XNNPACK_ENABLE_MEMOPT"] = self.options.memopt

--- a/recipes/xnnpack/config.yml
+++ b/recipes/xnnpack/config.yml
@@ -1,3 +1,5 @@
 versions:
   "cci.20210310":
     folder: all
+  "cci.20211026":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **xnnpack/cci.20211026**

* Updates xnnpack to latest version which means xnnpack support can be added to the tensorflow-lite recipe (see #7855)
* Switch to tarball downloads which are about 40% of the zipfile size

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
