### PR TITLE
protobuf: add 3.19.1 + modernize

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,29 +1,45 @@
 sources:
-  "3.9.1":
-    sha256: 98e615d592d237f94db8bf033fba78cd404d979b0b70351a9e5aaff725398357
-    url: https://github.com/protocolbuffers/protobuf/archive/v3.9.1.tar.gz
-  "3.11.3":
-    sha256: cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852
-    url: https://github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz
-  "3.11.4":
-    sha256: a79d19dcdf9139fa4b81206e318e33d245c4c9da1ffed21c87288ed4380426f9
-    url: https://github.com/protocolbuffers/protobuf/archive/v3.11.4.tar.gz
-  "3.12.4":
-    sha256: 512e5a674bf31f8b7928a64d8adf73ee67b8fe88339ad29adaa3b84dbaa570d8
-    url: https://github.com/protocolbuffers/protobuf/archive/v3.12.4.tar.gz
-  "3.13.0":
-    sha256: 9b4ee22c250fe31b16f1a24d61467e40780a3fbb9b91c3b65be2a376ed913a1a
-    url: https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz
-  "3.15.5":
-    sha256: bc3dbf1f09dba1b2eb3f2f70352ee97b9049066c9040ce0c9b67fb3294e91e4b
-    url: https://github.com/protocolbuffers/protobuf/archive/v3.15.5.tar.gz
-  "3.16.0":
-    sha256: 7892a35d979304a404400a101c46ce90e85ec9e2a766a86041bb361f626247f5
-    url: https://github.com/protocolbuffers/protobuf/archive/v3.16.0.tar.gz
+  "3.19.0":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.0.tar.gz"
+    sha256: "4a045294ec76cb6eae990a21adb5d8b3c78be486f1507faa601541d1ccefbd6b"
   "3.17.1":
-    sha256: 036D66D6EEC216160DD898CFB162E9D82C1904627642667CC32B104D407BB411
-    url: https://github.com/protocolbuffers/protobuf/archive/v3.17.1.tar.gz
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.17.1.tar.gz"
+    sha256: "036d66d6eec216160dd898cfb162e9d82c1904627642667cc32b104d407bb411"
+  "3.16.0":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.16.0.tar.gz"
+    sha256: "7892a35d979304a404400a101c46ce90e85ec9e2a766a86041bb361f626247f5"
+  "3.15.5":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.15.5.tar.gz"
+    sha256: "bc3dbf1f09dba1b2eb3f2f70352ee97b9049066c9040ce0c9b67fb3294e91e4b"
+  "3.13.0":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz"
+    sha256: "9b4ee22c250fe31b16f1a24d61467e40780a3fbb9b91c3b65be2a376ed913a1a"
+  "3.12.4":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.12.4.tar.gz"
+    sha256: "512e5a674bf31f8b7928a64d8adf73ee67b8fe88339ad29adaa3b84dbaa570d8"
+  "3.11.4":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.11.4.tar.gz"
+    sha256: "a79d19dcdf9139fa4b81206e318e33d245c4c9da1ffed21c87288ed4380426f9"
+  "3.11.3":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz"
+    sha256: "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852"
+  "3.9.1":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.9.1.tar.gz"
+    sha256: "98e615d592d237f94db8bf033fba78cd404d979b0b70351a9e5aaff725398357"
 patches:
+  "3.19.0":
+    - patch_file: "patches/upstream-pr-9153-msvc-runtime.patch"
+      base_path: "source_subfolder"
+  "3.15.5":
+    - patch_file: "patches/upstream-pr-8301-bundle-destination.patch"
+      base_path: "source_subfolder"
+  "3.13.0":
+    - patch_file: "patches/upstream-pr-7761-cmake-regex-fix.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/upstream-pr-7288-android-log.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/upstream-pr-8301-bundle-destination.patch"
+      base_path: "source_subfolder"
   "3.12.4":
     - patch_file: "patches/upstream-pr-7761-cmake-regex-fix.patch"
       base_path: "source_subfolder"
@@ -31,15 +47,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/upstream-pr-7288-android-log.patch"
       base_path: "source_subfolder"
-    - patch_file: "patches/upstream-pr-8301-bundle-destination.patch"
-      base_path: "source_subfolder"
-  "3.13.0":
-    - patch_file: "patches/upstream-pr-7761-cmake-regex-fix.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/upstream-pr-7288-android-log.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/upstream-pr-8301-bundle-destination.patch"
-      base_path: "source_subfolder"
-  "3.15.5":
     - patch_file: "patches/upstream-pr-8301-bundle-destination.patch"
       base_path: "source_subfolder"

--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "3.19.0":
-    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.0.tar.gz"
-    sha256: "4a045294ec76cb6eae990a21adb5d8b3c78be486f1507faa601541d1ccefbd6b"
+  "3.19.1":
+    url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.1.tar.gz"
+    sha256: "87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422"
   "3.17.1":
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.17.1.tar.gz"
     sha256: "036d66d6eec216160dd898cfb162e9d82c1904627642667cc32b104d407bb411"
@@ -27,7 +27,7 @@ sources:
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.9.1.tar.gz"
     sha256: "98e615d592d237f94db8bf033fba78cd404d979b0b70351a9e5aaff725398357"
 patches:
-  "3.19.0":
+  "3.19.1":
     - patch_file: "patches/upstream-pr-9153-msvc-runtime.patch"
       base_path: "source_subfolder"
   "3.15.5":

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -241,7 +241,6 @@ class ProtobufConan(ConanFile):
 
         # libprotoc
         self.cpp_info.components["libprotoc"].set_property("cmake_target_name", "protobuf::libprotoc")
-        self.cpp_info.components["libprotoc"].set_property("pkg_config_name", "libprotoc")
         self.cpp_info.components["libprotoc"].libs = [lib_prefix + "protoc" + lib_suffix]
         self.cpp_info.components["libprotoc"].requires = ["libprotobuf"]
 

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -80,8 +80,13 @@ class ProtobufConan(ConanFile):
                                                 "Visual Studio 2015 or higher.")
 
         if self.settings.compiler == "clang":
-           if tools.Version(self.version) >= "3.15.4" and tools.Version(self.settings.compiler.version) < "4":
+            if tools.Version(self.version) >= "3.15.4" and tools.Version(self.settings.compiler.version) < "4":
                 raise ConanInvalidConfiguration("protobuf {} doesn't support clang < 4".format(self.version))
+
+        if hasattr(self, "settings_build") and tools.cross_building(self) and \
+           self.settings.os == "Macos" and self.options.shared:
+            # FIXME: should be allowed, actually build succeeds but it fails at build time of test package due to SIP
+            raise ConanInvalidConfiguration("protobuf shared not supported yet in CCI while cross-building on Macos")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -214,9 +214,18 @@ class ProtobufConan(ConanFile):
         lib_prefix = "lib" if self.settings.compiler == "Visual Studio" else ""
         lib_suffix = "d" if self.settings.build_type == "Debug" else ""
 
+        build_modules = [
+            os.path.join(self._cmake_install_base_path, "protobuf-generate.cmake"),
+            os.path.join(self._cmake_install_base_path, "protobuf-module.cmake"),
+            os.path.join(self._cmake_install_base_path, "protobuf-options.cmake"),
+        ]
+
         # libprotobuf
         self.cpp_info.components["libprotobuf"].set_property("cmake_target_name", "protobuf::libprotobuf")
         self.cpp_info.components["libprotobuf"].set_property("pkg_config_name", "protobuf")
+        self.cpp_info.components["libprotobuf"].builddirs.append(self._cmake_install_base_path)
+        self.cpp_info.components["libprotobuf"].set_property("cmake_build_modules", build_modules)
+        self.cpp_info.components["libprotobuf"].build_modules = build_modules
         self.cpp_info.components["libprotobuf"].libs = [lib_prefix + "protobuf" + lib_suffix]
         if self.options.with_zlib:
             self.cpp_info.components["libprotobuf"].requires = ["zlib::zlib"]
@@ -229,12 +238,6 @@ class ProtobufConan(ConanFile):
         if self.settings.os == "Windows":
             if self.options.shared:
                 self.cpp_info.components["libprotobuf"].defines = ["PROTOBUF_USE_DLLS"]
-        self.cpp_info.components["libprotobuf"].builddirs.append(self._cmake_install_base_path)
-        self.cpp_info.components["libprotobuf"].build_modules = [
-            os.path.join(self._cmake_install_base_path, "protobuf-generate.cmake"),
-            os.path.join(self._cmake_install_base_path, "protobuf-module.cmake"),
-            os.path.join(self._cmake_install_base_path, "protobuf-options.cmake"),
-        ]
 
         # libprotoc
         self.cpp_info.components["libprotoc"].set_property("cmake_target_name", "protobuf::libprotoc")
@@ -246,6 +249,9 @@ class ProtobufConan(ConanFile):
         if self.options.lite:
             self.cpp_info.components["libprotobuf-lite"].set_property("cmake_target_name", "protobuf::libprotobuf-lite")
             self.cpp_info.components["libprotobuf-lite"].set_property("pkg_config_name", "protobuf-lite")
+            self.cpp_info.components["libprotobuf-lite"].builddirs.append(self._cmake_install_base_path)
+            self.cpp_info.components["libprotobuf-lite"].set_property("cmake_build_modules", build_modules)
+            self.cpp_info.components["libprotobuf-lite"].build_modules = build_modules
             self.cpp_info.components["libprotobuf-lite"].libs = [lib_prefix + "protobuf-lite" + lib_suffix]
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["libprotobuf-lite"].system_libs.append("pthread")
@@ -256,13 +262,6 @@ class ProtobufConan(ConanFile):
                     self.cpp_info.components["libprotobuf-lite"].defines = ["PROTOBUF_USE_DLLS"]
             if self.settings.os == "Android":
                 self.cpp_info.components["libprotobuf-lite"].system_libs.append("log")
-
-            self.cpp_info.components["libprotobuf-lite"].builddirs.append(self._cmake_install_base_path)
-            self.cpp_info.components["libprotobuf-lite"].build_modules = [
-                os.path.join(self._cmake_install_base_path, "protobuf-generate.cmake"),
-                os.path.join(self._cmake_install_base_path, "protobuf-module.cmake"),
-                os.path.join(self._cmake_install_base_path, "protobuf-options.cmake"),
-            ]
 
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bindir))

--- a/recipes/protobuf/all/patches/upstream-pr-9153-msvc-runtime.patch
+++ b/recipes/protobuf/all/patches/upstream-pr-9153-msvc-runtime.patch
@@ -1,0 +1,15 @@
+upstream PR: https://github.com/protocolbuffers/protobuf/pull/9153
+
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -182,7 +182,9 @@ else (protobuf_BUILD_SHARED_LIBS)
+   # making programmatic control difficult.  Prefer the functionality in newer
+   # CMake versions when available.
+   if(CMAKE_VERSION VERSION_GREATER 3.15 OR CMAKE_VERSION VERSION_EQUAL 3.15)
+-    set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
++    if(protobuf_MSVC_STATIC_RUNTIME)
++      set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
++    endif()
+   else()
+     # In case we are building static libraries, link also the runtime library statically
+     # so that MSVCR*.DLL is not required at runtime.

--- a/recipes/protobuf/all/test_package/conanfile.py
+++ b/recipes/protobuf/all/test_package/conanfile.py
@@ -3,12 +3,12 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build_requirements(self):
-        if tools.cross_building(self.settings):
-            self.build_requires(str(self.requires['protobuf']))
+        if hasattr(self, "settings_build") and tools.cross_building(self):
+            self.build_requires(str(self.requires["protobuf"]))
 
     def build(self):
         cmake = CMake(self)
@@ -17,7 +17,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             self.run("protoc --version", run_environment=True)
-
             self.run(os.path.join("bin", "test_package"), run_environment=True)

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,17 +1,19 @@
 versions:
-  "3.9.1":
+  "3.19.0":
     folder: all
-  "3.11.3":
-    folder: all
-  "3.11.4":
-    folder: all
-  "3.12.4":
-    folder: all
-  "3.13.0":
-    folder: all
-  "3.15.5":
+  "3.17.1":
     folder: all
   "3.16.0":
     folder: all
-  "3.17.1":
+  "3.15.5":
+    folder: all
+  "3.13.0":
+    folder: all
+  "3.12.4":
+    folder: all
+  "3.11.4":
+    folder: all
+  "3.11.3":
+    folder: all
+  "3.9.1":
     folder: all

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.19.0":
+  "3.19.1":
     folder: all
   "3.17.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

2 comments:

- Since we wrap upstream CMakeLists with our CMakeLists (it defeats any CMake policy set by upstream), the patch for 3.19.0 (https://github.com/protocolbuffers/protobuf/pull/9153) is not really required for the moment. But il will be necessary with CMakeToolchain generator.

- when cross-building test package is broken if shared, at least on Macos, because protobuf is also in build requirements and when calling protoc, shared lib of build context is not found or the one of host context is found. I don't have a fix...

closes https://github.com/conan-io/conan-center-index/issues/8534

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
