### PR TITLE
[gemmlowp] - fix static and shared configuration

### DIFF
--- a/recipes/gemmlowp/all/CMakeLists.txt
+++ b/recipes/gemmlowp/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include("conanbuildinfo.cmake")
-conan_basic_setup(TARGETS)
+conan_basic_setup()
 
 add_subdirectory("source_subfolder/contrib")

--- a/recipes/gemmlowp/all/conandata.yml
+++ b/recipes/gemmlowp/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "cci.20210928":
     url: "https://github.com/google/gemmlowp/archive/daf630d3d0c439dbe22229838a5ba1bc5f82908d.zip"
     sha256: "7b48199021cfad7d06ea84b975b5ff3c259b8f7c0d3d289e0c99e1708704e6db"
+patches:
+  "cci.20210928":
+    - patch_file: "patches/build-static-libraries.patch"
+      base_path: "source_subfolder"

--- a/recipes/gemmlowp/all/conanfile.py
+++ b/recipes/gemmlowp/all/conanfile.py
@@ -17,7 +17,7 @@ class GemmlowpConan(ConanFile):
                "fPIC": [True, False]}
     default_options = {"shared": False,
                        "fPIC": True}
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
     _cmake = None
 
@@ -31,10 +31,6 @@ class GemmlowpConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
-
-    def validate(self):
-        if self.settings.os == "Windows" and self.options.shared:
-            raise ConanInvalidConfiguration("shared is not supported on Windows")
 
     def configure(self):
         if self.options.shared:
@@ -53,6 +49,8 @@ class GemmlowpConan(ConanFile):
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, {}):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/gemmlowp/all/conanfile.py
+++ b/recipes/gemmlowp/all/conanfile.py
@@ -67,5 +67,7 @@ class GemmlowpConan(ConanFile):
         self.cpp_info.components["eight_bit_int_gemm"].names["cmake_find_package"] = "eight_bit_int_gemm"
         self.cpp_info.components["eight_bit_int_gemm"].names["cmake_find_package_multi"] = "eight_bit_int_gemm"
         self.cpp_info.components["eight_bit_int_gemm"].libs = ["eight_bit_int_gemm"]
+        if self.settings.compiler == "Visual Studio":
+            self.cpp_info.components["eight_bit_int_gemm"].defines = ["NOMINMAX"]
         if self.settings.os == "Linux":
             self.cpp_info.components["eight_bit_int_gemm"].system_libs.extend(["pthread"])

--- a/recipes/gemmlowp/all/conanfile.py
+++ b/recipes/gemmlowp/all/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
 
-required_conan_version = ">=1.37.0"
+required_conan_version = ">=1.33.0"
 
 class GemmlowpConan(ConanFile):
     name = "gemmlowp"
@@ -18,7 +18,7 @@ class GemmlowpConan(ConanFile):
     default_options = {"shared": False,
                        "fPIC": True}
     exports_sources = ["CMakeLists.txt", "patches/**"]
-    generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
+    generators = "cmake"
     _cmake = None
 
     @property
@@ -31,6 +31,10 @@ class GemmlowpConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
 
     def configure(self):
         if self.options.shared:
@@ -59,8 +63,6 @@ class GemmlowpConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.components["eight_bit_int_gemm"].includedirs.append(os.path.join("include", "gemmlowp"))

--- a/recipes/gemmlowp/all/patches/build-static-libraries.patch
+++ b/recipes/gemmlowp/all/patches/build-static-libraries.patch
@@ -1,0 +1,19 @@
+diff --git a/contrib/CMakeLists.txt b/contrib/CMakeLists.txt
+index d6833e8..e2932f8 100644
+--- a/contrib/CMakeLists.txt
++++ b/contrib/CMakeLists.txt
+@@ -47,12 +47,8 @@ list(APPEND gemmlowp_test_headers ${gemmlowp_headers})
+ file(GLOB fixedpoint_private_headers "${gemmlowp_src}/fixedpoint/*.h")
+ list(APPEND fixedpoint_private_headers "${gemmlowp_src}/internal/common.h")
+ 
+-# Eight bit int gemm library
+-if(WIN32)
+-    add_library(eight_bit_int_gemm STATIC ${eight_bit_int_gemm_sources_with_no_headers})
+-else()
+-    add_library(eight_bit_int_gemm SHARED ${eight_bit_int_gemm_sources_with_no_headers})
+-endif()
++add_library(eight_bit_int_gemm ${eight_bit_int_gemm_sources_with_no_headers})
++set_target_properties(eight_bit_int_gemm PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ target_link_libraries(eight_bit_int_gemm ${EXTERNAL_LIBRARIES})
+ 
+ # INTERFACE target to help header include

--- a/recipes/gemmlowp/all/test_package/CMakeLists.txt
+++ b/recipes/gemmlowp/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+conan_basic_setup()
 
 find_package(gemmlowp REQUIRED CONFIG)
 

--- a/recipes/gemmlowp/all/test_package/conanfile.py
+++ b/recipes/gemmlowp/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/gemmlowp/all/test_package/test_package.cpp
+++ b/recipes/gemmlowp/all/test_package/test_package.cpp
@@ -1,11 +1,60 @@
-#include <cstdlib>
+#include <array>
+#include <cstdint>
 #include <iostream>
-#define NOMINMAX
+
 #include <public/gemmlowp.h>
 
-int main()
-{
-    gemmlowp::GemmContext ctx;
-    ctx.set_max_num_threads(1);
-    return EXIT_SUCCESS;
+template <typename tScalar, gemmlowp::MapOrder tOrder>
+std::ostream& operator<<(std::ostream& s,
+                         const gemmlowp::MatrixMap<tScalar, tOrder>& m) {
+  for (int i = 0; i < m.rows(); i++) {
+    for (int j = 0; j < m.cols(); j++) {
+      if (j) {
+        s << '\t';
+      }
+      s << static_cast<float>(m(i, j));
+    }
+    s << '\n';
+  }
+  return s;
+}
+
+int main() {
+  const int rows = 2;
+  const int cols = 3;
+  const auto kOrder = gemmlowp::MapOrder::RowMajor;
+
+  std::array<uint8_t, rows * cols> lhs{
+      1, 2, 3,
+      4, 5, 6
+  };
+
+  std::array<uint8_t, rows * cols> rhs{
+    7, 8,
+    9, 10,
+    11, 12
+  };
+
+  std::array<uint8_t, rows * rows> result{};
+
+  const gemmlowp::MatrixMap<const uint8_t, kOrder> lhs_map(lhs.data(), rows, cols);
+  const gemmlowp::MatrixMap<const uint8_t, kOrder> rhs_map(rhs.data(), cols, rows);
+  std::cout << "LHS:\n " << lhs_map << "\n";
+  std::cout << "RHS:\n " << rhs_map << "\n\n";
+  gemmlowp::MatrixMap<uint8_t, kOrder> result_map(result.data(), rows, rows);
+
+  gemmlowp::GemmContext gemm_context{};
+  gemmlowp::Gemm<std::uint8_t, gemmlowp::DefaultL8R8BitDepthParams>(
+      &gemm_context,
+      lhs_map,
+      rhs_map,
+      &result_map,
+      0,
+      0,
+      0,
+      1,
+      0);
+
+  std::cout << "Result LHSxRHS: \n" << result_map << std::endl;
+  return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **gemmlowp/cci.20210928**

Addresses comments from https://github.com/conan-io/conan-center-index/pull/7527#issuecomment-937372331

* Backport the latest patch from upstream which enables both static and shared library builds
* Add a more comprehensive test package 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
