### PR TITLE
add signal option to cpr recipe

### DIFF
--- a/recipes/cpr/all/conanfile.py
+++ b/recipes/cpr/all/conanfile.py
@@ -21,12 +21,14 @@ class CprConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "with_ssl": ["openssl", "darwinssl", "winssl", _AUTO_SSL, _NO_SSL]
+        "with_ssl": ["openssl", "darwinssl", "winssl", _AUTO_SSL, _NO_SSL],
+        "signal": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_ssl": _AUTO_SSL
+        "with_ssl": _AUTO_SSL,
+        "signal": True,
     }
 
     _cmake = None
@@ -132,6 +134,7 @@ class CprConan(ConanFile):
             self._cmake.definitions[self._get_cmake_option("CPR_BUILD_TESTS")] = False
             self._cmake.definitions[self._get_cmake_option("CPR_GENERATE_COVERAGE")] = False
             self._cmake.definitions[self._get_cmake_option("CPR_USE_SYSTEM_GTEST")] = False
+            self._cmake.definitions["CPR_CURL_NOSIGNAL"] = not self.options.signal
 
             ssl_value = str(self.options.get_safe("with_ssl"))
             SSL_OPTIONS = {
@@ -197,7 +200,7 @@ class CprConan(ConanFile):
 
         if ssl_library not in (CprConan._AUTO_SSL, CprConan._NO_SSL, "winssl") and ssl_library != self.options["libcurl"].with_ssl:
             raise ConanInvalidConfiguration("cpr requires libcurl to be built with the option with_ssl='{}'.".format(self.options.get_safe('with_ssl')))
-            
+
         if ssl_library == "winssl" and self.options["libcurl"].with_ssl != "schannel":
             raise ConanInvalidConfiguration("cpr requires libcurl to be built with the option with_ssl='schannel'")
 


### PR DESCRIPTION
Specify library name and version:  **cpr/all**

Try to fix https://github.com/conan-io/conan-center-index/issues/7775.

CPR_CURL_NOSIGNAL has been supported since 1.3.0.
cpr recipe supports since 1.3.0 too.
So all versions of cpr recipe support CPR_CURL_NOSIGNAL.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
