### PR TITLE
[android-ndk] r23 Binary Name Changes

### DIFF
--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -127,13 +127,16 @@ class AndroidNDKConan(ConanFile):
     def _ndk_root(self):
         return os.path.join(self.package_folder, "toolchains", "llvm", "prebuilt", self._host)
 
-    def _tool_name(self, tool):
+    def _tool_name(self, tool, bare=False):
+        prefix = ""
+        suffix = ""
         if "clang" in tool:
             suffix = ".cmd" if self.settings_build.os == "Windows" else ""
-            return f"{self._clang_triplet}{self.settings_target.os.api_level}-{tool}{suffix}"
+            prefix = "llvm" if bare else f"{self._clang_triplet}{self.settings_target.os.api_level}"
         else:
             suffix = ".exe" if self.settings_build.os == "Windows" else ""
-            return f"{self._llvm_triplet}-{tool}{suffix}"
+            prefix = "llvm" if bare else f"{self._llvm_triplet}"
+        return f"{prefix}-{tool}{suffix}"
 
     @property
     def _cmake_system_processor(self):
@@ -153,9 +156,15 @@ class AndroidNDKConan(ConanFile):
             cmake_system_processor = "armv5te"
         return cmake_system_processor
 
-    def _define_tool_var(self, name, value):
+    def _define_tool_var(self, name, value, bare = False):
         ndk_bin = os.path.join(self._ndk_root, "bin")
-        path = os.path.join(ndk_bin, self._tool_name(value))
+        path = os.path.join(ndk_bin, self._tool_name(value, bare))
+        self.output.info(f"Creating {name} environment variable: {path}")
+        return path
+
+    def _define_tool_var_naked(self, name, value):
+        ndk_bin = os.path.join(self._ndk_root, "bin")
+        path = os.path.join(ndk_bin, value)
         self.output.info(f"Creating {name} environment variable: {path}")
         return path
 
@@ -230,17 +239,29 @@ class AndroidNDKConan(ConanFile):
 
         self.env_info.CC = self._define_tool_var("CC", "clang")
         self.env_info.CXX = self._define_tool_var("CXX", "clang++")
-        self.env_info.LD = self._define_tool_var("LD", "ld")
-        self.env_info.AR = self._define_tool_var("AR", "ar")
         self.env_info.AS = self._define_tool_var("AS", "as")
-        self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib")
-        self.env_info.STRIP = self._define_tool_var("STRIP", "strip")
-        self.env_info.ADDR2LINE = self._define_tool_var("ADDR2LINE", "addr2line")
-        self.env_info.NM = self._define_tool_var("NM", "nm")
-        self.env_info.OBJCOPY = self._define_tool_var("OBJCOPY", "objcopy")
-        self.env_info.OBJDUMP = self._define_tool_var("OBJDUMP", "objdump")
-        self.env_info.READELF = self._define_tool_var("READELF", "readelf")
-        self.env_info.ELFEDIT = self._define_tool_var("ELFEDIT", "elfedit")
+        if self.version == 'r23':
+            self.env_info.LD = self._define_tool_var_naked("LD", "ld")
+            self.env_info.AR = self._define_tool_var("AR", "ar", True)
+            self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib", True)
+            self.env_info.STRIP = self._define_tool_var("STRIP", "strip", True)
+            self.env_info.ADDR2LINE = self._define_tool_var("ADDR2LINE", "addr2line", True)
+            self.env_info.NM = self._define_tool_var("NM", "nm", True)
+            self.env_info.OBJCOPY = self._define_tool_var("OBJCOPY", "objcopy", True)
+            self.env_info.OBJDUMP = self._define_tool_var("OBJDUMP", "objdump", True)
+            self.env_info.READELF = self._define_tool_var("READELF", "readelf", True)
+            self.env_info.ELFEDIT = self._define_tool_var("ELFEDIT", "elfedit")
+        else:
+            self.env_info.LD = self._define_tool_var("LD", "ld")
+            self.env_info.AR = self._define_tool_var("AR", "ar")
+            self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib")
+            self.env_info.STRIP = self._define_tool_var("STRIP", "strip")
+            self.env_info.ADDR2LINE = self._define_tool_var("ADDR2LINE", "addr2line")
+            self.env_info.NM = self._define_tool_var("NM", "nm")
+            self.env_info.OBJCOPY = self._define_tool_var("OBJCOPY", "objcopy")
+            self.env_info.OBJDUMP = self._define_tool_var("OBJDUMP", "objdump")
+            self.env_info.READELF = self._define_tool_var("READELF", "readelf")
+            self.env_info.ELFEDIT = self._define_tool_var("ELFEDIT", "elfedit")
 
         self.env_info.ANDROID_PLATFORM = f"android-{self.settings_target.os.api_level}"
         self.env_info.ANDROID_TOOLCHAIN = "clang"

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -239,10 +239,10 @@ class AndroidNDKConan(ConanFile):
 
         self.env_info.CC = self._define_tool_var("CC", "clang")
         self.env_info.CXX = self._define_tool_var("CXX", "clang++")
-        self.env_info.AS = self._define_tool_var("AS", "as")
         if self.version == 'r23':
             self.env_info.LD = self._define_tool_var_naked("LD", "ld")
             self.env_info.AR = self._define_tool_var("AR", "ar", True)
+            self.env_info.AS = self._define_tool_var("AS", "as", True)
             self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib", True)
             self.env_info.STRIP = self._define_tool_var("STRIP", "strip", True)
             self.env_info.ADDR2LINE = self._define_tool_var("ADDR2LINE", "addr2line", True)
@@ -250,10 +250,11 @@ class AndroidNDKConan(ConanFile):
             self.env_info.OBJCOPY = self._define_tool_var("OBJCOPY", "objcopy", True)
             self.env_info.OBJDUMP = self._define_tool_var("OBJDUMP", "objdump", True)
             self.env_info.READELF = self._define_tool_var("READELF", "readelf", True)
-            self.env_info.ELFEDIT = self._define_tool_var("ELFEDIT", "elfedit")
+            # there doesn't seem to be an 'elfedit' included anymore.
         else:
             self.env_info.LD = self._define_tool_var("LD", "ld")
             self.env_info.AR = self._define_tool_var("AR", "ar")
+            self.env_info.AS = self._define_tool_var("AS", "as")
             self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib")
             self.env_info.STRIP = self._define_tool_var("STRIP", "strip")
             self.env_info.ADDR2LINE = self._define_tool_var("ADDR2LINE", "addr2line")


### PR DESCRIPTION
 **android-ndk/r23**

fixes: #7761

In the newest Android NDK package (r23), they changed many of the binary paths, including the original bug reported for the `ar` executable. This PR tries to address those missing packages.

Notes:

- `elfedit` doesn't seem to be included anymore? Can't find it in any of the three distribution zips.
- `as` seems to have a whole different naming convention. Just going to use the `llvm-as` instead of the platform-specific ones.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
