### PR TITLE
qt6: fix typo

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -850,7 +850,7 @@ class QtConan(ConanFile):
         if self.options.gui:
             gui_reqs = []
             if self.options.with_dbus:
-                gui_reqs.append("DBus", ["dbus::dbus"])
+                gui_reqs.append("DBus")
             if self.options.with_freetype:
                 gui_reqs.append("freetype::freetype")
             if self.options.with_libpng:
@@ -922,7 +922,7 @@ class QtConan(ConanFile):
         if self.options.widgets and self.options.get_safe("opengl", "no") != "no":
             _create_module("OpenGLWidgets", ["OpenGL", "Widgets"])
         if self.options.with_dbus:
-            _create_module("DBus")
+            _create_module("DBus", ["dbus::dbus"])
         _create_module("Concurrent")
         _create_module("Xml")
 


### PR DESCRIPTION
Specify library name and version:  **qt/6.*.***

Woopsie, I made a typo in my last PR.

double checking test: `-o qt:with_dbus=True` passes on https://github.com/eirikb/proof-of-conan/runs/4045689418?check_suite_focus=true (windows and macos. I'm investigating the linux error, but it's not related to this change)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
