### PR TITLE
ms-gsl: Fix CMake module file name, namespace, and target name for CMakeDeps generator

### DIFF
--- a/recipes/ms-gsl/all/conanfile.py
+++ b/recipes/ms-gsl/all/conanfile.py
@@ -2,6 +2,9 @@ import os
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.36.0"
+
+
 class MicrosoftGslConan(ConanFile):
     name = "ms-gsl"
     description = "Microsoft implementation of the Guidelines Support Library"
@@ -66,12 +69,8 @@ class MicrosoftGslConan(ConanFile):
         self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "Microsoft.GSL"
-        self.cpp_info.names["cmake_find_package_multi"] = "Microsoft.GSL"
-        self.cpp_info.components["_ms-gsl"].names["cmake_find_package"] = "GSL"
-        self.cpp_info.components["_ms-gsl"].names["cmake_find_package_multi"] = "GSL"
         self.cpp_info.set_property("cmake_file_name", "Microsoft.GSL")
-        self.cpp_info.set_property("cmake_target_namespace", "Microsoft.GSL")
+        self.cpp_info.set_property("cmake_target_name", "Microsoft.GSL")
         self.cpp_info.components["_ms-gsl"].set_property("cmake_target_name", "GSL")
         if tools.Version(self.version) < "3.0.0":
             self.cpp_info.components["_ms-gsl"].defines = [

--- a/recipes/ms-gsl/all/conanfile.py
+++ b/recipes/ms-gsl/all/conanfile.py
@@ -2,8 +2,6 @@ import os
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.40.0"
-
 class MicrosoftGslConan(ConanFile):
     name = "ms-gsl"
     description = "Microsoft implementation of the Guidelines Support Library"
@@ -68,10 +66,14 @@ class MicrosoftGslConan(ConanFile):
         self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
     def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "Microsoft.GSL"
+        self.cpp_info.names["cmake_find_package_multi"] = "Microsoft.GSL"
+        self.cpp_info.components["_ms-gsl"].names["cmake_find_package"] = "GSL"
+        self.cpp_info.components["_ms-gsl"].names["cmake_find_package_multi"] = "GSL"
         self.cpp_info.set_property("cmake_file_name", "Microsoft.GSL")
         self.cpp_info.set_property("cmake_target_namespace", "Microsoft.GSL")
-        self.cpp_info.set_property("cmake_target_name", "GSL")
+        self.cpp_info.components["_ms-gsl"].set_property("cmake_target_name", "GSL")
         if tools.Version(self.version) < "3.0.0":
-            self.cpp_info.defines = [
+            self.cpp_info.components["_ms-gsl"].defines = [
                 self._contract_map[str(self.options.on_contract_violation)]
             ]

--- a/recipes/ms-gsl/all/conanfile.py
+++ b/recipes/ms-gsl/all/conanfile.py
@@ -2,6 +2,8 @@ import os
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.40.0"
+
 class MicrosoftGslConan(ConanFile):
     name = "ms-gsl"
     description = "Microsoft implementation of the Guidelines Support Library"
@@ -66,14 +68,10 @@ class MicrosoftGslConan(ConanFile):
         self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "Microsoft.GSL"
-        self.cpp_info.names["cmake_find_package_multi"] = "Microsoft.GSL"
-        self.cpp_info.components["_ms-gsl"].names["cmake_find_package"] = "GSL"
-        self.cpp_info.components["_ms-gsl"].names["cmake_find_package_multi"] = "GSL"
         self.cpp_info.set_property("cmake_file_name", "Microsoft.GSL")
         self.cpp_info.set_property("cmake_target_namespace", "Microsoft.GSL")
-        self.cpp_info.components["_ms-gsl"].set_property("cmake_target_name", "GSL")
+        self.cpp_info.set_property("cmake_target_name", "GSL")
         if tools.Version(self.version) < "3.0.0":
-            self.cpp_info.components["_ms-gsl"].defines = [
+            self.cpp_info.defines = [
                 self._contract_map[str(self.options.on_contract_violation)]
             ]

--- a/recipes/ms-gsl/all/conanfile.py
+++ b/recipes/ms-gsl/all/conanfile.py
@@ -70,6 +70,9 @@ class MicrosoftGslConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "Microsoft.GSL"
         self.cpp_info.components["_ms-gsl"].names["cmake_find_package"] = "GSL"
         self.cpp_info.components["_ms-gsl"].names["cmake_find_package_multi"] = "GSL"
+        self.cpp_info.set_property("cmake_file_name", "Microsoft.GSL")
+        self.cpp_info.set_property("cmake_target_namespace", "Microsoft.GSL")
+        self.cpp_info.components["_ms-gsl"].set_property("cmake_target_name", "GSL")
         if tools.Version(self.version) < "3.0.0":
             self.cpp_info.components["_ms-gsl"].defines = [
                 self._contract_map[str(self.options.on_contract_violation)]


### PR DESCRIPTION
Specify library name and version:  **ms-gsl/3.1.0**

Fixes #7887.
Corrects the config file name, namespace, and target name used by the `ms-gsl` target when using the CMakeDeps generator.
This appears to be necessary since Conan 1.42.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
