### PR TITLE
gtest: Configure CMake configs for the CMakeDeps generator

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -145,10 +145,13 @@ class GTestConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "GTest"
         self.cpp_info.names["cmake_find_package_multi"] = "GTest"
+        self.cpp_info.set_property("cmake_file_name", "GTest")
+        self.cpp_info.set_property("cmake_target_namespace", "GTest")
         self.cpp_info.components["libgtest"].names["cmake_find_package"] = "gtest"
         self.cpp_info.components["libgtest"].names["cmake_find_package_multi"] = "gtest"
         self.cpp_info.components["libgtest"].names["pkg_config"] = "gtest"
         self.cpp_info.components["libgtest"].libs = ["gtest{}".format(self._postfix)]
+        self.cpp_info.components["libgtest"].set_property("cmake_target_name", "gtest")
         if self.settings.os == "Linux":
             self.cpp_info.components["libgtest"].system_libs.append("pthread")
 

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -145,6 +145,7 @@ class GTestConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "GTest")
         self.cpp_info.set_property("cmake_target_name", "GTest")
+        self.cpp_info.components["libgtest"].names["pkg_config"] = "gtest"
         self.cpp_info.components["libgtest"].set_property("cmake_target_name", "gtest")
         self.cpp_info.components["libgtest"].libs = ["gtest{}".format(self._postfix)]
         if self.settings.os == "Linux":
@@ -166,12 +167,15 @@ class GTestConan(ConanFile):
             self.cpp_info.components["gtest_main"].set_property("cmake_target_name", "gtest_main")
             self.cpp_info.components["gtest_main"].libs = ["gtest_main{}".format(self._postfix)]
             self.cpp_info.components["gtest_main"].requires = ["libgtest"]
+            self.cpp_info.components["gtest_main"].names["pkg_config"] = "gtest_main"
 
         if self.options.build_gmock:
             self.cpp_info.components["gmock"].set_property("cmake_target_name", "gmock")
+            self.cpp_info.components["gmock"].names["pkg_config"] = "gmock"
             self.cpp_info.components["gmock"].libs = ["gmock{}".format(self._postfix)]
             self.cpp_info.components["gmock"].requires = ["libgtest"]
             if not self.options.no_main:
                 self.cpp_info.components["gmock_main"].set_property("cmake_target_name", "gmock_main")
+                self.cpp_info.components["gmock_main"].names["pkg_config"] = "gmock_main"
                 self.cpp_info.components["gmock_main"].libs = ["gmock_main{}".format(self._postfix)]
                 self.cpp_info.components["gmock_main"].requires = ["gmock"]

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 import os
 import functools
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
 
 
 class GTestConan(ConanFile):
@@ -143,15 +143,10 @@ class GTestConan(ConanFile):
         return self.options.debug_postfix if self.settings.build_type == "Debug" else ""
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "GTest"
-        self.cpp_info.names["cmake_find_package_multi"] = "GTest"
         self.cpp_info.set_property("cmake_file_name", "GTest")
-        self.cpp_info.set_property("cmake_target_namespace", "GTest")
-        self.cpp_info.components["libgtest"].names["cmake_find_package"] = "gtest"
-        self.cpp_info.components["libgtest"].names["cmake_find_package_multi"] = "gtest"
-        self.cpp_info.components["libgtest"].names["pkg_config"] = "gtest"
-        self.cpp_info.components["libgtest"].libs = ["gtest{}".format(self._postfix)]
+        self.cpp_info.set_property("cmake_target_name", "GTest")
         self.cpp_info.components["libgtest"].set_property("cmake_target_name", "gtest")
+        self.cpp_info.components["libgtest"].libs = ["gtest{}".format(self._postfix)]
         if self.settings.os == "Linux":
             self.cpp_info.components["libgtest"].system_libs.append("pthread")
 
@@ -168,21 +163,15 @@ class GTestConan(ConanFile):
                     self.cpp_info.components["libgtest"].defines.append("GTEST_HAS_TR1_TUPLE=0")
 
         if not self.options.no_main:
+            self.cpp_info.components["gtest_main"].set_property("cmake_target_name", "gtest_main")
             self.cpp_info.components["gtest_main"].libs = ["gtest_main{}".format(self._postfix)]
             self.cpp_info.components["gtest_main"].requires = ["libgtest"]
-            self.cpp_info.components["gtest_main"].names["cmake_find_package"] = "gtest_main"
-            self.cpp_info.components["gtest_main"].names["cmake_find_package_multi"] = "gtest_main"
-            self.cpp_info.components["gtest_main"].names["pkg_config"] = "gtest_main"
 
         if self.options.build_gmock:
-            self.cpp_info.components["gmock"].names["cmake_find_package"] = "gmock"
-            self.cpp_info.components["gmock"].names["cmake_find_package_multi"] = "gmock"
-            self.cpp_info.components["gmock"].names["pkg_config"] = "gmock"
+            self.cpp_info.components["gmock"].set_property("cmake_target_name", "gmock")
             self.cpp_info.components["gmock"].libs = ["gmock{}".format(self._postfix)]
             self.cpp_info.components["gmock"].requires = ["libgtest"]
             if not self.options.no_main:
-                self.cpp_info.components["gmock_main"].names["cmake_find_package"] = "gmock_main"
-                self.cpp_info.components["gmock_main"].names["cmake_find_package_multi"] = "gmock_main"
-                self.cpp_info.components["gmock_main"].names["pkg_config"] = "gmock_main"
+                self.cpp_info.components["gmock_main"].set_property("cmake_target_name", "gmock_main")
                 self.cpp_info.components["gmock_main"].libs = ["gmock_main{}".format(self._postfix)]
                 self.cpp_info.components["gmock_main"].requires = ["gmock"]

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -145,8 +145,8 @@ class GTestConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "GTest")
         self.cpp_info.set_property("cmake_target_name", "GTest")
-        self.cpp_info.components["libgtest"].names["pkg_config"] = "gtest"
         self.cpp_info.components["libgtest"].set_property("cmake_target_name", "gtest")
+        self.cpp_info.components["libgtest"].set_property("pkg_config_name", "gtest")
         self.cpp_info.components["libgtest"].libs = ["gtest{}".format(self._postfix)]
         if self.settings.os == "Linux":
             self.cpp_info.components["libgtest"].system_libs.append("pthread")
@@ -165,17 +165,17 @@ class GTestConan(ConanFile):
 
         if not self.options.no_main:
             self.cpp_info.components["gtest_main"].set_property("cmake_target_name", "gtest_main")
+            self.cpp_info.components["gtest_main"].set_property("pkg_config_name", "gtest_main")
             self.cpp_info.components["gtest_main"].libs = ["gtest_main{}".format(self._postfix)]
             self.cpp_info.components["gtest_main"].requires = ["libgtest"]
-            self.cpp_info.components["gtest_main"].names["pkg_config"] = "gtest_main"
 
         if self.options.build_gmock:
             self.cpp_info.components["gmock"].set_property("cmake_target_name", "gmock")
-            self.cpp_info.components["gmock"].names["pkg_config"] = "gmock"
+            self.cpp_info.components["gmock"].set_property("pkg_config_name", "gmock")
             self.cpp_info.components["gmock"].libs = ["gmock{}".format(self._postfix)]
             self.cpp_info.components["gmock"].requires = ["libgtest"]
             if not self.options.no_main:
                 self.cpp_info.components["gmock_main"].set_property("cmake_target_name", "gmock_main")
-                self.cpp_info.components["gmock_main"].names["pkg_config"] = "gmock_main"
+                self.cpp_info.components["gmock_main"].set_property("pkg_config_name", "gmock_main")
                 self.cpp_info.components["gmock_main"].libs = ["gmock_main{}".format(self._postfix)]
                 self.cpp_info.components["gmock_main"].requires = ["gmock"]


### PR DESCRIPTION
Specify library name and version:  **gtest/1.11.0**

Fixes #7893.
Configures CMake FindPackage module characteristics for GTest properly for the CMakeDeps generator.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
