### PR TITLE
boost-ext-ut: Set cpp_info properties for CMakeDeps and Conan 1.42.0

### DIFF
--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -26,7 +26,7 @@ class UTConan(ConanFile):
             "Visual Studio": "16",
             "gcc": "9",
             "clang": "9",
-            "apple-clang": "12",
+            "apple-clang": "11" if tools.Version(self.version) < "1.1.8" else "12",
         }
 
     @property

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -18,7 +18,7 @@ class UTConan(ConanFile):
 
     @property
     def _minimum_cpp_standard(self):
-        return 17 if self.settings.os == "Linux" else 20
+        return 17 if self.settings.compiler in ["clang", "gcc"] else 20
 
     @property
     def _minimum_compilers_version(self):

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -26,7 +26,7 @@ class UTConan(ConanFile):
             "Visual Studio": "16",
             "gcc": "9",
             "clang": "9",
-            "apple-clang": "11",
+            "apple-clang": "12",
         }
 
     @property

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -2,6 +2,8 @@ from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.36.0"
+
 
 class UTConan(ConanFile):
     name = "boost-ext-ut"
@@ -66,12 +68,5 @@ class UTConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "ut")
-        self.cpp_info.set_property("cmake_target_namespace", "boost")
+        self.cpp_info.set_property("cmake_target_name", "boost")
         self.cpp_info.components["ut"].set_property("cmake_target_name", "ut")
-
-        self.cpp_info.names["cmake_find_package"] = "boost"
-        self.cpp_info.names["cmake_find_package_multi"] = "boost"
-        self.cpp_info.filenames["cmake_find_package"] = "ut"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "ut"
-        self.cpp_info.components["ut"].names["cmake_find_package"] = "ut"
-        self.cpp_info.components["ut"].names["cmake_find_package_multi"] = "ut"

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -23,10 +23,11 @@ class UTConan(ConanFile):
     @property
     def _minimum_compilers_version(self):
         return {
-            "Visual Studio": "16",
-            "gcc": "9",
-            "clang": "9",
             "apple-clang": "11" if tools.Version(self.version) < "1.1.8" else "12",
+            "clang": "9",
+            "gcc": "9",
+            "msvc": "19",
+            "Visual Studio": "16",
         }
 
     @property

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -18,7 +18,7 @@ class UTConan(ConanFile):
 
     @property
     def _minimum_cpp_standard(self):
-        return 17
+        return 17 if self.settings.os == "Linux" else 20
 
     @property
     def _minimum_compilers_version(self):

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -38,7 +38,11 @@ class UTConan(ConanFile):
             tools.check_min_cppstd(self, self._minimum_cpp_standard)
         min_version = self._minimum_compilers_version.get(
             str(self.settings.compiler))
-        if min_version:
+        if not min_version:
+            self.output.warn("{} recipe lacks information about the {} "
+                             "compiler support.".format(
+                                 self.name, self.settings.compiler))
+        else:
             if tools.Version(self.settings.compiler.version) < min_version:
                 raise ConanInvalidConfiguration(
                     "{} requires C++{} support. "
@@ -46,18 +50,6 @@ class UTConan(ConanFile):
                         self.name, self._minimum_cpp_standard,
                         self.settings.compiler,
                         self.settings.compiler.version))
-            if str(self.settings.compiler) == "apple-clang" and self.settings.compiler.version == "11" and not self.settings.compiler.get_safe("cppstd"):
-                raise ConanInvalidConfiguration(
-                    "{} requires C++{} support. "
-                    "The current compiler {} {} does not use it by default."
-                    "Set the compiler.cppstd setting to at least {} to enable it.".format(
-                        self.name, self._minimum_cpp_standard,
-                        self.settings.compiler,
-                        self.settings.compiler.version, self._minimum_cpp_standard))
-        else:
-            self.output.warn("{} recipe lacks information about the {} "
-                             "compiler support.".format(
-                                 self.name, self.settings.compiler))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
@@ -65,6 +65,10 @@ class UTConan(ConanFile):
         self.info.header_only()
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "ut")
+        self.cpp_info.set_property("cmake_target_namespace", "boost")
+        self.cpp_info.components["ut"].set_property("cmake_target_name", "ut")
+
         self.cpp_info.names["cmake_find_package"] = "boost"
         self.cpp_info.names["cmake_find_package_multi"] = "boost"
         self.cpp_info.filenames["cmake_find_package"] = "ut"

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -38,11 +38,7 @@ class UTConan(ConanFile):
             tools.check_min_cppstd(self, self._minimum_cpp_standard)
         min_version = self._minimum_compilers_version.get(
             str(self.settings.compiler))
-        if not min_version:
-            self.output.warn("{} recipe lacks information about the {} "
-                             "compiler support.".format(
-                                 self.name, self.settings.compiler))
-        else:
+        if min_version:
             if tools.Version(self.settings.compiler.version) < min_version:
                 raise ConanInvalidConfiguration(
                     "{} requires C++{} support. "
@@ -50,6 +46,18 @@ class UTConan(ConanFile):
                         self.name, self._minimum_cpp_standard,
                         self.settings.compiler,
                         self.settings.compiler.version))
+            if str(self.settings.compiler) == "apple-clang" and self.settings.compiler.version == "11" and not self.settings.compiler.get_safe("cppstd"):
+                raise ConanInvalidConfiguration(
+                    "{} requires C++{} support. "
+                    "The current compiler {} {} does not use it by default."
+                    "Set the compiler.cppstd setting to at least {} to enable it.".format(
+                        self.name, self._minimum_cpp_standard,
+                        self.settings.compiler,
+                        self.settings.compiler.version, self._minimum_cpp_standard))
+        else:
+            self.output.warn("{} recipe lacks information about the {} "
+                             "compiler support.".format(
+                                 self.name, self.settings.compiler))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/recipes/boost-ext-ut/all/test_package/CMakeLists.txt
+++ b/recipes/boost-ext-ut/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED yes)
 set(CMAKE_CXX_EXTENSIONS no)
 

--- a/recipes/boost-ext-ut/all/test_package/CMakeLists.txt
+++ b/recipes/boost-ext-ut/all/test_package/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED yes)
 set(CMAKE_CXX_EXTENSIONS no)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(ut REQUIRED CONFIG)
 


### PR DESCRIPTION
Specify library name and version:  **boost-ext-ut/1.1.8**

Update boost-ext-ut to work with CMakeDeps and Conan version 1.42.0 by setting the necessary `cpp_info` properties for the CMake FindModule.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
