### PR TITLE
libmysqlclient: fix building when zlib:shared=True

### DIFF
--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -151,12 +151,12 @@ class LibMysqlClientCConan(ConanFile):
     def build(self):
         self._patch_files()
         cmake = self._configure_cmake()
-        with tools.environment_append(RunEnvironment(self).vars):
+        with tools.run_environment(self):
             cmake.build()
 
     def package(self):
         cmake = self._configure_cmake()
-        with tools.environment_append(RunEnvironment(self).vars):
+        with tools.run_environment(self):
             cmake.install()
         os.mkdir(os.path.join(self.package_folder, "licenses"))
         tools.rename(os.path.join(self.package_folder, "LICENSE"), os.path.join(self.package_folder, "licenses", "LICENSE"))

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -151,11 +151,13 @@ class LibMysqlClientCConan(ConanFile):
     def build(self):
         self._patch_files()
         cmake = self._configure_cmake()
-        cmake.build()
+        with tools.environment_append(RunEnvironment(self).vars):
+            cmake.build()
 
     def package(self):
         cmake = self._configure_cmake()
-        cmake.install()
+        with tools.environment_append(RunEnvironment(self).vars):
+            cmake.install()
         os.mkdir(os.path.join(self.package_folder, "licenses"))
         tools.rename(os.path.join(self.package_folder, "LICENSE"), os.path.join(self.package_folder, "licenses", "LICENSE"))
         os.remove(os.path.join(self.package_folder, "README"))


### PR DESCRIPTION
Specify library name and version:  **libmysqlclient**

libmysqlclient builds ``comp_err.exe`` and other executables and then uses some of them in custom build actions. Some of these executables require zlib and as soon as it is not linked statically running executables fails. We need to adjust environment to make zlib dll file available to exe.

Closes #7901

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
