### PR TITLE
libcurl: fix test package when crossbuilding from x86_64 to x86 on Windows

### DIFF
--- a/recipes/libcurl/all/test_package/conanfile.py
+++ b/recipes/libcurl/all/test_package/conanfile.py
@@ -21,7 +21,7 @@ class TestPackageConan(ConanFile):
             return os.path.join("bin", "test_package")
 
     def test(self):
-        if not tools.cross_building(self):
+        if not tools.cross_building(self, skip_x64_x86=True):
             self.run(self._test_executable, run_environment=True)
         else:
             # We will dump information for the generated executable


### PR DESCRIPTION
Specify library name and version:  **libcurl**

Closes #7903

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
