### PR TITLE
boost: checking libiconv exists even if libc already found

### DIFF
--- a/recipes/boost/all/patches/1.69.0-locale-no-system.patch
+++ b/recipes/boost/all/patches/1.69.0-locale-no-system.patch
@@ -1,7 +1,7 @@
 This library links to boost_system, even though that library is header-only.
 --- libs/locale/build/Jamfile.v2
 +++ libs/locale/build/Jamfile.v2
-@@ -403,7 +403,7 @@
+@@ -410,7 +410,7 @@
          result += <source>util/gregorian.cpp ;
      }
      

--- a/recipes/boost/all/patches/boost_locale_fail_on_missing_backend.patch
+++ b/recipes/boost/all/patches/boost_locale_fail_on_missing_backend.patch
@@ -10,14 +10,21 @@ index 578e722..b715f59 100644
  feature.feature boost.locale.icu : on off :  optional propagated ;
  feature.feature boost.locale.posix : on off : optional propagated ;
  feature.feature boost.locale.std : on off : optional propagated ;
-@@ -217,6 +218,14 @@ rule configure-full ( properties * : flags-only )
+@@ -217,6 +217,21 @@ rule configure-full ( properties * : flags-only )
          if [ configure.builds has_iconv : $(properties) : "iconv (libc)" ]
          {
              found-iconv = true ;
 +            if <boost.locale.iconv.lib>libiconv in $(properties)
-+            {
-+                EXIT "- Boost.Locale found iconv (libc) instead of iconv (separate) library to be built." ;
-+            }
++			 {
++               if [ configure.builds has_external_iconv : $(properties) : "iconv (separate)" ]
++               {
++                   result += <library>iconv ;
++               }
++               else
++               {
++                   EXIT "- Boost.Locale found iconv (libc) instead of iconv (separate) library to be built." ;
++               }
++			 }
 +        }
 +        else if <boost.locale.iconv.lib>libc in $(properties)
 +        {


### PR DESCRIPTION
Specify library name and version:  **boost/1.77.0**

fix #7907 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
