### PR TITLE
Add missing define armadillo when use_extern_rng option is set to True

### DIFF
--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -267,6 +267,9 @@ class ArmadilloConan(ConanFile):
         self.cpp_info.libs = ["armadillo"]
         self.cpp_info.names["pkg_config"] = "armadillo"
 
+        if self.options.use_extern_rng:
+            self.cpp_info.defines.append("ARMA_USE_EXTERN_RNG")
+
         if self.settings.build_type == "Release":
             self.cpp_info.defines.append("ARMA_NO_DEBUG")
 

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -155,9 +155,10 @@ class ArmadilloConan(ConanFile):
                 f"DEPRECATION NOTICE: Value {opt} uses armadillo's default dependency search and will be replaced when this package becomes available in ConanCenter"
             )
 
-        if self.options.use_wrapper and not self.options.use_extern_rng:
+        # Ignore use_extern_rng when the option has been removed
+        if self.options.use_wrapper and not self.options.get_safe("use_extern_rng", True):
             raise ConanInvalidConfiguration(
-                "use_extern_rng must be enabled when use_wrapper is enabled"
+                "The wrapper requires the use of an external RNG. Set use_extern_rng=True and try again."
             )
 
     def requirements(self):

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -94,9 +94,7 @@ class ArmadilloConan(ConanFile):
         # According with the CMakeLists file in armadillo, MinGW doesn't correctly handle thread_local.
         # If any of MINGW, MSYS, CYGWIN or MSVC are True in during cmake configure, the ARMA_USE_EXTERN_RNG option will be set to false.
         # Therefore, in these cases we remove the `use_extern_rng` option in conan
-        from conans.client.tools.win import CYGWIN, MSYS2, MSYS
-        windows_subsystem = tools.os_info.detect_windows_subsystem()
-        if windows_subsystem in [MSYS, MSYS2, CYGWIN] or self.settings.compiler == "Visual Studio":
+        if self.settings.os == "Windows":
             del self.options.use_extern_rng
 
     def configure(self):

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -91,6 +91,13 @@ class ArmadilloConan(ConanFile):
             self.options.use_blas = "framework_accelerate"
             self.options.use_lapack = "framework_accelerate"
 
+        # According with the CMakeLists file in armadillo, MinGW doesn't correctly handle thread_local.
+        # If any of MINGW, MSYS, CYGWIN or MSVC are True in during cmake configure, the ARMA_USE_EXTERN_RNG option will be set to false.
+        # Therefore, in these cases we remove the `use_extern_rng` option in conan
+        windows_subsystem = tools.os_info.detect_windows_subsystem()
+        if windows_subsystem in ["MSYS", "MSYS2", "CYGWIN"] or self.settings.compiler == "msvc":
+            del self.options.use_extern_rng
+
     def configure(self):
         if self.options.shared:
             del self.options.fPIC

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -281,7 +281,7 @@ class ArmadilloConan(ConanFile):
         self.cpp_info.libs = ["armadillo"]
         self.cpp_info.names["pkg_config"] = "armadillo"
 
-        if self.options.use_extern_rng:
+        if self.options.get_safe("use_extern_rng"):
             self.cpp_info.defines.append("ARMA_USE_EXTERN_RNG")
 
         if self.settings.build_type == "Release":

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -94,8 +94,9 @@ class ArmadilloConan(ConanFile):
         # According with the CMakeLists file in armadillo, MinGW doesn't correctly handle thread_local.
         # If any of MINGW, MSYS, CYGWIN or MSVC are True in during cmake configure, the ARMA_USE_EXTERN_RNG option will be set to false.
         # Therefore, in these cases we remove the `use_extern_rng` option in conan
+        from conans.client.tools.win import CYGWIN, MSYS2, MSYS
         windows_subsystem = tools.os_info.detect_windows_subsystem()
-        if windows_subsystem in ["MSYS", "MSYS2", "CYGWIN"] or self.settings.compiler == "msvc":
+        if windows_subsystem in [MSYS, MSYS2, CYGWIN] or self.settings.compiler == "Visual Studio":
             del self.options.use_extern_rng
 
     def configure(self):

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -147,6 +147,11 @@ class ArmadilloConan(ConanFile):
                 f"DEPRECATION NOTICE: Value {opt} uses armadillo's default dependency search and will be replaced when this package becomes available in ConanCenter"
             )
 
+        if self.options.use_wrapper and not self.options.use_extern_rng:
+            raise ConanInvalidConfiguration(
+                "use_extern_rng must be enabled when use_wrapper is enabled"
+            )
+
     def requirements(self):
         # Optional requirements
         # TODO: "atlas/3.10.3" # Pending https://github.com/conan-io/conan-center-index/issues/6757

--- a/recipes/armadillo/all/conanfile.py
+++ b/recipes/armadillo/all/conanfile.py
@@ -206,7 +206,7 @@ class ArmadilloConan(ConanFile):
         )
         self._cmake.definitions["ARMA_USE_HDF5"] = self.options.use_hdf5
         self._cmake.definitions["ARMA_USE_ARPACK"] = self.options.use_arpack
-        self._cmake.definitions["ARMA_USE_EXTERN_RNG"] = self.options.use_extern_rng
+        self._cmake.definitions["ARMA_USE_EXTERN_RNG"] = self.options.get_safe("use_exern_rng", default=False)
         self._cmake.definitions["ARMA_USE_SUPERLU"] = self.options.use_superlu
         self._cmake.definitions["ARMA_USE_WRAPPER"] = self.options.use_wrapper
         self._cmake.definitions["ARMA_USE_ACCELERATE"] = (

--- a/recipes/armadillo/all/test_package/example.cpp
+++ b/recipes/armadillo/all/test_package/example.cpp
@@ -162,11 +162,9 @@ main(int argc, char** argv)
 #endif
 
   arma::vec v2{1,2,3,4};
-  v2.print("v2 (before randn)");
-
   arma::arma_rng::set_seed(1237);
   v2.randn();
-  v2.print("v2 (after randn)");
+  v2.print("v2 (randn):");
 
   return 0;
   }

--- a/recipes/armadillo/all/test_package/example.cpp
+++ b/recipes/armadillo/all/test_package/example.cpp
@@ -153,7 +153,20 @@ main(int argc, char** argv)
         }
   
   F.print("F:");
-  
+
+  // Test that the result of the use_extern_rng option in the conan recipe
+#ifdef ARMA_USE_EXTERN_RNG
+  cout << "ARMA_USE_EXTERN_RNG set." << endl;
+#else
+  cout << "ARMA_USE_EXTERN_RNG not set." << endl;
+#endif
+
+  arma::vec v2{1,2,3,4};
+  v2.print("v2 (before randn)");
+
+  arma::arma_rng::set_seed(1237);
+  v2.randn();
+  v2.print("v2 (after randn)");
+
   return 0;
   }
-


### PR DESCRIPTION

Specify library name and version:  **armadillo/10.7.0**

Add the define `ARMA_USE_EXTERN_RNG` when the `use_extern_rng` option is set to `True`, as in [my comment in issue #7334](https://github.com/conan-io/conan-center-index/pull/7334#issuecomment-951133407).

This is probably not necessary when the `use_wrapper` option is also set to `True`, since CMake should take care of that. However, since currently we have link problems when `use_wrapper` is set to `True` (see issue  [issue #7840](https://github.com/conan-io/conan-center-index/issues/7840)), I don't have a way to test it. Thus, I decided to be safe and always add the define when `use_extern_rng`  is set to `True`, regardless of the value of `use_wrapper`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
