### PR TITLE
Make all dependencies of websocketpp optional

### DIFF
--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -35,7 +35,6 @@ class WebsocketPPConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
-        conan.tools.files.rename(self, src = extracted_dir, dst = self._source_subfolder)
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -1,11 +1,11 @@
 import os
 from conans import ConanFile, tools
-
+import conan.tools.files
 
 class WebsocketPPConan(ConanFile):
     name = "websocketpp"
     description = "Header only C++ library that implements RFC6455 The WebSocket Protocol"
-    topics = ("conan", "websocketpp", "websocket", "network", "web", "rfc6455", "header-only")
+    topics = ("websocketpp", "websocket", "network", "web", "rfc6455", "header-only")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/zaphoyd/websocketpp"
     license = "BSD-3-Clause"
@@ -35,7 +35,7 @@ class WebsocketPPConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        conan.tools.files.rename(self, src = extracted_dir, dst = self._source_subfolder)
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -13,10 +13,16 @@ class WebsocketPPConan(ConanFile):
     license = "BSD-3-Clause"
     settings = "os", "arch", "compiler", "build_type"
     exports_sources = ["patches/*"]
-    options = {"asio": ["boost", "standalone", "none"],
-               "openssl": [True, False],
-               "zlib": [True, False]}
-    default_options = {"asio": "boost", "openssl": True, "zlib": True}
+    options = {
+        "asio": ["boost", "standalone", False],
+        "with_openssl": [True, False],
+        "with_zlib": [True, False],
+    }
+    default_options = {
+        "asio": "boost",
+        "with_openssl": True,
+        "with_zlib": True,
+    }
 
     @property
     def _source_subfolder(self):

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -33,8 +33,8 @@ class WebsocketPPConan(ConanFile):
             self.requires("boost/1.76.0")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
         conan.tools.files.rename(self, src = extracted_dir, dst = self._source_subfolder)
 
     def build(self):

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -32,7 +32,7 @@ class WebsocketPPConan(ConanFile):
         if self.options.asio == "standalone":
             self.requires("asio/1.19.2")
         elif self.options.asio == "boost":
-            self.requires("boost/1.76.0")
+            self.requires("boost/1.77.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -36,7 +36,7 @@ class WebsocketPPConan(ConanFile):
             self.requires("zlib/1.2.11")
 
         if self.options.asio == "standalone":
-            self.requires("asio/1.20.0")
+            self.requires("asio/1.21.0")
         elif self.options.asio == "boost":
             self.requires("boost/1.77.0")
 

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -11,19 +11,25 @@ class WebsocketPPConan(ConanFile):
     license = "BSD-3-Clause"
     settings = "os", "arch", "compiler", "build_type"
     exports_sources = ["patches/*"]
-    options = {"asio": ["boost", "standalone"]}
-    default_options = {"asio": "boost"}
-    
+    options = {"asio": ["boost", "standalone", "none"],
+               "openssl": [True, False],
+               "zlib": [True, False]}
+    default_options = {"asio": "boost", "openssl": True, "zlib": True}
+
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
     def requirements(self):
-        self.requires("openssl/1.1.1k")
-        self.requires("zlib/1.2.11")
+        if self.options.openssl:
+            self.requires("openssl/1.1.1k")
+
+        if self.options.zlib:
+            self.requires("zlib/1.2.11")
+
         if self.options.asio == "standalone":
             self.requires("asio/1.19.2")
-        else:
+        elif self.options.asio == "boost":
             self.requires("boost/1.76.0")
 
     def source(self):

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -30,7 +30,7 @@ class WebsocketPPConan(ConanFile):
             self.requires("zlib/1.2.11")
 
         if self.options.asio == "standalone":
-            self.requires("asio/1.19.2")
+            self.requires("asio/1.20.0")
         elif self.options.asio == "boost":
             self.requires("boost/1.77.0")
 

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -1,6 +1,8 @@
 import os
 from conans import ConanFile, tools
-import conan.tools.files
+
+required_conan_version = ">=1.33.0"
+
 
 class WebsocketPPConan(ConanFile):
     name = "websocketpp"

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -24,7 +24,7 @@ class WebsocketPPConan(ConanFile):
 
     def requirements(self):
         if self.options.openssl:
-            self.requires("openssl/1.1.1k")
+            self.requires("openssl/1.1.1l")
 
         if self.options.zlib:
             self.requires("zlib/1.2.11")

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -29,10 +29,10 @@ class WebsocketPPConan(ConanFile):
         return "source_subfolder"
 
     def requirements(self):
-        if self.options.openssl:
+        if self.options.with_openssl:
             self.requires("openssl/1.1.1l")
 
-        if self.options.zlib:
+        if self.options.with_zlib:
             self.requires("zlib/1.2.11")
 
         if self.options.asio == "standalone":


### PR DESCRIPTION
Make all dependencies of websocketpp package optional, since they are optional dependencies upstream.

Specify library name and version:  **websocketpp/0.8.2**

Closes #7899. Also fixes a couple of conan-center hook warnings.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
