### PR TITLE
meson: add version 0.60.1

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -83,3 +83,6 @@ sources:
   "0.60.0":
     url: "https://github.com/mesonbuild/meson/archive/0.60.0.tar.gz"
     sha256: "5672a560fc4094c88ca5b8be0487e099fe84357e5045f5aecf1113084800e6fd"
+  "0.60.1":
+    url: "https://github.com/mesonbuild/meson/archive/0.60.1.tar.gz"
+    sha256: "b06f7d621b90e094be0ea2157fa435648e069f19182d8d9402aa039727652b0c"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -55,3 +55,5 @@ versions:
     folder: all
   "0.60.0":
     folder: all
+  "0.60.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/0.60.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
