### PR TITLE
maddy 1.1.2 recipe

### DIFF
--- a/recipes/maddy/all/conandata.yml
+++ b/recipes/maddy/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.1.2":
+    sha256: ce66e1ee63bda3a6ab9c814edc0ed818abecca1c2218307ff87fb9ec1fc970fc
+    url: https://github.com/progsource/maddy/archive/refs/tags/1.1.2.tar.gz

--- a/recipes/maddy/all/conanfile.py
+++ b/recipes/maddy/all/conanfile.py
@@ -1,0 +1,30 @@
+import os
+from conans import ConanFile, tools
+
+
+class maddyConan(ConanFile):
+    name = "maddy"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/progsource/maddy"
+    description = "open-source, maddy is a C++ Markdown to HTML header-only parser library."
+    topics = ("maddy", "markdown", "header-only")
+    license = "MIT"
+
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        os.rename("maddy-{}".format(self.version), self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package(self):
+        self.copy("LICENSE", src=os.path.join(self.source_folder, self._source_subfolder), dst="licenses")
+        self.copy(
+            pattern="maddy/*.h", src=os.path.join(self.source_folder, self._source_subfolder, "include"), dst="include"
+        )

--- a/recipes/maddy/all/conanfile.py
+++ b/recipes/maddy/all/conanfile.py
@@ -8,7 +8,9 @@ class MaddyConan(ConanFile):
     name = "maddy"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/progsource/maddy"
-    description = "open-source, maddy is a C++ Markdown to HTML header-only parser library."
+    description = (
+        "open-source, maddy is a C++ Markdown to HTML header-only parser library."
+    )
     topics = ("maddy", "markdown", "header-only")
     license = "MIT"
 
@@ -19,14 +21,23 @@ class MaddyConan(ConanFile):
         return "source_subfolder"
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self_source_subfolder, strip_root=True)
+        tools.get(
+            **self.conan_data["sources"][self.version],
+            destination=self._source_subfolder,
+            strip_root=True
+        )
 
     def package_id(self):
         self.info.header_only()
 
     def package(self):
-        self.copy("LICENSE", src=os.path.join(self.source_folder, self._source_subfolder), dst="licenses")
         self.copy(
-            pattern="maddy/*.h", src=os.path.join(self.source_folder, self._source_subfolder, "include"), dst="include"
+            "LICENSE",
+            src=os.path.join(self.source_folder, self._source_subfolder),
+            dst="licenses",
+        )
+        self.copy(
+            pattern="maddy/*.h",
+            src=os.path.join(self.source_folder, self._source_subfolder, "include"),
+            dst="include",
         )

--- a/recipes/maddy/all/conanfile.py
+++ b/recipes/maddy/all/conanfile.py
@@ -19,8 +19,8 @@ class MaddyConan(ConanFile):
         return "source_subfolder"
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("maddy-{}".format(self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self_source_subfolder, strip_root=True)
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/maddy/all/conanfile.py
+++ b/recipes/maddy/all/conanfile.py
@@ -1,8 +1,10 @@
-import os
 from conans import ConanFile, tools
+import os
+
+required_conan_version = ">=1.33.0"
 
 
-class maddyConan(ConanFile):
+class MaddyConan(ConanFile):
     name = "maddy"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/progsource/maddy"

--- a/recipes/maddy/all/conanfile.py
+++ b/recipes/maddy/all/conanfile.py
@@ -20,6 +20,10 @@ class MaddyConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 14)
+
     def source(self):
         tools.get(
             **self.conan_data["sources"][self.version],

--- a/recipes/maddy/all/conanfile.py
+++ b/recipes/maddy/all/conanfile.py
@@ -13,7 +13,7 @@ class MaddyConan(ConanFile):
     )
     topics = ("maddy", "markdown", "header-only")
     license = "MIT"
-
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     @property

--- a/recipes/maddy/all/test_package/CMakeLists.txt
+++ b/recipes/maddy/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})
+set_target_properties(example PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED
+                                                         ON)

--- a/recipes/maddy/all/test_package/CMakeLists.txt
+++ b/recipes/maddy/all/test_package/CMakeLists.txt
@@ -2,9 +2,11 @@ cmake_minimum_required(VERSION 3.5)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-add_executable(example example.cpp)
-target_link_libraries(example ${CONAN_LIBS})
-set_target_properties(example PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED
-                                                         ON)
+find_package(maddy REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} example.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE maddy::maddy)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED
+                                                                 ON)

--- a/recipes/maddy/all/test_package/conanfile.py
+++ b/recipes/maddy/all/test_package/conanfile.py
@@ -13,5 +13,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "example")
+            bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/maddy/all/test_package/conanfile.py
+++ b/recipes/maddy/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class MaddyTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "example")
             self.run(bin_path, run_environment=True)

--- a/recipes/maddy/all/test_package/conanfile.py
+++ b/recipes/maddy/all/test_package/conanfile.py
@@ -2,9 +2,9 @@ from conans import ConanFile, CMake, tools
 import os
 
 
-class MaddyTestConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/maddy/all/test_package/conanfile.py
+++ b/recipes/maddy/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class MaddyTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/maddy/all/test_package/example.cpp
+++ b/recipes/maddy/all/test_package/example.cpp
@@ -12,7 +12,7 @@
 
 int main() {
   std::stringstream markdownInput(
-      "#Hello world from maddy!\nVisit "
+      "# Hello world from maddy!\nVisit "
       "[conan-center-index](https://github.com/conan-io/conan-center-index)\n");
 
   // config is optional

--- a/recipes/maddy/all/test_package/example.cpp
+++ b/recipes/maddy/all/test_package/example.cpp
@@ -2,6 +2,7 @@
  *  This example was copied from https://github.com/progsource/maddy/blob/master/README.md
  */
 
+#include <iostream>
 #include <memory>
 #include <string>
 #include <cstdlib>

--- a/recipes/maddy/all/test_package/example.cpp
+++ b/recipes/maddy/all/test_package/example.cpp
@@ -20,5 +20,7 @@ int main()
    std::shared_ptr<maddy::Parser> parser = std::make_shared<maddy::Parser>(config);
    std::string htmlOutput = parser->Parse(markdownInput);
 
+   std::cout << "html:\n" << htmlOutput;
+
    return EXIT_SUCCESS;
 }

--- a/recipes/maddy/all/test_package/example.cpp
+++ b/recipes/maddy/all/test_package/example.cpp
@@ -1,0 +1,24 @@
+/*
+ *  This example was copied from https://github.com/progsource/maddy/blob/master/README.md
+ */
+
+#include <memory>
+#include <string>
+#include <cstdlib>
+
+#include <maddy/parser.h>
+
+int main()
+{
+   std::stringstream markdownInput("");
+
+   // config is optional
+   std::shared_ptr<maddy::ParserConfig> config = std::make_shared<maddy::ParserConfig>();
+   config->isEmphasizedParserEnabled = true; // default
+   config->isHTMLWrappedInParagraph = true;  // default
+
+   std::shared_ptr<maddy::Parser> parser = std::make_shared<maddy::Parser>(config);
+   std::string htmlOutput = parser->Parse(markdownInput);
+
+   return EXIT_SUCCESS;
+}

--- a/recipes/maddy/all/test_package/example.cpp
+++ b/recipes/maddy/all/test_package/example.cpp
@@ -1,27 +1,31 @@
 /*
- *  This example was copied from https://github.com/progsource/maddy/blob/master/README.md
+ *  This example was copied from
+ * https://github.com/progsource/maddy/blob/master/README.md
  */
 
+#include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <string>
-#include <cstdlib>
 
 #include <maddy/parser.h>
 
-int main()
-{
-   std::stringstream markdownInput("#Hello world from maddy!\nVisit [conan-center-index](https://github.com/conan-io/conan-center-index)\n");
+int main() {
+  std::stringstream markdownInput(
+      "#Hello world from maddy!\nVisit "
+      "[conan-center-index](https://github.com/conan-io/conan-center-index)\n");
 
-   // config is optional
-   std::shared_ptr<maddy::ParserConfig> config = std::make_shared<maddy::ParserConfig>();
-   config->isEmphasizedParserEnabled = true; // default
-   config->isHTMLWrappedInParagraph = true;  // default
+  // config is optional
+  std::shared_ptr<maddy::ParserConfig> config =
+      std::make_shared<maddy::ParserConfig>();
+  config->isEmphasizedParserEnabled = true; // default
+  config->isHTMLWrappedInParagraph = true;  // default
 
-   std::shared_ptr<maddy::Parser> parser = std::make_shared<maddy::Parser>(config);
-   std::string htmlOutput = parser->Parse(markdownInput);
+  std::shared_ptr<maddy::Parser> parser =
+      std::make_shared<maddy::Parser>(config);
+  std::string htmlOutput = parser->Parse(markdownInput);
 
-   std::cout << "html:\n" << htmlOutput;
+  std::cout << "html:\n" << htmlOutput << "\n";
 
-   return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/recipes/maddy/all/test_package/example.cpp
+++ b/recipes/maddy/all/test_package/example.cpp
@@ -11,7 +11,7 @@
 
 int main()
 {
-   std::stringstream markdownInput("");
+   std::stringstream markdownInput("#Hello world from maddy!\nVisit [conan-center-index](https://github.com/conan-io/conan-center-index)\n");
 
    // config is optional
    std::shared_ptr<maddy::ParserConfig> config = std::make_shared<maddy::ParserConfig>();

--- a/recipes/maddy/config.yml
+++ b/recipes/maddy/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **maddy/1.1.2**

I needed a c++ markdown parser for a project of mine and could not find one within CCI.
It is not a dependency for other libraries I want to use. I am not the author of the library.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
