### PR TITLE
crowcpp-crow: fix include path with amalgamation option

### DIFF
--- a/recipes/crowcpp-crow/all/test_package/CMakeLists.txt
+++ b/recipes/crowcpp-crow/all/test_package/CMakeLists.txt
@@ -6,6 +6,14 @@ conan_basic_setup(TARGETS)
 
 find_package(crow REQUIRED)
 
+option(CROW_AMALGAMATION "CROW IS DEPLOYED AS AMALGAMATION" ON)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} crow::crow)
+
+if(CROW_AMALGAMATION)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE CROW_AMALGAMATION)
+endif(CROW_AMALGAMATION)
+unset(CROW_AMALGAMATION CACHE)
+
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/crowcpp-crow/all/test_package/conanfile.py
+++ b/recipes/crowcpp-crow/all/test_package/conanfile.py
@@ -8,6 +8,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["CROW_AMALGAMATION"] = self.options["crowcpp-crow"].amalgamation
         cmake.configure()
         cmake.build()
 

--- a/recipes/crowcpp-crow/all/test_package/test_package.cpp
+++ b/recipes/crowcpp-crow/all/test_package/test_package.cpp
@@ -1,4 +1,8 @@
-#include "crow/crow_all.h"
+#ifdef CROW_AMALGAMATION
+#include "crow_all.h"
+#else
+#include "crow.h"
+#endif
 
 int main()
 {


### PR DESCRIPTION
Specify library name and version:  **crowcpp-crow/all**

Try to fix https://github.com/conan-io/conan-center-index/issues/7831.

Add amalgamation option.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
