### PR TITLE
aws-c-io: add version 0.10.13

### DIFF
--- a/recipes/aws-c-io/all/conandata.yml
+++ b/recipes/aws-c-io/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10.13":
+    url: "https://github.com/awslabs/aws-c-io/archive/v0.10.13.tar.gz"
+    sha256: "ee34a93190e35a5c372ba73661dd69c48986e051a4b26dedb62bc5aa78f1660f"
   "0.10.9":
     url: "https://github.com/awslabs/aws-c-io/archive/v0.10.9.tar.gz"
     sha256: "c64464152abe8b7e23f10bc026ed54a15eaf0ec0aae625d28e2caf4489090327"

--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -6,7 +6,7 @@ required_conan_version = ">=1.33.0"
 class AwsCIO(ConanFile):
     name = "aws-c-io"
     description = "IO and TLS for application protocols"
-    topics = ("conan", "aws", "amazon", "cloud", )
+    topics = ("aws", "amazon", "cloud", "io", "tls",)
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-io"
     license = "Apache-2.0",
@@ -39,7 +39,15 @@ class AwsCIO(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-c-cal/0.5.12")
+        # the versions of aws-c-common and aws-c-io are tied since aws-c-common/0.6.12 and aws-c-io/0.10.10
+        # Please refer https://github.com/conan-io/conan-center-index/issues/7763
+        if tools.Version(self.version) <= "0.10.9":
+            self.requires("aws-c-common/0.6.11")
+            self.requires("aws-c-cal/0.5.11")
+        else:
+            self.requires("aws-c-common/0.6.15")
+            self.requires("aws-c-cal/0.5.12")
+
         if self.settings.os in ["Linux", "FreeBSD", "Android"]:
             self.requires("s2n/1.1.0")
 
@@ -73,7 +81,7 @@ class AwsCIO(ConanFile):
         self.cpp_info.components["aws-c-io-lib"].names["cmake_find_package"] = "aws-c-io"
         self.cpp_info.components["aws-c-io-lib"].names["cmake_find_package_multi"] = "aws-c-io"
         self.cpp_info.components["aws-c-io-lib"].libs = ["aws-c-io"]
-        self.cpp_info.components["aws-c-io-lib"].requires = ["aws-c-cal::aws-c-cal-lib"]
+        self.cpp_info.components["aws-c-io-lib"].requires = ["aws-c-cal::aws-c-cal-lib", "aws-c-common::aws-c-common-lib"]
 
         if self.settings.os == "Macos":
             self.cpp_info.components["aws-c-io-lib"].frameworks.append("Security")

--- a/recipes/aws-c-io/config.yml
+++ b/recipes/aws-c-io/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.10.13":
+    folder: all
   "0.10.9":
     folder: all
   "0.10.5":


### PR DESCRIPTION
Specify library name and version:  **aws-c-io/0.10.13**

- Append topics.
- Add aws-c-common to requirements because aws-c-io directly uses aws-c-common.
- Add version check logic to resolve https://github.com/conan-io/conan-center-index/issues/7763.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
