### PR TITLE
s2n: add version 1.2.0

### DIFF
--- a/recipes/s2n/all/conandata.yml
+++ b/recipes/s2n/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.0":
+    url: "https://github.com/awslabs/s2n/archive/v1.2.0.tar.gz"
+    sha256: "90c1b5f4ac2c46774c8f100cac4f2a951715ae0bf2661799b9aaa891e6fb1f30"
   "1.1.1":
     url: "https://github.com/awslabs/s2n/archive/v1.1.1.tar.gz"
     sha256: "a17ef1e55b0a6c3d422b8b857bcfd26af7d2f8b33628a540854a6c17b8bed4d8"

--- a/recipes/s2n/config.yml
+++ b/recipes/s2n/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.0":
+    folder: all
   "1.1.1":
     folder: all
   "1.1.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **s2n/1.2.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
