### PR TITLE
libmysqlclient: fix version detection for macos 12.0.x

### DIFF
--- a/recipes/libmysqlclient/all/conandata.yml
+++ b/recipes/libmysqlclient/all/conandata.yml
@@ -16,3 +16,5 @@ patches:
   "8.0.25":
     - base_path: "source_subfolder"
       patch_file: "patches/0004-fix-805-cpp17-build.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0005-fix-macos-12.0.x-version-detection.patch"

--- a/recipes/libmysqlclient/all/patches/0005-fix-macos-12.0.x-version-detection.patch
+++ b/recipes/libmysqlclient/all/patches/0005-fix-macos-12.0.x-version-detection.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/package_name.cmake b/cmake/package_name.cmake
+index 192035dd..dedc59c6 100644
+--- a/cmake/package_name.cmake
++++ b/cmake/package_name.cmake
+@@ -94,7 +94,7 @@ MACRO(GET_PACKAGE_FILE_NAME Var)
+ 
+       STRING(REGEX MATCH
+         "ProductVersion:[\n\t ]*([0-9]+)\\.([0-9]+)" UNUSED ${SW_VERS_PRODUCTVERSION})
+-      IF(NOT CMAKE_MATCH_1 OR NOT CMAKE_MATCH_2)
++      IF(CMAKE_MATCH_1 STREQUAL "" OR CMAKE_MATCH_2 STREQUAL "")
+         MESSAGE(FATAL_ERROR "Could not run sw_vers")
+       ENDIF()
+ 


### PR DESCRIPTION
libmysqlclient/8.0.25

Closes #7922
Duplicates #7945 (which can be closed)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
