### PR TITLE
added initial scylla-cpp-driver config

### DIFF
--- a/recipes/scylla-cpp-driver/all/CMakeLists.txt
+++ b/recipes/scylla-cpp-driver/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.4)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/scylla-cpp-driver/all/conandata.yml
+++ b/recipes/scylla-cpp-driver/all/conandata.yml
@@ -1,0 +1,11 @@
+sources:
+  "2.15.0":
+    url: "https://github.com/scylladb/cpp-driver/archive/refs/tags/2.15.0.tar.gz"
+    sha256: "8cccffc7f3b7a8edc51c5c4344fd6a60d5a7beec27a1a3fd52742003a2675cb9"
+  "2.15.1":
+    url: "https://github.com/scylladb/cpp-driver/archive/refs/tags/2.15.1.tar.gz"
+    sha256: "b3095e154f10d7a740dfa3155f66be50880b0110a06dd02dd097f1121a72d88d"
+  "2.15.2":
+    url: "https://github.com/scylladb/cpp-driver/archive/refs/tags/2.15.2.tar.gz"
+    sha256: "69305b5624dbeeb70b055b3d72b22e875be1bc49f721f1cccd3da6d420070c14"
+patches: []

--- a/recipes/scylla-cpp-driver/all/conanfile.py
+++ b/recipes/scylla-cpp-driver/all/conanfile.py
@@ -1,0 +1,95 @@
+import os
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.33.0"
+
+
+class ScyllaCppDriverConan(ConanFile):
+    name = "scylla-cpp-driver"
+    homepage = "https://github.com/scylladb/cpp-driver"
+    description = "A modern, feature-rich and shard-aware C/C++ client library for ScyllaDB."
+    topics = ("conan", "scylla", "scylladb", "driver", "database", "cassandra")
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "Apache-2.0"
+    exports_sources = ["CMakeLists.txt", "patches/*"]
+    generators = "cmake"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "boost_atomic": [True, False],
+        "kerberos": [True, False],
+        "openssl": [True, False],
+        "zlib": [True, False],
+        "build_static_lib": [True, False],
+        "build_shared_lib": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "boost_atomic": False,
+        "kerberos": False,
+        "openssl": True,
+        "zlib": True,
+        "build_static_lib": False,
+        "build_shared_lib": True,
+    }
+    short_paths = True
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["CASS_BUILD_EXAMPLES"] = False
+        self._cmake.definitions["CASS_BUILD_INTEGRATION_TESTS"] = False
+        self._cmake.definitions["CASS_BUILD_TESTS"] = False
+        self._cmake.definitions["CASS_BUILD_SHARED"] = self.options.build_shared_lib
+        self._cmake.definitions["CASS_BUILD_STATIC"] = self.options.build_static_lib
+        self._cmake.definitions["CASS_BUILD_UNIT_TESTS"] = False
+        self._cmake.definitions["CASS_DEBUG_CUSTOM_ALLOC"] = False
+        self._cmake.definitions["CASS_USE_BOOST_ATOMIC"] = self.options.boost_atomic
+        self._cmake.definitions["CASS_USE_KERBEROS"] = self.options.kerberos
+        self._cmake.definitions["CASS_USE_LIBSSH2"] = False
+        self._cmake.definitions["CASS_USE_OPENSSL"] = self.options.openssl
+        self._cmake.definitions["CASS_USE_STD_ATOMIC"] = not self.options.boost_atomic
+        self._cmake.definitions["CASS_USE_ZLIB"] = self.options.zlib
+
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("License.txt", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.names["cmake_find_package"] = "ScyllaCppDriver"
+        self.cpp_info.names["cmake_find_package_multi"] = "ScyllaCppDriver"

--- a/recipes/scylla-cpp-driver/all/test_package/CMakeLists.txt
+++ b/recipes/scylla-cpp-driver/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/scylla-cpp-driver/all/test_package/conanfile.py
+++ b/recipes/scylla-cpp-driver/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+
+import os
+
+from conans import ConanFile, CMake, tools
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/scylla-cpp-driver/all/test_package/test_package.cpp
+++ b/recipes/scylla-cpp-driver/all/test_package/test_package.cpp
@@ -1,0 +1,39 @@
+#include <cassandra.h>
+
+#include <memory>
+#include <string>
+
+struct Basic_ {
+  cass_bool_t bln;
+  cass_float_t flt;
+  cass_double_t dbl;
+  cass_int32_t i32;
+  cass_int64_t i64;
+};
+typedef struct Basic_ Basic;
+
+int insert_into_basic(const char* key, const Basic* basic) {
+  const char* query =
+      "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, "
+      "?, ?, ?, ?);";
+
+  auto statement =
+      std::unique_ptr<CassStatement, decltype(&cass_statement_free)>(
+          cass_statement_new(query, 6), &cass_statement_free);
+
+  cass_statement_bind_string(statement.get(), 0, key);
+  cass_statement_bind_bool(statement.get(), 1, basic->bln);
+  cass_statement_bind_float(statement.get(), 2, basic->flt);
+  cass_statement_bind_double(statement.get(), 3, basic->dbl);
+  cass_statement_bind_int32(statement.get(), 4, basic->i32);
+  cass_statement_bind_int64(statement.get(), 5, basic->i64);
+
+  return 0;
+}
+
+int main(int argc, char* argv[]) {
+  Basic input = {cass_true, 0.001f, 0.0002, 1, 2};
+
+  insert_into_basic("test", &input);
+  return 0;
+}

--- a/recipes/scylla-cpp-driver/config.yml
+++ b/recipes/scylla-cpp-driver/config.yml
@@ -1,0 +1,7 @@
+versions:
+  "2.15.0":
+    folder: all
+  "2.15.1":
+    folder: all
+  "2.15.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **scylla-cpp-driver/2.15.* **

Adding the ScyllaCppDriver to allow users to connect to scylla databases in CPP code. Closes #7471

---

- [X ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
