### PR TITLE
fix building of qt5 with clang 13

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -24,3 +24,5 @@ patches:
       base_path: "qt5/qtdeclarative"
     - patch_file: "patches/f830b86.diff"
       base_path: "qt5/qtwebengine/src/3rdparty"
+    - patch_file: "patches/dece6f5.diff"
+      base_path: "qt5/qtbase"

--- a/recipes/qt/5.x.x/patches/dece6f5.diff
+++ b/recipes/qt/5.x.x/patches/dece6f5.diff
@@ -1,0 +1,14 @@
+diff --git a/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h b/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
+index e070ba977d..35a62f59e3 100644
+--- a/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
++++ b/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
+@@ -43,6 +43,9 @@
+ #include <qpa/qplatformgraphicsbuffer.h>
+ #include <private/qcore_mac_p.h>
+ 
++
++#include <CoreGraphics/CGColorSpace.h>
++
+ QT_BEGIN_NAMESPACE
+ 
+ class QIOSurfaceGraphicsBuffer : public QPlatformGraphicsBuffer


### PR DESCRIPTION
Specify library name and version:  **qt/5.x.x**

Fixes #7942 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
