### PR TITLE
pcre2: ftp.pcre.org is down, download sources from sourceforge.net

### DIFF
--- a/recipes/pcre2/all/conandata.yml
+++ b/recipes/pcre2/all/conandata.yml
@@ -1,16 +1,26 @@
 sources:
   "10.32":
-    url: "https://ftp.pcre.org/pub/pcre/pcre2-10.32.tar.gz"
+    url:
+      - "https://sourceforge.net/projects/pcre/files/pcre2/10.32/pcre2-10.32.tar.gz"
+      - "https://ftp.pcre.org/pub/pcre/pcre2-10.32.tar.gz"
     sha256: "9ca9be72e1a04f22be308323caa8c06ebd0c51efe99ee11278186cafbc4fe3af"
   "10.33":
-    url: "https://ftp.pcre.org/pub/pcre/pcre2-10.33.tar.gz"
+    url:
+      - "https://sourceforge.net/projects/pcre/files/pcre2/10.33/pcre2-10.33.tar.gz"
+      - "https://ftp.pcre.org/pub/pcre/pcre2-10.33.tar.gz"
     sha256: "e2e2899a97489fc6ad1b0cc3da7952c7cca991b4a0f7db6649b75d9721025d31"
   "10.35":
-    url: "https://ftp.pcre.org/pub/pcre/pcre2-10.35.tar.gz"
+    url:
+      - "https://sourceforge.net/projects/pcre/files/pcre2/10.35/pcre2-10.35.tar.gz"
+      - "https://ftp.pcre.org/pub/pcre/pcre2-10.35.tar.gz"
     sha256: "8fdcef8c8f4cd735169dd0225fd010487970c1bcadd49e9b90e26c7250a33dc9"
   "10.36":
-    url: "https://ftp.pcre.org/pub/pcre/pcre2-10.36.tar.gz"
+    url:
+      - "https://sourceforge.net/projects/pcre/files/pcre2/10.36/pcre2-10.36.tar.gz"
+      - "https://ftp.pcre.org/pub/pcre/pcre2-10.36.tar.gz"
     sha256: "b95ddb9414f91a967a887d69617059fb672b914f56fa3d613812c1ee8e8a1a37"
   "10.37":
-    url: "https://ftp.pcre.org/pub/pcre/pcre2-10.37.tar.gz"
+    url:
+      - "https://sourceforge.net/projects/pcre/files/pcre2/10.37/pcre2-10.37.tar.gz"
+      - "https://ftp.pcre.org/pub/pcre/pcre2-10.37.tar.gz"
     sha256: "04e214c0c40a97b8a5c2b4ae88a3aa8a93e6f2e45c6b3534ddac351f26548577"


### PR DESCRIPTION
The title says it all.