### PR TITLE
[farmhash] use cmake to build

### DIFF
--- a/recipes/farmhash/all/CMakeLists.txt
+++ b/recipes/farmhash/all/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.4)
+project(farmhash CXX)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+set(FARMHASH_SOURCE_DIR source_subfolder)
+
+# Transcribed from farmhash/src/Makefile.am
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles(
+  "int main(int argc, char* argv[]) { return (int)__builtin_expect(0, 0); }"
+  FARMHASH_HAS_BUILTIN_EXPECT
+)
+
+add_library(farmhash "${FARMHASH_SOURCE_DIR}/src/farmhash.cc" )
+target_include_directories(farmhash PRIVATE "${FARMHASH_SOURCE_DIR}/src")
+
+if(NOT FARMHASH_HAS_BUILTIN_EXPECT)
+  target_compile_definitions(farmhash PUBLIC -DFARMHASH_NO_BUILTIN_EXPECT)
+endif()
+
+set_target_properties(farmhash
+    PROPERTIES
+    PUBLIC_HEADER "${FARMHASH_SOURCE_DIR}/src/farmhash.h"
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+
+install (TARGETS ${PROJECT_NAME}
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    PUBLIC_HEADER DESTINATION include
+)

--- a/recipes/farmhash/all/conanfile.py
+++ b/recipes/farmhash/all/conanfile.py
@@ -1,8 +1,7 @@
-from conans import ConanFile, tools, AutoToolsBuildEnvironment
-from conans.errors import ConanInvalidConfiguration
-import os
+from conans import ConanFile, tools, CMake
 
 required_conan_version = ">=1.33.0"
+
 
 class farmhashConan(ConanFile):
     name = "farmhash"
@@ -12,31 +11,26 @@ class farmhashConan(ConanFile):
     homepage = "https://github.com/google/farmhash"
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "arch", "compiler", "build_type"
-
+    exports_sources = ["CMakeLists.txt"]
     options = {
         "shared": [True, False],
-        "fPIC": [True, False],
-        "no_builtin_expect": [True, False]
+        "fPIC": [True, False]
     }
     default_options = {
         "shared": False,
-        "fPIC": True,
-        "no_builtin_expect": False
+        "fPIC": True
     }
+    generators = "cmake"
 
-    _autotools = None
+    _cmake = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
     @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
-    def validate(self):
-        if self.settings.os == "Windows":
-            raise ConanInvalidConfiguration("This recipe does not support Windows currently.")
+    def _build_subfolder(self):
+        return "source_subfolder"
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -46,38 +40,25 @@ class farmhashConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
-    def build_requirements(self):
-        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires("msys2/cci.latest")
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True,
                   destination=self._source_subfolder)
 
-    def _configure_autotools(self):
-        if self._autotools:
-            return self._autotools
-        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        conf_args = []
-        if self.options.shared:
-            conf_args.extend(["--enable-shared", "--disable-static"])
-        else:
-            conf_args.extend(["--disable-shared", "--enable-static"])
-        if self.options.no_builtin_expect:
-            self._autotools.defines.append("FARMHASH_NO_BUILTIN_EXPECT")
-        self._autotools.configure(configure_dir=self._source_subfolder, args=conf_args)
-        return self._autotools
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
 
     def build(self):
-        autotools = self._configure_autotools()
-        autotools.make()
+        cmake = self._configure_cmake()
+        cmake.build()
 
     def package(self):
-        autotools = self._configure_autotools()
-        autotools.install()
+        cmake = self._configure_cmake()
+        cmake.install()
         self.copy("COPYING", src=self._source_subfolder, dst="licenses")
-        tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
-        tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.libs=["farmhash"]

--- a/recipes/farmhash/all/test_package/conanfile.py
+++ b/recipes/farmhash/all/test_package/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
+
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"


### PR DESCRIPTION
**farmhash/cci.20190513**

Build farmhash using CMake. Enables Windows support.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
