### PR TITLE
[poco] Add support for building POCO C++ Libraries release 1.11.1.

### DIFF
--- a/recipes/poco/all/conandata.yml
+++ b/recipes/poco/all/conandata.yml
@@ -17,6 +17,9 @@ sources:
   1.11.0:
     sha256: 8a7bfd0883ee95e223058edce8364c7d61026ac1882e29643822ce9b753f3602
     url: https://github.com/pocoproject/poco/archive/poco-1.11.0-release.tar.gz
+  1.11.1:
+    sha256: 2412a5819a239ff2ee58f81033bcc39c40460d7a8b330013a687c8c0bd2b4ac0
+    url: https://github.com/pocoproject/poco/archive/poco-1.11.1-release.tar.gz
 patches:
   1.8.1:
     - patch_file: patches/1.8.1.patch
@@ -41,6 +44,11 @@ patches:
       base_path: source_subfolder
   1.11.0:
     - patch_file: patches/1.11.0.patch
+      base_path: source_subfolder
+    - patch_file: patches/0002-mysql-include.patch
+      base_path: source_subfolder
+  1.11.1:
+    - patch_file: patches/1.11.1.patch
       base_path: source_subfolder
     - patch_file: patches/0002-mysql-include.patch
       base_path: source_subfolder

--- a/recipes/poco/all/patches/1.11.1.patch
+++ b/recipes/poco/all/patches/1.11.1.patch
@@ -1,0 +1,41 @@
+diff --git a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
+index 6b276be..81cb8b7 100644
+--- a/Foundation/CMakeLists.txt
++++ b/Foundation/CMakeLists.txt
+@@ -101,7 +101,7 @@ set_target_properties(Foundation
+ )
+ 
+ if(POCO_UNBUNDLED)
+-	target_link_libraries(Foundation PUBLIC Pcre::Pcre ZLIB::ZLIB)
++	target_link_libraries(Foundation PUBLIC PCRE::PCRE ZLIB::ZLIB)
+ 	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED)
+ endif(POCO_UNBUNDLED)
+ 
+diff --git a/NetSSL_Win/CMakeLists.txt b/NetSSL_Win/CMakeLists.txt
+index 3e2b5ff..2ab7590 100644
+--- a/NetSSL_Win/CMakeLists.txt
++++ b/NetSSL_Win/CMakeLists.txt
+@@ -21,7 +21,7 @@ set_target_properties(NetSSLWin
+ 	DEFINE_SYMBOL NetSSL_Win_EXPORTS
+ )
+ 
+-target_link_libraries(NetSSLWin PUBLIC Poco::Net Poco::Util Crypt32.lib)
++target_link_libraries(NetSSLWin PUBLIC Poco::Net Poco::Util crypt32 ws2_32)
+ target_include_directories(NetSSLWin
+ 	PUBLIC
+ 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+
+diff --git a/cmake/PocoMacros.cmake b/cmake/PocoMacros.cmake
+index 038779ec9..fa7afdb1b 100644
+--- a/cmake/PocoMacros.cmake
++++ b/cmake/PocoMacros.cmake
+@@ -40,7 +40,7 @@ if(WIN32)
+ 			endforeach()
+ 		endif(X64)
+ 	endif()
+-	find_program(CMAKE_MC_COMPILER mc.exe HINTS "${sdk_bindir}" "${kit_bindir}" "${kit81_bindir}" ${kit10_bindir}
++	find_program(CMAKE_MC_COMPILER NAMES mc.exe windmc.exe HINTS "${sdk_bindir}" "${kit_bindir}" "${kit81_bindir}" ${kit10_bindir}
+ 		DOC "path to message compiler")
+ 	if(NOT CMAKE_MC_COMPILER)
+ 		message(FATAL_ERROR "message compiler not found: required to build")
+ 

--- a/recipes/poco/config.yml
+++ b/recipes/poco/config.yml
@@ -1,4 +1,6 @@
 versions:
+  1.11.1:
+    folder: all
   1.11.0:
     folder: all
   1.10.1:


### PR DESCRIPTION
Specify library name and version:  poco/1.11.1

This upgrades the existing recipe to support the latest POCO C++ Libraries 1.11.1 release.
