### PR TITLE
For NDK/r22, correct LD environment variable.

### DIFF
--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -326,4 +326,3 @@ def unzip_fix_symlinks(url, target_folder, sha256):
                     shutil.copy2(target, full_name)
 
     os.unlink(filename)
-

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -161,11 +161,11 @@ class AndroidNDKConan(ConanFile):
             cmake_system_processor = "armv5te"
         return cmake_system_processor
 
-    def _define_tool_var(self, name, value, bare = False, skip_check=False):
+    def _define_tool_var(self, name, value, bare = False):
         ndk_bin = os.path.join(self._ndk_root, "bin")
         path = os.path.join(ndk_bin, self._tool_name(value, bare))
-        if not skip_check and not os.path.isfile(path):
-            raise ConanException(f"'Environment variable {name} has no direct target: '{path}'")
+        if not os.path.isfile(path):
+            raise ConanException(f"'Environment variable {name} could not be created: '{path}'")
         self.output.info(f"Creating {name} environment variable: {path}")
         return path
 
@@ -173,7 +173,7 @@ class AndroidNDKConan(ConanFile):
         ndk_bin = os.path.join(self._ndk_root, "bin")
         path = os.path.join(ndk_bin, value)
         if not os.path.isfile(path):
-            raise ConanException(f"'Environment variable {name} has no direct target: '{path}'")
+            raise ConanException(f"'Environment variable {name} could not be created: '{path}'")
         self.output.info(f"Creating {name} environment variable: {path}")
         return path
 
@@ -263,7 +263,9 @@ class AndroidNDKConan(ConanFile):
             self.env_info.READELF = self._define_tool_var("READELF", "readelf", True)
             # there doesn't seem to be an 'elfedit' included anymore.
         else:
-            self.env_info.LD = self._define_tool_var("LD", "ld", skip_check=True)
+            # don't define LD to $prefix-ld/$prefix-ld.gold/$prefix-bfd.
+            # Build scripts should use the compiler (CC/CXX) as frontend.
+            # self.env_info.LD = self._define_tool_var("LD", "ld")
             self.env_info.AR = self._define_tool_var("AR", "ar")
             self.env_info.AS = self._define_tool_var("AS", "as")
             self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib")
@@ -322,3 +324,4 @@ def unzip_fix_symlinks(url, target_folder, sha256):
                     shutil.copy2(target, full_name)
 
     os.unlink(filename)
+

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -263,9 +263,11 @@ class AndroidNDKConan(ConanFile):
             self.env_info.READELF = self._define_tool_var("READELF", "readelf", True)
             # there doesn't seem to be an 'elfedit' included anymore.
         else:
-            # Don't define LD to $prefix-ld/$prefix-ld.gold/$prefix-bfd:
-            # build scripts should use the compiler (CC/CXX) as frontend.
-            # self.env_info.LD = self._define_tool_var("LD", "ld")
+            if tools.Version(self._ndk_version) >= 22:
+                # Special handling for LD in r22 required: ld has no prefix
+                self.env_info.LD = self._define_tool_var_naked("LD", "ld")
+            else:
+                self.env_info.LD = self._define_tool_var("LD", "ld")
             self.env_info.AR = self._define_tool_var("AR", "ar")
             self.env_info.AS = self._define_tool_var("AS", "as")
             self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib")

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -263,8 +263,8 @@ class AndroidNDKConan(ConanFile):
             self.env_info.READELF = self._define_tool_var("READELF", "readelf", True)
             # there doesn't seem to be an 'elfedit' included anymore.
         else:
-            # don't define LD to $prefix-ld/$prefix-ld.gold/$prefix-bfd.
-            # Build scripts should use the compiler (CC/CXX) as frontend.
+            # Don't define LD to $prefix-ld/$prefix-ld.gold/$prefix-bfd:
+            # build scripts should use the compiler (CC/CXX) as frontend.
             # self.env_info.LD = self._define_tool_var("LD", "ld")
             self.env_info.AR = self._define_tool_var("AR", "ar")
             self.env_info.AS = self._define_tool_var("AS", "as")

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -161,11 +161,11 @@ class AndroidNDKConan(ConanFile):
             cmake_system_processor = "armv5te"
         return cmake_system_processor
 
-    def _define_tool_var(self, name, value, bare = False):
+    def _define_tool_var(self, name, value, bare = False, skip_check=False):
         ndk_bin = os.path.join(self._ndk_root, "bin")
         path = os.path.join(ndk_bin, self._tool_name(value, bare))
-        if not os.path.isfile(path):
-            raise ConanException(f"'Environment variable {name} could not be created: '{path}'")
+        if not skip_check and not os.path.isfile(path):
+            raise ConanException(f"'Environment variable {name} has no direct target: '{path}'")
         self.output.info(f"Creating {name} environment variable: {path}")
         return path
 
@@ -173,7 +173,7 @@ class AndroidNDKConan(ConanFile):
         ndk_bin = os.path.join(self._ndk_root, "bin")
         path = os.path.join(ndk_bin, value)
         if not os.path.isfile(path):
-            raise ConanException(f"'Environment variable {name} could not be created: '{path}'")
+            raise ConanException(f"'Environment variable {name} has no direct target: '{path}'")
         self.output.info(f"Creating {name} environment variable: {path}")
         return path
 
@@ -263,7 +263,7 @@ class AndroidNDKConan(ConanFile):
             self.env_info.READELF = self._define_tool_var("READELF", "readelf", True)
             # there doesn't seem to be an 'elfedit' included anymore.
         else:
-            self.env_info.LD = self._define_tool_var("LD", "ld")
+            self.env_info.LD = self._define_tool_var("LD", "ld", skip_check=True)
             self.env_info.AR = self._define_tool_var("AR", "ar")
             self.env_info.AS = self._define_tool_var("AS", "as")
             self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib")


### PR DESCRIPTION
Specify library name and version:  **android_ndk/r22**

Try to fix #7953 by relaxing the checks, but only for the `LD` variable. As far as I have seen, there is no direct executable in the previous recipe revision at this location for r22 too. I guess the correct tool is located at runtime with the additonal option `-fuse-ld=gold` respectively with an appropriate default.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
