### PR TITLE
uwebsockets: add version 20.8.0 with some options

### DIFF
--- a/recipes/uwebsockets/all/conandata.yml
+++ b/recipes/uwebsockets/all/conandata.yml
@@ -8,7 +8,9 @@ sources:
   "19.2.0":
     url: "https://github.com/uNetworking/uWebSockets/archive/v19.2.0.tar.gz"
     sha256: "2956075293090754bc2431c53634f93a1e74739c61392be6040cb3ed29430ec2"
-
   "19.3.0":
     url: "https://github.com/uNetworking/uWebSockets/archive/v19.3.0.tar.gz"
     sha256: "6f709b4e5fe053a94a952da93c07c919b36bcb8c838c69067560ae85f97c5621"
+  "20.8.0":
+    url: "https://github.com/uNetworking/uWebSockets/archive/v20.8.0.tar.gz"
+    sha256: "6ab4bc0207f44eacbb9c82fd0dc59a49ef84e13698ccdbfb44b92c6a0eaa951a"

--- a/recipes/uwebsockets/all/conanfile.py
+++ b/recipes/uwebsockets/all/conanfile.py
@@ -27,6 +27,11 @@ class UwebsocketsConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    def config_options(self):
+        # libdeflate is not supported before 19.0.0
+        if tools.Version(self.version) < "19.0.0":
+            del self.options.with_libdeflate
+
     def configure(self):
         minimal_cpp_standard = "17"
         if self.settings.compiler.cppstd:
@@ -58,14 +63,10 @@ class UwebsocketsConan(ConanFile):
                 % (self.name, minimal_cpp_standard)
             )
 
-        # libdeflate is not supported before 19.0.0
-        if tools.Version(self.version) < "19.0.0":
-            self.options.with_libdeflate = False
-
     def requirements(self):
         if self.options.with_zlib:
             self.requires("zlib/1.2.11")
-        if self.options.with_libdeflate:
+        if self.options.get_safe("with_libdeflate", False):
             self.requires("libdeflate/1.8")
 
         if tools.Version(self.version) >= "19.0.0":
@@ -92,13 +93,13 @@ class UwebsocketsConan(ConanFile):
         )
 
     def package_id(self):
-        self.info.header_only()
+        self.settings.clear()
 
     def package_info(self):
         self.cpp_info.includedirs.append(os.path.join("include", "uWebSockets"))
         if not self.options.with_zlib:
             self.cpp_info.defines.append("UWS_NO_ZLIB")
-        if self.options.with_libdeflate:
+        if self.options.get_safe("with_libdeflate", False):
             self.cpp_info.defines.append("UWS_USE_LIBDEFLATE")
         self.cpp_info.filenames["cmake_find_package"] = "uwebsockets"
         self.cpp_info.filenames["cmake_find_package_multi"] = "uwebsockets"

--- a/recipes/uwebsockets/all/conanfile.py
+++ b/recipes/uwebsockets/all/conanfile.py
@@ -3,6 +3,7 @@ import os
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.33.0"
 
 class UwebsocketsConan(ConanFile):
     name = "uwebsockets"
@@ -10,9 +11,17 @@ class UwebsocketsConan(ConanFile):
     description = "Simple, secure & standards compliant web server for the most demanding of applications"
     license = "Apache-2.0"
     homepage = "https://github.com/uNetworking/uWebSockets"
-    topics = ("conan", "websocket", "network")
+    topics = ("websocket", "network", "server", )
     settings = "compiler"
     no_copy_source = True
+    options = {
+        "with_zlib": [True, False,],
+        "with_libdeflate": [True, False,],
+    }
+    default_options = {
+        "with_zlib": True,
+        "with_libdeflate": False,
+    }
 
     @property
     def _source_subfolder(self):
@@ -49,17 +58,23 @@ class UwebsocketsConan(ConanFile):
                 % (self.name, minimal_cpp_standard)
             )
 
+        # libdeflate is not supported before 19.0.0
+        if tools.Version(self.version) < "19.0.0":
+            self.options.with_libdeflate = False
+
     def requirements(self):
-        self.requires("zlib/1.2.11")
+        if self.options.with_zlib:
+            self.requires("zlib/1.2.11")
+        if self.options.with_libdeflate:
+            self.requires("libdeflate/1.8")
 
         if tools.Version(self.version) >= "19.0.0":
-            self.requires("usockets/0.7.1")
+            self.requires("usockets/0.8.1")
         else:
             self.requires("usockets/0.4.0")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("uWebSockets-%s" % self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
@@ -81,3 +96,9 @@ class UwebsocketsConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.includedirs.append(os.path.join("include", "uWebSockets"))
+        if not self.options.with_zlib:
+            self.cpp_info.defines.append("UWS_NO_ZLIB")
+        if self.options.with_libdeflate:
+            self.cpp_info.defines.append("UWS_USE_LIBDEFLATE")
+        self.cpp_info.filenames["cmake_find_package"] = "uwebsockets"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "uwebsockets"

--- a/recipes/uwebsockets/all/test_package/CMakeLists.txt
+++ b/recipes/uwebsockets/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(uwebsockets CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} uwebsockets::uwebsockets)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/recipes/uwebsockets/all/test_package/conanfile.py
+++ b/recipes/uwebsockets/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/uwebsockets/config.yml
+++ b/recipes/uwebsockets/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "19.3.0":
     folder: all
+  "20.8.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **uwebsockets/all**

add following options:
- with_zlib (in current recipe, no way to disable zlib)
- with_deflate (supported since 19.0.0)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
