### PR TITLE
spirv-cross: add cci.20210823 + modernize

### DIFF
--- a/recipes/spirv-cross/all/conandata.yml
+++ b/recipes/spirv-cross/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20210823":
+    url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/0e2880ab990e79ce6cc8c79c219feda42d98b1e8.tar.gz"
+    sha256: "611cf4d30d88c48a4a04848a66ae4c5d3a63ccf965fd6017d9ea86ec5c7a088d"
   "cci.20210621":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/9cdeefb5e322fc26b5fed70795fe79725648df1f.tar.gz"
     sha256: "3742c24e7ccc09fce10e9d88c2f9a2e85f5142cc742be6df5cc3ba3f96defa92"

--- a/recipes/spirv-cross/config.yml
+++ b/recipes/spirv-cross/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20210823":
+    folder: all
   "cci.20210621":
     folder: all
   "20210115":


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

spirv-cross commit compatible with MoltenVK 1.1.5 (Vulkan 1.2.189): https://github.com/KhronosGroup/MoltenVK/blob/v1.1.5/ExternalRevisions/SPIRV-Cross_repo_revision

patch for BUNDLE DESTINATION no longer required (fixed upstream)

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
