### PR TITLE
openssl: change os.rename to tools.rename

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -217,7 +217,7 @@ class OpenSSLConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
         extracted_folder = "openssl-" + self.version
-        os.rename(extracted_folder, self._source_subfolder)
+        tools.rename(extracted_folder, self._source_subfolder)
 
     def configure(self):
         if self.options.shared:
@@ -795,8 +795,8 @@ class OpenSSLConan(ConanFile):
         if self._use_nmake:
             if self.settings.build_type == 'Debug' and self._full_version >= "1.1.0":
                 with tools.chdir(os.path.join(self.package_folder, 'lib')):
-                    os.rename('libssl.lib', 'libssld.lib')
-                    os.rename('libcrypto.lib', 'libcryptod.lib')
+                    tools.rename('libssl.lib', 'libssld.lib')
+                    tools.rename('libcrypto.lib', 'libcryptod.lib')
         # Old OpenSSL version family has issues with permissions.
         # See https://github.com/conan-io/conan/issues/5831
         if self._full_version < "1.1.0" and self.options.shared and self.settings.os in ("Android", "FreeBSD", "Linux"):


### PR DESCRIPTION
avoiding "PermissionError: [WinError 5] Access denie" under Windows.

Specify library name and version:  **openssl/1.1.1**

[related issue](https://github.com/conan-io/conan/issues/6560)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
