### PR TITLE
avir: add recipe

### DIFF
--- a/recipes/avir/all/conandata.yml
+++ b/recipes/avir/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.0":
+    url: "https://github.com/avaneev/avir/archive/refs/tags/3.0.tar.gz"
+    sha256: "011909d31cf782152a69f570563eb70700504f168174a6049b6acbb9b9f511ea"

--- a/recipes/avir/all/conanfile.py
+++ b/recipes/avir/all/conanfile.py
@@ -1,0 +1,35 @@
+import os
+
+from conans.errors import ConanInvalidConfiguration
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.33.0"
+
+class AVIRConan(ConanFile):
+    name = "avir"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "High-quality pro image resizing / scaling C++ library, image resize"
+    topics = ("image-processing", "image-resizer", "lanczos", )
+    homepage = "https://github.com/avaneev/avir"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi", "cmake_find_package"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy("*.h", dst="include", src=self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "avir"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "avir"

--- a/recipes/avir/all/conanfile.py
+++ b/recipes/avir/all/conanfile.py
@@ -12,8 +12,6 @@ class AVIRConan(ConanFile):
     description = "High-quality pro image resizing / scaling C++ library, image resize"
     topics = ("image-processing", "image-resizer", "lanczos", )
     homepage = "https://github.com/avaneev/avir"
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi", "cmake_find_package"
     no_copy_source = True
 
     @property

--- a/recipes/avir/all/test_package/CMakeLists.txt
+++ b/recipes/avir/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(avir CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} avir::avir)

--- a/recipes/avir/all/test_package/conanfile.py
+++ b/recipes/avir/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class AVIRTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/avir/all/test_package/test_package.cpp
+++ b/recipes/avir/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include "avir.h"
+
+int main() {
+    avir::CImageResizer<> ImageResizer(8);
+
+    return 0;
+}
+

--- a/recipes/avir/config.yml
+++ b/recipes/avir/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **avir/3.0**

avir is header only library for image resizing.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
