### PR TITLE
aws-c-io:fix Package [s2n] require not used in components requires

### DIFF
--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -79,5 +79,5 @@ class AwsCIO(ConanFile):
             self.cpp_info.components["aws-c-io-lib"].frameworks.append("Security")
         if self.settings.os == "Windows":
             self.cpp_info.components["aws-c-io-lib"].system_libs = ["crypt32", "secur32", "shlwapi"]
-        if self.settings.os in ["Linux", "FreeBSD"]:
+        if self.settings.os in ["Linux", "FreeBSD", "Android"]:
             self.cpp_info.components["aws-c-io-lib"].requires.append("s2n::s2n-lib")


### PR DESCRIPTION
The last commit introduced s2n under Android ( line 43), While not set it as components under Android.

Specify library name and version: aws-c-io/0.10.9


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
