### PR TITLE
pcapplusplus: add version 21.11

### DIFF
--- a/recipes/pcapplusplus/all/conandata.yml
+++ b/recipes/pcapplusplus/all/conandata.yml
@@ -2,7 +2,13 @@ sources:
   "21.05":
     url: "https://github.com/seladb/PcapPlusPlus/archive/v21.05.tar.gz"
     sha256: "f7bc2caea72544f42e3547c8acf65fca07ddd4cd45f7be2f5132dd1826ea27bb"
+  "21.11":
+    url: "https://github.com/seladb/PcapPlusPlus/archive/v21.11.tar.gz"
+    sha256: "56b8566b14b2586b8afc358e7c98268bc1dd6192197b29a3917b9df2120c51b0"
 patches:
   "21.05":
+    - patch_file: "patches/0001-Pass-CXXFLAGS-CPPFLAGS-when-compiling-3rd-party-sour.patch"
+      base_path: "source_subfolder"
+  "21.11":
     - patch_file: "patches/0001-Pass-CXXFLAGS-CPPFLAGS-when-compiling-3rd-party-sour.patch"
       base_path: "source_subfolder"

--- a/recipes/pcapplusplus/config.yml
+++ b/recipes/pcapplusplus/config.yml
@@ -1,3 +1,5 @@
 versions:
   "21.05":
     folder: all
+  "21.11":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **pcapplusplus/21.11**

Bump PcapPlusPlus to v21.11. I'm the author of this library.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
