### PR TITLE
Add support for the latest release of the ICU library, 70.1

### DIFF
--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "69.1":
     url: "https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-src.tgz"
     sha256: "4cba7b7acd1d3c42c44bb0c14be6637098c7faf2b330ce876bc5f3b915d09745"
+  "70.1":
+    url: "https://github.com/unicode-org/icu/releases/download/release-70-1/icu4c-70_1-src.tgz"
+    sha256: "8d205428c17bf13bb535300669ed28b338a157b1c01ae66d31d0d3e2d47c3fd5"
 patches:
   "67.1":
     - patch_file: "patches/6aba9344a18f4f32e8070ee53b79495630901c26.patch"
@@ -33,5 +36,8 @@ patches:
     - patch_file: "patches/0001-67.1-fix-mingw.patch"
       base_path: "source_subfolder"
   "69.1":
+    - patch_file: "patches/0001-69.1-fix-mingw.patch"
+      base_path: "source_subfolder"
+  "70.1":
     - patch_file: "patches/0001-69.1-fix-mingw.patch"
       base_path: "source_subfolder"

--- a/recipes/icu/config.yml
+++ b/recipes/icu/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "69.1":
     folder: all
+  "70.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **icu/70.1**

Update the ICU recipe to support the latest release, ICU 70 released on October 27, 2021.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
