### PR TITLE
csvmonkey: add recipe

### DIFF
--- a/recipes/csvmonkey/all/conandata.yml
+++ b/recipes/csvmonkey/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.5":
+    url: "https://github.com/dw/csvmonkey/archive/594ad9854b7a77ccb8e26260b1e1a4300ba18465.tar.gz"
+    sha256: "89db5c3cdee4e6d59945edbca054695d9ee2d1150c92a26282c0e35f041729ac"

--- a/recipes/csvmonkey/all/conanfile.py
+++ b/recipes/csvmonkey/all/conanfile.py
@@ -10,7 +10,7 @@ class CSVMONEKYConan(ConanFile):
     license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
     description = "Header-only vectorized, lazy-decoding, zero-copy CSV file parser "
-    topics = ("csv parser", "header only", "vectorized")
+    topics = ("csv-parser", "header-only", "vectorized")
     homepage = "https://github.com/dw/csvmonkey/"
     settings = "arch", "compiler"
     no_copy_source = True

--- a/recipes/csvmonkey/all/conanfile.py
+++ b/recipes/csvmonkey/all/conanfile.py
@@ -12,7 +12,7 @@ class CSVMONEKYConan(ConanFile):
     description = "Header-only vectorized, lazy-decoding, zero-copy CSV file parser "
     topics = ("csv parser", "header only", "vectorized")
     homepage = "https://github.com/dw/csvmonkey/"
-    settings = "arch"
+    settings = "arch", "compiler"
     no_copy_source = True
 
     @property
@@ -37,4 +37,8 @@ class CSVMONEKYConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "csvmonkey")
         self.cpp_info.set_property("cmake_target_name", "csvmonkey")
         self.cpp_info.set_property("pkg_config_name", "csvmonkey")
-        self.cpp_info.cxxflags.append("-msse4.2")
+
+        if self.settings.compiler == "Visual Studio":
+            self.cpp_info.cxxflags.append("/arch:AVX")
+        else:
+            self.cpp_info.cxxflags.append("-msse4.2")

--- a/recipes/csvmonkey/all/conanfile.py
+++ b/recipes/csvmonkey/all/conanfile.py
@@ -14,6 +14,8 @@ class CSVMONEKYConan(ConanFile):
     homepage = "https://github.com/dw/csvmonkey/"
     settings = "arch", "compiler"
     no_copy_source = True
+    options = {"with_spirit": [True, False]}
+    default_options = {"with_spirit": False}
 
     @property
     def _source_subfolder(self):
@@ -26,6 +28,10 @@ class CSVMONEKYConan(ConanFile):
         if self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration("{} doesn't support Visual Studio C++.".format(self.name))
 
+    def requirements(self):
+        if self.options.with_spirit:
+            self.requires("boost/1.77.0")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
@@ -34,10 +40,11 @@ class CSVMONEKYConan(ConanFile):
         self.copy("*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
     def package_id(self):
-        self.info.header_only()
+        self.info.settings.clear()
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "csvmonkey")
         self.cpp_info.set_property("cmake_target_name", "csvmonkey")
         self.cpp_info.set_property("pkg_config_name", "csvmonkey")
+        if self.options.with_spirit:
             self.cpp_info.defines.append("USE_SPIRIT")

--- a/recipes/csvmonkey/all/conanfile.py
+++ b/recipes/csvmonkey/all/conanfile.py
@@ -23,6 +23,9 @@ class CSVMONEKYConan(ConanFile):
         if self.settings.arch not in ("x86", "x86_64",):
             raise ConanInvalidConfiguration("{} requires x86 architecture.".format(self.name))
 
+        if self.settings.compiler == "Visual Studio":
+            raise ConanInvalidConfiguration("{} doesn't support Visual Studio C++.".format(self.name))
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 

--- a/recipes/csvmonkey/all/conanfile.py
+++ b/recipes/csvmonkey/all/conanfile.py
@@ -40,7 +40,7 @@ class CSVMONEKYConan(ConanFile):
         self.copy("*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
     def package_id(self):
-        self.info.settings.clear()
+        self.info.header_only()
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "csvmonkey")

--- a/recipes/csvmonkey/all/conanfile.py
+++ b/recipes/csvmonkey/all/conanfile.py
@@ -40,8 +40,4 @@ class CSVMONEKYConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "csvmonkey")
         self.cpp_info.set_property("cmake_target_name", "csvmonkey")
         self.cpp_info.set_property("pkg_config_name", "csvmonkey")
-
-        if self.settings.compiler == "Visual Studio":
-            self.cpp_info.cxxflags.append("/arch:AVX")
-        else:
-            self.cpp_info.cxxflags.append("-msse4.2")
+            self.cpp_info.defines.append("USE_SPIRIT")

--- a/recipes/csvmonkey/all/conanfile.py
+++ b/recipes/csvmonkey/all/conanfile.py
@@ -1,0 +1,40 @@
+import os
+
+from conans.errors import ConanInvalidConfiguration
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.36.0"
+
+class CSVMONEKYConan(ConanFile):
+    name = "csvmonkey"
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "Header-only vectorized, lazy-decoding, zero-copy CSV file parser "
+    topics = ("csv parser", "header only", "vectorized")
+    homepage = "https://github.com/dw/csvmonkey/"
+    settings = "arch"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def validate(self):
+        if self.settings.arch not in ("x86", "x86_64",):
+            raise ConanInvalidConfiguration("{} requires x86 architecture.".format(self.name))
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy("LICENSE*", "licenses", self._source_subfolder)
+        self.copy("*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "csvmonkey")
+        self.cpp_info.set_property("cmake_target_name", "csvmonkey")
+        self.cpp_info.set_property("pkg_config_name", "csvmonkey")
+        self.cpp_info.cxxflags.append("-msse4.2")

--- a/recipes/csvmonkey/all/test_package/CMakeLists.txt
+++ b/recipes/csvmonkey/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(csvmonkey CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} csvmonkey::csvmonkey)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/csvmonkey/all/test_package/conanfile.py
+++ b/recipes/csvmonkey/all/test_package/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conans import ConanFile, CMake, tools
 
 class CSVMonkeyTestConan(ConanFile):
-    settings = "build_type"
+    settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):

--- a/recipes/csvmonkey/all/test_package/conanfile.py
+++ b/recipes/csvmonkey/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class CSVMonkeyTestConan(ConanFile):
+    settings = "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/csvmonkey/all/test_package/test_package.cpp
+++ b/recipes/csvmonkey/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include "csvmonkey.hpp"
+
+int main() {
+    csvmonkey::MappedFileCursor stream{};
+
+    return 0;
+}

--- a/recipes/csvmonkey/config.yml
+++ b/recipes/csvmonkey/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.0.5":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **csvmonkey/0.0.5**

csvmonkey is header only csv parser on x86, x86_64 architecture.

csvmonkey doesn't use git tag for release.
csvmonkey uses version of setup.py in root folder.
sources of recipe is archive url with commit id.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
