### PR TITLE
[tensorflow-lite] support non-intel architectures

### DIFF
--- a/recipes/tensorflow-lite/all/conandata.yml
+++ b/recipes/tensorflow-lite/all/conandata.yml
@@ -8,3 +8,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/link_targets.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/non_x86_support.patch"
+      base_path: "source_subfolder"

--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -109,7 +109,8 @@ class TensorflowLiteConan(ConanFile):
         self.requires("fft/cci.20061228")
         self.requires("flatbuffers/2.0.0")
         self.requires("gemmlowp/cci.20210928")
-        self.requires("intel-neon2sse/cci.20210225")
+        if self.settings.arch in ("x86", "x86_64"):
+            self.requires("intel-neon2sse/cci.20210225")
         self.requires("ruy/cci.20210622")
         if self.options.with_xnnpack:
             self.requires("xnnpack/cci.20211026")
@@ -133,6 +134,9 @@ class TensorflowLiteConan(ConanFile):
             "TFLITE_ENABLE_XNNPACK": self.options.with_xnnpack,
             "TFLITE_ENABLE_MMAP": self.options.get_safe("with_mmap", False)
         })
+        if self.settings.arch == "armv8":
+            # Not defined by Conan for Apple Silicon. See https://github.com/conan-io/conan/pull/8026
+            self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = "arm64"
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 

--- a/recipes/tensorflow-lite/all/patches/non_x86_support.patch
+++ b/recipes/tensorflow-lite/all/patches/non_x86_support.patch
@@ -1,0 +1,31 @@
+diff --git a/tensorflow/lite/CMakeLists.txt b/tensorflow/lite/CMakeLists.txt
+index e135b08a0b..c2605f9075 100644
+--- a/tensorflow/lite/CMakeLists.txt
++++ b/tensorflow/lite/CMakeLists.txt
+@@ -124,7 +124,6 @@ find_package(farmhash REQUIRED)
+ find_package(fft REQUIRED)
+ find_package(Flatbuffers REQUIRED)
+ find_package(gemmlowp REQUIRED)
+-find_package(NEON_2_SSE REQUIRED)
+ find_package(ruy REQUIRED)
+ # Generate TensorFlow Lite FlatBuffer code.
+ # We used to have an actual compilation logic with flatc but decided to use
+@@ -141,6 +140,10 @@ set(TFLITE_TARGET_PUBLIC_OPTIONS "")
+ set(TFLITE_TARGET_PRIVATE_OPTIONS "")
+ # Additional library dependencies based upon enabled features.
+ set(TFLITE_TARGET_DEPENDENCIES "")
++if (NOT CMAKE_SYSTEM_PROCESSOR OR CMAKE_SYSTEM_PROCESSOR MATCHES "x86")
++	find_package(NEON_2_SSE REQUIRED)
++	list(APPEND TFLITE_TARGET_DEPENDENCIES NEON_2_SSE::NEON_2_SSE)
++endif()
+ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+   # TFLite uses deprecated methods in neon2sse which generates a huge number of
+   # warnings so surpress these until they're fixed.
+@@ -412,7 +415,6 @@ target_include_directories(tensorflow-lite
+ target_link_libraries(tensorflow-lite
+   PUBLIC
+     Eigen3::Eigen
+-    NEON_2_SSE::NEON_2_SSE
+     absl::flags
+     absl::hash
+     absl::status


### PR DESCRIPTION
Specify library name and version:  **tensorflow-lite/2.6.0**

Adds support for non-intel architectures

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
