### PR TITLE
add spirv-cross/cci.20210930

### DIFF
--- a/recipes/spirv-cross/all/conandata.yml
+++ b/recipes/spirv-cross/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "cci.20210930":
-    url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/97a438d214b24e4958ca137a18639670648cedd0.zip"
-    sha256: "34d789f8a78eb4cadaecaa032c515f11cf48f3eab09a6bad641660c236a2f350"
+    url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/97a438d214b24e4958ca137a18639670648cedd0.tar.gz"
+    sha256: "dd07ce3c261fe8c08dbfbb3dd274f35de50ea8610f57fe5de4fe2b782c4accbd"
   "cci.20210823":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/0e2880ab990e79ce6cc8c79c219feda42d98b1e8.tar.gz"
     sha256: "611cf4d30d88c48a4a04848a66ae4c5d3a63ccf965fd6017d9ea86ec5c7a088d"

--- a/recipes/spirv-cross/all/conandata.yml
+++ b/recipes/spirv-cross/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20210930":
+    url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/97a438d214b24e4958ca137a18639670648cedd0.zip"
+    sha256: "34d789f8a78eb4cadaecaa032c515f11cf48f3eab09a6bad641660c236a2f350"
   "cci.20210823":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/0e2880ab990e79ce6cc8c79c219feda42d98b1e8.tar.gz"
     sha256: "611cf4d30d88c48a4a04848a66ae4c5d3a63ccf965fd6017d9ea86ec5c7a088d"

--- a/recipes/spirv-cross/config.yml
+++ b/recipes/spirv-cross/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20210930":
+    folder: all
   "cci.20210823":
     folder: all
   "cci.20210621":


### PR DESCRIPTION
Specify library name and version:  **spirv-cross/cci.20210930**

version bump.
I need specifically this version for https://github.com/conan-io/conan-center-index/pull/7804

also relates to https://github.com/conan-io/conan-center-index/pull/7978
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
