### PR TITLE
add recipe for uchardet

### DIFF
--- a/recipes/uchardet/all/CMakeLists.txt
+++ b/recipes/uchardet/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include("conanbuildinfo.cmake")
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/uchardet/all/conandata.yml
+++ b/recipes/uchardet/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.7":
+    sha1: de19b7e614f11572582a0d47f7d5d6f8ec649199
+    url: https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.7.tar.xz

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -55,7 +55,6 @@ class UchardetConan(ConanFile):
         return self._cmake
 
     def build(self):
-        self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -1,0 +1,74 @@
+from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class UchardetConan(ConanFile):
+    name = "uchardet"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/freedesktop/uchardet"
+    description = "uchardet is an encoding detector library, which takes a sequence of bytes in an unknown character encoding and attempts to determine the encoding of the text. Returned encoding names are iconv-compatible."
+    topics = ("conan", "encoding", "detector")
+    license = "MPL 1.1"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "check_sse2": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "check_sse2": True,
+    }
+
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake", "cmake_find_package"
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
+        self._cmake.definitions["CHECK_SSE2"] = self.options.check_sse2
+        self._cmake.definitions["BUILD_BINARY"] = False
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        self._patch_sources()
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "uchardet"
+        self.cpp_info.names["cmake_find_package_multi"] = "uchardet"
+        self.cpp_info.names["pkgconfig"] = "libuchardet"
+        postfix = "d" if self.settings.build_type == "Debug" else ""
+        self.cpp_info.libs = ["uchardet" + postfix]

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -9,7 +9,7 @@ class UchardetConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/freedesktop/uchardet"
     description = "uchardet is an encoding detector library, which takes a sequence of bytes in an unknown character encoding and attempts to determine the encoding of the text. Returned encoding names are iconv-compatible."
-    topics = ("conan", "encoding", "detector")
+    topics = ("encoding", "detector")
     license = "MPL 1.1"
 
     settings = "os", "arch", "compiler", "build_type"

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -50,8 +50,8 @@ class UchardetConan(ConanFile):
 
     def _patch_sources(self):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              "${CMAKE_BINARY_DIR}/uchardet.pc",
-                              "${CMAKE_CURRENT_BINARY_DIR}/uchardet.pc")
+            "${CMAKE_BINARY_DIR}",
+            "${CMAKE_CURRENT_BINARY_DIR}")
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -69,7 +69,7 @@ class UchardetConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-        self._cmake.definitions["CHECK_SSE2"] = self.options.check_sse2
+        self._cmake.definitions["CHECK_SSE2"] = self.options.get_safe("check_sse2", False)
         self._cmake.definitions["BUILD_BINARY"] = False
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -72,8 +72,8 @@ class UchardetConan(ConanFile):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "uchardet"

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -10,7 +10,7 @@ class UchardetConan(ConanFile):
     homepage = "https://github.com/freedesktop/uchardet"
     description = "uchardet is an encoding detector library, which takes a sequence of bytes in an unknown character encoding and attempts to determine the encoding of the text. Returned encoding names are iconv-compatible."
     topics = "encoding", "detector"
-    license = "MPL 1.1"
+    license = "MPL-1.1"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -37,6 +37,8 @@ class UchardetConan(ConanFile):
         return "build_subfolder"
 
     def config_options(self):
+        if self.settings.arch not in ("x86", "x86_64"):
+            del self.options.check_sse2
         if self.settings.os == "Windows":
             del self.options.fPIC
 

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -71,6 +71,7 @@ class UchardetConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["CHECK_SSE2"] = self.options.get_safe("check_sse2", False)
         self._cmake.definitions["BUILD_BINARY"] = False
+        self._cmake.definitions["BUILD_STATIC"] = False  # disable building static libraries when self.options.shared is True
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -52,6 +52,9 @@ class UchardetConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
             "${CMAKE_BINARY_DIR}",
             "${CMAKE_CURRENT_BINARY_DIR}")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            'string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} TARGET_ARCHITECTURE)',
+            'string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" TARGET_ARCHITECTURE)')
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -79,5 +79,4 @@ class UchardetConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "uchardet"
         self.cpp_info.names["cmake_find_package_multi"] = "uchardet"
         self.cpp_info.names["pkgconfig"] = "libuchardet"
-        postfix = "d" if self.settings.build_type == "Debug" else ""
-        self.cpp_info.libs = ["uchardet" + postfix]
+        self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -90,4 +90,6 @@ class UchardetConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "uchardet"
         self.cpp_info.names["cmake_find_package_multi"] = "uchardet"
         self.cpp_info.names["pkgconfig"] = "libuchardet"
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = ["uchardet"]
+        if self.options.shared:
+            self.cpp_info.defines.append("UCHARDET_SHARED")

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -67,7 +67,6 @@ class UchardetConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-        self._cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
         self._cmake.definitions["CHECK_SSE2"] = self.options.check_sse2
         self._cmake.definitions["BUILD_BINARY"] = False
         self._cmake.configure(build_folder=self._build_subfolder)

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -9,7 +9,7 @@ class UchardetConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/freedesktop/uchardet"
     description = "uchardet is an encoding detector library, which takes a sequence of bytes in an unknown character encoding and attempts to determine the encoding of the text. Returned encoding names are iconv-compatible."
-    topics = ("encoding", "detector")
+    topics = "encoding", "detector"
     license = "MPL 1.1"
 
     settings = "os", "arch", "compiler", "build_type"

--- a/recipes/uchardet/all/conanfile.py
+++ b/recipes/uchardet/all/conanfile.py
@@ -49,12 +49,19 @@ class UchardetConan(ConanFile):
                   destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
+        # the following fixes that apply to uchardet version 0.0.7
+        # fix broken cmake
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
             "${CMAKE_BINARY_DIR}",
             "${CMAKE_CURRENT_BINARY_DIR}")
+        # fix problem with mac os
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
             'string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} TARGET_ARCHITECTURE)',
             'string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" TARGET_ARCHITECTURE)')
+        # disable building tests
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            "add_subdirectory(test)",
+            "#add_subdirectory(test)")
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/uchardet/all/test_package/CMakeLists.txt
+++ b/recipes/uchardet/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(uchardet REQUIRED CONFIG)
 

--- a/recipes/uchardet/all/test_package/CMakeLists.txt
+++ b/recipes/uchardet/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(uchardet REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} uchardet)

--- a/recipes/uchardet/all/test_package/CMakeLists.txt
+++ b/recipes/uchardet/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+conan_basic_setup()
 
 find_package(uchardet REQUIRED CONFIG)
 

--- a/recipes/uchardet/all/test_package/CMakeLists.txt
+++ b/recipes/uchardet/all/test_package/CMakeLists.txt
@@ -7,4 +7,4 @@ conan_basic_setup()
 find_package(uchardet REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} uchardet)
+target_link_libraries(${PROJECT_NAME} PRIVATE uchardet::uchardet)

--- a/recipes/uchardet/all/test_package/CMakeLists.txt
+++ b/recipes/uchardet/all/test_package/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package CXX)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)

--- a/recipes/uchardet/all/test_package/conanfile.py
+++ b/recipes/uchardet/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/uchardet/all/test_package/conanfile.py
+++ b/recipes/uchardet/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/uchardet/all/test_package/test_package.cpp
+++ b/recipes/uchardet/all/test_package/test_package.cpp
@@ -1,9 +1,7 @@
-#include <iostream>
-#include <uchardet.h>
+#include <uchardet/uchardet.h>
 
 int main(int argc, char** argv) {
     auto ud = uchardet_new();
     uchardet_delete(ud);
-    LOG(INFO) << "It works";
     return 0;
 }

--- a/recipes/uchardet/all/test_package/test_package.cpp
+++ b/recipes/uchardet/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+#include <uchardet.h>
+
+int main(int argc, char** argv) {
+    auto ud = uchardet_new();
+    uchardet_delete(ud);
+    LOG(INFO) << "It works";
+    return 0;
+}

--- a/recipes/uchardet/config.yml
+++ b/recipes/uchardet/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.0.7":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **uchardet/0.0.7**

We want to use the library in https://github.com/opendocument-app/OpenDocument.core. I did not develop the library. Later we might also try to add `OpenDocument.core` to the conan index.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
