### PR TITLE
Fix "Package require 'boost' not used in components requires"

### DIFF
--- a/recipes/logr/all/conanfile.py
+++ b/recipes/logr/all/conanfile.py
@@ -145,5 +145,5 @@ class LogrConan(ConanFile):
             self.cpp_info.components["logr_boostlog"].includedirs = []
             self.cpp_info.components["logr_boostlog"].requires = [
                 "logr::logr_base",
-                "Boost::log",
+                "boost::log",
             ]


### PR DESCRIPTION
Specify library name and version:  **logr/0.3.0**


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
