### PR TITLE
[Fix for Issue #8041] YASM: Fixed build fail of Visual Studio / MSBuild for RelWithDebInfo …

### DIFF
--- a/recipes/yasm/all/conanfile.py
+++ b/recipes/yasm/all/conanfile.py
@@ -52,6 +52,9 @@ class YASMConan(ConanFile):
                 msbuild.build_env.link_flags.append("/MACHINE:X86")
             elif self.settings.arch == "x86_64":
                 msbuild.build_env.link_flags.append("/SAFESEH:NO /MACHINE:X64")
+            if self.settings.build_type == "RelWithDebInfo":
+                self.output.info("YASM build type was {}, adjusting it to Release".format(self.settings.build_type))
+                self.settings.build_type = "Release"
             msbuild.build(project_file="yasm.sln",
                           targets=["yasm"], platforms={"x86": "Win32"}, force_vcvars=True)
 


### PR DESCRIPTION
…configuration

This correpsonds to Issue #8041

Library name and version:  yasm/1.3.0

Conan version: 1.42.1
Operating System: Win 10
Compiler: Visual Studio 2019

Build of YASM fails when compiler build type is set to RelWithDebInfo. Fixed by defaulting to Release if RelWithDebInfo is detected.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
