### PR TITLE
add rapidjson/cci.20211112

### DIFF
--- a/recipes/rapidjson/all/conandata.yml
+++ b/recipes/rapidjson/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "cci.20200410":
     url: "https://github.com/Tencent/rapidjson/archive/8f4c021fa2f1e001d2376095928fc0532adf2ae6.zip"
     sha256: e6fc99c7df7f29995838a764dd68df87b71db360f7727ace467b21b82c85efda
+  "cci.20211112":
+    url: "https://github.com/Tencent/rapidjson/archive/0d4517f15a8d7167ba9ae67f3f22a559ca841e3b.tar.gz"
+    sha256: 3697fdcea30dc7c2b2bb68d2521a6b8793f4d3269de751eed2c5fd477ff329ce

--- a/recipes/rapidjson/config.yml
+++ b/recipes/rapidjson/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: "all"
   "cci.20200410":
     folder: "all"
+  "cci.20211112":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **rapidjson/cci.20211112**

This merge request closes https://github.com/conan-io/conan-center-index/issues/8030
This is a version bump for rapidjson lib. Why I need this is:
- i need [this bug](https://github.com/Tencent/rapidjson/issues/1846) to build my project in c++20 mode safely
- the current latest release of rapidjson in conan center is almost one year old
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
