### PR TITLE
Automake: autoconf should be a build_requirement

### DIFF
--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -34,11 +34,11 @@ class AutomakeConan(ConanFile):
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
 
-    def requirements(self):
-        self.requires("autoconf/2.71")
-        # automake requires perl-Thread-Queue package
+    #def requirements(self):
+    #    automake requires perl-Thread-Queue package
 
     def build_requirements(self):
+        self.build_requires("autoconf/2.71")
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 

--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -34,11 +34,11 @@ class AutomakeConan(ConanFile):
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
 
-    #def requirements(self):
-    #    automake requires perl-Thread-Queue package
+    def requirements(self):
+        self.requires("autoconf/2.71")
+        # automake requires perl-Thread-Queue package
 
     def build_requirements(self):
-        self.build_requires("autoconf/2.71")
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 

--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -39,6 +39,8 @@ class AutomakeConan(ConanFile):
         # automake requires perl-Thread-Queue package
 
     def build_requirements(self):
+        if hasattr(self, "settings_build"):
+            self.build_requires("autoconf/2.71")
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 

--- a/recipes/automake/all/test_package/conanfile.py
+++ b/recipes/automake/all/test_package/conanfile.py
@@ -17,6 +17,7 @@ class TestPackageConan(ConanFile):
         return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
+        self.build_requires("autoconf/2.71")
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 

--- a/recipes/automake/all/test_package/conanfile.py
+++ b/recipes/automake/all/test_package/conanfile.py
@@ -17,7 +17,6 @@ class TestPackageConan(ConanFile):
         return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
-        self.build_requires("autoconf/2.71")
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 

--- a/recipes/automake/all/test_package/conanfile.py
+++ b/recipes/automake/all/test_package/conanfile.py
@@ -10,7 +10,7 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     exports_sources = "configure.ac", "Makefile.am", "test_package_1.c", "test_package.cpp"
     # DON'T COPY extra.m4 TO BUILD FOLDER!!!
-    test_type = "build_requires"
+    test_type = "build_requires", "requires"
 
     @property
     def _settings_build(self):


### PR DESCRIPTION
Automake fails to build if the 2 profiles approach is used, reporting that `autoconf` needs to be installed. The root cause of the issue: `autoconf` should be a `build_requirement` and not a `requirement`.


This change could have a ripple effect in recipes that mark `automake` as a `requirement` (It should be a `build_requirement`) since they wont inherit `autoconf` now. An example of this is `libtool`.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
