### PR TITLE
[zfp] add bit stream size option

### DIFF
--- a/recipes/zfp/all/conanfile.py
+++ b/recipes/zfp/all/conanfile.py
@@ -15,6 +15,7 @@ class ZfpConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "bit_stream_word_size": [8,16,32,64],
         "with_cuda": [True, False],
         "with_bit_stream_strided": [True, False],
         "with_aligned_alloc": [True, False],
@@ -26,6 +27,7 @@ class ZfpConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
+        "bit_stream_word_size": 64,
         "with_cuda": False,
         "with_bit_stream_strided": False,
         "with_aligned_alloc": False,
@@ -69,6 +71,7 @@ class ZfpConan(ConanFile):
         self._cmake.definitions["BUILD_CFP"] = True
         self._cmake.definitions["BUILD_UTILITIES"] = False
         self._cmake.definitions["ZFP_WITH_CUDA"] = self.options.with_cuda
+        self._cmake.definitions["ZFP_BIT_STREAM_WORD_SIZE"] = self.options.bit_stream_word_size
         self._cmake.definitions["ZFP_WITH_BIT_STREAM_STRIDED"] = self.options.with_bit_stream_strided
         self._cmake.definitions["ZFP_WITH_ALIGNED_ALLOC"] = self.options.with_aligned_alloc
         self._cmake.definitions["ZFP_WITH_CACHE_TWOWAY"] = self.options.with_cache_twoway


### PR DESCRIPTION
Specify library name and version:  **zfp/0.5.5**

Adds a `bit_stream_word_size` option which corresponds to the `ZFP_BIT_STREAM_WORD_SIZE` CMake option. This enables the package to be used to build the ZFP HDF5 filter which requires a non-default setting of this value.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
