### PR TITLE
aws-c-cal: fix weak reference to libcrypto

### DIFF
--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -98,10 +98,14 @@ class AwsCCal(ConanFile):
         elif self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.components["aws-c-cal-lib"].system_libs.append("dl")
         if self._needs_openssl:
-            self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
-            if not self.options["openssl"].shared:
+            if self.options["openssl"].shared:
                 self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
+            else:
+                self.cpp_info.components["_dummy_crypto"].requires.append("openssl::crypto")
                 lib_path = os.path.join(self.deps_cpp_info["openssl"].rootpath, "lib", "libcrypto.a")
                 link_flag = "-Wl,--whole-archive,{},--no-whole-archive".format(lib_path)
                 self.cpp_info.components["aws-c-cal-lib"].exelinkflags.append(link_flag)
                 self.cpp_info.components["aws-c-cal-lib"].sharedlinkflags.append(link_flag)
+                self.cpp_info.components["aws-c-cal-lib"].system_libs.extend(["dl", "rt"])
+                if not self.options["openssl"].no_threads:
+                    self.cpp_info.components["aws-c-cal-lib"].system_libs.append("pthread")

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -98,4 +98,11 @@ class AwsCCal(ConanFile):
         elif self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.components["aws-c-cal-lib"].system_libs.append("dl")
         if self._needs_openssl:
-            self.cpp_info.components["_dummy_crypto"].requires.append("openssl::crypto")
+            if self.options["openssl"].shared:
+                self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
+            else:
+                self.cpp_info.components["_dummy_crypto"].requires.append("openssl::crypto")
+                lib_path = os.path.join(self.deps_cpp_info["openssl"].rootpath, "lib", "libcrypto.a")
+                link_flag = "-Wl,--whole-archive,{},--no-whole-archive".format(lib_path)
+                self.cpp_info.components["aws-c-cal-lib"].exelinkflags.append(link_flag)
+                self.cpp_info.components["aws-c-cal-lib"].sharedlinkflags.append(link_flag)

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -98,10 +98,9 @@ class AwsCCal(ConanFile):
         elif self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.components["aws-c-cal-lib"].system_libs.append("dl")
         if self._needs_openssl:
-            if self.options["openssl"].shared:
+            self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
+            if not self.options["openssl"].shared:
                 self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
-            else:
-                self.cpp_info.components["_dummy_crypto"].requires.append("openssl::crypto")
                 lib_path = os.path.join(self.deps_cpp_info["openssl"].rootpath, "lib", "libcrypto.a")
                 link_flag = "-Wl,--whole-archive,{},--no-whole-archive".format(lib_path)
                 self.cpp_info.components["aws-c-cal-lib"].exelinkflags.append(link_flag)

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -102,9 +102,9 @@ class AwsCCal(ConanFile):
                 self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
             else:
                 self.cpp_info.components["_dummy_crypto"].requires.append("openssl::crypto")
-                # aws-c-cal dynamically search the openssl symbols.
-                # Mark them as undefined so the linker will include them.
-                # This avoid dynamical look-up for a system crypto library.
+                # aws-c-cal does not statically link to openssl and searches dynamically for openssl symbols .
+                # Mark these as undefined so the linker will include them.
+                # This avoids dynamical look-up for a system crypto library.
                 crypto_symbols = [
                     "HMAC_CTX_init", "HMAC_CTX_cleanup", "HMAC_Update", "HMAC_Final", "HMAC_Init_ex",
                 ]

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -108,7 +108,6 @@ class AwsCCal(ConanFile):
                 crypto_symbols = [
                     "HMAC_CTX_init", "HMAC_CTX_cleanup", "HMAC_Update", "HMAC_Final", "HMAC_Init_ex",
                 ]
-                for crypto_symbol in cryto_symbols:
-                    link_flag = f"-Wl,-u{crypto_symbol}"
-                    self.cpp_info.components["aws-c-cal-lib"].exelinkflags.append(link_flag)
-                    self.cpp_info.components["aws-c-cal-lib"].sharedlinkflags.append(link_flag)
+                crypto_link_flags = "-Wl," + ",".join(f"-u,{symbol}" for symbol in crypto_symbols)
+                self.cpp_info.components["aws-c-cal-lib"].exelinkflags.append(crypto_link_flags)
+                self.cpp_info.components["aws-c-cal-lib"].sharedlinkflags.append(crypto_link_flags)

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -92,11 +92,11 @@ class AwsCCal(ConanFile):
             self.cpp_info.components["aws-c-cal-lib"].frameworks.append("Security")
         elif self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.components["aws-c-cal-lib"].system_libs.append("dl")
+
+        self.user_info.with_openssl = self._needs_openssl
         if self._needs_openssl:
-            if self.options["openssl"].shared:
-                self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
-            else:
-                self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
+            self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
+            if not self.options["openssl"].shared:
                 # aws-c-cal does not statically link to openssl and searches dynamically for openssl symbols .
                 # Mark these as undefined so the linker will include them.
                 # This avoids dynamical look-up for a system crypto library.

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -101,7 +101,7 @@ class AwsCCal(ConanFile):
             if self.options["openssl"].shared:
                 self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
             else:
-                self.cpp_info.components["_dummy_crypto"].requires.append("openssl::crypto")
+                self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
                 # aws-c-cal does not statically link to openssl and searches dynamically for openssl symbols .
                 # Mark these as undefined so the linker will include them.
                 # This avoids dynamical look-up for a system crypto library.

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -101,13 +101,15 @@ class AwsCCal(ConanFile):
             if self.options["openssl"].shared:
                 self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
             else:
-                self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
                 # aws-c-cal does not statically link to openssl and searches dynamically for openssl symbols .
                 # Mark these as undefined so the linker will include them.
                 # This avoids dynamical look-up for a system crypto library.
+                # To make sure the openssl library appears AFTER these extra link flags, create a target for openssl
+                self.cpp_info.components["_openssl_crypto"].requires.append("openssl::crypto")
                 crypto_symbols = [
                     "HMAC_CTX_init", "HMAC_CTX_cleanup", "HMAC_Update", "HMAC_Final", "HMAC_Init_ex",
                 ]
                 crypto_link_flags = "-Wl," + ",".join(f"-u,{symbol}" for symbol in crypto_symbols)
                 self.cpp_info.components["aws-c-cal-lib"].exelinkflags.append(crypto_link_flags)
                 self.cpp_info.components["aws-c-cal-lib"].sharedlinkflags.append(crypto_link_flags)
+                self.cpp_info.components["aws-c-cal-lib"].requires =["_openssl_crypto"]

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -82,6 +82,8 @@ class AwsCCal(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-cal")
+        self.cpp_info.names["cmake_find_package"] = "AWS"
+        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
         self.cpp_info.set_property("cmake_target_name", "AWS")
         self.cpp_info.components["aws-c-cal-lib"].set_property("cmake_target_name", "aws-c-cal")
         self.cpp_info.components["aws-c-cal-lib"].libs = ["aws-c-cal"]

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -81,6 +81,8 @@ class AwsCCal(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-cal"))
 
     def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "aws-c-cal"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-cal"
         self.cpp_info.set_property("cmake_file_name", "aws-c-cal")
         self.cpp_info.names["cmake_find_package"] = "AWS"
         self.cpp_info.names["cmake_find_package_multi"] = "AWS"

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -85,6 +85,8 @@ class AwsCCal(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "AWS"
         self.cpp_info.names["cmake_find_package_multi"] = "AWS"
         self.cpp_info.set_property("cmake_target_name", "AWS")
+        self.cpp_info.components["aws-c-cal-lib"].names["cmake_find_package"] = "aws-c-cal"
+        self.cpp_info.components["aws-c-cal-lib"].names["cmake_find_package_multi"] = "aws-c-cal"
         self.cpp_info.components["aws-c-cal-lib"].set_property("cmake_target_name", "aws-c-cal")
         self.cpp_info.components["aws-c-cal-lib"].libs = ["aws-c-cal"]
         self.cpp_info.components["aws-c-cal-lib"].requires = ["aws-c-common::aws-c-common-lib"]

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -102,7 +102,6 @@ class AwsCCal(ConanFile):
                 self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
             else:
                 self.cpp_info.components["aws-c-cal-lib"].requires.append("openssl::crypto")
-                # self.cpp_info.components["_openssl_crypto"].requires.append("openssl::crypto")
                 # aws-c-cal does not statically link to openssl and searches dynamically for openssl symbols .
                 # Mark these as undefined so the linker will include them.
                 # This avoids dynamical look-up for a system crypto library.

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -1,9 +1,7 @@
 from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
 import os
 
-
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
 
 class AwsCCal(ConanFile):
     name = "aws-c-cal"
@@ -83,12 +81,9 @@ class AwsCCal(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-cal"))
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-cal"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-cal"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-cal-lib"].names["cmake_find_package"] = "aws-c-cal"
-        self.cpp_info.components["aws-c-cal-lib"].names["cmake_find_package_multi"] = "aws-c-cal"
+        self.cpp_info.set_property("cmake_file_name", "aws-c-cal")
+        self.cpp_info.set_property("cmake_target_name", "AWS")
+        self.cpp_info.components["aws-c-cal-lib"].set_property("cmake_target_name", "aws-c-cal")
         self.cpp_info.components["aws-c-cal-lib"].libs = ["aws-c-cal"]
         self.cpp_info.components["aws-c-cal-lib"].requires = ["aws-c-common::aws-c-common-lib"]
         if self.settings.os == "Windows":

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -116,6 +116,6 @@ class AwsCCal(ConanFile):
                     crypto_symbols.extend([
                         "HMAC_CTX_init", "HMAC_CTX_cleanup", "HMAC_CTX_reset",
                     ])
-                crypto_link_flags = "-Wl," + ",".join(f"-u,{symbol}" for symbol in crypto_symbols)
+                crypto_link_flags = "-Wl," + ",".join(f"-u{symbol}" for symbol in crypto_symbols)
                 self.cpp_info.components["aws-c-cal-lib"].exelinkflags.append(crypto_link_flags)
                 self.cpp_info.components["aws-c-cal-lib"].sharedlinkflags.append(crypto_link_flags)

--- a/recipes/aws-c-cal/all/test_package/conanfile.py
+++ b/recipes/aws-c-cal/all/test_package/conanfile.py
@@ -16,6 +16,6 @@ class TestPackageConan(ConanFile):
             stream = io.StringIO()
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True, output=stream)
-            print(stream.getvalue())
+            self.output.info(stream.getvalue())
             if self.deps_user_info["aws-c-cal"].with_openssl == "True":
                 assert "found static libcrypto" in stream.getvalue()

--- a/recipes/aws-c-cal/all/test_package/conanfile.py
+++ b/recipes/aws-c-cal/all/test_package/conanfile.py
@@ -17,5 +17,5 @@ class TestPackageConan(ConanFile):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True, output=stream)
             print(stream.getvalue())
-            if bool(self.deps_user_info["aws-c-cal"].with_openssl):
+            if self.deps_user_info["aws-c-cal"].with_openssl == "True":
                 assert "found static libcrypto" in stream.getvalue()

--- a/recipes/aws-c-cal/all/test_package/conanfile.py
+++ b/recipes/aws-c-cal/all/test_package/conanfile.py
@@ -16,6 +16,6 @@ class TestPackageConan(ConanFile):
             stream = io.StringIO()
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True, output=stream)
+            print(stream.getvalue())
             if bool(self.deps_user_info["aws-c-cal"].with_openssl):
                 assert "found static libcrypto" in stream.getvalue()
-

--- a/recipes/aws-c-cal/all/test_package/conanfile.py
+++ b/recipes/aws-c-cal/all/test_package/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, CMake, tools
 import os
-
+import io
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
@@ -13,5 +13,9 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self.settings):
+            stream = io.StringIO()
             bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+            self.run(bin_path, run_environment=True, output=stream)
+            if bool(self.deps_user_info["aws-c-cal"].with_openssl):
+                assert "found static libcrypto" in stream.getvalue()
+

--- a/recipes/aws-c-cal/all/test_package/test_package.c
+++ b/recipes/aws-c-cal/all/test_package/test_package.c
@@ -1,9 +1,19 @@
 #include <aws/cal/cal.h>
 
 int main() {
-    struct aws_allocator *allocator = aws_default_allocator();
+    struct aws_allocator* allocator = aws_default_allocator();
+
+    struct aws_logger_standard_options options;
+    options.level    = AWS_LL_TRACE;
+    options.filename = NULL;
+    options.file     = stdout;
+    struct aws_logger logger;
+    aws_logger_init_standard(&logger, allocator, &options);
+    aws_logger_set(&logger);
+
     aws_cal_library_init(allocator);
     aws_cal_library_clean_up();
+    aws_logger_clean_up(&logger);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Specify library name and version:  **aws-c-cal/all**

Try to fix: https://github.com/conan-io/conan-center-index/issues/8005

To solve this, compiler have to link libcrypto between whole-archive and no-whole-archive option.

So I use `exelinkflags`, `sharedlinkflags` instead of `requires`.
I know it's dirty method.
If there are another clear way, please suggest.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
