### PR TITLE
verilator: add version 4.214

### DIFF
--- a/recipes/verilator/all/conandata.yml
+++ b/recipes/verilator/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "4.034":
     url: "https://www.veripool.org/ftp/verilator-4.034.tgz"
     sha256: "54ed7b06ee28b5d21f9d0ee98406d29a508e6124b0d10e54bb32081613ddb80b"
+  "4.214":
+    url: "https://github.com/verilator/verilator/archive/refs/tags/v4.214.tar.gz"
+    sha256: "e14c7f6ffb00a6746ae2a8ea0424e90a1a30067e8ae4c96b8c42689ca1ca0b1f"
 patches:
   "4.034":
     - patch_file: "patches/0001-split-opt-and-debug-build-install.patch"
@@ -10,3 +13,4 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0003-add-msvc_link-sh.patch"
       base_path: "source_subfolder"
+  "4.214": []

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -11,7 +11,7 @@ class VerilatorConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.veripool.org/wiki/verilator"
     description = "Verilator compiles synthesizable Verilog and Synthesis assertions into single- or multithreaded C++ or SystemC code"
-    topics = ("conan", "verilog", "HDL", "EDA", "simulator", "hardware", "fpga")
+    topics = ("verilog", "hdl", "eda", "simulator", "hardware", "fpga")
     exports_sources = "patches/**"
 
     settings = "os", "arch", "compiler", "build_type"
@@ -22,9 +22,12 @@ class VerilatorConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
     def build_requirements(self):
-        if tools.os_info.is_windows and "CONAN_BASH_PATH" not in os.environ \
-                and tools.os_info.detect_windows_subsystem() != "msys2":
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             if self.settings.compiler == "Visual Studio":
                 self.build_requires("msys2/20190524")
                 self.build_requires("automake/1.16.2")

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -31,6 +31,7 @@ class VerilatorConan(ConanFile):
             self.build_requires("winflexbison/2.5.22")
             self.build_requires("strawberryperl/5.30.0.1")
         else:
+            self.build_requires("autoconf/2.69")
             self.build_requires("flex/2.6.4")
             self.build_requires("bison/3.5.3")
 
@@ -61,6 +62,8 @@ class VerilatorConan(ConanFile):
     def _configure_autotools(self):
         if self._autotools:
             return self._autotools
+        with tools.chdir(self._source_subfolder):
+            self.run("autoconf", run_environment=True)
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
         self._autotools.libs = []
         self._autotools.library_paths = []

--- a/recipes/verilator/config.yml
+++ b/recipes/verilator/config.yml
@@ -1,3 +1,5 @@
 versions:
   "4.034":
     folder: all
+  "4.214":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **verilator/4.214**

Added new version for verilator package.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
