### PR TITLE
[zfp] add necessary link flags for openmp

### DIFF
--- a/recipes/zfp/all/conanfile.py
+++ b/recipes/zfp/all/conanfile.py
@@ -91,6 +91,18 @@ class ZfpConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        if not self.options.shared and self.options.with_openmp:
+            openmp_flags = []
+            if self.settings.compiler in ("Visual Studio", "msvc"):
+                openmp_flags = ["-openmp"]
+            elif self.settings.compiler in ("gcc", "clang"):
+                openmp_flags = ["-fopenmp"]
+            elif self.settings.compiler == "apple-clang":
+                openmp_flags = ["-Xpreprocessor", "-fopenmp"]
+
+            self.cpp_info.components["_zfp"].sharedlinkflags = openmp_flags
+            self.cpp_info.components["_zfp"].exelinkflags = openmp_flags
+
         # zfp
         self.cpp_info.components["_zfp"].names["cmake_find_package"] = "zfp"
         self.cpp_info.components["_zfp"].names["cmake_find_package_multi"] = "zfp"


### PR DESCRIPTION
Specify library name and version:  **zfp/0.5.5**

Add the necessary linker flags if building with openmp (used the soxr recipe as a reference)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
