### PR TITLE
aws-c-http: add version 0.6.10 with update dependencies

### DIFF
--- a/recipes/aws-c-http/all/conandata.yml
+++ b/recipes/aws-c-http/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.10":
+    url: "https://github.com/awslabs/aws-c-http/archive/v0.6.10.tar.gz"
+    sha256: "4413faf2b8f6a83c898bb535cf83542fa548d7ecc1acf681dc79b7959a07231a"
   "0.6.7":
     url: "https://github.com/awslabs/aws-c-http/archive/v0.6.7.tar.gz"
     sha256: "2244d1e26ce5b5f40f96e570b1c4332a07c645ef744644d5b90b089d3695ec3b"

--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -1,12 +1,12 @@
 import os
 from conans import ConanFile, CMake, tools
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
 
 class AwsCHttp(ConanFile):
     name = "aws-c-http"
     description = "C99 implementation of the HTTP/1.1 and HTTP/2 specifications"
-    topics = ("conan", "aws", "amazon", "cloud", )
+    topics = ("aws", "amazon", "cloud", "http", "http2", )
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-http"
     license = "Apache-2.0",
@@ -39,9 +39,9 @@ class AwsCHttp(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.9")
+        self.requires("aws-c-common/0.6.15")
         self.requires("aws-c-compression/0.2.14")
-        self.requires("aws-c-io/0.10.9")
+        self.requires("aws-c-io/0.10.13")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -66,12 +66,9 @@ class AwsCHttp(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-http"))
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-http"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-http"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package"] = "aws-c-http"
-        self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package_multi"] = "aws-c-http"
+        self.cpp_info.set_property("cmake_file_name", "aws-c-http")
+        self.cpp_info.set_property("cmake_target_name", "AWS")
+        self.cpp_info.components["aws-c-http-lib"].set_property("cmake_target_name", "aws-c-http")
         self.cpp_info.components["aws-c-http-lib"].libs = ["aws-c-http"]
         self.cpp_info.components["aws-c-http-lib"].requires = [
             "aws-c-common::aws-c-common-lib",

--- a/recipes/aws-c-http/all/test_package/CMakeLists.txt
+++ b/recipes/aws-c-http/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(aws-c-http REQUIRED CONFIG)
 

--- a/recipes/aws-c-http/all/test_package/conanfile.py
+++ b/recipes/aws-c-http/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/aws-c-http/config.yml
+++ b/recipes/aws-c-http/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.10":
+    folder: all
   "0.6.7":
     folder: all
   "0.6.5":


### PR DESCRIPTION
Specify library name and version:  **aws-c-http**

Concerning https://github.com/conan-io/conan-center-index/issues/7763,
The versions of aws-c-common and aws-c-io are roughly tighted.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
