### PR TITLE
aws-c-event-stream: update dependencies

### DIFF
--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -1,13 +1,13 @@
 from conans import CMake, ConanFile, tools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
 
 
 class AwsCEventStream(ConanFile):
     name = "aws-c-event-stream"
     description = "C99 implementation of the vnd.amazon.eventstream content-type"
-    topics = ("conan", "aws", "eventstream", "content", )
+    topics = ("aws", "eventstream", "content", )
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-event-stream"
     license = "Apache-2.0",
@@ -40,10 +40,10 @@ class AwsCEventStream(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-checksums/0.1.11")
-        self.requires("aws-c-common/0.6.9")
+        self.requires("aws-checksums/0.1.12")
+        self.requires("aws-c-common/0.6.15")
         if tools.Version(self.version) >= "0.2":
-            self.requires("aws-c-io/0.10.9")
+            self.requires("aws-c-io/0.10.13")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -72,12 +72,9 @@ class AwsCEventStream(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-event-stream"))
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-event-stream"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-event-stream"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package"] = "aws-c-event-stream"
-        self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package_multi"] = "aws-c-event-stream"
+        self.cpp_info.set_property("cmake_file_name", "aws-c-event-stream")
+        self.cpp_info.set_property("cmake_target_name", "AWS")
+        self.cpp_info.components["aws-c-event-stream-lib"].set_property("cmake_target_package", "aws-c-event-stream")
         self.cpp_info.components["aws-c-event-stream-lib"].libs = ["aws-c-event-stream"]
         self.cpp_info.components["aws-c-event-stream-lib"].requires = ["aws-c-common::aws-c-common-lib", "aws-checksums::aws-checksums"]
         if tools.Version(self.version) >= "0.2":

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -74,7 +74,7 @@ class AwsCEventStream(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-event-stream")
         self.cpp_info.set_property("cmake_target_name", "AWS")
-        self.cpp_info.components["aws-c-event-stream-lib"].set_property("cmake_target_package", "aws-c-event-stream")
+        self.cpp_info.components["aws-c-event-stream-lib"].set_property("cmake_target_name", "aws-c-event-stream")
         self.cpp_info.components["aws-c-event-stream-lib"].libs = ["aws-c-event-stream"]
         self.cpp_info.components["aws-c-event-stream-lib"].requires = ["aws-c-common::aws-c-common-lib", "aws-checksums::aws-checksums"]
         if tools.Version(self.version) >= "0.2":

--- a/recipes/aws-c-event-stream/all/test_package/CMakeLists.txt
+++ b/recipes/aws-c-event-stream/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(aws-c-event-stream REQUIRED CONFIG)
 

--- a/recipes/aws-c-event-stream/all/test_package/conanfile.py
+++ b/recipes/aws-c-event-stream/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **aws-c-event-stream/all**

Concerning #7763,
The versions of aws-c-common and aws-c-io are roughly tighted.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
