### PR TITLE
certify: fix CMake imported target

### DIFF
--- a/recipes/certify/all/conanfile.py
+++ b/recipes/certify/all/conanfile.py
@@ -39,12 +39,18 @@ class CertifyConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, self._min_cppstd)
+
+        def lazy_lt_semver(v1, v2):
+            lv1 = [int(v) for v in v1.split(".")]
+            lv2 = [int(v) for v in v2.split(".")]
+            min_length = min(len(lv1), len(lv2))
+            return lv1[:min_length] < lv2[:min_length]
+
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version:
-            if tools.Version(self.settings.compiler.version) < minimum_version:
-                raise ConanInvalidConfiguration("{} requires C++17, which your compiler does not support.".format(self.name))
-        else:
+        if not minimum_version:
             self.output.warn("{} requires C++17. Your compiler is unknown. Assuming it supports C++17.".format(self.name))
+        elif lazy_lt_semver(str(self.settings.compiler.version), minimum_version):
+            raise ConanInvalidConfiguration("{} requires C++17, which your compiler does not support.".format(self.name))
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/certify/all/conanfile.py
+++ b/recipes/certify/all/conanfile.py
@@ -12,8 +12,7 @@ class CertifyConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/djarek/certify"
     license = "BSL-1.0"
-    settings = "compiler"
-    generators = "cmake", "cmake_find_package"
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     @property
@@ -47,6 +46,9 @@ class CertifyConan(ConanFile):
         else:
             self.output.warn("{} requires C++17. Your compiler is unknown. Assuming it supports C++17.".format(self.name))
 
+    def package_id(self):
+        self.info.header_only()
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   strip_root=True, destination=self._source_subfolder)
@@ -57,10 +59,6 @@ class CertifyConan(ConanFile):
         self.copy(pattern="*", dst="include",
                   src=os.path.join(self._source_subfolder, "include"))
 
-    def package_id(self):
-        self.info.header_only()
-
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "certify"
         self.cpp_info.names["cmake_find_package_multi"] = "certify"
-        self.cpp_info.names["pkg_config"] = "certify"

--- a/recipes/certify/all/conanfile.py
+++ b/recipes/certify/all/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
 
 
 class CertifyConan(ConanFile):
@@ -60,5 +60,7 @@ class CertifyConan(ConanFile):
                   src=os.path.join(self._source_subfolder, "include"))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "certify"
-        self.cpp_info.names["cmake_find_package_multi"] = "certify"
+        self.cpp_info.set_property("cmake_file_name", "certify")
+        self.cpp_info.set_property("cmake_target_name", "certify")
+        self.cpp_info.components["_certify"].set_property("cmake_target_name", "core")
+        self.cpp_info.components["_certify"].requires = ["boost::boost", "openssl::openssl"]

--- a/recipes/certify/all/test_package/CMakeLists.txt
+++ b/recipes/certify/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
@@ -7,5 +7,5 @@ conan_basic_setup(TARGETS)
 find_package(certify REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE certify::certify)
+target_link_libraries(${PROJECT_NAME} PRIVATE certify::core)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)

--- a/recipes/certify/all/test_package/CMakeLists.txt
+++ b/recipes/certify/all/test_package/CMakeLists.txt
@@ -1,6 +1,4 @@
 cmake_minimum_required(VERSION 3.13)
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Imported target of upstream is `certify::core`, not `certify::certify`

https://github.com/djarek/certify/blob/2d719a9ad79ce1a61684278a30196527e412a0b6/CMakeLists.txt#L31 + https://github.com/djarek/certify/blob/2d719a9ad79ce1a61684278a30196527e412a0b6/CMakeLists.txt#L74-L77

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
