### PR TITLE
openscenegraph: Declare "result" as LONG for Mingw build

### DIFF
--- a/recipes/openscenegraph/all/conandata.yml
+++ b/recipes/openscenegraph/all/conandata.yml
@@ -14,3 +14,5 @@ patches:
       base_path: source_subfolder
     - patch_file: patches/0005-use-JPEG-target-for-plugin.patch
       base_path: source_subfolder
+    - patch_file: patches/0006-Declare-result-as-LONG-for-Mingw-build.patch
+      base_path: source_subfolder

--- a/recipes/openscenegraph/all/patches/0006-Declare-result-as-LONG-for-Mingw-build.patch
+++ b/recipes/openscenegraph/all/patches/0006-Declare-result-as-LONG-for-Mingw-build.patch
@@ -1,0 +1,29 @@
+From d1f1f1c180256a09fa940b660facf20740d08edb Mon Sep 17 00:00:00 2001
+From: ItsBasi <5033630+ItsBasi@users.noreply.github.com>
+Date: Tue, 16 Nov 2021 21:24:10 +0100
+Subject: [PATCH] Declare "result" as LONG for Mingw build
+
+Win32's ChangeDisplaySettingsEx() API function is documented as returning `LONG`, which evidently is not always the same as `unsigned int` (Mingw64.)
+This cause a compile error on Mingw with clang10.
+
+This patch was taken from the upstream commit 67468cce344dd5e503aaa1063845f34720563f79.
+---
+ src/osgViewer/GraphicsWindowWin32.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/osgViewer/GraphicsWindowWin32.cpp b/src/osgViewer/GraphicsWindowWin32.cpp
+index 88156a6..f1f3bf6 100644
+--- a/src/osgViewer/GraphicsWindowWin32.cpp
++++ b/src/osgViewer/GraphicsWindowWin32.cpp
+@@ -1101,7 +1101,7 @@ bool Win32WindowingSystem::changeScreenSettings( const osg::GraphicsContext::Scr
+     // Start by testing if the change would be successful (without applying it)
+     //
+ 
+-    unsigned int result = ::ChangeDisplaySettingsEx(displayDevice.DeviceName, &deviceMode, NULL, CDS_TEST, NULL);
++    LONG result = ::ChangeDisplaySettingsEx(displayDevice.DeviceName, &deviceMode, NULL, CDS_TEST, NULL);
+     if (result==DISP_CHANGE_SUCCESSFUL)
+     {
+         result = ::ChangeDisplaySettingsEx(displayDevice.DeviceName, &deviceMode, NULL, 0, NULL);
+-- 
+2.34.0.windows.1
+

--- a/recipes/openscenegraph/all/test_package/conanfile.py
+++ b/recipes/openscenegraph/all/test_package/conanfile.py
@@ -20,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Win32's ChangeDisplaySettingsEx() API function is documented as returning
`LONG`, which evidently is not always the same as `unsigned int` (Mingw64.)
This cause a compile error on Mingw with clang10.

This patch was taken from the upstream commit
67468cce344dd5e503aaa1063845f34720563f79.

Specify library name and version:  openscenegraph/3.6.5

This is just a ported patch from the source repository.
---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
