### PR TITLE
wiringpi: add version cci.20210727

### DIFF
--- a/recipes/wiringpi/all/conandata.yml
+++ b/recipes/wiringpi/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20210727":
+    sha256: d85f063b1bfe73fd23ed20a3dfb7968be97172a78113d510e2a5f7ddeacc4799
+    url: https://github.com/WiringPi/WiringPi/archive/7f8fe26e4f775abfced43c07657a353f03ddb2d0.tar.gz
   "2.50":
     sha256: f1ddf17e876f88e074d4597767e365a1b5ef20414a38754884935b38d8c8e932
     url: https://github.com/WiringPi/WiringPi/archive/final_official_2.50.tar.gz

--- a/recipes/wiringpi/all/conanfile.py
+++ b/recipes/wiringpi/all/conanfile.py
@@ -2,13 +2,14 @@ import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.33.0"
 
 class WiringpiConan(ConanFile):
     name = "wiringpi"
     license = "LGPL-3.0"
     description = "GPIO Interface library for the Raspberry Pi"
     homepage = "http://wiringpi.com"
-    topics = ("conan", "wiringpi", "gpio", "raspberrypi")
+    topics = ("wiringpi", "gpio", "raspberrypi")
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False],
@@ -40,8 +41,8 @@ class WiringpiConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("WiringPi-final_official_" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/wiringpi/all/conanfile.py
+++ b/recipes/wiringpi/all/conanfile.py
@@ -33,12 +33,14 @@ class WiringpiConan(ConanFile):
         return "build_subfolder"
 
     def configure(self):
-        if self.settings.os != "Linux":
-            raise ConanInvalidConfiguration("WiringPi only works for Linux.")
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("{} only works for Linux.".format(self.name))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/wiringpi/all/test_package/CMakeLists.txt
+++ b/recipes/wiringpi/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(wiringpi REQUIRED CONFIG)
 
 add_executable(test_package test_package.c)
-target_link_libraries(test_package ${CONAN_LIBS})
+target_link_libraries(test_package wiringpi::wiringpi)

--- a/recipes/wiringpi/all/test_package/conanfile.py
+++ b/recipes/wiringpi/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 
 class TestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/wiringpi/config.yml
+++ b/recipes/wiringpi/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "cci.20210727":
+    folder: "all"
   "2.50":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **wiringpi/cci.20210727**

The latest release of wiringpi is 2.5.0 at 2019-12.
After that release, there are a lot of modification to support new hardware.
But  there seems to be no plan to release 2.6.0 currently.
So I am going to add snapshot version to recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
