### PR TITLE
emsdk: prepopulate cache

### DIFF
--- a/recipes/emsdk/all/conanfile.py
+++ b/recipes/emsdk/all/conanfile.py
@@ -63,6 +63,7 @@ class EmSDKConan(ConanFile):
                 if key != 'nodejs':
                     self.run("%s install %s" % (emsdk, value))
                     self.run("%s activate %s" % (emsdk, value))
+            self.run("echo \"int main(){}\" | em++ -x c++ -") # force cache population
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)

--- a/recipes/emsdk/all/conanfile.py
+++ b/recipes/emsdk/all/conanfile.py
@@ -65,12 +65,12 @@ class EmSDKConan(ConanFile):
                     self.run("%s activate %s" % (emsdk, value))
 
     @property
-    def _emscripten_path(self):
-        return os.path.join(self.package_folder, "bin", "upstream", "emscripten")
-
-    @property
-    def _emscripten_cache(self):
-        return os.path.join(self.package_folder,  "bin", ".emscripten_cache")
+    def _emscripten_env(self):
+        return {"PATH": [self.package_folder, os.path.join(self.package_folder, "bin", "upstream", "emscripten")],
+                "EMSDK": self.package_folder,
+                "EMSCRIPTEN": os.path.join(self.package_folder, "bin", "upstream", "emscripten"),
+                "EM_CONFIG": os.path.join(self.package_folder, "bin", ".emscripten"),
+                "EM_CACHE": os.path.join(self.package_folder,  "bin", ".emscripten_cache")}
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
@@ -88,10 +88,12 @@ class EmSDKConan(ConanFile):
         tools.replace_in_file(toolchain,
                               "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)",
                               "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)")
-        with tools.environment_append({"PATH": [self._emscripten_path],"EM_CACHE": self._emscripten_cache}):
+        with tools.environment_append(self._emscripten_env):
             tools.save("deleteme.cpp", "int main(){}")
-            self.run("em++ deleteme.cpp") # force cache population
+            self.run("em++ deleteme.cpp", run_environment=True) # force cache population
             tools.remove_files_by_mask(".", "deleteme.*")
+
+
 
     def _define_tool_var(self, name, value):
         suffix = ".bat" if self.settings.os == "Windows" else ""
@@ -102,29 +104,12 @@ class EmSDKConan(ConanFile):
         return path
 
     def package_info(self):
-        emsdk = self.package_folder
-        em_config = os.path.join(emsdk, "bin", ".emscripten")
-        emscripten = self._emscripten_path
-        em_cache = self._emscripten_cache
-        toolchain = os.path.join(emscripten, "cmake", "Modules", "Platform", "Emscripten.cmake")
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
 
-        self.output.info("Appending PATH environment variable: %s" % emsdk)
-        self.env_info.PATH.append(emsdk)
-
-        self.output.info("Appending PATH environment variable: %s" % emscripten)
-        self.env_info.PATH.append(emscripten)
-
-        self.output.info("Creating EMSDK environment variable: %s" % emsdk)
-        self.env_info.EMSDK = emsdk
-
-        self.output.info("Creating EMSCRIPTEN environment variable: %s" % emscripten)
-        self.env_info.EMSCRIPTEN = emscripten
-
-        self.output.info("Creating EM_CONFIG environment variable: %s" % em_config)
-        self.env_info.EM_CONFIG = em_config
-
-        self.output.info("Creating EM_CACHE environment variable: %s" % em_cache)
-        self.env_info.EM_CACHE = em_cache
+        for var, val in self._emscripten_env.items():
+            self.output.info("Creating %s environment variable: %s" % (var, val))
+            setattr(self.env_info, var, val)
 
         # If we are not building for Emscripten, probably we don't want to inject following environment variables,
         #   but it might be legit use cases... until we find them, let's be conservative.
@@ -135,6 +120,8 @@ class EmSDKConan(ConanFile):
             self.output.warn("You've added {}/{} as a build requirement, while os={} != Emscripten".format(self.name, self.version, self.settings_target.os))
             return
 
+
+        toolchain = os.path.join(self.package_folder, "bin", "upstream", "emscripten", "cmake", "Modules", "Platform", "Emscripten.cmake")
         self.output.info("Creating CONAN_CMAKE_TOOLCHAIN_FILE environment variable: %s" % toolchain)
         self.env_info.CONAN_CMAKE_TOOLCHAIN_FILE = toolchain
 
@@ -151,6 +138,3 @@ class EmSDKConan(ConanFile):
             "bin/upstream/emscripten/tests/cmake/target_library",
             "bin/upstream/lib/cmake/llvm",
         ]
-
-        self.cpp_info.includedirs = []
-        self.cpp_info.libdirs = []

--- a/recipes/emsdk/all/conanfile.py
+++ b/recipes/emsdk/all/conanfile.py
@@ -88,10 +88,11 @@ class EmSDKConan(ConanFile):
         tools.replace_in_file(toolchain,
                               "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)",
                               "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)")
-        with tools.environment_append(self._emscripten_env):
-            tools.save("deleteme.cpp", "int main(){}")
-            self.run("em++ deleteme.cpp", run_environment=True) # force cache population
-            tools.remove_files_by_mask(".", "deleteme.*")
+        if not tools.cross_building(self):
+            with tools.environment_append(self._emscripten_env):
+                tools.save("deleteme.cpp", "int main(){}")
+                self.run("em++ deleteme.cpp", run_environment=True) # force cache population
+                tools.remove_files_by_mask(".", "deleteme.*")
 
 
 


### PR DESCRIPTION
during first compilaton, emcc generates cache frolibc, libcompiler_rt, libc++ etc.
We want this caching to happen during package creation, not during consumption

Specify library name and version:  **emsdk/***

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
