### PR TITLE
- [protobuf] use shim

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -23,6 +23,9 @@ sources:
   "3.17.1":
     sha256: 036D66D6EEC216160DD898CFB162E9D82C1904627642667CC32B104D407BB411
     url: https://github.com/protocolbuffers/protobuf/archive/v3.17.1.tar.gz
+  "3.19.1":
+    sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
+    url: https://github.com/protocolbuffers/protobuf/archive/v3.19.1.tar.gz
 patches:
   "3.12.4":
     - patch_file: "patches/upstream-pr-7761-cmake-regex-fix.patch"

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -15,3 +15,5 @@ versions:
     folder: all
   "3.17.1":
     folder: all
+  "3.19.1":
+    folder: all


### PR DESCRIPTION
a **tentative** solution to use shim for protoc
pros:
- proc works out of the box, without environment needed

open question
- could it be a conan client feature (generator)?
- renaming an original executable is kinda dirty, maybe better use another name/directory
- protoc could easily locate its own libraries, but what if for instance it depends on shared OpenSSL, how is it going to find it (especially, as it's a relocatable package)?

need to investigate why wrong environment is applied in test package and where is it coming from
I get:
```
dyld: Library not loaded: libprotoc.3.19.1.0.dylib
  Referenced from: /Users/sse4/.conan/data/protobuf/3.19.1/_/_/package/0cc172aa121124c6c686058b4a38104ec1833e66/bin/protoc
  Reason: no suitable image found.  Did find:
	/Users/sse4/.conan/data/protobuf/3.19.1/_/_/package/11130ddef5771b4b1df8dc19ee7e3083fa32a4eb/lib/libprotoc.3.19.1.0.dylib: mach-o, but wrong architecture
	/Users/sse4/.conan/data/protobuf/3.19.1/_/_/package/11130ddef5771b4b1df8dc19ee7e3083fa32a4eb/lib/libprotoc.3.19.1.0.dylib: stat() failed with errno=1
```
`protoc` is x86_64
```
$ file /Users/sse4/.conan/data/protobuf/3.19.1/_/_/package/0cc172aa121124c6c686058b4a38104ec1833e66/bin/protoc
/Users/sse4/.conan/data/protobuf/3.19.1/_/_/package/0cc172aa121124c6c686058b4a38104ec1833e66/bin/protoc: Mach-O 64-bit executable x86_64
```
and `libprotoc` is arm:
```
$ file /Users/sse4/.conan/data/protobuf/3.19.1/_/_/package/11130ddef5771b4b1df8dc19ee7e3083fa32a4eb/lib/libprotoc.3.19.1.0.dylib
/Users/sse4/.conan/data/protobuf/3.19.1/_/_/package/11130ddef5771b4b1df8dc19ee7e3083fa32a4eb/lib/libprotoc.3.19.1.0.dylib: Mach-O 64-bit dynamically linked shared library arm64
```

so it's clearly using `DYLD_LIBRARY_PATH` from the build context, despite `run_environment=True`.
right now, the recipe has lots of various tricks in find package:
https://github.com/conan-io/conan-center-index/blob/45f2de23abc1e54833d186f447595519325d6cf8/recipes/protobuf/all/conanfile.py#L124
https://github.com/conan-io/conan-center-index/blob/45f2de23abc1e54833d186f447595519325d6cf8/recipes/protobuf/all/conanfile.py#L147

Specify library name and version:  **protobuf/all**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
