### PR TITLE
- [bison] fix apple

### DIFF
--- a/recipes/bison/all/conanfile.py
+++ b/recipes/bison/all/conanfile.py
@@ -90,6 +90,8 @@ class BisonConan(ConanFile):
         host, build = None, None
         if self.settings.os == "Windows":
             self._autotools.defines.append("_WINDOWS")
+        if self.settings.compiler == "apple-clang":
+            args.append("gl_cv_compiler_check_decl_option=")
         if self.settings.compiler == "Visual Studio":
             # Avoid a `Assertion Failed Dialog Box` during configure with build_type=Debug
             # Visual Studio does not support the %n format flag:


### PR DESCRIPTION
compiling locally I get the following error:
```
source_subfolder/lib/pipe2-safer.c:34:7: error: implicit declaration of function 'pipe2' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  if (pipe2 (fd, flags) == 0)
      ^
source_subfolder/lib/pipe2-safer.c:34:7: note: did you mean 'pipe'?
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/unistd.h:470:6: note: 'pipe' declared here
int      pipe(int [2]);
         ^
1 error generated.
```

Specify library name and version:  **bison/all**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
