### PR TITLE
fix LD suffix issue android-ndk/r22,r23 for LD on Windows

### DIFF
--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -171,7 +171,8 @@ class AndroidNDKConan(ConanFile):
 
     def _define_tool_var_naked(self, name, value):
         ndk_bin = os.path.join(self._ndk_root, "bin")
-        path = os.path.join(ndk_bin, value)
+        suffix = ".exe" if self.settings_build.os == "Windows" else ""
+        path = os.path.join(ndk_bin, value + suffix)
         if not os.path.isfile(path):
             raise ConanException(f"'Environment variable {name} could not be created: '{path}'")
         self.output.info(f"Creating {name} environment variable: {path}")


### PR DESCRIPTION
fix LD suffix issue android-ndk/r22,r23 for LD on Windows

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
