### PR TITLE
xtensor: fix cxx11 abi workarounds

### DIFF
--- a/recipes/xtensor/all/conandata.yml
+++ b/recipes/xtensor/all/conandata.yml
@@ -20,3 +20,19 @@ sources:
   "0.21.2":
     sha256: a32490bc8499f59f8e30c288e178ff41c9511cf4959dc59c9628b29b77049a4a
     url: https://github.com/xtensor-stack/xtensor/archive/0.21.2.tar.gz
+patches:
+  "0.24.0":
+    - patch_file: "patches/0.24.0-cxx11-abi.patch"
+      base_path: "source_subfolder"
+  "0.23.10":
+    - patch_file: "patches/0.23.9-cxx11-abi.patch"
+      base_path: "source_subfolder"
+  "0.23.9":
+    - patch_file: "patches/0.23.9-cxx11-abi.patch"
+      base_path: "source_subfolder"
+  "0.21.5":
+    - patch_file: "patches/0.21.5-cxx11-abi.patch"
+      base_path: "source_subfolder"
+  "0.21.4":
+    - patch_file: "patches/0.21.4-cxx11-abi.patch"
+      base_path: "source_subfolder"

--- a/recipes/xtensor/all/conanfile.py
+++ b/recipes/xtensor/all/conanfile.py
@@ -24,11 +24,14 @@ class XtensorConan(ConanFile):
         "tbb": False,
         "openmp": False,
     }
-    no_copy_source = True
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def export_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def configure(self):
         if self.options.tbb and self.options.openmp:
@@ -67,6 +70,10 @@ class XtensorConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
 
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
@@ -112,5 +119,3 @@ class XtensorConan(ConanFile):
             self.cpp_info.defines.append("XTENSOR_USE_TBB")
         if self.options.openmp:
             self.cpp_info.defines.append("XTENSOR_USE_OPENMP")
-        if self.settings.compiler.get_safe("libcxx") in ("libstdc++", "libstdc++11"):
-            self.cpp_info.defines.append("XTENSOR_GLIBCXX_USE_CXX11_ABI=1")

--- a/recipes/xtensor/all/patches/0.21.4-cxx11-abi.patch
+++ b/recipes/xtensor/all/patches/0.21.4-cxx11-abi.patch
@@ -1,0 +1,22 @@
+diff --git a/include/xtensor/xutils.hpp b/include/xtensor/xutils.hpp
+index ce3ce72..936d387 100644
+--- a/include/xtensor/xutils.hpp
++++ b/include/xtensor/xutils.hpp
+@@ -611,12 +611,16 @@ namespace xt
+     /********************************************
+      * xtrivial_default_construct implemenation *
+      ********************************************/
+-
++#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 7
++// has_trivial_default_constructor has not been available since libstdc++-7.
++#define XTENSOR_GLIBCXX_USE_CXX11_ABI 1
++#else
+ #if defined(_GLIBCXX_USE_CXX11_ABI)
+ #if _GLIBCXX_USE_CXX11_ABI || (defined(_GLIBCXX_USE_DUAL_ABI) && !_GLIBCXX_USE_DUAL_ABI)
+ #define XTENSOR_GLIBCXX_USE_CXX11_ABI 1
+ #endif
+ #endif
++#endif
+ 
+ #if !defined(__GNUG__) || defined(_LIBCPP_VERSION) || defined(XTENSOR_GLIBCXX_USE_CXX11_ABI)
+ 

--- a/recipes/xtensor/all/patches/0.21.5-cxx11-abi.patch
+++ b/recipes/xtensor/all/patches/0.21.5-cxx11-abi.patch
@@ -1,0 +1,22 @@
+diff --git a/include/xtensor/xutils.hpp b/include/xtensor/xutils.hpp
+index 5a3f31b..1e99c9b 100644
+--- a/include/xtensor/xutils.hpp
++++ b/include/xtensor/xutils.hpp
+@@ -612,12 +612,16 @@ namespace xt
+     /********************************************
+      * xtrivial_default_construct implemenation *
+      ********************************************/
+-
++#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 7
++// has_trivial_default_constructor has not been available since libstdc++-7.
++#define XTENSOR_GLIBCXX_USE_CXX11_ABI 1
++#else
+ #if defined(_GLIBCXX_USE_CXX11_ABI)
+ #if _GLIBCXX_USE_CXX11_ABI || (defined(_GLIBCXX_USE_DUAL_ABI) && !_GLIBCXX_USE_DUAL_ABI)
+ #define XTENSOR_GLIBCXX_USE_CXX11_ABI 1
+ #endif
+ #endif
++#endif
+ 
+ #if !defined(__GNUG__) || defined(_LIBCPP_VERSION) || defined(XTENSOR_GLIBCXX_USE_CXX11_ABI)
+ 

--- a/recipes/xtensor/all/patches/0.23.9-cxx11-abi.patch
+++ b/recipes/xtensor/all/patches/0.23.9-cxx11-abi.patch
@@ -1,0 +1,21 @@
+diff --git a/include/xtensor/xutils.hpp b/include/xtensor/xutils.hpp
+index 85d8d18..fe3d0f6 100644
+--- a/include/xtensor/xutils.hpp
++++ b/include/xtensor/xutils.hpp
+@@ -638,11 +638,16 @@ namespace xt
+      * xtrivial_default_construct implemenation *
+      ********************************************/
+ 
++#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 7
++// has_trivial_default_constructor has not been available since libstdc++-7.
++#define XTENSOR_GLIBCXX_USE_CXX11_ABI 1
++#else
+ #if defined(_GLIBCXX_USE_CXX11_ABI)
+ #if _GLIBCXX_USE_CXX11_ABI || (defined(_GLIBCXX_USE_DUAL_ABI) && !_GLIBCXX_USE_DUAL_ABI)
+ #define XTENSOR_GLIBCXX_USE_CXX11_ABI 1
+ #endif
+ #endif
++#endif
+ 
+ #if !defined(__GNUG__) || defined(_LIBCPP_VERSION) || defined(XTENSOR_GLIBCXX_USE_CXX11_ABI)
+ 

--- a/recipes/xtensor/all/patches/0.24.0-cxx11-abi.patch
+++ b/recipes/xtensor/all/patches/0.24.0-cxx11-abi.patch
@@ -1,0 +1,21 @@
+diff --git a/include/xtensor/xutils.hpp b/include/xtensor/xutils.hpp
+index ed8f2ea..ba7ccea 100644
+--- a/include/xtensor/xutils.hpp
++++ b/include/xtensor/xutils.hpp
+@@ -637,11 +637,16 @@ namespace xt
+      * xtrivial_default_construct implemenation *
+      ********************************************/
+ 
++#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 7
++// has_trivial_default_constructor has not been available since libstdc++-7.
++#define XTENSOR_GLIBCXX_USE_CXX11_ABI 1
++#else
+ #if defined(_GLIBCXX_USE_CXX11_ABI)
+ #if _GLIBCXX_USE_CXX11_ABI || (defined(_GLIBCXX_USE_DUAL_ABI) && !_GLIBCXX_USE_DUAL_ABI)
+ #define XTENSOR_GLIBCXX_USE_CXX11_ABI 1
+ #endif
+ #endif
++#endif
+ 
+ #if !defined(__GNUG__) || defined(_LIBCPP_VERSION) || defined(XTENSOR_GLIBCXX_USE_CXX11_ABI)
+ 


### PR DESCRIPTION
Specify library name and version:  **xtensor/all**

In PR "xtensor: add version 0.24" , 
we introduced a workaround to solve cxx11 abi issue.
https://github.com/conan-io/conan-center-index/pull/7946#issuecomment-966496013

After that, I make PR to xtensor and PR is merged.
https://github.com/xtensor-stack/xtensor/pull/2459

Now I want to provide patches to xtensor recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
