### PR TITLE
prometheus-cpp: Bump to 1.0.0 (and libcurl dependency to 7.79.1)

### DIFF
--- a/recipes/prometheus-cpp/all/conandata.yml
+++ b/recipes/prometheus-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/jupp0r/prometheus-cpp/archive/v1.0.0.tar.gz"
+    sha256: "07018db604ea3e61f5078583e87c80932ea10c300d979061490ee1b7dc8e3a41"
   "0.12.3":
     url: "https://github.com/jupp0r/prometheus-cpp/archive/v0.12.3.tar.gz"
     sha256: "e021e76e8e933672f1af0d223307282004f585a054354f8d894db39debddff8e"

--- a/recipes/prometheus-cpp/all/conanfile.py
+++ b/recipes/prometheus-cpp/all/conanfile.py
@@ -52,7 +52,7 @@ class PrometheusCppConan(ConanFile):
         if self.options.with_pull:
             self.requires("civetweb/1.14")
         if self.options.with_push:
-            self.requires("libcurl/7.77.0")
+            self.requires("libcurl/7.79.1")
         if self.options.get_safe("with_compression"):
             self.requires("zlib/1.2.11")
 

--- a/recipes/prometheus-cpp/config.yml
+++ b/recipes/prometheus-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "0.12.3":
     folder: all
   "0.12.1":


### PR DESCRIPTION
Specify library name and version:  **prometheus-cpp/1.0.0**

- [x] Are you the author of the library?

This is my first PR to bump a version in conan-center. Please be gentle :)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
