### PR TITLE
[Help Wanted] aws-c-mqtt: add version 0.7.9

### DIFF
--- a/recipes/aws-c-mqtt/all/CMakeLists.txt
+++ b/recipes/aws-c-mqtt/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper LANGUAGES C)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/aws-c-mqtt/all/CMakeLists.txt
+++ b/recipes/aws-c-mqtt/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper LANGUAGES C)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+conan_basic_setup()
 
 add_subdirectory(source_subfolder)

--- a/recipes/aws-c-mqtt/all/conandata.yml
+++ b/recipes/aws-c-mqtt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.7.9":
+    url: "https://github.com/awslabs/aws-c-mqtt/archive/v0.7.9.tar.gz"
+    sha256: "8556ae7c2b30ebb4ccb61becb120a848ea33315f7cf85436ebe5f21b75ab09c4"
   "0.7.6":
     url: "https://github.com/awslabs/aws-c-mqtt/archive/v0.7.6.tar.gz"
     sha256: "a02c0525f7ddcdc058cd9f507b2f3a8be0383fc946920ed32c9d780cc29703ac"

--- a/recipes/aws-c-mqtt/all/conanfile.py
+++ b/recipes/aws-c-mqtt/all/conanfile.py
@@ -1,12 +1,12 @@
 from conans import ConanFile, CMake, tools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
 
 class AwsCMQTT(ConanFile):
     name = "aws-c-mqtt"
     description = "C99 implementation of the MQTT 3.1.1 specification."
-    topics = ("conan", "aws", "amazon", "cloud", )
+    topics = ("aws", "amazon", "cloud", "mqtt")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-mqtt"
     license = "Apache-2.0",
@@ -39,10 +39,10 @@ class AwsCMQTT(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.9")
+        self.requires("aws-c-common/0.6.15")
         self.requires("aws-c-cal/0.5.12")
-        self.requires("aws-c-io/0.10.9")
-        self.requires("aws-c-http/0.6.7")
+        self.requires("aws-c-io/0.10.13")
+        self.requires("aws-c-http/0.6.10")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -67,12 +67,9 @@ class AwsCMQTT(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-mqtt"))
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-mqtt"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-mqtt"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-mqtt-lib"].names["cmake_find_package"] = "aws-c-mqtt"
-        self.cpp_info.components["aws-c-mqtt-lib"].names["cmake_find_package_multi"] = "aws-c-mqtt"
+        self.cpp_info.set_property("cmake_file_name", "aws-c-mqtt")
+        self.cpp_info.set_property("cmake_target_name", "AWS")
+        self.cpp_info.components["aws-c-mqtt-lib"].set_property("cmake_target_name", "aws-c-mqtt")
         self.cpp_info.components["aws-c-mqtt-lib"].libs = ["aws-c-mqtt"]
         self.cpp_info.components["aws-c-mqtt-lib"].requires = [
             "aws-c-common::aws-c-common-lib",

--- a/recipes/aws-c-mqtt/all/test_package/CMakeLists.txt
+++ b/recipes/aws-c-mqtt/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(aws-c-mqtt REQUIRED CONFIG)
 

--- a/recipes/aws-c-mqtt/config.yml
+++ b/recipes/aws-c-mqtt/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.7.9":
+    folder: all
   "0.7.6":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **aws-c-mqtt/0.7.9**


Concerning #7763,
The versions of aws-c-common and aws-c-io are roughly tighted.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
