### PR TITLE
Add package i2c-tools

### DIFF
--- a/recipes/i2c-tools/all/conandata.yml
+++ b/recipes/i2c-tools/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "4.3":
+    url: "https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/i2c-tools-4.3.tar.gz"
+    sha256: "eec464e42301d93586cbeca3845ed61bff40f560670e5b35baec57301d438148"

--- a/recipes/i2c-tools/all/conanfile.py
+++ b/recipes/i2c-tools/all/conanfile.py
@@ -12,8 +12,14 @@ class I2cConan(ConanFile):
     topics = ("i2c")
     os = "linux"
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
     generators = "cmake"
 
     def validate(self):

--- a/recipes/i2c-tools/all/conanfile.py
+++ b/recipes/i2c-tools/all/conanfile.py
@@ -30,7 +30,9 @@ class I2cConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def build(self):
-        self.run("make", cwd=self._source_subfolder)
+        autotools = AutotoolsBuildEnvironment(self)
+        autotools.make(target="libi2c.so" if self.options.shared else "libi2c.a")
+        
 
     def package(self):
         self.copy("*.h", dst="include", src=self._source_subfolder, keep_path=False)

--- a/recipes/i2c-tools/all/conanfile.py
+++ b/recipes/i2c-tools/all/conanfile.py
@@ -7,7 +7,6 @@ requires_conan_version = ">=1.33.0"
 class I2cConan(ConanFile):
     name = "i2c-tools"
     license = "LGPL 2.1"
-    author = "Eirik Brandtzæg eirikb@eirikb.no"
     url = "https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/"
     description = "I2C tools for the linux kernel as well as an I2C library."
     topics = ("i2c")

--- a/recipes/i2c-tools/all/conanfile.py
+++ b/recipes/i2c-tools/all/conanfile.py
@@ -7,7 +7,8 @@ requires_conan_version = ">=1.33.0"
 class I2cConan(ConanFile):
     name = "i2c-tools"
     license = "GPL-2.0-or-later", "LGPL-2.1"
-    url = "https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/"
     description = "I2C tools for the linux kernel as well as an I2C library."
     topics = ("i2c")
     os = "linux"

--- a/recipes/i2c-tools/all/conanfile.py
+++ b/recipes/i2c-tools/all/conanfile.py
@@ -1,6 +1,8 @@
 import os
 from conans import ConanFile, CMake, tools, AutoToolsBuildEnvironment
 
+requires_conan_version = ">=1.33.0"
+
 
 class I2cConan(ConanFile):
     name = "i2c-tools"

--- a/recipes/i2c-tools/all/conanfile.py
+++ b/recipes/i2c-tools/all/conanfile.py
@@ -1,0 +1,43 @@
+import os
+from conans import ConanFile, CMake, tools, AutoToolsBuildEnvironment
+
+
+class I2cConan(ConanFile):
+    name = "i2c-tools"
+    license = "LGPL 2.1"
+    author = "Eirik Brandtzæg eirikb@eirikb.no"
+    url = "https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/"
+    description = "I2C tools for the linux kernel as well as an I2C library."
+    topics = ("i2c")
+    os = "linux"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+    generators = "cmake"
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("i2c-tools only support Linux")
+
+    @property
+    def _source_subfolder(self):
+        return "i2c-tools"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "i2c-tools-{}".format(self.version)
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def build(self):
+        self.run("make", cwd=self._source_subfolder)
+
+    def package(self):
+        self.copy("*.h", dst="include", src=self._source_subfolder, keep_path=False)
+        self.copy("*.h", dst="include/i2c", src=self._source_subfolder, keep_path=False)
+        self.copy("*.so", dst="lib", keep_path=False)
+        self.copy("*.so.0", dst="lib", keep_path=False)
+        self.copy("*.dylib", dst="lib", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["i2c"]

--- a/recipes/i2c-tools/all/conanfile.py
+++ b/recipes/i2c-tools/all/conanfile.py
@@ -45,7 +45,6 @@ class I2cConan(ConanFile):
         self.copy("*.h", dst="include/i2c", src=self._source_subfolder, keep_path=False)
         self.copy("*.so", dst="lib", keep_path=False)
         self.copy("*.so.0", dst="lib", keep_path=False)
-        self.copy("*.dylib", dst="lib", keep_path=False)
         self.copy("*.a", dst="lib", keep_path=False)
 
     def package_info(self):

--- a/recipes/i2c-tools/all/test_package/CMakeLists.txt
+++ b/recipes/i2c-tools/all/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(example example.cpp)
+target_link_libraries(example ${CONAN_LIBS})
+
+# CTest is a testing tool that can be used to test your project.
+# enable_testing()
+# add_test(NAME example
+#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+#          COMMAND example)

--- a/recipes/i2c-tools/all/test_package/CMakeLists.txt
+++ b/recipes/i2c-tools/all/test_package/CMakeLists.txt
@@ -2,13 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(i2c-tools REQUIRED CONFIG)
 
 add_executable(example example.cpp)
-target_link_libraries(example ${CONAN_LIBS})
-
-# CTest is a testing tool that can be used to test your project.
-# enable_testing()
-# add_test(NAME example
-#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-#          COMMAND example)
+target_link_libraries(example PRIVATE i2c-tools::i2c-tools)

--- a/recipes/i2c-tools/all/test_package/conanfile.py
+++ b/recipes/i2c-tools/all/test_package/conanfile.py
@@ -1,25 +1,17 @@
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
 
-
-class I2cTestConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
-        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
-        # in "test_package"
         cmake.configure()
         cmake.build()
 
-    def imports(self):
-        self.copy("*.dll", dst="bin", src="bin")
-        self.copy("*.dylib*", dst="bin", src="lib")
-        self.copy('*.so*', dst='bin', src='lib')
-
     def test(self):
         if not tools.cross_building(self):
-            os.chdir("bin")
-            self.run(".%sexample" % os.sep)
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/i2c-tools/all/test_package/conanfile.py
+++ b/recipes/i2c-tools/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class I2cTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
+        # in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def imports(self):
+        self.copy("*.dll", dst="bin", src="bin")
+        self.copy("*.dylib*", dst="bin", src="lib")
+        self.copy('*.so*', dst='bin', src='lib')
+
+    def test(self):
+        if not tools.cross_building(self):
+            os.chdir("bin")
+            self.run(".%sexample" % os.sep)

--- a/recipes/i2c-tools/all/test_package/example.cpp
+++ b/recipes/i2c-tools/all/test_package/example.cpp
@@ -1,0 +1,4 @@
+#include "i2c/smbus.h"
+
+int main() {
+}

--- a/recipes/i2c-tools/config.yml
+++ b/recipes/i2c-tools/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "4.3":
+    folder: "all"

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -6,7 +6,7 @@ import functools
 import os
 import textwrap
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
 
 
 class OpenSSLConan(ConanFile):
@@ -711,13 +711,14 @@ class OpenSSLConan(ConanFile):
                             "conan-official-{}-variables.cmake".format(self.name))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "OpenSSL"
-        self.cpp_info.names["cmake_find_package_multi"] = "OpenSSL"
-        self.cpp_info.names["pkg_config"] = "openssl"
+        self.cpp_info.set_property("cmake_target_name", "OpenSSL")
+        self.cpp_info.set_property("pkg_config_name", "openssl")
+
         self.cpp_info.components["ssl"].builddirs.append(self._module_subfolder)
-        self.cpp_info.components["ssl"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.components["ssl"].set_property("cmake_build_modules", [self._module_file_rel_path])
         self.cpp_info.components["crypto"].builddirs.append(self._module_subfolder)
-        self.cpp_info.components["crypto"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.components["crypto"].set_property("cmake_build_modules", [self._module_file_rel_path])
+
         if self._use_nmake:
             libsuffix = "d" if self.settings.build_type == "Debug" else ""
             self.cpp_info.components["ssl"].libs = ["libssl" + libsuffix]
@@ -743,9 +744,7 @@ class OpenSSLConan(ConanFile):
             self.cpp_info.components["crypto"].system_libs.append("atomic")
             self.cpp_info.components["ssl"].system_libs.append("atomic")
 
-        self.cpp_info.components["crypto"].names["cmake_find_package"] = "Crypto"
-        self.cpp_info.components["crypto"].names["cmake_find_package_multi"] = "Crypto"
-        self.cpp_info.components["crypto"].names["pkg_config"] = "libcrypto"
-        self.cpp_info.components["ssl"].names["cmake_find_package"] = "SSL"
-        self.cpp_info.components["ssl"].names["cmake_find_package_multi"] = "SSL"
-        self.cpp_info.components["ssl"].names["pkg_config"] = "libssl"
+        self.cpp_info.components["crypto"].set_property("cmake_target_name", "Crypto")
+        self.cpp_info.components["crypto"].set_property("pkg_config_name", "libcrypto")
+        self.cpp_info.components["ssl"].set_property("cmake_target_name", "SSL")
+        self.cpp_info.components["ssl"].set_property("pkg_config_name", "libssl")


### PR DESCRIPTION
Specify library name and version:  **i2c-tools/4.3**

Hi. My end goal is to push [ddcutil](https://github.com/rockowitz/ddcutil).
To do this I need at least two new packages: **i2c-tools** and **libkmod** (both in kernel.org).

I will see if I can get this package accepted before I try to push libkmod, and eventually ddcutil.  
This isn't my first PR, but it is my first PR with a new package.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

No hooks tested, but I have tried multiple different builds: https://github.com/eirikb/proof-of-conan/actions/runs/1476530986
