### PR TITLE
aws-c-sdkutils: add recipe

### DIFF
--- a/recipes/aws-c-sdkutils/all/CMakeLists.txt
+++ b/recipes/aws-c-sdkutils/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper LANGUAGES C)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/aws-c-sdkutils/all/conandata.yml
+++ b/recipes/aws-c-sdkutils/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.1":
+    url: "https://github.com/awslabs/aws-c-sdkutils/archive/refs/tags/v0.1.1.tar.gz"
+    sha256: "201a5f694c912c952f50abab54fa0e576db75ddf6e8710c589896038ff9673f7"

--- a/recipes/aws-c-sdkutils/all/conanfile.py
+++ b/recipes/aws-c-sdkutils/all/conanfile.py
@@ -1,0 +1,72 @@
+import os
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.36.0"
+
+class AwsCSDKUtils(ConanFile):
+    name = "aws-c-sdkutils"
+    description = "aws c language sdk utility library."
+    topics = ("aws", "amazon", "cloud", "utility")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/awslabs/aws-c-sdkutils"
+    license = "Apache-2.0",
+    exports_sources = "CMakeLists.txt",
+    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.cppstd
+        del self.settings.compiler.libcxx
+
+    def requirements(self):
+        self.requires("aws-c-common/0.6.15")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-sdkutils"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "aws-c-sdkutils")
+        self.cpp_info.set_property("cmake_target_name", "AWS")
+        self.cpp_info.components["aws-c-sdkutils-lib"].set_property("cmake_target_name", "aws-c-sdkutils")
+        self.cpp_info.components["aws-c-sdkutils-lib"].libs = ["aws-c-sdkutils"]
+        self.cpp_info.components["aws-c-sdkutils-lib"].requires = ["aws-c-common::aws-c-common-lib"]
+

--- a/recipes/aws-c-sdkutils/all/conanfile.py
+++ b/recipes/aws-c-sdkutils/all/conanfile.py
@@ -64,8 +64,14 @@ class AwsCSDKUtils(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-sdkutils"))
 
     def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "aws-c-sdkutils"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-sdkutils"
         self.cpp_info.set_property("cmake_file_name", "aws-c-sdkutils")
+        self.cpp_info.names["cmake_find_package"] = "AWS"
+        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
         self.cpp_info.set_property("cmake_target_name", "AWS")
+        self.cpp_info.components["aws-c-sdkutils-lib"].names["cmake_find_package"] = "aws-c-sdkutils"
+        self.cpp_info.components["aws-c-sdkutils-lib"].names["cmake_find_package_multi"] = "aws-c-sdkutils"
         self.cpp_info.components["aws-c-sdkutils-lib"].set_property("cmake_target_name", "aws-c-sdkutils")
         self.cpp_info.components["aws-c-sdkutils-lib"].libs = ["aws-c-sdkutils"]
         self.cpp_info.components["aws-c-sdkutils-lib"].requires = ["aws-c-common::aws-c-common-lib"]

--- a/recipes/aws-c-sdkutils/all/test_package/CMakeLists.txt
+++ b/recipes/aws-c-sdkutils/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(aws-c-sdkutils REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} AWS::aws-c-sdkutils)

--- a/recipes/aws-c-sdkutils/all/test_package/conanfile.py
+++ b/recipes/aws-c-sdkutils/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/aws-c-sdkutils/all/test_package/test_package.c
+++ b/recipes/aws-c-sdkutils/all/test_package/test_package.c
@@ -1,0 +1,10 @@
+#include <aws/common/allocator.h>
+#include <aws/sdkutils/sdkutils.h>
+
+int main() {
+    struct aws_allocator *allocator = aws_default_allocator();
+    aws_sdkutils_library_init(allocator);
+    aws_sdkutils_library_clean_up();
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/aws-c-sdkutils/config.yml
+++ b/recipes/aws-c-sdkutils/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **aws-c-sdkutils/0.1.1**

aws-c-sdkutils seems to be inmature library because it has no description in github repository.
But aws-c-sdkutils has been required by aws-c-auth since 0.6.5. (Please refer  https://github.com/awslabs/aws-c-auth/releases/tag/v0.6.5).

So we have to create aws-c-sdkutils recipe for updating aws-c-auth.

The description of aws-c-sdkutils recipe is my poor description.
It have to be modified in future release.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
