### PR TITLE
pcre2: remove dead download URLs

### DIFF
--- a/recipes/pcre2/all/conandata.yml
+++ b/recipes/pcre2/all/conandata.yml
@@ -1,27 +1,22 @@
 sources:
   "10.32":
     url:
-      - "https://sourceforge.net/projects/pcre/files/pcre2/10.32/pcre2-10.32.tar.bz2" 
-      - "https://ftp.pcre.org/pub/pcre/pcre2-10.32.tar.bz2"
+      - "https://sourceforge.net/projects/pcre/files/pcre2/10.32/pcre2-10.32.tar.bz2"
     sha256: "f29e89cc5de813f45786580101aaee3984a65818631d4ddbda7b32f699b87c2e"
   "10.33":
     url:
-      - "https://sourceforge.net/projects/pcre/files/pcre2/10.33/pcre2-10.33.tar.bz2" 
-      - "https://ftp.pcre.org/pub/pcre/pcre2-10.33.tar.bz2"
+      - "https://sourceforge.net/projects/pcre/files/pcre2/10.33/pcre2-10.33.tar.bz2"
     sha256: "35514dff0ccdf02b55bd2e9fa586a1b9d01f62332c3356e379eabb75f789d8aa"
   "10.35":
     url:
-      - "https://sourceforge.net/projects/pcre/files/pcre2/10.35/pcre2-10.35.tar.bz2" 
-      - "https://ftp.pcre.org/pub/pcre/pcre2-10.35.tar.bz2"
+      - "https://sourceforge.net/projects/pcre/files/pcre2/10.35/pcre2-10.35.tar.bz2"
     sha256: "9ccba8e02b0ce78046cdfb52e5c177f0f445e421059e43becca4359c669d4613"
   "10.36":
     url:
-      - "https://sourceforge.net/projects/pcre/files/pcre2/10.36/pcre2-10.36.tar.bz2" 
-      - "https://ftp.pcre.org/pub/pcre/pcre2-10.36.tar.bz2"
+      - "https://sourceforge.net/projects/pcre/files/pcre2/10.36/pcre2-10.36.tar.bz2"
     sha256: "a9ef39278113542968c7c73a31cfcb81aca1faa64690f400b907e8ab6b4a665c"
   "10.37":
     url:
-      - "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.37/pcre2-10.37.tar.bz2" 
+      - "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.37/pcre2-10.37.tar.bz2"
       - "https://sourceforge.net/projects/pcre/files/pcre2/10.37/pcre2-10.37.tar.bz2"
-      - "https://ftp.pcre.org/pub/pcre/pcre2-10.37.tar.bz2"
     sha256: "4d95a96e8b80529893b4562be12648d798b957b1ba1aae39606bbc2ab956d270"


### PR DESCRIPTION
From the website https://www.pcre.org:

> Note that the former ftp.pcre.org FTP site is no longer available. You will need to update any scripts that download PCRE source code to download via HTTPS, Git, or Subversion from the new home on GitHub instead.

Fixes #8103

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
