### PR TITLE
pcre: remove dead download URLs

### DIFF
--- a/recipes/pcre/all/conandata.yml
+++ b/recipes/pcre/all/conandata.yml
@@ -1,19 +1,10 @@
 sources:
   "8.45":
-    url: [
-      "https://sourceforge.net/projects/pcre/files/pcre/8.45/pcre-8.45.tar.bz2",
-      "https://ftp.pcre.org/pub/pcre/pcre-8.45.tar.bz2",
-    ]
+    url: "https://sourceforge.net/projects/pcre/files/pcre/8.45/pcre-8.45.tar.bz2"
     sha256: "4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8"
   "8.44":
-    url: [
-      "https://sourceforge.net/projects/pcre/files/pcre/8.44/pcre-8.44.tar.bz2",
-      "https://ftp.pcre.org/pub/pcre/pcre-8.44.tar.bz2",
-    ]
+    url: "https://sourceforge.net/projects/pcre/files/pcre/8.44/pcre-8.44.tar.bz2"
     sha256: "19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d"
   "8.41":
-    url: [
-      "https://sourceforge.net/projects/pcre/files/pcre/8.41/pcre-8.41.tar.bz2",
-      "https://ftp.pcre.org/pub/pcre/pcre-8.41.tar.bz2",
-    ]
+    url: "https://sourceforge.net/projects/pcre/files/pcre/8.41/pcre-8.41.tar.bz2"
     sha256: "e62c7eac5ae7c0e7286db61ff82912e1c0b7a0c13706616e94a7dd729321b530"


### PR DESCRIPTION
From the website https://www.pcre.org:

> Note that the former ftp.pcre.org FTP site is no longer available. You will need to update any scripts that download PCRE source code to download via HTTPS, Git, or Subversion from the new home on GitHub instead.

Fixes #8103

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
