### PR TITLE
sentry-crashpad: Fix linking when using MSVC.

### DIFF
--- a/recipes/sentry-crashpad/all/conandata.yml
+++ b/recipes/sentry-crashpad/all/conandata.yml
@@ -24,6 +24,9 @@ sources:
     url: "https://github.com/getsentry/sentry-native/releases/download/0.2.6/sentry-native-0.2.6.zip"
     sha256: "0d93bd77f70a64f3681d4928dfca6b327374218a84d33ee31489114d8e4716c0"
 patches:
+  "0.4.12":
+    - patch_file: "patches/0.4.12-0001-getopt.patch"
+      base_path: "source_subfolder"
   "0.4.9":
     - patch_file: "patches/0.4.9-0001-missing-installed-headers.patch"
       base_path: "source_subfolder"

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -125,10 +125,15 @@ class SentryCrashpadConan(ConanFile):
         if self.settings.os in ("Linux", "FreeBSD"):
             self.cpp_info.components["compat"].system_libs.append("dl")
 
+        if self.settings.os == "Windows":
+            self.cpp_info.components["getopt"].libs = ["crashpad_getopt"]
+
         self.cpp_info.components["util"].libs = ["crashpad_util"]
         self.cpp_info.components["util"].requires = ["compat", "mini_chromium", "zlib::zlib"]
         if self.settings.os in ("Linux", "FreeBSD"):
             self.cpp_info.components["util"].system_libs.extend(["pthread", "rt"])
+        elif self.settings.os == "Windows":
+            self.cpp_info.components["util"].system_libs.append("winhttp")
         if self.options.get_safe("with_tls") == "openssl":
             self.cpp_info.components["util"].requires.append("openssl::openssl")
 
@@ -141,6 +146,8 @@ class SentryCrashpadConan(ConanFile):
 
         self.cpp_info.components["snapshot"].libs = ["crashpad_snapshot"]
         self.cpp_info.components["snapshot"].requires = ["client", "compat", "util", "mini_chromium"]
+        if self.settings.os == "Windows":
+            self.cpp_info.components["snapshot"].system_libs.append("PowrProf")
 
         self.cpp_info.components["minidump"].libs = ["crashpad_minidump"]
         self.cpp_info.components["minidump"].requires = ["compat", "snapshot", "util", "mini_chromium"]
@@ -148,6 +155,8 @@ class SentryCrashpadConan(ConanFile):
         if tools.Version(self.version) > "0.3":
             self.cpp_info.components["handler"].libs = ["crashpad_handler_lib"]
             self.cpp_info.components["handler"].requires = ["compat", "minidump", "snapshot", "util", "mini_chromium"]
+            if self.settings.os == "Windows":
+                self.cpp_info.components["handler"].requires.append("getopt")
 
         self.cpp_info.components["tools"].libs = ["crashpad_tools"]
 

--- a/recipes/sentry-crashpad/all/patches/0.4.12-0001-getopt.patch
+++ b/recipes/sentry-crashpad/all/patches/0.4.12-0001-getopt.patch
@@ -1,0 +1,20 @@
+--- a/external/crashpad/handler/CMakeLists.txt
++++ b/external/crashpad/handler/CMakeLists.txt
+@@ -64,6 +64,7 @@ target_link_libraries(crashpad_handler_lib
+ 
+ if(WIN32)
+     if(MSVC)
++        target_link_libraries(crashpad_handler_lib PUBLIC crashpad_getopt)
+         target_compile_options(crashpad_handler_lib PRIVATE "/wd4201")
+     endif()
+ endif()
+--- a/external/crashpad/third_party/getopt/CMakeLists.txt
++++ b/external/crashpad/third_party/getopt/CMakeLists.txt
+@@ -9,6 +9,7 @@ if(MSVC)
+     target_link_libraries(crashpad_getopt PRIVATE
+         $<BUILD_INTERFACE:crashpad_interface>
+     )
++    crashpad_install_target(crashpad_getopt)
+ else()
+     add_library(crashpad_getopt INTERFACE)
+ endif()


### PR DESCRIPTION
Specify library name and version:  **sentry-crashpad/0.4.12**

Customized getopt library inside crashpad is used from `crashpad_handler` library. Hence we need to install and link the `crashpad_getopt` library for MSVC builds. Most crashpad users probably don't build their own crash handlers so that is why this issue has not been noticed before.

Upstream PR: https://github.com/getsentry/crashpad/pull/55

Also add couple of missing system libraries to link against on Windows.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
