### PR TITLE
tree-sitter: modernize + use cmake + bump

### DIFF
--- a/recipes/tree-sitter/all/CMakeLists.txt
+++ b/recipes/tree-sitter/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.4)
 project(tree-sitter C)
 
 include(conanbuildinfo.cmake)
@@ -21,6 +21,7 @@ set_target_properties(${PROJECT_NAME}
     PROPERTIES
         C_STANDARD 99
         PUBLIC_HEADER "${HEADERS}"
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
 
 include(GNUInstallDirs)

--- a/recipes/tree-sitter/all/CMakeLists.txt
+++ b/recipes/tree-sitter/all/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.0)
+project(tree-sitter C)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+# Use cmake script instead of Makefile to support MSVC + follow fPIC option
+
+file(GLOB SOURCES RELATIVE "${PROJECT_SOURCE_DIR}" source_subfolder/lib/src/*.c)
+list(REMOVE_ITEM SOURCES source_subfolder/lib/src/lib.c)
+
+file(GLOB HEADERS source_subfolder/lib/include/tree_sitter/*.h)
+
+add_library(${PROJECT_NAME} ${SOURCES})
+target_include_directories(${PROJECT_NAME}
+    PRIVATE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/source_subfolder/lib/include>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/source_subfolder/lib/src>
+)
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        C_STANDARD 99
+        PUBLIC_HEADER "${HEADERS}"
+)
+
+include(GNUInstallDirs)
+install(TARGETS ${PROJECT_NAME}
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter"
+)

--- a/recipes/tree-sitter/all/conandata.yml
+++ b/recipes/tree-sitter/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.20.0":
+    url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.20.0.tar.gz"
+    sha256: "4a8070b9de17c3b8096181fe8530320ab3e8cca685d8bee6a3e8d164b5fb47da"
   "0.17.3":
-    url: https://github.com/tree-sitter/tree-sitter/archive/0.17.3.tar.gz
-    sha256: a897e5c9a7ccb74271d9b20d59121d2d2e9de8b896c4d1cfaac0f8104c1ef9f8
+    url: "https://github.com/tree-sitter/tree-sitter/archive/0.17.3.tar.gz"
+    sha256: "a897e5c9a7ccb74271d9b20d59121d2d2e9de8b896c4d1cfaac0f8104c1ef9f8"

--- a/recipes/tree-sitter/all/conanfile.py
+++ b/recipes/tree-sitter/all/conanfile.py
@@ -35,6 +35,8 @@ class TreeSitterConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        del self.settings.compiler.cppstd
+        del self.settings.compiler.libcxx
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/tree-sitter/all/conanfile.py
+++ b/recipes/tree-sitter/all/conanfile.py
@@ -1,9 +1,8 @@
-import os
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
-from conans.errors import ConanInvalidConfiguration
-import shutil
+from conans import CMake, ConanFile, tools
+import functools
 
-required_conan_version = ">=1.29.1"
+required_conan_version = ">=1.33.0"
+
 
 class TreeSitterConan(ConanFile):
     name = "tree-sitter"
@@ -12,53 +11,49 @@ class TreeSitterConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://tree-sitter.github.io/tree-sitter"
     license = "MIT"
-    settings = "os", "compiler", "build_type", "arch"
-    options = {"fPIC": [True, False],
-               "shared": [True, False]}
-    default_options = {"fPIC": True,
-                       "shared": False}
-    _autotools = None
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+        "shared": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "shared": False,
+    }
 
+    generators = "cmake"
+    exports_sources = "CMakeLists.txt"
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
-    def configure(self):
+    def config_options(self):
         if self.settings.os == "Windows":
-            raise ConanInvalidConfiguration("tree-sitter is not support on {}.".format(self.settings.os))
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
-    def _configure_autotools(self):
-        if not self._autotools:
-            self._autotools = AutoToolsBuildEnvironment(self)
-
-        return self._autotools
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
 
     def build(self):
-        autotools = self._configure_autotools()
-
-        with tools.chdir(self._source_subfolder):
-            autotools.make()
+        cmake = self._configure_cmake()
+        cmake.build()
 
     def package(self):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-
-        autotools = self._configure_autotools()
-        with tools.chdir(self._source_subfolder):
-            autotools.install(args=["PREFIX={}".format(self.package_folder)])
-
-            if self.options.shared:
-                tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.a")
-            else:
-                tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.so*")
-                tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.dylib*")
-
-        tools.rmdir(os.path.join(self.package_folder, os.path.join("lib", "pkgconfig")))
-
+        cmake = self._configure_cmake()
+        cmake.install()
 
     def package_info(self):
         self.cpp_info.names["pkg_config"] = "tree-sitter"

--- a/recipes/tree-sitter/all/test_package/CMakeLists.txt
+++ b/recipes/tree-sitter/all/test_package/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(tree-sitter REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} tree-sitter::tree-sitter)

--- a/recipes/tree-sitter/all/test_package/conanfile.py
+++ b/recipes/tree-sitter/all/test_package/conanfile.py
@@ -1,17 +1,17 @@
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
-                
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/tree-sitter/all/test_package/test_package.c
+++ b/recipes/tree-sitter/all/test_package/test_package.c
@@ -1,11 +1,8 @@
 #include <tree_sitter/api.h>
-#include <stdio.h>
 
-//More datailed example search at https://tree-sitter.github.io/tree-sitter/using-parsers#getting-started
+//More detailed example search at https://tree-sitter.github.io/tree-sitter/using-parsers#getting-started
 int main() {
-  TSParser *parser = ts_parser_new();
-  ts_parser_delete(parser);
-  printf( "Test package\n" );
-  return 0;
+    TSParser *parser = ts_parser_new();
+    ts_parser_delete(parser);
+    return 0;
 }
-

--- a/recipes/tree-sitter/config.yml
+++ b/recipes/tree-sitter/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.20.0":
+    folder: all
   "0.17.3":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **tree-sitter/0.20.0**

- use cmake to support MSVC (untested) + use correct fPIC flags

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
