### PR TITLE
tree-sitter-c: add tree-sitter-c/0.20.1 recipe

### DIFF
--- a/recipes/tree-sitter-c/all/CMakeLists.txt
+++ b/recipes/tree-sitter-c/all/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.0)
+project(tree-sitter-c C)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(tree-sitter REQUIRED CONFIG)
+
+file(WRITE api.h [[
+#pragma once
+#include <tree_sitter/parser.h>
+
+extern const TSLanguage *tree_sitter_c(void);
+]])
+
+add_library(${PROJECT_NAME}
+    source_subfolder/src/parser.c
+)
+target_link_libraries(${PROJECT_NAME}
+    PUBLIC
+        tree-sitter::tree-sitter
+)
+target_include_directories(${PROJECT_NAME}
+    PRIVATE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/source_subfolder/lib/include>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/source_subfolder/src>
+)
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+        C_STANDARD 99
+        PUBLIC_HEADER "api.h"
+)
+
+include(GNUInstallDirs)
+install(TARGETS ${PROJECT_NAME}
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tree_sitter_c"
+)

--- a/recipes/tree-sitter-c/all/CMakeLists.txt
+++ b/recipes/tree-sitter-c/all/CMakeLists.txt
@@ -5,12 +5,14 @@ include(conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
 find_package(tree-sitter REQUIRED CONFIG)
+include(GenerateExportHeader)
 
 file(WRITE api.h [[
 #pragma once
 #include <tree_sitter/parser.h>
+#include "tree_sitter_c_export.h"
 
-extern const TSLanguage *tree_sitter_c(void);
+TREE_SITTER_C_EXPORT const TSLanguage *tree_sitter_c(void);
 ]])
 
 add_library(${PROJECT_NAME}
@@ -28,7 +30,11 @@ target_include_directories(${PROJECT_NAME}
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
         C_STANDARD 99
-        PUBLIC_HEADER "api.h"
+        PUBLIC_HEADER "api.h;${CMAKE_CURRENT_BINARY_DIR}/tree_sitter_c_export.h"
+)
+generate_export_header(${PROJECT_NAME}
+    BASE_NAME TREE_SITTER_C
+    EXPORT_FILE_NAME "tree_sitter_c_export.h"
 )
 
 include(GNUInstallDirs)

--- a/recipes/tree-sitter-c/all/conandata.yml
+++ b/recipes/tree-sitter-c/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.20.1":
+    url: "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v0.20.1.tar.gz"
+    sha256: "ffcc2ef0eded59ad1acec9aec4f9b0c7dd209fc1a85d85f8b0e81298e3dddcc2"

--- a/recipes/tree-sitter-c/all/conanfile.py
+++ b/recipes/tree-sitter-c/all/conanfile.py
@@ -35,6 +35,8 @@ class TreeSitterCConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
 
     def requirements(self):
         self.requires("tree-sitter/0.20.0")

--- a/recipes/tree-sitter-c/all/conanfile.py
+++ b/recipes/tree-sitter-c/all/conanfile.py
@@ -1,0 +1,62 @@
+from conans import CMake, ConanFile, tools
+import functools
+
+required_conan_version = ">=1.33.0"
+
+
+class TreeSitterCConan(ConanFile):
+    name = "tree-sitter-c"
+    description = "C grammar for tree-sitter."
+    topics = ("parser", "grammar", "tree", "c", "ide")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/tree-sitter/tree-sitter-c"
+    license = "MIT"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+        "shared": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "shared": False,
+    }
+
+    generators = "cmake", "cmake_find_package_multi"
+    exports_sources = "CMakeLists.txt"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def requirements(self):
+        self.requires("tree-sitter/0.20.0")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["tree-sitter-c"]

--- a/recipes/tree-sitter-c/all/conanfile.py
+++ b/recipes/tree-sitter-c/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import CMake, ConanFile, tools
 import functools
+import os
 
 required_conan_version = ">=1.33.0"
 
@@ -51,7 +52,15 @@ class TreeSitterCConan(ConanFile):
         cmake.configure()
         return cmake
 
+    def _patch_sources(self):
+        if not self.options.shared:
+            tools.replace_in_file(
+                os.path.join(self._source_subfolder, "src", "parser.c"),
+                "__declspec(dllexport)", ""
+            )
+
     def build(self):
+        self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/tree-sitter-c/all/test_package/CMakeLists.txt
+++ b/recipes/tree-sitter-c/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(tree-sitter-c REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} tree-sitter-c::tree-sitter-c)

--- a/recipes/tree-sitter-c/all/test_package/conanfile.py
+++ b/recipes/tree-sitter-c/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/tree-sitter-c/all/test_package/test_package.c
+++ b/recipes/tree-sitter-c/all/test_package/test_package.c
@@ -1,0 +1,27 @@
+#include <tree_sitter/api.h>
+#include <tree_sitter_c/api.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+int main() {
+    TSParser *parser = ts_parser_new();
+    ts_parser_set_language(parser, tree_sitter_c());
+    const char *source_code = "int a[] = {42, 1337};\n";
+    TSTree *tree = ts_parser_parse_string(
+        parser,
+        NULL,
+        source_code,
+        strlen(source_code)
+    );
+    TSNode root_node = ts_tree_root_node(tree);
+
+    char *string = ts_node_string(root_node);
+    printf("Syntax tree: %s\n", string);
+    free(string);
+
+    ts_tree_delete(tree);
+    ts_parser_delete(parser);
+    return 0;
+}
+

--- a/recipes/tree-sitter-c/config.yml
+++ b/recipes/tree-sitter-c/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.20.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **tree-sitter-c/0.20.1**

It appears tree-sitter-c does not contain a build system.
It is meant to be dropped inside a project.

Depends on #8121

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
