### PR TITLE
Bump spirv-cross/cci.20211113

### DIFF
--- a/recipes/spirv-cross/all/conandata.yml
+++ b/recipes/spirv-cross/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20211113":
+    url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/7c3cb0b12c9965497b08403c82ac1b82846fa7be.tar.gz"
+    sha256: "5bb6837e2b75db1a9e36e7d6eac40d905e3460ff3b5234f391adc6bdf6aadcdf"
   "cci.20210930":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/97a438d214b24e4958ca137a18639670648cedd0.tar.gz"
     sha256: "dd07ce3c261fe8c08dbfbb3dd274f35de50ea8610f57fe5de4fe2b782c4accbd"

--- a/recipes/spirv-cross/config.yml
+++ b/recipes/spirv-cross/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20211113":
+    folder: all
   "cci.20210930":
     folder: all
   "cci.20210823":


### PR DESCRIPTION
MoltenVK 1.1.6 (Vulkan 1.2.198) depends on this commit of spirv-cross.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
