### PR TITLE
Fix broken logr package under some options

### DIFF
--- a/recipes/logr/all/conanfile.py
+++ b/recipes/logr/all/conanfile.py
@@ -132,18 +132,18 @@ class LogrConan(ConanFile):
         elif self.options.backend == "glog":
             self.cpp_info.components["logr_glog"].includedirs = []
             self.cpp_info.components["logr_glog"].requires = [
-                "logr::logr_base",
+                "logr_base",
                 "glog::glog",
             ]
         elif self.options.backend == "log4cplus":
             self.cpp_info.components["logr_log4cplus"].includedirs = []
             self.cpp_info.components["logr_log4cplus"].requires = [
-                "logr::logr_base",
+                "logr_base",
                 "log4cplus::log4cplus",
             ]
         elif self.options.backend == "boostlog":
             self.cpp_info.components["logr_boostlog"].includedirs = []
             self.cpp_info.components["logr_boostlog"].requires = [
-                "logr::logr_base",
+                "logr_base",
                 "boost::log",
             ]


### PR DESCRIPTION
The error:
```
Package require 'logr' declared in components requires but not defined as a recipe requirement
```

Specify library name and version:  **logr/0.3.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
