### PR TITLE
libdivide: add version 5.0.0

### DIFF
--- a/recipes/libdivide/all/conandata.yml
+++ b/recipes/libdivide/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.0":
+    url: "https://github.com/ridiculousfish/libdivide/archive/refs/tags/5.0.tar.gz"
+    sha256: "01ffdf90bc475e42170741d381eb9cfb631d9d7ddac7337368bcd80df8c98356"
   "3.0":
     url: "https://github.com/ridiculousfish/libdivide/archive/v3.0.tar.gz"
     sha256: "7c0baed201e78f12f290d3f8c22c974d2fa44aefd9820f8484f7972a431ff264"

--- a/recipes/libdivide/all/conanfile.py
+++ b/recipes/libdivide/all/conanfile.py
@@ -12,10 +12,18 @@ class LibdivideConan(ConanFile):
     settings = "arch", "compiler"
     no_copy_source = True
     options = {
-        "simd_intrinsics": [False, "sse2", "avx2", "avx512"]
+        "simd_intrinsics": [False, "sse2", "avx2", "avx512"],
+        "sse2": [True, False],
+        "avx2": [True, False],
+        "avx512": [True, False],
+        "neon": [True, False],
     }
     default_options = {
-        "simd_intrinsics": False
+        "simd_intrinsics": False,
+        "sse2": False,
+        "avx2": False,
+        "avx512": False,
+        "neon": False,
     }
 
     @property
@@ -23,11 +31,24 @@ class LibdivideConan(ConanFile):
         return "source_subfolder"
 
     def config_options(self):
-        if self.settings.arch not in ["x86", "x86_64"]:
-            del self.options.simd_intrinsics
+        if tools.Version(self.version) < "4.0.0":
+            del self.options.sse2
+            del self.options.avx2
+            del self.options.avx512
+            del self.options.neon
+            if self.settings.arch not in ["x86", "x86_64"]:
+                del self.options.simd_intrinsics
+        else:
+            del self.options.simd_intrinsics        
+            if self.settings.arch not in ["x86", "x86_64"]:
+                del self.options.sse2
+                del self.options.avx2
+                del self.options.avx512
+            if not str(self.settings.arch).startswith("arm"):
+                del self.options.neon
 
     def configure(self):
-        if self.settings.compiler.cppstd:
+        if tools.Version(self.version) < "4.0.0" and self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
 
     def package_id(self):
@@ -49,3 +70,11 @@ class LibdivideConan(ConanFile):
                  "avx2": "LIBDIVIDE_AVX2",
                  "avx512": "LIBDIVIDE_AVX512"}[str(simd)]
             ]
+        if self.options.get_safe("sse2", False):
+            self.cpp_info.defines.append("LIBDIVIDE_SSE2")    
+        if self.options.get_safe("avx2", False):
+            self.cpp_info.defines.append("LIBDIVIDE_AVX2")    
+        if self.options.get_safe("avx512", False):
+            self.cpp_info.defines.append("LIBDIVIDE_AVX512")    
+        if self.options.get_safe("neon", False):
+            self.cpp_info.defines.append("LIBDIVIDE_NEON")    

--- a/recipes/libdivide/all/conanfile.py
+++ b/recipes/libdivide/all/conanfile.py
@@ -1,11 +1,11 @@
 from conans import ConanFile, tools
-import os
 
+required_conan_version = ">=1.33.0"
 
 class LibdivideConan(ConanFile):
     name = "libdivide"
     description = "Header-only C/C++ library for optimizing integer division."
-    topics = ("conan", "libdivide", "division", "integer")
+    topics = ("libdivide", "division", "integer", )
     license = ["Zlib", "BSL-1.0"]
     homepage = "http://libdivide.com/"
     url = "https://github.com/conan-io/conan-center-index"
@@ -39,7 +39,7 @@ class LibdivideConan(ConanFile):
             if self.settings.arch not in ["x86", "x86_64"]:
                 del self.options.simd_intrinsics
         else:
-            del self.options.simd_intrinsics        
+            del self.options.simd_intrinsics
             if self.settings.arch not in ["x86", "x86_64"]:
                 del self.options.sse2
                 del self.options.avx2
@@ -55,8 +55,7 @@ class LibdivideConan(ConanFile):
         self.info.header_only()
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def package(self):
         self.copy("LICENSE.txt", dst="licenses", src=self._source_subfolder)
@@ -71,10 +70,10 @@ class LibdivideConan(ConanFile):
                  "avx512": "LIBDIVIDE_AVX512"}[str(simd)]
             ]
         if self.options.get_safe("sse2", False):
-            self.cpp_info.defines.append("LIBDIVIDE_SSE2")    
+            self.cpp_info.defines.append("LIBDIVIDE_SSE2")
         if self.options.get_safe("avx2", False):
-            self.cpp_info.defines.append("LIBDIVIDE_AVX2")    
+            self.cpp_info.defines.append("LIBDIVIDE_AVX2")
         if self.options.get_safe("avx512", False):
-            self.cpp_info.defines.append("LIBDIVIDE_AVX512")    
+            self.cpp_info.defines.append("LIBDIVIDE_AVX512")
         if self.options.get_safe("neon", False):
-            self.cpp_info.defines.append("LIBDIVIDE_NEON")    
+            self.cpp_info.defines.append("LIBDIVIDE_NEON")

--- a/recipes/libdivide/all/conanfile.py
+++ b/recipes/libdivide/all/conanfile.py
@@ -60,6 +60,9 @@ class LibdivideConan(ConanFile):
     def package(self):
         self.copy("LICENSE.txt", dst="licenses", src=self._source_subfolder)
         self.copy("libdivide.h", dst="include", src=self._source_subfolder)
+        self.copy("constant_fast_div.h", dst="include", src=self._source_subfolder)
+        self.copy("s16_ldparams.h", dst="include", src=self._source_subfolder)
+        self.copy("u16_ldparams.h", dst="include", src=self._source_subfolder)
 
     def package_info(self):
         simd = self.options.get_safe("simd_intrinsics", False)

--- a/recipes/libdivide/config.yml
+++ b/recipes/libdivide/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "5.0":
+    folder: all
   "3.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libdivide/5.0.0**

Since libdivide/4.0, SSE2/AVX2/AVX512/NEON have been independent options.
While threre are auto detection logic In CMakeLists.txt of libdivide, libdivide is header only library.

I append sse2/avx2/avx512/neon options for append the corresponding definitions.
I know it is not the best way. 
Please tell me if you find better idea.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
