### PR TITLE
Added patch for glBinding type conversion error mingw 11

### DIFF
--- a/recipes/glbinding/all/conandata.yml
+++ b/recipes/glbinding/all/conandata.yml
@@ -6,3 +6,5 @@ patches:
   "3.1.0":
     - patch_file: "patches/cmake-install.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/getProcAddr.patch"
+      base_path: "source_subfolder/source/glbinding/source"

--- a/recipes/glbinding/all/patches/getProcAddr.patch
+++ b/recipes/glbinding/all/patches/getProcAddr.patch
@@ -1,0 +1,21 @@
+--- a/getProcAddress.cpp
++++ b/getProcAddress.cpp
+@@ -21,7 +21,7 @@ ProcAddress getProcAddress(const char * name)
+     static auto module = LoadLibrary(_T("OPENGL32.DLL"));
+ 
+ 	// Prevent static linking of opengl32
+-	static auto wglGetProcAddress_ = reinterpret_cast<void * (__stdcall *)(const char *)>(::GetProcAddress(module, "wglGetProcAddress"));
++	static auto wglGetProcAddress_ = reinterpret_cast<void * (__stdcall *)(const char *)>((uintptr_t)::GetProcAddress(module, "wglGetProcAddress"));
+ 	assert(wglGetProcAddress_ != nullptr);
+ 
+ 	auto procAddress = wglGetProcAddress_(name);
+@@ -30,7 +30,7 @@ ProcAddress getProcAddress(const char * name)
+ 		return reinterpret_cast<ProcAddress>(procAddress);
+ 	}
+ 
+-	procAddress = ::GetProcAddress(module, name);
++	procAddress = (void*)::GetProcAddress(module, name);
+     return reinterpret_cast<ProcAddress>(procAddress);
+ }
+
+


### PR DESCRIPTION
Specify library name and version:  **glbinding/3.1.0**

There was a type conversion error happening on mingw 11 builds on windows. An [upstream merge request](https://github.com/cginternals/glbinding/pull/298/commits/d4eb1d678236f11b95fe9a343fcd25623d19cc84 ) was created to address this, but a new version of glbinding hasn't been released with this change. This patch adds the change to the current version.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
