### PR TITLE
PhysX character controller needs PhysX extensions

### DIFF
--- a/recipes/physx/4.x.x/conanfile.py
+++ b/recipes/physx/4.x.x/conanfile.py
@@ -4,6 +4,8 @@ import shutil
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.32.0"
+
 
 class PhysXConan(ConanFile):
     name = "physx"
@@ -54,17 +56,16 @@ class PhysXConan(ConanFile):
         if self.settings.os not in ["Windows", "Android"]:
             del self.options.enable_simd
 
-    def validate(self):
-        if self.settings.os == "Macos" and not (self.settings.arch == "x86" or self.settings.arch == "x86_64"):
-            raise ConanInvalidConfiguration(
-                "{} only supports x86 and x86_64 on macOS".format(self.name))
-
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
 
+    def validate(self):
         if self.settings.os not in ["Windows", "Linux", "Macos", "Android", "iOS"]:
             raise ConanInvalidConfiguration("Current os is not supported")
+
+        if self.settings.os == "Macos" and self.settings.arch not in ["x86", "x86_64"]:
+            raise ConanInvalidConfiguration("{} only supports x86 and x86_64 on macOS".format(self.name))
 
         build_type = self.settings.build_type
         if build_type not in ["Debug", "RelWithDebInfo", "Release"]:

--- a/recipes/physx/4.x.x/conanfile.py
+++ b/recipes/physx/4.x.x/conanfile.py
@@ -54,6 +54,11 @@ class PhysXConan(ConanFile):
         if self.settings.os not in ["Windows", "Android"]:
             del self.options.enable_simd
 
+    def validate(self):
+        if self.settings.os == "Macos" and not (self.settings.arch == "x86" or self.settings.arch == "x86_64"):
+            raise ConanInvalidConfiguration(
+                "{} only supports x86 and x86_64 on macOS".format(self.name))
+
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
@@ -328,7 +333,7 @@ class PhysXConan(ConanFile):
         self.cpp_info.components["physxcharacterkinematic"].names["cmake_find_package"] = "PhysXCharacterKinematic"
         self.cpp_info.components["physxcharacterkinematic"].names["cmake_find_package_multi"] = "PhysXCharacterKinematic"
         self.cpp_info.components["physxcharacterkinematic"].libs = ["PhysXCharacterKinematic"]
-        self.cpp_info.components["physxcharacterkinematic"].requires = ["physxfoundation"]
+        self.cpp_info.components["physxcharacterkinematic"].requires = ["physxfoundation", "physxcommon", "physxextensions"]
         # PhysXCooking
         self.cpp_info.components["physxcooking"].names["cmake_find_package"] = "PhysXCooking"
         self.cpp_info.components["physxcooking"].names["cmake_find_package_multi"] = "PhysXCooking"
@@ -340,9 +345,9 @@ class PhysXConan(ConanFile):
         self.cpp_info.components["physxvehicle"].names["cmake_find_package"] = "PhysXVehicle"
         self.cpp_info.components["physxvehicle"].names["cmake_find_package_multi"] = "PhysXVehicle"
         self.cpp_info.components["physxvehicle"].libs = ["PhysXVehicle"]
-        self.cpp_info.components["physxvehicle"].requires = ["physxfoundation", "physxpvdsdk"]
+        self.cpp_info.components["physxvehicle"].requires = ["physxfoundation", "physxpvdsdk", "physxextensions"]
         # PhysXExtensions
         self.cpp_info.components["physxextensions"].names["cmake_find_package"] = "PhysXExtensions"
         self.cpp_info.components["physxextensions"].names["cmake_find_package_multi"] = "PhysXExtensions"
         self.cpp_info.components["physxextensions"].libs = ["PhysXExtensions"]
-        self.cpp_info.components["physxextensions"].requires = ["physxfoundation", "physxpvdsdk", "physxmain"]
+        self.cpp_info.components["physxextensions"].requires = ["physxfoundation", "physxpvdsdk", "physxmain", "physxcommon"]

--- a/recipes/physx/4.x.x/test_package/CMakeLists.txt
+++ b/recipes/physx/4.x.x/test_package/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-find_package(PhysX REQUIRED PhysX PhysXExtensions)
+find_package(PhysX REQUIRED PhysX PhysXExtensions CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PhysX::PhysX PhysX::PhysXExtensions)

--- a/recipes/physx/4.x.x/test_package/conanfile.py
+++ b/recipes/physx/4.x.x/test_package/conanfile.py
@@ -1,11 +1,10 @@
-import os
-
 from conans import ConanFile, CMake, tools
+import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -14,6 +13,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
The PhysX character controller needs the PhysX extensions as a dependency. 
Otherwise, linking will fail on Linux.

Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
