### PR TITLE
libtool: Fix builds with pr:b==pr:h

### DIFF
--- a/recipes/libtool/all/conanfile.py
+++ b/recipes/libtool/all/conanfile.py
@@ -44,13 +44,15 @@ class LibtoolConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def requirements(self):
-        self.requires("automake/1.16.3")
+        self.requires("automake/1.16.4")
 
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
+        if hasattr(self, "settings_build"):
+            self.build_requires("automake/1.16.4")
         self.build_requires("gnu-config/cci.20201022")
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")

--- a/recipes/libtool/all/test_package/conanfile.py
+++ b/recipes/libtool/all/test_package/conanfile.py
@@ -8,6 +8,7 @@ import shutil
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
+    test_type = "build_requires", "requires"
 
     @property
     def _settings_build(self):


### PR DESCRIPTION
If we try to build the current recipe using `pr:b` == `pr:h`, it fails like this:

```
$ conan create recipes/libtool/all libtool/2.4.6@eriff/stable -pr:b default -pr:h default
Exporting package recipe
libtool/2.4.6@eriff/stable exports: File 'conandata.yml' found. Exporting it...
libtool/2.4.6@eriff/stable exports: Copied 1 '.yml' file: conandata.yml
libtool/2.4.6@eriff/stable exports_sources: Copied 2 '.patch' files: 0002-libtool-fix-type-libtool.patch, 0001-libtool-relocatable.patch
libtool/2.4.6@eriff/stable: A new conanfile.py version was exported
libtool/2.4.6@eriff/stable: Folder: /home/eric/.conan/data/libtool/2.4.6/eriff/stable/export
libtool/2.4.6@brewst/stable: Using the exported files summary hash as the recipe revision: e6856628f435936ba6e14adb452777d1 
libtool/2.4.6@eriff/stable: Package recipe modified in export, forcing source folder removal
libtool/2.4.6@eriff/stable: Use the --keep-source, -k option to skip it
libtool/2.4.6@eriff/stable: Removing the local binary packages from different recipe revisions
libtool/2.4.6@eriff/stable: Exported revision: e6856628f435936ba6e14adb452777d1
Configuration (profile_host):
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=gcc
compiler.libcxx=libstdc++
compiler.version=8
os=Linux
os_build=Linux
[options]
[build_requires]
[env]

Configuration (profile_build):
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=gcc
compiler.libcxx=libstdc++
compiler.version=8
os=Linux
os_build=Linux
[options]
[build_requires]
[env]

libtool/2.4.6@eriff/stable: Forced build from source
libtool/2.4.6@eriff/stable (test package): Installing package
Requirements
    autoconf/2.71 from local cache - Cache
    automake/1.16.3 from 'conan-center' - Cache
    libtool/2.4.6@eriff/stable from local cache - Cache
    m4/1.4.19 from local cache - Cache
Packages
    autoconf/2.71:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache
    automake/1.16.3:258f6f05ca54813b3d7180161753df7f9ccf7e1d - Cache
    libtool/2.4.6@eriff/stable:9a742fb357948de0898e8481664b356888dece9e - Build
    m4/1.4.19:24647d9fe8ec489125dfbae4b3ebefaf7581674c - Cache
Build requirements
    gnu-config/cci.20201022 from local cache - Cache
Build requirements packages
    gnu-config/cci.20201022:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache

Installing (downloading, building) binaries...
gnu-config/cci.20201022: Already installed!
gnu-config/cci.20201022: Appending PATH environment variable: /home/eric/.conan/data/gnu-config/cci.20201022/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin
m4/1.4.19: Already installed!
m4/1.4.19: Appending PATH environment variable: /home/eric/.conan/data/m4/1.4.19/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin
m4/1.4.19: Setting M4 environment variable: /home/eric/.conan/data/m4/1.4.19/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/m4
autoconf/2.71: Already installed!
autoconf/2.71: Appending PATH env var with : /home/eric/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin
autoconf/2.71: Setting AC_MACRODIR to /home/eric/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/share/autoconf
autoconf/2.71: Setting AUTOCONF to /home/eric/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/autoconf
autoconf/2.71: Setting AUTORECONF to /home/eric/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/autoreconf
autoconf/2.71: Setting AUTOHEADER to /home/eric/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/autoheader
autoconf/2.71: Setting AUTOM4TE to /home/eric/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/autom4te
autoconf/2.71: Setting AUTOM4TE_PERLLIBDIR to /home/eric/.conan/data/autoconf/2.71/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin/share/autoconf
automake/1.16.3: Already installed!
automake/1.16.3: Appending PATH environment variable:: /home/eric/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/bin
automake/1.16.3: Appending ACLOCAL environment variable with: /home/eric/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/bin/aclocal
automake/1.16.3: Setting AUTOMAKE_DATADIR to /home/eric/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/res
automake/1.16.3: Setting AUTOMAKE_LIBDIR to /home/eric/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/res/automake-1.16
automake/1.16.3: Setting AUTOMAKE_PERLLIBDIR to /home/eric/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/res/automake-1.16
automake/1.16.3: Setting AUTOMAKE to /home/eric/.conan/data/automake/1.16.3/_/_/package/258f6f05ca54813b3d7180161753df7f9ccf7e1d/bin/automake
automake/1.16.3: Append M4 include directories to AUTOMAKE_CONAN_INCLUDES environment variable
libtool/2.4.6@eriff/stable: Applying build-requirement: gnu-config/cci.20201022
libtool/2.4.6@eriff/stable: Configuring sources in /home/eric/.conan/data/libtool/2.4.6/eriff/stable/source
Downloading libtool-2.4.6.tar.gz completed [1764.35k]                                    

libtool/2.4.6@eriff/stable: Copying sources to build folder
libtool/2.4.6@eriff/stable: Building your package in /home/eric/.conan/data/libtool/2.4.6/eriff/stable/build/9a742fb357948de0898e8481664b356888dece9e
libtool/2.4.6@eriff/stable: Generator txt created conanbuildinfo.txt
libtool/2.4.6@eriff/stable: Aggregating env generators
libtool/2.4.6@eriff/stable: Calling build()
libtool/2.4.6@eriff/stable: Calling:
 > source_subfolder/configure '--datarootdir=/home/eric/.conan/data/libtool/2.4.6/eriff/stable/package/9a742fb357948de0898e8481664b356888dece9e/res' '--prefix=/home/eric/.conan/data/libtool/2.4.6/eriff/stable/package/9a742fb357948de0898e8481664b356888dece9e' '--enable-shared' '--enable-static' '--enable-ltdl-install' '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' '--libexecdir=${prefix}/bin' '--libdir=${prefix}/lib' '--includedir=${prefix}/include' '--oldincludedir=${prefix}/include' 
## ------------------------- ##
## Configuring libtool 2.4.6 ##
## ------------------------- ##

checking for GNU M4 that supports accurate traces... configure: error: no acceptable m4 could be found in $PATH.
GNU M4 1.4.6 or later is required; 1.4.16 or newer is recommended.
GNU M4 1.4.15 uses a buggy replacement strstr on some systems.
Glibc 2.9 - 2.12 and GNU M4 1.4.11 - 1.4.15 have another strstr bug.
libtool/2.4.6@eriff/stable: 
libtool/2.4.6@eriff/stable: ERROR: Package '9a742fb357948de0898e8481664b356888dece9e' build failed
libtool/2.4.6@eriff/stable: WARN: Build folder /home/eric/.conan/data/libtool/2.4.6/brewst/stable/build/9a742fb357948de0898e8481664b356888dece9e
ERROR: libtool/2.4.6@brewst/stable: Error in build() method, line 107
	autotools = self._configure_autotools()
while calling '_configure_autotools', line 89
	self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder)
	ConanException: Error 1 while executing source_subfolder/configure '--datarootdir=/home/eric/.conan/data/libtool/2.4.6/eriff/stable/package/9a742fb357948de0898e8481664b356888dece9e/res' '--prefix=/home/eric/.conan/data/libtool/2.4.6/eriff/stable/package/9a742fb357948de0898e8481664b356888dece9e' '--enable-shared' '--enable-static' '--enable-ltdl-install' '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' '--libexecdir=${prefix}/bin' '--libdir=${prefix}/lib' '--includedir=${prefix}/include' '--oldincludedir=${prefix}/include' 

```
This is because `automake` should be a `build_requirement` and not a `requirement`. To avoid breaking all recipes that depend on `libtool` but expect to inherit `automake` from it, we left `automake` as a `requirement` and include it conditionally as a `build_requirement` as well.
We had a similar discussion here: https://github.com/conan-io/conan-center-index/pull/8056#discussion_r749528705


FYI: @madebr @SpaceIm 


---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
