### PR TITLE
Fix ffmpeg cross-compilation on Windows

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -198,12 +198,15 @@ class FFMpegConan(ConanFile):
 
     @property
     def _target_os(self):
-        _, _, target_os = tools.get_gnu_triplet(
-            "Macos" if tools.is_apple_os(self.settings.os) else str(self.settings.os),
-            str(self.settings.arch),
-            str(self.settings.compiler) if self.settings.os == "Windows" else None,
-        ).split("-")
-        return target_os
+        if self.settings.compiler == "Visual Studio":
+            return "win32"
+        else:
+            _, _, target_os = tools.get_gnu_triplet(
+                "Macos" if tools.is_apple_os(self.settings.os) else str(self.settings.os),
+                str(self.settings.arch),
+                str(self.settings.compiler) if self.settings.os == "Windows" else None,
+            ).split("-")
+            return target_os
 
     def _patch_sources(self):
         if self.settings.compiler == "Visual Studio" and self.options.with_libx264 and not self.options["libx264"].shared:


### PR DESCRIPTION
Specify library name and version:  **ffmpeg/4.4**

Mostly to fix broken x86 build on 64-bit Windows host

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
