### PR TITLE
odbc: don't set LIBS environment variable for autotools

### DIFF
--- a/recipes/odbc/all/conanfile.py
+++ b/recipes/odbc/all/conanfile.py
@@ -57,6 +57,7 @@ class OdbcConan(ConanFile):
         if self._autotools:
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self)
+        self._autotools.libs = []
         static_flag = "no" if self.options.shared else "yes"
         shared_flag = "yes" if self.options.shared else "no"
         libiconv_flag = "yes" if self.options.with_libiconv else "no"


### PR DESCRIPTION
Specify library name and version:  **odbc/all**

Same fix as https://github.com/conan-io/conan-center-index/pull/3080

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
