### PR TITLE
imagemagick: don't set LIBS environment variable for autotools

### DIFF
--- a/recipes/imagemagick/all/conanfile.py
+++ b/recipes/imagemagick/all/conanfile.py
@@ -319,6 +319,7 @@ class ImageMagicConan(ConanFile):
         self._autotools = AutoToolsBuildEnvironment(
             self, win_bash=tools.os_info.is_windows
         )
+        self._autotools.libs = []
 
         # FIXME: workaround for xorg/system adding system includes https://github.com/conan-io/conan-center-index/issues/6880
         xft_path = os.path.join(self.build_folder, "xft.pc")


### PR DESCRIPTION
Specify library name and version:  **imagemagick/all**

Same fix as #3080

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
