### PR TITLE
adding new package cvplot

### DIFF
--- a/recipes/cvplot/all/conandata.yml
+++ b/recipes/cvplot/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.2.2":
+    url: "https://github.com/Profactor/cv-plot/archive/refs/tags/v1.2.2.tar.gz"
+    sha256: "a7dbc80a8ec13fa2cfdc4f1389a1eb0cb83b56f021c64214d733812d3e301bc5"

--- a/recipes/cvplot/all/conanfile.py
+++ b/recipes/cvplot/all/conanfile.py
@@ -25,7 +25,7 @@ class CvPlotConan(ConanFile):
 
     def configure(self):
         if self.options.header_only:
-            self.options.remove("shared")
+            del self.options.shared
 
     def package_id(self):
         if self.options.header_only:

--- a/recipes/cvplot/all/conanfile.py
+++ b/recipes/cvplot/all/conanfile.py
@@ -1,7 +1,7 @@
 from conans import ConanFile, tools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class CvPlotConan(ConanFile):
@@ -31,3 +31,6 @@ class CvPlotConan(ConanFile):
             
     def package_info(self):
         self.cpp_info.defines.append("CVPLOT_HEADER_ONLY")
+        self.cpp_info.set_property("cmake_find_mode", "both") 
+        self.cpp_info.names["cmake_find_package"] = "CvPlot"
+        self.cpp_info.names["cmake_find_package_multi"] = "CvPlot"

--- a/recipes/cvplot/all/conanfile.py
+++ b/recipes/cvplot/all/conanfile.py
@@ -1,0 +1,66 @@
+import os
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.33.0"
+
+
+class CvPlotConan(ConanFile):
+    name = "cvplot"
+    description = "fast modular opencv plotting library"
+    license = "MIT License"
+    topics = ("plot", "opencv")
+    homepage = "https://github.com/Profactor/cv-plot"
+    url = "https://github.com/conan-io/conan-center-index"
+    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"shared": [True, False], "header_only": [True, False]}
+    default_options = {"shared": False, "header_only": False}
+    requires = "opencv/4.5.3"
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def configure(self):
+        if self.options.header_only:
+            self.options.remove("shared")
+
+    def package_id(self):
+        if self.options.header_only:
+            self.info.header_only()
+            
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def build(self):
+        if not self.options.header_only:
+            cmake = self._configure_cmake()
+            cmake.build()
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["CVPLOT_HEADER_ONLY"] = self.options.header_only
+        self._cmake.definitions["CVPLOT_WITH_TESTS"] = False
+        self._cmake.definitions["CVPLOT_WITH_EXAMPLES"] = False
+        self._cmake.configure(source_folder=self._source_subfolder)
+        return self._cmake
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        if self.options.header_only:
+            self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "CvPlot", "inc"))
+        else:
+            cmake = self._configure_cmake()
+            cmake.install()
+        
+    def package_info(self):
+        if self.options.header_only:
+            self.cpp_info.defines.append("CVPLOT_HEADER_ONLY")
+        else:
+            self.cpp_info.libs = ["CvPlot"]
+            if self.options.shared:
+                self.cpp_info.defines.append("CVPLOT_SHARED")

--- a/recipes/cvplot/all/conanfile.py
+++ b/recipes/cvplot/all/conanfile.py
@@ -8,7 +8,7 @@ class CvPlotConan(ConanFile):
     name = "cvplot"
     description = "fast modular opencv plotting library"
     license = "MIT"
-    topics = ("plot", "opencv")
+    topics = ("plot", "opencv", "diagram", "plotting")
     homepage = "https://github.com/Profactor/cv-plot"
     url = "https://github.com/conan-io/conan-center-index"
     generators = "cmake"

--- a/recipes/cvplot/all/conanfile.py
+++ b/recipes/cvplot/all/conanfile.py
@@ -7,7 +7,7 @@ required_conan_version = ">=1.33.0"
 class CvPlotConan(ConanFile):
     name = "cvplot"
     description = "fast modular opencv plotting library"
-    license = "MIT License"
+    license = "MIT"
     topics = ("plot", "opencv")
     homepage = "https://github.com/Profactor/cv-plot"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/cvplot/all/conanfile.py
+++ b/recipes/cvplot/all/conanfile.py
@@ -11,7 +11,6 @@ class CvPlotConan(ConanFile):
     topics = ("plot", "opencv", "diagram", "plotting")
     homepage = "https://github.com/Profactor/cv-plot"
     url = "https://github.com/conan-io/conan-center-index"
-    generators = "cmake"
     requires = "opencv/4.5.3"
     no_copy_source = True
 

--- a/recipes/cvplot/all/conanfile.py
+++ b/recipes/cvplot/all/conanfile.py
@@ -1,5 +1,5 @@
+from conans import ConanFile, tools
 import os
-from conans import ConanFile, CMake, tools
 
 required_conan_version = ">=1.33.0"
 
@@ -12,55 +12,22 @@ class CvPlotConan(ConanFile):
     homepage = "https://github.com/Profactor/cv-plot"
     url = "https://github.com/conan-io/conan-center-index"
     generators = "cmake"
-    settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "header_only": [True, False]}
-    default_options = {"shared": False, "header_only": False}
     requires = "opencv/4.5.3"
-
-    _cmake = None
+    no_copy_source = True
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
-    def configure(self):
-        if self.options.header_only:
-            del self.options.shared
-
-    def package_id(self):
-        if self.options.header_only:
-            self.info.header_only()
-            
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
-    def build(self):
-        if not self.options.header_only:
-            cmake = self._configure_cmake()
-            cmake.build()
-
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["CVPLOT_HEADER_ONLY"] = self.options.header_only
-        self._cmake.definitions["CVPLOT_WITH_TESTS"] = False
-        self._cmake.definitions["CVPLOT_WITH_EXAMPLES"] = False
-        self._cmake.configure(source_folder=self._source_subfolder)
-        return self._cmake
-
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        if self.options.header_only:
-            self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "CvPlot", "inc"))
-        else:
-            cmake = self._configure_cmake()
-            cmake.install()
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "CvPlot", "inc"))
         
+    def package_id(self):
+        self.info.header_only()
+            
     def package_info(self):
-        if self.options.header_only:
-            self.cpp_info.defines.append("CVPLOT_HEADER_ONLY")
-        else:
-            self.cpp_info.libs = ["CvPlot"]
-            if self.options.shared:
-                self.cpp_info.defines.append("CVPLOT_SHARED")
+        self.cpp_info.defines.append("CVPLOT_HEADER_ONLY")

--- a/recipes/cvplot/all/test_package/CMakeLists.txt
+++ b/recipes/cvplot/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/cvplot/all/test_package/CMakeLists.txt
+++ b/recipes/cvplot/all/test_package/CMakeLists.txt
@@ -2,9 +2,11 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(CvPlot CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} CvPlot::CvPlot)
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)

--- a/recipes/cvplot/all/test_package/CMakeLists.txt
+++ b/recipes/cvplot/all/test_package/CMakeLists.txt
@@ -6,3 +6,5 @@ conan_basic_setup()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)

--- a/recipes/cvplot/all/test_package/conanfile.py
+++ b/recipes/cvplot/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/cvplot/all/test_package/conanfile.py
+++ b/recipes/cvplot/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        bin_path = os.path.join("bin", "test_package")
+        self.run(bin_path, run_environment=True)

--- a/recipes/cvplot/all/test_package/conanfile.py
+++ b/recipes/cvplot/all/test_package/conanfile.py
@@ -1,6 +1,6 @@
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
@@ -12,5 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        bin_path = os.path.join("bin", "test_package")
-        self.run(bin_path, run_environment=True)
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/cvplot/all/test_package/test_package.cpp
+++ b/recipes/cvplot/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+#include <CvPlot/cvplot.h>
+
+using namespace CvPlot;
+
+int main() {
+	Axes axes = plot(std::vector<double>{ 3, 3, 4, 6, 4, 3 }, "-o");
+	cv::Mat mat = axes.render(400, 600);
+    return 0;
+}

--- a/recipes/cvplot/config.yml
+++ b/recipes/cvplot/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.2.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **cvplot/1.2.2**

Hi, I am the author of cvplot. We provided cvplot conan packages on bintray until sunset. Would be great to have them in conan center now. 

There is a header_only option in the recipe, I am not sure if I used it correctly. E.g. `conan search cvplot/1.2.2@ -q header_only=True` does not find the package, but I guess that is by design.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
