### PR TITLE
android-ndk: Various Fixes and Version Upgrades 

### DIFF
--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -5,10 +5,6 @@ sources:
         "x86_64":
           url: "https://dl.google.com/android/repository/android-ndk-r23b-windows.zip"
           sha256: "36270f8b2cfdd940f410bd8ffe6ce86ffaa8e87ff1c4fd4a8be5130268357778"
-      "Linux":
-        "x86_64":
-          url: "https://dl.google.com/android/repository/android-ndk-r23b-linux.zip"
-          sha256: "c6e97f9c8cfe5b7be0a9e6c15af8e7a179475b7ded23e2d1c1fa0945d6fb4382"
   "r23":
     url:
       "Windows":

--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -1,4 +1,14 @@
 sources:
+  "r23b":
+    url:
+      "Windows":
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r23b-windows.zip"
+          sha256: "36270f8b2cfdd940f410bd8ffe6ce86ffaa8e87ff1c4fd4a8be5130268357778"
+      "Linux":
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r23b-linux.zip"
+          sha256: "c6e97f9c8cfe5b7be0a9e6c15af8e7a179475b7ded23e2d1c1fa0945d6fb4382"
   "r23":
     url:
       "Windows":
@@ -9,10 +19,6 @@ sources:
         "x86_64":
           url: "https://dl.google.com/android/repository/android-ndk-r23-linux.zip"
           sha256: "e3eacf80016b91d4cd2c8ca9f34eebd32df912bb799c859cc5450b6b19277b4f"
-      "Macos":
-        "x86_64":
-          url: "https://dl.google.com/android/repository/android-ndk-r23-darwin.zip"
-          sha256: "163ff3bb72306ffa814de35c49819bccae9df10855a4e3fbba52ad4111fcccae"
   "r22b":
     url:
       "Windows":

--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -19,6 +19,10 @@ sources:
         "x86_64":
           url: "https://dl.google.com/android/repository/android-ndk-r23-linux.zip"
           sha256: "e3eacf80016b91d4cd2c8ca9f34eebd32df912bb799c859cc5450b6b19277b4f"
+      "Macos":
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r23-darwin.zip"
+          sha256: "163ff3bb72306ffa814de35c49819bccae9df10855a4e3fbba52ad4111fcccae"
   "r22b":
     url:
       "Windows":

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -94,18 +94,20 @@ class AndroidNDKConan(ConanFile):
         return f"{arch}-linux-{abi}"
 
     @property
+    def _ndk_major_minor(self):
+        match = re.search(r"r(\d+)(\w?)", self.version)
+        assert match
+        major, minor = match.groups()
+        assert major
+        return int(major), minor if minor else "a"
+
+    @property
     def _ndk_version_major(self):
-        match = re.search(r"r(\d+)\w?", self.version)
-        assert(match != None)
-        assert(match.group(1))
-        return int(match.group(1))
-        
+        return self._ndk_major_minor[0]
+
     @property
     def _ndk_version_minor(self):
-        match = re.search(r"r\d+(\w?)", self.version)
-        assert(match != None)
-        # pretend that there's an 'a' for the first of each major version
-        return match.group(1) if match.group(1) else 'a'
+        return self._ndk_major_minor[1]
 
     def _fix_permissions(self):
         if os.name != "posix":

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -37,7 +37,7 @@ class AndroidNDKConan(ConanFile):
             raise ConanInvalidConfiguration(f"os,arch={self.settings.os},{self.settings.arch} is not supported by {self.name} (no binaries are available)")
 
     def build(self):
-        if self.version in ['r23']:
+        if self.version in ['r23', 'r23b']:
             data = self.conan_data["sources"][self.version]["url"][str(self.settings.os)][str(self.settings.arch)]
             unzip_fix_symlinks(url=data["url"], target_folder=self._source_subfolder, sha256=data["sha256"])
         else:
@@ -314,8 +314,7 @@ def unzip_fix_symlinks(url, target_folder, sha256):
     # Most of the logic borrowed from this PR https://github.com/conan-io/conan/pull/8100
 
     filename = "android_sdk.zip"
-    tools.download(url, filename)
-    tools.check_sha256(filename, sha256)
+    tools.download(url, filename, sha256=sha256)
     tools.unzip(filename, destination=target_folder, strip_root=True)
 
     def is_symlink_zipinfo(zi):

--- a/recipes/android-ndk/config.yml
+++ b/recipes/android-ndk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "r23b":
+    folder: all
   "r23":
     folder: all
   "r22b":


### PR DESCRIPTION
 **android-ndk/r22**
 **android-ndk/r22b**
 **android-ndk/r23**
 **android-ndk/r23b**

This PR is to address a myriad of issues caused by my last PR for `android-ndk`. It turns out that the android-ndk is a super complicated package, with differences across OS's and versions of the upstream package.

- First and foremost, remove the raising of the ConanException that was introduced. This was stopping many builds across user's systems, and it really should be just an error message. (#7953)
- Properly wrap the windows executables in all cases. (#8086)
- Add support for Android NDK r23b for Windows only. Mac and Linux upstream r23b packages have broken symlinks that cause problems in creating the package.

For testing, I still believe that there needs to be a better way to test this kind of package, which heavily depends on different configurations at run time. That said, I did my best and went hard. I have 3 different systems (windows, mac, linux) with every version of the NDK that's listed in this package, and tried most combinations of creating this package, and subsequently using it to build another package as a test (libsodium). 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
