### PR TITLE
zlib-ng: add version 2.0.5 and change repository

### DIFF
--- a/recipes/zlib-ng/all/conandata.yml
+++ b/recipes/zlib-ng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.5":
+    sha256: ""
+    url: "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.5.tar.gz"
   "2.0.2":
     sha256: "dd37886f22ca6890e403ea6c1d60f36eab1d08d2f232a35f5b02126621149d28"
     url: "https://github.com/Dead2/zlib-ng/archive/2.0.2.tar.gz"

--- a/recipes/zlib-ng/all/conandata.yml
+++ b/recipes/zlib-ng/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "2.0.5":
-    sha256: ""
+    sha256: "eca3fe72aea7036c31d00ca120493923c4d5b99fe02e6d3322f7c88dbdcd0085"
     url: "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.5.tar.gz"
   "2.0.2":
     sha256: "dd37886f22ca6890e403ea6c1d60f36eab1d08d2f232a35f5b02126621149d28"
-    url: "https://github.com/Dead2/zlib-ng/archive/2.0.2.tar.gz"
+    url: "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.2.tar.gz"

--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -85,9 +85,8 @@ class ZlibNgConan(ConanFile):
         suffix = "" if self.options.zlib_compat else "-ng"
         self.cpp_info.names["pkg_config"] = "zlib" + suffix
         if self.settings.os == "Windows":
-            static_flag = "" if self.options.shared else "static"
             build_type = "d" if self.settings.build_type == "Debug" else ""
-            self.cpp_info.libs = ["zlib{}{}{}".format(static_flag, suffix, build_type)]
+            self.cpp_info.libs = ["zlib{}{}".format(suffix, build_type)]
         else:
             self.cpp_info.libs = ["z{}".format(suffix)]
         if self.options.zlib_compat:

--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -85,8 +85,9 @@ class ZlibNgConan(ConanFile):
         suffix = "" if self.options.zlib_compat else "-ng"
         self.cpp_info.names["pkg_config"] = "zlib" + suffix
         if self.settings.os == "Windows":
+            static_flag = "static" if self.options.shared and tools.Version(self.version) >= "2.0.5" else ""
             build_type = "d" if self.settings.build_type == "Debug" else ""
-            self.cpp_info.libs = ["zlib{}{}".format(suffix, build_type)]
+            self.cpp_info.libs = ["zlib{}{}{}".format(static_flag, suffix, build_type)]
         else:
             self.cpp_info.libs = ["z{}".format(suffix)]
         if self.options.zlib_compat:

--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -85,7 +85,7 @@ class ZlibNgConan(ConanFile):
         suffix = "" if self.options.zlib_compat else "-ng"
         self.cpp_info.names["pkg_config"] = "zlib" + suffix
         if self.settings.os == "Windows":
-            static_flag = "" if not self.options.shared else "static"
+            static_flag = "" if self.options.shared else "static"
             build_type = "d" if self.settings.build_type == "Debug" else ""
             self.cpp_info.libs = ["zlib{}{}{}".format(static_flag, suffix, build_type)]
         else:

--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -85,11 +85,9 @@ class ZlibNgConan(ConanFile):
         suffix = "" if self.options.zlib_compat else "-ng"
         self.cpp_info.names["pkg_config"] = "zlib" + suffix
         if self.settings.os == "Windows":
-            if self.settings.build_type == "Debug":
-                self.cpp_info.libs = ["zlib{}d".format(suffix)]
-            else:
-                self.cpp_info.libs = ["zlib{}".format(suffix)]
-
+            static_flag = "" if not self.options.shared else "static"
+            build_type = "d" if self.settings.build_type == "Debug" else ""
+            self.cpp_info.libs = ["zlib{}{}{}".format(static_flag, suffix, build_type)]
         else:
             self.cpp_info.libs = ["z{}".format(suffix)]
         if self.options.zlib_compat:

--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -85,7 +85,7 @@ class ZlibNgConan(ConanFile):
         suffix = "" if self.options.zlib_compat else "-ng"
         self.cpp_info.names["pkg_config"] = "zlib" + suffix
         if self.settings.os == "Windows":
-            static_flag = "static" if self.options.shared and tools.Version(self.version) >= "2.0.5" else ""
+            static_flag = "static" if not self.options.shared and tools.Version(self.version) >= "2.0.5" else ""
             build_type = "d" if self.settings.build_type == "Debug" else ""
             self.cpp_info.libs = ["zlib{}{}{}".format(static_flag, suffix, build_type)]
         else:

--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -3,15 +3,17 @@ from conans.errors import ConanInvalidConfiguration
 
 import os
 
+equired_conan_version = ">=1.33.0"
+
 class ZlibNgConan(ConanFile):
     name = "zlib-ng"
     description = "zlib data compression library for the next generation systems"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/Dead2/zlib-ng/"
+    homepage = "https://github.com/zlib-ng/zlib-ng/"
     license ="Zlib"
-    topics = ("conan", "zlib", "compression")
+    topics = ("zlib", "compression")
     exports_sources = ["CMakeLists.txt"]
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake",
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False],
                "zlib_compat": [True, False],
@@ -48,8 +50,8 @@ class ZlibNgConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("zlib-ng-{}".format(self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
 
     def validate(self):
         if self.options.zlib_compat and not self.options.with_gzfileop:

--- a/recipes/zlib-ng/all/test_package/conanfile.py
+++ b/recipes/zlib-ng/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/zlib-ng/config.yml
+++ b/recipes/zlib-ng/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.0.5":
+    folder: all
   "2.0.2":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **zlib-ng/2.0.5**

The recipe for zlib-ng points to the Dead2/zlib-ng repository.
Dead2/zlib-ng is not active, but zlib-ng/zlib-ng is active and has released zlib-ng/2.0.5.
Recently, Dead2 has been pushing source to zlib-ng/zlib-ng, so it seems that zlib-ng/zlib-ng is the main repository.

If it is against the policy modifying repositories from versions in the middle, I will create other recipes.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
