### PR TITLE
pybind11: add version 2.8.1

### DIFF
--- a/recipes/pybind11/all/conandata.yml
+++ b/recipes/pybind11/all/conandata.yml
@@ -20,4 +20,7 @@ sources:
   2.7.1:
     url: "https://github.com/pybind/pybind11/archive/v2.7.1.tar.gz"
     sha256: "616d1c42e4cf14fa27b2a4ff759d7d7b33006fdc5ad8fd603bb2c22622f27020"
+  2.8.1:
+    url: "https://github.com/pybind/pybind11/archive/v2.8.1.tar.gz"
+    sha256: "f1bcc07caa568eb312411dde5308b1e250bd0e1bc020fae855bf9f43209940cc"
 

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -13,3 +13,6 @@ versions:
     folder: all
   "2.7.1":
     folder: all
+  "2.8.1":
+    folder: all
+

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -15,4 +15,3 @@ versions:
     folder: all
   "2.8.1":
     folder: all
-


### PR DESCRIPTION
Specify library name and version:  **pybind11/2.8.1**

Update to version 2.8.1

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
