### PR TITLE
libzippp: add version 5.0

### DIFF
--- a/recipes/libzippp/all/conandata.yml
+++ b/recipes/libzippp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.0":
+    url: "https://github.com/ctabin/libzippp/archive/libzippp-v5.0-1.8.0.tar.gz"
+    sha256: "b70f2d0f64eb68b00a16290bac40ac1a3fd3d2896cfddc93e370a7fa28c591c5"
   "4.0":
     url: "https://github.com/ctabin/libzippp/archive/libzippp-v4.0-1.7.3.tar.gz"
     sha256: "7560c2d8bbace39245ba6e89c5454b8bc5eb753bb13451bca2c7b5810c0a2f2d"

--- a/recipes/libzippp/all/conandata.yml
+++ b/recipes/libzippp/all/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  "5.0":
+  "5.0-1.8.0":
     url: "https://github.com/ctabin/libzippp/archive/libzippp-v5.0-1.8.0.tar.gz"
     sha256: "b70f2d0f64eb68b00a16290bac40ac1a3fd3d2896cfddc93e370a7fa28c591c5"
   "4.0":

--- a/recipes/libzippp/all/conanfile.py
+++ b/recipes/libzippp/all/conanfile.py
@@ -37,12 +37,18 @@ class LibZipppConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    def validate(self):
+        libzippp_version = str(self.version)
+        if libzippp_version != "4.0" and len(libzippp_version.split("-")) != 2:
+            raise tools.ConanInvalidConfiguration("{}: version number must include '-'. (ex. '5.0-1.8.0')".format(self.name))
+
     def requirements(self):
         self.requires("zlib/1.2.11")
         if tools.Version(self.version) == "4.0":
             self.requires("libzip/1.7.3")
         else:
-            self.requires("libzip/1.8.0")
+            libzip_version = str(self.version).split("-")[1]
+            self.requires("libzip/{}".format(libzip_version))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/libzippp/all/conanfile.py
+++ b/recipes/libzippp/all/conanfile.py
@@ -83,6 +83,8 @@ class LibZipppConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.names["cmake_find_package"] = "libzippp"
+        self.cpp_info.names["cmake_find_package_multi"] = "libzippp"
         self.cpp_info.set_property("cmake_file_name", "libzippp")
         if self.options.with_encryption:
             self.cpp_info.defines.append("LIBZIPPP_WITH_ENCRYPTION")

--- a/recipes/libzippp/all/conanfile.py
+++ b/recipes/libzippp/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
+required_conan_version = ">=1.36.0"
 
 class LibZipppConan(ConanFile):
     name = "libzippp"
@@ -8,7 +9,7 @@ class LibZipppConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/ctabin/libzippp"
     license = "BSD-3-Clause"
-    topics = ("conan", "zip", "libzippp", "zip-archives", "zip-editing")
+    topics = ("zip", "libzippp", "zip-archives", "zip-editing")
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake", "cmake_find_package_multi"
     settings = "os", "compiler", "build_type", "arch"
@@ -37,14 +38,15 @@ class LibZipppConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("libzip/1.7.3")
+        self.requires("zlib/1.2.11")
+        if tools.Version(self.version) == "4.0":
+            self.requires("libzip/1.7.3")
+        else:
+            self.requires("libzip/1.8.0")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        # eg. 'libzippp-libzippp-v4.0-1.7.3'
-        extracted_dir = self.name + "-" + self.name + "-v" + self.version + \
-            "-" + self.deps_cpp_info["libzip"].version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:
@@ -75,7 +77,6 @@ class LibZipppConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
-        self.cpp_info.names["cmake_find_package"] = "libzippp"
-        self.cpp_info.names["cmake_find_package_multi"] = "libzippp"
+        self.cpp_info.set_property("cmake_file_name", "libzippp")
         if self.options.with_encryption:
             self.cpp_info.defines.append("LIBZIPPP_WITH_ENCRYPTION")

--- a/recipes/libzippp/all/test_package/CMakeLists.txt
+++ b/recipes/libzippp/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(libzippp REQUIRED)
 

--- a/recipes/libzippp/all/test_package/conanfile.py
+++ b/recipes/libzippp/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/libzippp/config.yml
+++ b/recipes/libzippp/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "5.0":
+    folder: all
   "4.0":
     folder: all

--- a/recipes/libzippp/config.yml
+++ b/recipes/libzippp/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "5.0":
+  "5.0-1.8.0":
     folder: all
   "4.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libzippp/5.0**

libzippp depends on zlib and libzip, and the versions of libzipp and libzip are strongly tied.

As follows.

| libzippp | libzip |
|-----------|------|
| 4.0-1.7.3  |  1.7.3 |
| 4.0-1.8.0  |  1.8.0 |
| 5.0-1.8.0  |  1.8.0 |

I don't think the version numbers of current recipes are accurate.
I think it should have been "4.0-1.7.3" instead of "4.0".
However, for compatibility, I'm going to add version "5.0" instead of  "5.0-1.8.0" as well.
If it's better to use the exact version, I'll fix it.


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
