### PR TITLE
msgpack-c: add recipe (separeted from msgpack)

### DIFF
--- a/recipes/msgpack-c/all/CMakeLists.txt
+++ b/recipes/msgpack-c/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/msgpack-c/all/conandata.yml
+++ b/recipes/msgpack-c/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "4.0.0":
+    url: "https://github.com/msgpack/msgpack-c/releases/download/c-4.0.0/msgpack-c-4.0.0.tar.gz"
+    sha256: "420fe35e7572f2a168d17e660ef981a589c9cbe77faa25eb34a520e1fcc032c8"

--- a/recipes/msgpack-c/all/conanfile.py
+++ b/recipes/msgpack-c/all/conanfile.py
@@ -1,0 +1,75 @@
+from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.36.0"
+
+class MsgpackCConan(ConanFile):
+    name = "msgpack-c"
+    description = "MessagePack implementation for C"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/msgpack/msgpack-c"
+    topics = ("msgpack", "message-pack", "serialization")
+    license = "BSL-1.0"
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake"
+    settings = "os", "arch", "build_type", "compiler"
+    options = {
+        "fPIC": [True, False],
+        "shared": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "shared": False,
+    }
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["MSGPACK_ENABLE_SHARED"] = self.options.shared
+        self._cmake.definitions["MSGPACK_ENABLE_STATIC"] = not self.options.shared
+        self._cmake.definitions["MSGPACK_32BIT"] = self.settings.arch == "x86"
+        self._cmake.definitions["MSGPACK_BUILD_EXAMPLES"] = False
+        self._cmake.definitions["MSGPACK_BUILD_TESTS"] = False
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE_1_0.txt", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_target_name", "msgpack")
+        self.cpp_info.components["msgpack"].set_property("cmake_target_name", "msgpack-c")
+        self.cpp_info.components["msgpack"].libs = tools.collect_libs(self)

--- a/recipes/msgpack-c/all/conanfile.py
+++ b/recipes/msgpack-c/all/conanfile.py
@@ -70,6 +70,7 @@ class MsgpackCConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "msgpack-c")
         self.cpp_info.set_property("cmake_target_name", "msgpack")
         self.cpp_info.components["msgpack"].set_property("cmake_target_name", "msgpack-c")
         self.cpp_info.components["msgpack"].libs = ["msgpackc"]

--- a/recipes/msgpack-c/all/conanfile.py
+++ b/recipes/msgpack-c/all/conanfile.py
@@ -72,4 +72,4 @@ class MsgpackCConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_target_name", "msgpack")
         self.cpp_info.components["msgpack"].set_property("cmake_target_name", "msgpack-c")
-        self.cpp_info.components["msgpack"].libs = tools.collect_libs(self)
+        self.cpp_info.components["msgpack"].libs = ["msgpackc"]

--- a/recipes/msgpack-c/all/conanfile.py
+++ b/recipes/msgpack-c/all/conanfile.py
@@ -70,7 +70,13 @@ class MsgpackCConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "msgpack-c"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "msgpack-c"
         self.cpp_info.set_property("cmake_file_name", "msgpack-c")
+        self.cpp_info.names["cmake_find_package"] = "msgpack"
+        self.cpp_info.names["cmake_find_package_multi"] = "msgpack"
         self.cpp_info.set_property("cmake_target_name", "msgpack")
+        self.cpp_info.components["msgpack"].names["cmake_find_package"] = "msgpack-c"
+        self.cpp_info.components["msgpack"].names["cmake_find_package_multi"] = "msgpack-c"
         self.cpp_info.components["msgpack"].set_property("cmake_target_name", "msgpack-c")
         self.cpp_info.components["msgpack"].libs = ["msgpackc"]

--- a/recipes/msgpack-c/all/test_package/CMakeLists.txt
+++ b/recipes/msgpack-c/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(msgpack-c REQUIRED CONFIG)
 

--- a/recipes/msgpack-c/all/test_package/CMakeLists.txt
+++ b/recipes/msgpack-c/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(msgpack-c REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} msgpack::msgpack-c)

--- a/recipes/msgpack-c/all/test_package/conanfile.py
+++ b/recipes/msgpack-c/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_c_path = os.path.join("bin", "test_package")
+            self.run(bin_c_path, run_environment=True)

--- a/recipes/msgpack-c/all/test_package/test_package.c
+++ b/recipes/msgpack-c/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include <msgpack.h>
+
+#include <stdio.h>
+
+int main() {
+    printf("msgpack version %s\n", msgpack_version());
+    return 0;
+}

--- a/recipes/msgpack-c/config.yml
+++ b/recipes/msgpack-c/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "4.0.0":
+    folder: all

--- a/recipes/odbc/all/conanfile.py
+++ b/recipes/odbc/all/conanfile.py
@@ -57,6 +57,7 @@ class OdbcConan(ConanFile):
         if self._autotools:
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self)
+        self._autotools.libs = []
         static_flag = "no" if self.options.shared else "yes"
         shared_flag = "yes" if self.options.shared else "no"
         libiconv_flag = "yes" if self.options.with_libiconv else "no"


### PR DESCRIPTION
Specify library name and version:  **msgpack-c/4.0.0**

Current msgpack recipe provide C++ and C API which are enabled by recipe's options("c_api", "cpp_api").

Since msgpack 4.0.0, msgpack provide separated release of C++ and C.
https://github.com/msgpack/msgpack-c/releases/tag/cpp-4.0.0
Release cycles of C++ and C are also different. 

 | C++ | C |
|---|----------|
|  3.2.1 | 3.2.1 |
| 3.3.0 | 3.3.0 |
| 4.0.0 | 4.0.0 |
| 4.0.1 | - |
| 4.0.2 | - | 

I think it is difficult to maintain current recipe.
I'm going to separate msgpack recipe as follows:

| recipe name |  language | 
|---|---|
| msgpack | C++ |
| msgpack-c | C |

I know it is not the only way to solve it.
Please review my thought.


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
