### PR TITLE
- [protobuf] use VirtualRunEnv

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -23,6 +23,9 @@ sources:
   "3.17.1":
     sha256: 036D66D6EEC216160DD898CFB162E9D82C1904627642667CC32B104D407BB411
     url: https://github.com/protocolbuffers/protobuf/archive/v3.17.1.tar.gz
+  "3.19.1":
+    sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
+    url: https://github.com/protocolbuffers/protobuf/archive/v3.19.1.tar.gz
 patches:
   "3.12.4":
     - patch_file: "patches/upstream-pr-7761-cmake-regex-fix.patch"

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -141,23 +141,6 @@ class ProtobufConan(ConanFile):
             protoc_target
         )
 
-        # Set DYLD_LIBRARY_PATH in command line to avoid issues with shared protobuf
-        # (even with virtualrunenv, this fix might be required due to SIP)
-        # Only works with cmake, cmake_find_package or cmake_find_package_multi generators
-        if tools.is_apple_os(self.settings.os):
-            tools.replace_in_file(
-                protobuf_config_cmake,
-                "add_custom_command(",
-                ("set(CUSTOM_DYLD_LIBRARY_PATH ${CONAN_LIB_DIRS} ${Protobuf_LIB_DIRS} ${Protobuf_LIB_DIRS_RELEASE} ${Protobuf_LIB_DIRS_DEBUG} ${Protobuf_LIB_DIRS_RELWITHDEBINFO} ${Protobuf_LIB_DIRS_MINSIZEREL})\n"
-                 "string(REPLACE \";\" \":\" CUSTOM_DYLD_LIBRARY_PATH \"${CUSTOM_DYLD_LIBRARY_PATH}\")\n"
-                 "add_custom_command(")
-            )
-            tools.replace_in_file(
-                protobuf_config_cmake,
-                "COMMAND  protobuf::protoc",
-                "COMMAND ${CMAKE_COMMAND} -E env \"DYLD_LIBRARY_PATH=${CUSTOM_DYLD_LIBRARY_PATH}\" $<TARGET_FILE:protobuf::protoc>"
-            )
-
         # Disable a potential warning in protobuf-module.cmake.in
         # TODO: remove this patch? Is it really useful?
         protobuf_module_cmake = os.path.join(self._source_subfolder, "cmake", "protobuf-module.cmake.in")

--- a/recipes/protobuf/all/test_package/conanfile.py
+++ b/recipes/protobuf/all/test_package/conanfile.py
@@ -9,6 +9,10 @@ class TestPackageConan(ConanFile):
     def build_requirements(self):
         if hasattr(self, "settings_build"):
             self.build_requires(str(self.requires['protobuf']))
+        if tools.is_apple_os(self.settings.os):
+            # FIXME: CCI uses 3.16.4 on apple-clang 11 machine
+            # up-to-date CMake is required to whitelist DYLD_LIBRARY_PATH for SIP protection
+            self.build_requires("cmake/3.22.0")
 
     @contextmanager
     def _env(self):

--- a/recipes/protobuf/all/test_package/conanfile.py
+++ b/recipes/protobuf/all/test_package/conanfile.py
@@ -1,20 +1,32 @@
 from conans import ConanFile, CMake, tools
 import os
-
+from contextlib import contextmanager
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "cmake", "cmake_find_package_multi", "VirtualRunEnv", "VirtualBuildEnv"
 
     def build_requirements(self):
-        if tools.cross_building(self.settings):
+        if hasattr(self, "settings_build"):
             self.build_requires(str(self.requires['protobuf']))
 
+    @contextmanager
+    def _env(self):
+        if hasattr(self, "settings_build"):
+            # 2 profiles - nothing is needed, VirtualRunEnv/VirtualBuildEnv manages the things
+            yield
+        else:
+            from conans import RunEnvironment
+            env_build = RunEnvironment(self)
+            with tools.environment_append(env_build.vars):
+                yield
+
     def build(self):
-        cmake = CMake(self)
-        cmake.definitions["protobuf_LITE"] = self.options["protobuf"].lite
-        cmake.configure()
-        cmake.build()
+        with self._env():
+            cmake = CMake(self)
+            cmake.definitions["protobuf_LITE"] = self.options["protobuf"].lite
+            cmake.configure()
+            cmake.build()
 
     def test(self):
         if not tools.cross_building(self.settings):

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -15,3 +15,5 @@ versions:
     folder: all
   "3.17.1":
     folder: all
+  "3.19.1":
+    folder: all


### PR DESCRIPTION
an alternative approach to use fix shared protobuf, without shims (unlike #8084)

some notes:
- CMake has removed SIP protection for DYLD_LIBRARY_PATH since 3.16.7/3.17.3, see https://gitlab.kitware.com/cmake/cmake/-/issues/20678
- therefore, we can inherit DYLD_LIBRARY_PATH from `conan` (python) to `cmake`, then to `protoc`
- thus, we no longer need a workaround setting DYLD_LIBRARY_PATH within CMake config file or build module
- we may use new [VirtualRunEnv](https://docs.conan.io/en/latest/reference/conanfile/tools/env/virtualrunenv.html?highlight=virtualrunenv) helper, which automatically applies for all `self.run` invocations (include ones within `CMake` build helper). it works for both 1.x and 2.x. but it needs two profile mode.
- for legacy single profile mode (which is still used on CI for x86_64 builds) we may use legacy [RunEnvironment](https://docs.conan.io/en/latest/reference/build_helpers/run_environment.html?highlight=runenvironment) helper
- in dual profile mode, protobuf should be a build requires (even if we aren't cross-building!), so helper knows where to populate environment from
- in future (once migrate CCI to always use dual profiles) we may simplify code to remove an unnecessary context manager

therefore, there are 3 generic cases, which I was able to verify locally:

- x86_64, single profile (`--profile=default`)
- x86_64, dual profile (`--profile:host=default --profile:build=default`)
- ARMv8 M1, dual profile (`--profile:host=m1 --profile:build=default`)

all cases are only interesting with `-o protobuf:shared=True` (or `-o:h protobuf:shared=True -o:b protobuf:shared=True` in case of dual profiles).

why remove a workaround?
- it's incorrect anyway (uses DYLD_LIBRARY_PATH from the wrong context)
- less code - less bugs
- it's only for CMake, but other build systems (autotools, meson) will suffer the same issue
- effectively no longer needed since CMake 3.16+

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
