### PR TITLE
meson: add version 0.60.2

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -86,3 +86,6 @@ sources:
   "0.60.1":
     url: "https://github.com/mesonbuild/meson/archive/0.60.1.tar.gz"
     sha256: "b06f7d621b90e094be0ea2157fa435648e069f19182d8d9402aa039727652b0c"
+  "0.60.2":
+    url: "https://github.com/mesonbuild/meson/archive/0.60.2.tar.gz"
+    sha256: "fc7c2f315b5b63fee0414b0b94b5a7d0e9c71c8c9bb8487314eb5a9a33984b8d"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -57,3 +57,5 @@ versions:
     folder: all
   "0.60.1":
     folder: all
+  "0.60.2":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/0.60.2**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
