### PR TITLE
[tensorflow-lite] require ruy:fPIC if building linux shared

### DIFF
--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -78,9 +78,9 @@ class TensorflowLiteConan(ConanFile):
         elif lazy_lt_semver(str(self.settings.compiler.version), minimum_version):
             raise ConanInvalidConfiguration(f"{self.name} requires C++14, which your compiler does not support.")
         if self.options.shared:
-            if self.settings.os == "Linux" and not self.options["ruy"].shared:
+            if self.settings.os == "Linux" and not self.options["ruy"].fPIC:
                 raise ConanInvalidConfiguration(
-                        f"The project {self.name}/{self.version} with shared=True on Linux requires ruy:shared=True")
+                        f"The project {self.name}/{self.version} with shared=True on Linux requires ruy:fPIC=True")
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -94,7 +94,7 @@ class TensorflowLiteConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
             if self.settings.os == "Linux":
-                self.options["ruy"].shared = True
+                self.options["ruy"].fPIC = True
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)


### PR DESCRIPTION
Specify library name and version:  **tensorflow-lite/2.6.0**

Instead of requiring `ruy:shared`, require `ruy:fPIC`. This enables a fully self-contained static build.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
