### PR TITLE
aws-c-http: revert filenames, names in cpp_info

### DIFF
--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -66,8 +66,14 @@ class AwsCHttp(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-http"))
 
     def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "aws-c-http"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-http"
         self.cpp_info.set_property("cmake_file_name", "aws-c-http")
+        self.cpp_info.names["cmake_find_package"] = "AWS"
+        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
         self.cpp_info.set_property("cmake_target_name", "AWS")
+        self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package"] = "aws-c-http"
+        self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package_multi"] = "aws-c-http"
         self.cpp_info.components["aws-c-http-lib"].set_property("cmake_target_name", "aws-c-http")
         self.cpp_info.components["aws-c-http-lib"].libs = ["aws-c-http"]
         self.cpp_info.components["aws-c-http-lib"].requires = [


### PR DESCRIPTION
Specify library name and version:  **aws-c-http/all**

I want to revert cpp_info.{filenames, names} to fix https://github.com/conan-io/conan-center-index/pull/8092#issuecomment-981220393


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
