### PR TITLE
paho-mqtt-cpp: allow shared library builds on windows

### DIFF
--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -37,9 +37,6 @@ class PahoMqttCppConan(ConanFile):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, minimal_cpp_standard)
 
-        if self.settings.os == "Windows" and self.options.shared:
-            raise ConanInvalidConfiguration("{} can not be built as shared on Windows.".format(self.name))
-
         self.options["paho-mqtt-c"].shared = self.options.shared
         self.options["paho-mqtt-c"].ssl = self.options.ssl
 

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -33,6 +33,9 @@ class PahoMqttCppConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
         minimal_cpp_standard = "11"
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, minimal_cpp_standard)


### PR DESCRIPTION
**paho-mqtt-cpp/1.2.0**

Removing superfluous restriction on Windows. With this PR, paho-mqtt-cpp can be built as shared library (DLL) on Windows. Fixes issue #8097.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
