### PR TITLE
aws-c-event-stream: recover cpp_info.names

### DIFF
--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -74,6 +74,8 @@ class AwsCEventStream(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-event-stream")
         self.cpp_info.set_property("cmake_target_name", "AWS")
+        self.cpp_info.names["cmake_find_package"] = "AWS"
+        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
         self.cpp_info.components["aws-c-event-stream-lib"].set_property("cmake_target_name", "aws-c-event-stream")
         self.cpp_info.components["aws-c-event-stream-lib"].libs = ["aws-c-event-stream"]
         self.cpp_info.components["aws-c-event-stream-lib"].requires = ["aws-c-common::aws-c-common-lib", "aws-checksums::aws-checksums"]


### PR DESCRIPTION
Specify library name and version:  **aws-c-event-stream**

Reason: https://github.com/conan-io/conan/pull/10077#issuecomment-980051717

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
