### PR TITLE
asyncplusplus: Reverted cpp_info.names

### DIFF
--- a/recipes/asyncplusplus/all/conanfile.py
+++ b/recipes/asyncplusplus/all/conanfile.py
@@ -92,6 +92,8 @@ class AsyncplusplusConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "Async++")
         self.cpp_info.set_property("cmake_target_name", "Async++")
+        self.cpp_info.names["cmake_find_package"] = "Async++"
+        self.cpp_info.names["cmake_find_package_multi"] = "Async++"
         self.cpp_info.builddirs.append(self._module_subfolder)
         self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
         self.cpp_info.libs = ["async++"]

--- a/recipes/asyncplusplus/all/conanfile.py
+++ b/recipes/asyncplusplus/all/conanfile.py
@@ -96,6 +96,10 @@ class AsyncplusplusConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "Async++"
         self.cpp_info.builddirs.append(self._module_subfolder)
         self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
+
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+
         self.cpp_info.libs = ["async++"]
         if not self.options.shared:
             self.cpp_info.defines = ["LIBASYNC_STATIC"]


### PR DESCRIPTION
Specify library name and version:  **asyncplusplus**

Reason: https://github.com/conan-io/conan/pull/10077#issuecomment-980051717

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
