### PR TITLE
boost-ext-ut: Revert cpp_info.names

### DIFF
--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -71,3 +71,10 @@ class UTConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "ut")
         self.cpp_info.set_property("cmake_target_name", "boost")
         self.cpp_info.components["ut"].set_property("cmake_target_name", "ut")
+
+        self.cpp_info.names["cmake_find_package"] = "boost"
+        self.cpp_info.names["cmake_find_package_multi"] = "boost"
+        self.cpp_info.filenames["cmake_find_package"] = "ut"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "ut"
+        self.cpp_info.components["ut"].names["cmake_find_package"] = "ut"
+        self.cpp_info.components["ut"].names["cmake_find_package_multi"] = "ut"


### PR DESCRIPTION
Specify library name and version:  **boost-ext-ut**


Reason: https://github.com/conan-io/conan/pull/10077#issuecomment-980051717

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.