### PR TITLE
gtest: Revert cpp_info.names

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -143,11 +143,18 @@ class GTestConan(ConanFile):
         return self.options.debug_postfix if self.settings.build_type == "Debug" else ""
 
     def package_info(self):
+
         self.cpp_info.set_property("cmake_file_name", "GTest")
         self.cpp_info.set_property("cmake_target_name", "GTest")
         self.cpp_info.components["libgtest"].set_property("cmake_target_name", "gtest")
         self.cpp_info.components["libgtest"].set_property("pkg_config_name", "gtest")
         self.cpp_info.components["libgtest"].libs = ["gtest{}".format(self._postfix)]
+
+        self.cpp_info.names["cmake_find_package"] = "GTest"
+        self.cpp_info.names["cmake_find_package_multi"] = "GTest"
+        self.cpp_info.components["libgtest"].names["cmake_find_package"] = "gtest"
+        self.cpp_info.components["libgtest"].names["cmake_find_package_multi"] = "gtest"
+
         if self.settings.os == "Linux":
             self.cpp_info.components["libgtest"].system_libs.append("pthread")
 
@@ -169,13 +176,24 @@ class GTestConan(ConanFile):
             self.cpp_info.components["gtest_main"].libs = ["gtest_main{}".format(self._postfix)]
             self.cpp_info.components["gtest_main"].requires = ["libgtest"]
 
+            self.cpp_info.components["gtest_main"].names["cmake_find_package"] = "gtest_main"
+            self.cpp_info.components["gtest_main"].names["cmake_find_package_multi"] = "gtest_main"
+
         if self.options.build_gmock:
             self.cpp_info.components["gmock"].set_property("cmake_target_name", "gmock")
             self.cpp_info.components["gmock"].set_property("pkg_config_name", "gmock")
             self.cpp_info.components["gmock"].libs = ["gmock{}".format(self._postfix)]
             self.cpp_info.components["gmock"].requires = ["libgtest"]
+
+            self.cpp_info.components["gmock"].names["cmake_find_package"] = "gmock"
+            self.cpp_info.components["gmock"].names["cmake_find_package_multi"] = "gmock"
+
             if not self.options.no_main:
                 self.cpp_info.components["gmock_main"].set_property("cmake_target_name", "gmock_main")
                 self.cpp_info.components["gmock_main"].set_property("pkg_config_name", "gmock_main")
                 self.cpp_info.components["gmock_main"].libs = ["gmock_main{}".format(self._postfix)]
                 self.cpp_info.components["gmock_main"].requires = ["gmock"]
+
+                self.cpp_info.components["gmock_main"].names["cmake_find_package"] = "gmock_main"
+                self.cpp_info.components["gmock_main"].names["cmake_find_package_multi"] = "gmock_main"
+


### PR DESCRIPTION
Specify library name and version:  **gtest**
Reason: https://github.com/conan-io/conan/pull/10077#issuecomment-980051717

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
