### PR TITLE
libcurl: Revert cpp_info.names

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -541,6 +541,11 @@ class LibcurlConan(ConanFile):
         self.cpp_info.components["curl"].set_property("cmake_target_name", "libcurl")
         self.cpp_info.components["curl"].set_property("pkg_config_name", "libcurl")
 
+        self.cpp_info.names["cmake_find_package"] = "CURL"
+        self.cpp_info.names["cmake_find_package_multi"] = "CURL"
+        self.cpp_info.components["curl"].names["cmake_find_package"] = "libcurl"
+        self.cpp_info.components["curl"].names["cmake_find_package_multi"] = "libcurl"
+
         if self.settings.compiler == "Visual Studio":
             self.cpp_info.components["curl"].libs = ["libcurl_imp"] if self.options.shared else ["libcurl"]
         else:


### PR DESCRIPTION
Specify library name and version:  **libcurl**

Reason: https://github.com/conan-io/conan/pull/10077#issuecomment-980051717

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
