### PR TITLE
litehtml: Add cpp_info.names

### DIFF
--- a/recipes/litehtml/all/conanfile.py
+++ b/recipes/litehtml/all/conanfile.py
@@ -136,6 +136,10 @@ class LitehtmlConan(ConanFile):
 
         self.cpp_info.components["litehtml_litehtml"].builddirs.append(self._module_subfolder)
         self.cpp_info.components["litehtml_litehtml"].set_property("cmake_build_modules", [self._module_file_rel_path])
+
+        self.cpp_info.components["litehtml_litehtml"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.components["litehtml_litehtml"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+
         self.cpp_info.components["litehtml_litehtml"].libs = ["litehtml"]
         self.cpp_info.components["litehtml_litehtml"].requires = ["gumbo"]
         if self.options.with_icu:

--- a/recipes/litehtml/all/conanfile.py
+++ b/recipes/litehtml/all/conanfile.py
@@ -104,7 +104,7 @@ class LitehtmlConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),
-            {"litehtml": "litehtml::litehtml", 
+            {"litehtml": "litehtml::litehtml",
              "gumbo":"litehtml::gumbo"}
         )
 
@@ -130,14 +130,20 @@ class LitehtmlConan(ConanFile):
                             "conan-official-{}-targets.cmake".format(self.name))
     def package_info(self):
         self.cpp_info.components["litehtml_litehtml"].set_property("cmake_target_name", "litehtml")
+
+        self.cpp_info.components["litehtml_litehtml"].names["cmake_find_package"] = "litehtml"
+        self.cpp_info.components["litehtml_litehtml"].names["cmake_find_package_multi"] = "litehtml"
+
         self.cpp_info.components["litehtml_litehtml"].builddirs.append(self._module_subfolder)
         self.cpp_info.components["litehtml_litehtml"].set_property("cmake_build_modules", [self._module_file_rel_path])
         self.cpp_info.components["litehtml_litehtml"].libs = ["litehtml"]
         self.cpp_info.components["litehtml_litehtml"].requires = ["gumbo"]
         if self.options.with_icu:
             self.cpp_info.components["litehtml_litehtml"].requires.append("icu::icu")
-        
+
         if True: # FIXME: remove once we use a vendored gumbo library
             self.cpp_info.components["gumbo"].set_property("cmake_target_name", "gumbo")
             self.cpp_info.components["gumbo"].libs = ["gumbo"]
 
+            self.cpp_info.components["gumbo"].names["cmake_find_package"] = "gumbo"
+            self.cpp_info.components["gumbo"].names["cmake_find_package_multi"] = "gumbo"


### PR DESCRIPTION
Specify library name and version:  **litehtml**

Reason: https://github.com/conan-io/conan/pull/10077#issuecomment-980051717

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
