### PR TITLE
redis-plus-plus: Revert cpp_info.names

### DIFF
--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -121,6 +121,12 @@ class RedisPlusPlusConan(ConanFile):
         self.cpp_info.components["redis++lib"].set_property("cmake_target_name", "redis++" + "_static" if not self.options.shared else "")
         self.cpp_info.components["redis++lib"].set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
 
+        self.cpp_info.names["cmake_find_package"] = "redis++"
+        self.cpp_info.names["cmake_find_package_multi"] = "redis++"
+        self.cpp_info.names["pkg_config"] = "redis++"
+        self.cpp_info.components["redis++lib"].names["cmake_find_package"] = "redis++" + "_static" if not self.options.shared else ""
+        self.cpp_info.components["redis++lib"].names["cmake_find_package_multi"] = "redis++" + "_static" if not self.options.shared else ""
+
         suffix = "_static" if self.settings.os == "Windows" and not self.options.shared else ""
         self.cpp_info.components["redis++lib"].libs = ["redis++" + suffix]
         self.cpp_info.components["redis++lib"].requires = ["hiredis::hiredis"]


### PR DESCRIPTION
Specify library name and version:  **redis-plus-plus**

Reason: https://github.com/conan-io/conan/pull/10077#issuecomment-980051717

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
