### PR TITLE
spirv: Revert cpp_info.names 

### DIFF
--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -215,6 +215,8 @@ class SpirvCrossConan(ConanFile):
 
             self.cpp_info.components[target_lib].names["cmake_find_package"] = target_lib
             self.cpp_info.components[target_lib].names["cmake_find_package_multi"] = target_lib
+            self.cpp_info.components[target_lib].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+            self.cpp_info.components[target_lib].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
 
             if self.options.shared:
                 self.cpp_info.components[target_lib].set_property("pkg_config_name", target_lib)

--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -218,7 +218,6 @@ class SpirvCrossConan(ConanFile):
 
             if self.options.shared:
                 self.cpp_info.components[target_lib].set_property("pkg_config_name", target_lib)
-
             prefix = "d" if self.settings.os == "Windows" and self.settings.build_type == "Debug" else ""
             self.cpp_info.components[target_lib].libs = ["{}{}".format(target_lib, prefix)]
             self.cpp_info.components[target_lib].includedirs.append(os.path.join("include", "spirv_cross"))

--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -219,8 +219,6 @@ class SpirvCrossConan(ConanFile):
             if self.options.shared:
                 self.cpp_info.components[target_lib].set_property("pkg_config_name", target_lib)
 
-                self.cpp_info.components[target_lib].names["pkg_config"] = target_lib
-
             prefix = "d" if self.settings.os == "Windows" and self.settings.build_type == "Debug" else ""
             self.cpp_info.components[target_lib].libs = ["{}{}".format(target_lib, prefix)]
             self.cpp_info.components[target_lib].includedirs.append(os.path.join("include", "spirv_cross"))

--- a/recipes/spirv-cross/all/conanfile.py
+++ b/recipes/spirv-cross/all/conanfile.py
@@ -212,8 +212,15 @@ class SpirvCrossConan(ConanFile):
             self.cpp_info.components[target_lib].set_property("cmake_target_name", target_lib)
             self.cpp_info.components[target_lib].builddirs.append(self._module_subfolder)
             self.cpp_info.components[target_lib].set_property("cmake_build_modules", [self._module_file_rel_path])
+
+            self.cpp_info.components[target_lib].names["cmake_find_package"] = target_lib
+            self.cpp_info.components[target_lib].names["cmake_find_package_multi"] = target_lib
+
             if self.options.shared:
                 self.cpp_info.components[target_lib].set_property("pkg_config_name", target_lib)
+
+                self.cpp_info.components[target_lib].names["pkg_config"] = target_lib
+
             prefix = "d" if self.settings.os == "Windows" and self.settings.build_type == "Debug" else ""
             self.cpp_info.components[target_lib].libs = ["{}{}".format(target_lib, prefix)]
             self.cpp_info.components[target_lib].includedirs.append(os.path.join("include", "spirv_cross"))


### PR DESCRIPTION
Specify library name and version:  **spirv-cross**

Reason: https://github.com/conan-io/conan/pull/10077#issuecomment-980051717

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
