### PR TITLE
vulkan-headers: Revert cpp_info.names

### DIFF
--- a/recipes/vulkan-headers/all/conanfile.py
+++ b/recipes/vulkan-headers/all/conanfile.py
@@ -41,3 +41,12 @@ class VulkanHeadersConan(ConanFile):
         self.cpp_info.components["vulkanregistry"].includedirs = [os.path.join("res", "vulkan", "registry")]
         self.cpp_info.components["vulkanregistry"].bindirs = []
         self.cpp_info.components["vulkanregistry"].libdirs = []
+
+        self.cpp_info.filenames["cmake_find_package"] = "VulkanHeaders"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "VulkanHeaders"
+        self.cpp_info.names["cmake_find_package"] = "Vulkan"
+        self.cpp_info.names["cmake_find_package_multi"] = "Vulkan"
+        self.cpp_info.components["vulkanheaders"].names["cmake_find_package"] = "Headers"
+        self.cpp_info.components["vulkanheaders"].names["cmake_find_package_multi"] = "Headers"
+        self.cpp_info.components["vulkanregistry"].names["cmake_find_package"] = "Registry"
+        self.cpp_info.components["vulkanregistry"].names["cmake_find_package_multi"] = "Registry"


### PR DESCRIPTION
Specify library name and version:  **vulkan-headers**

Reason: https://github.com/conan-io/conan/pull/10077#issuecomment-980051717

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
