### PR TITLE
automake Added build_type to settings to build with V2, deleted build_type fro…

### DIFF
--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -11,7 +11,7 @@ class AutomakeConan(ConanFile):
     description = "Automake is a tool for automatically generating Makefile.in files compliant with the GNU Coding Standards."
     topics = ("conan", "automake", "configure", "build")
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
-    settings = "os", "arch", "compiler"
+    settings = "os", "arch", "compiler", "build_type"
 
     exports_sources = "patches/*"
 
@@ -47,6 +47,7 @@ class AutomakeConan(ConanFile):
     def package_id(self):
         del self.info.settings.arch
         del self.info.settings.compiler
+        del self.info.settings.build_type
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],


### PR DESCRIPTION

Specify library name and version:  **automake/1.16.4**

Reason: [Issue#8238](https://github.com/conan-io/conan-center-index/issues/8238) Conan V2 complains of missing build_type.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
