### PR TITLE
cairo: Add OpenGL support, fix dependency tree and other fixes.

### DIFF
--- a/recipes/cairo/meson/conandata.yml
+++ b/recipes/cairo/meson/conandata.yml
@@ -10,3 +10,5 @@ patches:
       base_path: "source_subfolder/util/cairo-trace"
     - patch_file: "patches/cairo-1.17.4-xlib-xrender-option.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/cairo-1.17.4-symbol-lookup-backport.patch"
+      base_path: "source_subfolder"

--- a/recipes/cairo/meson/conandata.yml
+++ b/recipes/cairo/meson/conandata.yml
@@ -6,3 +6,7 @@ patches:
   "1.17.4":
     - patch_file: "patches/binutils-2.34-libbfd-fix.patch"
       base_path: "source_subfolder/util/cairo-trace"
+    - patch_file: "patches/cairo-1.17.4-trace-cflags-fix.patch"
+      base_path: "source_subfolder/util/cairo-trace"
+    - patch_file: "patches/cairo-1.17.4-xlib-xrender-option.patch"
+      base_path: "source_subfolder"

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -4,6 +4,7 @@ import glob
 import os
 import shutil
 
+required_conan_version = ">=1.38.0"
 
 class CairoConan(ConanFile):
     name = "cairo"
@@ -22,8 +23,11 @@ class CairoConan(ConanFile):
         "with_xlib_xrender": [True, False],
         "with_xcb": [True, False],
         "with_glib": [True, False],
+        "with_lzo": [True, False],
         "with_zlib": [True, False],
         "with_png": [True, False],
+        "with_opengl": [False, "desktop", "gles2", "gles3"],
+        "tee": [True, False],
     }
     default_options = {
         "shared": False,
@@ -31,11 +35,14 @@ class CairoConan(ConanFile):
         "with_freetype": True,
         "with_fontconfig": True,
         "with_xlib": True,
-        "with_xlib_xrender": False,
+        "with_xlib_xrender": True,
         "with_xcb": True,
         "with_glib": True,
+        "with_lzo": True,
         "with_zlib": True,
         "with_png": True,
+        "with_opengl": "desktop",
+        "tee": True,
     }
 
     exports_sources = "patches/*"
@@ -72,25 +79,40 @@ class CairoConan(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires('expat/2.4.1')  # cairo-xml
         self.requires("pixman/0.40.0")
-        if self.options.get_safe("with_zlib", True):
+        if self.options.with_zlib and self.options.with_png:
+            self.requires("expat/2.4.1")
+        if self.options.with_lzo:
+            self.requires("lzo/2.10")
+        if self.options.with_zlib:
             self.requires("zlib/1.2.11")
-        if self.options.get_safe("with_freetype", True):
+        if self.options.with_freetype:
             self.requires("freetype/2.11.0")
-        if self.options.get_safe("with_fontconfig", True):
+        if self.options.with_fontconfig:
             self.requires("fontconfig/2.13.93")
-        if self.options.get_safe("with_png", True):
-            self.requires('libpng/1.6.37')
-        if self.options.get_safe("with_glib", True):
-            self.requires("glib/2.70.0")
+        if self.options.with_png:
+            self.requires("libpng/1.6.37")
+        if self.options.with_glib:
+            self.requires("glib/2.70.1")
         if self.settings.os == "Linux":
             if self.options.with_xlib or self.options.with_xlib_xrender or self.options.with_xcb:
                 self.requires("xorg/system")
+        if self.options.with_opengl == "desktop":
+            self.requires("opengl/system")
+            if self.settings.os == "Windows":
+                self.requires("glext/cci.20210420")
+                self.requires("wglext/cci.20200813")
+                self.requires("khrplatform/cci.20200529")
+        if self.options.with_opengl and self.settings.os != "Windows":
+            self.requires("egl/system")
 
     def build_requirements(self):
         self.build_requires("meson/0.59.1")
         self.build_requires("pkgconf/1.7.4")
+
+    def validate(self):
+        if self.options.get_safe("with_xlib_xrender") and not self.options.get_safe("with_xlib"):
+            raise ConanInvalidConfiguration("'with_xlib_xrender' option requires 'with_xlib' option to be enabled as well!")
 
     @property
     def _is_msvc(self):
@@ -103,36 +125,54 @@ class CairoConan(ConanFile):
     def _configure_meson(self):
         yes_no = lambda v: "enabled" if v else "disabled"
         meson = Meson(self)
+
         defs = dict()
         defs["tests"] = "disabled"
-        defs["zlib"] = yes_no(self.options.get_safe("with_zlib", True))
-        defs["png"] = yes_no(self.options.get_safe("with_png", True))
-        defs["freetype"] = yes_no(self.options.get_safe("with_freetype", True))
-        defs["fontconfig"] = yes_no(self.options.get_safe("with_fontconfig", True))
+        defs["zlib"] = yes_no(self.options.with_zlib)
+        defs["png"] = yes_no(self.options.with_png)
+        defs["freetype"] = yes_no(self.options.with_freetype)
+        defs["fontconfig"] = yes_no(self.options.with_fontconfig)
         if self.settings.os == "Linux":
-            defs["xcb"] = yes_no(self.options.get_safe("with_xcb", True))
-            defs["xlib"] = yes_no(self.options.get_safe("with_xlib", True))
+            defs["xcb"] = yes_no(self.options.get_safe("with_xcb"))
+            defs["xlib"] = yes_no(self.options.get_safe("with_xlib"))
+            defs["xlib-xrender"] = yes_no(self.options.get_safe("with_xlib_xrender"))
         else:
-            defs['xcb'] = "disabled"
-            defs["xlib"] = 'disabled'
+            defs["xcb"] = "disabled"
+            defs["xlib"] = "disabled"
+        if self.options.with_opengl == "desktop":
+            defs["gl-backend"] = "gl"
+        elif self.options.with_opengl == "gles2":
+            defs["gl-backend"] = "glesv2"
+        elif self.options.with_opengl == "gles3":
+            defs["gl-backend"] = "glesv3"
+        else:
+            defs["gl-backend"] = "disabled"
+        defs["glesv2"] = yes_no(self.options.with_opengl)
+        defs["glesv3"] = yes_no(self.options.with_opengl)
+        defs["tee"] = yes_no(self.options.tee)
 
         # future options to add, see meson_options.txt.
         # for now, disabling explicitly, to avoid non-reproducible auto-detection of system libs
         defs["cogl"] = "disabled"  # https://gitlab.gnome.org/GNOME/cogl
         defs["directfb"] = "disabled"
-        defs["gl-backend"] = "disabled"  # 'gl', 'glesv2', 'glesv3', opengl/system?
-        defs["glesv2"] = "disabled"
-        defs["glesv3"] = "disabled"
-        defs["drm"] = "disabled"
+        defs["drm"] = "disabled" # not yet compilable in cairo 1.17.4
         defs["openvg"] = "disabled"  # https://www.khronos.org/openvg/
-        defs["qt"] = "disabled"  # qt/6.2.0 - potential cyclic dependency via GLib?
-        defs["tee"] = "disabled"  # no idea what is tee
+        defs["qt"] = "disabled" # not yet compilable in cairo 1.17.4
         defs["gtk2-utils"] = "disabled"
         defs["spectre"] = "disabled"  # https://www.freedesktop.org/wiki/Software/libspectre/
 
         if not self.options.shared and self.settings.compiler == "Visual Studio":
             meson.options["c_args"] = " -DCAIRO_WIN32_STATIC_BUILD"
             meson.options["cpp_args"] = " -DCAIRO_WIN32_STATIC_BUILD"
+        if self.options.with_opengl == "desktop" and self.settings.os == "Windows":
+            gl_includes = []
+            for dependency in ["glext", "wglext", "khrplatform"]:
+                package = self.dependencies[dependency]
+                for include in package.cpp_info.includedirs:
+                    gl_includes.append(os.path.join(package.package_folder, include))
+            for gl_include in gl_includes:
+                meson.options["c_args"] += " -I{}".format(gl_include)
+                meson.options["cpp_args"] += " -I{}".format(gl_include)
         meson.configure(
             source_folder=self._source_subfolder,
             args=["--wrap-mode=nofallback"],
@@ -146,7 +186,7 @@ class CairoConan(ConanFile):
             tools.patch(**patch)
 
         # Dependency freetype2 found: NO found 2.11.0 but need: '>= 9.7.3'
-        if self.options.get_safe("with_freetype", True):
+        if self.options.with_freetype:
             tools.replace_in_file("freetype2.pc",
                                   "Version: %s" % self.deps_cpp_info["freetype"].version,
                                   "Version: 9.7.3")
@@ -175,76 +215,169 @@ class CairoConan(ConanFile):
         self.cpp_info.components["cairo_"].names["pkg_config"] = "cairo"
         self.cpp_info.components["cairo_"].libs = ["cairo"]
         self.cpp_info.components["cairo_"].includedirs.insert(0, os.path.join("include", "cairo"))
-        self.cpp_info.components["cairo_"].requires = ["pixman::pixman", "libpng::libpng", "zlib::zlib"]
-        if self.options.get_safe("with_freetype", True):
+        if self.settings.os == "Linux":
+            self.cpp_info.components["cairo_"].system_libs.extend(["m", "dl", "pthread", "bfd"])
+            self.cpp_info.components["cairo_"].cflags = ["-pthread"]
+            self.cpp_info.components["cairo_"].cxxflags = ["-pthread"]
+        if self.options.with_lzo:
+            self.cpp_info.components["cairo_"].requires.append("lzo::lzo")
+        if self.options.with_zlib:
+            self.cpp_info.components["cairo_"].requires.append("zlib::zlib")
+        if self.options.with_png:
+            self.cpp_info.components["cairo_"].requires.append("libpng::libpng")
+        if self.options.with_fontconfig:
+            self.cpp_info.components["cairo_"].requires.append("fontconfig::fontconfig")
+        if self.options.with_freetype:
             self.cpp_info.components["cairo_"].requires.append("freetype::freetype")
-
+        if self.options.get_safe("with_xlib"):
+            self.cpp_info.components["cairo_"].requires.extend(["xorg::x11", "xorg::xext"])
+        if self.options.get_safe("with_xlib_xrender"):
+            self.cpp_info.components["cairo_"].requires.append("xorg::xrender")
+        if self.options.get_safe("with_xcb"):
+            self.cpp_info.components["cairo_"].requires.extend(["xorg::xcb", "xorg::xcb-render", "xorg::xcb-shm"])
+        if self.options.get_safe("with_xlib") and self.options.get_safe("with_xcb"):
+            self.cpp_info.components["cairo_"].requires.append("xorg::x11-xcb")
+        if tools.is_apple_os(self.settings.os):
+            self.cpp_info.components["cairo_"].frameworks.append("CoreGraphics")
         if self.settings.os == "Windows":
             self.cpp_info.components["cairo_"].system_libs.extend(["gdi32", "msimg32", "user32"])
             if not self.options.shared:
                 self.cpp_info.components["cairo_"].defines.append("CAIRO_WIN32_STATIC_BUILD=1")
+        if self.options.with_opengl == "desktop":
+            self.cpp_info.components["cairo_"].requires.append("opengl::opengl")
+            if self.settings.os == "Windows":
+                self.cpp_info.components["cairo_"].requires.extend(["glext::glext", "wglext::wglext", "khrplatform::khrplatform"])
+        if self.options.with_opengl and self.settings.os != "Windows":
+            self.cpp_info.components["cairo_"].requires.append("egl::egl")
+        if self.options.with_opengl == "gles2" or self.options.with_opengl == "gles3":
+            self.cpp_info.components["cairo_"].system_libs.append("GLESv2")
+        self.cpp_info.components["cairo_"].requires.append("pixman::pixman")
 
-        if self.options.get_safe("with_glib", True):
-            self.cpp_info.components["cairo_"].requires.extend(["glib::gobject-2.0", "glib::glib-2.0"])
-        if self.options.get_safe("with_fontconfig", True):
-            self.cpp_info.components["cairo_"].requires.append("fontconfig::fontconfig")
-        if self.settings.os == "Linux":
-            self.cpp_info.components["cairo_"].system_libs = ["pthread"]
-            self.cpp_info.components["cairo_"].cflags = ["-pthread"]
-            self.cpp_info.components["cairo_"].cxxflags = ["-pthread"]
-            if self.options.with_xcb:
-                self.cpp_info.components["cairo_"].requires.extend(["xorg::xcb-shm", "xorg::xcb"])
-            if self.options.with_xlib_xrender:
-                self.cpp_info.components["cairo_"].requires.extend(["xorg::xcb-render"])
-            if self.options.with_xlib:
-                self.cpp_info.components["cairo_"].requires.extend(["xorg::x11", "xorg::xext"])
-        if tools.is_apple_os(self.settings.os):
-            self.cpp_info.components["cairo_"].frameworks.append("CoreGraphics")
-
-        self.cpp_info.components["cairo-xml"].names["pkg_config"] = "cairo-xml"
-        self.cpp_info.components["cairo-xml"].requires = ["cairo_", "expat::expat"]
-
-        if self.settings.os == "Windows":
-            self.cpp_info.components["cairo-win32"].names["pkg_config"] = "cairo-win32"
-            self.cpp_info.components["cairo-win32"].requires = ["cairo_", "pixman::pixman", "libpng::libpng"]
-
-            self.cpp_info.components["cairo-win32-font"].names["pkg_config"] = "cairo-win32-font"
-            self.cpp_info.components["cairo-win32-font"].requires = ["cairo_"]
-
-        if self.options.get_safe("with_glib", True):
-            self.cpp_info.components["cairo-gobject"].names["pkg_config"] = "cairo-gobject"
-            self.cpp_info.components["cairo-gobject"].libs = ["cairo-gobject"]
-            self.cpp_info.components["cairo-gobject"].requires = ["cairo_", "glib::gobject-2.0", "glib::glib-2.0"]
-        if self.options.get_safe("with_fontconfig", True):
-            self.cpp_info.components["cairo-fc"].names["pkg_config"] = "cairo-fc"
-            self.cpp_info.components["cairo-fc"].requires = ["cairo_", "fontconfig::fontconfig"]
-        if self.options.get_safe("with_freetype", True):
-            self.cpp_info.components["cairo-ft"].names["pkg_config"] = "cairo-ft"
-            self.cpp_info.components["cairo-ft"].requires = ["cairo_", "freetype::freetype"]
-        if self.options.get_safe("with_zlib", True):
-            self.cpp_info.components["cairo-pdf"].names["pkg_config"] = "cairo-pdf"
-            self.cpp_info.components["cairo-pdf"].requires = ["cairo_", "zlib::zlib"]
-        if self.options.get_safe("with_png", True):
+        # built-features
+        if self.options.with_png:
             self.cpp_info.components["cairo-png"].names["pkg_config"] = "cairo-png"
             self.cpp_info.components["cairo-png"].requires = ["cairo_", "libpng::libpng"]
 
-        self.cpp_info.components["cairo-ps"].names["pkg_config"] = "cairo-ps"
-        self.cpp_info.components["cairo-ps"].requires = ["cairo_"]
+        if self.options.with_png:
+            self.cpp_info.components["cairo-svg"].names["pkg_config"] = "cairo-svg"
+            self.cpp_info.components["cairo-svg"].requires = ["cairo_", "libpng::libpng"]
 
-        self.cpp_info.components["cairo-script"].names["pkg_config"] = "cairo-script"
-        self.cpp_info.components["cairo-script"].requires = ["cairo_"]
+        if self.options.with_fontconfig:
+            self.cpp_info.components["cairo-fc"].names["pkg_config"] = "cairo-fc"
+            self.cpp_info.components["cairo-fc"].requires = ["cairo_", "fontconfig::fontconfig"]
 
-        self.cpp_info.components["cairo-svg"].names["pkg_config"] = "cairo-svg"
-        self.cpp_info.components["cairo-svg"].requires = ["cairo_"]
+        if self.options.with_freetype:
+            self.cpp_info.components["cairo-ft"].names["pkg_config"] = "cairo-ft"
+            self.cpp_info.components["cairo-ft"].requires = ["cairo_", "freetype::freetype"]
 
-        if self.settings.os == "Linux":
-            if self.options.get_safe("with_xlib", True):
-                self.cpp_info.components["cairo-xlib"].names["pkg_config"] = "cairo-xlib"
-                self.cpp_info.components["cairo-xlib"].requires = ["cairo_", "xorg::x11", "xorg::xext"]
+        if self.options.get_safe("with_xlib"):
+            self.cpp_info.components["cairo-xlib"].names["pkg_config"] = "cairo-xlib"
+            self.cpp_info.components["cairo-xlib"].requires = ["cairo_", "xorg::x11", "xorg::xext"]
+
+        if self.options.get_safe("with_xlib_xrender"):
+            self.cpp_info.components["cairo-xlib-xrender"].names["pkg_config"] = "cairo-xlib-xrender"
+            self.cpp_info.components["cairo-xlib-xrender"].requires = ["cairo_", "xorg::xrender"]
+
+        if self.options.get_safe("with_xcb"):
+            self.cpp_info.components["cairo-xcb"].names["pkg_config"] = "cairo-xcb"
+            self.cpp_info.components["cairo-xcb"].requires = ["cairo_", "xorg::xcb", "xorg::xcb-render"]
+
+        if self.options.get_safe("with_xlib") and self.options.get_safe("with_xcb"):
+            self.cpp_info.components["cairo-xlib-xcb"].names["pkg_config"] = "cairo-xlib-xcb"
+            self.cpp_info.components["cairo-xlib-xcb"].requires = ["cairo_", "xorg::x11-xcb"]
+
+        if self.options.get_safe("with_xcb"):
+            self.cpp_info.components["cairo-xcb-shm"].names["pkg_config"] = "cairo-xcb-shm"
+            self.cpp_info.components["cairo-xcb-shm"].requires = ["cairo_", "xorg::xcb-shm"]
 
         if tools.is_apple_os(self.settings.os):
             self.cpp_info.components["cairo-quartz"].names["pkg_config"] = "cairo-quartz"
             self.cpp_info.components["cairo-quartz"].requires = ["cairo_"]
-            self.cpp_info.components["cairo-quartz"].frameworks.extend(["CoreFoundation", "CoreGraphics"])
+
+            self.cpp_info.components["cairo-quartz-image"].names["pkg_config"] = "cairo-quartz-image"
+            self.cpp_info.components["cairo-quartz-image"].requires = ["cairo_"]
+
             self.cpp_info.components["cairo-quartz-font"].names["pkg_config"] = "cairo-quartz-font"
             self.cpp_info.components["cairo-quartz-font"].requires = ["cairo_"]
+
+        if self.settings.os == "Windows":
+            self.cpp_info.components["cairo-win32"].names["pkg_config"] = "cairo-win32"
+            self.cpp_info.components["cairo-win32"].requires = ["cairo_"]
+
+            self.cpp_info.components["cairo-win32-font"].names["pkg_config"] = "cairo-win32-font"
+            self.cpp_info.components["cairo-win32-font"].requires = ["cairo_"]
+
+        if self.options.with_opengl == "desktop":
+            self.cpp_info.components["cairo-gl"].names["pkg_config"] = "cairo-gl"
+            self.cpp_info.components["cairo-gl"].requires = ["cairo_", "opengl::opengl"]
+
+            if self.settings.os == "Linux":
+                self.cpp_info.components["cairo-glx"].names["pkg_config"] = "cairo-glx"
+                self.cpp_info.components["cairo-glx"].requires = ["cairo_", "opengl::opengl"]
+
+            if self.settings.os == "Windows":
+                self.cpp_info.components["cairo-wgl"].names["pkg_config"] = "cairo-wgl"
+                self.cpp_info.components["cairo-wgl"].requires = ["cairo_", "glext::glext", "wglext::wglext"]
+
+        if self.options.with_opengl == "gles2":
+            self.cpp_info.components["cairo-glesv2"].names["pkg_config"] = "cairo-glesv2"
+            self.cpp_info.components["cairo-glesv2"].requires = ["cairo_"]
+            self.cpp_info.components["cairo-glesv2"].system_libs = ["GLESv2"]
+
+        if self.options.with_opengl == "gles3":
+            self.cpp_info.components["cairo-glesv3"].names["pkg_config"] = "cairo-glesv3"
+            self.cpp_info.components["cairo-glesv3"].requires = ["cairo_"]
+            self.cpp_info.components["cairo-glesv3"].system_libs = ["GLESv2"]
+
+        if self.options.with_opengl and self.settings.os != "Windows":
+            self.cpp_info.components["cairo-egl"].names["pkg_config"] = "cairo-egl"
+            self.cpp_info.components["cairo-egl"].requires = ["cairo_", "egl::egl"]
+
+        if self.options.with_zlib:
+            self.cpp_info.components["cairo-script"].names["pkg_config"] = "cairo-script"
+            self.cpp_info.components["cairo-script"].requires = ["cairo_", "zlib::zlib"]
+
+        if self.options.with_zlib:
+            self.cpp_info.components["cairo-ps"].names["pkg_config"] = "cairo-ps"
+            self.cpp_info.components["cairo-ps"].requires = ["cairo_", "zlib::zlib"]
+
+        if self.options.with_zlib:
+            self.cpp_info.components["cairo-pdf"].names["pkg_config"] = "cairo-pdf"
+            self.cpp_info.components["cairo-pdf"].requires = ["cairo_", "zlib::zlib"]
+
+        if self.options.with_zlib and self.options.with_png:
+            self.cpp_info.components["cairo-xml"].names["pkg_config"] = "cairo-xml"
+            self.cpp_info.components["cairo-xml"].requires = ["cairo_", "zlib::zlib"]
+
+        if self.options.tee:
+            self.cpp_info.components["cairo-tee"].names["pkg_config"] = "cairo-tee"
+            self.cpp_info.components["cairo-tee"].requires = ["cairo_"]
+
+        # util directory
+        if self.options.with_glib:
+            self.cpp_info.components["cairo-gobject"].names["pkg_config"] = "cairo-gobject"
+            self.cpp_info.components["cairo-gobject"].libs = ["cairo-gobject"]
+            self.cpp_info.components["cairo-gobject"].requires = ["cairo_", "glib::gobject-2.0", "glib::glib-2.0"]
+
+        if self.options.with_zlib:
+            self.cpp_info.components["cairo-script-interpreter"].libs = ["cairo-script-interpreter"]
+            self.cpp_info.components["cairo-script-interpreter"].requires = ["cairo_"]
+
+        if self.options.with_zlib and self.settings.os != "Windows":
+            self.cpp_info.components["cairo-trace"].libs = ["cairo-trace"]
+            self.cpp_info.components["cairo-trace"].requires = ["cairo_"]
+            self.cpp_info.components["cairo-trace"].libdirs.append(os.path.join(self.package_folder, "lib", "cairo"))
+
+        if self.options.with_zlib and self.options.tee and self.settings.os != "Windows":
+            self.cpp_info.components["cairo-fdr"].libs = ["cairo-fdr"]
+            self.cpp_info.components["cairo-fdr"].requires = ["cairo_"]
+            self.cpp_info.components["cairo-fdr"].libdirs.append(os.path.join(self.package_folder, "lib", "cairo"))
+
+        if self.options.with_glib and self.options.with_png and self.options.with_zlib and self.options.tee and self.settings.os != "Windows":
+            self.cpp_info.components["cairo-sphinx"].libs = ["cairo-sphinx"]
+            self.cpp_info.components["cairo-sphinx"].requires = ["cairo_"]
+            self.cpp_info.components["cairo-sphinx"].libdirs.append(os.path.join(self.package_folder, "lib", "cairo"))
+
+        # binary tools
+        if self.options.with_zlib and self.options.with_png:
+            self.cpp_info.components["cairo_util_"].requires.append("expat::expat") # trace-to-xml.c, xml-to-trace.c

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -106,7 +106,7 @@ class CairoConan(ConanFile):
                 self.requires("glext/cci.20210420")
                 self.requires("wglext/cci.20200813")
                 self.requires("khrplatform/cci.20200529")
-        if self.options.with_opengl and self.settings.os != "Windows":
+        if self.options.with_opengl and self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("egl/system")
 
     def build_requirements(self):
@@ -256,7 +256,7 @@ class CairoConan(ConanFile):
             self.cpp_info.components["cairo_"].requires.append("opengl::opengl")
             if self.settings.os == "Windows":
                 self.cpp_info.components["cairo_"].requires.extend(["glext::glext", "wglext::wglext", "khrplatform::khrplatform"])
-        if self.options.with_opengl and self.settings.os != "Windows":
+        if self.options.with_opengl and self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["cairo_"].requires.append("egl::egl")
         if self.options.with_opengl == "gles2" or self.options.with_opengl == "gles3":
             self.cpp_info.components["cairo_"].system_libs.append("GLESv2")
@@ -338,7 +338,7 @@ class CairoConan(ConanFile):
             self.cpp_info.components["cairo-glesv3"].requires = ["cairo_"]
             self.cpp_info.components["cairo-glesv3"].system_libs = ["GLESv2"]
 
-        if self.options.with_opengl and self.settings.os != "Windows":
+        if self.options.with_opengl and self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["cairo-egl"].names["pkg_config"] = "cairo-egl"
             self.cpp_info.components["cairo-egl"].requires = ["cairo_", "egl::egl"]
 

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -27,6 +27,7 @@ class CairoConan(ConanFile):
         "with_zlib": [True, False],
         "with_png": [True, False],
         "with_opengl": [False, "desktop", "gles2", "gles3"],
+        "with_symbol_lookup": [True, False],
         "tee": [True, False],
     }
     default_options = {
@@ -42,6 +43,7 @@ class CairoConan(ConanFile):
         "with_zlib": True,
         "with_png": True,
         "with_opengl": "desktop",
+        "with_symbol_lookup": False,
         "tee": True,
     }
 
@@ -71,6 +73,7 @@ class CairoConan(ConanFile):
             del self.options.with_xlib
             del self.options.with_xlib_xrender
             del self.options.with_xcb
+            del self.options.with_symbol_lookup
 
     def configure(self):
         if self.options.shared:
@@ -150,6 +153,7 @@ class CairoConan(ConanFile):
         defs["glesv2"] = yes_no(self.options.with_opengl)
         defs["glesv3"] = yes_no(self.options.with_opengl)
         defs["tee"] = yes_no(self.options.tee)
+        defs["symbol-lookup"] = yes_no(self.options.get_safe("with_symbol_lookup"))
 
         # future options to add, see meson_options.txt.
         # for now, disabling explicitly, to avoid non-reproducible auto-detection of system libs
@@ -216,7 +220,9 @@ class CairoConan(ConanFile):
         self.cpp_info.components["cairo_"].libs = ["cairo"]
         self.cpp_info.components["cairo_"].includedirs.insert(0, os.path.join("include", "cairo"))
         if self.settings.os == "Linux":
-            self.cpp_info.components["cairo_"].system_libs.extend(["m", "dl", "pthread", "bfd"])
+            self.cpp_info.components["cairo_"].system_libs.extend(["m", "dl", "pthread"])
+            if self.options.get_safe("with_symbol_lookup"):
+                self.cpp_info.components["cairo_"].system_libs.append("bfd")
             self.cpp_info.components["cairo_"].cflags = ["-pthread"]
             self.cpp_info.components["cairo_"].cxxflags = ["-pthread"]
         if self.options.with_lzo:

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -165,9 +165,9 @@ class CairoConan(ConanFile):
         defs["gtk2-utils"] = "disabled"
         defs["spectre"] = "disabled"  # https://www.freedesktop.org/wiki/Software/libspectre/
 
+        meson_args = ""
         if not self.options.shared and self.settings.compiler == "Visual Studio":
-            meson.options["c_args"] = " -DCAIRO_WIN32_STATIC_BUILD"
-            meson.options["cpp_args"] = " -DCAIRO_WIN32_STATIC_BUILD"
+            meson_args += " -DCAIRO_WIN32_STATIC_BUILD"
         if self.options.with_opengl == "desktop" and self.settings.os == "Windows":
             gl_includes = []
             for dependency in ["glext", "wglext", "khrplatform"]:
@@ -175,8 +175,11 @@ class CairoConan(ConanFile):
                 for include in package.cpp_info.includedirs:
                     gl_includes.append(os.path.join(package.package_folder, include))
             for gl_include in gl_includes:
-                meson.options["c_args"] += " -I{}".format(gl_include)
-                meson.options["cpp_args"] += " -I{}".format(gl_include)
+                meson_args += " -I{}".format(gl_include)
+        if len(meson_args):
+            meson.options["c_args"] = meson_args
+            meson.options["cpp_args"] = meson_args
+
         meson.configure(
             source_folder=self._source_subfolder,
             args=["--wrap-mode=nofallback"],

--- a/recipes/cairo/meson/patches/cairo-1.17.4-symbol-lookup-backport.patch
+++ b/recipes/cairo/meson/patches/cairo-1.17.4-symbol-lookup-backport.patch
@@ -1,0 +1,25 @@
+Backport new 'symbol-lookup' meson option from git master to cairo 1.17.4.
+This option is needed to turn linking with libbfd deterministically on or off. @sh0
+
+--- meson.build	2021-12-01 03:56:33.290547341 +0200
++++ meson.build	2021-12-01 03:58:17.955355490 +0200
+@@ -659,7 +659,7 @@
+ 
+ # Untested, libiberty.h is in a libiberty subfolder for me
+ # FIXME: automagic
+-bfd_dep = cc.find_library('bfd', required: false)
++bfd_dep = cc.find_library('bfd', has_headers: ['bfd.h'], required: get_option('symbol-lookup'))
+ if bfd_dep.found() and cc.has_function('bfd_openr', dependencies: [bfd_dep])
+   if cc.has_header('libiberty.h')
+     conf.set('HAVE_BFD', 1)
+--- meson_options.txt	2021-12-01 03:56:33.290547341 +0200
++++ meson_options.txt	2021-12-01 03:57:29.498907256 +0200
+@@ -30,6 +30,8 @@
+ # Misc deps
+ option('glib', type : 'feature', value : 'auto')
+ option('spectre', type : 'feature', value : 'auto')
++option('symbol-lookup', type: 'feature', value : 'auto',
++       description: 'Symbol lookup in debug utils via binutils/bfd')
+ 
+ # FIXME: implement these to avoid automagic
+ #option('egl', type : 'feature', value : 'auto')

--- a/recipes/cairo/meson/patches/cairo-1.17.4-trace-cflags-fix.patch
+++ b/recipes/cairo/meson/patches/cairo-1.17.4-trace-cflags-fix.patch
@@ -1,0 +1,20 @@
+Add missing 'PACKAGE' and 'PACKAGE_VERSION' defines for libbfd headers included by 'lookup-symbol.c'.
+Offending lines in 'bfd.h':
+
+   #if !defined PACKAGE && !defined PACKAGE_VERSION
+   #error config.h must be included before this header
+   #endif
+
+Previously autotools provided those defines for Cairo, but they are no longer generated with meson. @sh0
+
+--- meson.build	2020-11-27 01:20:59.000000000 +0200
++++ meson.build	2021-12-01 00:42:26.798320019 +0200
+@@ -12,7 +12,7 @@
+   include_directories: [incbase, incsrc],
+   dependencies: deps,
+   link_args: extra_link_args,
+-  c_args: ['-DSHARED_LIB_EXT="@0@"'.format(shared_lib_ext), '-DHAVE_CONFIG_H'] + pthread_c_args,
++  c_args: ['-DPACKAGE', '-DPACKAGE_VERSION', '-DSHARED_LIB_EXT="@0@"'.format(shared_lib_ext), '-DHAVE_CONFIG_H'] + pthread_c_args,
+   install: true,
+   install_dir: join_paths(get_option('prefix'), get_option('libdir'), 'cairo'),
+ )

--- a/recipes/cairo/meson/patches/cairo-1.17.4-xlib-xrender-option.patch
+++ b/recipes/cairo/meson/patches/cairo-1.17.4-xlib-xrender-option.patch
@@ -1,0 +1,26 @@
+This patch adds option to enable or disable xlib-xrender component.
+Without it 'xrender' is always required when 'xlib' option is enabled. @sh0
+
+--- meson.build	2020-11-27 01:20:59.000000000 +0200
++++ meson.build	2021-12-01 00:34:50.366334030 +0200
+@@ -273,8 +273,8 @@
+   endif
+ endif
+ 
+-if feature_conf.get('CAIRO_HAS_XLIB_SURFACE', 0) == 1
+-  xrender_dep = dependency('xrender', required: get_option('xlib'),
++if feature_conf.get('CAIRO_HAS_XLIB_SURFACE', 0) == 1 and get_option('xlib-xrender').enabled()
++  xrender_dep = dependency('xrender', required: true,
+                            version: xrender_required_version)
+ 
+   if xrender_dep.found()
+--- meson_options.txt	2020-11-27 01:20:59.000000000 +0200
++++ meson_options.txt	2021-12-01 00:32:43.480337924 +0200
+@@ -17,6 +17,7 @@
+ option('tee', type : 'feature', value : 'disabled')
+ option('xcb', type : 'feature', value : 'auto')
+ option('xlib', type : 'feature', value : 'auto')
++option('xlib-xrender', type : 'feature', value : 'disabled')
+ #option('xml', type : 'feature', value : 'disabled')
+ option('zlib', type : 'feature', value : 'auto') # script, ps, pdf, xml surfaces
+ 


### PR DESCRIPTION
Specify library name and version:  **cairo/1.17.4**

Adds OpenGL support (desktop, gles2, gles3). On Windows the header include paths are injected through `c_args`.

New 'lzo' dependency. Adds option to enable compilation of 'tee' backend.

Painstaikingly follow what Cairo meson files are doing and replicate that in `package_info`, preferably in the same order. What is important is that `cairo_` component is linked with all dependencies. We also add dependencies to all `cairo-*` components to mimic meson generated pkg-config files, but it is in fact optional in Conan ecosystem.

Reduces `get_safe` usage.

Also adds couple patches - details are in patch headers.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
