### PR TITLE
paho-mqtt-cpp: update paho-mqtt-c dependency

### DIFF
--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -51,7 +51,7 @@ class PahoMqttCppConan(ConanFile):
 
     def requirements(self):
         if tools.Version(self.version) >= "1.2.0":
-            self.requires("paho-mqtt-c/1.3.8")
+            self.requires("paho-mqtt-c/1.3.9")
         else:
             self.requires("paho-mqtt-c/1.3.1") # https://github.com/eclipse/paho.mqtt.cpp/releases/tag/v1.1
 

--- a/recipes/paho-mqtt-cpp/all/conanfile.py
+++ b/recipes/paho-mqtt-cpp/all/conanfile.py
@@ -56,9 +56,7 @@ class PahoMqttCppConan(ConanFile):
             self.requires("paho-mqtt-c/1.3.1") # https://github.com/eclipse/paho.mqtt.cpp/releases/tag/v1.1
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name.replace("-", ".") + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def _configure_cmake(self):
         if self._cmake:


### PR DESCRIPTION
**paho-mqtt-cpp/1.2.0**

Update paho-mqtt-c dependency to latest version 1.3.9.
It contains some important bug fixes (see https://github.com/eclipse/paho.mqtt.c/milestone/16?closed=1)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
