### PR TITLE
Use absolute target names in litehtml

### DIFF
--- a/recipes/litehtml/all/conanfile.py
+++ b/recipes/litehtml/all/conanfile.py
@@ -3,7 +3,7 @@ import textwrap
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class LitehtmlConan(ConanFile):
@@ -129,7 +129,7 @@ class LitehtmlConan(ConanFile):
         return os.path.join(self._module_subfolder,
                             "conan-official-{}-targets.cmake".format(self.name))
     def package_info(self):
-        self.cpp_info.components["litehtml_litehtml"].set_property("cmake_target_name", "litehtml")
+        self.cpp_info.components["litehtml_litehtml"].set_property("cmake_target_name", "litehtml::litehtml")
 
         self.cpp_info.components["litehtml_litehtml"].names["cmake_find_package"] = "litehtml"
         self.cpp_info.components["litehtml_litehtml"].names["cmake_find_package_multi"] = "litehtml"
@@ -146,7 +146,7 @@ class LitehtmlConan(ConanFile):
             self.cpp_info.components["litehtml_litehtml"].requires.append("icu::icu")
 
         if True: # FIXME: remove once we use a vendored gumbo library
-            self.cpp_info.components["gumbo"].set_property("cmake_target_name", "gumbo")
+            self.cpp_info.components["gumbo"].set_property("cmake_target_name", "litehtml::gumbo")
             self.cpp_info.components["gumbo"].libs = ["gumbo"]
 
             self.cpp_info.components["gumbo"].names["cmake_find_package"] = "gumbo"

--- a/recipes/litehtml/all/conanfile.py
+++ b/recipes/litehtml/all/conanfile.py
@@ -135,7 +135,6 @@ class LitehtmlConan(ConanFile):
         self.cpp_info.components["litehtml_litehtml"].names["cmake_find_package_multi"] = "litehtml"
 
         self.cpp_info.components["litehtml_litehtml"].builddirs.append(self._module_subfolder)
-        self.cpp_info.components["litehtml_litehtml"].set_property("cmake_build_modules", [self._module_file_rel_path])
 
         self.cpp_info.components["litehtml_litehtml"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
         self.cpp_info.components["litehtml_litehtml"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/litehtml/all/conanfile.py
+++ b/recipes/litehtml/all/conanfile.py
@@ -129,7 +129,7 @@ class LitehtmlConan(ConanFile):
         return os.path.join(self._module_subfolder,
                             "conan-official-{}-targets.cmake".format(self.name))
     def package_info(self):
-        self.cpp_info.components["litehtml_litehtml"].set_property("cmake_target_name", "litehtml::litehtml")
+        self.cpp_info.components["litehtml_litehtml"].set_property("cmake_target_name", "litehtml")
 
         self.cpp_info.components["litehtml_litehtml"].names["cmake_find_package"] = "litehtml"
         self.cpp_info.components["litehtml_litehtml"].names["cmake_find_package_multi"] = "litehtml"
@@ -146,7 +146,7 @@ class LitehtmlConan(ConanFile):
             self.cpp_info.components["litehtml_litehtml"].requires.append("icu::icu")
 
         if True: # FIXME: remove once we use a vendored gumbo library
-            self.cpp_info.components["gumbo"].set_property("cmake_target_name", "litehtml::gumbo")
+            self.cpp_info.components["gumbo"].set_property("cmake_target_name", "gumbo")
             self.cpp_info.components["gumbo"].libs = ["gumbo"]
 
             self.cpp_info.components["gumbo"].names["cmake_find_package"] = "gumbo"


### PR DESCRIPTION
This PR updates the targetnames for CMakeDeps via set_property. This must stay as draft until we release Conan 1.43 that includes changes that allow specifying target names with the namespace included (conan-io/conan#10099).