### PR TITLE
Use absolute target names in proj

### DIFF
--- a/recipes/proj/all/conanfile.py
+++ b/recipes/proj/all/conanfile.py
@@ -133,7 +133,6 @@ class ProjConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", cmake_config_filename)
         self.cpp_info.set_property("cmake_target_name", "{}::proj".format(cmake_namespace))
         self.cpp_info.set_property("pkg_config_name", "proj")
-        self.cpp_info.components["projlib"].set_property("cmake_target_name", "{}::proj".format(cmake_namespace))
         self.cpp_info.components["projlib"].set_property("pkg_config_name", "proj")
         self.cpp_info.components["projlib"].libs = tools.collect_libs(self)
 

--- a/recipes/proj/all/conanfile.py
+++ b/recipes/proj/all/conanfile.py
@@ -131,7 +131,7 @@ class ProjConan(ConanFile):
         cmake_config_filename = "proj" if proj_version >= "7.0.0" else "proj4"
         cmake_namespace = "PROJ" if proj_version >= "7.0.0" else "PROJ4"
         self.cpp_info.set_property("cmake_file_name", cmake_config_filename)
-        self.cpp_info.set_property("cmake_target_name", "{0}::{0}".format(cmake_namespace))
+        self.cpp_info.set_property("cmake_target_name", "{}::proj".format(cmake_namespace))
         self.cpp_info.set_property("pkg_config_name", "proj")
         self.cpp_info.components["projlib"].set_property("cmake_target_name", "{}::proj".format(cmake_namespace))
         self.cpp_info.components["projlib"].set_property("pkg_config_name", "proj")

--- a/recipes/proj/all/conanfile.py
+++ b/recipes/proj/all/conanfile.py
@@ -1,7 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class ProjConan(ConanFile):
@@ -131,9 +131,9 @@ class ProjConan(ConanFile):
         cmake_config_filename = "proj" if proj_version >= "7.0.0" else "proj4"
         cmake_namespace = "PROJ" if proj_version >= "7.0.0" else "PROJ4"
         self.cpp_info.set_property("cmake_file_name", cmake_config_filename)
-        self.cpp_info.set_property("cmake_target_name", cmake_namespace)
+        self.cpp_info.set_property("cmake_target_name", "{0}::{0}".format(cmake_namespace))
         self.cpp_info.set_property("pkg_config_name", "proj")
-        self.cpp_info.components["projlib"].set_property("cmake_target_name", "proj")
+        self.cpp_info.components["projlib"].set_property("cmake_target_name", "{}::proj".format(cmake_namespace))
         self.cpp_info.components["projlib"].set_property("pkg_config_name", "proj")
         self.cpp_info.components["projlib"].libs = tools.collect_libs(self)
 


### PR DESCRIPTION
This PR updates the targetnames for CMakeDeps via set_property. This must stay as draft until we release Conan 1.43 that includes changes that allow specifying target names with the namespace included (conan-io/conan#10099).