### PR TITLE
Use absolute target names in tensorflow-lite

### DIFF
--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -163,8 +163,7 @@ class TensorflowLiteConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "tensorflowlite")
-        self.cpp_info.set_property("cmake_target_name", "tensorflowlite::tensorflowlite")
-        self.cpp_info.set_property("cmake_target_aliases", ["tensorflow::tensorflowlite"])
+        self.cpp_info.set_property("cmake_target_name", "tensorflow::tensorflowlite")
 
         self.cpp_info.filenames["cmake_find_package"] = "tensorflowlite"
         self.cpp_info.filenames["cmake_find_package_multi"] = "tensorflowlite"

--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -4,7 +4,7 @@ import textwrap
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class TensorflowLiteConan(ConanFile):
@@ -163,8 +163,8 @@ class TensorflowLiteConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "tensorflowlite")
-        self.cpp_info.set_property("cmake_target_name", "tensorflowlite")
-        self.cpp_info.set_property("cmake_build_modules", [os.path.join(self._module_subfolder, self._module_file)])
+        self.cpp_info.set_property("cmake_target_name", "tensorflowlite::tensorflowlite")
+        self.cpp_info.set_property("cmake_target_aliases", ["tensorflow::tensorflowlite"])
 
         self.cpp_info.filenames["cmake_find_package"] = "tensorflowlite"
         self.cpp_info.filenames["cmake_find_package_multi"] = "tensorflowlite"


### PR DESCRIPTION
This PR updates the targetnames for CMakeDeps via set_property. This must stay as draft until we release Conan 1.43 that includes changes that allow specifying target names with the namespace included (conan-io/conan#10099).