### PR TITLE
libx264 recipe breaks when cross-building

### DIFF
--- a/recipes/libx264/all/conanfile.py
+++ b/recipes/libx264/all/conanfile.py
@@ -99,7 +99,7 @@ class LibX264Conan(ConanFile):
 
         if self._with_nasm:
             # FIXME: get using user_build_info
-            self._override_env["AS"] = os.path.join(self.deps_cpp_info["nasm"].rootpath, "bin", "nasm{}".format(".exe" if tools.os_info.is_windows else "")).replace("\\", "/")
+            self._override_env["AS"] = os.path.join(self.dependencies.build["nasm"].package_folder, "bin", "nasm{}".format(".exe" if tools.os_info.is_windows else "")).replace("\\", "/")
         if tools.cross_building(self):
             if self.settings.os == "Android":
                 # the as of ndk does not work well for building libx264

--- a/recipes/libx264/all/conanfile.py
+++ b/recipes/libx264/all/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, tools, AutoToolsBuildEnvironment
 import contextlib
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.38.0"
 
 
 class LibX264Conan(ConanFile):


### PR DESCRIPTION
Specify library name and version:  **libx264/20191217**

I get a KeyError when trying to access `self.deps_cpp_info["nasm"]` when providing a host and build profile. 

self.deps_cpp_info seems completely empty for me
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
