### PR TITLE
Use absolute target names in gdal

### DIFF
--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 from contextlib import contextmanager
 import os
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class GdalConan(ConanFile):
@@ -834,7 +834,7 @@ class GdalConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "GDAL")
-        self.cpp_info.set_property("cmake_target_name", "GDAL")
+        self.cpp_info.set_property("cmake_target_name", "GDAL::GDAL")
         self.cpp_info.set_property("pkg_config_name", "gdal")
 
         self.cpp_info.names["cmake_find_package"] = "GDAL"

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -835,6 +835,7 @@ class GdalConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "GDAL")
         self.cpp_info.set_property("cmake_target_name", "GDAL::GDAL")
+        self.cpp_info.set_property("cmake_find_mode", "both") 
         self.cpp_info.set_property("pkg_config_name", "gdal")
 
         self.cpp_info.names["cmake_find_package"] = "GDAL"


### PR DESCRIPTION
This PR updates the targetnames for CMakeDeps via set_property. This must stay as draft until we release Conan 1.43 that includes changes that allow specifying target names with the namespace included (conan-io/conan#10099).