### PR TITLE
Use absolute target names in ms-gl

### DIFF
--- a/recipes/ms-gsl/all/conanfile.py
+++ b/recipes/ms-gsl/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class MicrosoftGslConan(ConanFile):
@@ -70,14 +70,12 @@ class MicrosoftGslConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "Microsoft.GSL")
-        self.cpp_info.set_property("cmake_target_name", "Microsoft.GSL")
+        self.cpp_info.set_property("cmake_target_name", "Microsoft.GSL::GSL")
 
         self.cpp_info.filenames["cmake_find_package"] = "Microsoft.GSL"
         self.cpp_info.filenames["cmake_find_package_multi"] = "Microsoft.GSL"
         self.cpp_info.names["cmake_find_package"] = "Microsoft.GSL"
         self.cpp_info.names["cmake_find_package_multi"] = "Microsoft.GSL"
-
-        self.cpp_info.components["_ms-gsl"].set_property("cmake_target_name", "GSL")
 
         self.cpp_info.components["_ms-gsl"].names["cmake_find_package"] = "GSL"
         self.cpp_info.components["_ms-gsl"].names["cmake_find_package_multi"] = "GSL"


### PR DESCRIPTION
This PR updates the targetnames for CMakeDeps via set_property. This must stay as draft until we release Conan 1.43 that includes changes that allow specifying target names with the namespace included (conan-io/conan#10099).