### PR TITLE
boost/* Add s390 and s390x support

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -879,6 +879,8 @@ class BoostConan(ConanFile):
             return "mips64"
         elif str(self.settings.arch).startswith("mips"):
             return "mips1"
+        elif str(self.settings.arch).startswith("s390"):
+            return "s390x"
         else:
             return None
 


### PR DESCRIPTION
boost/*

Add support for the s390 and s390x (zlinux) architectures.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
