### PR TITLE
Added harfuzz-susbset option for building

### DIFF
--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -23,6 +23,7 @@ class HarfbuzzConan(ConanFile):
         "with_gdi": [True, False],
         "with_uniscribe": [True, False],
         "with_directwrite": [True, False],
+        "with_subset": [True, False],
     }
     default_options = {
         "shared": False,
@@ -33,6 +34,7 @@ class HarfbuzzConan(ConanFile):
         "with_gdi": True,
         "with_uniscribe": True,
         "with_directwrite": False,
+        "with_subset": False,
     }
 
     short_paths = True
@@ -86,7 +88,7 @@ class HarfbuzzConan(ConanFile):
             cmake.definitions["HB_HAVE_UNISCRIBE"] = self.options.with_uniscribe
             cmake.definitions["HB_HAVE_DIRECTWRITE"] = self.options.with_directwrite
         cmake.definitions["HB_BUILD_UTILS"] = False
-        cmake.definitions["HB_BUILD_SUBSET"] = False
+        cmake.definitions["HB_BUILD_SUBSET"] = self.options.with_subset
         cmake.definitions["HB_HAVE_GOBJECT"] = False
         cmake.definitions["HB_HAVE_INTROSPECTION"] = False
         # fix for MinGW debug build
@@ -114,6 +116,8 @@ class HarfbuzzConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "harfbuzz"
         if self.options.with_icu:
             self.cpp_info.libs.append("harfbuzz-icu")
+        if self.options.with_subset:
+            self.cpp_info.libs.append("harfbuzz-subset")
         self.cpp_info.libs.append("harfbuzz")
         self.cpp_info.includedirs.append(os.path.join("include", "harfbuzz"))
         if self.settings.os == "Linux":


### PR DESCRIPTION
Specify library name and version:  **harfbuzz/3.1.2**

Thanks. For our project we need to build the harfbuzz-subset also. It seems, that this configuration was disabled in: 
https://github.com/conan-io/conan-center-index/commit/35af556bb66d981a77aedba4a1be3453122f9edc#diff-7c9779798c546535184e3e17e059881fef98f3d3710943bf1fc37b2edb13f42d

So, I've decided to add the option for the package flexibility.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
