### PR TITLE
aws-c-http: Use absolute targets

### DIFF
--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -74,6 +74,7 @@ class AwsCHttp(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "AWS"
         self.cpp_info.names["cmake_find_package_multi"] = "AWS"
 
+        self.cpp_info.components["aws-c-http-lib"].set_property("cmake_target_name", "AWS::aws-c-http")
         self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package"] = "aws-c-http"
         self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package_multi"] = "aws-c-http"
         self.cpp_info.components["aws-c-http-lib"].libs = ["aws-c-http"]

--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -1,7 +1,7 @@
 import os
 from conans import ConanFile, CMake, tools
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 class AwsCHttp(ConanFile):
     name = "aws-c-http"

--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -66,15 +66,16 @@ class AwsCHttp(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-http"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "aws-c-http")
+        self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-http")
+
         self.cpp_info.filenames["cmake_find_package"] = "aws-c-http"
         self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-http"
-        self.cpp_info.set_property("cmake_file_name", "aws-c-http")
         self.cpp_info.names["cmake_find_package"] = "AWS"
         self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.set_property("cmake_target_name", "AWS::AWS")
+
         self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package"] = "aws-c-http"
         self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package_multi"] = "aws-c-http"
-        self.cpp_info.components["aws-c-http-lib"].set_property("cmake_target_name", "AWS::aws-c-http")
         self.cpp_info.components["aws-c-http-lib"].libs = ["aws-c-http"]
         self.cpp_info.components["aws-c-http-lib"].requires = [
             "aws-c-common::aws-c-common-lib",

--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -71,10 +71,10 @@ class AwsCHttp(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "aws-c-http")
         self.cpp_info.names["cmake_find_package"] = "AWS"
         self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.set_property("cmake_target_name", "AWS")
+        self.cpp_info.set_property("cmake_target_name", "AWS::AWS")
         self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package"] = "aws-c-http"
         self.cpp_info.components["aws-c-http-lib"].names["cmake_find_package_multi"] = "aws-c-http"
-        self.cpp_info.components["aws-c-http-lib"].set_property("cmake_target_name", "aws-c-http")
+        self.cpp_info.components["aws-c-http-lib"].set_property("cmake_target_name", "AWS::aws-c-http")
         self.cpp_info.components["aws-c-http-lib"].libs = ["aws-c-http"]
         self.cpp_info.components["aws-c-http-lib"].requires = [
             "aws-c-common::aws-c-common-lib",


### PR DESCRIPTION
This PR updates the target names for CMakeDeps via set_property.
Conan version required: 1.43
Conan feature related: https://github.com/conan-io/conan/pull/10099