### PR TITLE
ktx: Use absolute target names

### DIFF
--- a/recipes/ktx/all/conanfile.py
+++ b/recipes/ktx/all/conanfile.py
@@ -117,7 +117,7 @@ class KtxConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "Ktx")
         self.cpp_info.set_property("cmake_target_name", "KTX::KTX")
-        self.cpp_info.components["libktx"].set_property("cmake_target_name", "ktx::ktx")
+        self.cpp_info.components["libktx"].set_property("cmake_target_name", "KTX::ktx")
 
         self.cpp_info.filenames["cmake_find_package"] = "Ktx"
         self.cpp_info.filenames["cmake_find_package_multi"] = "Ktx"

--- a/recipes/ktx/all/conanfile.py
+++ b/recipes/ktx/all/conanfile.py
@@ -1,7 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class KtxConan(ConanFile):
@@ -116,8 +116,8 @@ class KtxConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "Ktx")
-        self.cpp_info.set_property("cmake_target_name", "KTX")
-        self.cpp_info.components["libktx"].set_property("cmake_target_name", "ktx")
+        self.cpp_info.set_property("cmake_target_name", "KTX::KTX")
+        self.cpp_info.components["libktx"].set_property("cmake_target_name", "ktx::ktx")
 
         self.cpp_info.filenames["cmake_find_package"] = "Ktx"
         self.cpp_info.filenames["cmake_find_package_multi"] = "Ktx"

--- a/recipes/ktx/all/conanfile.py
+++ b/recipes/ktx/all/conanfile.py
@@ -116,8 +116,7 @@ class KtxConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "Ktx")
-        self.cpp_info.set_property("cmake_target_name", "KTX::KTX")
-        self.cpp_info.components["libktx"].set_property("cmake_target_name", "KTX::ktx")
+        self.cpp_info.set_property("cmake_target_name", "KTX::ktx")
 
         self.cpp_info.filenames["cmake_find_package"] = "Ktx"
         self.cpp_info.filenames["cmake_find_package_multi"] = "Ktx"


### PR DESCRIPTION
This PR updates the target names for CMakeDeps via set_property.
Conan version required: 1.43
Conan feature related: conan-io/conan#10099