### PR TITLE
aws-c-event-stream: Use absolute target names

### DIFF
--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -73,7 +73,7 @@ class AwsCEventStream(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-event-stream")
-        self.cpp_info.set_property("cmake_target_name", "AWS::AWS")
+        self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-event-stream")
         self.cpp_info.filenames["cmake_find_package"] = "aws-c-event-stream"
         self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-event-stream"
         self.cpp_info.names["cmake_find_package"] = "AWS"

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -1,7 +1,7 @@
 from conans import CMake, ConanFile, tools
 import os
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class AwsCEventStream(ConanFile):

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -78,7 +78,6 @@ class AwsCEventStream(ConanFile):
         self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-event-stream"
         self.cpp_info.names["cmake_find_package"] = "AWS"
         self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-event-stream-lib"].set_property("cmake_target_name", "AWS::aws-c-event-stream")
         self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package"] = "aws-c-event-stream"
         self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package_multi"] = "aws-c-event-stream"
         self.cpp_info.components["aws-c-event-stream-lib"].libs = ["aws-c-event-stream"]

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -73,12 +73,12 @@ class AwsCEventStream(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-event-stream")
-        self.cpp_info.set_property("cmake_target_name", "AWS")
+        self.cpp_info.set_property("cmake_target_name", "AWS::AWS")
         self.cpp_info.filenames["cmake_find_package"] = "aws-c-event-stream"
         self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-event-stream"
         self.cpp_info.names["cmake_find_package"] = "AWS"
         self.cpp_info.names["cmake_find_package_multi"] = "AWS"
-        self.cpp_info.components["aws-c-event-stream-lib"].set_property("cmake_target_name", "aws-c-event-stream")
+        self.cpp_info.components["aws-c-event-stream-lib"].set_property("cmake_target_name", "AWS::aws-c-event-stream")
         self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package"] = "aws-c-event-stream"
         self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package_multi"] = "aws-c-event-stream"
         self.cpp_info.components["aws-c-event-stream-lib"].libs = ["aws-c-event-stream"]


### PR DESCRIPTION
This PR updates the target names for CMakeDeps via set_property.
Conan version required: 1.43
Conan feature related: conan-io/conan#10099