### PR TITLE
libcurl: Use absolute target names

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -4,7 +4,7 @@ import re
 from conans import ConanFile, AutoToolsBuildEnvironment, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class LibcurlConan(ConanFile):
@@ -536,9 +536,9 @@ class LibcurlConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "CURL")
-        self.cpp_info.set_property("cmake_target_name", "CURL")
+        self.cpp_info.set_property("cmake_target_name", "CURL::CURL")
         self.cpp_info.set_property("pkg_config_name", "libcurl")
-        self.cpp_info.components["curl"].set_property("cmake_target_name", "libcurl")
+        self.cpp_info.components["curl"].set_property("cmake_target_name", "CURL::libcurl")
         self.cpp_info.components["curl"].set_property("pkg_config_name", "libcurl")
 
         self.cpp_info.names["cmake_find_package"] = "CURL"

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -537,6 +537,7 @@ class LibcurlConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "CURL")
         self.cpp_info.set_property("cmake_target_name", "CURL::libcurl")
+        self.cpp_info.set_property("cmake_find_mode", "both") 
         self.cpp_info.set_property("pkg_config_name", "libcurl")
 
         self.cpp_info.names["cmake_find_package"] = "CURL"

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -536,7 +536,7 @@ class LibcurlConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "CURL")
-        self.cpp_info.set_property("cmake_target_name", "CURL::CURL")
+        self.cpp_info.set_property("cmake_target_name", "CURL::libcurl")
         self.cpp_info.set_property("pkg_config_name", "libcurl")
         self.cpp_info.components["curl"].set_property("cmake_target_name", "CURL::libcurl")
         self.cpp_info.components["curl"].set_property("pkg_config_name", "libcurl")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -538,7 +538,6 @@ class LibcurlConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "CURL")
         self.cpp_info.set_property("cmake_target_name", "CURL::libcurl")
         self.cpp_info.set_property("pkg_config_name", "libcurl")
-        self.cpp_info.components["curl"].set_property("cmake_target_name", "CURL::libcurl")
         self.cpp_info.components["curl"].set_property("pkg_config_name", "libcurl")
 
         self.cpp_info.names["cmake_find_package"] = "CURL"

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -538,7 +538,6 @@ class LibcurlConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "CURL")
         self.cpp_info.set_property("cmake_target_name", "CURL::libcurl")
         self.cpp_info.set_property("pkg_config_name", "libcurl")
-        self.cpp_info.components["curl"].set_property("pkg_config_name", "libcurl")
 
         self.cpp_info.names["cmake_find_package"] = "CURL"
         self.cpp_info.names["cmake_find_package_multi"] = "CURL"


### PR DESCRIPTION
This PR updates the target names for CMakeDeps via set_property.
Conan version required: 1.43
Conan feature related: conan-io/conan#10099