### PR TITLE
redis-plus-plus: Use absolute target names

### DIFF
--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -115,7 +115,7 @@ class RedisPlusPlusConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "redis++")
-        self.cpp_info.set_property("cmake_target_name", "redis++::redis++")
+        self.cpp_info.set_property("cmake_target_name", "redis++::redis++" + "_static" if not self.options.shared else "")
         self.cpp_info.set_property("pkg_config_name", "redis++")
         self.cpp_info.components["redis++lib"].set_property("cmake_target_name", "redis++::redis++" + "_static" if not self.options.shared else "")
         self.cpp_info.components["redis++lib"].set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")

--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -117,7 +117,6 @@ class RedisPlusPlusConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "redis++")
         self.cpp_info.set_property("cmake_target_name", "redis++::redis++" + "_static" if not self.options.shared else "")
         self.cpp_info.set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
-        self.cpp_info.components["redis++lib"].set_property("cmake_target_name", "redis++::redis++" + "_static" if not self.options.shared else "")
         self.cpp_info.components["redis++lib"].set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
 
         self.cpp_info.names["cmake_find_package"] = "redis++"

--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -116,7 +116,7 @@ class RedisPlusPlusConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "redis++")
         self.cpp_info.set_property("cmake_target_name", "redis++::redis++" + "_static" if not self.options.shared else "")
-        self.cpp_info.set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
+        self.cpp_info.components["redis++lib"].set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
 
         self.cpp_info.names["cmake_find_package"] = "redis++"
         self.cpp_info.names["cmake_find_package_multi"] = "redis++"

--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -117,7 +117,6 @@ class RedisPlusPlusConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "redis++")
         self.cpp_info.set_property("cmake_target_name", "redis++::redis++" + "_static" if not self.options.shared else "")
         self.cpp_info.set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
-        self.cpp_info.components["redis++lib"].set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
 
         self.cpp_info.names["cmake_find_package"] = "redis++"
         self.cpp_info.names["cmake_find_package_multi"] = "redis++"

--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -114,9 +114,11 @@ class RedisPlusPlusConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "redis++")
         self.cpp_info.set_property("cmake_target_name", "redis++::redis++")
         self.cpp_info.set_property("pkg_config_name", "redis++")
         self.cpp_info.components["redis++lib"].set_property("cmake_target_name", "redis++::redis++" + "_static" if not self.options.shared else "")
+        self.cpp_info.components["redis++lib"].set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
 
         self.cpp_info.names["cmake_find_package"] = "redis++"
         self.cpp_info.names["cmake_find_package_multi"] = "redis++"

--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -116,6 +116,7 @@ class RedisPlusPlusConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "redis++")
         self.cpp_info.set_property("cmake_target_name", "redis++::redis++" + "_static" if not self.options.shared else "")
+        self.cpp_info.components["redis++lib"].set_property("cmake_target_name", "redis++" + "_static" if not self.options.shared else "")
         self.cpp_info.components["redis++lib"].set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
 
         self.cpp_info.names["cmake_find_package"] = "redis++"

--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class RedisPlusPlusConan(ConanFile):
@@ -114,12 +114,9 @@ class RedisPlusPlusConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.set_property("cmake_file_name", "redis++")
-        self.cpp_info.set_property("cmake_target_name", "redis++")
+        self.cpp_info.set_property("cmake_target_name", "redis++::redis++")
         self.cpp_info.set_property("pkg_config_name", "redis++")
-        self.cpp_info.components["redis++lib"].set_property("cmake_find_package", "redis++" + "_static" if not self.options.shared else "")
-        self.cpp_info.components["redis++lib"].set_property("cmake_target_name", "redis++" + "_static" if not self.options.shared else "")
-        self.cpp_info.components["redis++lib"].set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
+        self.cpp_info.components["redis++lib"].set_property("cmake_target_name", "redis++::redis++" + "_static" if not self.options.shared else "")
 
         self.cpp_info.names["cmake_find_package"] = "redis++"
         self.cpp_info.names["cmake_find_package_multi"] = "redis++"

--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -116,7 +116,7 @@ class RedisPlusPlusConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "redis++")
         self.cpp_info.set_property("cmake_target_name", "redis++::redis++" + "_static" if not self.options.shared else "")
-        self.cpp_info.set_property("pkg_config_name", "redis++")
+        self.cpp_info.set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
         self.cpp_info.components["redis++lib"].set_property("cmake_target_name", "redis++::redis++" + "_static" if not self.options.shared else "")
         self.cpp_info.components["redis++lib"].set_property("pkg_config_name", "redis++" + "_static" if not self.options.shared else "")
 


### PR DESCRIPTION
This PR updates the target names for CMakeDeps via set_property.
Conan version required: 1.43
Conan feature related: conan-io/conan#10099