### PR TITLE
re2: Use absolute target names

### DIFF
--- a/recipes/re2/all/conanfile.py
+++ b/recipes/re2/all/conanfile.py
@@ -1,7 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class Re2Conan(ConanFile):
@@ -70,7 +70,7 @@ class Re2Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "re2")
-        self.cpp_info.set_property("cmake_target_name", "re2")
+        self.cpp_info.set_property("cmake_target_name", "re2::re2")
 
         self.cpp_info.names["cmake_find_package"] = "re2"
         self.cpp_info.names["cmake_find_package_multi"] = "re2"


### PR DESCRIPTION
This PR updates the target names for CMakeDeps via set_property.
Conan version required: 1.43
Conan feature related: conan-io/conan#10099