### PR TITLE
allow building crashpad on Apple M1 CPUs

### DIFF
--- a/recipes/crashpad/all/conandata.yml
+++ b/recipes/crashpad/all/conandata.yml
@@ -23,3 +23,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/cci.20210507-0007-use-system-zlib.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/cci.20210507-0008-allow-aarch64-arch.patch"
+      base_path: "source_subfolder"

--- a/recipes/crashpad/all/patches/cci.20210507-0008-allow-aarch64-arch.patch
+++ b/recipes/crashpad/all/patches/cci.20210507-0008-allow-aarch64-arch.patch
@@ -1,0 +1,12 @@
+index 71bf1ce6..345dfbf8 100644
+--- a/util/BUILD.gn
++++ b/util/BUILD.gn
+@@ -132,7 +132,7 @@ if (crashpad_is_mac || crashpad_is_ios) {
+         "--arch",
+         "armv7",
+       ]
+-    } else if (current_cpu == "arm64") {
++    } else if (current_cpu == "arm64" || current_cpu == "aarch64") {
+       args += [
+         "--arch",
+         "arm64",


### PR DESCRIPTION
Specify library name and version:  **crashpad/cci.20210507**

Building crashpad on an Apple M1 notebook failed with an `assert` in `util/BUILD.gn`. IIUC, the M1 architecture reports itself as "aarch64" instead of "arm64". As those two are equivalent, they can be treated as equal when specifying the build flags.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
