### PR TITLE
[onedpl] requires tbbmalloc

### DIFF
--- a/recipes/onedpl/all/conanfile.py
+++ b/recipes/onedpl/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conans import ConanFile, CMake, tools
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 class OneDplConan(ConanFile):
     name = "onedpl"

--- a/recipes/onedpl/all/conanfile.py
+++ b/recipes/onedpl/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conans import ConanFile, CMake, tools
 
-required_conan_version = ">=1.28.0"
+required_conan_version = ">=1.36.0"
 
 class OneDplConan(ConanFile):
     name = "onedpl"
@@ -14,6 +14,7 @@ class OneDplConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/oneapi-src/oneDPL"
     topics = ("stl", "parallelism")
+    settings = "os", "arch", "build_type", "compiler"
     options = {
         "backend": ["tbb", "serial"]
     }
@@ -60,12 +61,16 @@ class OneDplConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "ParallelSTL"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "ParallelSTL"
-        self.cpp_info.names["cmake_find_package"] = "pstl"
-        self.cpp_info.names["cmake_find_package_multi"] = "pstl"
-        self.cpp_info.components["_onedpl"].names["cmake_find_package"] = "ParallelSTL"
-        self.cpp_info.components["_onedpl"].names["cmake_find_package_multi"] = "ParallelSTL"
+        target_name = "ParallelSTL"
+        namespace = "pstl"
+        self.cpp_info.filenames["cmake_find_package"] = target_name
+        self.cpp_info.filenames["cmake_find_package_multi"] = target_name
+        self.cpp_info.names["cmake_find_package"] = namespace
+        self.cpp_info.names["cmake_find_package_multi"] = namespace
+        self.cpp_info.set_property("cmake_file_name", target_name)
+        self.cpp_info.set_property("cmake_target_name", f"{namespace}::{target_name}")
+        self.cpp_info.components["_onedpl"].names["cmake_find_package"] = target_name
+        self.cpp_info.components["_onedpl"].names["cmake_find_package_multi"] = target_name
         self.cpp_info.components["_onedpl"].includedirs = ["include", os.path.join("lib", "stdlib")]
         if self.options.backend == "tbb":
             self.cpp_info.components["_onedpl"].requires = ["tbb::libtbb", "tbb::tbbmalloc"]

--- a/recipes/onedpl/all/conanfile.py
+++ b/recipes/onedpl/all/conanfile.py
@@ -2,6 +2,7 @@ import os
 
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+from conan.tools import files
 
 required_conan_version = ">=1.43.0"
 
@@ -49,8 +50,7 @@ class OneDplConan(ConanFile):
         self.info.header_only()
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("oneDPL-" + self.version, self._source_subfolder)
+        files.get(self, **self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def _configure_cmake(self):
         cmake = CMake(self)

--- a/recipes/onedpl/all/conanfile.py
+++ b/recipes/onedpl/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.43.0"
 
@@ -28,6 +29,10 @@ class OneDplConan(ConanFile):
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def validate(self):
+        if self.options.backend == "tbb" and not self.options["tbb"].tbbmalloc:
+            raise ConanInvalidConfiguration(f"recipe {self.name}/{self.version} with backend=tbb requires tbb:malloc")
 
     def configure(self):
         if self.settings.compiler.cppstd:

--- a/recipes/onedpl/all/conanfile.py
+++ b/recipes/onedpl/all/conanfile.py
@@ -14,9 +14,12 @@ class OneDplConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/oneapi-src/oneDPL"
     topics = ("stl", "parallelism")
-    settings = "os", "arch", "build_type", "compiler"
-    options = {"backend": ["tbb", "serial"]}
-    default_options = {"backend": "tbb"}
+    options = {
+        "backend": ["tbb", "serial"]
+    }
+    default_options = {
+        "backend": "tbb"
+    }
     generators = ["cmake", "cmake_find_package"]
     exports = ["CMakeLists.txt"]
     no_copy_source = True
@@ -28,6 +31,9 @@ class OneDplConan(ConanFile):
     def configure(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
+        if self.options.backend == "tbb":
+            # Listed as an OPTIONAL_COMPONENT but optional components not supported by conan
+            self.options["tbb"].tbbmalloc = True
 
     def requirements(self):
         if self.options.backend == "tbb":
@@ -62,4 +68,4 @@ class OneDplConan(ConanFile):
         self.cpp_info.components["_onedpl"].names["cmake_find_package_multi"] = "ParallelSTL"
         self.cpp_info.components["_onedpl"].includedirs = ["include", os.path.join("lib", "stdlib")]
         if self.options.backend == "tbb":
-            self.cpp_info.components["_onedpl"].requires = ["tbb::tbb"]
+            self.cpp_info.components["_onedpl"].requires = ["tbb::libtbb", "tbb::tbbmalloc"]

--- a/recipes/onedpl/all/test_package/CMakeLists.txt
+++ b/recipes/onedpl/all/test_package/CMakeLists.txt
@@ -4,6 +4,9 @@ project(test_package CXX)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQURIED ON)
+
 find_package(ParallelSTL REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)


### PR DESCRIPTION
Specify library name and version:  **onedpl/20200330**

onedpl requires `tbb::malloc` which is not enabled by default. (actually an "OPTIONAL_COMPONENT" but these appear to be required by conan)

Also removed `settings` as this is a header-only library.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
