### PR TITLE
imagemagick: reimplement djvu options

### DIFF
--- a/recipes/imagemagick/all/conanfile.py
+++ b/recipes/imagemagick/all/conanfile.py
@@ -61,6 +61,7 @@ class ImageMagicConan(ConanFile):
         "with_webp": False,
         "with_xml2": True,
         "with_freetype": True,
+        "with_djvu": False,
         "utilities": True,
     }
     exports_sources = "patches/*"
@@ -366,8 +367,8 @@ class ImageMagicConan(ConanFile):
             "--with-webp={}".format(yes_no(self.options.with_webp)),
             "--with-xml={}".format(yes_no(self.options.with_xml2)),
             "--with-freetype={}".format(yes_no(self.options.with_freetype)),
-            "--with-utilities={}".format(yes_no(self.options.utilities)),
             "--with-djvu={}".format(yes_no(self.options.with_djvu)),
+            "--with-utilities={}".format(yes_no(self.options.utilities)),
         ]
         self._autotools.configure(args=args)
 

--- a/recipes/imagemagick/all/conanfile.py
+++ b/recipes/imagemagick/all/conanfile.py
@@ -38,6 +38,7 @@ class ImageMagicConan(ConanFile):
         "with_webp": [True, False],
         "with_xml2": [True, False],
         "with_freetype": [True, False],
+        "with_djvu": [True, False],
         "utilities": [True, False],
     }
     default_options = {
@@ -131,6 +132,11 @@ class ImageMagicConan(ConanFile):
             self.requires("libxml2/2.9.10")
         if self.options.with_freetype:
             self.requires("freetype/2.10.4")
+        if self.options.with_djvu:
+            # FIXME: missing djvu recipe
+            self.output.warn(
+                "There is no djvu package available on Conan (yet). This recipe will use the one present on the system (if available)."
+            )
 
     def source(self):
         tools.get(
@@ -361,6 +367,7 @@ class ImageMagicConan(ConanFile):
             "--with-xml={}".format(yes_no(self.options.with_xml2)),
             "--with-freetype={}".format(yes_no(self.options.with_freetype)),
             "--with-utilities={}".format(yes_no(self.options.utilities)),
+            "--with-djvu={}".format(yes_no(self.options.with_djvu)),
         ]
         self._autotools.configure(args=args)
 


### PR DESCRIPTION
Specify library name and version:  **imagemagick/all**

It looks like djvu options got removed in https://github.com/conan-io/conan-center-index/pull/7952 I don't believe this was intended so I'm adding them back.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
