### PR TITLE
Add freetype/2.11.1

### DIFF
--- a/recipes/freetype/all/conandata.yml
+++ b/recipes/freetype/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "2.11.1":
+    url: [
+      "https://download.savannah.gnu.org/releases/freetype/freetype-2.11.1.tar.gz",
+      "https://sourceforge.net/projects/freetype/files/freetype2/2.11.1/freetype-2.11.1.tar.gz/download",
+    ]
+    sha256: "f8db94d307e9c54961b39a1cc799a67d46681480696ed72ecf78d4473770f09b"
   "2.11.0":
     url: [
       "https://download.savannah.gnu.org/releases/freetype/freetype-2.11.0.tar.gz",

--- a/recipes/freetype/config.yml
+++ b/recipes/freetype/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.11.1":
+    folder: all
   "2.11.0":
     folder: all
   "2.10.4":


### PR DESCRIPTION
Specify library name and version:  **freetype/2.11.1**

freetype/2.11.0 (required by the recently updated cairo recipe) segfaults on some glyphs in my app, freetype/2.11.1 seems to have been fixed.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
