### PR TITLE
autoconf: remove no-perl-path-in-shebang patch

### DIFF
--- a/recipes/autoconf/all/patches/2.69-0002-no-perl-path-in-shebang.patch
+++ b/recipes/autoconf/all/patches/2.69-0002-no-perl-path-in-shebang.patch
@@ -2,7 +2,7 @@
 +++ bin/autoheader.in
 @@ -1,4 +1,4 @@
 -#! @PERL@
-+#! /usr/bin/perl
++#! /usr/bin/env perl
  # -*- Perl -*-
  # @configure_input@
  
@@ -10,39 +10,44 @@
 +++ bin/autom4te.in
 @@ -1,4 +1,4 @@
 -#! @PERL@ -w
-+#! /usr/bin/perl -w
- # -*- perl -*-
+-# -*- perl -*-
++#! /usr/bin/env perl
++# -*- perl -*- -w
  # @configure_input@
  
 --- bin/autoreconf.in
 +++ bin/autoreconf.in
 @@ -1,4 +1,4 @@
 -#! @PERL@ -w
-+#! /usr/bin/perl -w
- # -*- perl -*-
+-# -*- perl -*-
++#! /usr/bin/env perl
++# -*- perl -*- -w
  # @configure_input@
  
 --- bin/autoscan.in
 +++ bin/autoscan.in
 @@ -1,4 +1,4 @@
 -#! @PERL@ -w
-+#! /usr/bin/perl -w
- # -*- perl -*-
+-# -*- perl -*-
++#! /usr/bin/env perl
++# -*- perl -*- -w
  # @configure_input@
  
 --- bin/autoupdate.in
 +++ bin/autoupdate.in
 @@ -1,4 +1,4 @@
 -#! @PERL@ -w
-+#! /usr/bin/perl -w
- # -*- perl -*-
+-# -*- perl -*-
++#! /usr/bin/env perl
++# -*- perl -*- -w
  # @configure_input@
  
 --- bin/ifnames.in
 +++ bin/ifnames.in
 @@ -1,4 +1,4 @@
 -#! @PERL@ -w
-+#! /usr/bin/perl -w
- # -*- perl -*-
+-# -*- perl -*-
++#! /usr/bin/env perl
++# -*- perl -*- -w
  # @configure_input@
  

--- a/recipes/autoconf/all/patches/2.71-0002-no-perl-path-in-shebang.patch
+++ b/recipes/autoconf/all/patches/2.71-0002-no-perl-path-in-shebang.patch
@@ -2,7 +2,7 @@
 +++ bin/autoheader.in
 @@ -1,4 +1,4 @@
 -#! @PERL@
-+#! /usr/bin/perl
++#! /usr/bin/env perl
  # -*- Perl -*-
  # @configure_input@
  
@@ -10,7 +10,7 @@
 +++ bin/autom4te.in
 @@ -1,4 +1,4 @@
 -#! @PERL@
-+#! /usr/bin/perl
++#! /usr/bin/env perl
  # -*- perl -*-
  # @configure_input@
  
@@ -18,7 +18,7 @@
 +++ bin/autoreconf.in
 @@ -1,4 +1,4 @@
 -#! @PERL@
-+#! /usr/bin/perl
++#! /usr/bin/env perl
  # -*- perl -*-
  # @configure_input@
  
@@ -26,7 +26,7 @@
 +++ bin/autoscan.in
 @@ -1,4 +1,4 @@
 -#! @PERL@
-+#! /usr/bin/perl
++#! /usr/bin/env perl
  # -*- perl -*-
  # @configure_input@
  
@@ -34,7 +34,7 @@
 +++ bin/autoupdate.in
 @@ -1,4 +1,4 @@
 -#! @PERL@
-+#! /usr/bin/perl
++#! /usr/bin/env perl
  # -*- perl -*-
  # @configure_input@
  
@@ -42,7 +42,7 @@
 +++ bin/ifnames.in
 @@ -1,4 +1,4 @@
 -#! @PERL@
-+#! /usr/bin/perl
++#! /usr/bin/env perl
  # -*- perl -*-
  # @configure_input@
  


### PR DESCRIPTION
Not all systems have perl at /usr/bin/perl and the build fails for all
systems that don't. The configure script correctly identifies the perl
path and substitutes it in the @PERL@ variable, so this should work
without the patch.

Specify library name and version:  **autoconf/all**

/cc @madebr as previous contributor to that file.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
