### PR TITLE
opencl-icd-loader: package_info states that no incudes are packaged

### DIFF
--- a/recipes/opencl-icd-loader/all/conanfile.py
+++ b/recipes/opencl-icd-loader/all/conanfile.py
@@ -70,6 +70,7 @@ class OpenclIcdLoaderConan(ConanFile):
         cmake.install()
 
     def package_info(self):
+        self.cpp_info.includedirs = []
         self.cpp_info.libs = ["OpenCL"]
         if not self.options.shared:
             if self.settings.os == "Linux":


### PR DESCRIPTION
Some generators (e.g. CMakeDeps) are more strict with the listed includes.
By default includedirs equals ["include"] which CMakeDeps passes to cmake
which in turn throws error due to non existing folder.

See https://github.com/conan-io/conan/issues/10032.

Specify library name and version:  **opencl-icd-loader/all**

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
