### PR TITLE
gtest: Fix GTest CMake targets for CMakeDeps and Conan 1.43

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 import os
 import functools
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class GTestConan(ConanFile):
@@ -145,8 +145,7 @@ class GTestConan(ConanFile):
     def package_info(self):
 
         self.cpp_info.set_property("cmake_file_name", "GTest")
-        self.cpp_info.set_property("cmake_target_name", "GTest")
-        self.cpp_info.components["libgtest"].set_property("cmake_target_name", "gtest")
+        self.cpp_info.components["libgtest"].set_property("cmake_target_name", "GTest::gtest")
         self.cpp_info.components["libgtest"].set_property("pkg_config_name", "gtest")
         self.cpp_info.components["libgtest"].libs = ["gtest{}".format(self._postfix)]
 
@@ -171,7 +170,7 @@ class GTestConan(ConanFile):
                     self.cpp_info.components["libgtest"].defines.append("GTEST_HAS_TR1_TUPLE=0")
 
         if not self.options.no_main:
-            self.cpp_info.components["gtest_main"].set_property("cmake_target_name", "gtest_main")
+            self.cpp_info.components["gtest_main"].set_property("cmake_target_name", "GTest::gtest_main")
             self.cpp_info.components["gtest_main"].set_property("pkg_config_name", "gtest_main")
             self.cpp_info.components["gtest_main"].libs = ["gtest_main{}".format(self._postfix)]
             self.cpp_info.components["gtest_main"].requires = ["libgtest"]
@@ -180,7 +179,7 @@ class GTestConan(ConanFile):
             self.cpp_info.components["gtest_main"].names["cmake_find_package_multi"] = "gtest_main"
 
         if self.options.build_gmock:
-            self.cpp_info.components["gmock"].set_property("cmake_target_name", "gmock")
+            self.cpp_info.components["gmock"].set_property("cmake_target_name", "GTest::gmock")
             self.cpp_info.components["gmock"].set_property("pkg_config_name", "gmock")
             self.cpp_info.components["gmock"].libs = ["gmock{}".format(self._postfix)]
             self.cpp_info.components["gmock"].requires = ["libgtest"]
@@ -189,7 +188,7 @@ class GTestConan(ConanFile):
             self.cpp_info.components["gmock"].names["cmake_find_package_multi"] = "gmock"
 
             if not self.options.no_main:
-                self.cpp_info.components["gmock_main"].set_property("cmake_target_name", "gmock_main")
+                self.cpp_info.components["gmock_main"].set_property("cmake_target_name", "GTest::gmock_main")
                 self.cpp_info.components["gmock_main"].set_property("pkg_config_name", "gmock_main")
                 self.cpp_info.components["gmock_main"].libs = ["gmock_main{}".format(self._postfix)]
                 self.cpp_info.components["gmock_main"].requires = ["gmock"]


### PR DESCRIPTION
Specify library name and version:  **gtest/1.11.0**

Namespaces the GoogleTest CMake targets to fix namespaces due to the Conan 1.43 changes.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
