### PR TITLE
boost-ext-ut: Make CMake target name absolute for Conan 1.43

### DIFF
--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class UTConan(ConanFile):
@@ -69,8 +69,7 @@ class UTConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "ut")
-        self.cpp_info.set_property("cmake_target_name", "boost")
-        self.cpp_info.components["ut"].set_property("cmake_target_name", "ut")
+        self.cpp_info.components["ut"].set_property("cmake_target_name", "boost::ut")
 
         self.cpp_info.names["cmake_find_package"] = "boost"
         self.cpp_info.names["cmake_find_package_multi"] = "boost"


### PR DESCRIPTION
Specify library name and version:  **boost-ext-ut/1.1.8**

Conan 1.43 requires using the full namespace for CMake targets.
This PR updates `boost-ext-ut` to use the fully qualified CMake target name to fix the name for the CMakeDeps generator.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
