### PR TITLE
fast_float: add version 3.4.0 using absolute target names

### DIFF
--- a/recipes/fast_float/all/conandata.yml
+++ b/recipes/fast_float/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.4.0":
+    url: "https://github.com/fastfloat/fast_float/archive/v3.4.0.tar.gz"
+    sha256: "a242877d2fae81ca412033f5ebf5dbc43cb029c56b4af78e33106b9a69f8f58e"
   "3.2.0":
     url: "https://github.com/fastfloat/fast_float/archive/v3.2.0.tar.gz"
     sha256: "c26d78b2b76704b117c416292bc47fa3e4bb69a131e82debe0e8fd5c7afdf18e"

--- a/recipes/fast_float/all/conanfile.py
+++ b/recipes/fast_float/all/conanfile.py
@@ -1,7 +1,7 @@
 from conans import ConanFile, tools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class FastFloatConan(ConanFile):
@@ -9,7 +9,7 @@ class FastFloatConan(ConanFile):
     description = "Fast and exact implementation of the C++ from_chars " \
                   "functions for float and double types."
     license = ("Apache-2.0", "MIT")
-    topics = ("conan", "fast_float", "conversion", "from_chars")
+    topics = ("fast_float", "conversion", "from_chars")
     homepage = "https://github.com/fastfloat/fast_float"
     url = "https://github.com/conan-io/conan-center-index"
 
@@ -39,5 +39,6 @@ class FastFloatConan(ConanFile):
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "FastFloat"
         self.cpp_info.names["cmake_find_package_multi"] = "FastFloat"
+        self.cpp_info.set_property("cmake_target_name", "FastFloat::fast_float")
         self.cpp_info.components["fastfloat"].names["cmake_find_package"] = "fast_float"
         self.cpp_info.components["fastfloat"].names["cmake_find_package_multi"] = "fast_float"

--- a/recipes/fast_float/all/test_package/conanfile.py
+++ b/recipes/fast_float/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/fast_float/config.yml
+++ b/recipes/fast_float/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.4.0":
+    folder: all
   "3.2.0":
     folder: all
   "3.1.0":


### PR DESCRIPTION
Specify library name and version:  **fast_float/3.4.0**

waiting for conan/1.43.0

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
