### PR TITLE
etl: add version 20.21.0

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.21.0":
+    url: "https://github.com/ETLCPP/etl/archive/20.21.0.tar.gz"
+    sha256: "4e59b57cb54b9ee764c5a083693edc033d8e9630544d489015a9a7b7e07c91a0"
   "20.19.0":
     url: "https://github.com/ETLCPP/etl/archive/refs/tags/20.19.0.zip"
     sha256: "ce57c7543867b2fe2ff3c056d8ae8ebaced51c38547d19ddb3aa60aeeb1a5411"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "20.21.0":
+    folder: all
   "20.19.0":
     folder: all


### PR DESCRIPTION
ETL 20.21.0

===============================================================================
20.21.0
Added contains() method to etl::map and etl::set + variants.
Added support for transparent comparators.
When ETL_NO_ATOMICS is defined the timer.h file does not define timer_semaphore_t.
etl::deque::resize throws etl::deque_full instead of etl::deque_out_of_bounds, if requested size is too large.

===============================================================================
20.20.0
Updated container 'insert' and 'erase' to C++11 style const_iterator parameters. (#463)
Fixed container template function overload abiguity. (#466)
Harmonize copy ctor and assignment for etl::delegate. (#465)
Added constexpr support for etl::enum_type. (#462)
Added 'make' functions to construct containers.
Remove unnecessary casts that causes warnings. (#461)
Added non-const string pointer overload. (#449)
Changed != to < in etl::ipool to get rid of erroneous clang-tidy nullptr dereference warning. (#457)
Added ifdef guard for MSVC pragma (#455)