### PR TITLE
fmt: Don't use the OS API when compiling for baremetal

### DIFF
--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class FmtConan(ConanFile):
@@ -49,6 +49,8 @@ class FmtConan(ConanFile):
             del self.options.fPIC
         if not self._has_with_os_api_option:
             del self.options.with_os_api
+        elif self.settings.os == "baremetal":
+            self.options.with_os_api = False
 
     def configure(self):
         if self.options.header_only:


### PR DESCRIPTION
Specify library name and version:  **fmt/8.0.1**

When using `fmt` on `baremetal`, there is no operating system, so `fmt`'s operating system extensions are not available.
However, the option defaults to on.
To make `fmt` compile as expected for `baremetal`, the `with_os_api` option will now be disabled by default when targeting `baremetal`.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
