### PR TITLE
behaviortree.cpp: fix unportable use of PRId64

### DIFF
--- a/recipes/behaviortree.cpp/all/conandata.yml
+++ b/recipes/behaviortree.cpp/all/conandata.yml
@@ -12,3 +12,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0004-win-sigaction.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0005-stdc-format.patch"
+      base_path: "source_subfolder"

--- a/recipes/behaviortree.cpp/all/patches/0005-stdc-format.patch
+++ b/recipes/behaviortree.cpp/all/patches/0005-stdc-format.patch
@@ -1,0 +1,12 @@
+diff --git a/3rdparty/minitrace/minitrace.h b/3rdparty/minitrace/minitrace.h
+index c7d5b31..d68dc52 100644
+--- a/3rdparty/minitrace/minitrace.h
++++ b/3rdparty/minitrace/minitrace.h
+@@ -21,6 +21,7 @@
+ // More:
+ // http://www.altdevblogaday.com/2012/08/21/using-chrometracing-to-view-your-inline-profiling-data/
+ 
++#define __STDC_FORMAT_MACROS
+ #include <inttypes.h>
+ 
+ #define MTR_ENABLED


### PR DESCRIPTION
Specify library name and version:  **behaviortree.cpp/3.5.6**

The original error in some version of gcc:

    error: expected ``)' before 'PRIu64'

To use PRId64 and be portable, we need to define the macro `__STDC_FORMAT_MACROS` before `inttypes.h` was included.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
