### PR TITLE
Allow gperf to build with pr:b==pr:h

### DIFF
--- a/recipes/gperf/all/test_package/conanfile.py
+++ b/recipes/gperf/all/test_package/conanfile.py
@@ -3,6 +3,7 @@ from conans import ConanFile, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch"
+    test_type = "build_requires"
 
     def test(self):
         if not tools.cross_building(self):

--- a/recipes/gperf/all/test_package/conanfile.py
+++ b/recipes/gperf/all/test_package/conanfile.py
@@ -3,8 +3,7 @@ from conans import ConanFile, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch"
-    test_type = "build_requires"
 
     def test(self):
         if not tools.cross_building(self):
-            self.run("gperf --version")
+            self.run("gperf --version", run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **gperf/**

Current recipe of `gperf` fails to build if `pr:b == pr:h`:
```bash
$ conan create recipes/gperf/all gperf/3.1@asd/asd -pr:b default -pr:h default
....
gperf/3.1@asd/asd (test package): Generator txt created conanbuildinfo.txt
gperf/3.1@asd/asd (test package): Aggregating env generators
gperf/3.1@asd/asd (test package): Generated conaninfo.txt
gperf/3.1@asd/asd (test package): Generated graphinfo
Using lockfile: '/home/eric/github/conan-center-index-eriff/recipes/gperf/all/test_package/build/7f6cc68115e0d1c58c111cf15e9636a11456d971/conan.lock'
Using cached profile from lockfile
gperf/3.1@asd/asd (test package): Calling build()
gperf/3.1@asd/asd (test package): WARN: This conanfile has no build step
gperf/3.1@asd/asd (test package): Running test()
/bin/sh: 1: gperf: not found
ERROR: gperf/3.1@asd/asd (test package): Error in test() method, line 9
	self.run("gperf --version")
	ConanException: Error 127 while executing gperf --version
```

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
