### PR TITLE
apr/1.7.0 fix deprecated sys_siglist.

### DIFF
--- a/recipes/apr/all/conandata.yml
+++ b/recipes/apr/all/conandata.yml
@@ -14,3 +14,5 @@ patches:
       patch_file: "patches/0004-autotools-mingw.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/0005-clang12-apple.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0005-clang12-apple.patch"

--- a/recipes/apr/all/conandata.yml
+++ b/recipes/apr/all/conandata.yml
@@ -15,4 +15,4 @@ patches:
     - base_path: "source_subfolder"
       patch_file: "patches/0005-clang12-apple.patch"
     - base_path: "source_subfolder"
-      patch_file: "patches/0005-clang12-apple.patch"
+      patch_file: "patches/0006-sys_siglist-fix.patch"

--- a/recipes/apr/all/patches/0006-sys_siglist-fix.patch
+++ b/recipes/apr/all/patches/0006-sys_siglist-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/threadproc/unix/signals.c b/threadproc/unix/signals.c
+index c735eab..e8b44c3 100644
+--- a/threadproc/unix/signals.c
++++ b/threadproc/unix/signals.c
+@@ -116,7 +116,7 @@ void apr_signal_init(apr_pool_t *pglobal)
+ }
+ const char *apr_signal_description_get(int signum)
+ {
+-    return (signum >= 0) ? sys_siglist[signum] : "unknown signal (number)";
++    return (signum >= 0) ? strsignal(signum) : "unknown signal (number)";
+ }
+ 
+ #else /* !(SYS_SIGLIST_DECLARED || HAVE_DECL_SYS_SIGLIST) */


### PR DESCRIPTION
Specify library name and version:  **apr/1.7.0**

apr was still using a deprecated sys_siglist call that will fail to build on systems with glibc > 2.32
This replaces the deprecated sys_siglist with the newer strsignal

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
