### PR TITLE
libcurl: disable unix sockets in MSVC and mingw

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -11,7 +11,7 @@ class LibcurlConan(ConanFile):
     name = "libcurl"
 
     description = "command line tool and library for transferring data with URLs"
-    topics = ("conan", "curl", "libcurl", "data-transfer")
+    topics = ("curl", "libcurl", "data-transfer")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://curl.haxx.se"
     license = "MIT"
@@ -136,7 +136,7 @@ class LibcurlConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-            if tools.os_info.detect_windows_subsystem() == None:
+            if self.settings.os.subsystem == None:
                 del self.options.with_unix_sockets
         if not self._has_zstd_option:
             del self.options.with_zstd
@@ -150,9 +150,6 @@ class LibcurlConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-
-        if self.settings.os == "Windows" and tools.os_info.detect_windows_subsystem() == None:
-            self.options.with_unix_sockets = False
 
         # These options are not used in CMake build yet
         if self._is_using_cmake_build:
@@ -321,7 +318,7 @@ class LibcurlConan(ConanFile):
             "--enable-manual={}".format(yes_no(self.options.with_docs)),
             "--enable-verbose={}".format(yes_no(self.options.with_verbose_debug)),
             "--enable-symbol-hiding={}".format(yes_no(self.options.with_symbol_hiding)),
-            "--enable-unix-sockets={}".format(yes_no(self.options.with_unix_sockets)),
+            "--enable-unix-sockets={}".format(yes_no(self.options.get_safe("with_unix_sockets", False))),
         ]
         if self.options.with_ssl == "openssl":
             params.append("--with-ssl={}".format(tools.unix_path(self.deps_cpp_info["openssl"].rootpath)))

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -151,12 +151,8 @@ class LibcurlConan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
-        if self.options.with_ssl == "schannel" and self.settings.os != "Windows":
-            raise ConanInvalidConfiguration("schannel only suppported on Windows.")
-        if self.options.with_ssl == "darwinssl" and not tools.is_apple_os(self.settings.os):
-            raise ConanInvalidConfiguration("darwinssl only suppported on Apple like OS (Macos, iOS, watchOS or tvOS).")
-        if self.options.with_ssl == "wolfssl" and self._is_using_cmake_build and tools.Version(self.version) < "7.70.0":
-            raise ConanInvalidConfiguration("Before 7.70.0, libcurl has no wolfssl support for Visual Studio or \"Windows to Android cross compilation\"")
+        if self.settings.os == "Windows" and tools.os_info.detect_windows_subsystem() == None:
+            self.options.with_unix_sockets = False
 
         # These options are not used in CMake build yet
         if self._is_using_cmake_build:
@@ -325,7 +321,7 @@ class LibcurlConan(ConanFile):
             "--enable-manual={}".format(yes_no(self.options.with_docs)),
             "--enable-verbose={}".format(yes_no(self.options.with_verbose_debug)),
             "--enable-symbol-hiding={}".format(yes_no(self.options.with_symbol_hiding)),
-            "--enable-unix-sockets={}".format(yes_no(self.options.get_safe("with_unix_sockets", False))),
+            "--enable-unix-sockets={}".format(yes_no(self.options.with_unix_sockets)),
         ]
         if self.options.with_ssl == "openssl":
             params.append("--with-ssl={}".format(tools.unix_path(self.deps_cpp_info["openssl"].rootpath)))
@@ -605,3 +601,9 @@ class LibcurlConan(ConanFile):
         if self.options.with_ssl == "openssl":
             if self.options.with_ntlm and self.options["openssl"].no_des:
                 raise ConanInvalidConfiguration("option with_ntlm=True requires openssl:no_des=False")
+        if self.options.with_ssl == "schannel" and self.settings.os != "Windows":
+            raise ConanInvalidConfiguration("schannel only suppported on Windows.")
+        if self.options.with_ssl == "darwinssl" and not tools.is_apple_os(self.settings.os):
+            raise ConanInvalidConfiguration("darwinssl only suppported on Apple like OS (Macos, iOS, watchOS or tvOS).")
+        if self.options.with_ssl == "wolfssl" and self._is_using_cmake_build and tools.Version(self.version) < "7.70.0":
+            raise ConanInvalidConfiguration("Before 7.70.0, libcurl has no wolfssl support for Visual Studio or \"Windows to Android cross compilation\"")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -136,6 +136,8 @@ class LibcurlConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+            if tools.os_info.detect_windows_subsystem() == None:
+                del self.options.with_unix_sockets
         if not self._has_zstd_option:
             del self.options.with_zstd
         if not self._has_metalink_option:
@@ -323,7 +325,7 @@ class LibcurlConan(ConanFile):
             "--enable-manual={}".format(yes_no(self.options.with_docs)),
             "--enable-verbose={}".format(yes_no(self.options.with_verbose_debug)),
             "--enable-symbol-hiding={}".format(yes_no(self.options.with_symbol_hiding)),
-            "--enable-unix-sockets={}".format(yes_no(self.options.with_unix_sockets)),
+            "--enable-unix-sockets={}".format(yes_no(self.options.get_safe("with_unix_sockets", False))),
         ]
         if self.options.with_ssl == "openssl":
             params.append("--with-ssl={}".format(tools.unix_path(self.deps_cpp_info["openssl"].rootpath)))


### PR DESCRIPTION
Specify library name and version:  **libcur/all**

In mingw, libcurl recipe is failed by "--enable-unix-sockets=True" which is default value.
I think it should be deleted in mingw because mingw has never supported unix sockets.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
