### PR TITLE
msgpack-cxx: add recipe

### DIFF
--- a/recipes/msgpack-cxx/all/conandata.yml
+++ b/recipes/msgpack-cxx/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "4.0.3":
+    url: "https://github.com/msgpack/msgpack-c/archive/cpp-4.0.3.tar.gz"
+    sha256: "23d737b1e959dfb6ca420564563f098e758adacc0b18003c56abf1b945bd1d4a"

--- a/recipes/msgpack-cxx/all/conanfile.py
+++ b/recipes/msgpack-cxx/all/conanfile.py
@@ -11,7 +11,6 @@ class MsgpackCXXConan(ConanFile):
     homepage = "https://github.com/msgpack/msgpack-c"
     topics = ("msgpack", "message-pack", "serialization")
     license = "BSL-1.0"
-    generators = "cmake"
     no_copy_source = True
 
     @property

--- a/recipes/msgpack-cxx/all/conanfile.py
+++ b/recipes/msgpack-cxx/all/conanfile.py
@@ -1,0 +1,59 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.36.0"
+
+class MsgpackCXXConan(ConanFile):
+    name = "msgpack-cxx"
+    description = "The official C++ library for MessagePack"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/msgpack/msgpack-c"
+    topics = ("msgpack", "message-pack", "serialization")
+    license = "BSL-1.0"
+    generators = "cmake"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def configure(self):
+        self.options["boost"].header_only = False
+        self.options["boost"].without_chrono = False
+        self.options["boost"].without_context = False
+        self.options["boost"].without_system = False
+        self.options["boost"].without_timer = False
+
+    def requirements(self):
+        self.requires("boost/1.77.0")
+
+    def package_id(self):
+        self.info.header_only()
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy("LICENSE_1_0.txt", dst="licenses", src=self._source_subfolder)
+        self.copy("*.h", dst="include", src=os.path.join(self._source_subfolder, "include"))
+        self.copy("*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
+
+    def package_info(self):
+        self.cpp_info.filenames["cmake_find_package"] = "msgpack-cxx"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "msgpack-cxx"
+        self.cpp_info.set_property("cmake_file_name", "msgpack-cxx")
+        self.cpp_info.names["cmake_find_package"] = "msgpack"
+        self.cpp_info.names["cmake_find_package_multi"] = "msgpack"
+        self.cpp_info.set_property("cmake_target_name", "msgpack")
+        self.cpp_info.components["msgpack"].names["cmake_find_package"] = "msgpack-cxx"
+        self.cpp_info.components["msgpack"].names["cmake_find_package_multi"] = "msgpack-cxx"
+        self.cpp_info.components["msgpack"].set_property("cmake_target_name", "msgpack-cxx")
+        self.cpp_info.components["msgpack"].set_property("pkg_config_name", "msgpack-cxx")
+        self.cpp_info.components["msgpack"].defines = ["MSGPACK_USE_BOOST"]
+        self.cpp_info.components["msgpack"].requires = ["boost::boost"]

--- a/recipes/msgpack-cxx/all/conanfile.py
+++ b/recipes/msgpack-cxx/all/conanfile.py
@@ -21,12 +21,15 @@ class MsgpackCXXConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
-    def configure(self):
-        self.options["boost"].header_only = False
-        self.options["boost"].without_chrono = False
-        self.options["boost"].without_context = False
-        self.options["boost"].without_system = False
-        self.options["boost"].without_timer = False
+    def validate(self):
+        if self.options["boost"].header_only == True:
+            raise ConanInvalidConfiguration("{} requires boost with header_only = False".format(self.name))
+
+        if self.options["boost"].without_chrono == True or \
+            self.options["boost"].without_context == True or \
+            self.options["boost"].without_system == True or \
+            self.options["boost"].without_timer == True:
+            raise ConanInvalidConfiguration("{} requires boost with chrono, context, system, timer enabled".format(self.name))
 
     def requirements(self):
         self.requires("boost/1.77.0")

--- a/recipes/msgpack-cxx/all/test_package/CMakeLists.txt
+++ b/recipes/msgpack-cxx/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(msgpack-cxx REQUIRED CONFIG)
+
+  add_executable(${PROJECT_NAME} test_package.cpp)
+  target_link_libraries(${PROJECT_NAME} msgpack::msgpack-cxx)
+  set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/msgpack-cxx/all/test_package/CMakeLists.txt
+++ b/recipes/msgpack-cxx/all/test_package/CMakeLists.txt
@@ -6,6 +6,6 @@ conan_basic_setup(TARGETS)
 
 find_package(msgpack-cxx REQUIRED CONFIG)
 
-  add_executable(${PROJECT_NAME} test_package.cpp)
-  target_link_libraries(${PROJECT_NAME} msgpack::msgpack-cxx)
-  set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} msgpack::msgpack-cxx)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/msgpack-cxx/all/test_package/conanfile.py
+++ b/recipes/msgpack-cxx/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_cpp_path = os.path.join("bin", "test_package")
+            self.run(bin_cpp_path, run_environment=True)

--- a/recipes/msgpack-cxx/all/test_package/test_package.cpp
+++ b/recipes/msgpack-cxx/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <tuple>
+
+#include <msgpack.hpp>
+
+int main() {
+    msgpack::object obj(123);
+    std::cout << obj << "\n";
+    return 0;
+}

--- a/recipes/msgpack-cxx/config.yml
+++ b/recipes/msgpack-cxx/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "4.0.3":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **msgpack-cxx/4.0.3**

This recipe is separated from msgpack.
Because msgpack is separated C and C++ code base.

See also https://github.com/conan-io/conan-center-index/pull/8183.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
