### PR TITLE
ade: support CYGWIN, MINGW, MSYS

### DIFF
--- a/recipes/ade/all/conanfile.py
+++ b/recipes/ade/all/conanfile.py
@@ -53,6 +53,7 @@ class AdeConan(ConanFile):
         return self._cmake
 
     def build(self):
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"), "    if(UNIX)", "    if(UNIX OR CYGWIN OR MINGW OR MSYS)")
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -103,3 +104,4 @@ class AdeConan(ConanFile):
         self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
 
         self.cpp_info.libs = ["ade"]
+        self.cpp_info.system_libs = ["ssp"]

--- a/recipes/ade/all/conanfile.py
+++ b/recipes/ade/all/conanfile.py
@@ -104,4 +104,5 @@ class AdeConan(ConanFile):
         self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
 
         self.cpp_info.libs = ["ade"]
-        self.cpp_info.system_libs = ["ssp"]
+        if self.settings.os == "Windows" and self.settings.compiler != "Visual Studio":
+            self.cpp_info.system_libs = ["ssp"]


### PR DESCRIPTION
Specify library name and version:  **ade/all**

The CMakeLists.txt of ade does not take into account gcc/clang on Windows.
However, a small patch confirms that it can be compiled, and I would like to update the recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
