### PR TITLE
xorg: don't install xorg-dev

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -44,9 +44,14 @@ class ConanXOrg(ConanFile):
         packages = []
         if tools.os_info.is_linux and self.settings.os == "Linux":
             if tools.os_info.with_apt:
-                packages = ["xorg-dev", "libx11-xcb-dev", "libxcb-render0-dev", "libxcb-render-util0-dev", "libxcb-xkb-dev",
-                            "libxcb-icccm4-dev", "libxcb-image0-dev", "libxcb-keysyms1-dev", "libxcb-randr0-dev", "libxcb-shape0-dev",
-                            "libxcb-sync-dev", "libxcb-xfixes0-dev", "libxcb-xinerama0-dev", "xkb-data", "libxcb-dri3-dev"]
+                packages = ["libx11-dev", "libx11-xcb-dev", "libfontenc-dev", "libice-dev", "libsm-dev", "libxau-dev", 
+                            "libxcomposite-dev", "libxcursor-dev", "libxdamage-dev", "libxdmcp-dev", "libxext-dev", "libxfixes-dev", 
+                            "libxft-dev", "libxi-dev", "libxinerama-dev", "libxkbfile-dev", "libxmu-dev", "libxmuu-dev", 
+                            "libxpm-dev", "libxrandr-dev", "libxrender-dev", "libxres-dev", "libxss-dev", "libxt-dev", "libxtst-dev", 
+                            "libxv-dev", "libxvmc-dev", "libxxf86vm-dev", "xtrans-dev", "libxcb-render0-dev",
+                            "libxcb-render-util0-dev", "libxcb-xkb-dev", "libxcb-icccm4-dev", "libxcb-image0-dev",
+                            "libxcb-keysyms1-dev", "libxcb-randr0-dev", "libxcb-shape0-dev", "libxcb-sync-dev", "libxcb-xfixes0-dev",
+                            "libxcb-xinerama0-dev", "xkb-data", "libxcb-dri3-dev"]
                 if (tools.os_info.linux_distro == "ubuntu" and tools.os_info.os_version < "15") or\
                    (tools.os_info.linux_distro == "debian" and tools.os_info.os_version < "12") or\
                    (tools.os_info.linux_distro == "raspbian" and tools.os_info.os_version < "12"):

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -44,7 +44,7 @@ class ConanXOrg(ConanFile):
         packages = []
         if tools.os_info.is_linux and self.settings.os == "Linux":
             if tools.os_info.with_apt:
-                packages = ["libx11-dev", "libx11-xcb-dev", "libfontenc-dev", "libice-dev", "libsm-dev", "libxau-dev", 
+                packages = ["libx11-dev", "libx11-xcb-dev", "libfontenc-dev", "libice-dev", "libsm-dev", "libxau-dev", "libxaw7-dev",
                             "libxcomposite-dev", "libxcursor-dev", "libxdamage-dev", "libxdmcp-dev", "libxext-dev", "libxfixes-dev", 
                             "libxft-dev", "libxi-dev", "libxinerama-dev", "libxkbfile-dev", "libxmu-dev", "libxmuu-dev", 
                             "libxpm-dev", "libxrandr-dev", "libxrender-dev", "libxres-dev", "libxss-dev", "libxt-dev", "libxtst-dev", 


### PR DESCRIPTION
Specify library name and version:  **xorg/system**

`xorg-dev` installs `xserver-xorg-dev`, which is useless for conan packages, and brings unwanted stuff like libpciaccess, mesa-common-dev, libpixman, etc.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
