### PR TITLE
nodejs: add linux arm versions

### DIFF
--- a/recipes/nodejs/all/conandata.yml
+++ b/recipes/nodejs/all/conandata.yml
@@ -34,6 +34,12 @@ sources:
           "x86_64":
               url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-x64.tar.xz"
               sha256: "5347ece975747e4d9768d4ed3f8b2220c955ac01f8a695347cd7f71ff5efa318"
+          "armv7":
+              url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-armv7l.tar.xz"
+              sha256: "c8817e30fb910476ec1f223de7eedd31f3d157ddf2003a3083d7f5662180e4de"
+          "armv8":
+              url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-arm64.tar.xz"
+              sha256: "67dd97e41aad1bc11736e99cba119525b4f3472b132c46730ba8cf03f7076e23"
       Macos:
           "x86_64":
               url: "https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-x64.tar.gz"

--- a/recipes/nodejs/all/conanfile.py
+++ b/recipes/nodejs/all/conanfile.py
@@ -19,14 +19,23 @@ class NodejsConan(ConanFile):
     def _source_subfolder(self):
         return os.path.join(self.source_folder, "source_subfolder")
 
+    @property
+    def _nodejs_arch(self):
+        if str(self.settings.os) == "Linux":
+            if str(self.settings.arch).startswith("armv7"):
+                return "armv7"
+            if str(self.settings.arch).startswith("armv8") and "32" not in str(self.settings.arch):
+                return "armv8"
+        return str(self.settings.arch)
+
     def validate(self):
         if (not (self.version in self.conan_data["sources"]) or
             not (str(self.settings.os) in self.conan_data["sources"][self.version]) or
-            not (str(self.settings.arch) in self.conan_data["sources"][self.version][str(self.settings.os)] ) ):
+            not (self._nodejs_arch in self.conan_data["sources"][self.version][str(self.settings.os)] ) ):
             raise ConanInvalidConfiguration("Binaries for this combination of architecture/version/os not available")
 
     def build(self):
-        tools.get(**self.conan_data["sources"][self.version][str(self.settings.os)][str(self.settings.arch)], destination=self._source_subfolder, strip_root=True)
+        tools.get(**self.conan_data["sources"][self.version][str(self.settings.os)][self._nodejs_arch], destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)


### PR DESCRIPTION
Specify library name and version:  **nodejs/16.3.0**

Trying to build qt on raspberry pi, nodejs is a requirement.

---

- [*] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [*] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [*] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [*] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
