### PR TITLE
add more releases of libsystemd

### DIFF
--- a/recipes/libsystemd/config.yml
+++ b/recipes/libsystemd/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "249.4":
     folder: all
+  "249.5":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  
```
libsystemd/249.5
libsystemd/249.6
libsystemd/249.7
```

There is a bug in the 249.4 release of libsystemd that cause this package to fail on some systems. This update just ads functional versions beyond that one 
https://github.com/systemd/systemd/issues/20694

Are you the author of the library? No

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
