### PR TITLE
qt: Fix entry point flag for MSVC and add qtEntryPoint component.

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -683,8 +683,16 @@ class QtConan(ConanFile):
     def _cmake_executables_file(self):
         return os.path.join("lib", "cmake", "Qt6Core", "conan_qt_executables_variables.cmake")
 
+    @property
+    def _cmake_entry_point_file(self):
+        return os.path.join("lib", "cmake", "Qt6Core", "conan_qt_entry_point.cmake")
+
     def _cmake_qt6_private_file(self, module):
         return os.path.join("lib", "cmake", "Qt6{0}".format(module), "conan_qt_qt6_{0}private.cmake".format(module.lower()))
+
+    @property
+    def _create_entry_point_targets(self):
+        return not self.options.no_entrypoint and self.settings.os in ["Windows", "iOS"]
 
     def package(self):
         cmake = self._configure_cmake()
@@ -1126,7 +1134,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("qtwebview"):
             _create_module("WebView", ["Core", "Gui"])
 
-        if not self.options.no_entrypoint:
+        if self._create_entry_point_targets:
             if self.settings.os == "Windows":
                 self.cpp_info.components["qtEntryPointImplementation"].names["cmake_find_package"] = "EntryPointImplementation"
                 self.cpp_info.components["qtEntryPointImplementation"].names["cmake_find_package_multi"] = "EntryPointImplementation"
@@ -1149,7 +1157,20 @@ class QtConan(ConanFile):
                     self.cpp_info.components["qtEntryPointPrivate"].requires.append("qtEntryPointImplementation")
             if self.settings.os == "iOS":
                 self.cpp_info.components["qtEntryPointPrivate"].exelinkflags.append("-Wl,-e,_qt_main_wrapper")
-            self.cpp_info.components["qtCore"].requires.append("qtEntryPointPrivate")
+
+            contents = textwrap.dedent("""\
+                set(entrypoint_conditions "$<NOT:$<BOOL:$<TARGET_PROPERTY:qt_no_entrypoint>>>")
+                list(APPEND entrypoint_conditions "$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>")
+                if(WIN32)
+                    list(APPEND entrypoint_conditions "$<BOOL:$<TARGET_PROPERTY:WIN32_EXECUTABLE>>")
+                endif()
+                list(JOIN entrypoint_conditions "," entrypoint_conditions)
+                set(entrypoint_conditions "$<AND:${entrypoint_conditions}>")
+                set_property(
+                    TARGET ${QT_CMAKE_EXPORT_NAMESPACE}::Core
+                    APPEND PROPERTY INTERFACE_LINK_LIBRARIES "$<${entrypoint_conditions}:${QT_CMAKE_EXPORT_NAMESPACE}::EntryPointPrivate>"
+                )""")
+            tools.save(os.path.join(self.package_folder, self._cmake_entry_point_file), contents)
 
         if self.settings.os != "Windows":
             self.cpp_info.components["qtCore"].cxxflags.append("-fPIC")
@@ -1180,6 +1201,9 @@ class QtConan(ConanFile):
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_executables_file)
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package"].append(self._cmake_qt6_private_file("Core"))
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_qt6_private_file("Core"))
+        if self._create_entry_point_targets:
+            self.cpp_info.components["qtCore"].build_modules["cmake_find_package"].append(self._cmake_entry_point_file)
+            self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_entry_point_file)
 
         self.cpp_info.components["qtGui"].build_modules["cmake_find_package"].append(self._cmake_qt6_private_file("Gui"))
         self.cpp_info.components["qtGui"].build_modules["cmake_find_package_multi"].append(self._cmake_qt6_private_file("Gui"))

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -844,7 +844,6 @@ class QtConan(ConanFile):
 
         _create_module("Core", core_reqs)
         if self.settings.compiler == "Visual Studio":
-            self.cpp_info.components["qtCore"].exelinkflags.append("-ENTRY:mainCRTStartup")
             if tools.Version(self.version) >= "6.2.0":
                 self.cpp_info.components["qtCore"].cxxflags.append("-Zc:__cplusplus")
                 self.cpp_info.components["qtCore"].system_libs.append("synchronization")
@@ -1124,6 +1123,10 @@ class QtConan(ConanFile):
 
         if self.options.get_safe("qtwebview"):
             _create_module("WebView", ["Core", "Gui"])
+
+        if self.settings.os == "Windows":
+            _create_module("EntryPoint")
+            self.cpp_info.components["qtEntryPoint"].system_libs.append("shell32")
 
         if self.settings.os != "Windows":
             self.cpp_info.components["qtCore"].cxxflags.append("-fPIC")


### PR DESCRIPTION
Specify library name and version:  **qt/6.2.2**

Preface: MSVC has multiple standard entry points for executables - `main`, `wmain`, `WinMain` and `wWinMain`. Projects linked with `/SUBSYSTEM:CONSOLE` implicitly use `/ENTRY:mainCRTStartup` or `/ENTRY:wmainCRTStartup` flags. These CRT functions internally call user `main` or `wmain` functions. Projects linked with `/SUBSYSTEM:WINDOWS` imply `/ENTRY:WinMainCRTStartup` or `/ENTRY:wWinMainCRTStartup`. These in turn call user defined `WinMain` or `wWinMain` depending on what linker finds.

The `/SUBSYSTEM` and `/ENTRY` flags should be added to a project by user as some projects need to customize entry point. Hence remove `qtCore` flag `-ENTRY:mainCRTStartup`. Without this change user defined `/ENTRY` flag might be overridden depending on flag order.

Qt provides a `Qt6EntryPoint.lib` static library to ease `WinMain` usage. Essentially this library defines `WinMain` entry point that converts command line arguments to classic `argv`, `argc` format and calls user `main` or `qMain` function. This commit adds that library through `_create_module`. Only available on Windows.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
