### PR TITLE
doctest: Update url's to new doctest organization

### DIFF
--- a/recipes/doctest/2.x.x/conandata.yml
+++ b/recipes/doctest/2.x.x/conandata.yml
@@ -1,31 +1,31 @@
 sources:
   "2.3.5":
-    url: "https://github.com/onqtam/doctest/archive/2.3.5.tar.gz"
+    url: "https://github.com/doctest/doctest/archive/2.3.5.tar.gz"
     sha256: "71d1ca0916bfea8f4550de196b66f2226f2fdb5fd4a2885a3b4c2dd8f035a8c9"
   "2.3.6":
-    url: "https://github.com/onqtam/doctest/archive/2.3.6.tar.gz"
+    url: "https://github.com/doctest/doctest/archive/2.3.6.tar.gz"
     sha256: "f63c3c01021ba3fb35a0702127abfaa6fc44aaefd309e2c246e62a083deffa1f"
   "2.3.7":
-    url: "https://github.com/onqtam/doctest/archive/2.3.7.tar.gz"
+    url: "https://github.com/doctest/doctest/archive/2.3.7.tar.gz"
     sha256: "a70cd25875029879e577b08cfaa57a76c7bea62c473ca94d85ec87ea53af7177"
   "2.3.8":
-    url: "https://github.com/onqtam/doctest/archive/2.3.8.tar.gz"
+    url: "https://github.com/doctest/doctest/archive/2.3.8.tar.gz"
     sha256: "d7232437eceb46ad5de03cacdee770c80f2e53e7b8efc1c8a8ed29539f64efa5"
   "2.4.0":
-    url: "https://github.com/onqtam/doctest/archive/2.4.0.tar.gz"
+    url: "https://github.com/doctest/doctest/archive/2.4.0.tar.gz"
     sha256: "f689f48e92c088928d88d8481e769c8e804f0a608b484ab8ef3d6ab6045b5444"
   "2.4.1":
-    url: "https://github.com/onqtam/doctest/archive/2.4.1.tar.gz"
+    url: "https://github.com/doctest/doctest/archive/2.4.1.tar.gz"
     sha256: "0a0f0be21ee23e36ff6b8b9d63c06a7792e04cce342e1df3dee0e40d1e21b9f0"
   "2.4.3":
-    url: "https://github.com/onqtam/doctest/archive/2.4.3.tar.gz"
+    url: "https://github.com/doctest/doctest/archive/2.4.3.tar.gz"
     sha256: "18c0f87f526bf34bb595c2841a2f0f33b28ab8c817d7c71ed1ba4665815d9ef6"
   "2.4.4":
-    url: "https://github.com/onqtam/doctest/archive/2.4.4.tar.gz"
+    url: "https://github.com/doctest/doctest/archive/2.4.4.tar.gz"
     sha256: "3bcb62ad316bf4230873a336fcc6eb6292116568a6e19ab8cdd37a1610773d70"
   "2.4.5":
-    url: "https://github.com/onqtam/doctest/archive/2.4.5.tar.gz"
+    url: "https://github.com/doctest/doctest/archive/2.4.5.tar.gz"
     sha256: "b76ece19f0e473e3afa5c545dbdce2dd70bfef98ed0f383443b2f9fd9f86d5b4"
   "2.4.6":
-    url: "https://github.com/onqtam/doctest/archive/2.4.6.tar.gz"
+    url: "https://github.com/doctest/doctest/archive/2.4.6.tar.gz"
     sha256: "39110778e6baf373ef04342d7cb3fe35da104cb40769103e8a2f0035f5a5f1cb"

--- a/recipes/doctest/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/doctest/2.x.x/test_package/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
 
 enable_testing()
 
-doctest_discover_tests(${PROJECT_NAME} ADD_LABELS 1)
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})


### PR DESCRIPTION
The maintainer onqtam moved the doctest project to a dedicated organization. (https://github.com/doctest/doctest/issues/554)
This change makes it so that downloads do not have to rely on redirects.

Specify library name and version:  **doctest/all**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
