### PR TITLE
libxml2: do not lose system libs for ICU

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, tools, AutoToolsBuildEnvironment, VisualStudioBuildEnvironment
 from contextlib import contextmanager
+import itertools
 import os
 import textwrap
 
@@ -149,7 +150,7 @@ class Libxml2Conan(ConanFile):
             def fix_library(option, package, old_libname):
                 if option:
                     libs = []
-                    for lib in self.deps_cpp_info[package].libs:
+                    for lib in itertools.chain(self.deps_cpp_info[package].libs, self.deps_cpp_info[package].system_libs):
                         libname = lib
                         if not libname.endswith('.lib'):
                             libname += '.lib'


### PR DESCRIPTION
Specify library name and version:  **libxml/all**

Fix compilation with libxml2:icu=True. Recipe was losing system lib "advapi32.lib"

Closes #8407 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
