### PR TITLE
[hdf5/all] Use a relative include path

### DIFF
--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -242,7 +242,7 @@ class Hdf5Conan(ConanFile):
 
         components = self._components()
         add_component("hdf5_c", **components["hdf5_c"])
-        self.cpp_info.components["hdf5_c"].includedirs.append(os.path.join(self.package_folder, "include", "hdf5"))
+        self.cpp_info.components["hdf5_c"].includedirs.append("include/hdf5")
         if self.settings.os == "Linux":
             self.cpp_info.components["hdf5_c"].system_libs.extend(["dl", "m"])
             if self.options.get_safe("threadsafe"):

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -242,7 +242,7 @@ class Hdf5Conan(ConanFile):
 
         components = self._components()
         add_component("hdf5_c", **components["hdf5_c"])
-        self.cpp_info.components["hdf5_c"].includedirs.append("include/hdf5")
+        self.cpp_info.components["hdf5_c"].includedirs.append(os.path.join("include", "hdf5"))
         if self.settings.os == "Linux":
             self.cpp_info.components["hdf5_c"].system_libs.extend(["dl", "m"])
             if self.options.get_safe("threadsafe"):


### PR DESCRIPTION
This prevents a bug where the MSBuildDeps generator would generate invalid entries in the property sheet.
Since conan-io/conan#9686 the property sheet uses variable references and assumes the include path is relative to the package dir.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
