### PR TITLE
msgpack: make deprecated

### DIFF
--- a/recipes/msgpack/all/conanfile.py
+++ b/recipes/msgpack/all/conanfile.py
@@ -29,7 +29,7 @@ class MsgpackConan(ConanFile):
         "with_boost": False,
         "header_only": False
     }
-    deprecated = "msgpack-c", "msgpack-cxx"
+    deprecated = "msgpack-c or msgpack-cxx"
 
     _cmake = None
 

--- a/recipes/msgpack/all/conanfile.py
+++ b/recipes/msgpack/all/conanfile.py
@@ -29,6 +29,7 @@ class MsgpackConan(ConanFile):
         "with_boost": False,
         "header_only": False
     }
+    deprecated = "msgpack-c", "msgpack-cxx"
 
     _cmake = None
 


### PR DESCRIPTION
Specify library name and version:  **msgpack/all**

I created 2 PR for msgpack being separated into c and cxx versions.
They are already merged.

https://github.com/conan-io/conan-center-index/pull/8183
https://github.com/conan-io/conan-center-index/pull/8380

msgpack recipe will not  be updated in the future.
Therefore, I want to deprecate msgpack recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
