### PR TITLE
log4cxx/0.12.1 patch re-connect for socket appender.

### DIFF
--- a/recipes/log4cxx/all/conandata.yml
+++ b/recipes/log4cxx/all/conandata.yml
@@ -12,3 +12,6 @@ patches:
   "0.12.1":
     - base_path: "source_subfolder"
       patch_file: "patches/0001-find-apr.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0002-fix-mutex-disconnect.patch"
+

--- a/recipes/log4cxx/all/patches/0002-fix-mutex-disconnect.patch
+++ b/recipes/log4cxx/all/patches/0002-fix-mutex-disconnect.patch
@@ -1,82 +1,417 @@
+diff --git a/src/main/cpp/appenderskeleton.cpp b/src/main/cpp/appenderskeleton.cpp
+index 6df2551..0705c6e 100644
+--- a/src/main/cpp/appenderskeleton.cpp
++++ b/src/main/cpp/appenderskeleton.cpp
+@@ -39,7 +39,7 @@ AppenderSkeleton::AppenderSkeleton()
+ 		tailFilter(),
+ 		pool()
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	closed = false;
+ }
+ 
+@@ -52,7 +52,7 @@ AppenderSkeleton::AppenderSkeleton(const LayoutPtr& layout1)
+ 	  tailFilter(),
+ 	  pool()
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	closed = false;
+ }
+ 
+@@ -70,7 +70,7 @@ void AppenderSkeleton::finalize()
+ 
+ void AppenderSkeleton::addFilter(const spi::FilterPtr& newFilter)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 
+ 	if (headFilter == 0)
+ 	{
+@@ -85,7 +85,7 @@ void AppenderSkeleton::addFilter(const spi::FilterPtr& newFilter)
+ 
+ void AppenderSkeleton::clearFilters()
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	headFilter = tailFilter = 0;
+ }
+ 
+@@ -96,7 +96,7 @@ bool AppenderSkeleton::isAsSevereAsThreshold(const LevelPtr& level) const
+ 
+ void AppenderSkeleton::doAppend(const spi::LoggingEventPtr& event, Pool& pool1)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 
+ 	doAppendImpl(event, pool1);
+ }
+@@ -139,7 +139,7 @@ void AppenderSkeleton::doAppendImpl(const spi::LoggingEventPtr& event, Pool& poo
+ 
+ void AppenderSkeleton::setErrorHandler(const spi::ErrorHandlerPtr errorHandler1)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 
+ 	if (errorHandler1 == 0)
+ 	{
+@@ -155,7 +155,7 @@ void AppenderSkeleton::setErrorHandler(const spi::ErrorHandlerPtr errorHandler1)
+ 
+ void AppenderSkeleton::setThreshold(const LevelPtr& threshold1)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	this->threshold = threshold1;
+ }
+ 
+diff --git a/src/main/cpp/asyncappender.cpp b/src/main/cpp/asyncappender.cpp
+index 6da23b1..39018c8 100644
+--- a/src/main/cpp/asyncappender.cpp
++++ b/src/main/cpp/asyncappender.cpp
+@@ -91,7 +91,7 @@ void AsyncAppender::setOption(const LogString& option,
+ 
+ void AsyncAppender::doAppend(const spi::LoggingEventPtr& event, Pool& pool1)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 
+ 	doAppendImpl(event, pool1);
+ }
+diff --git a/src/main/cpp/fileappender.cpp b/src/main/cpp/fileappender.cpp
+index cca1abb..e04d730 100644
+--- a/src/main/cpp/fileappender.cpp
++++ b/src/main/cpp/fileappender.cpp
+@@ -36,7 +36,7 @@ IMPLEMENT_LOG4CXX_OBJECT(FileAppender)
+ 
+ FileAppender::FileAppender()
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	fileAppend = true;
+ 	bufferedIO = false;
+ 	bufferSize = 8 * 1024;
+@@ -47,7 +47,7 @@ FileAppender::FileAppender(const LayoutPtr& layout1, const LogString& fileName1,
+ 	: WriterAppender(layout1)
+ {
+ 	{
+-		std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++		std::lock_guard<std::recursive_mutex> lock(mutex);
+ 		fileAppend = append1;
+ 		fileName = fileName1;
+ 		bufferedIO = bufferedIO1;
+@@ -62,7 +62,7 @@ FileAppender::FileAppender(const LayoutPtr& layout1, const LogString& fileName1,
+ 	: WriterAppender(layout1)
+ {
+ 	{
+-		std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++		std::lock_guard<std::recursive_mutex> lock(mutex);
+ 		fileAppend = append1;
+ 		fileName = fileName1;
+ 		bufferedIO = false;
+@@ -76,7 +76,7 @@ FileAppender::FileAppender(const LayoutPtr& layout1, const LogString& fileName1)
+ 	: WriterAppender(layout1)
+ {
+ 	{
+-		std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++		std::lock_guard<std::recursive_mutex> lock(mutex);
+ 		fileAppend = true;
+ 		fileName = fileName1;
+ 		bufferedIO = false;
+@@ -93,13 +93,13 @@ FileAppender::~FileAppender()
+ 
+ void FileAppender::setAppend(bool fileAppend1)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	this->fileAppend = fileAppend1;
+ }
+ 
+ void FileAppender::setFile(const LogString& file)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	setFileInternal(file);
+ }
+ 
+@@ -110,7 +110,7 @@ void FileAppender::setFileInternal(const LogString& file)
+ 
+ void FileAppender::setBufferedIO(bool bufferedIO1)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	this->bufferedIO = bufferedIO1;
+ 
+ 	if (bufferedIO1)
+@@ -125,27 +125,27 @@ void FileAppender::setOption(const LogString& option,
+ 	if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("FILE"), LOG4CXX_STR("file"))
+ 		|| StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("FILENAME"), LOG4CXX_STR("filename")))
+ 	{
+-		std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++		std::lock_guard<std::recursive_mutex> lock(mutex);
+ 		fileName = stripDuplicateBackslashes(value);
+ 	}
+ 	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("APPEND"), LOG4CXX_STR("append")))
+ 	{
+-		std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++		std::lock_guard<std::recursive_mutex> lock(mutex);
+ 		fileAppend = OptionConverter::toBoolean(value, true);
+ 	}
+ 	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("BUFFEREDIO"), LOG4CXX_STR("bufferedio")))
+ 	{
+-		std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++		std::lock_guard<std::recursive_mutex> lock(mutex);
+ 		bufferedIO = OptionConverter::toBoolean(value, true);
+ 	}
+ 	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("IMMEDIATEFLUSH"), LOG4CXX_STR("immediateflush")))
+ 	{
+-		std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++		std::lock_guard<std::recursive_mutex> lock(mutex);
+ 		bufferedIO = !OptionConverter::toBoolean(value, false);
+ 	}
+ 	else if (StringHelper::equalsIgnoreCase(option, LOG4CXX_STR("BUFFERSIZE"), LOG4CXX_STR("buffersize")))
+ 	{
+-		std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++		std::lock_guard<std::recursive_mutex> lock(mutex);
+ 		bufferSize = OptionConverter::toFileSize(value, 8 * 1024);
+ 	}
+ 	else
+@@ -156,7 +156,7 @@ void FileAppender::setOption(const LogString& option,
+ 
+ void FileAppender::activateOptions(Pool& p)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	activateOptionsInternal(p);
+ }
+ 
+diff --git a/src/main/cpp/rollingfileappender.cpp b/src/main/cpp/rollingfileappender.cpp
+index 7d236f4..48aad5f 100644
+--- a/src/main/cpp/rollingfileappender.cpp
++++ b/src/main/cpp/rollingfileappender.cpp
+@@ -94,7 +94,7 @@ void RollingFileAppenderSkeleton::activateOptions(Pool& p)
+ 	}
+ 
+ 	{
+-		std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++		std::lock_guard<std::recursive_mutex> lock(mutex);
+ 		triggeringPolicy->activateOptions(p);
+ 		rollingPolicy->activateOptions(p);
+ 
+@@ -183,7 +183,7 @@ void RollingFileAppenderSkeleton::releaseFileLock(apr_file_t* lock_file)
+  */
+ bool RollingFileAppenderSkeleton::rollover(Pool& p)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	return rolloverInternal(p);
+ }
+ 
 diff --git a/src/main/cpp/socketappender.cpp b/src/main/cpp/socketappender.cpp
-index 57f8ade..5f9fb8b 100644
+index 57f8ade..4809a35 100644
 --- a/src/main/cpp/socketappender.cpp
 +++ b/src/main/cpp/socketappender.cpp
-@@ -124,7 +124,7 @@ void SocketAppender::append(const spi::LoggingEventPtr& event, log4cxx::helpers:
+@@ -78,7 +78,7 @@ int SocketAppender::getDefaultPort() const
  
- 		if (getReconnectionDelay() > 0)
- 		{
--			fireConnector();
-+			fireConnectorInternal();
- 		}
- 	}
- }
+ void SocketAppender::setSocket(log4cxx::helpers::SocketPtr& socket, Pool& p)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 
+ 	SocketOutputStreamPtr sock = SocketOutputStreamPtr(new SocketOutputStream(socket));
+ 	oos = ObjectOutputStreamPtr(new ObjectOutputStream(sock, p));
 diff --git a/src/main/cpp/socketappenderskeleton.cpp b/src/main/cpp/socketappenderskeleton.cpp
-index 122de9d..3787d1a 100644
+index 122de9d..a12e31c 100644
 --- a/src/main/cpp/socketappenderskeleton.cpp
 +++ b/src/main/cpp/socketappenderskeleton.cpp
-@@ -158,10 +158,20 @@ void SocketAppenderSkeleton::fireConnector()
- {
- 	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
+@@ -77,7 +77,7 @@ void SocketAppenderSkeleton::activateOptions(Pool& p)
  
-+	fireConnectorInternal();
-+}
+ void SocketAppenderSkeleton::close()
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 
+ 	if (closed)
+ 	{
+@@ -156,7 +156,14 @@ void SocketAppenderSkeleton::setOption(const LogString& option, const LogString&
+ 
+ void SocketAppenderSkeleton::fireConnector()
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
 +
-+void SocketAppenderSkeleton::fireConnectorInternal()
-+{
++	if( thread.joinable() ){
++		// This should only get called if the thread has already exited.
++		// We could have a potential bug if fireConnector is called while
++		// the thread is waiting for a connection
++		thread.join();
++	}
+ 
  	if ( !thread.joinable() )
  	{
- 		LogLog::debug(LOG4CXX_STR("Connector thread not alive: starting monitor."));
--
-+		thread = std::thread( &SocketAppenderSkeleton::monitor, this );
-+	}
-+	else
-+	{
-+		interrupt.notify_all();
-+		thread.join();
- 		thread = std::thread( &SocketAppenderSkeleton::monitor, this );
- 	}
- }
-@@ -175,8 +185,6 @@ void SocketAppenderSkeleton::monitor()
+@@ -175,12 +182,6 @@ void SocketAppenderSkeleton::monitor()
  	{
  		try
  		{
 -			std::this_thread::sleep_for( std::chrono::milliseconds( reconnectionDelay ) );
 -
- 			std::unique_lock<std::mutex> lock( interrupt_mutex );
- 			interrupt.wait_for( lock, std::chrono::milliseconds( reconnectionDelay ),
- 				std::bind(&SocketAppenderSkeleton::is_closed, this) );
+-			std::unique_lock<std::mutex> lock( interrupt_mutex );
+-			interrupt.wait_for( lock, std::chrono::milliseconds( reconnectionDelay ),
+-				std::bind(&SocketAppenderSkeleton::is_closed, this) );
+-
+ 			if (!closed)
+ 			{
+ 				LogLog::debug(LogString(LOG4CXX_STR("Attempting connection to "))
+@@ -189,9 +190,8 @@ void SocketAppenderSkeleton::monitor()
+ 				Pool p;
+ 				setSocket(socket, p);
+ 				LogLog::debug(LOG4CXX_STR("Connection established. Exiting connector thread."));
++				return;
+ 			}
+-
+-			return;
+ 		}
+ 		catch (InterruptedException&)
+ 		{
+@@ -215,6 +215,10 @@ void SocketAppenderSkeleton::monitor()
+ 				+ exmsg);
+ 		}
+ 
++		std::unique_lock<std::mutex> lock( interrupt_mutex );
++		interrupt.wait_for( lock, std::chrono::milliseconds( reconnectionDelay ),
++			std::bind(&SocketAppenderSkeleton::is_closed, this) );
++
+ 		isClosed = closed;
+ 	}
+ 
+diff --git a/src/main/cpp/sockethubappender.cpp b/src/main/cpp/sockethubappender.cpp
+index a88eb42..0377ae6 100644
+--- a/src/main/cpp/sockethubappender.cpp
++++ b/src/main/cpp/sockethubappender.cpp
+@@ -83,7 +83,7 @@ void SocketHubAppender::setOption(const LogString& option,
+ void SocketHubAppender::close()
+ {
+ 	{
+-		std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++		std::lock_guard<std::recursive_mutex> lock(mutex);
+ 
+ 		if (closed)
+ 		{
+@@ -103,7 +103,7 @@ void SocketHubAppender::close()
+ 		thread.join();
+ 	}
+ 
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	// close all of the connections
+ 	LogLog::debug(LOG4CXX_STR("closing client connections"));
+ 
+@@ -233,7 +233,7 @@ void SocketHubAppender::monitor()
+ 					+ LOG4CXX_STR(")"));
+ 
+ 				// add it to the oosList.
+-				std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++				std::lock_guard<std::recursive_mutex> lock(mutex);
+ 				OutputStreamPtr os(new SocketOutputStream(socket));
+ 				Pool p;
+ 				ObjectOutputStreamPtr oos(new ObjectOutputStream(os, p));
+diff --git a/src/main/cpp/telnetappender.cpp b/src/main/cpp/telnetappender.cpp
+index 418aac0..9606f6b 100644
+--- a/src/main/cpp/telnetappender.cpp
++++ b/src/main/cpp/telnetappender.cpp
+@@ -83,13 +83,13 @@ void TelnetAppender::setOption(const LogString& option,
+ 
+ LogString TelnetAppender::getEncoding() const
+ {
+-	log4cxx::shared_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	return encoding;
+ }
+ 
+ void TelnetAppender::setEncoding(const LogString& value)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	encoder = CharsetEncoder::getEncoder(value);
+ 	encoding = value;
+ }
+@@ -97,7 +97,7 @@ void TelnetAppender::setEncoding(const LogString& value)
+ 
+ void TelnetAppender::close()
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 
+ 	if (closed)
+ 	{
+@@ -194,7 +194,7 @@ void TelnetAppender::append(const spi::LoggingEventPtr& event, Pool& p)
+ 		LogString::const_iterator msgIter(msg.begin());
+ 		ByteBuffer buf(bytes, bytesSize);
+ 
+-		log4cxx::shared_lock<log4cxx::shared_mutex> lock(mutex);
++		std::lock_guard<std::recursive_mutex> lock(mutex);
+ 
+ 		while (msgIter != msg.end())
+ 		{
+@@ -250,7 +250,7 @@ void TelnetAppender::acceptConnections()
+ 				//
+ 				//   find unoccupied connection
+ 				//
+-				std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++				std::lock_guard<std::recursive_mutex> lock(mutex);
+ 
+ 				for (ConnectionList::iterator iter = connections.begin();
+ 					iter != connections.end();
+diff --git a/src/main/cpp/writerappender.cpp b/src/main/cpp/writerappender.cpp
+index 57996f5..1d4303d 100644
+--- a/src/main/cpp/writerappender.cpp
++++ b/src/main/cpp/writerappender.cpp
+@@ -151,7 +151,7 @@ bool WriterAppender::checkEntryConditions() const
+    */
+ void WriterAppender::close()
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 
+ 	if (closed)
+ 	{
+@@ -278,7 +278,7 @@ void WriterAppender::writeHeader(Pool& p)
+ 
+ void WriterAppender::setWriter(const WriterPtr& newWriter)
+ {
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	setWriterInternal(newWriter);
+ }
+ 
 diff --git a/src/main/cpp/xmlsocketappender.cpp b/src/main/cpp/xmlsocketappender.cpp
-index d5b9942..4c1c70d 100644
+index d5b9942..36fdfce 100644
 --- a/src/main/cpp/xmlsocketappender.cpp
 +++ b/src/main/cpp/xmlsocketappender.cpp
-@@ -122,7 +122,7 @@ void XMLSocketAppender::append(const spi::LoggingEventPtr& event, log4cxx::helpe
+@@ -84,7 +84,7 @@ void XMLSocketAppender::setSocket(log4cxx::helpers::SocketPtr& socket, Pool& p)
+ {
+ 	OutputStreamPtr os(new SocketOutputStream(socket));
+ 	CharsetEncoderPtr charset(CharsetEncoder::getUTF8Encoder());
+-	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
++	std::lock_guard<std::recursive_mutex> lock(mutex);
+ 	writer = OutputStreamWriterPtr(new OutputStreamWriter(os, charset));
+ }
  
- 			if (getReconnectionDelay() > 0)
- 			{
--				fireConnector();
-+				fireConnectorInternal();
- 			}
- 		}
- 	}
-diff --git a/src/main/include/log4cxx/net/socketappenderskeleton.h b/src/main/include/log4cxx/net/socketappenderskeleton.h
-index 88d2a15..8020613 100644
---- a/src/main/include/log4cxx/net/socketappenderskeleton.h
-+++ b/src/main/include/log4cxx/net/socketappenderskeleton.h
-@@ -178,6 +178,11 @@ class LOG4CXX_EXPORT SocketAppenderSkeleton : public AppenderSkeleton
+diff --git a/src/main/include/log4cxx/appenderskeleton.h b/src/main/include/log4cxx/appenderskeleton.h
+index b89b09e..3b7af8b 100644
+--- a/src/main/include/log4cxx/appenderskeleton.h
++++ b/src/main/include/log4cxx/appenderskeleton.h
+@@ -74,7 +74,7 @@ class LOG4CXX_EXPORT AppenderSkeleton :
+ 		bool closed;
  
- 		virtual int getDefaultPort() const = 0;
+ 		log4cxx::helpers::Pool pool;
+-		mutable log4cxx::shared_mutex mutex;
++		mutable std::recursive_mutex mutex;
  
-+		/**
-+		 * Fire the connector.  Caller must have mutex locked.
-+		 */
-+		void fireConnectorInternal();
-+
- 	private:
- 		void connect(log4cxx::helpers::Pool& p);
  		/**
+ 		Subclasses of <code>AppenderSkeleton</code> should implement this
 diff --git a/src/test/cpp/net/socketappendertestcase.cpp b/src/test/cpp/net/socketappendertestcase.cpp
-index fe3753c..4496888 100644
+index fe3753c..fe5c8e0 100644
 --- a/src/test/cpp/net/socketappendertestcase.cpp
 +++ b/src/test/cpp/net/socketappendertestcase.cpp
 @@ -16,6 +16,9 @@
@@ -89,7 +424,7 @@ index fe3753c..4496888 100644
  #include "../appenderskeletontestcase.h"
  #include "apr.h"
  
-@@ -34,17 +37,64 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
+@@ -34,16 +37,62 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
  		//
  		LOGUNIT_TEST(testDefaultThreshold);
  		LOGUNIT_TEST(testSetOptionThreshold);
@@ -115,42 +450,40 @@ index fe3753c..4496888 100644
  		}
 +
 +		void testInvalidHost(){
-+			log4cxx::net::SocketAppenderPtr appender = std::make_shared<log4cxx::net::SocketAppender>();
-+			log4cxx::PatternLayoutPtr layout = std::make_shared<log4cxx::PatternLayout>(LOG4CXX_STR("%m%n"));
++//			log4cxx::net::SocketAppenderPtr appender = std::make_shared<log4cxx::net::SocketAppender>();
++//			log4cxx::PatternLayoutPtr layout = std::make_shared<log4cxx::PatternLayout>(LOG4CXX_STR("%m%n"));
 +
-+			log4cxx::helpers::ServerSocket serverSocket(4445);
++//			log4cxx::helpers::ServerSocket serverSocket(4445);
 +
-+			appender->setLayout(layout);
-+			appender->setRemoteHost(LOG4CXX_STR("localhost"));
-+			appender->setReconnectionDelay(1);
-+			appender->setPort(4445);
-+			log4cxx::helpers::Pool pool;
-+			appender->activateOptions(pool);
++//			appender->setLayout(layout);
++//			appender->setRemoteHost(LOG4CXX_STR("localhost"));
++//			appender->setReconnectionDelay(1);
++//			appender->setPort(4445);
++//			log4cxx::helpers::Pool pool;
++//			appender->activateOptions(pool);
 +
-+			BasicConfigurator::configure(appender);
++//			BasicConfigurator::configure(appender);
 +
-+			log4cxx::Logger::getRootLogger()->setLevel(log4cxx::Level::getAll());
++//			log4cxx::Logger::getRootLogger()->setLevel(log4cxx::Level::getAll());
 +
-+			std::thread th1( [](){
-+				for( int x = 0; x < 3000; x++ ){
-+					LOG4CXX_INFO(Logger::getLogger(LOG4CXX_STR("test")), "Some message" );
-+				}
-+			});
-+			std::thread th2( [](){
-+				for( int x = 0; x < 3000; x++ ){
-+					LOG4CXX_INFO(Logger::getLogger(LOG4CXX_STR("test")), "Some message" );
-+				}
-+			});
++//			std::thread th1( [](){
++//				for( int x = 0; x < 3000; x++ ){
++//					LOG4CXX_INFO(Logger::getLogger(LOG4CXX_STR("test")), "Some message" );
++//				}
++//			});
++//			std::thread th2( [](){
++//				for( int x = 0; x < 3000; x++ ){
++//					LOG4CXX_INFO(Logger::getLogger(LOG4CXX_STR("test")), "Some message" );
++//				}
++//			});
 +
-+			SocketPtr incomingSocket = serverSocket.accept();
-+			incomingSocket->close();
-+			serverSocket.close();
-+			// If we do not get here, we have deadlocked
-+			th1.join();
-+			th2.join();
++//			SocketPtr incomingSocket = serverSocket.accept();
++//			incomingSocket->close();
++
++//			// If we do not get here, we have deadlocked
++//			th1.join();
++//			th2.join();
 +		}
  };
  
  LOGUNIT_TEST_SUITE_REGISTRATION(SocketAppenderTestCase);
- #endif
-+

--- a/recipes/log4cxx/all/patches/0002-fix-mutex-disconnect.patch
+++ b/recipes/log4cxx/all/patches/0002-fix-mutex-disconnect.patch
@@ -1,0 +1,156 @@
+diff --git a/src/main/cpp/socketappender.cpp b/src/main/cpp/socketappender.cpp
+index 57f8ade..5f9fb8b 100644
+--- a/src/main/cpp/socketappender.cpp
++++ b/src/main/cpp/socketappender.cpp
+@@ -124,7 +124,7 @@ void SocketAppender::append(const spi::LoggingEventPtr& event, log4cxx::helpers:
+ 
+ 		if (getReconnectionDelay() > 0)
+ 		{
+-			fireConnector();
++			fireConnectorInternal();
+ 		}
+ 	}
+ }
+diff --git a/src/main/cpp/socketappenderskeleton.cpp b/src/main/cpp/socketappenderskeleton.cpp
+index 122de9d..3787d1a 100644
+--- a/src/main/cpp/socketappenderskeleton.cpp
++++ b/src/main/cpp/socketappenderskeleton.cpp
+@@ -158,10 +158,20 @@ void SocketAppenderSkeleton::fireConnector()
+ {
+ 	std::unique_lock<log4cxx::shared_mutex> lock(mutex);
+ 
++	fireConnectorInternal();
++}
++
++void SocketAppenderSkeleton::fireConnectorInternal()
++{
+ 	if ( !thread.joinable() )
+ 	{
+ 		LogLog::debug(LOG4CXX_STR("Connector thread not alive: starting monitor."));
+-
++		thread = std::thread( &SocketAppenderSkeleton::monitor, this );
++	}
++	else
++	{
++		interrupt.notify_all();
++		thread.join();
+ 		thread = std::thread( &SocketAppenderSkeleton::monitor, this );
+ 	}
+ }
+@@ -175,8 +185,6 @@ void SocketAppenderSkeleton::monitor()
+ 	{
+ 		try
+ 		{
+-			std::this_thread::sleep_for( std::chrono::milliseconds( reconnectionDelay ) );
+-
+ 			std::unique_lock<std::mutex> lock( interrupt_mutex );
+ 			interrupt.wait_for( lock, std::chrono::milliseconds( reconnectionDelay ),
+ 				std::bind(&SocketAppenderSkeleton::is_closed, this) );
+diff --git a/src/main/cpp/xmlsocketappender.cpp b/src/main/cpp/xmlsocketappender.cpp
+index d5b9942..4c1c70d 100644
+--- a/src/main/cpp/xmlsocketappender.cpp
++++ b/src/main/cpp/xmlsocketappender.cpp
+@@ -122,7 +122,7 @@ void XMLSocketAppender::append(const spi::LoggingEventPtr& event, log4cxx::helpe
+ 
+ 			if (getReconnectionDelay() > 0)
+ 			{
+-				fireConnector();
++				fireConnectorInternal();
+ 			}
+ 		}
+ 	}
+diff --git a/src/main/include/log4cxx/net/socketappenderskeleton.h b/src/main/include/log4cxx/net/socketappenderskeleton.h
+index 88d2a15..8020613 100644
+--- a/src/main/include/log4cxx/net/socketappenderskeleton.h
++++ b/src/main/include/log4cxx/net/socketappenderskeleton.h
+@@ -178,6 +178,11 @@ class LOG4CXX_EXPORT SocketAppenderSkeleton : public AppenderSkeleton
+ 
+ 		virtual int getDefaultPort() const = 0;
+ 
++		/**
++		 * Fire the connector.  Caller must have mutex locked.
++		 */
++		void fireConnectorInternal();
++
+ 	private:
+ 		void connect(log4cxx::helpers::Pool& p);
+ 		/**
+diff --git a/src/test/cpp/net/socketappendertestcase.cpp b/src/test/cpp/net/socketappendertestcase.cpp
+index fe3753c..4496888 100644
+--- a/src/test/cpp/net/socketappendertestcase.cpp
++++ b/src/test/cpp/net/socketappendertestcase.cpp
+@@ -16,6 +16,9 @@
+  */
+ 
+ #include <log4cxx/net/socketappender.h>
++#include <log4cxx/patternlayout.h>
++#include <log4cxx/basicconfigurator.h>
++#include <log4cxx/helpers/serversocket.h>
+ #include "../appenderskeletontestcase.h"
+ #include "apr.h"
+ 
+@@ -34,17 +37,64 @@ class SocketAppenderTestCase : public AppenderSkeletonTestCase
+ 		//
+ 		LOGUNIT_TEST(testDefaultThreshold);
+ 		LOGUNIT_TEST(testSetOptionThreshold);
++		LOGUNIT_TEST(testInvalidHost);
+ 
+ 		LOGUNIT_TEST_SUITE_END();
+ 
+ 
+ 	public:
+ 
++		void setUp()
++		{
++		}
++
++		void tearDown()
++		{
++			BasicConfigurator::resetConfiguration();
++		}
++
+ 		AppenderSkeleton* createAppenderSkeleton() const
+ 		{
+ 			return new log4cxx::net::SocketAppender();
+ 		}
++
++		void testInvalidHost(){
++			log4cxx::net::SocketAppenderPtr appender = std::make_shared<log4cxx::net::SocketAppender>();
++			log4cxx::PatternLayoutPtr layout = std::make_shared<log4cxx::PatternLayout>(LOG4CXX_STR("%m%n"));
++
++			log4cxx::helpers::ServerSocket serverSocket(4445);
++
++			appender->setLayout(layout);
++			appender->setRemoteHost(LOG4CXX_STR("localhost"));
++			appender->setReconnectionDelay(1);
++			appender->setPort(4445);
++			log4cxx::helpers::Pool pool;
++			appender->activateOptions(pool);
++
++			BasicConfigurator::configure(appender);
++
++			log4cxx::Logger::getRootLogger()->setLevel(log4cxx::Level::getAll());
++
++			std::thread th1( [](){
++				for( int x = 0; x < 3000; x++ ){
++					LOG4CXX_INFO(Logger::getLogger(LOG4CXX_STR("test")), "Some message" );
++				}
++			});
++			std::thread th2( [](){
++				for( int x = 0; x < 3000; x++ ){
++					LOG4CXX_INFO(Logger::getLogger(LOG4CXX_STR("test")), "Some message" );
++				}
++			});
++
++			SocketPtr incomingSocket = serverSocket.accept();
++			incomingSocket->close();
++			serverSocket.close();
++			// If we do not get here, we have deadlocked
++			th1.join();
++			th2.join();
++		}
+ };
+ 
+ LOGUNIT_TEST_SUITE_REGISTRATION(SocketAppenderTestCase);
+ #endif
++


### PR DESCRIPTION
Specify library name and version:  **log4cxx/0.12.1**

The socket appender will throw a mutex exception and not start the monitor thread back up. This is a patch to fix those issues until an official release with fixes is made.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
