### PR TITLE
Added option to disable stack protection for SQLiteCpp

### DIFF
--- a/recipes/sqlitecpp/all/conanfile.py
+++ b/recipes/sqlitecpp/all/conanfile.py
@@ -19,11 +19,13 @@ class SQLiteCppConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "lint": [True, False, "deprecated"],
+        "stack_protection": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "lint": "deprecated",
+        "stack_protection": True
     }
 
     exports_sources = ["CMakeLists.txt", "patches/*"]
@@ -86,6 +88,7 @@ class SQLiteCppConan(ConanFile):
         self._cmake.definitions["SQLITECPP_RUN_DOXYGEN"] = False
         self._cmake.definitions["SQLITECPP_BUILD_EXAMPLES"] = False
         self._cmake.definitions["SQLITECPP_BUILD_TESTS"] = False
+        self._cmake.definitions["SQLITECPP_USE_STACK_PROTECTION"] = self.options.stack_protection
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version: **SQLiteCpp/3.1.1**

Using MinGW on Windows it is required to disable stack protection for SQLiteCpp. It is supported by the CMake variable SQLITECPP_USE_STACK_PROTECTION, see https://github.com/SRombauts/SQLiteCpp/pull/286
___
- [x] I've read the guidelines for contributing.
- [x] I've followed the PEP8 style guides for Python code in the recipes.
- [x] I've used the latest Conan client version.
- [x] I've tried at least one configuration locally with the conan-center hook activated.