### PR TITLE
add range-v3/cci.20211210

### DIFF
--- a/recipes/range-v3/all/conandata.yml
+++ b/recipes/range-v3/all/conandata.yml
@@ -9,5 +9,5 @@ sources:
     url: https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz
     sha256: 376376615dbba43d3bef75aa590931431ecb49eb36d07bb726a19f680c75e20c
   "cci.20211210":
-    url: https://github.com/ericniebler/range-v3/archieve/9aa032ccd0eb4bd77f58e5b181168f1038c222c6.tar.gz
+    url: https://github.com/ericniebler/range-v3/archive/9aa032ccd0eb4bd77f58e5b181168f1038c222c6.tar.gz
     sha256: 9118c039e2f25e457c000fba53bacbcac1926da193ff53698b23320deb7fa901

--- a/recipes/range-v3/all/conandata.yml
+++ b/recipes/range-v3/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "0.11.0":
     url: https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz
     sha256: 376376615dbba43d3bef75aa590931431ecb49eb36d07bb726a19f680c75e20c
+  "cci.20211210":
+    url: https://github.com/ericniebler/range-v3/archieve/9aa032ccd0eb4bd77f58e5b181168f1038c222c6.tar.gz
+    sha256: 9118c039e2f25e457c000fba53bacbcac1926da193ff53698b23320deb7fa901

--- a/recipes/range-v3/all/conanfile.py
+++ b/recipes/range-v3/all/conanfile.py
@@ -64,10 +64,12 @@ class Rangev3Conan(ConanFile):
         self.copy("LICENSE.txt", dst="licenses", src=self._source_subfolder)
 
     def package_info(self):
+        self.cpp_info.components["range-v3-main"].names["cmake_find_package"] = "range-v3"
+        self.cpp_info.components["range-v3-main"].names["cmake_find_package_multi"] = "range-v3"
         self.cpp_info.components["range-v3-meta"].names["cmake_find_package"] = "meta"
         self.cpp_info.components["range-v3-meta"].names["cmake_find_package_multi"] = "meta"
         if self.settings.compiler == "Visual Studio":
-            self.cpp_info.components["range-v3-meta"].cxxflags = ["/permissive-"]
+            self.cpp_info.components["range-v3-main"].cxxflags = ["/permissive-", "/experimental:preprocessor"]
         self.cpp_info.components["range-v3-concepts"].names["cmake_find_package"] = "concepts"
         self.cpp_info.components["range-v3-concepts"].names["cmake_find_package_multi"] = "concepts"
         self.cpp_info.components["range-v3-concepts"].requires = ["range-v3-meta"]

--- a/recipes/range-v3/all/conanfile.py
+++ b/recipes/range-v3/all/conanfile.py
@@ -19,6 +19,12 @@ class Rangev3Conan(ConanFile):
 
     @property
     def _compilers_minimum_version(self):
+        if self.version.startswith('cci.'):
+            return {
+                "gcc": "6.5",
+                "Visual Studio": "16",
+                "clang": "5.0"
+            }
         rangev3_version = tools.Version(self.version)
         return {
             "gcc": "5" if rangev3_version < "0.10.0" else "6.5",
@@ -51,9 +57,7 @@ class Rangev3Conan(ConanFile):
         self.info.header_only()
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_folder = self.name + "-" + self.version
-        os.rename(extracted_folder, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def package(self):
         self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))

--- a/recipes/range-v3/config.yml
+++ b/recipes/range-v3/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "0.11.0":
     folder: all
+  "cci.20211210":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **range-v3/cci.20211210**

This merge request closes https://github.com/conan-io/conan-center-index/issues/8386. Why I need this:
 - [this issue](https://github.com/ericniebler/range-v3/issues/1633) breaks compilation on clang-13, and is fixed in the latest master
 - range-v3 has no release for more then a year

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
