### PR TITLE
Update sdbus-cpp to 1.0.0

### DIFF
--- a/recipes/sdbus-cpp/all/conandata.yml
+++ b/recipes/sdbus-cpp/all/conandata.yml
@@ -2,7 +2,14 @@ sources:
   "0.8.3":
     url: "https://github.com/Kistler-Group/sdbus-cpp/archive/v0.8.3.tar.gz"
     sha256: "0fd575ae0f463773dd9141242d1133731e2b780fd6526650ce992ba711d88628"
+  "1.0.0":
+    url: "https://github.com/Kistler-Group/sdbus-cpp/archive/v1.0.0.tar.gz"
+    sha256: "3db82112c0d8a171a4115d761e3a592b62091fa7600988736652595178ae4e94"
 patches:
   "0.8.3":
     - base_path: "source_subfolder"
       patch_file: "patches/0001-xml2cpp-Add-missing-EXPAT-include-dirs-136.patch"
+  "1.0.0":
+    - base_path: "source_subfolder"
+      patch_file: "patches/0002-correct-readme-cpack-resource-path.patch"
+

--- a/recipes/sdbus-cpp/all/patches/0002-correct-readme-cpack-resource-path.patch
+++ b/recipes/sdbus-cpp/all/patches/0002-correct-readme-cpack-resource-path.patch
@@ -1,0 +1,20 @@
+diff --color -Naur --label a/CMakeLists.txt --label b/CMakeLists.txt a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -180,7 +180,6 @@
+ #----------------------------------
+ 
+ option(BUILD_DOC "Build documentation for sdbus-c++" ON)
+-
+ if(BUILD_DOC)
+     message(STATUS "Building with documentation")
+     option(BUILD_DOXYGEN_DOC "Build doxygen documentation for sdbus-c++ API" OFF)
+@@ -217,7 +216,7 @@
+ set(CPACK_PACKAGE_VENDOR "Kistler")
+ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "high-level C++ D-Bus library")
+ set(CPACK_PACKAGE_CONTACT "info@kistler.com")
+-set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.md")
++set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+ set(CPACK_COMPONENTS_ALL runtime dev doc)
+ set(CPACK_COMPONENT_DEV_DEPENDS "runtime")
+ 

--- a/recipes/sdbus-cpp/config.yml
+++ b/recipes/sdbus-cpp/config.yml
@@ -1,3 +1,5 @@
 versions:
   "0.8.3":
     folder: all
+  "1.0.0":
+    folder: all


### PR DESCRIPTION
**sdbus-cpp/1.0.0**
---
Needed this version. There is a small bug in the CMakeLists.txt preventing recipes to build with vanilla archive. I patched it.
I'll notify a member of the maintaining team to incorporate the change in next version.

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.