### PR TITLE
boost/1.78.0: Add Boost 1.78

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -52,6 +52,12 @@ sources:
       "https://sourceforge.net/projects/boost/files/boost/1.77.0/boost_1_77_0.tar.bz2"
     ]
     sha256: "fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854"
+  1.78.0:
+    url: [
+      "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2",
+      "https://sourceforge.net/projects/boost/files/boost/1.78.0/boost_1_78_0.tar.bz2"
+    ]
+    sha256: "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc"
 patches:
   1.69.0:
     - patch_file: "patches/boost_build_asmflags.patch"
@@ -221,4 +227,9 @@ patches:
     - patch_file: "patches/1.77.0-type_erasure-no-system.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/1.77.0-fiber-mingw.patch"
+      base_path: "source_subfolder"
+  1.78.0:
+    - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/1.78.0-b2-fix-install.patch"
       base_path: "source_subfolder"

--- a/recipes/boost/all/dependencies/dependencies-1.78.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.78.0.yml
@@ -1,0 +1,276 @@
+configure_options:
+- atomic
+- chrono
+- container
+- context
+- contract
+- coroutine
+- date_time
+- exception
+- fiber
+- filesystem
+- graph
+- graph_parallel
+- iostreams
+- json
+- locale
+- log
+- math
+- mpi
+- nowide
+- program_options
+- python
+- random
+- regex
+- serialization
+- stacktrace
+- system
+- test
+- thread
+- timer
+- type_erasure
+- wave
+dependencies:
+  atomic: []
+  chrono:
+  - system
+  container: []
+  context: []
+  contract:
+  - exception
+  - thread
+  coroutine:
+  - context
+  - exception
+  - system
+  date_time: []
+  exception: []
+  fiber:
+  - context
+  - filesystem
+  fiber_numa:
+  - fiber
+  filesystem:
+  - atomic
+  - system
+  graph:
+  - math
+  - random
+  - regex
+  - serialization
+  graph_parallel:
+  - filesystem
+  - graph
+  - mpi
+  - random
+  - serialization
+  iostreams:
+  - random
+  - regex
+  json:
+  - container
+  - exception
+  - system
+  locale:
+  - thread
+  log:
+  - atomic
+  - container
+  - date_time
+  - exception
+  - filesystem
+  - random
+  - regex
+  - system
+  - thread
+  log_setup:
+  - log
+  math: []
+  math_c99:
+  - math
+  math_c99f:
+  - math
+  math_c99l:
+  - math
+  math_tr1:
+  - math
+  math_tr1f:
+  - math
+  math_tr1l:
+  - math
+  mpi:
+  - graph
+  - serialization
+  mpi_python:
+  - mpi
+  - python
+  nowide:
+  - filesystem
+  numpy:
+  - python
+  prg_exec_monitor:
+  - test
+  program_options: []
+  python: []
+  random:
+  - system
+  regex: []
+  serialization: []
+  stacktrace: []
+  stacktrace_addr2line:
+  - stacktrace
+  stacktrace_backtrace:
+  - stacktrace
+  stacktrace_basic:
+  - stacktrace
+  stacktrace_noop:
+  - stacktrace
+  stacktrace_windbg:
+  - stacktrace
+  stacktrace_windbg_cached:
+  - stacktrace
+  system: []
+  test:
+  - exception
+  test_exec_monitor:
+  - test
+  thread:
+  - atomic
+  - chrono
+  - container
+  - date_time
+  - exception
+  - system
+  timer:
+  - chrono
+  - system
+  type_erasure:
+  - thread
+  unit_test_framework:
+  - prg_exec_monitor
+  - test
+  - test_exec_monitor
+  wave:
+  - filesystem
+  - serialization
+  wserialization:
+  - serialization
+libs:
+  atomic:
+  - boost_atomic
+  chrono:
+  - boost_chrono
+  container:
+  - boost_container
+  context:
+  - boost_context
+  contract:
+  - boost_contract
+  coroutine:
+  - boost_coroutine
+  date_time:
+  - boost_date_time
+  exception:
+  - boost_exception
+  fiber:
+  - boost_fiber
+  fiber_numa:
+  - boost_fiber_numa
+  filesystem:
+  - boost_filesystem
+  graph:
+  - boost_graph
+  graph_parallel:
+  - boost_graph_parallel
+  iostreams:
+  - boost_iostreams
+  json:
+  - boost_json
+  locale:
+  - boost_locale
+  log:
+  - boost_log
+  log_setup:
+  - boost_log_setup
+  math: []
+  math_c99:
+  - boost_math_c99
+  math_c99f:
+  - boost_math_c99f
+  math_c99l:
+  - boost_math_c99l
+  math_tr1:
+  - boost_math_tr1
+  math_tr1f:
+  - boost_math_tr1f
+  math_tr1l:
+  - boost_math_tr1l
+  mpi:
+  - boost_mpi
+  mpi_python:
+  - boost_mpi_python
+  nowide:
+  - boost_nowide
+  numpy:
+  - boost_numpy{py_major}{py_minor}
+  prg_exec_monitor:
+  - boost_prg_exec_monitor
+  program_options:
+  - boost_program_options
+  python:
+  - boost_python{py_major}{py_minor}
+  random:
+  - boost_random
+  regex:
+  - boost_regex
+  serialization:
+  - boost_serialization
+  stacktrace: []
+  stacktrace_addr2line:
+  - boost_stacktrace_addr2line
+  stacktrace_backtrace:
+  - boost_stacktrace_backtrace
+  stacktrace_basic:
+  - boost_stacktrace_basic
+  stacktrace_noop:
+  - boost_stacktrace_noop
+  stacktrace_windbg:
+  - boost_stacktrace_windbg
+  stacktrace_windbg_cached:
+  - boost_stacktrace_windbg_cached
+  system:
+  - boost_system
+  test: []
+  test_exec_monitor:
+  - boost_test_exec_monitor
+  thread:
+  - boost_thread
+  timer:
+  - boost_timer
+  type_erasure:
+  - boost_type_erasure
+  unit_test_framework:
+  - boost_unit_test_framework
+  wave:
+  - boost_wave
+  wserialization:
+  - boost_wserialization
+requirements:
+  iostreams:
+  - bzip2
+  - lzma
+  - zlib
+  - zstd
+  locale:
+  - iconv
+  - icu
+  python:
+  - python
+  regex:
+  - icu
+  stacktrace:
+  - backtrace
+static_only:
+- boost_exception
+- boost_test_exec_monitor
+version: 1.78.0

--- a/recipes/boost/all/patches/1.78.0-b2-fix-install.patch
+++ b/recipes/boost/all/patches/1.78.0-b2-fix-install.patch
@@ -1,0 +1,62 @@
+--- tools/build/src/tools/stage.jam	2021-12-09 16:30:45.956457531 +0300
++++ tools/build/src/tools/stage.jam	2021-12-09 16:30:45.952457519 +0300
+@@ -476,10 +476,14 @@ class install-target-class : basic-targe
+         }
+         DELETE_MODULE $(result) ;
+         return [ sequence.unique $(result2) ] ;
+     }
+ 
++    rule skip-from-usage-requirements ( )
++    {
++    }
++
+     # Returns true iff 'type' is subtype of some element of 'types-to-include'.
+     #
+     local rule include-type ( type : types-to-include * )
+     {
+         local found ;
+
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ tools/build/test/install_build_no.py	2021-12-09 16:30:45.953457522 +0300
+@@ -0,0 +1,26 @@
++#!/usr/bin/python
++
++# Copyright 2021 Dmitry Arkhipov (grisumbras@gmail.com)
++# Distributed under the Boost Software License, Version 1.0.
++# (See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
++
++# Check that <build>no in usage-requirements of dependencies does not affect
++# install rule, i.e. a skipped installed target does not affect insallation of
++# other targets.
++
++import BoostBuild
++
++t = BoostBuild.Tester()
++
++t.write("a.cpp", "int main() {}\n")
++
++t.write("jamroot.jam", """
++make x : : maker : <build>no ;
++exe a : a.cpp ;
++install install : x a ;
++""")
++
++t.run_build_system()
++t.expect_addition("install/a.exe")
++
++t.cleanup()
+
+--- tools/build/test/test_all.py	2021-12-09 16:30:45.956457531 +0300
++++ tools/build/test/test_all.py	2021-12-09 16:30:45.953457522 +0300
+@@ -248,10 +248,11 @@ tests = ["abs_workdir",
+          "implicit_dependency",
+          "indirect_conditional",
+          "inherit_toolset",
+          "inherited_dependency",
+          "inline",
++         "install_build_no",
+          "libjpeg",
+          "liblzma",
+          "libpng",
+          "libtiff",
+          "libzstd",

--- a/recipes/boost/config.yml
+++ b/recipes/boost/config.yml
@@ -17,3 +17,5 @@ versions:
       folder: all
     1.77.0:
       folder: all
+    1.78.0:
+      folder: all


### PR DESCRIPTION
Specify library name and version:  **boost/1.78.0**

Adds the latest version of Boost, version 1.78.0.
Fixes #8424.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
