### PR TITLE
daw_header_libraries: add version 2.5.3 with absolute target names

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.3":
+    url: "https://github.com/beached/header_libraries/archive/refs/tags/v2.5.3.tar.gz"
+    sha256: "0fd08b31947e5f0da45c875bbb44d178d4250225e2623fb845cd458605390233"
   "1.29.7":
     url: "https://github.com/beached/header_libraries/archive/refs/tags/v1.29.7.tar.gz"
     sha256: "524c34f3f5d2af498e7bcaff7802b914ba42acde29f7e3ecce41a035db0bf5bd"

--- a/recipes/daw_header_libraries/all/conanfile.py
+++ b/recipes/daw_header_libraries/all/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conans.errors import ConanInvalidConfiguration
 from conans import ConanFile, CMake, tools
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 class DawHeaderLibrariesConan(ConanFile):
     name = "daw_header_libraries"
@@ -12,8 +12,8 @@ class DawHeaderLibrariesConan(ConanFile):
     description = "Various header libraries mostly future std lib, replacements for(e.g. visit), or some misc"
     topics = ("algorithms", "helpers", "data-structures")
     homepage = "https://github.com/beached/header_libraries"
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi", "cmake_find_package"
+    settings = "compiler",
+    generators = "cmake",
     no_copy_source = True
 
     _compiler_required_cpp17 = {
@@ -60,7 +60,12 @@ class DawHeaderLibrariesConan(ConanFile):
     def package_info(self):
         self.cpp_info.filenames["cmake_find_package"] = "daw-header-libraries"
         self.cpp_info.filenames["cmake_find_package_multi"] = "daw-header-libraries"
+        self.cpp_info.set_property("cmake_file_name", "daw-header-libraries")
+
         self.cpp_info.names["cmake_find_package"] = "daw"
         self.cpp_info.names["cmake_find_package_multi"] = "daw"
+        self.cpp_info.set_property("cmake_target_name", "daw::daw-header-libraries")
+
         self.cpp_info.components["daw"].names["cmake_find_package"] = "daw-header-libraries"
         self.cpp_info.components["daw"].names["cmake_find_package_multi"] = "daw-header-libraries"
+        self.cpp_info.components["daw"].set_property("cmake_target_name", "daw::daw-header-libraries")

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.5.3":
+    folder: all
   "1.29.7":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **daw_header_libraries/2.5.3**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
