### PR TITLE
[open62541] fix: patch python files to use python3 by default.

### DIFF
--- a/recipes/open62541/all/conandata.yml
+++ b/recipes/open62541/all/conandata.yml
@@ -44,3 +44,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0003-disable-sanitizers-1_2_x.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0003-fix-use-usr-bin-env-python3.patch"
+      base_path: "source_subfolder"

--- a/recipes/open62541/all/patches/0003-fix-use-usr-bin-env-python3.patch
+++ b/recipes/open62541/all/patches/0003-fix-use-usr-bin-env-python3.patch
@@ -1,0 +1,113 @@
+diff --git a/tools/amalgamate.py b/tools/amalgamate.py
+index 8db9d2f7..6e042a6a 100755
+--- a/tools/amalgamate.py
++++ b/tools/amalgamate.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # coding: UTF-8
+ # This Source Code Form is subject to the terms of the Mozilla Public
+diff --git a/tools/c2rst.py b/tools/c2rst.py
+index b9971e54..036b6b92 100755
+--- a/tools/c2rst.py
++++ b/tools/c2rst.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this 
+diff --git a/tools/gdb-prettyprint.py b/tools/gdb-prettyprint.py
+index ca80df44..486ee9a7 100644
+--- a/tools/gdb-prettyprint.py
++++ b/tools/gdb-prettyprint.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # Load into gdb with 'source <path-to>/tools/gdb-prettyprint.py'
+ # Make sure to have 'set print pretty on' to get nice structure printouts
+diff --git a/tools/generate_datatypes.py b/tools/generate_datatypes.py
+index 3ad6a8a3..227dd41c 100755
+--- a/tools/generate_datatypes.py
++++ b/tools/generate_datatypes.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+diff --git a/tools/generate_nodeid_header.py b/tools/generate_nodeid_header.py
+index b7c8a9f7..14b7062c 100644
+--- a/tools/generate_nodeid_header.py
++++ b/tools/generate_nodeid_header.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this 
+diff --git a/tools/generate_statuscode_descriptions.py b/tools/generate_statuscode_descriptions.py
+index 9679af23..d6ced7df 100755
+--- a/tools/generate_statuscode_descriptions.py
++++ b/tools/generate_statuscode_descriptions.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this 
+diff --git a/tools/nodeset_compiler/nodeset.py b/tools/nodeset_compiler/nodeset.py
+index 1889ff6d..b5e016cc 100644
+--- a/tools/nodeset_compiler/nodeset.py
++++ b/tools/nodeset_compiler/nodeset.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ # -*- coding: utf-8 -*-
+ 
+ ### This Source Code Form is subject to the terms of the Mozilla Public
+diff --git a/tools/nodeset_compiler/nodeset_testing.py b/tools/nodeset_compiler/nodeset_testing.py
+index a1121086..5997f82e 100644
+--- a/tools/nodeset_compiler/nodeset_testing.py
++++ b/tools/nodeset_compiler/nodeset_testing.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ ### This Source Code Form is subject to the terms of the Mozilla Public
+ ### License, v. 2.0. If a copy of the MPL was not distributed with this
+diff --git a/tools/prepare_packaging.py b/tools/prepare_packaging.py
+index bb775b1f..84d7b2d0 100644
+--- a/tools/prepare_packaging.py
++++ b/tools/prepare_packaging.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+diff --git a/tools/update_copyright_header.py b/tools/update_copyright_header.py
+index a8d950df..1ce6fed6 100755
+--- a/tools/update_copyright_header.py
++++ b/tools/update_copyright_header.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ # -*- coding: utf-8 -*-
+ # This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+diff --git a/tools/valgrind_check_error.py b/tools/valgrind_check_error.py
+index e192cecc..a263f6aa 100755
+--- a/tools/valgrind_check_error.py
++++ b/tools/valgrind_check_error.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # coding: UTF-8
+ # This Source Code Form is subject to the terms of the Mozilla Public
+-- 
+2.17.1
+


### PR DESCRIPTION
Specify library name and version:  **open62541/1.2.2**

This ports https://github.com/open62541/open62541/pull/4862 to 1.2.2 conan package

Newer Ubuntu versions such as 20.04 do not have `python` as a command, since there is only `python3`.

See also https://askubuntu.com/q/1296790/141958

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
