### PR TITLE
[giflib] Add option to disable compilation of gif_utilities

### DIFF
--- a/recipes/giflib/5.2.x/CMakeLists.txt
+++ b/recipes/giflib/5.2.x/CMakeLists.txt
@@ -23,15 +23,6 @@ if(WIN32 AND BUILD_SHARED_LIBS)
     set_property(TARGET ${PROJECT_NAME} PROPERTY PREFIX "")
 endif()
 
-set(GIF_UTILS
-    gif2rgb
-    gifbuild
-    giffix
-    giftext
-    giftool
-    gifclrmp
-)
-
 add_library(giflib_util STATIC
     "source_subfolder/qprintf.c"
     "source_subfolder/quantize.c"
@@ -39,16 +30,30 @@ add_library(giflib_util STATIC
 )
 target_link_libraries(giflib_util PRIVATE ${PROJECT_NAME})
 
-foreach(GIF_UTIL ${GIF_UTILS})
-    add_executable(${GIF_UTIL} "source_subfolder/${GIF_UTIL}.c")
-    target_link_libraries(${GIF_UTIL} PRIVATE ${PROJECT_NAME} giflib_util)
-endforeach()
-find_library(M_LIBRARY NAMES m)
-if(M_LIBRARY)
-    target_link_libraries(gifclrmp PRIVATE ${M_LIBRARY})
+
+set(INSTALL_TARGETS ${PROJECT_NAME})
+
+if (ENABLE_UTILS)
+    set(GIF_UTILS
+        gif2rgb
+        gifbuild
+        giffix
+        giftext
+        giftool
+        gifclrmp
+    )
+    foreach(GIF_UTIL ${GIF_UTILS})
+        add_executable(${GIF_UTIL} "source_subfolder/${GIF_UTIL}.c")
+        target_link_libraries(${GIF_UTIL} PRIVATE ${PROJECT_NAME} giflib_util)
+    endforeach()
+    set(INSTALL_TARGETS ${PROJECT_NAME} ${GIF_UTILS})
+    find_library(M_LIBRARY NAMES m)
+    if(M_LIBRARY)
+        target_link_libraries(gifclrmp PRIVATE ${M_LIBRARY})
+    endif()
 endif()
 
-install(TARGETS ${PROJECT_NAME} ${GIF_UTILS}
+install(TARGETS ${INSTALL_TARGETS}
         ARCHIVE DESTINATION "lib"
         LIBRARY DESTINATION "lib"
         RUNTIME DESTINATION "bin"

--- a/recipes/giflib/5.2.x/CMakeLists.txt
+++ b/recipes/giflib/5.2.x/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(giflib_util PRIVATE ${PROJECT_NAME})
 
 set(INSTALL_TARGETS ${PROJECT_NAME})
 
-if (ENABLE_UTILS)
+if (UTILS)
     set(GIF_UTILS
         gif2rgb
         gifbuild

--- a/recipes/giflib/5.2.x/conanfile.py
+++ b/recipes/giflib/5.2.x/conanfile.py
@@ -15,10 +15,12 @@ class GiflibConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "enable_utils" : [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "enable_utils" : True,
     }
 
     exports_sources = "CMakeLists.txt", "patches/*"
@@ -52,6 +54,7 @@ class GiflibConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        self._cmake.definitions["ENABLE_UTILS"] = self.options.enable_utils
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/giflib/5.2.x/conanfile.py
+++ b/recipes/giflib/5.2.x/conanfile.py
@@ -15,12 +15,12 @@ class GiflibConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "enable_utils" : [True, False],
+        "utils" : [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "enable_utils" : True,
+        "utils" : True,
     }
 
     exports_sources = "CMakeLists.txt", "patches/*"
@@ -54,7 +54,7 @@ class GiflibConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-        self._cmake.definitions["ENABLE_UTILS"] = self.options.enable_utils
+        self._cmake.definitions["UTILS"] = self.options.utils
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/giflib/5.2.x/test_package/conanfile.py
+++ b/recipes/giflib/5.2.x/test_package/conanfile.py
@@ -14,7 +14,8 @@ class TestPackageConan(ConanFile):
     def test(self):
         if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
-            self.run("{} testimg.gif".format(bin_path), run_environment=True)
-            assert os.path.isfile("testimg.gif")
-            self.run("gif2rgb -o testimg.rgb testimg.gif".format(bin_path), run_environment=True)
-            assert os.path.isfile("testimg.rgb.R")
+            if self.options["giflib"].enable_utils:
+                self.run("{} testimg.gif".format(bin_path), run_environment=True)
+                assert os.path.isfile("testimg.gif")
+                self.run("gif2rgb -o testimg.rgb testimg.gif".format(bin_path), run_environment=True)
+                assert os.path.isfile("testimg.rgb.R")

--- a/recipes/giflib/5.2.x/test_package/conanfile.py
+++ b/recipes/giflib/5.2.x/test_package/conanfile.py
@@ -14,7 +14,7 @@ class TestPackageConan(ConanFile):
     def test(self):
         if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
-            if self.options["giflib"].enable_utils:
+            if self.options["giflib"].utils:
                 self.run("{} testimg.gif".format(bin_path), run_environment=True)
                 assert os.path.isfile("testimg.gif")
                 self.run("gif2rgb -o testimg.rgb testimg.gif".format(bin_path), run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **giflib/5.2.x**

Adds logic to the conanfile and cmakelists.txt to to control the compilation of the gif_utilities via option. These utilities make use of of the GNU module getopt which may not available in places such as AIX and HP-UX

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
