### PR TITLE
Update zulu dependency, needed for M1

### DIFF
--- a/recipes/djinni-support-lib/1.x.x/conanfile.py
+++ b/recipes/djinni-support-lib/1.x.x/conanfile.py
@@ -70,7 +70,7 @@ class DjinniSuppotLib(ConanFile):
 
     def build_requirements(self):
         if not self.options.system_java and self._jni_support:
-            self.build_requires("zulu-openjdk/11.0.8@")
+            self.build_requires("zulu-openjdk/11.0.12@")
 
     def config_options(self):
         if self.settings.os == "Windows":


### PR DESCRIPTION
Specify library name and version:  **djinni-support-lib/1.2.0**

Update (optional) zulu-openjdk dependency so the package also works on Mac M1

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
