### PR TITLE
opencv/4.5.3: Add support for DNN on CUDA

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -34,6 +34,7 @@ class OpenCVConan(ConanFile):
         "with_cuda": [True, False],
         "with_cublas": [True, False],
         "with_cufft": [True, False],
+        "with_cudnn": [True, False],
         "with_v4l": [True, False],
         "with_ffmpeg": [True, False],
         "with_imgcodec_hdr": [True, False],
@@ -42,6 +43,7 @@ class OpenCVConan(ConanFile):
         "with_imgcodec_sunraster": [True, False],
         "neon": [True, False],
         "dnn": [True, False],
+        "dnn_cuda": [True, False],
         "detect_cpu_baseline": [True, False],
         "nonfree": [True, False],
     }
@@ -65,6 +67,7 @@ class OpenCVConan(ConanFile):
         "with_cuda": False,
         "with_cublas": False,
         "with_cufft": False,
+        "with_cudnn": False,
         "with_v4l": False,
         "with_ffmpeg": True,
         "with_imgcodec_hdr": False,
@@ -73,6 +76,7 @@ class OpenCVConan(ConanFile):
         "with_imgcodec_sunraster": False,
         "neon": True,
         "dnn": True,
+        "dnn_cuda": False,
         "detect_cpu_baseline": False,
         "nonfree": False,
     }
@@ -139,9 +143,13 @@ class OpenCVConan(ConanFile):
         if not self.options.contrib:
             del self.options.contrib_freetype
             del self.options.contrib_sfm
+        if not self.options.dnn:
+            del self.options.dnn_cuda
         if not self.options.with_cuda:
             del self.options.with_cublas
+            del self.options.with_cudnn
             del self.options.with_cufft
+            del self.options.dnn_cuda
         if bool(self.options.with_jpeg):
             if self.options.get_safe("with_jpeg2000") == "jasper":
                 self.options["jasper"].with_libjpeg = self.options.with_jpeg
@@ -198,6 +206,9 @@ class OpenCVConan(ConanFile):
             raise ConanInvalidConfiguration("Clang 3.x can build OpenCV 4.x due an internal bug.")
         if self.options.with_cuda and not self.options.contrib:
             raise ConanInvalidConfiguration("contrib must be enabled for cuda")
+        if self.options.get_safe("dnn_cuda", False) and \
+            (not self.options.with_cuda or not self.options.contrib or not self.options.with_cublas or not self.options.with_cudnn):
+            raise ConanInvalidConfiguration("with_cublas, with_cudnn and contrib must be enabled for dnn_cuda")
 
     def build_requirements(self):
         if self.options.dnn and hasattr(self, "settings_build"):
@@ -381,6 +392,7 @@ class OpenCVConan(ConanFile):
         if self.options.dnn:
             self._cmake.definitions["PROTOBUF_UPDATE_FILES"] = True
             self._cmake.definitions["BUILD_opencv_dnn"] = True
+        self._cmake.definitions["OPENCV_DNN_CUDA"] = self.options.get_safe("dnn_cuda", False)
 
         if self.options.contrib:
             self._cmake.definitions['OPENCV_EXTRA_MODULES_PATH'] = os.path.join(self.build_folder, self._contrib_folder, 'modules')
@@ -405,6 +417,7 @@ class OpenCVConan(ConanFile):
             self._cmake.definitions["CUDA_NVCC_FLAGS"] = "--expt-relaxed-constexpr"
         self._cmake.definitions["WITH_CUBLAS"] = self.options.get_safe("with_cublas", False)
         self._cmake.definitions["WITH_CUFFT"] = self.options.get_safe("with_cufft", False)
+        self._cmake.definitions["WITH_CUDNN"] = self.options.get_safe("with_cudnn", False)
 
         self._cmake.definitions["ENABLE_PIC"] = self.options.get_safe("fPIC", True)
 


### PR DESCRIPTION
Add new option **dnn_cuda** which enable/disable compilation of opencv_dnn module with Cuda backend.
Add new option **with_cudnn** which enable/disable cmake flag WITH_CUDNN and is necessary for opencv_dnn with Cuda. 
Add additional checks in validate function.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
