### PR TITLE
incbin: add recipe

### DIFF
--- a/recipes/incbin/all/conandata.yml
+++ b/recipes/incbin/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20211107":
+    url: "https://github.com/graphitemaster/incbin/archive/6e576cae5ab5810f25e2631f2e0b80cbe7dc8cbf.tar.gz"
+    sha256: "d23582689c46604cad116495dbd8aceb1974b46164114a231e8c8144ae12b230"

--- a/recipes/incbin/all/conanfile.py
+++ b/recipes/incbin/all/conanfile.py
@@ -1,0 +1,32 @@
+from conans.errors import ConanInvalidConfiguration
+from conans import ConanFile, tools
+
+required_conan_version = ">=1.33.0"
+
+class IncbinConan(ConanFile):
+    name = "incbin"
+    license = "Unlicense"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "Include binary files in C/C++"
+    topics = ("include", "binary", "preprocess")
+    homepage = "https://github.com/graphitemaster/incbin/"
+    no_copy_source = True
+    settings = "compiler"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def validate(self):
+        if self.settings.compiler == "Visual Studio":
+            raise ConanInvalidConfiguration("Currently incbin recipe is not supported for Visual Studio because it requires external command 'incbin'.")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy("UNLICENSE", "licenses", self._source_subfolder)
+        self.copy("incbin.h", "include", self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/incbin/all/test_package/CMakeLists.txt
+++ b/recipes/incbin/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(incbin CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} incbin::incbin)
+target_compile_definitions(${PROJECT_NAME} PUBLIC INCBIN_FILE="${CMAKE_SOURCE_DIR}/CMakeLists.txt")

--- a/recipes/incbin/all/test_package/conanfile.py
+++ b/recipes/incbin/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/incbin/all/test_package/test_package.c
+++ b/recipes/incbin/all/test_package/test_package.c
@@ -1,0 +1,15 @@
+#define INCBIN_PREFIX g_
+#define INCBIN_STYLE INCBIN_STYLE_SNAKE
+#include "incbin.h"
+
+INCBIN(cmake, INCBIN_FILE);
+
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+    (void)g_cmake_data[0];
+    (void)*g_cmake_end;
+    printf(INCBIN_FILE" size is %d\n", g_cmake_size);
+
+    return 0;
+}

--- a/recipes/incbin/config.yml
+++ b/recipes/incbin/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20211107":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **incbin/cci.20211107**

try to close https://github.com/conan-io/conan-center-index/issues/8413.

Current recipe doesn't support Visual Studio because incbin for Visual Studio needs helper command.
I'm trying to support Visual Studio now.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
