### PR TITLE
tesseract/5.0.0: fix wrong compiler version being output

### DIFF
--- a/recipes/tesseract/all/conanfile.py
+++ b/recipes/tesseract/all/conanfile.py
@@ -94,7 +94,7 @@ class TesseractConan(ConanFile):
             self.output.warn(
                 "%s recipe lacks information about the %s compiler standard version support" % (self.name, compiler))
         elif compiler_version < minimal_version[compiler]:
-            raise ConanInvalidConfiguration("{} requires a {} version >= {}".format(self.name, compiler, compiler_version))
+            raise ConanInvalidConfiguration("{} requires a {} version >= {}, but {} was found".format(self.name, compiler, minimal_version[compiler], compiler_version))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],


### PR DESCRIPTION
The compiler version shown was the one used instead of the one required.

Bonify error message to include required and currently found compiler version.

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
