### PR TITLE
msgpack-c: fix CMake names

### DIFF
--- a/recipes/msgpack-c/all/conanfile.py
+++ b/recipes/msgpack-c/all/conanfile.py
@@ -1,7 +1,9 @@
 from conans import ConanFile, CMake, tools
 import os
+import textwrap
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
+
 
 class MsgpackCConan(ConanFile):
     name = "msgpack-c"
@@ -68,16 +70,41 @@ class MsgpackCConan(ConanFile):
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"msgpackc": "msgpack::msgpack"}
+        )
+
+    @staticmethod
+    def _create_cmake_module_alias_targets(module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent("""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """.format(alias=alias, aliased=aliased))
+        tools.save(module_file, content)
+
+    @property
+    def _module_subfolder(self):
+        return os.path.join("lib", "cmake")
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join(self._module_subfolder,
+                            "conan-official-{}-targets.cmake".format(self.name))
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "msgpack-c"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "msgpack-c"
-        self.cpp_info.set_property("cmake_file_name", "msgpack-c")
+        self.cpp_info.set_property("cmake_file_name", "msgpack")
+        self.cpp_info.set_property("cmake_target_name", "msgpackc")
+        self.cpp_info.set_property("pkg_config_name", "msgpack")
+
         self.cpp_info.names["cmake_find_package"] = "msgpack"
         self.cpp_info.names["cmake_find_package_multi"] = "msgpack"
-        self.cpp_info.set_property("cmake_target_name", "msgpack")
-        self.cpp_info.components["msgpack"].names["cmake_find_package"] = "msgpack-c"
-        self.cpp_info.components["msgpack"].names["cmake_find_package_multi"] = "msgpack-c"
-        self.cpp_info.components["msgpack"].set_property("cmake_target_name", "msgpack-c")
-        self.cpp_info.components["msgpack"].set_property("pkg_config_name", "msgpack")
-        self.cpp_info.components["msgpack"].libs = ["msgpackc"]
+        self.cpp_info.builddirs.append(self._module_subfolder)
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+
+        self.cpp_info.libs = ["msgpackc"]

--- a/recipes/msgpack-c/all/test_package/CMakeLists.txt
+++ b/recipes/msgpack-c/all/test_package/CMakeLists.txt
@@ -4,7 +4,7 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(msgpack-c REQUIRED CONFIG)
+find_package(msgpack REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} msgpack::msgpack-c)
+target_link_libraries(${PROJECT_NAME} msgpackc)


### PR DESCRIPTION
- config file is `msgpack-config.cmake`
- imported target is `msgpackc` and is not namespaced

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
