### PR TITLE
msgpack-cxx: fix CMake names + bump boost

### DIFF
--- a/recipes/msgpack-cxx/all/conanfile.py
+++ b/recipes/msgpack-cxx/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 import textwrap
@@ -23,6 +23,9 @@ class MsgpackCXXConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    def requirements(self):
+        self.requires("boost/1.78.0")
+
     def validate(self):
         if self.options["boost"].header_only == True:
             raise ConanInvalidConfiguration("{} requires boost with header_only = False".format(self.name))
@@ -32,9 +35,6 @@ class MsgpackCXXConan(ConanFile):
             self.options["boost"].without_system == True or \
             self.options["boost"].without_timer == True:
             raise ConanInvalidConfiguration("{} requires boost with chrono, context, system, timer enabled".format(self.name))
-
-    def requirements(self):
-        self.requires("boost/1.77.0")
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/msgpack-cxx/all/conanfile.py
+++ b/recipes/msgpack-cxx/all/conanfile.py
@@ -1,8 +1,10 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
+import textwrap
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
+
 
 class MsgpackCXXConan(ConanFile):
     name = "msgpack-cxx"
@@ -45,17 +47,42 @@ class MsgpackCXXConan(ConanFile):
         self.copy("LICENSE_1_0.txt", dst="licenses", src=self._source_subfolder)
         self.copy("*.h", dst="include", src=os.path.join(self._source_subfolder, "include"))
         self.copy("*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"msgpackc-cxx": "msgpackc-cxx::msgpackc-cxx"}
+        )
+
+    @staticmethod
+    def _create_cmake_module_alias_targets(module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent("""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """.format(alias=alias, aliased=aliased))
+        tools.save(module_file, content)
+
+    @property
+    def _module_subfolder(self):
+        return os.path.join("lib", "cmake")
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join(self._module_subfolder,
+                            "conan-official-{}-targets.cmake".format(self.name))
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "msgpack-cxx"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "msgpack-cxx"
-        self.cpp_info.set_property("cmake_file_name", "msgpack-cxx")
-        self.cpp_info.names["cmake_find_package"] = "msgpack"
-        self.cpp_info.names["cmake_find_package_multi"] = "msgpack"
-        self.cpp_info.set_property("cmake_target_name", "msgpack")
-        self.cpp_info.components["msgpack"].names["cmake_find_package"] = "msgpack-cxx"
-        self.cpp_info.components["msgpack"].names["cmake_find_package_multi"] = "msgpack-cxx"
-        self.cpp_info.components["msgpack"].set_property("cmake_target_name", "msgpack-cxx")
-        self.cpp_info.components["msgpack"].set_property("pkg_config_name", "msgpack-cxx")
-        self.cpp_info.components["msgpack"].defines = ["MSGPACK_USE_BOOST"]
-        self.cpp_info.components["msgpack"].requires = ["boost::boost"]
+        self.cpp_info.set_property("cmake_file_name", "msgpack")
+        self.cpp_info.set_property("cmake_target_name", "msgpackc-cxx")
+
+        self.cpp_info.filenames["cmake_find_package"] = "msgpack"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "msgpack"
+        self.cpp_info.names["cmake_find_package"] = "msgpackc-cxx"
+        self.cpp_info.names["cmake_find_package_multi"] = "msgpackc-cxx"
+        self.cpp_info.builddirs.append(self._module_subfolder)
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+
+        self.cpp_info.defines = ["MSGPACK_USE_BOOST"]

--- a/recipes/msgpack-cxx/all/test_package/CMakeLists.txt
+++ b/recipes/msgpack-cxx/all/test_package/CMakeLists.txt
@@ -4,8 +4,8 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(msgpack-cxx REQUIRED CONFIG)
+find_package(msgpack REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} msgpack::msgpack-cxx)
+target_link_libraries(${PROJECT_NAME} msgpackc-cxx)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)


### PR DESCRIPTION
- config file is `msgpack-config.cmake`
- imported target is `msgpackc-cxx` and is not namespaced

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
