### PR TITLE
aws-sdk-cpp use openssl

### DIFF
--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -340,12 +340,14 @@ class AwsSdkCppConan(ConanFile):
                     See https://github.com/aws/aws-sdk-cpp/issues/1542""")
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.9")
         if self._use_aws_crt_cpp:
+            self.requires("aws-c-common/0.6.15")
             self.requires("aws-c-cal/0.5.12")
-            self.requires("aws-c-io/0.10.9")
-            self.requires("aws-crt-cpp/0.14.3")
+            self.requires("aws-c-http/0.6.10")
+            self.requires("aws-c-io/0.10.13")
+            self.requires("aws-crt-cpp/0.17.12")
         else:
+            self.requires("aws-c-common/0.6.9")
             self.requires("aws-c-event-stream/0.1.5")
         if self.settings.os != "Windows":
             self.requires("openssl/1.1.1l")
@@ -379,6 +381,8 @@ class AwsSdkCppConan(ConanFile):
         self._cmake.definitions["ENABLE_TESTING"] = False
         self._cmake.definitions["AUTORUN_UNIT_TESTS"] = False
         self._cmake.definitions["BUILD_DEPS"] = False
+        if self.settings.os != "Windows":
+            self._cmake.definitions["ENABLE_OPENSSL_ENCRYPTION"] = True
 
         self._cmake.definitions["MINIMIZE_SIZE"] = self.options.min_size
         if self.settings.compiler == "Visual Studio" and not self._use_aws_crt_cpp:
@@ -421,8 +425,9 @@ class AwsSdkCppConan(ConanFile):
         self.cpp_info.components["core"].requires = ["aws-c-common::aws-c-common-lib"]
         if self._use_aws_crt_cpp:
             self.cpp_info.components["core"].requires.extend([
-                "aws-c-io::aws-c-io-lib",
                 "aws-c-cal::aws-c-cal-lib",
+                "aws-c-http::aws-c-http-lib",
+                "aws-c-io::aws-c-io-lib",
                 "aws-crt-cpp::aws-crt-cpp-lib",
             ])
         else:

--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -340,14 +340,13 @@ class AwsSdkCppConan(ConanFile):
                     See https://github.com/aws/aws-sdk-cpp/issues/1542""")
 
     def requirements(self):
+        self.requires("aws-c-common/0.6.15")
         if self._use_aws_crt_cpp:
-            self.requires("aws-c-common/0.6.15")
             self.requires("aws-c-cal/0.5.12")
             self.requires("aws-c-http/0.6.10")
             self.requires("aws-c-io/0.10.13")
             self.requires("aws-crt-cpp/0.17.12")
         else:
-            self.requires("aws-c-common/0.6.9")
             self.requires("aws-c-event-stream/0.1.5")
         if self.settings.os != "Windows":
             self.requires("openssl/1.1.1l")


### PR DESCRIPTION
Specify library name and version:  **aws-sdk-cpp/...**

The purpose of this pull request is to make the SDK compliant with the Apple Store which reject private API usage on MacOS and [iOS](https://github.com/aws/aws-sdk-cpp/issues/1619).

Switching to openssl fix the issue. This change seems reasonable since openssl is already in the recipe requirements.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
