### PR TITLE
add ddcutil/1.2.1

### DIFF
--- a/recipes/ddcutil/all/conandata.yml
+++ b/recipes/ddcutil/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "1.2.1":
+    url: "https://github.com/rockowitz/ddcutil/archive/refs/tags/v1.2.1.tar.gz"
+    sha256: "33108b541cb10fcb334eb47b9836315f43b216e6a1bd9316df5c6e1299f7fd57"
+patches:
+  "1.2.1":
+    - patch_file: "patches/0001-remove-werror-flag.patch"
+      base_path: "source_subfolder"

--- a/recipes/ddcutil/all/conanfile.py
+++ b/recipes/ddcutil/all/conanfile.py
@@ -9,7 +9,7 @@ class DdcutilConan(ConanFile):
     description = "ddcutil is a Linux program for managing monitor settings, such as brightness, color levels, and input source"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://www.ddcutil.com/"
-    topics = ("ddcutil", "display", "monitor", "settings", "Linux")
+    topics = ("ddcutil", "display", "monitor", "settings", "linux")
     license = "GPL-2.0-or-later"
     
     settings = "os", "compiler", "build_type", "arch"

--- a/recipes/ddcutil/all/conanfile.py
+++ b/recipes/ddcutil/all/conanfile.py
@@ -1,0 +1,114 @@
+from conans import ConanFile, tools, AutoToolsBuildEnvironment
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+class DdcutilConan(ConanFile):
+    name = "ddcutil"
+    description = "ddcutil is a Linux program for managing monitor settings, such as brightness, color levels, and input source"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://www.ddcutil.com/"
+    topics = ("ddcutil", "display", "monitor", "settings", "Linux")
+    license = "GPL-2.0-or-later"
+    
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    exports_sources = ["patches/*"]
+    generators = "pkg_config"
+    _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+    
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def requirements(self):
+        self.requires("glib/2.70.1")
+        self.requires("i2c-tools/4.3")
+        self.requires("libdrm/2.4.109")
+        self.requires("libkmod/system")
+        self.requires("libudev/system")
+        self.requires("libusb/1.0.24")
+        self.requires("xorg/system")
+        self.requires("zlib/1.2.11")
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("ddcutil is only available for Linux")
+
+    def build_requirements(self):
+        self.build_requires("autoconf/2.71")
+        self.build_requires("automake/1.16.4")
+        self.build_requires("libtool/2.4.6")
+        self.build_requires("m4/1.4.19")
+        self.build_requires("pkgconf/1.7.4")    
+    
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def system_requirements(self):
+        packages = []
+        if tools.os_info.is_linux and self.settings.os == "Linux":
+            if tools.os_info.with_yum:
+                packages = ["hwdata", "libgudev"]
+            elif tools.os_info.with_apt:
+                packages = ["hwdata", "libgudev-1.0-dev"]
+            elif tools.os_info.with_pacman:
+                packages = ["hwids", "libgudev"]
+            elif tools.os_info.with_zypper:
+                packages = ["hwdata", "libgudev-1_0-0"]
+            else:
+                self.output.warn("Don't know how to install %s for your distro." % self.name)
+        if packages:
+            package_tool = tools.SystemPackageTool(conanfile=self, default_mode='verify')
+            for p in packages:
+                package_tool.install(update=True, packages=p)
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self)
+        conf_args = []
+        if self.options.shared:
+            conf_args.extend(["--enable-shared", "--disable-static"])
+        else:
+            conf_args.extend(["--disable-shared", "--enable-static"])
+        with tools.environment_append(tools.RunEnvironment(self).vars):
+            self._autotools.configure(configure_dir=self._source_subfolder, args=conf_args)
+        return self._autotools
+
+    def build(self):
+        for patch in self.conan_data["patches"].get(self.version, []):
+            tools.patch(**patch)
+        with tools.chdir(self._source_subfolder):
+            self.run("{} -fiv".format(tools.get_env("AUTORECONF")))
+        autotools = self._configure_autotools()
+        autotools.make()
+
+    def package(self):
+        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
+        autotools = self._configure_autotools()
+        autotools.install()
+        if not self.options.shared and tools.Version(self.version) <= "1.2.2":
+            # see https://github.com/rockowitz/ddcutil/issues/242
+            self.copy("*/libddcutil.a", dst="lib", src="./", keep_path=False)
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        if self.settings.os == "Linux":
+            self.cpp_info.libs.extend(["pthread"])

--- a/recipes/ddcutil/all/patches/0001-remove-werror-flag.patch
+++ b/recipes/ddcutil/all/patches/0001-remove-werror-flag.patch
@@ -1,0 +1,26 @@
+diff --git a/a/src/app_sysenv/Makefile.am b/b/src/app_sysenv/Makefile.am
+index 4377284..cdf47a6 100644
+--- a/a/src/app_sysenv/Makefile.am
++++ b/b/src/app_sysenv/Makefile.am
+@@ -12,7 +12,7 @@ endif
+ 
+ 
+ AM_CFLAGS = -Wall 
+-AM_CFLAGS += -Werror
++# AM_CFLAGS += -Werror
+ # AM_CFLAGS += -Wpedantic
+ 
+ if ENABLE_CALLGRAPH_COND
+diff --git a/a/src/i2c/Makefile.am b/b/src/i2c/Makefile.am
+index 5bd2e1d..7889c96 100644
+--- a/a/src/i2c/Makefile.am
++++ b/b/src/i2c/Makefile.am
+@@ -4,7 +4,7 @@ AM_CPPFLAGS =        \
+   -I$(top_srcdir)/src/public
+ 
+ AM_CFLAGS = -Wall 
+-AM_CFLAGS += -Werror
++# AM_CFLAGS += -Werror
+ # AM_CFLAGS += -Wpedantic
+ 
+ if ENABLE_CALLGRAPH_COND

--- a/recipes/ddcutil/all/test_package/CMakeLists.txt
+++ b/recipes/ddcutil/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(ddcutil REQUIRED CONFIG)
+
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ddcutil::ddcutil)

--- a/recipes/ddcutil/all/test_package/conanfile.py
+++ b/recipes/ddcutil/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/ddcutil/all/test_package/test_package.c
+++ b/recipes/ddcutil/all/test_package/test_package.c
@@ -1,0 +1,96 @@
+/* clmain.c
+ *
+ * Framework for test code
+ *
+ * <copyright>
+ * Copyright (C) 2014-2020 Sanford Rockowitz <rockowitz@minsoft.com>
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * </endcopyright>
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "ddcutil_c_api.h"
+
+
+#define DDC_ERRMSG(function_name,status_code) \
+   printf("(%s) %s() returned %d (%s): %s\n",      \
+          __func__, function_name, status_code,    \
+          ddca_rc_name(status_code),      \
+          ddca_rc_desc(status_code))
+
+
+int main(int argc, char** argv) {
+   printf("\n(%s) Starting.\n", __func__);
+
+   ddca_reset_stats();
+
+   DDCA_Status rc;
+
+   DDCA_Display_Ref dref;
+   DDCA_Display_Handle dh = NULL;  // initialize to avoid clang analyzer warning
+
+   DDCA_Display_Info_List* dlist = NULL;
+   ddca_get_display_info_list2(
+         false,    // don't include invalid displays
+         &dlist);
+
+   for (int ndx = 0; ndx <  dlist->ct; ndx++) {
+      DDCA_Display_Info * dinfo = &dlist->info[ndx];
+      ddca_report_display_info(dinfo, /* depth=*/ 1);
+      printf("\n(%s) ===> Test loop for display %d\n", __func__, dinfo->dispno);
+
+#ifdef ALT
+      DDCA_Display_Identifier did = NULL;
+      printf("Create a Display Identifier for display %d...\n", dispno);
+      rc = ddca_create_dispno_display_identifier(dispno, &did);
+
+      printf("Create a display reference from the display identifier...\n");
+      rc = ddca_get_display_ref(did, &dref);
+      assert(rc == 0);
+
+      rc = ddca_free_display_identifier(did);
+      printf("ddca_free_display_identifier() returned %d\n", rc);
+#endif
+
+      dref = dinfo->dref;
+
+      printf("Open the display reference, creating a display handle...\n");
+      rc = ddca_open_display2(dref, false, &dh);
+      if (rc != 0) {
+         DDC_ERRMSG("ddca_open_display2", rc);
+         continue;
+      }
+      printf("(%s) Opened display handle: %s\n", __func__, ddca_dh_repr(dh));
+
+      //
+      //  Insert test code here
+      //
+
+      rc = ddca_close_display(dh);
+      if (rc != 0)
+         DDC_ERRMSG("ddca_close_display", rc);
+   }
+
+   ddca_show_stats(DDCA_STATS_ALL, /*by_thread=*/false, 0);
+   return 0;
+}

--- a/recipes/ddcutil/config.yml
+++ b/recipes/ddcutil/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.2.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **ddcutil/1.2.1**

Adding recipe for [ddcutil](https://github.com/rockowitz/ddcutil). (example usage of this library is to control display brightness on Linux)

---

- [✓] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [✓] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [✓] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [✓] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
