### PR TITLE
glfw: bump conan version to >1.43.0 because of set_property

### DIFF
--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -2,8 +2,7 @@ from conans import ConanFile, CMake, tools
 import os
 import textwrap
 
-# TODO: bump to 1.43.0 due to set_property()
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class GlfwConan(ConanFile):


### PR DESCRIPTION
Bumping conan version adding set_property with absolute targets.