### PR TITLE
sqlite3 use different name for bin target to avoid collision in pdb file names

### DIFF
--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -150,7 +150,6 @@ install(DIRECTORY source_subfolder/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 if(SQLITE3_BUILD_EXECUTABLE)
     add_executable(sqlite3-bin source_subfolder/shell.c)
     target_link_libraries(sqlite3-bin PRIVATE ${PROJECT_NAME})
-    set_target_properties(sqlite3-bin PROPERTIES OUTPUT_NAME "sqlite3")
     include(CheckSymbolExists)
     check_symbol_exists(system "stdlib.h" HAVE_SYSTEM)
     if(NOT HAVE_SYSTEM)

--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -150,6 +150,7 @@ install(DIRECTORY source_subfolder/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 if(SQLITE3_BUILD_EXECUTABLE)
     add_executable(sqlite3-bin source_subfolder/shell.c)
     target_link_libraries(sqlite3-bin PRIVATE ${PROJECT_NAME})
+    set_target_properties(sqlite3-bin PROPERTIES OUTPUT_NAME "sqlite3" PDB_NAME "sqlite3-bin")
     include(CheckSymbolExists)
     check_symbol_exists(system "stdlib.h" HAVE_SYSTEM)
     if(NOT HAVE_SYSTEM)


### PR DESCRIPTION
**sqlite3/3.36.0**

Using the same target name for the library and the executable will lead to collision in pdb file names on windows.

sqlite3.exe will generate sqlite3.pdb
sqlite3.dll will generate sqlite3.pdb

pdb files override each other.
 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
