### PR TITLE
Update changelog - 29-December-2021 - 16:41 CET

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 29-December-2021 - 16:41 CET
+
+- [config] Add Linux GCC 11, Clang 12 & 13 configurations with new epoch feature.
+- [config] Drop Linux GCC 6 and clang 10 configurations.
+- [fix] Fixed some unexpected errors.
+- [feature] Prepare pipeline to work with ansible provisioned machines.
+
 ### 17-December-2021 - 09:56 CET
 
 - [feature] Introduce 'epoch' concept to build configurations as a strategy to build packages for new compilers.


### PR DESCRIPTION
### 29-December-2021 - 16:41 CET

- [config] Add Linux GCC 11, Clang 12 & 13 configurations with new epoch feature.
- [config] Drop Linux GCC 6 and clang 10 configurations.
- [fix] Fixed some unexpected errors.
- [feature] Prepare pipeline to work with ansible provisioned machines.


---

In this deployment, we are introducing a new feature that will help us to evolve ConanCenter. We've called it **epochs** and I think it deserves some explanation here.

### The problem

Whenever we want to add a new compiler version we need to follow the dependency-graph order, so all the binary packages from the requirements are already available when trying to build some consumer library. 

In the past we used to generate these new configurations behind the scenes. After any successful build of a PR, we triggered a pipeline in the backstage to generate those configurations, but we didn't report its state. Contributors shouldn't be bothered by these new compilers, otherwise they would need to create a full chain of PRs just to make their PR happy.

### Before

To help with that process, we forced the generation of binaries using some batch processes behind the scenes (and manual annotations) and fixed recipes if needed. When this has happened, you have seen many PRs from our side fixing those configurations (remember the journey to generate M1 binaries)

![image](https://user-images.githubusercontent.com/1406456/147753217-70cc1cbe-e90d-4a3f-b0fb-61b22c35dfea.png)

This approach was good enough, but it had one major drawback... as these new configurations were not enforced in PRs, any contributor could unexpectedly break some recipe that was already fixed, and break all the consumers (missing binaries). So we needed to run and check all the graph in order again and again.

### Epochs

With epochs, new compilers are listed in a new epoch. Every time we are about to build a PR we check the epoch of all the requirements and select the newest one. So, if all the requirements are already in a new epoch, the PR will use that new epoch and will try to build the new configurations.

With this process we achieve two objectives:
 * PRs will be tested for new compilers if the requirements already have their binaries available. Contributors will get feedback about them and their PR will fail if those new configurations fail.
 * Once a reference has been moved to a new epoch, it never goes back. Once we have fixed a recipe for some new configuration, it will always be validated in the following PRs, so there won't be steps back.

This is completely transparent to users. You will get the same notifications in your PR. Eventually of the references will be moved to new epochs just by creating regular PRs. Of course there is no magic here, those PRs need to happen, and we will need to force some compilations behind the scenes to move existing libraries to new epochs, but at least 
> Once a reference has been moved to a new epoch, it never goes back. Once we have fixed a recipe for some new configuration, it will always be validated in the following PRs, so there won't be steps back.

This is very important to us, as it removes the need for those _crunches_ when we wanted to add new compilers. Now we can add new versions at any time and generation of binaries is decoupled in time.

--- 

Random FAQ:
 * Can I know which epoch is being used in my PR? 
 
   Not directly, but in the report you can check the compilers and versions that are being built. Newer epochs always contain more compilers/versions.

 * Can I know which requirement is blocking other consumers to move to a new epoch?
 
   Not yet, but we are thinking about how to provide this information (maybe something like https://github.com/conan-io/conan-center-index/pull/2232), because we are sure that you will help us to move those reference forward.

 * Can I know the compilers and version that are used for each epoch?
 
   We really need to improve the output from this automation: https://github.com/conan-io/conan-center-index/pull/8579

---

As always, feedback is more than welcome. And feel free to ask anything about this new feature... or to suggest other ideas around it. We are building together a game-changer for C++ developers. You, contributors, rock! 😊 

As a final note, special thanks to the people that are working on these features (and not only these), developing, testing and coming up with the ideas: @danimtb , @SSE4 and @uilianries . 

And Happy New Year!! 🎉 🎉  <sup>(this should be the last release of 2021 🤞 )</sup>