### PR TITLE
Fix libjpeg-turbo build for Android

### DIFF
--- a/recipes/libjpeg-turbo/all/CMakeLists.txt
+++ b/recipes/libjpeg-turbo/all/CMakeLists.txt
@@ -5,4 +5,9 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup(NO_OUTPUT_DIRS)
 
+if(NOT CMAKE_SYSTEM_PROCESSOR)
+    set(CMAKE_SYSTEM_PROCESSOR ${CONAN_LIBJPEG_SYSTEM_PROCESSOR})
+endif()
+
+
 add_subdirectory("source_subfolder")

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -123,7 +123,7 @@ class LibjpegTurboConan(ConanFile):
                 "armv8": "aarch64",
                 "armv8.3": "aarch64",
             }.get(str(self.settings.arch), str(self.settings.arch))
-            self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = cmake_system_processor
+            self._cmake.definitions["CONAN_LIBJPEG_SYSTEM_PROCESSOR"] = cmake_system_processor
 
         self._cmake.configure()
         return self._cmake


### PR DESCRIPTION
It didn't work for Android/armv7 because the recipe specifies
CMAKE_SYSTEM_PROCESSOR=armv7 which is not known to Android NDK CMake scripts.
However Conan specifies enough details to CMake in Android build, so there's
no need to specify CMAKE_SYSTEM_PROCESSOR manually.

Specify library name and version:  **libjpeg-turbo/2.1.2**

---

- [x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
