### PR TITLE
add scdoc documentation tool

### DIFF
--- a/recipes/scdoc/all/conandata.yml
+++ b/recipes/scdoc/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.11.12":
+    url: "https://git.sr.ht/~sircmpwn/scdoc/archive/1.11.2.tar.gz"
+    sha256: "e9ff9981b5854301789a6778ee64ef1f6d1e5f4829a9dd3e58a9a63eacc2e6f0"

--- a/recipes/scdoc/all/conanfile.py
+++ b/recipes/scdoc/all/conanfile.py
@@ -1,0 +1,79 @@
+from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class ScdocInstallerConan(ConanFile):
+    name = "scdoc"
+    description = "scdoc is a simple man page generator for POSIX systems written in C99."
+    topics = ("manpage", "documentation", "posix")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://git.sr.ht/~sircmpwn/scdoc"
+    license = "MIT"
+    settings = "os", "arch", "compiler", "build_type"
+    _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def build_requirements(self):
+        self.build_requires("make/4.3")
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def package_id(self):
+        del self.info.settings.compiler
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True,
+                  destination=self._source_subfolder)
+
+    @staticmethod
+    def _chmod_plus_x(filename):
+        if os.name == "posix":
+            os.chmod(filename, os.stat(filename).st_mode | 0o111)
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self)
+        return self._autotools
+
+    def build(self):
+        autotools = self._configure_autotools()
+        with tools.chdir(self._source_subfolder):
+            autotools.make()
+
+    def package(self):
+        autotools = self._configure_autotools()
+        with tools.chdir(self._source_subfolder):
+            autotools.install(args=[f"PREFIX={self.package_folder}"])
+        self.copy(pattern="COPYING", dst="licenses",
+                  src=self._source_subfolder)
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.libdirs = []
+
+        scdoc_root = os.path.join(self.package_folder, "bin")
+        self.output.info(
+            "Appending PATH environment variable: {}".format(scdoc_root))
+        self.env_info.PATH.append(scdoc_root)
+        self._chmod_plus_x(os.path.join(scdoc_root, "scdoc"))
+        pkgconfig_variables = {
+            'exec_prefix': '${prefix}/bin',
+            'scdoc': '${exec_prefix}/scdoc',
+        }
+        self.cpp_info.set_property(
+            "pkg_config_custom_content",
+            "\n".join("%s=%s" % (key, value) for key,value in pkgconfig_variables.items()))
+
+    def validate(self):
+        if self.settings.os in ["Macos", "Windows"]:
+            raise ConanInvalidConfiguration(
+                f"Builds aren't supported on {self.settings.os}")

--- a/recipes/scdoc/all/test_package/conanfile.py
+++ b/recipes/scdoc/all/test_package/conanfile.py
@@ -1,0 +1,10 @@
+from conans import ConanFile, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run(
+                f"scdoc < {os.path.join(self.source_folder,'test_package.1.scd')}", run_environment=True)

--- a/recipes/scdoc/all/test_package/test_package.1.scd
+++ b/recipes/scdoc/all/test_package/test_package.1.scd
@@ -1,0 +1,9 @@
+test_package(1)
+
+# NAME
+
+test_package - This is a test package for scdoc
+
+# DESCRIPTION
+
+This is a simple scd file for test_package.

--- a/recipes/scdoc/config.yml
+++ b/recipes/scdoc/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.11.12":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **scdoc/1.11.12**

I am not the author of the tool but I need it for some of my projects.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
