### PR TITLE
mpdecimal: Enable build on Apple Silicon (M1)

### DIFF
--- a/recipes/mpdecimal/2.4.2/conanfile.py
+++ b/recipes/mpdecimal/2.4.2/conanfile.py
@@ -163,6 +163,8 @@ class MpdecimalConan(ConanFile):
         if self._autotools:
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            self._autotools.link_flags.append("-arch arm64")
         self._autotools .configure()
         return self._autotools
 

--- a/recipes/mpdecimal/2.4.2/conanfile.py
+++ b/recipes/mpdecimal/2.4.2/conanfile.py
@@ -30,7 +30,7 @@ class MpdecimalConan(ConanFile):
     _autotools = None
 
     def configure(self):
-        if self.settings.arch not in ("x86", "x86_64"):
+        if self.settings.os != "Macos" and self.settings.arch not in ("x86", "x86_64"):
             raise ConanInvalidConfiguration("Arch is unsupported")
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd

--- a/recipes/mpdecimal/2.4.2/conanfile.py
+++ b/recipes/mpdecimal/2.4.2/conanfile.py
@@ -34,6 +34,8 @@ class MpdecimalConan(ConanFile):
             raise ConanInvalidConfiguration("Arch is unsupported")
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+        if self.options.shared:
+            del self.options.fPIC
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -123,6 +123,8 @@ class MpdecimalConan(ConanFile):
         if self._autotools:
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            self._autotools.link_flags.append("-arch arm64")
         conf_args = [
             "--enable-cxx" if self.options.cxx else "--disable-cxx"
         ]

--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -123,12 +123,14 @@ class MpdecimalConan(ConanFile):
         if self._autotools:
             return self._autotools
         self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        conf_vars = self._autotools.vars
         if self.settings.os == "Macos" and self.settings.arch == "armv8":
-            self._autotools.link_flags.append("-arch arm64")
+            conf_vars["LDFLAGS"] += " -arch arm64"
+            conf_vars["LDXXFLAGS"] = "-arch arm64"
         conf_args = [
             "--enable-cxx" if self.options.cxx else "--disable-cxx"
         ]
-        self._autotools.configure(args=conf_args)
+        self._autotools.configure(args=conf_args, vars=conf_vars)
         return self._autotools
 
     @property

--- a/recipes/mpdecimal/2.5.x/conanfile.py
+++ b/recipes/mpdecimal/2.5.x/conanfile.py
@@ -55,7 +55,7 @@ class MpdecimalConan(ConanFile):
                 self.build_requires("msys2/cci.latest")
 
     def validate(self):
-        if self.settings.arch not in ("x86", "x86_64"):
+        if self.settings.os != "Macos" and self.settings.arch not in ("x86", "x86_64"):
             raise ConanInvalidConfiguration("Arch is unsupported")
         if self.options.cxx:
             if self.options.shared and self.settings.os == "Windows":

--- a/recipes/mpdecimal/2.5.x/test_package/CMakeLists.txt
+++ b/recipes/mpdecimal/2.5.x/test_package/CMakeLists.txt
@@ -4,6 +4,11 @@ project(test_package)
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup(TARGETS)
 
+# Workaround for -rpath on arm64: https://cmake.org/cmake/help/latest/release/3.20.html#id2
+if(CMAKE_VERSION VERSION_LESS "3.20.1" AND CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+    set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
+endif()
+
 # This is a non-official mpdecimal module!
 find_package(mpdecimal REQUIRED)
 


### PR DESCRIPTION
Specify library name and version:  **mpdecimal/all**

This PR enables building `mpdecimal` on Apple ARM. Previously, the recipe explicitly disabled non-x86 architectures, however `mpdecimal` itself supports pretty much everything. I suspect that non-x86 was originally disabled because of MSVC build complications, as I see that x86 and x64 are explicitly mentioned in the MSVC-specific bits of the recipe.

Simply dropping this check on macOS, produces a good build on Apple ARM64 CPUs. Tested on my M1 Mac.

I suspect that Linux ARM64 would also work fine but I can't verify this so I've only enabled it for macOS.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
