### PR TITLE
nanobench: add version 4.3.6

### DIFF
--- a/recipes/nanobench/all/conandata.yml
+++ b/recipes/nanobench/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "4.3.5":
     url: "https://github.com/martinus/nanobench/archive/v4.3.5.tar.gz"
     sha256: "205e6cf0ea901f64af971335bfe8011c1f6bd66f6ae678c616da0eddfbe70437"
+  "4.3.6":
+    url: "https://github.com/martinus/nanobench/archive/v4.3.6.tar.gz"
+    sha256: "cfa223fefca8752c0c96416f3440a9b02219f4695a8307db7e8c7054aaed7f01"

--- a/recipes/nanobench/config.yml
+++ b/recipes/nanobench/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: "all"
   "4.3.5":
     folder: "all"
+  "4.3.6":
+    folder: "all"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **nanobench/4.3.6**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
