### PR TITLE
Add catch2:default_reporter option

### DIFF
--- a/recipes/catch2/2.x.x/conandata.yml
+++ b/recipes/catch2/2.x.x/conandata.yml
@@ -44,7 +44,7 @@ sources:
   2.13.6:
     url: https://github.com/catchorg/Catch2/archive/v2.13.6.tar.gz
     sha256: 48dfbb77b9193653e4e72df9633d2e0383b9b625a47060759668480fdf24fbd4
-  "2.13.7":
+  2.13.7:
     url: "https://github.com/catchorg/Catch2/archive/v2.13.7.tar.gz"
     sha256: "3cdb4138a072e4c0290034fe22d9f0a80d3bcfb8d7a8a5c49ad75d3a5da24fae"
 patches:

--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -38,6 +38,10 @@ class ConanRecipe(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    @property
+    def _default_reporter_str(self):
+        return '"{}"'.format(str(self.options.default_reporter).strip('"'))
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -46,9 +50,6 @@ class ConanRecipe(ConanFile):
         if not self.options.with_main:
             del self.options.fPIC
             del self.options.with_benchmark
-        if self.options.default_reporter:
-            if '"' not in str(self.options.default_reporter):
-                self.options.default_reporter = '"{}"'.format(self.options.default_reporter)
 
     def validate(self):
         if tools.Version(self.version) < "2.13.1" and self.settings.arch == "armv8":
@@ -70,7 +71,7 @@ class ConanRecipe(ConanFile):
         self._cmake.definitions["enable_benchmark"] = self.options.get_safe("with_benchmark", False)
         self._cmake.definitions["CATCH_CONFIG_PREFIX_ALL"] = self.options.with_prefix
         if self.options.default_reporter:
-            self._cmake.definitions["CATCH_CONFIG_DEFAULT_REPORTER"] = self.options.default_reporter
+            self._cmake.definitions["CATCH_CONFIG_DEFAULT_REPORTER"] = self._default_reporter_str
 
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
@@ -130,4 +131,4 @@ class ConanRecipe(ConanFile):
         if self.options.with_prefix:
             defines.append("CATCH_CONFIG_PREFIX_ALL")
         if self.options.default_reporter:
-            defines.append("CATCH_CONFIG_DEFAULT_REPORTER={}".format(self.options.default_reporter))
+            defines.append("CATCH_CONFIG_DEFAULT_REPORTER={}".format(self._default_reporter_str))

--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -19,12 +19,14 @@ class ConanRecipe(ConanFile):
         "with_main": [True, False],
         "with_benchmark": [True, False],
         "with_prefix": [True, False],
+        "default_reporter": "ANY",
     }
     default_options = {
         "fPIC": True,
         "with_main": False,
         "with_benchmark": False,
         "with_prefix": False,
+        "default_reporter": None,
     }
     _cmake = None
 
@@ -44,6 +46,9 @@ class ConanRecipe(ConanFile):
         if not self.options.with_main:
             del self.options.fPIC
             del self.options.with_benchmark
+        if self.options.default_reporter:
+            if '"' not in str(self.options.default_reporter):
+                self.options.default_reporter = '"{}"'.format(self.options.default_reporter)
 
     def validate(self):
         if tools.Version(self.version) < "2.13.1" and self.settings.arch == "armv8":
@@ -64,6 +69,8 @@ class ConanRecipe(ConanFile):
         self._cmake.definitions["CATCH_BUILD_STATIC_LIBRARY"] = self.options.with_main
         self._cmake.definitions["enable_benchmark"] = self.options.get_safe("with_benchmark", False)
         self._cmake.definitions["CATCH_CONFIG_PREFIX_ALL"] = self.options.with_prefix
+        if self.options.default_reporter:
+            self._cmake.definitions["CATCH_CONFIG_DEFAULT_REPORTER"] = self.options.default_reporter
 
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
@@ -112,12 +119,15 @@ class ConanRecipe(ConanFile):
             self.cpp_info.components["Catch2WithMain"].system_libs = ["log"] if self.settings.os == "Android" else []
             self.cpp_info.components["Catch2WithMain"].names["cmake_find_package"] = "Catch2WithMain"
             self.cpp_info.components["Catch2WithMain"].names["cmake_find_package_multi"] = "Catch2WithMain"
-            if self.options.get_safe("with_benchmark", False):
-                self.cpp_info.components["Catch2WithMain"].defines.append("CATCH_CONFIG_ENABLE_BENCHMARKING")
-            if self.options.with_prefix:
-                self.cpp_info.components["Catch2WithMain"].defines.append("CATCH_CONFIG_PREFIX_ALL")
+            defines = self.cpp_info.components["Catch2WithMain"].defines
         else:
             self.cpp_info.builddirs = [os.path.join("lib", "cmake", "Catch2")]
             self.cpp_info.system_libs = ["log"] if self.settings.os == "Android" else []
-            if self.options.with_prefix:
-                self.cpp_info.defines.append("CATCH_CONFIG_PREFIX_ALL")
+            defines = self.cpp_info.defines
+
+        if self.options.get_safe("with_benchmark", False):
+            defines.append("CATCH_CONFIG_ENABLE_BENCHMARKING")
+        if self.options.with_prefix:
+            defines.append("CATCH_CONFIG_PREFIX_ALL")
+        if self.options.default_reporter:
+            defines.append("CATCH_CONFIG_DEFAULT_REPORTER={}".format(self.options.default_reporter))

--- a/recipes/catch2/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/catch2/2.x.x/test_package/CMakeLists.txt
@@ -3,7 +3,6 @@ project(test_package)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_EXPORT_COMPILE_COMMANDS YES)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/catch2/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/catch2/2.x.x/test_package/CMakeLists.txt
@@ -3,6 +3,7 @@ project(test_package)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS YES)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/catch2/2.x.x/test_package/test_all.sh
+++ b/recipes/catch2/2.x.x/test_package/test_all.sh
@@ -6,3 +6,4 @@ conan test $DIR $1 --build=catch2
 conan test $DIR $1 --build=catch2 -o catch2:with_main=True -o catch2:with_benchmark=True 
 conan test $DIR $1 --build=catch2 -o catch2:with_prefix=True 
 conan test $DIR $1 --build=catch2 -o catch2:with_main=True -o catch2:with_prefix=True 
+conan test $DIR $1 --build=catch2 -o catch2:default_reporter=xml

--- a/recipes/catch2/2.x.x/test_package/test_all.sh
+++ b/recipes/catch2/2.x.x/test_package/test_all.sh
@@ -7,3 +7,4 @@ conan test $DIR $1 --build=catch2 -o catch2:with_main=True -o catch2:with_benchm
 conan test $DIR $1 --build=catch2 -o catch2:with_prefix=True 
 conan test $DIR $1 --build=catch2 -o catch2:with_main=True -o catch2:with_prefix=True 
 conan test $DIR $1 --build=catch2 -o catch2:default_reporter=xml
+conan test $DIR $1 --build=catch2 -o catch2:with_main=True -o catch2:default_reporter=xml


### PR DESCRIPTION
Specify library name and version:  **catch2/2.13.7**

See https://github.com/catchorg/Catch2/blob/v2.x/docs/configuration.md#default-reporter

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
