### PR TITLE
cpython: Add PATH variable only if env_vars option is enabled.

### DIFF
--- a/recipes/cpython/all/conanfile.py
+++ b/recipes/cpython/all/conanfile.py
@@ -700,9 +700,10 @@ class CPythonConan(ConanFile):
                 self.cpp_info.components["_hidden"].requires.append("tk::tk")
             self.cpp_info.components["_hidden"].libdirs = []
 
-        bindir = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable: {}".format(bindir))
-        self.env_info.PATH.append(bindir)
+        if self.options.env_vars:
+            bindir = os.path.join(self.package_folder, "bin")
+            self.output.info("Appending PATH environment variable: {}".format(bindir))
+            self.env_info.PATH.append(bindir)
 
         python = self._cpython_interpreter_path
         self.user_info.python = python
@@ -724,7 +725,7 @@ class CPythonConan(ConanFile):
 
         if self.settings.compiler == "Visual Studio":
             if self.options.env_vars:
-                self.output.info("Setting PYTHON environment variable: {}".format(pythonhome))
+                self.output.info("Setting PYTHONHOME environment variable: {}".format(pythonhome))
                 self.env_info.PYTHONHOME = pythonhome
 
         if self._is_py2:


### PR DESCRIPTION
Specify library name and version:  **cpython/3.10.0**

Currently when `env_vars` option is off the `PATH` variable still gets expanded with `python` executable path. This may hijack system Python depending on PATH order in `activate_run` etc. Moreover since `PYTHONHOME`/`PYTHON_ROOT` are not defined that Conan Python is broken as it tries to load wrong system Python standard libraries. This PR proposes to only expand PATH when `env_vars` is enabled. Thoughts?

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
