### PR TITLE
opencv/4.x: add possibility to set cpu_baseline and cpu_dispatch

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -44,7 +44,8 @@ class OpenCVConan(ConanFile):
         "neon": [True, False],
         "dnn": [True, False],
         "dnn_cuda": [True, False],
-        "detect_cpu_baseline": [True, False],
+        "cpu_baseline": "ANY",
+        "cpu_dispatch": "ANY",
         "nonfree": [True, False],
     }
     default_options = {
@@ -77,7 +78,8 @@ class OpenCVConan(ConanFile):
         "neon": True,
         "dnn": True,
         "dnn_cuda": False,
-        "detect_cpu_baseline": False,
+        "cpu_baseline": None,
+        "cpu_dispatch": None,
         "nonfree": False,
     }
 
@@ -382,8 +384,11 @@ class OpenCVConan(ConanFile):
         self._cmake.definitions["OPENCV_MODULES_PUBLIC"] = "opencv"
         self._cmake.definitions["OPENCV_ENABLE_NONFREE"] = self.options.nonfree
 
-        if self.options.detect_cpu_baseline:
-            self._cmake.definitions["CPU_BASELINE"] = "DETECT"
+        if self.options.cpu_baseline:
+            self._cmake.definitions["CPU_BASELINE"] = self.options.cpu_baseline
+
+        if self.options.cpu_dispatch:
+            self._cmake.definitions["CPU_DISPATCH"] = self.options.cpu_dispatch
 
         if self.options.get_safe("neon") is not None:
             self._cmake.definitions["ENABLE_NEON"] = self.options.get_safe("neon")


### PR DESCRIPTION
Mirror cpu_baseline and cpu_dispatch capability from OpenCV. 

Options are available since 3.3

https://github.com/opencv/opencv/wiki/CPU-optimizations-build-options#customizing-cmake-options
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
