### PR TITLE
cspice: add 0067 + modernize

### DIFF
--- a/recipes/cspice/all/CMakeLists.txt
+++ b/recipes/cspice/all/CMakeLists.txt
@@ -50,7 +50,7 @@ install(FILES ${INCLUDE_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 if(BUILD_UTILITIES)
   # csupport is common to all utilities
   file(GLOB CSUPPORT_SRC_FILES "${SRC_DIR}/csupport/*.c")
-  add_library(csupport OBJECT ${CSUPPORT_SRC_FILES})
+  add_library(csupport STATIC ${CSUPPORT_SRC_FILES})
 
   # Walk into all utilities subfolders and build them (except cook_c which only contains examples)
   file(GLOB CSPICE_UTILITIES_SUBDIRS RELATIVE ${SRC_DIR} "${SRC_DIR}/*_c")

--- a/recipes/cspice/all/CMakeLists.txt
+++ b/recipes/cspice/all/CMakeLists.txt
@@ -9,15 +9,25 @@ include(GNUInstallDirs)
 option(BUILD_UTILITIES "Build cspice utilities" ON)
 
 add_compile_options(
-  $<$<AND:$<C_COMPILER_ID:AppleClang>,$<VERSION_GREATER_EQUAL:${CMAKE_C_COMPILER_VERSION},12>>:-Wno-error=implicit-function-declaration>
+  $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:AppleClang>>:-Wno-implicit-int>
+  $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:AppleClang>>:-Wno-format>
+  $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:AppleClang>>:-Wno-pointer-to-int-cast>
   $<$<C_COMPILER_ID:AppleClang>:-Wno-logical-op-parentheses>
   $<$<C_COMPILER_ID:AppleClang>:-Wno-shift-op-parentheses>
   $<$<C_COMPILER_ID:AppleClang>:-Wno-parentheses>
   $<$<C_COMPILER_ID:AppleClang>:-Wno-dangling-else>
   $<$<C_COMPILER_ID:AppleClang>:-Wno-unsequenced>
-  $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:AppleClang>>:-Wno-implicit-int>
-  $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:AppleClang>>:-Wno-format>
-  $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:AppleClang>>:-Wno-pointer-to-int-cast>
+  $<$<C_COMPILER_ID:MSVC>:/wd4101>
+  $<$<C_COMPILER_ID:MSVC>:/wd4244>
+  $<$<C_COMPILER_ID:MSVC>:/wd4267>
+  $<$<C_COMPILER_ID:MSVC>:/wd4311>
+  $<$<C_COMPILER_ID:MSVC>:/wd4477>
+  $<$<C_COMPILER_ID:MSVC>:/wd4554>
+  $<$<C_COMPILER_ID:MSVC>:/wd4723>
+  $<$<C_COMPILER_ID:MSVC>:/wd4996>
+  # Behavior of implicitly defined functions changed in AppleClang 12
+  # https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes
+  $<$<AND:$<C_COMPILER_ID:AppleClang>,$<VERSION_GREATER_EQUAL:${CMAKE_C_COMPILER_VERSION},12>>:-Wno-error=implicit-function-declaration>
 )
 
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder/src)
@@ -26,7 +36,7 @@ file(GLOB CSPICE_SRC_FILES ${SRC_DIR}/cspice/*.c)
 add_library(cspice ${CSPICE_SRC_FILES})
 
 if(WIN32)
-  target_compile_definitions(cspice PRIVATE "_COMPLEX_DEFINED;MSDOS;OMIT_BLANK_CC;NON_ANSI_STDIO")
+  target_compile_definitions(cspice PRIVATE "_COMPLEX_DEFINED;MSDOS;OMIT_BLANK_CC;NON_ANSI_STDIO;_CRT_SECURE_NO_WARNINGS")
   set_target_properties(cspice PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 elseif(UNIX)
   target_compile_definitions(cspice PRIVATE "NON_UNIX_STDIO")

--- a/recipes/cspice/all/CMakeLists.txt
+++ b/recipes/cspice/all/CMakeLists.txt
@@ -4,6 +4,8 @@ project(cspice C)
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
+include(GNUInstallDirs)
+
 option(BUILD_UTILITIES "Build cspice utilities" ON)
 
 add_compile_options(
@@ -43,7 +45,7 @@ install(
 )
 
 file(GLOB INCLUDE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder/include/*.h)
-install(FILES ${INCLUDE_FILES} DESTINATION include)
+install(FILES ${INCLUDE_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(BUILD_UTILITIES)
   # csupport is common to all utilities

--- a/recipes/cspice/all/CMakeLists.txt
+++ b/recipes/cspice/all/CMakeLists.txt
@@ -1,10 +1,22 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.7)
 project(cspice C)
 
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 option(BUILD_UTILITIES "Build cspice utilities" ON)
+
+add_compile_options(
+  $<$<AND:$<C_COMPILER_ID:AppleClang>,$<VERSION_GREATER_EQUAL:${CMAKE_C_COMPILER_VERSION},12>>:-Wno-error=implicit-function-declaration>
+  $<$<C_COMPILER_ID:AppleClang>:-Wno-logical-op-parentheses>
+  $<$<C_COMPILER_ID:AppleClang>:-Wno-shift-op-parentheses>
+  $<$<C_COMPILER_ID:AppleClang>:-Wno-parentheses>
+  $<$<C_COMPILER_ID:AppleClang>:-Wno-dangling-else>
+  $<$<C_COMPILER_ID:AppleClang>:-Wno-unsequenced>
+  $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:AppleClang>>:-Wno-implicit-int>
+  $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:AppleClang>>:-Wno-format>
+  $<$<OR:$<C_COMPILER_ID:GNU>,$<C_COMPILER_ID:AppleClang>>:-Wno-pointer-to-int-cast>
+)
 
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder/src)
 
@@ -21,13 +33,6 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_link_libraries(cspice PRIVATE m)
-endif()
-
-# Behavior of implicitly defined functions changed in AppleClang 12
-# https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes
-if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND
-   CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "12")
-  target_compile_options(cspice PRIVATE -Wno-error=implicit-function-declaration)
 endif()
 
 install(

--- a/recipes/cspice/all/conandata.yml
+++ b/recipes/cspice/all/conandata.yml
@@ -1,4 +1,57 @@
 sources:
+  "0067":
+    url:
+      "Macos":
+        "apple-clang":
+          "x86_64": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/MacIntel_OSX_AppleC_64bit/packages/cspice.tar.Z"
+          "armv8": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/MacM1_OSX_clang_64bit/packages/cspice.tar.Z"
+      "Linux":
+        "gcc":
+          "x86": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/PC_Linux_GCC_32bit/packages/cspice.tar.Z"
+          "x86_64": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z"
+      "Windows":
+        "Visual Studio":
+          "x86": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/PC_Windows_VisualC_32bit/packages/cspice.zip"
+          "x86_64": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/PC_Windows_VisualC_64bit/packages/cspice.zip"
+        "msvc":
+          "x86": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/PC_Windows_VisualC_32bit/packages/cspice.zip"
+          "x86_64": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/PC_Windows_VisualC_64bit/packages/cspice.zip"
+      "cygwin":
+        "gcc":
+          "x86_64": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/PC_Cygwin_GCC_64bit/packages/cspice.tar.gz"
+      "SunOs":
+        "sun-cc":
+          "sparc": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/SunSPARC_Solaris_SunC_32bit/packages/cspice.tar.Z"
+          "sparcv9": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/SunSPARC_Solaris_SunC_64bit/packages/cspice.tar.Z"
+        "gcc":
+          "sparc": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/SunSPARC_Solaris_GCC_32bit/packages/cspice.tar.Z"
+          "sparcv9": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0067/C/SunSPARC_Solaris_GCC_64bit/packages/cspice.tar.Z"
+    sha256:
+      "Macos":
+        "apple-clang":
+          "x86_64": "6f4980445fee4d363dbce6f571819f4a248358d2c1bebca47e0743eedfe9935e"
+          "armv8": "0deae048443e11ca4d093cac651d9785d4f2594631a183d85a3d58949f4d0aa9"
+      "Linux":
+        "gcc":
+          "x86": "33d75cd94acf6546e53d7ebc4e7d3d6d42ac27c83cb0d8f04c91a8b50c1149e3"
+          "x86_64": "60a95b51a6472f1afe7e40d77ebdee43c12bb5b8823676ccc74692ddfede06ce"
+      "Windows":
+        "Visual Studio":
+          "x86": "bc566e6a975c888fc5fd89d76554329501446bda88c8bab937c0725faead170f"
+          "x86_64": "98d60b814b412fa55294aeaaeb7dab46d849cc87a8b709ffe835d08de17625dc"
+        "msvc":
+          "x86": "bc566e6a975c888fc5fd89d76554329501446bda88c8bab937c0725faead170f"
+          "x86_64": "98d60b814b412fa55294aeaaeb7dab46d849cc87a8b709ffe835d08de17625dc"
+      "cygwin":
+        "gcc":
+          "x86_64": "78ca611638653e1b86347d2b58d8bc761c256e5d0037314fcb7c3eedb3e981bd"
+      "SunOs":
+        "sun-cc":
+          "sparc": "382d6bc51312c0af8b52d6995c255a5af468551bb04c79fb2e6171dc10de95f3"
+          "sparcv9": "f2510faccdcfeb4ed75ed3fc377059629ae090c29e7d22189e0933e9a905143b"
+        "gcc":
+          "sparc": "b26c645d11b12f906c4283202d630c114710288531f2dfc118721b81de25722f"
+          "sparcv9": "b0936d1ef0973fcdbd2b204faacd128059d8a656d73e4f276dfc6709d8080eee"
   "0066":
     url:
       "Macos":
@@ -11,6 +64,9 @@ sources:
           "x86_64": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0066/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z"
       "Windows":
         "Visual Studio":
+          "x86": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0066/C/PC_Windows_VisualC_32bit/packages/cspice.zip"
+          "x86_64": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0066/C/PC_Windows_VisualC_64bit/packages/cspice.zip"
+        "msvc":
           "x86": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0066/C/PC_Windows_VisualC_32bit/packages/cspice.zip"
           "x86_64": "https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0066/C/PC_Windows_VisualC_64bit/packages/cspice.zip"
       "cygwin":
@@ -37,6 +93,9 @@ sources:
           "x86_64": "93cd4fbce5818f8b7fecf3914c5756b8d41fd5bdaaeac1f4037b5a5410bc4768"
       "Windows":
         "Visual Studio":
+          "x86": "db48e5beddc0e50f7a0224bb2c6f2b39fc38f84628ad5cd455e847fc70aa5e75"
+          "x86_64": "b29dfb0b41ae8322c60ee9d162beb97433d21e12843ecbe03d819e5edef45920"
+        "msvc":
           "x86": "db48e5beddc0e50f7a0224bb2c6f2b39fc38f84628ad5cd455e847fc70aa5e75"
           "x86_64": "b29dfb0b41ae8322c60ee9d162beb97433d21e12843ecbe03d819e5edef45920"
       "cygwin":

--- a/recipes/cspice/all/conandata.yml
+++ b/recipes/cspice/all/conandata.yml
@@ -112,6 +112,9 @@ sources:
           "sparc": "463c93a54f432fa41e1733bc4ec0e584f1017f48f84e0e9fafe4adc4163064c9"
           "sparcv9": "4e86fad7e8fa947abddd3d78174efc65476a3f54627747ffc2027ee572af48b3"
 patches:
+  "0067":
+    - patch_file: "patches/isatty.patch"
+      base_path: "source_subfolder"
   "0066":
     - patch_file: "patches/isatty.patch"
       base_path: "source_subfolder"

--- a/recipes/cspice/all/conanfile.py
+++ b/recipes/cspice/all/conanfile.py
@@ -77,7 +77,8 @@ class CspiceConan(ConanFile):
 
     def build(self):
         self._get_sources()
-        self._patch_sources()
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -96,15 +97,6 @@ class CspiceConan(ConanFile):
         else:
             tools.get(url, sha256=sha256)
         tools.rename(self.name, self._source_subfolder)
-
-    def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        # TODO: find a more elegant patch, there is likely some conflict between
-        #       fio.h and io.h in 0067 but the diff with 0066 is not obvious.
-        if str(self.settings.compiler) in ["Visual Studio", "msvc"] and self.version == "0067":
-            tools.replace_in_file(os.path.join(self._source_subfolder, "src", "cspice", "fio.h"),
-                                  "extern int isatty(int);", "")
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/cspice/all/conanfile.py
+++ b/recipes/cspice/all/conanfile.py
@@ -52,17 +52,17 @@ class CspiceConan(ConanFile):
         the_os = self._get_os_or_subsystem()
         if the_os not in sources_url_per_triplet:
             raise ConanInvalidConfiguration(
-                "cspice N{} does not support {0}".format(self.version, the_os)
+                "cspice N{0} does not support {1}".format(self.version, the_os)
             )
         compiler = str(self.settings.compiler)
         if compiler not in sources_url_per_triplet[the_os]:
             raise ConanInvalidConfiguration(
-                "cspice N{} does not support {0} on {1}".format(self.version, compiler, the_os)
+                "cspice N{0} does not support {1} on {2}".format(self.version, compiler, the_os)
             )
         arch = str(self.settings.arch)
         if arch not in sources_url_per_triplet[the_os][compiler]:
             raise ConanInvalidConfiguration(
-                "cspice N{} does not support {0} on {1} {2}".format(self.version, compiler, the_os, arch)
+                "cspice N{0} does not support {1} on {2} {3}".format(self.version, compiler, the_os, arch)
             )
 
     def _get_os_or_subsystem(self):

--- a/recipes/cspice/all/conanfile.py
+++ b/recipes/cspice/all/conanfile.py
@@ -1,34 +1,41 @@
-import os
-
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
 
 class CspiceConan(ConanFile):
     name = "cspice"
     description = "NASA C SPICE library"
     license = "TSPA"
-    topics = ("conan", "spice", "naif", "kernels", "space", "nasa", "jpl", "spacecraft", "planet", "robotics")
+    topics = ("spice", "naif", "kernels", "space", "nasa", "jpl", "spacecraft", "planet", "robotics")
     homepage = "https://naif.jpl.nasa.gov/naif/toolkit.html"
     url = "https://github.com/conan-io/conan-center-index"
-    exports_sources = ["CMakeLists.txt", "patches/**"]
-    generators = "cmake"
+
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "utilities": [True, False]
+        "utilities": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "utilities": True
+        "utilities": True,
     }
 
+    generators = "cmake"
     _cmake = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -39,9 +46,8 @@ class CspiceConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-        self._raise_if_not_supported_triplet()
 
-    def _raise_if_not_supported_triplet(self):
+    def validate(self):
         sources_url_per_triplet = self.conan_data["sources"][self.version]["url"]
         the_os = self._get_os_or_subsystem()
         if the_os not in sources_url_per_triplet:
@@ -65,7 +71,7 @@ class CspiceConan(ConanFile):
 
     def build(self):
         self._get_sources()
-        for patch in self.conan_data["patches"][self.version]:
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
@@ -84,7 +90,7 @@ class CspiceConan(ConanFile):
             os.remove(filename)
         else:
             tools.get(url, sha256=sha256)
-        os.rename(self.name, self._source_subfolder)
+        tools.rename(self.name, self._source_subfolder)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/cspice/all/conanfile.py
+++ b/recipes/cspice/all/conanfile.py
@@ -71,8 +71,7 @@ class CspiceConan(ConanFile):
 
     def build(self):
         self._get_sources()
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+        self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -91,6 +90,15 @@ class CspiceConan(ConanFile):
         else:
             tools.get(url, sha256=sha256)
         tools.rename(self.name, self._source_subfolder)
+
+    def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        # TODO: find a more elegant patch, there is likely some conflict between
+        #       fio.h and io.h in 0067 but the diff with 0066 is not obvious.
+        if str(self.settings.compiler) in ["Visual Studio", "msvc"] and self.version == "0067":
+            tools.replace_in_file(os.path.join(self._source_subfolder, "src", "cspice", "fio.h"),
+                                  "extern int isatty(int);", "")
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/cspice/all/conanfile.py
+++ b/recipes/cspice/all/conanfile.py
@@ -51,13 +51,19 @@ class CspiceConan(ConanFile):
         sources_url_per_triplet = self.conan_data["sources"][self.version]["url"]
         the_os = self._get_os_or_subsystem()
         if the_os not in sources_url_per_triplet:
-            raise ConanInvalidConfiguration("cspice does not support {0}".format(the_os))
+            raise ConanInvalidConfiguration(
+                "cspice N{} does not support {0}".format(self.version, the_os)
+            )
         compiler = str(self.settings.compiler)
         if compiler not in sources_url_per_triplet[the_os]:
-            raise ConanInvalidConfiguration("cspice does not support {0} on {1}".format(compiler, the_os))
+            raise ConanInvalidConfiguration(
+                "cspice N{} does not support {0} on {1}".format(self.version, compiler, the_os)
+            )
         arch = str(self.settings.arch)
         if arch not in sources_url_per_triplet[the_os][compiler]:
-            raise ConanInvalidConfiguration("cspice does not support {0} on {1} {2}".format(compiler, the_os, arch))
+            raise ConanInvalidConfiguration(
+                "cspice N{} does not support {0} on {1} {2}".format(self.version, compiler, the_os, arch)
+            )
 
     def _get_os_or_subsystem(self):
         if self.settings.os == "Windows" and self.settings.os.subsystem != "None":

--- a/recipes/cspice/all/test_package/conanfile.py
+++ b/recipes/cspice/all/test_package/conanfile.py
@@ -1,9 +1,9 @@
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
 
     def build(self):
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/cspice/config.yml
+++ b/recipes/cspice/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0067":
+    folder: all
   "0066":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

cspice/0067 fails with Visual Studio/MD:

```
FAILED: CMakeFiles/cspice.dir/source_subfolder/src/cspice/open.c.obj 
C:\PROGRA~2\MICROS~1\2019\ENTERP~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\cl.exe  /nologo -DMSDOS -DNON_ANSI_STDIO -DOMIT_BLANK_CC -D_COMPLEX_DEFINED  /DWIN32 /D_WINDOWS /W3  /MP2 /MD /O2 /Ob2 /DNDEBUG /showIncludes /FoCMakeFiles\cspice.dir\source_subfolder\src\cspice\open.c.obj /FdCMakeFiles\cspice.dir\cspice.pdb /FS -c source_subfolder\src\cspice\open.c
C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\ucrt\corecrt_io.h(493): error C2375: 'isatty': redefinition; different linkage
C:\Users\runneradmin\.conan\data\cspice\0067\SpaceIm\testing\build\3fd2c61e5dbc8cb70c3caae76c906873c5085b9b\source_subfolder\src\cspice\fio.h(76): note: see declaration of 'isatty'
source_subfolder\src\cspice\open.c(326): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
source_subfolder\src\cspice\open.c(388): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
source_subfolder\src\cspice\open.c(285): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
source_subfolder\src\cspice\open.c(303): warning C4996: 'access': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _access. See online help for details.
source_subfolder\src\cspice\open.c(327): warning C4996: 'mktemp': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _mktemp. See online help for details.
source_subfolder\src\cspice\open.c(363): warning C4996: 'access': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _access. See online help for details.
source_subfolder\src\cspice\open.c(382): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
source_subfolder\src\cspice\open.c(391): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
source_subfolder\src\cspice\open.c(392): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
source_subfolder\src\cspice\open.c(394): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
source_subfolder\src\cspice\open.c(438): warning C4267: '=': conversion from 'size_t' to 'ftnlen', possible loss of data
source_subfolder\src\cspice\open.c(434): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
```

Need to investigate.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
