### PR TITLE
cpp-peglib: add version 1.3.8

### DIFF
--- a/recipes/cpp-peglib/1.x.x/conandata.yml
+++ b/recipes/cpp-peglib/1.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.8":
+    url: "https://github.com/yhirose/cpp-peglib/archive/v1.3.8.tar.gz"
+    sha256: "6d266806825ec491f1e3d1eb8a2163114f328a691f7c9fbce7bb3edf2f42074c"
   "1.3.7":
     url: "https://github.com/yhirose/cpp-peglib/archive/v1.3.7.tar.gz"
     sha256: "3f68843d442e5013ff927cadc6ae2e2364305fbf30dee287c798b094642124f8"

--- a/recipes/cpp-peglib/1.x.x/test_package/CMakeLists.txt
+++ b/recipes/cpp-peglib/1.x.x/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(cpp-peglib CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} cpp-peglib::cpp-peglib)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)

--- a/recipes/cpp-peglib/1.x.x/test_package/conanfile.py
+++ b/recipes/cpp-peglib/1.x.x/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/cpp-peglib/config.yml
+++ b/recipes/cpp-peglib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.8":
+    folder: "1.x.x"
   "1.3.7":
     folder: "1.x.x"
   "1.3.5":


### PR DESCRIPTION
Specify library name and version:  **cpp-peglib/1.3.8**

patch for 1.3.7 is already merged in 1.3.8.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
