### PR TITLE
foxglove-websocket: add version 0.0.1

### DIFF
--- a/recipes/foxglove-websocket/all/conandata.yml
+++ b/recipes/foxglove-websocket/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  0.0.1:
+    # TODO: replace with tag
+    url: https://github.com/foxglove/ws-protocol/archive/4b30ea2a835865636e70130c001b1f54bcb693cb.zip
+    sha256: 5dcbd9d19f695d3bceb03d2d97ef8049d99e4d31fa1686eedd01d2111841bff1

--- a/recipes/foxglove-websocket/all/conandata.yml
+++ b/recipes/foxglove-websocket/all/conandata.yml
@@ -1,5 +1,4 @@
 sources:
   0.0.1:
-    # TODO: replace with tag
-    url: https://github.com/foxglove/ws-protocol/archive/4b30ea2a835865636e70130c001b1f54bcb693cb.zip
-    sha256: 5dcbd9d19f695d3bceb03d2d97ef8049d99e4d31fa1686eedd01d2111841bff1
+    url: https://github.com/foxglove/ws-protocol/archive/refs/tags/releases/cpp/v0.0.1.tar.gz
+    sha256: 94766f44973f0c0ce7e87039b9ef9d5b4a8bc73727047568170ac61262625c9b

--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -26,7 +26,7 @@ class FoxgloveWebSocketConan(ConanFile):
             tools.check_min_cppstd(self, "17")
         if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 8:
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
-        if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) <= "16.8":
+        if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) <= 15:
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
 
     def configure(self):

--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -14,7 +14,7 @@ class FoxgloveWebSocketConan(ConanFile):
     generators = "cmake"
 
     _source_root = "source_root"
-    _source_package_path = os.path.join(_source_root, "cpp", "foxglove_websocket")
+    _source_package_path = os.path.join(_source_root, "cpp", "foxglove-websocket")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_root)

--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -24,7 +24,7 @@ class FoxgloveWebSocketConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "17")
-        if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 5:
+        if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 8:
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
 
     def configure(self):

--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 
 
@@ -23,6 +24,8 @@ class FoxgloveWebSocketConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "17")
+        if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 5:
+            raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
 
     def configure(self):
         self.options["websocketpp"].asio = "standalone"

--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -26,6 +26,8 @@ class FoxgloveWebSocketConan(ConanFile):
             tools.check_min_cppstd(self, "17")
         if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 8:
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
+        if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) <= "16.8":
+            raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
 
     def configure(self):
         self.options["websocketpp"].asio = "standalone"

--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -1,0 +1,34 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class FoxgloveWebSocketConan(ConanFile):
+    name = "foxglove-websocket"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/foxglove/ws-protocol"
+    description = "A C++ server implementation of the Foxglove WebSocket Protocol"
+    license = "MIT"
+    topics = ("foxglove", "websocket")
+
+    settings = ("os", "compiler", "build_type", "arch")
+    requires = ("nlohmann_json/[^3.10.4]", "websocketpp/[^0.8.2]")
+    generators = "cmake"
+
+    _source_root = "source_root"
+    _source_package_path = os.path.join(_source_root, "cpp", "foxglove_websocket")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_root)
+
+    def validate(self):
+        tools.check_min_cppstd(self, "17")
+
+    def configure(self):
+        self.options["websocketpp"].asio = "standalone"
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_package_path)
+        self.copy("include/*", src=self._source_package_path)
+
+    def package_id(self):
+        self.info.header_only()
+

--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -26,7 +26,7 @@ class FoxgloveWebSocketConan(ConanFile):
             tools.check_min_cppstd(self, "17")
         if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 8:
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
-        if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) <= 15:
+        if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) <= "16.8":
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
 
     def configure(self):

--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
+
 class FoxgloveWebSocketConan(ConanFile):
     name = "foxglove-websocket"
     url = "https://github.com/conan-io/conan-center-index"
@@ -31,4 +32,3 @@ class FoxgloveWebSocketConan(ConanFile):
 
     def package_id(self):
         self.info.header_only()
-

--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -13,7 +13,7 @@ class FoxgloveWebSocketConan(ConanFile):
 
     settings = ("os", "compiler", "build_type", "arch")
     requires = ("nlohmann_json/3.10.5", "websocketpp/0.8.2")
-    generators = "cmake"
+    generators = ("cmake", "cmake_find_package")
 
     _source_root = "source_root"
     _source_package_path = os.path.join(_source_root, "cpp", "foxglove-websocket")

--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -11,7 +11,7 @@ class FoxgloveWebSocketConan(ConanFile):
     topics = ("foxglove", "websocket")
 
     settings = ("os", "compiler", "build_type", "arch")
-    requires = ("nlohmann_json/[^3.10.4]", "websocketpp/[^0.8.2]")
+    requires = ("nlohmann_json/3.10.5", "websocketpp/0.8.2")
     generators = "cmake"
 
     _source_root = "source_root"
@@ -21,7 +21,8 @@ class FoxgloveWebSocketConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_root)
 
     def validate(self):
-        tools.check_min_cppstd(self, "17")
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, "17")
 
     def configure(self):
         self.options["websocketpp"].asio = "standalone"

--- a/recipes/foxglove-websocket/all/test_package/CMakeLists.txt
+++ b/recipes/foxglove-websocket/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package ${CONAN_LIBS})

--- a/recipes/foxglove-websocket/all/test_package/CMakeLists.txt
+++ b/recipes/foxglove-websocket/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(foxglove-websocket REQUIRED CONFIG)
 
 add_executable(test_package test_package.cpp)
 set_target_properties(test_package PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
-target_link_libraries(test_package ${CONAN_LIBS})
+target_link_libraries(test_package foxglove-websocket::foxglove-websocket)

--- a/recipes/foxglove-websocket/all/test_package/CMakeLists.txt
+++ b/recipes/foxglove-websocket/all/test_package/CMakeLists.txt
@@ -5,4 +5,5 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_executable(test_package test_package.cpp)
+set_target_properties(test_package PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 target_link_libraries(test_package ${CONAN_LIBS})

--- a/recipes/foxglove-websocket/all/test_package/conanfile.py
+++ b/recipes/foxglove-websocket/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = ("os", "arch", "compiler", "build_type")
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/foxglove-websocket/all/test_package/conanfile.py
+++ b/recipes/foxglove-websocket/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = ("os", "arch", "compiler", "build_type")
-    generators = "cmake", "cmake_find_package"
+    generators = ("cmake", "cmake_find_package")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/foxglove-websocket/all/test_package/conanfile.py
+++ b/recipes/foxglove-websocket/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = ("os", "arch", "compiler", "build_type")
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/foxglove-websocket/all/test_package/conanfile.py
+++ b/recipes/foxglove-websocket/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = ("os", "arch", "compiler", "build_type")
-    generators = ("cmake", "cmake_find_package")
+    generators = ("cmake", "cmake_find_package_multi")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/foxglove-websocket/all/test_package/test_package.cpp
+++ b/recipes/foxglove-websocket/all/test_package/test_package.cpp
@@ -1,7 +1,7 @@
-#include <foxglove_websocket/server.hpp>
+#include <foxglove/websocket/server.hpp>
 
 int main() {
-    foxglove_websocket::Server server{0, "example"};
+    foxglove::websocket::Server server{0, "example"};
     server.getEndpoint().set_timer(0, [&](std::error_code const& ec) {
       server.stop();
     });

--- a/recipes/foxglove-websocket/all/test_package/test_package.cpp
+++ b/recipes/foxglove-websocket/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <foxglove_websocket/server.hpp>
+
+int main() {
+    foxglove_websocket::Server server{0, "example"};
+    server.getEndpoint().set_timer(0, [&](std::error_code const& ec) {
+      server.stop();
+    });
+    server.run();
+    return 0;
+}

--- a/recipes/foxglove-websocket/all/test_package/test_package.cpp
+++ b/recipes/foxglove-websocket/all/test_package/test_package.cpp
@@ -1,3 +1,4 @@
+#include <string_view>
 #include <foxglove/websocket/server.hpp>
 
 int main() {

--- a/recipes/foxglove-websocket/config.yml
+++ b/recipes/foxglove-websocket/config.yml
@@ -1,0 +1,3 @@
+versions:
+  0.0.1:
+    folder: all


### PR DESCRIPTION
Hello 👋

I'm the author of this package, `foxglove-websocket`, which is part of a larger project at [foxglove/ws-protocol](https://github.com/foxglove/ws-protocol) ([read more here](https://foxglove.dev/blog/announcing-the-foxglove-websocket-protocol)). We would like the C++ server library to be available on ConanCenter. This is the first version of the package. It's currently a header-only library, with dependencies on `nlohmann_json` and `websocketpp`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
  - Built in a `conanio/clang10` Docker container using `-s compiler.cppstd=17 -s compiler.libcxx=libc++`.
