### PR TITLE
swig/4.0.2: Replace get_exe_path by something that works on both Ubuntu and macOS

### DIFF
--- a/recipes/swig/all/conanfile.py
+++ b/recipes/swig/all/conanfile.py
@@ -86,6 +86,8 @@ class SwigConan(ConanFile):
             "--host={}".format(self.settings.arch),
             "--with-swiglibdir={}".format(self._swiglibdir),
         ]
+        if self.settings.compiler == 'gcc':
+            args.append("LIBS=-ldl")
 
         host, build = None, None
 
@@ -108,7 +110,7 @@ class SwigConan(ConanFile):
             autotools.libs.extend(["mingwex", "ssp"])
 
         autotools.configure(args=args, configure_dir=self._source_subfolder,
-                                  host=host, build=build)
+                            host=host, build=build)
         return autotools
 
     def _patch_sources(self):

--- a/recipes/swig/all/patches/0001-swig-linux-library-path.patch
+++ b/recipes/swig/all/patches/0001-swig-linux-library-path.patch
@@ -1,18 +1,25 @@
 --- Source/Modules/main.cxx
 +++ Source/Modules/main.cxx
-@@ -879,6 +879,23 @@
+@@ -879,6 +881,30 @@ static void getoptions(int argc, char *argv[]) {
    }
  }
- 
+
 +#if defined(HAVE_UNISTD_H) && !defined(_WIN32)
 +#include <libgen.h>
 +#include <unistd.h>
++#include <dlfcn.h>
 +
 +static String *get_exe_path(void) {
-+    char buffer[PATH_MAX];
-+    ssize_t nb = readlink("/proc/self/exe", buffer, PATH_MAX);
-+    if (nb != -1) {
-+        buffer[nb] = '\0';
++    Dl_info info;
++    if (dladdr("main", &info)) {
++        char buffer[PATH_MAX];
++        char* res = NULL;
++
++        res = realpath(info.dli_fname, buffer);
++        if (!res) {
++         return NewString(SWIG_LIB);
++        }
++
 +        dirname(buffer);
 +        strcat(buffer, "/swiglib");
 +        return NewStringWithSize(buffer, strlen(buffer));


### PR DESCRIPTION
- Fixes #8674
- Specify library name and version:  **swig/4.0.2**
- Replace get_exe_path by something that works on both Ubuntu and macOS so that swiglib is correctly defined on macOS as well


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
