### PR TITLE
libssh2/* Add option to enable debug logging.

### DIFF
--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -20,6 +20,7 @@ class Libssh2Conan(ConanFile):
         "enable_crypt_none": [True, False],
         "enable_mac_none": [True, False],
         "crypto_backend": ["openssl", "mbedtls"],
+        "enable_debug_logging": [True, False],
     }
     default_options = {
         "shared": False,
@@ -28,6 +29,7 @@ class Libssh2Conan(ConanFile):
         "enable_crypt_none": False,
         "enable_mac_none": False,
         "crypto_backend": "openssl",
+        "enable_debug_logging": False,
     }
 
     exports_sources = ["CMakeLists.txt", "patches/*"]
@@ -74,6 +76,7 @@ class Libssh2Conan(ConanFile):
         self._cmake.definitions["ENABLE_ZLIB_COMPRESSION"] = self.options.with_zlib
         self._cmake.definitions["ENABLE_CRYPT_NONE"] = self.options.enable_crypt_none
         self._cmake.definitions["ENABLE_MAC_NONE"] = self.options.enable_mac_none
+        self._cmake.definitions["ENABLE_DEBUG_LOGGING"] = self.options.enable_debug_logging
         if self.options.crypto_backend == "openssl":
             self._cmake.definitions["CRYPTO_BACKEND"] = "OpenSSL"
             self._cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath


### PR DESCRIPTION
libssh2/*

libssh2 debug logging is very useful in many instances during development and when testing in various environments.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
