### PR TITLE
cmake: bump openssl + add env vars to buildenv_info

### DIFF
--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -31,6 +31,10 @@ class CMakeConan(ConanFile):
         if self.settings.os == "Windows":
             self.options.with_openssl = False
 
+    def requirements(self):
+        if self.options.with_openssl:
+            self.requires("openssl/1.1.1m")
+
     def validate(self):
         if self.settings.os == "Macos" and self.settings.arch == "x86":
             raise ConanInvalidConfiguration("CMake does not support x86 for macOS")
@@ -58,10 +62,6 @@ class CMakeConan(ConanFile):
         if version < minimal_version[compiler]:
             raise ConanInvalidConfiguration(
                 "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
-
-    def requirements(self):
-        if self.options.with_openssl:
-            self.requires("openssl/1.1.1l")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conans import tools, ConanFile, CMake
 from conans.errors import ConanInvalidConfiguration, ConanException
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.35.0"
 
 class CMakeConan(ConanFile):
     name = "cmake"
@@ -111,8 +111,10 @@ class CMakeConan(ConanFile):
         self.output.info("Appending PATH environment variable: {}".format(bindir))
         self.env_info.PATH.append(bindir)
 
+        self.buildenv_info.prepend_path("CMAKE_ROOT", self.package_folder)
         self.env_info.CMAKE_ROOT = self.package_folder
         mod_path = os.path.join(self.package_folder, "share", "cmake-%s" % minor, "Modules")
+        self.buildenv_info.prepend_path("CMAKE_MODULE_PATH", mod_path)
         self.env_info.CMAKE_MODULE_PATH = mod_path
         if not os.path.exists(mod_path):
             raise ConanException("Module path not found: %s" % mod_path)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

To fix this kind of tedious error (version conflict between build requires and requires if 1 profile, or just inside build requires with 2 profiles):

```
ERROR: Conflict in cmake/3.20.1:
    'cmake/3.20.1' requires 'openssl/1.1.1k' while 'capnproto/0.8.0' requires 'openssl/1.1.1m'.
    To fix this conflict you need to override the package 'openssl' in your root package.
```

https://github.com/conan-io/conan-center-index/pull/8708#issuecomment-1008156818

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
