### PR TITLE
sassc: add Windows support

### DIFF
--- a/recipes/sassc/all/conanfile.py
+++ b/recipes/sassc/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conans import ConanFile, AutoToolsBuildEnvironment, tools, MSBuild
 from conans.errors import ConanInvalidConfiguration
 import os
 
@@ -13,6 +13,7 @@ class SasscConan(ConanFile):
     description = "libsass command line driver"
     topics = ("Sass", "sassc", "compiler")
     settings = "os", "compiler", "build_type", "arch"
+    generators = "visual_studio"
 
     _autotools = None
 
@@ -20,23 +21,34 @@ class SasscConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _is_msvc(self):
+        return self.settings.os == "Windows" and self.settings.compiler == "Visual Studio"
+
     def config_options(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
     def configure(self):
-        if self.settings.os not in ["Linux", "FreeBSD", "Macos"]:
-            raise ConanInvalidConfiguration("sassc supports only Linux, FreeBSD and Macos at this time, contributions are welcomed")
+        if not self._is_msvc and self.settings.os not in ["Linux", "FreeBSD", "Macos"]:
+            raise ConanInvalidConfiguration("sassc supports only Linux, FreeBSD, Macos and Windows Visual Studio at this time, contributions are welcomed")
 
     def requirements(self):
         self.requires("libsass/3.6.4")
 
     def build_requirements(self):
-        self.build_requires("libtool/2.4.6")
+        if not self._is_msvc:
+            self.build_requires("libtool/2.4.6")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
+
+    def _patch_sources(self):
+        tools.replace_in_file(
+            os.path.join(self.build_folder, self._source_subfolder, "win", "sassc.vcxproj"),
+            "$(LIBSASS_DIR)\\win\\libsass.targets",
+            os.path.join(self.build_folder, "conanbuildinfo.props"))
 
     def _configure_autotools(self):
         if self._autotools:
@@ -45,17 +57,32 @@ class SasscConan(ConanFile):
         self._autotools.configure(args=["--disable-tests"])
         return self._autotools
 
+    def _build_msbuild(self):
+        msbuild = MSBuild(self)
+        platforms = {
+            "x86": "Win32",
+            "x86_64": "Win64"
+        }
+        msbuild.build("win/sassc.sln", platforms=platforms)
+
     def build(self):
+        self._patch_sources()
         with tools.chdir(self._source_subfolder):
-            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True)
-            tools.save(path="VERSION", content="%s" % self.version)
-            autotools = self._configure_autotools()
-            autotools.make()
+            if self._is_msvc:
+                self._build_msbuild()
+            else:
+                self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True)
+                tools.save(path="VERSION", content="%s" % self.version)
+                autotools = self._configure_autotools()
+                autotools.make()
 
     def package(self):
         with tools.chdir(self._source_subfolder):
-            autotools = self._configure_autotools()
-            autotools.install()
+            if self._is_msvc:
+                self.copy("*.exe", dst="bin", src=os.path.join(self._source_subfolder, "bin"), keep_path=False)
+            else:
+                autotools = self._configure_autotools()
+                autotools.install()
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
 
     def package_info(self):


### PR DESCRIPTION
Specify library name and version:  **sassc/3.6.2*

This PR adds Windows support for sassc.

This is useful because it is a dependency of gtk 4 (which I'm trying to create a Windows package in CCI)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
