### PR TITLE
Add libpqxx/7.3.2

### DIFF
--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -38,6 +38,9 @@ sources:
   "7.3.1":
     url: "https://github.com/jtv/libpqxx/archive/7.3.1.tar.gz"
     sha256: "c794e7e5c4f1ef078463ecafe747a6508a0272d83b32a8cdcfb84bb37218a78b"
+  "7.3.2":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.3.2.tar.gz"
+    sha256: "493991345de5cbddfed8836917a333add2cd00ecbfd21b1acbc9345ce784225f"
   "7.4.0":
     url: "https://github.com/jtv/libpqxx/archive/7.4.0.tar.gz"
     sha256: "930e95d0c709905f9d842081cd33b5226f5803ed1fc6ef5b6e3b131ddaeddecb"
@@ -102,6 +105,11 @@ patches:
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
   "7.3.1":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-msvc-compilation-7.3.1.patch"
+      base_path: "source_subfolder"
+  "7.3.2":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/fix-msvc-compilation-7.3.1.patch"

--- a/recipes/libpqxx/config.yml
+++ b/recipes/libpqxx/config.yml
@@ -25,6 +25,8 @@ versions:
     folder: all
   "7.3.1":
     folder: all
+  "7.3.2":
+    folder: all
   "7.4.0":
     folder: all
   "7.4.1":


### PR DESCRIPTION
Specify library name and version:  **libpqxx/7.3.2**

This release fixes a library problem with GB18030 encoding.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
