### PR TITLE
Add libpqxx/7.4.2

### DIFF
--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -44,6 +44,9 @@ sources:
   "7.4.1":
     url: "https://github.com/jtv/libpqxx/archive/7.4.1.tar.gz"
     sha256: "73b2f0a0af786d6039291b60250bee577bc7ea7c10b7550ec37da448940848b7"
+  "7.4.2":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.4.2.tar.gz"
+    sha256: "325d50c51a417e890f7d71805f90a8d7949dce659f721b0f15d7f91bf954091d"
   "7.5.0":
     url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.5.0.tar.gz"
     sha256: "62744ddba939880675f1e76275c98c1653f60b0e725f013299f4a437351bf2b0"
@@ -112,6 +115,9 @@ patches:
     - patch_file: "patches/fix-apple-clang-compilation-7.4.0.patch"
       base_path: "source_subfolder"
   "7.4.1":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+      base_path: "source_subfolder"
+  "7.4.2":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
   "7.5.0":

--- a/recipes/libpqxx/config.yml
+++ b/recipes/libpqxx/config.yml
@@ -29,6 +29,8 @@ versions:
     folder: all
   "7.4.1":
     folder: all
+  "7.4.2":
+    folder: all
   "7.5.0":
     folder: all
   "7.5.1":


### PR DESCRIPTION
Specify library name and version:  **libpqxx/7.4.2**

This release fixes a library problem with GB18030 encoding.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
