### PR TITLE
Add libpqxx/7.5.3

### DIFF
--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -53,6 +53,9 @@ sources:
   "7.5.2":
     url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.5.2.tar.gz"
     sha256: "62e140667fb1bc9b61fa01cbf46f8ff73236eba6f3f7fbcf98108ce6bbc18dcd"
+  "7.5.3":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.5.3.tar.gz"
+    sha256: "4229ed9205e484a4bafb10edd6ce75b98c12d63c082a98baada0c01766d218e0"
   "7.6.0":
     url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.6.0.tar.gz"
     sha256: "8194ce4eff3fee5325963ccc28d3542cfaa54ba1400833d0df6948de3573c118"
@@ -121,6 +124,9 @@ patches:
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
   "7.5.2":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+      base_path: "source_subfolder"
+  "7.5.3":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
   "7.6.0":

--- a/recipes/libpqxx/config.yml
+++ b/recipes/libpqxx/config.yml
@@ -35,5 +35,7 @@ versions:
     folder: all
   "7.5.2":
     folder: all
+  "7.5.3":
+    folder: all
   "7.6.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libpqxx/7.5.3**

This release fixes a library problem with GB18030 encoding.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
