### PR TITLE
Add libpqxx/7.6.1

### DIFF
--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -56,6 +56,9 @@ sources:
   "7.6.0":
     url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.6.0.tar.gz"
     sha256: "8194ce4eff3fee5325963ccc28d3542cfaa54ba1400833d0df6948de3573c118"
+  "7.6.1":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.6.1.tar.gz"
+    sha256: "7f4ad37fce20e8c9a61387cd5d6f85cf264f2bc9c0e6b27e8d5751a5429f87d0"
 patches:
   "7.0.1":
     - patch_file: "patches/0001-cmake-fix-module.patch"
@@ -124,6 +127,11 @@ patches:
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
   "7.6.0":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-inline-constexpr-local-variable-problem-7.6.0.patch"
+      base_path: "source_subfolder"
+  "7.6.1":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/fix-inline-constexpr-local-variable-problem-7.6.0.patch"

--- a/recipes/libpqxx/config.yml
+++ b/recipes/libpqxx/config.yml
@@ -37,3 +37,5 @@ versions:
     folder: all
   "7.6.0":
     folder: all
+  "7.6.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libpqxx/7.6.1**

This release fixes a library problem with GB18030 encoding.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
