### PR TITLE
don't use distutils if Python version >= 3.10

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -584,8 +584,16 @@ class BoostConan(ConanFile):
         obtain value of python variable, either by sysconfig, or by distutils.sysconfig
         :param name: name of variable to be queried (such as LIBRARY or LDLIBRARY)
         :return: value of python sysconfig variable
+
+        NOTE: distutils is deprecated and breaks the recipe since Python 3.10
         """
-        return self._get_python_sc_var(name) or self._get_python_du_var(name)
+        python_version_parts = self.info.options.python_version.split('.')
+        python_major = int(python_version_parts[0])
+        python_minor = int(python_version_parts[1])
+        if(python_major >= 3 and python_minor >= 10):
+            return self._get_python_sc_var(name)
+        else:
+            return self._get_python_sc_var(name) or self._get_python_du_var(name)
 
     def _detect_python_version(self):
         """


### PR DESCRIPTION
Specify library name and version:  **boost/1.78.0**

Boost recipe is broken with Python 3.10, see https://github.com/conan-io/conan-center-index/issues/8638

fixes #8638

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
