### PR TITLE
Add libpqxx/7.7.0 and backport releases

### DIFF
--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -38,12 +38,18 @@ sources:
   "7.3.1":
     url: "https://github.com/jtv/libpqxx/archive/7.3.1.tar.gz"
     sha256: "c794e7e5c4f1ef078463ecafe747a6508a0272d83b32a8cdcfb84bb37218a78b"
+  "7.3.2":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.3.2.tar.gz"
+    sha256: "493991345de5cbddfed8836917a333add2cd00ecbfd21b1acbc9345ce784225f"
   "7.4.0":
     url: "https://github.com/jtv/libpqxx/archive/7.4.0.tar.gz"
     sha256: "930e95d0c709905f9d842081cd33b5226f5803ed1fc6ef5b6e3b131ddaeddecb"
   "7.4.1":
     url: "https://github.com/jtv/libpqxx/archive/7.4.1.tar.gz"
     sha256: "73b2f0a0af786d6039291b60250bee577bc7ea7c10b7550ec37da448940848b7"
+  "7.4.2":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.4.2.tar.gz"
+    sha256: "325d50c51a417e890f7d71805f90a8d7949dce659f721b0f15d7f91bf954091d"
   "7.5.0":
     url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.5.0.tar.gz"
     sha256: "62744ddba939880675f1e76275c98c1653f60b0e725f013299f4a437351bf2b0"
@@ -53,9 +59,18 @@ sources:
   "7.5.2":
     url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.5.2.tar.gz"
     sha256: "62e140667fb1bc9b61fa01cbf46f8ff73236eba6f3f7fbcf98108ce6bbc18dcd"
+  "7.5.3":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.5.3.tar.gz"
+    sha256: "4229ed9205e484a4bafb10edd6ce75b98c12d63c082a98baada0c01766d218e0"
   "7.6.0":
     url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.6.0.tar.gz"
     sha256: "8194ce4eff3fee5325963ccc28d3542cfaa54ba1400833d0df6948de3573c118"
+  "7.6.1":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.6.1.tar.gz"
+    sha256: "7f4ad37fce20e8c9a61387cd5d6f85cf264f2bc9c0e6b27e8d5751a5429f87d0"
+  "7.7.0":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.7.0.tar.gz"
+    sha256: "2d99de960aa3016915bc69326b369fcee04425e57fbe9dad48dd3fa6203879fb"
 patches:
   "7.0.1":
     - patch_file: "patches/0001-cmake-fix-module.patch"
@@ -106,12 +121,20 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/fix-msvc-compilation-7.3.1.patch"
       base_path: "source_subfolder"
+  "7.3.2":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-msvc-compilation-7.3.1.patch"
+      base_path: "source_subfolder"
   "7.4.0":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/fix-apple-clang-compilation-7.4.0.patch"
       base_path: "source_subfolder"
   "7.4.1":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+      base_path: "source_subfolder"
+  "7.4.2":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
   "7.5.0":
@@ -123,8 +146,19 @@ patches:
   "7.5.2":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
+  "7.5.3":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+      base_path: "source_subfolder"
   "7.6.0":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/fix-inline-constexpr-local-variable-problem-7.6.0.patch"
+      base_path: "source_subfolder"
+  "7.6.1":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-inline-constexpr-local-variable-problem-7.6.0.patch"
+      base_path: "source_subfolder"
+  "7.7.0":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"

--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -162,3 +162,5 @@ patches:
   "7.7.0":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-clang-compilation-7.7.0.patch"
+      base_path: "source_subfolder"

--- a/recipes/libpqxx/all/conanfile.py
+++ b/recipes/libpqxx/all/conanfile.py
@@ -44,8 +44,10 @@ class LibpqxxRecipe(ConanFile):
         compiler_version = Version(self.settings.compiler.version.value)
 
         lib_version = Version(self.version)
+        lib_version_7_6_0_or_later = lib_version >= "7.6.0"
         minimum_compiler_version = {
-            "Visual Studio": "16" if lib_version >= "7.6.0" else "15",
+            "Visual Studio": "16" if lib_version_7_6_0_or_later else "15",
+            "msvc": "192" if lib_version_7_6_0_or_later else "191",
             "gcc": "8" if lib_version >= "7.5.0" else "7",
             "clang": "6",
             "apple-clang": "10"

--- a/recipes/libpqxx/all/patches/fix-clang-compilation-7.7.0.patch
+++ b/recipes/libpqxx/all/patches/fix-clang-compilation-7.7.0.patch
@@ -1,0 +1,24 @@
+diff --git a/src/strconv.cxx b/src/strconv.cxx
+index 36758307..824d0d28 100644
+--- a/src/strconv.cxx
++++ b/src/strconv.cxx
+@@ -438,7 +438,8 @@ template<typename T>
+   if (pqxx::internal::is_digit(initial))
+   {
+     for (; pqxx::internal::is_digit(data[i]); ++i)
+-      result = absorb_digit_positive(result, digit_to_number(data[i]));
++      result = absorb_digit_positive(
++        result, pqxx::internal::digit_to_number(data[i]));
+   }
+   else if (initial == '-')
+   {
+@@ -452,7 +453,8 @@ template<typename T>
+         "Converting string to " + pqxx::type_name<T> +
+         ", but it contains only a sign."};
+     for (; i < std::size(text) and pqxx::internal::is_digit(data[i]); ++i)
+-      result = absorb_digit_negative(result, digit_to_number(data[i]));
++      result = absorb_digit_negative(
++        result, pqxx::internal::digit_to_number(data[i]));
+   }
+   else
+   {

--- a/recipes/libpqxx/all/patches/fix-clang-compilation-7.7.0.patch
+++ b/recipes/libpqxx/all/patches/fix-clang-compilation-7.7.0.patch
@@ -1,3 +1,4 @@
+Fix clang compile error 7.7.0 (https://github.com/jtv/libpqxx/pull/519)
 diff --git a/src/strconv.cxx b/src/strconv.cxx
 index 36758307..824d0d28 100644
 --- a/src/strconv.cxx

--- a/recipes/libpqxx/config.yml
+++ b/recipes/libpqxx/config.yml
@@ -25,9 +25,13 @@ versions:
     folder: all
   "7.3.1":
     folder: all
+  "7.3.2":
+    folder: all
   "7.4.0":
     folder: all
   "7.4.1":
+    folder: all
+  "7.4.2":
     folder: all
   "7.5.0":
     folder: all
@@ -35,5 +39,11 @@ versions:
     folder: all
   "7.5.2":
     folder: all
+  "7.5.3":
+    folder: all
   "7.6.0":
+    folder: all
+  "7.6.1":
+    folder: all
+  "7.7.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libpqxx/7.7.0**, **libpqxx/7.6.1**, **libpqxx/7.5.3**, **libpqxx/7.4.2**, **libpqxx/7.3.2**

Version 7.7.0 is the latest minor version release.
Other than that, the added bug fix version is a backported release, which fixes the GB18030 encoding bug.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
