### PR TITLE
bitmagic: add version 7.9.3

### DIFF
--- a/recipes/bitmagic/all/conandata.yml
+++ b/recipes/bitmagic/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.9.3":
+    url: "https://github.com/tlk00/BitMagic/archive/v7.9.3.tar.gz"
+    sha256: "fa1799f702dac47148dc8e2672957b1fc5be440d043ef2c4d275c04b434182e1"
   "7.8.0":
     url: "https://github.com/tlk00/BitMagic/archive/v7.8.0.tar.gz"
     sha256: "78e1d2ba81ad14595c976ecb0e8d18a9b652dfe8e394964f94bd98cc8164391b"

--- a/recipes/bitmagic/config.yml
+++ b/recipes/bitmagic/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.9.3":
+    folder: all
   "7.8.0":
     folder: all
   "7.7.7":


### PR DESCRIPTION
Specify library name and version:  **bitmagic/7.9.3**

bitmagic is not listed as "Open One" in "[request] Updatable recipes".
So I create PR by hand.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
