### PR TITLE
protobuf: add version 3.19.2

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.19.2":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.19.2.tar.gz"
+    sha256: "4dd35e788944b7686aac898f77df4e9a54da0ca694b8801bd6b2a9ffc1b3085e"
   "3.19.1":
     url: "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.1.tar.gz"
     sha256: "87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422"
@@ -27,6 +30,9 @@ sources:
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.9.1.tar.gz"
     sha256: "98e615d592d237f94db8bf033fba78cd404d979b0b70351a9e5aaff725398357"
 patches:
+  "3.19.2":
+    - patch_file: "patches/upstream-pr-9153-msvc-runtime.patch"
+      base_path: "source_subfolder"
   "3.19.1":
     - patch_file: "patches/upstream-pr-9153-msvc-runtime.patch"
       base_path: "source_subfolder"

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.19.2":
+    folder: all
   "3.19.1":
     folder: all
   "3.17.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **protobuf/3.19.2**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
