### PR TITLE
Fix zlib packaging on latest conan not renaming binary appropriately

### DIFF
--- a/recipes/zlib/all/CMakeLists.txt
+++ b/recipes/zlib/all/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.15)
 project(cmake_wrapper)
 
+cmake_policy(SET CMP0091 NEW)
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 

--- a/recipes/zlib/all/conanfile.py
+++ b/recipes/zlib/all/conanfile.py
@@ -86,11 +86,11 @@ class ZlibConan(ConanFile):
             suffix = "d" if self.settings.build_type == "Debug" else ""
 
             if self.options.shared:
-                if self.settings.compiler == "Visual Studio" and suffix:
+                if self.settings.compiler in ("Visual Studio", "msvc") and suffix:
                     current_lib = os.path.join(lib_path, "zlib%s.lib" % suffix)
                     tools.rename(current_lib, os.path.join(lib_path, "zlib.lib"))
             else:
-                if self.settings.compiler == "Visual Studio":
+                if self.settings.compiler in ("Visual Studio", "msvc"):
                     current_lib = os.path.join(lib_path, "zlibstatic%s.lib" % suffix)
                     tools.rename(current_lib, os.path.join(lib_path, "zlib.lib"))
                 elif self.settings.compiler in ("clang", "gcc", ):


### PR DESCRIPTION
Specify library name and version:  **zlib/1.2.11**

Update the recipe to rename files properly from the utterly stupid names produced by zlib build scripts.
Fixes #8788 

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
