### PR TITLE
libarchive: Allow with_cng on Windows hosts

### DIFF
--- a/recipes/libarchive/all/conanfile.py
+++ b/recipes/libarchive/all/conanfile.py
@@ -92,7 +92,7 @@ class LibarchiveConan(ConanFile):
             self.requires("libiconv/1.16")
         if self.options.with_pcreposix:
             self.requires("pcre/8.45")
-        if self.options.with_cng:
+        if self.settings.os != "Windows" and self.options.with_cng:
             # TODO: add cng when available in CCI
             raise ConanInvalidConfiguration("cng recipe not yet available in CCI.")
         if self.options.with_nettle:
@@ -220,5 +220,7 @@ class LibarchiveConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "LibArchive"
 
         self.cpp_info.libs = tools.collect_libs(self)
+        if self.settings.os == "Windows" and self.options.with_cng:
+            self.cpp_info.system_libs.append("bcrypt")
         if str(self.settings.compiler) in ["Visual Studio", "msvc"] and not self.options.shared:
             self.cpp_info.defines = ["LIBARCHIVE_STATIC"]


### PR DESCRIPTION
Specify library name and version: libarchive/3.5.2

We don't need any external dependency for cng on Windows, therefore we should allow it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
