### PR TITLE
cajun-jsonapi/2.1.1

### DIFF
--- a/recipes/cajun-jsonapi/all/conandata.yml
+++ b/recipes/cajun-jsonapi/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "2.0.3":
     url: https://github.com/cajun-jsonapi/cajun-jsonapi/archive/2.0.3.tar.gz
     sha256: b47f9338f1fbaee5ffc7247a94219e767d22d02fb6cdd37a51a9367700b72f34
+  "2.1.1":
+    url: https://github.com/cajun-jsonapi/cajun-jsonapi/archive/refs/tags/2.1.1.tar.gz
+    sha256: 88f1eecf105e7ea337cd4142d1ea1bd165e84b0fa91cdaa098437b2e153a234c

--- a/recipes/cajun-jsonapi/all/conanfile.py
+++ b/recipes/cajun-jsonapi/all/conanfile.py
@@ -27,10 +27,20 @@ class CajunJsonApiConan(ConanFile):
         return file_content[:file_content.find("*/")]
 
     def package(self):
-        tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), self._extract_license())
+        packageVersion = tools.Version(self.version)
+        if packageVersion < "2.1.0":
+            # No dedicated LICENSE file in older versions, extracting license text from comments
+            tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), self._extract_license())
+            # Prior to v2.1.0 there was no "cajun" subfolder in sources but it was present in RPM packages
+            # (e.g. https://centos.pkgs.org/7/epel-x86_64/cajun-jsonapi-devel-2.0.3-2.el7.noarch.rpm.html)
+            # For ease of migration from RPM dependencies to Conan creating intermediate "cajun" folder
+            # so that '#include "cajun/json/..."' statements worked correctly
+            self.copy('*.h', dst=os.path.join('include', 'cajun', 'json'), src=os.path.join(self._source_subfolder, 'json'))
+            self.copy('*.inl', dst=os.path.join('include', 'cajun', 'json'), src=os.path.join(self._source_subfolder, 'json'))
+        else:
+            self.copy('*.h', dst=os.path.join('include'), src=os.path.join(self._source_subfolder, 'include'))
+            self.copy('*.inl', dst=os.path.join('include'), src=os.path.join(self._source_subfolder, 'include'))
         self.copy('LICENSE', dst='licenses', src=self._source_subfolder)
-        self.copy('*.h', dst=os.path.join('include', 'json'), src=os.path.join(self._source_subfolder, 'json'))
-        self.copy('*.inl', dst=os.path.join('include', 'json'), src=os.path.join(self._source_subfolder, 'json'))
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/cajun-jsonapi/all/conanfile.py
+++ b/recipes/cajun-jsonapi/all/conanfile.py
@@ -27,7 +27,7 @@ class CajunJsonApiConan(ConanFile):
         return file_content[:file_content.find("*/")]
 
     def package(self):
-        packageVersion = tools.Version(self.version)
+        package_version = tools.Version(self.version)
         if packageVersion < "2.1.0":
             # No dedicated LICENSE file in older versions, extracting license text from comments
             tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), self._extract_license())

--- a/recipes/cajun-jsonapi/all/conanfile.py
+++ b/recipes/cajun-jsonapi/all/conanfile.py
@@ -28,7 +28,7 @@ class CajunJsonApiConan(ConanFile):
 
     def package(self):
         package_version = tools.Version(self.version)
-        if packageVersion < "2.1.0":
+        if package_version < "2.1.0":
             # No dedicated LICENSE file in older versions, extracting license text from comments
             tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), self._extract_license())
             # Prior to v2.1.0 there was no "cajun" subfolder in sources but it was present in RPM packages

--- a/recipes/cajun-jsonapi/all/test_package/main.cpp
+++ b/recipes/cajun-jsonapi/all/test_package/main.cpp
@@ -1,43 +1,43 @@
-#include <json/reader.h>
-#include <json/writer.h>
-#include <json/elements.h>
+#include <cajun/json/reader.h> // Recommended include path as of v2.1.0
+#include <cajun/json/writer.h>
+#include <json/elements.h> // Shortened include path used prior to v2.1.0
 
 #include <iostream>
 #include <sstream>
 
 int main()
 {
-   using namespace json;
+    using namespace json;
 
-   Object objAPA;
-   objAPA["Name"] = String("Schlafly American Pale Ale");
-   objAPA["Origin"] = String("St. Louis, MO, USA");
-   objAPA["ABV"] = Number(3.8);
-   objAPA["BottleConditioned"] = Boolean(true);
+    Object objAPA;
+    objAPA["Name"] = String("Schlafly American Pale Ale");
+    objAPA["Origin"] = String("St. Louis, MO, USA");
+    objAPA["ABV"] = Number(3.8);
+    objAPA["BottleConditioned"] = Boolean(true);
 
-   Array arrayBeer;
-   arrayBeer.Insert(objAPA);
+    Array arrayBeer;
+    arrayBeer.Insert(objAPA);
 
-   Object objDocument;
-   objDocument["Delicious Beers"] = arrayBeer;
+    Object objDocument;
+    objDocument["Delicious Beers"] = arrayBeer;
 
-   Number numDeleteThis = objDocument["AnotherMember"];
+    Number numDeleteThis = objDocument["AnotherMember"];
 
-   objDocument["Delicious Beers"][1]["Name"] = String("John Smith's Extra Smooth");
-   objDocument["Delicious Beers"][1]["Origin"] = String("Tadcaster, Yorkshire, UK");
-   objDocument["Delicious Beers"][1]["ABV"] = Number(3.8);
-   objDocument["Delicious Beers"][1]["BottleConditioned"] = Boolean(false);
+    objDocument["Delicious Beers"][1]["Name"] = String("John Smith's Extra Smooth");
+    objDocument["Delicious Beers"][1]["Origin"] = String("Tadcaster, Yorkshire, UK");
+    objDocument["Delicious Beers"][1]["ABV"] = Number(3.8);
+    objDocument["Delicious Beers"][1]["BottleConditioned"] = Boolean(false);
 
-   const Object& objRoot = objDocument;
+    const Object &objRoot = objDocument;
 
-   const Array& arrayBeers = objRoot["Delicious Beers"];
-   const Object& objBeer0 = arrayBeers[0];
-   const String& strName0 = objBeer0["Name"];
+    const Array &arrayBeers = objRoot["Delicious Beers"];
+    const Object &objBeer0 = arrayBeers[0];
+    const String &strName0 = objBeer0["Name"];
 
-   const Number numAbv1 = objRoot["Delicious Beers"][1]["ABV"];
+    const Number numAbv1 = objRoot["Delicious Beers"][1]["ABV"];
 
-   std::cout << "First beer name: " << strName0.Value() << std::endl;
-   std::cout << "First beer ABV: " << numAbv1.Value() << std::endl;
+    std::cout << "First beer name: " << strName0.Value() << std::endl;
+    std::cout << "First beer ABV: " << numAbv1.Value() << std::endl;
 
-   return 0;
+    return 0;
 }

--- a/recipes/cajun-jsonapi/config.yml
+++ b/recipes/cajun-jsonapi/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.0.3":
     folder: "all"
+  "2.1.1":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **cajun-jsonapi/2.1.1**

This PR addresses #8816. In addition to adding latest version of the library, it ensures that both old and new package versions can be included in the source code in 2 ways:
1. `#include "json/someheader.h"`
2. `#include "cajun/json/someheader.h"`

1st option was originally used in the `2.0.3` recipe for the reasons of being aligned with the upstream library folder structure. The problem was that [there are RPMs out there](https://centos.pkgs.org/7/epel-x86_64/cajun-jsonapi-devel-2.0.3-2.el7.noarch.rpm.html) for the same library version (`2.0.3`) that have different includedirs structure (with `cajun/` prefix). This PR attempts to make it so that both old (`< 2.1.0`) and latest (`>= 2.1.0`) recipe versions can use both of the above mentioned include styles.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
