### PR TITLE
rapidyaml: add recipe

### DIFF
--- a/recipes/rapidyaml/all/CMakeLists.txt
+++ b/recipes/rapidyaml/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper LANGUAGES CXX)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/rapidyaml/all/conandata.yml
+++ b/recipes/rapidyaml/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.3.0":
+    url: "https://github.com/biojppm/rapidyaml/releases/download/v0.3.0/rapidyaml-0.3.0-src.tgz"
+    sha256: "38854b8359eaf42cc27352f4b7321f509f6775445a3e2746cc8cd1e468a52aa9"

--- a/recipes/rapidyaml/all/conanfile.py
+++ b/recipes/rapidyaml/all/conanfile.py
@@ -1,0 +1,87 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+class RapidYAMLConan(ConanFile):
+    name = "rapidyaml"
+    description = "a library to parse and emit YAML, and do it fast."
+    topics = ("yaml", "parser", "emitter")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/biojppm/rapidyaml"
+    license = "MIT",
+    settings = "os", "arch", "compiler", "build_type"
+    exports_sources = ["CMakeLists.txt"]
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_default_callbacks": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_default_callbacks": True,
+    }
+
+    generators = "cmake"
+
+    _compiler_required_cpp11 = {
+        "Visual Studio": "13",
+        "gcc": "5",
+        "clang": "4",
+    }
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+
+        minimum_version = self._compiler_required_cpp11.get(str(self.settings.compiler), False)
+        if minimum_version:
+            if tools.Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration("{} requires C++11, which your compiler does not support.".format(self.name))
+        else:
+            self.output.warn("{0} requires C++11. Your compiler is unknown. Assuming it supports C++11.".format(self.name))
+
+        if self.settings.compiler == "clang" and self.settings.compiler.get_safe("libcxx") == "libc++":
+            raise ConanInvalidConfiguration("{} doesn't support clang with libc++".format(self.name))
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["RYML_DEFAULT_CALLBACKS"] = self.options.with_default_callbacks
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["ryml"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["rt", "pthread"]

--- a/recipes/rapidyaml/all/conanfile.py
+++ b/recipes/rapidyaml/all/conanfile.py
@@ -77,11 +77,15 @@ class RapidYAMLConan(ConanFile):
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "ryml")
+        self.cpp_info.set_property("cmake_target_name", "ryml::ryml")
         self.cpp_info.libs = ["ryml"]
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs = ["rt", "pthread"]
+
+        self.cpp_info.names["cmake_find_package"] = "ryml"
+        self.cpp_info.names["cmake_find_package_multi"] = "ryml"

--- a/recipes/rapidyaml/all/conanfile.py
+++ b/recipes/rapidyaml/all/conanfile.py
@@ -28,7 +28,7 @@ class RapidYAMLConan(ConanFile):
 
     _compiler_required_cpp11 = {
         "Visual Studio": "13",
-        "gcc": "5",
+        "gcc": "6",
         "clang": "4",
     }
 

--- a/recipes/rapidyaml/all/conanfile.py
+++ b/recipes/rapidyaml/all/conanfile.py
@@ -81,11 +81,13 @@ class RapidYAMLConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "include"), "*.natvis")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "ryml")
         self.cpp_info.set_property("cmake_target_name", "ryml::ryml")
-        self.cpp_info.libs = ["ryml"]
+        # TODO: create c4core recipe
+        self.cpp_info.libs = ["ryml", "c4core"]
 
         self.cpp_info.names["cmake_find_package"] = "ryml"
         self.cpp_info.names["cmake_find_package_multi"] = "ryml"

--- a/recipes/rapidyaml/all/conanfile.py
+++ b/recipes/rapidyaml/all/conanfile.py
@@ -80,6 +80,7 @@ class RapidYAMLConan(ConanFile):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.remove_files_by_mask(os.path.join(self.package_folder, "include"), "*.natvis")
 

--- a/recipes/rapidyaml/all/test_package/CMakeLists.txt
+++ b/recipes/rapidyaml/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(rapidyaml REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} rapidyaml::rapidyaml)
+set(CMAKE_CXX_STANDARD 11)

--- a/recipes/rapidyaml/all/test_package/CMakeLists.txt
+++ b/recipes/rapidyaml/all/test_package/CMakeLists.txt
@@ -4,8 +4,8 @@ project(test_package LANGUAGES CXX)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(rapidyaml REQUIRED CONFIG)
+find_package(ryml REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} rapidyaml::rapidyaml)
+target_link_libraries(${PROJECT_NAME} ryml::ryml)
 set(CMAKE_CXX_STANDARD 11)

--- a/recipes/rapidyaml/all/test_package/CMakeLists.txt
+++ b/recipes/rapidyaml/all/test_package/CMakeLists.txt
@@ -6,6 +6,7 @@ conan_basic_setup(TARGETS)
 
 find_package(ryml REQUIRED CONFIG)
 
+set(CMAKE_CXX_STANDARD 11)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ryml::ryml)
-set(CMAKE_CXX_STANDARD 11)

--- a/recipes/rapidyaml/all/test_package/conanfile.py
+++ b/recipes/rapidyaml/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/rapidyaml/all/test_package/test_package.cpp
+++ b/recipes/rapidyaml/all/test_package/test_package.cpp
@@ -1,0 +1,15 @@
+#include <ryml_std.hpp> // optional header. BUT when used, needs to be included BEFORE ryml.hpp
+#include <ryml.hpp>
+#include <c4/yml/preprocess.hpp> // needed only for the json sample
+#include <c4/format.hpp> // needed only needed for the examples below
+#include <c4/fs/fs.hpp>
+
+#include <cstdio>
+#include <chrono>
+
+int main() {
+    char yml_buf[] = "{foo: 1, bar: [2, 3], john: doe}";
+    ryml::Tree tree = ryml::parse_in_place(ryml::substr(yml_buf));
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/rapidyaml/all/test_package/test_package.cpp
+++ b/recipes/rapidyaml/all/test_package/test_package.cpp
@@ -1,15 +1,26 @@
-#include <ryml_std.hpp> // optional header. BUT when used, needs to be included BEFORE ryml.hpp
-#include <ryml.hpp>
-#include <c4/yml/preprocess.hpp> // needed only for the json sample
-#include <c4/format.hpp> // needed only needed for the examples below
-#include <c4/fs/fs.hpp>
+#include <c4/yml/std/std.hpp>
+#include <c4/yml/parse.hpp>
+#include <c4/yml/emit.hpp>
 
-#include <cstdio>
-#include <chrono>
+#include <iostream>
 
 int main() {
-    char yml_buf[] = "{foo: 1, bar: [2, 3], john: doe}";
-    ryml::Tree tree = ryml::parse_in_place(ryml::substr(yml_buf));
+    auto tree = c4::yml::parse("{foo: 1}");
+    auto const value = tree["foo"].val();
+    
+    std::cout << value << std::endl;
+
+    auto bar = tree.rootref()["bar"];
+    bar |= c4::yml::SEQ;
+    bar.append_child() = "bar0";
+    bar.append_child() = "bar1";
+    bar.append_child() = "bar2";
+
+    std::string buffer;
+
+    c4::yml::emitrs(tree, &buffer);
+
+    std::cout << buffer << std::endl;
 
     return EXIT_SUCCESS;
 }

--- a/recipes/rapidyaml/config.yml
+++ b/recipes/rapidyaml/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.3.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **rapidyaml:0.3.0**

jsonnet requires rapidyaml since 0.1.8.

rapidyaml uses several libraries internally (ex. c4core, fast_float).
First, create a recipe for rapidyaml and include the dependent libraries.
Next, create the dependent libraries and update the rapidyaml recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
