### PR TITLE
Fix #8848 - Add new recipe for whereami/20220112

### DIFF
--- a/recipes/whereami/all/CMakeLists.txt
+++ b/recipes/whereami/all/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.4.3)
+project(whereami C)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+if (WIN32 AND BUILD_SHARED_LIBS)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+set(WHEREAMI_SRC "${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder")
+
+set(SOURCE_FILES ${WHEREAMI_SRC}/src/whereami.c)
+set(HEADER_FILES ${WHEREAMI_SRC}/src/whereami.h)
+
+add_library(${CMAKE_PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${WHEREAMI_SRC}/src)
+set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY C_STANDARD 99)
+
+install(TARGETS ${CMAKE_PROJECT_NAME}
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+
+install(FILES ${HEADER_FILES} DESTINATION include)

--- a/recipes/whereami/all/conandata.yml
+++ b/recipes/whereami/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "20220112":
+    url: "https://github.com/gpakosz/whereami/archive/f15606a65908bb097e1887a08a40ae083e9a5c53.tar.gz"
+    sha256: "005d51ed0a99845b27ed9df4834b609abfc1811b187aeee1a85929004704dd6d"

--- a/recipes/whereami/all/conanfile.py
+++ b/recipes/whereami/all/conanfile.py
@@ -6,6 +6,8 @@ required_conan_version = ">=1.33.0"
 class WhereamiConan(ConanFile):
     name = "whereami"
     description = "Locate the current executable and the current module/library on the file system"
+    topics = ("whereami", "introspection", "getmodulefilename",
+              "dladdr", "executable-path", "getexecutablepath")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/gpakosz/whereami"
     license = ("MIT", "WTFPL")

--- a/recipes/whereami/all/conanfile.py
+++ b/recipes/whereami/all/conanfile.py
@@ -12,7 +12,7 @@ class WhereamiConan(ConanFile):
               "dladdr", "executable-path", "getexecutablepath")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/gpakosz/whereami"
-    license = "MIT"  # + WTFPLv2
+    license = ("MIT", "WTFPL")
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
@@ -36,11 +36,8 @@ class WhereamiConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        url = self.conan_data["sources"][self.version]["url"]
-        commit = url[url.rfind("/")+1:url.find(".tar.gz")]
-        extracted_folder = self.name + "-" + commit
-        os.rename(extracted_folder, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:
@@ -87,7 +84,6 @@ class WhereamiConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
-        print(self.cpp_info.libs)
         self.cpp_info.names["cmake_find_package"] = "whereami"
         self.cpp_info.names["cmake_find_package_multi"] = "whereami"
         self.cpp_info.builddirs.append(self._module_subfolder)

--- a/recipes/whereami/all/conanfile.py
+++ b/recipes/whereami/all/conanfile.py
@@ -1,6 +1,4 @@
 from conans import ConanFile, CMake, tools
-import os
-import textwrap
 
 required_conan_version = ">=1.33.0"
 
@@ -8,8 +6,6 @@ required_conan_version = ">=1.33.0"
 class WhereamiConan(ConanFile):
     name = "whereami"
     description = "Locate the current executable and the current module/library on the file system"
-    topics = ("conan", "whereami", "introspection", "getmodulefilename",
-              "dladdr", "executable-path", "getexecutablepath")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/gpakosz/whereami"
     license = ("MIT", "WTFPL")
@@ -56,36 +52,6 @@ class WhereamiConan(ConanFile):
                   src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
-            {"whereami": "whereami::whereami"}
-        )
-
-    @staticmethod
-    def _create_cmake_module_alias_targets(module_file, targets):
-        content = ""
-        for alias, aliased in targets.items():
-            content += textwrap.dedent("""\
-                if(TARGET {aliased} AND NOT TARGET {alias})
-                    add_library({alias} INTERFACE IMPORTED)
-                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
-                endif()
-            """.format(alias=alias, aliased=aliased))
-        tools.save(module_file, content)
-
-    @property
-    def _module_subfolder(self):
-        return os.path.join("lib", "cmake")
-
-    @property
-    def _module_file_rel_path(self):
-        return os.path.join(self._module_subfolder,
-                            "conan-official-{}-targets.cmake".format(self.name))
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
-        self.cpp_info.names["cmake_find_package"] = "whereami"
-        self.cpp_info.names["cmake_find_package_multi"] = "whereami"
-        self.cpp_info.builddirs.append(self._module_subfolder)
-        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+        self.cpp_info.libs = ["whereami"]

--- a/recipes/whereami/all/conanfile.py
+++ b/recipes/whereami/all/conanfile.py
@@ -1,0 +1,95 @@
+from conans import ConanFile, CMake, tools
+import os
+import textwrap
+
+required_conan_version = ">=1.33.0"
+
+
+class WhereamiConan(ConanFile):
+    name = "whereami"
+    description = "Locate the current executable and the current module/library on the file system"
+    topics = ("conan", "whereami", "introspection", "getmodulefilename",
+              "dladdr", "executable-path", "getexecutablepath")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/gpakosz/whereami"
+    license = "MIT"  # + WTFPLv2
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == 'Windows':
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        url = self.conan_data["sources"][self.version]["url"]
+        commit = url[url.rfind("/")+1:url.find(".tar.gz")]
+        extracted_folder = self.name + "-" + commit
+        os.rename(extracted_folder, self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+
+        self._cmake = CMake(self)
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE.*", dst="licenses",
+                  src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"whereami": "whereami::whereami"}
+        )
+
+    @staticmethod
+    def _create_cmake_module_alias_targets(module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent("""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """.format(alias=alias, aliased=aliased))
+        tools.save(module_file, content)
+
+    @property
+    def _module_subfolder(self):
+        return os.path.join("lib", "cmake")
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join(self._module_subfolder,
+                            "conan-official-{}-targets.cmake".format(self.name))
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        print(self.cpp_info.libs)
+        self.cpp_info.names["cmake_find_package"] = "whereami"
+        self.cpp_info.names["cmake_find_package_multi"] = "whereami"
+        self.cpp_info.builddirs.append(self._module_subfolder)
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/whereami/all/test_package/CMakeLists.txt
+++ b/recipes/whereami/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(whereami REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} whereami::whereami)

--- a/recipes/whereami/all/test_package/conanfile.py
+++ b/recipes/whereami/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/whereami/all/test_package/conanfile.py
+++ b/recipes/whereami/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/whereami/all/test_package/test_package.c
+++ b/recipes/whereami/all/test_package/test_package.c
@@ -1,0 +1,46 @@
+#include <whereami.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+
+  int length = wai_getExecutablePath(NULL, 0, NULL);
+
+  if (length > 0) {
+    char* path = (char*)malloc(length + 1);
+    if (!path) {
+      abort();
+    }
+    int dirname_length = 0;
+    wai_getExecutablePath(path, length, &dirname_length);
+    path[length] = '\0';
+
+    printf("Executable path: %s\n", path);
+    path[dirname_length] = '\0';
+    printf("  dirname: %s\n", path);
+    printf("  basename: %s\n", path + dirname_length + 1);
+
+    free(path);
+  }
+
+  printf("\n");
+
+  length = wai_getModulePath(NULL, 0, NULL);
+  if (length > 0) {
+    char* path = (char*)malloc(length + 1);
+    if (!path) {
+      abort();
+    }
+    int dirname_length = 0;
+    wai_getModulePath(path, length, &dirname_length);
+    path[length] = '\0';
+
+    printf("module path: %s\n", path);
+    path[dirname_length] = '\0';
+    printf("  dirname: %s\n", path);
+    printf("  basename: %s\n", path + dirname_length + 1);
+    free(path);
+  }
+
+  return 0;
+}

--- a/recipes/whereami/config.yml
+++ b/recipes/whereami/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "20220112":
+    folder: "all"


### PR DESCRIPTION
- Fix #8848 
- Specify library name and version:  **whereami/20220112**

cf https://github.com/gpakosz/whereami

I somewhat adapted https://github.com/bincrafters/conan-whereami. Revamped the example to use a C one (following https://github.com/gpakosz/whereami/blob/master/example/executable.c), conformed to conan-hooks, and added a cmake target.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
