### PR TITLE
cpprestsdk: depend on boost's minor version

### DIFF
--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -62,6 +62,9 @@ class CppRestSDKConan(ConanFile):
         if self.options.with_websockets:
             self.requires("websocketpp/0.8.2")
 
+    def package_id(self):
+        self.info.requires["boost"].minor_mode()
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 


### PR DESCRIPTION
Specify library name and version:  **cpprestsdk/2.10.18**

cpprestsdk depends on boost, which does not follow semver. If a package depends on cpprestsdk and on a version of boost different than the one cpprestsdk was built against, bad things happen.
This PR changes the dependency mode to minor, in order to avoid that.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
