### PR TITLE
- [libusb] fix RelWithDebInfo (and others like MinSizeRel)

### DIFF
--- a/recipes/libusb/all/conanfile.py
+++ b/recipes/libusb/all/conanfile.py
@@ -112,7 +112,8 @@ class LibUSBConan(ConanFile):
                 "WholeProgramOptimization": "true" if any(re.finditer("(^| )[/-]GL($| )", tools.get_env("CFLAGS", ""))) else "false",
             }
             msbuild = MSBuild(self)
-            msbuild.build(solution_file, platforms=platforms, upgrade_project=False, properties=properties)
+            build_type = "Debug" if self.settings.build_type == "Debug" else "Release"
+            msbuild.build(solution_file, platforms=platforms, upgrade_project=False, properties=properties, build_type=build_type)
 
     def _configure_autotools(self):
         if not self._autotools:


### PR DESCRIPTION
closes: #8774

Specify library name and version:  **libusb/all**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
