### PR TITLE
litehtml: improve CMakeDeps + allow shared with MinGW

### DIFF
--- a/recipes/litehtml/all/test_package/CMakeLists.txt
+++ b/recipes/litehtml/all/test_package/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
-set(CMAKE_CXX_STANDARD 11)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(litehtml REQUIRED)
+find_package(litehtml REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} litehtml::litehtml)
+target_link_libraries(${PROJECT_NAME} litehtml)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/litehtml/all/test_package/conanfile.py
+++ b/recipes/litehtml/all/test_package/conanfile.py
@@ -3,8 +3,8 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- Avoid to create undesirable `litehtml::litehtml` in CMakeDeps.
- allow shared with MinGW

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
