### PR TITLE
add support for CMakeDeps to CLI11

### DIFF
--- a/recipes/cli11/all/conanfile.py
+++ b/recipes/cli11/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
+required_conan_version = ">=1.43.0"
 
 class CLI11Conan(ConanFile):
     name = "cli11"
@@ -36,6 +37,9 @@ class CLI11Conan(ConanFile):
         self.info.header_only()
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_target_name", "CLI11::CLI11")
+        self.cpp_info.set_property("cmake_file_name", "CLI11")
+        self.cpp_info.set_property("pkg_config_name", "CLI11")
         self.cpp_info.names["cmake_find_package"] = "CLI11"
         self.cpp_info.names["cmake_find_package_multi"] = "CLI11"
         self.cpp_info.names["pkg_config"] = "CLI11"


### PR DESCRIPTION
Specify library name and version:  **cli11/all**

The `cli11` package doesn't handle `CMakeDeps` as the original project creates a `CLI11::CLI11` target but `CMakeDeps` would create a `cli11::cli11` one. `cmake_find_package` and `cmake_find_package_multi` were already properly configured so I left that untouched.

I tested locally switching from `cmake_find_package` to `CMakeDeps` in one of my projects and everything seems fine after this patch
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
