### PR TITLE
cpputest: fix CMake targets & modernize

### DIFF
--- a/recipes/cpputest/all/conanfile.py
+++ b/recipes/cpputest/all/conanfile.py
@@ -1,19 +1,23 @@
-import os
-
 from conans import ConanFile, CMake, tools
+import os
+import textwrap
+
+required_conan_version = ">=1.43.0"
+
 
 class CppUTestConan(ConanFile):
     name = "cpputest"
-    description = \
-"CppUTest is a C /C++ based unit xUnit test framework for unit testing and for test-driving your code." \
-"It is written in C++ but is used in C and C++ projects and frequently" \
-"used in embedded systems but it works for any C/C++ project."
+    description = (
+        "CppUTest is a C /C++ based unit xUnit test framework for unit testing "
+        "and for test-driving your code. It is written in C++ but is used in C "
+        "and C++ projects and frequently used in embedded systems but it works "
+        "for any C/C++ project."
+    )
     license = "BSD-3-Clause"
-    topics = ("conan", "testing", "unit-testing")
+    topics = ("testing", "unit-testing")
     homepage = "https://cpputest.github.io"
     url = "https://github.com/conan-io/conan-center-index"
-    exports_sources = ["CMakeLists.txt"]
-    generators = "cmake"
+
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
@@ -26,6 +30,8 @@ class CppUTestConan(ConanFile):
         "with_leak_detection": True,
     }
 
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake"
     _cmake = None
 
     @property
@@ -41,8 +47,8 @@ class CppUTestConan(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def build(self):
         cmake = self._configure_cmake()
@@ -68,24 +74,59 @@ class CppUTestConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "CppUTest", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "CppUTest"))
+
+        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {
+                "CppUTest": "CppUTest::CppUTest",
+                "CppUTestExt": "CppUTest::CppUTestExt",
+            }
+        )
+
+    @staticmethod
+    def _create_cmake_module_alias_targets(module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent("""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """.format(alias=alias, aliased=aliased))
+        tools.save(module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", "conan-official-{}-targets.cmake".format(self.name))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "CppUTest"
-        self.cpp_info.names["cmake_find_package_multi"] = "CppUTest"
-        self.cpp_info.names["pkg_config"] = "cpputest"
+        self.cpp_info.set_property("cmake_file_name", "CppUTest")
+        self.cpp_info.set_property("pkg_config_name", "cpputest")
 
-        self.cpp_info.components["CppUTest"].names["cmake_find_package"] = "CppUTest"
-        self.cpp_info.components["CppUTest"].names["cmake_find_package_multi"] = "CppUTest"
+        self.cpp_info.components["CppUTest"].set_property("cmake_target_name", "CppUTest")
         self.cpp_info.components["CppUTest"].libs = ["CppUTest"]
+        if self.settings.os == "Windows":
+            self.cpp_info.components["CppUTest"].system_libs.append("winmm")
+        elif self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.components["CppUTest"].system_libs.append("pthread")
 
         if self.options.with_extensions:
-            self.cpp_info.components["CppUTestExt"].names["cmake_find_package"] = "CppUTestExt"
-            self.cpp_info.components["CppUTestExt"].names["cmake_find_package_multi"] = "CppUTestExt"
+            self.cpp_info.components["CppUTestExt"].set_property("cmake_target_name", "CppUTestExt")
             self.cpp_info.components["CppUTestExt"].libs = ["CppUTestExt"]
             self.cpp_info.components["CppUTestExt"].requires = ["CppUTest"]
 
-        if self.settings.os == "Windows":
-            self.cpp_info.components["CppUTest"].system_libs.extend(["winmm"])
-        elif self.settings.os in ("Linux", "FreeBSD"):
-            self.cpp_info.components["CppUTest"].system_libs = ["pthread"]
+        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
+        self.cpp_info.names["cmake_find_package"] = "CppUTest"
+        self.cpp_info.names["cmake_find_package_multi"] = "CppUTest"
+        self.cpp_info.names["pkg_config"] = "cpputest"
+        self.cpp_info.components["CppUTest"].names["cmake_find_package"] = "CppUTest"
+        self.cpp_info.components["CppUTest"].names["cmake_find_package_multi"] = "CppUTest"
+        self.cpp_info.components["CppUTest"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.components["CppUTest"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+        if self.options.with_extensions:
+            self.cpp_info.components["CppUTestExt"].names["cmake_find_package"] = "CppUTestExt"
+            self.cpp_info.components["CppUTestExt"].names["cmake_find_package_multi"] = "CppUTestExt"
+            self.cpp_info.components["CppUTestExt"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+            self.cpp_info.components["CppUTestExt"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/cpputest/all/test_package/CMakeLists.txt
+++ b/recipes/cpputest/all/test_package/CMakeLists.txt
@@ -2,15 +2,14 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(CppUTest REQUIRED CONFIG)
 
 add_executable(test_package test_package.cpp)
-target_link_libraries(test_package CppUTest::CppUTest)
+target_link_libraries(test_package CppUTest)
 
 if(WITH_EXTENSIONS)
     add_executable(test_package_with_extensions test_package_with_extensions.cpp)
-    # Note: CppUTest::CppUTestExt adds dependency on CppUTest::CppUTest
-    target_link_libraries(test_package_with_extensions CppUTest::CppUTestExt)
+    target_link_libraries(test_package_with_extensions CppUTestExt)
 endif()

--- a/recipes/cpputest/all/test_package/conanfile.py
+++ b/recipes/cpputest/all/test_package/conanfile.py
@@ -1,9 +1,9 @@
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
@@ -13,7 +13,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if tools.cross_building(self.settings):
+        if tools.cross_building(self):
             return
 
         self.run(os.path.join("bin", "test_package"), run_environment=True)


### PR DESCRIPTION
- CMake imported targets are not namespaced in upstream config files: CppUTest & CppUTestExt
- add CMakeDeps & PkgConfigDeps support

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
