### PR TITLE
Fix emscripten not producing any binaries

### DIFF
--- a/recipes/brotli/all/patches/0002-target-props.patch
+++ b/recipes/brotli/all/patches/0002-target-props.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -183,6 +183,16 @@ foreach(lib IN LISTS BROTLI_SHARED_LIBS)
+@@ -183,6 +183,16 @@
    set_target_properties (${lib} PROPERTIES DEFINE_SYMBOL "${LIB}_SHARED_COMPILATION")
  endforeach()
  
@@ -17,7 +17,7 @@
  foreach(lib IN LISTS BROTLI_SHARED_LIBS BROTLI_STATIC_LIBS)
    target_link_libraries(${lib} ${LIBM_LIBRARY})
    set_property(TARGET ${lib} APPEND PROPERTY INCLUDE_DIRECTORIES ${BROTLI_INCLUDE_DIRS})
-@@ -190,7 +200,6 @@ foreach(lib IN LISTS BROTLI_SHARED_LIBS BROTLI_STATIC_LIBS)
+@@ -190,7 +200,6 @@
      VERSION "${BROTLI_ABI_COMPATIBILITY}.${BROTLI_ABI_AGE}.${BROTLI_ABI_REVISION}"
      SOVERSION "${BROTLI_ABI_COMPATIBILITY}")
    if(NOT BROTLI_EMSCRIPTEN)
@@ -25,14 +25,14 @@
    endif()
    set_property(TARGET ${lib} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${BROTLI_INCLUDE_DIRS}")
  endforeach()
-@@ -217,15 +226,13 @@ endif()
+@@ -217,15 +226,12 @@
  # Build the brotli executable
  add_executable(brotli ${BROTLI_CLI_C})
  target_link_libraries(brotli ${BROTLI_LIBRARIES_STATIC})
 +set_target_properties(brotli PROPERTIES EXCLUDE_FROM_ALL ON EXCLUDE_FROM_DEFAULT ON)
  
  # Installation
- if(NOT BROTLI_EMSCRIPTEN)
+-if(NOT BROTLI_EMSCRIPTEN)
  if(NOT BROTLI_BUNDLED_MODE)
 -  install(
 -    TARGETS brotli
@@ -43,7 +43,7 @@
    install(
      TARGETS ${BROTLI_LIBRARIES_CORE}
      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-@@ -233,12 +240,14 @@ if(NOT BROTLI_BUNDLED_MODE)
+@@ -233,19 +239,20 @@
      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
    )
  
@@ -58,3 +58,10 @@
  
    install(
      DIRECTORY ${BROTLI_INCLUDE_DIRS}/brotli
+     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+   )
+ endif()  # BROTLI_BUNDLED_MODE
+-endif()  # BROTLI_EMSCRIPTEN
+ 
+ # Tests
+ 

--- a/recipes/brotli/all/patches/0002-target-props.patch
+++ b/recipes/brotli/all/patches/0002-target-props.patch
@@ -64,3 +64,4 @@
 -endif()  # BROTLI_EMSCRIPTEN
  
  # Tests
+ 

--- a/recipes/brotli/all/patches/0002-target-props.patch
+++ b/recipes/brotli/all/patches/0002-target-props.patch
@@ -64,4 +64,3 @@
 -endif()  # BROTLI_EMSCRIPTEN
  
  # Tests
- 


### PR DESCRIPTION
Specify library name and version:  **brotli/1.0.9**

When using the package with Emscripten it will not produce any binaries and the cmake install step will error out (because it doesn't create an install target in the makefile if there's nothing to install)


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
