### PR TITLE
qt5: Fixup CC/CXX environment variables usage in test recipe

### DIFF
--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -43,17 +43,17 @@ class TestPackageConan(ConanFile):
                         os.environ[var] = val
                     return val
 
-                value = _getenvpath('CC')
+                value = _getenvpath("CC")
                 if value:
-                    args += ['QMAKE_CC=' + value,
-                             'QMAKE_LINK_C=' + value,
-                             'QMAKE_LINK_C_SHLIB=' + value]
+                    args += ['QMAKE_CC="' + value + '"',
+                             'QMAKE_LINK_C="' + value + '"',
+                             'QMAKE_LINK_C_SHLIB="' + value + '"']
 
                 value = _getenvpath('CXX')
                 if value:
-                    args += ['QMAKE_CXX=' + value,
-                             'QMAKE_LINK=' + value,
-                             'QMAKE_LINK_SHLIB=' + value]
+                    args += ['QMAKE_CXX="' + value + '"',
+                             'QMAKE_LINK="' + value + '"',
+                             'QMAKE_LINK_SHLIB="' + value + '"']
 
                 self.run("qmake %s" % " ".join(args), run_environment=True)
                 if tools.os_info.is_windows:


### PR DESCRIPTION
Specify library name and version:  **qt/5.15.2**

The environment variables `CC`/`CXX` may contain spaces, e.g. if you use
a Yocto SDK for cross-compiling. Therefore, also in the test package we 
should put the values in quotes to prevent word splitting.

Use same syntax as in `recipes/qt/5.x.x/conanfile.py` to be consisted.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
