### PR TITLE
libjpeg: fix sha256 of archives again

### DIFF
--- a/recipes/libjpeg/all/conandata.yml
+++ b/recipes/libjpeg/all/conandata.yml
@@ -1,18 +1,14 @@
 sources:
-  "9c":
-    url:
-      - "http://ijg.org/files/jpegsrc.v9c.tar.gz"
-      - "https://opticode.ch/mirror/jpegsrc.v9c.tar.gz"
-    sha256: "1e9793e1c6ba66e7e0b6e5fe7fd0f9e935cc697854d5737adec54d93e5b3f730"
   "9d":
-    url:
-      - "http://ijg.org/files/jpegsrc.v9d.tar.gz"
-      - "https://opticode.ch/mirror/jpegsrc.v9d.tar.gz"
-    sha256: "6c434a3be59f8f62425b2e3c077e785c9ce30ee5874ea1c270e843f273ba71ee"
-patches:
+    url: "http://ijg.org/files/jpegsrc.v9d.tar.gz"
+    sha256: "2303a6acfb6cc533e0e86e8a9d29f7e6079e118b9de3f96e07a71a11c082fa6a"
   "9c":
+    url: "http://ijg.org/files/jpegsrc.v9c.tar.gz"
+    sha256: "682aee469c3ca857c4c38c37a6edadbfca4b04d42e56613b11590ec6aa4a278d"
+patches:
+  "9d":
     - patch_file: "patches/0001-libjpeg-add-msvc-dll-support.patch"
       base_path: "source_subfolder"
-  "9d":
+  "9c":
     - patch_file: "patches/0001-libjpeg-add-msvc-dll-support.patch"
       base_path: "source_subfolder"

--- a/recipes/libjpeg/config.yml
+++ b/recipes/libjpeg/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "9c":
-    folder: all
   "9d":
+    folder: all
+  "9c":
     folder: all


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/8921

I had to remove the mirror, sha is different now.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
