### PR TITLE
doctest: add 2.4.8

### DIFF
--- a/recipes/doctest/2.x.x/conandata.yml
+++ b/recipes/doctest/2.x.x/conandata.yml
@@ -29,3 +29,6 @@ sources:
   "2.4.6":
     url: "https://github.com/doctest/doctest/archive/2.4.6.tar.gz"
     sha256: "39110778e6baf373ef04342d7cb3fe35da104cb40769103e8a2f0035f5a5f1cb"
+  "2.4.8":
+    url: "https://github.com/doctest/doctest/archive/v2.4.8.tar.gz"
+    sha256: "f52763630aa17bd9772b54e14b6cdd632c87adf0169455a86a49bd94abf2cd83"

--- a/recipes/doctest/config.yml
+++ b/recipes/doctest/config.yml
@@ -19,3 +19,5 @@ versions:
     folder: 2.x.x
   2.4.6:
     folder: 2.x.x
+  2.4.8:
+    folder: 2.x.x


### PR DESCRIPTION
Specify library name and version:  **doctest/2.4.8**

One notable thing about this and future doctest versions is the addition of the common "v" prefix to the tags and download url's (https://github.com/doctest/doctest/issues/579).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
