### PR TITLE
source_location: new recipe

### DIFF
--- a/recipes/source_location/all/conandata.yml
+++ b/recipes/source_location/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/Rechip/source_location/archive/refs/tags/v0.1.0.zip"
+    sha256: "fe1d09c9ece4306cb1cc92df60d4396dad181151f26b6eb7db2834beaedc0302"

--- a/recipes/source_location/all/conandata.yml
+++ b/recipes/source_location/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.1.0":
-    url: "https://github.com/Rechip/source_location/archive/refs/tags/v0.1.0.zip"
-    sha256: "fe1d09c9ece4306cb1cc92df60d4396dad181151f26b6eb7db2834beaedc0302"
+  "0.1.1":
+    url: "https://github.com/Rechip/source_location/archive/refs/tags/v0.1.1.zip"
+    sha256: "2e177025c77d96cf9ccd994008dc5281e2385e1ee1bc89ca261807ce3f32c692"

--- a/recipes/source_location/all/conanfile.py
+++ b/recipes/source_location/all/conanfile.py
@@ -20,8 +20,6 @@ class SourceLocationConan(ConanFile):
         return "source_subfolder"
 
     def source(self):
-        print(self.version)
-        print(self.conan_data)
         tools.get(**self.conan_data["sources"][self.version],
                   strip_root=True, destination=self._source_subfolder)
 

--- a/recipes/source_location/all/conanfile.py
+++ b/recipes/source_location/all/conanfile.py
@@ -35,6 +35,7 @@ class SourceLocationConan(ConanFile):
             "Visual Studio": "16.6",
             "gcc": "7.1",
             "clang": "9",
+            "apple-clang": "12",
         }
 
     def validate(self):

--- a/recipes/source_location/all/conanfile.py
+++ b/recipes/source_location/all/conanfile.py
@@ -1,0 +1,59 @@
+import os
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.33.0"
+
+
+class SourceLocationConan(ConanFile):
+    name = "source_location"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/Rechip/source_location"
+    description = "source_location header for some older compilers"
+    topics = ("cpp", "source_location", "header-only")
+    settings = ["compiler"]
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        print(self.version)
+        print(self.conan_data)
+        tools.get(**self.conan_data["sources"][self.version],
+                  strip_root=True, destination=self._source_subfolder)
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses",
+                  src=self._source_subfolder)
+        self.copy(pattern="*", dst="include",
+                  src=os.path.join(self._source_subfolder, "include"))
+
+    @property
+    def _minimum_compilers_version(self):
+        return {
+            "Visual Studio": "16.6",
+            "gcc": "7.1",
+            "clang": "9",
+        }
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, "11")
+        minimum_version = self._minimum_compilers_version.get(
+            str(self.settings.compiler), False)
+        if not minimum_version:
+            self.output.warn(
+                "source_location requires C++11. Your compiler is unknown. Assuming it supports C++11 and required functionality.")
+        elif tools.Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                "source_location requires C++11 and some embedded functionality, which your compiler does not support.")
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "source_location"
+        self.cpp_info.names["cmake_find_package_multi"] = "source_location"

--- a/recipes/source_location/all/conanfile.py
+++ b/recipes/source_location/all/conanfile.py
@@ -39,7 +39,7 @@ class SourceLocationConan(ConanFile):
         }
 
     def validate(self):
-        if self.settings.compiler.cppstd:
+        if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "11")
         minimum_version = self._minimum_compilers_version.get(
             str(self.settings.compiler), False)
@@ -52,7 +52,3 @@ class SourceLocationConan(ConanFile):
 
     def package_id(self):
         self.info.header_only()
-
-    def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "source_location"
-        self.cpp_info.names["cmake_find_package_multi"] = "source_location"

--- a/recipes/source_location/all/test_package/CMakeLists.txt
+++ b/recipes/source_location/all/test_package/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.4)
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(source_location CONFIG REQUIRED)
+add_executable(${PROJECT_NAME} src/test.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE source_location::source_location)
+
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+    	CXX_STANDARD 11
+    	CXX_STANDARD_REQUIRED ON
+    	CXX_EXTENSIONS OFF
+)

--- a/recipes/source_location/all/test_package/conanfile.py
+++ b/recipes/source_location/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "arch", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        self.cmake = CMake(self)
+        self.cmake.configure()
+        self.cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/source_location/all/test_package/src/test.cpp
+++ b/recipes/source_location/all/test_package/src/test.cpp
@@ -1,0 +1,8 @@
+#include <cstdlib>
+#include <source_location>
+
+int main() {
+	constexpr auto loc = std::source_location::current();
+
+	return loc.line() == 5 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/recipes/source_location/config.yml
+++ b/recipes/source_location/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all

--- a/recipes/source_location/config.yml
+++ b/recipes/source_location/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1.0":
+  "0.1.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **source_location/0.1.0**

In order to provide compatibility for the source_location header on the pull request pipeline compilers to get #8705 going, I have created this compatibility library.
Funny fact: During my research, I have found out, that functionality for source_location has been in compilers for a long time (basic support in gcc 4.8.1) it was just the header file missing.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
