### PR TITLE
flann: modernize & deprecate with_hdf5 option

### DIFF
--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -16,12 +16,12 @@ class FlannConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "with_hdf5": [True, False],
+        "with_hdf5": [True, False, "deprecated"],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_hdf5": False,
+        "with_hdf5": "deprecated",
     }
 
     generators = "cmake", "cmake_find_package"
@@ -47,11 +47,14 @@ class FlannConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        if self.options.with_hdf5 != "deprecated":
+            self.output.warn("with_hdf5 is a deprecated option. Do not use.")
 
     def requirements(self):
         self.requires("lz4/1.9.3")
-        if self.options.with_hdf5:
-            self.requires("hdf5/1.12.0")
+
+    def package_id(self):
+        del self.info.options.with_hdf5
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -135,8 +138,6 @@ class FlannConan(ConanFile):
         if not self.options.shared and tools.stdcpp_library(self):
             self.cpp_info.components["flann_cpp"].system_libs.append(tools.stdcpp_library(self))
         self.cpp_info.components["flann_cpp"].requires = ["lz4::lz4"]
-        if self.options.with_hdf5:
-            self.cpp_info.components["flann_cpp"].requires = ["hdf5::hdf5"]
 
         # flann
         flann_c_lib = "flann" if self.options.shared else "flann_s"

--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -49,7 +49,7 @@ class FlannConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("lz4/1.9.2")
+        self.requires("lz4/1.9.3")
         if self.options.with_hdf5:
             self.requires("hdf5/1.12.0")
 

--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -1,31 +1,30 @@
-import glob
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
+required_conan_version = ">=1.43.0"
 
 
-class LibFlannConan(ConanFile):
+class FlannConan(ConanFile):
     name = "flann"
     description = "Fast Library for Approximate Nearest Neighbors"
-    topics = "conan", "flann"
+    topics = ("flann", "nns", "nearest-neighbor-search", "knn", "kd-tree")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.cs.ubc.ca/research/flann/"
     license = "BSD-3-Clause"
-    exports_sources = ["CMakeLists.txt", "patches/**"]
-    generators = "cmake", "cmake_find_package"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "with_hdf5": [True, False]
+        "with_hdf5": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_hdf5": False
+        "with_hdf5": False,
     }
 
+    generators = "cmake", "cmake_find_package"
     _cmake = None
 
     @property
@@ -35,6 +34,11 @@ class LibFlannConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -50,9 +54,8 @@ class LibFlannConan(ConanFile):
             self.requires("hdf5/1.12.0")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, {}):
@@ -104,39 +107,51 @@ class LibFlannConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        # Remove vc runtimes
+        if self.settings.os == "Windows":
+            if self.options.shared:
+                for dll_pattern_to_remove in ["concrt*.dll", "msvcp*.dll", "vcruntime*.dll"]:
+                    tools.remove_files_by_mask(
+                        os.path.join(self.package_folder, "bin"),
+                        dll_pattern_to_remove,
+                    )
+            else:
+                tools.rmdir(os.path.join(self.package_folder, "bin"))
         # Remove static/dynamic libraries depending on the build mode
-        if self.options.shared:
-            # Remove MS runtime files
-            for dll_pattern_to_remove in ["concrt*.dll", "msvcp*.dll", "vcruntime*.dll"]:
-                for dll_to_remove in glob.glob(os.path.join(self.package_folder, "bin", dll_pattern_to_remove)):
-                    os.remove(dll_to_remove)
-        else:
-            tools.rmdir(os.path.join(self.package_folder, "bin"))
         libs_pattern_to_remove = ["*flann_cpp_s.*", "*flann_s.*"] if self.options.shared else ["*flann_cpp.*", "*flann.*"]
         for lib_pattern_to_remove in libs_pattern_to_remove:
-            for lib_to_remove in glob.glob(os.path.join(self.package_folder, "lib", lib_pattern_to_remove)):
-                os.remove(lib_to_remove)
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), lib_pattern_to_remove)
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "Flann"
-        self.cpp_info.names["cmake_find_package_multi"] = "flann"
+        self.cpp_info.set_property("cmake_find_mode", "both")
+        self.cpp_info.set_property("cmake_module_file_name", "Flann")
+        self.cpp_info.set_property("cmake_file_name", "flann")
+        self.cpp_info.set_property("pkg_config_name", "flann")
+
         # flann_cpp
         flann_cpp_lib = "flann_cpp" if self.options.shared else "flann_cpp_s"
-        self.cpp_info.components["flann_cpp"].names["cmake_find_package"] = flann_cpp_lib
-        self.cpp_info.components["flann_cpp"].names["cmake_find_package_multi"] = flann_cpp_lib
+        self.cpp_info.components["flann_cpp"].set_property("cmake_file_name", flann_cpp_lib)
         self.cpp_info.components["flann_cpp"].libs = [flann_cpp_lib]
         if not self.options.shared and tools.stdcpp_library(self):
             self.cpp_info.components["flann_cpp"].system_libs.append(tools.stdcpp_library(self))
         self.cpp_info.components["flann_cpp"].requires = ["lz4::lz4"]
         if self.options.with_hdf5:
             self.cpp_info.components["flann_cpp"].requires = ["hdf5::hdf5"]
+
         # flann
         flann_c_lib = "flann" if self.options.shared else "flann_s"
-        self.cpp_info.components["flann_c"].names["cmake_find_package"] = flann_c_lib
-        self.cpp_info.components["flann_c"].names["cmake_find_package_multi"] = flann_c_lib
+        self.cpp_info.components["flann_c"].set_property("cmake_file_name", flann_c_lib)
         self.cpp_info.components["flann_c"].libs = [flann_c_lib]
         if self.settings.os == "Linux":
             self.cpp_info.components["flann_c"].system_libs.append("m")
         if not self.options.shared:
             self.cpp_info.components["flann_c"].defines.append("FLANN_STATIC")
         self.cpp_info.components["flann_c"].requires = ["flann_cpp"]
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.names["cmake_find_package"] = "Flann"
+        self.cpp_info.names["cmake_find_package_multi"] = "flann"
+        self.cpp_info.components["flann_cpp"].names["cmake_find_package"] = flann_cpp_lib
+        self.cpp_info.components["flann_cpp"].names["cmake_find_package_multi"] = flann_cpp_lib
+        self.cpp_info.components["flann_c"].names["cmake_find_package"] = flann_c_lib
+        self.cpp_info.components["flann_c"].names["cmake_find_package_multi"] = flann_c_lib

--- a/recipes/flann/all/test_package/CMakeLists.txt
+++ b/recipes/flann/all/test_package/CMakeLists.txt
@@ -2,13 +2,13 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(flann REQUIRED CONFIG)
 
-add_executable(${CMAKE_PROJECT_NAME} test_package.c)
-if(FLANN_SHARED)
-  target_link_libraries(${CMAKE_PROJECT_NAME} flann::flann)
+add_executable(${PROJECT_NAME} test_package.c)
+if(TARGET flann::flann_s)
+  target_link_libraries(${PROJECT_NAME} flann::flann_s)
 else()
-  target_link_libraries(${CMAKE_PROJECT_NAME} flann::flann_s)
+  target_link_libraries(${PROJECT_NAME} flann::flann)
 endif()

--- a/recipes/flann/all/test_package/conanfile.py
+++ b/recipes/flann/all/test_package/conanfile.py
@@ -1,19 +1,17 @@
-import os.path
-
 from conans import ConanFile, CMake, tools
+import os
 
 
-class FlannTestConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["FLANN_SHARED"] = self.options["flann"].shared
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
flann library itself never uses hdf5, it's only useful for executables not built in this recipe.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
