### PR TITLE
xtr: bump to 1.0.1

### DIFF
--- a/recipes/xtr/all/conandata.yml
+++ b/recipes/xtr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.1":
+    url: "https://github.com/choll/xtr/archive/refs/tags/1.0.1.tar.gz"
+    sha256: "7cc5ec7a2d7d2979e33b928191def79dc05c8074f4c8bb76cd0a20d9b514be0c"
   "1.0.0":
     url: "https://github.com/choll/xtr/archive/refs/tags/1.0.0.tar.gz"
     sha256: "c828883f3045762442fb8a69ed2633e523493a307a0cb2717ac0df93606db7fd"

--- a/recipes/xtr/config.yml
+++ b/recipes/xtr/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.1":
+    folder: all
   "1.0.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **xtr/1.0.1**

Bump xtr to 1.0.1, I am the library author.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
