### PR TITLE
FFMPEG : Enable nonfree if SSL and GPL are enable

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -333,7 +333,7 @@ class FFMpegConan(ConanFile):
             "--disable-cuda",  # FIXME: CUDA support
             "--disable-cuvid",  # FIXME: CUVID support
             # Licenses
-            opt_enable_disable("nonfree", self.options.with_libfdk_aac),
+            opt_enable_disable("nonfree", self.options.with_libfdk_aac or ( self.options.with_ssl and ( self.options.with_libx264 or self.options.with_libx265 or self.options.postproc ) ) ),
             opt_enable_disable("gpl", self.options.with_libx264 or self.options.with_libx265 or self.options.postproc)
         ]
         args.append("--arch={}".format(self._target_arch))


### PR DESCRIPTION
If SSL is enable with GPL, the build fails with output : openssl is incompatible with the gpl and --enable-nonfree is not specified.

Specify library name and version:  **ffmpeg/4.3.2**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
