### PR TITLE
[cereal] fixes

### DIFF
--- a/recipes/cereal/all/conanfile.py
+++ b/recipes/cereal/all/conanfile.py
@@ -10,7 +10,7 @@ class CerealConan(ConanFile):
     name = "cereal"
     description = "Serialization header-only library for C++11."
     license = "BSD-3-Clause"
-    topics = ("conan", "cereal", "header-only", "serialization", "cpp11")
+    topics = ("cereal", "header-only", "serialization", "cpp11")
     homepage = "https://github.com/USCiLab/cereal"
     url = "https://github.com/conan-io/conan-center-index"
     exports_sources = "CMakeLists.txt"

--- a/recipes/cereal/all/conanfile.py
+++ b/recipes/cereal/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conan.tools.files import rename
 import os
 import textwrap
 
@@ -28,7 +29,7 @@ class CerealConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        rename(self, self.name + "-" + self.version, self._source_subfolder)
 
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)

--- a/recipes/cereal/all/test_package/conanfile.py
+++ b/recipes/cereal/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **cereal/1.3.0**

Fixes a couple of conan hooks warnings in the current recipe and test package.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
