### PR TITLE
add cereal 1.3.1

### DIFF
--- a/recipes/cereal/all/conandata.yml
+++ b/recipes/cereal/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.3.0":
     url: "https://github.com/USCiLab/cereal/archive/v1.3.0.tar.gz"
     sha256: "329ea3e3130b026c03a4acc50e168e7daff4e6e661bc6a7dfec0d77b570851d5"
+  "1.3.1":
+    url: "https://github.com/USCiLab/cereal/archive/v1.3.1.tar.gz"
+    sha256: "65ea6ddda98f4274f5c10fb3e07b2269ccdd1e5cbb227be6a2fd78b8f382c976"

--- a/recipes/cereal/all/conanfile.py
+++ b/recipes/cereal/all/conanfile.py
@@ -34,9 +34,16 @@ class CerealConan(ConanFile):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = CMake(self)
         cmake.definitions["JUST_INSTALL_CEREAL"] = True
+        cmake.definitions["CEREAL_INSTALL"] = True
         cmake.configure()
         cmake.install()
+
+        # The "share" folder was being removed up to and including version 1.3.0.
+        # The module files were moved to lib/cmake from 1.3.1 on, so now removing both
+        # as to avoid breaking versions < 1.3.1
         tools.rmdir(os.path.join(self.package_folder, "share"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_subfolder, self._module_file),
             {"cereal": "cereal::cereal"}

--- a/recipes/cereal/all/test_package/CMakeLists.txt
+++ b/recipes/cereal/all/test_package/CMakeLists.txt
@@ -7,5 +7,5 @@ conan_basic_setup(TARGETS)
 find_package(cereal CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} cereal)
+target_link_libraries(${PROJECT_NAME} cereal::cereal)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)

--- a/recipes/cereal/config.yml
+++ b/recipes/cereal/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.3.0":
     folder: all
+  "1.3.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **cereal/1.3.1**

This PR adds version 1.3.1
I wasn't sure how to change the recipe in a clean way here and couldn't find something crystal clear on the documentation so I have a **question**:
What is the proper way to update a recipe that would otherwise break a previous version package being created? In this situation, I would have to remove the line that removes the `share` directory from the package (since it's not valid in `1.3.1`), but if I do and run the previous version (`1.3.0`) it will break. Thanks in advance for the answer!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
