### PR TITLE
podofo: do not raise by default for Visual Studio + modernize

### DIFF
--- a/recipes/podofo/all/conandata.yml
+++ b/recipes/podofo/all/conandata.yml
@@ -1,14 +1,14 @@
 sources:
-  "0.9.6":
-    url: "https://netcologne.dl.sourceforge.net/project/podofo/podofo/0.9.6/podofo-0.9.6.tar.gz"
-    sha256: "e9163650955ab8e4b9532e7aa43b841bac45701f7b0f9b793a98c8ca3ef14072"
   "0.9.7":
     url: "https://netcologne.dl.sourceforge.net/project/podofo/podofo/0.9.7/podofo-0.9.7.tar.gz"
     sha256: "7cf2e716daaef89647c54ffcd08940492fd40c385ef040ce7529396bfadc1eb8"
-patches:
   "0.9.6":
-    - patch_file: "patches/0001-fix-cmake-0.9.6.patch"
-      base_path: "source_subfolder"
+    url: "https://netcologne.dl.sourceforge.net/project/podofo/podofo/0.9.6/podofo-0.9.6.tar.gz"
+    sha256: "e9163650955ab8e4b9532e7aa43b841bac45701f7b0f9b793a98c8ca3ef14072"
+patches:
   "0.9.7":
     - patch_file: "patches/0001-fix-cmake-0.9.7.patch"
+      base_path: "source_subfolder"
+  "0.9.6":
+    - patch_file: "patches/0001-fix-cmake-0.9.6.patch"
       base_path: "source_subfolder"

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -65,12 +65,12 @@ class PodofoConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("freetype/2.10.4")
+        self.requires("freetype/2.11.1")
         self.requires("zlib/1.2.11")
         if self.settings.os != "Windows":
             self.requires("fontconfig/2.13.93")
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1k")
+            self.requires("openssl/1.1.1m")
         if self.options.with_libidn:
             self.requires("libidn/1.36")
         if self.options.with_jpeg:

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -51,6 +51,10 @@ class PodofoConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self.settings.compiler == "Visual Studio":
+            # libunistring recipe raises for Visual Studio
+            # TODO: Enable again when fixed?
+            self.options.with_unistring = False
 
     def configure(self):
         if self.options.shared:

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -47,6 +47,10 @@ class PodofoConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+
     def export_sources(self):
         self.copy("CMakeLists.txt")
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -55,7 +59,7 @@ class PodofoConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if self.settings.compiler == "Visual Studio":
+        if self._is_msvc:
             # libunistring recipe raises for Visual Studio
             # TODO: Enable again when fixed?
             self.options.with_unistring = False

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -12,7 +12,7 @@ class PodofoConan(ConanFile):
     description = "PoDoFo is a library to work with the PDF file format."
     topics = ("PDF", "PoDoFo", "podofo")
 
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -36,7 +36,6 @@ class PodofoConan(ConanFile):
         "with_unistring": True,
     }
 
-    exports_sources = ["CMakeLists.txt", "patches/**"]
     generators = "cmake", "cmake_find_package"
     _cmake = None
 
@@ -47,6 +46,11 @@ class PodofoConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -123,6 +127,7 @@ class PodofoConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "libpodofo-{}".format(tools.Version(self.version).major))
         self.cpp_info.names["pkg_config"] = "libpodofo-{}".format(tools.Version(self.version).major)
         self.cpp_info.libs = ["podofo"]
         if self.settings.os == "Windows" and self.options.shared:

--- a/recipes/podofo/config.yml
+++ b/recipes/podofo/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.9.6":
-    folder: all
   "0.9.7":
+    folder: all
+  "0.9.6":
     folder: all


### PR DESCRIPTION
libunistring doesn't support (yet?) Visual Studio, so podofo indirectly raises for this configuration. Therefore conan-center doesn't provide a pre build binary for this configuration.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
