### PR TITLE
duckdb: add recipe

### DIFF
--- a/recipes/duckdb/all/CMakeLists.txt
+++ b/recipes/duckdb/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper LANGUAGES C)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/duckdb/all/conandata.yml
+++ b/recipes/duckdb/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.3.1":
+    url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.3.1.tar.gz"
+    sha256: "ae2367d0a393be59e137ffa975f48f60b113b2a72aacc24fbc59afa0cbc3a511"

--- a/recipes/duckdb/all/conandata.yml
+++ b/recipes/duckdb/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
   "0.3.1":
-    url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.3.1.tar.gz"
-    sha256: "ae2367d0a393be59e137ffa975f48f60b113b2a72aacc24fbc59afa0cbc3a511"
+    - url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.3.1.tar.gz"
+      sha256: "ae2367d0a393be59e137ffa975f48f60b113b2a72aacc24fbc59afa0cbc3a511"
+    - url: "https://github.com/duckdb/duckdb/releases/download/v0.3.1/libduckdb-src.zip"
+      sha256: "0a6acb62a13435fa5fe0928fba53ca1355ccf35a1d357c1a769b3d798564f17d"
+patches:
+  "0.3.1":
+    - patch_file: "patches/001-fix-cmake-targets.patch"
+      base_path: "source_subfolder"

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -1,6 +1,5 @@
 from conans import ConanFile, CMake, tools
 import os
-import shutil
 
 required_conan_version = ">=1.33.0"
 

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -16,11 +16,27 @@ class DuckdbConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_icu": [True, False],
+        "with_parquet": [True, False],
+        "with_tpch": [True, False],
+        "with_tpcds": [True, False],
+        "with_fts": [True, False],
+        "with_httpfs": [True, False],
+        "with_threads": [True, False],
+        "with_rdtsc": [True, False],
+        "query_log": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_icu": False,
+        "with_parquet": False,
+        "with_tpch": False,
+        "with_tpcds": False,
+        "with_fts": False,
+        "with_httpfs": False,
+        "query_log": False,
+        "with_threads": True,
+        "with_rdtsc": False,
     }
 
     _cmake = None
@@ -48,6 +64,14 @@ class DuckdbConan(ConanFile):
         self._cmake.definitions["BUILD_UNITTESTS"] = False
         self._cmake.definitions["BUILD_STATIC_LIBS"] = not self.options.shared
         self._cmake.definitions["BUILD_ICU_EXTENSION"] = self.options.with_icu
+        self._cmake.definitions["BUILD_PARQUET_EXTENSION"] = self.options.with_parquet
+        self._cmake.definitions["BUILD_TPCH_EXTENSION"] = self.options.with_tpch
+        self._cmake.definitions["BUILD_TPCDS_EXTENSION"] = self.options.with_tpcds
+        self._cmake.definitions["BUILD_FTS_EXTENSION"] = self.options.with_fts
+        self._cmake.definitions["BUILD_HTTPFS_EXTENSION"] = self.options.with_httpfs
+        self._cmake.definitions["FORCE_QUERY_LOG"] = self.options.query_log
+        self._cmake.definitions["DISABLE_THREADS"] = not self.options.with_threads
+        self._cmake.definitions["BUILD_RDTSC"] = self.options.with_rdtsc
         self._cmake.configure()
         return self._cmake
 
@@ -70,5 +94,15 @@ class DuckdbConan(ConanFile):
             self.cpp_info.libs = ["duckdb_static"]
             if self.options.with_icu:
                 self.cpp_info.libs.append("icu_extension")
+            if self.options.with_parquet:
+                self.cpp_info.libs.append("parquet_extension")
+            if self.options.with_tpch:
+                self.cpp_info.libs.append("tpch_extension")
+            if self.options.with_tpcds:
+                self.cpp_info.libs.append("tpcds_extension")
+            if self.options.with_fts:
+                self.cpp_info.libs.append("fts_extension")
+            if self.options.with_httpfs:
+                self.cpp_info.libs.append("httpfs_extension")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread", "dl"]

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -50,6 +50,14 @@ class DuckdbConan(ConanFile):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             self.copy(patch["patch_file"])
 
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
     def source(self):
         tools.get(**(self.conan_data["sources"][self.version][0]),
                   destination=self._source_subfolder, strip_root=True)

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -56,6 +56,10 @@ class DuckdbConan(ConanFile):
         tools.get(**(self.conan_data["sources"][self.version][1]),
                   destination=os.path.join(self._source_subfolder, "src", "amalgamation"))
 
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 import os
+import shutil
 
 required_conan_version = ">=1.33.0"
 
@@ -10,16 +11,17 @@ class DuckdbConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index/"
     description = "DuckDB is an embeddable SQL OLAP Database Management System"
     topics = ("sql", "database", "olap", "embedded-database")
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
-    exports = "CMakeLists.txt"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_icu": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_icu": False,
     }
 
     _cmake = None
@@ -28,19 +30,31 @@ class DuckdbConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
+        tools.get(**(self.conan_data["sources"][self.version][0]),
                   destination=self._source_subfolder, strip_root=True)
+        tools.get(**(self.conan_data["sources"][self.version][1]),
+                  destination=os.path.join(self._source_subfolder, "src", "amalgamation"))
 
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        self._cmake.definitions["AMALGAMATION_BUILD"] = True
         self._cmake.definitions["BUILD_UNITTESTS"] = False
+        self._cmake.definitions["BUILD_STATIC_LIBS"] = not self.options.shared
+        self._cmake.definitions["BUILD_ICU_EXTENSION"] = self.options.with_icu
         self._cmake.configure()
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -51,7 +65,11 @@ class DuckdbConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.libs = ["duckdb"]
+        if self.options.shared:
+            self.cpp_info.libs = ["duckdb"]  
+        else:
+            self.cpp_info.libs = ["duckdb_static"]
+            if self.options.with_icu:
+                self.cpp_info.libs.append("icu_extension")
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.append("pthread")
-            self.cpp_info.system_libs.append("dl")
+            self.cpp_info.system_libs = ["pthread", "dl"]

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -1,0 +1,57 @@
+from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+class DuckdbConan(ConanFile):
+    name = "duckdb"
+    license = "MIT"
+    homepage = "https://github.com/cwida/duckdb"
+    url = "https://github.com/conan-io/conan-center-index/"
+    description = "DuckDB is an embeddable SQL OLAP Database Management System"
+    topics = ("sql", "database", "olap", "embedded-database")
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+    exports = "CMakeLists.txt"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["BUILD_UNITTESTS"] = False
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["duckdb"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.system_libs.append("dl")

--- a/recipes/duckdb/all/patches/001-fix-cmake-targets.patch
+++ b/recipes/duckdb/all/patches/001-fix-cmake-targets.patch
@@ -12,61 +12,45 @@ index 9f5dcce..4d6d981 100644
  add_subdirectory(extension)
  
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 752e0d6..281b056 100644
+index 752e0d6..cad0320 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -57,23 +57,25 @@ else()
-       utf8proc
-       hyperloglog)
+@@ -15,16 +15,18 @@ if(AMALGAMATION_BUILD)
+     add_definitions(/bigobj)
+   endif()
  
--  add_library(duckdb SHARED ${ALL_OBJECT_FILES})
--  target_link_libraries(duckdb ${DUCKDB_LINK_LIBS})
+-  add_library(duckdb SHARED "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.cpp")
+-  target_link_libraries(duckdb ${CMAKE_DL_LIBS})
 -  link_threads(duckdb)
 -  link_extension_libraries(duckdb)
 -
--  add_library(duckdb_static STATIC ${ALL_OBJECT_FILES})
--  target_link_libraries(duckdb_static ${DUCKDB_LINK_LIBS})
+-  add_library(duckdb_static STATIC
+-              "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.cpp")
+-  target_link_libraries(duckdb_static ${CMAKE_DL_LIBS})
 -  link_threads(duckdb_static)
 -  link_extension_libraries(duckdb_static)
--
--  target_include_directories(
--    duckdb PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
--                  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
--
--  target_include_directories(
--    duckdb_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
--                         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 +  if (NOT BUILD_STATIC_LIBS)
-+    add_library(duckdb SHARED ${ALL_OBJECT_FILES})
-+    target_link_libraries(duckdb ${DUCKDB_LINK_LIBS})
++    add_library(duckdb SHARED "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.cpp")
++    target_link_libraries(duckdb ${CMAKE_DL_LIBS})
 +    link_threads(duckdb)
 +    link_extension_libraries(duckdb)
-+
-+    target_include_directories(
-+      duckdb PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-+                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)  
 +  else()
-+    add_library(duckdb_static STATIC ${ALL_OBJECT_FILES})
-+    target_link_libraries(duckdb_static ${DUCKDB_LINK_LIBS})
++    add_library(duckdb_static STATIC
++                "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.cpp")
++    target_link_libraries(duckdb_static ${CMAKE_DL_LIBS})
 +    link_threads(duckdb_static)
 +    link_extension_libraries(duckdb_static)
-+
-+    target_include_directories(
-+      duckdb_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-+                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)  
 +  endif()
  
-   install(
-     DIRECTORY "${PROJECT_SOURCE_DIR}/src/include/duckdb"
-@@ -152,8 +154,16 @@ if(BUILD_PYTHON
+   install(FILES "${PROJECT_SOURCE_DIR}/src/amalgamation/duckdb.hpp"
+                 "${PROJECT_SOURCE_DIR}/src/include/duckdb.h"
+@@ -152,8 +154,17 @@ if(BUILD_PYTHON
    endif()
  endif()
  
 -install(
 -  TARGETS duckdb duckdb_static
--  EXPORT "${DUCKDB_EXPORT_SET}"
--  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
--  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
++
 +if (NOT BUILD_STATIC_LIBS)
 +  install(
 +    TARGETS duckdb
@@ -75,9 +59,9 @@ index 752e0d6..281b056 100644
 +    ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
 +else()
 +  install(
-+    TARGETS duckdb_static
-+    EXPORT "${DUCKDB_EXPORT_SET}"
-+    LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
-+    ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
++  TARGETS duckdb_static
+   EXPORT "${DUCKDB_EXPORT_SET}"
+   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
 +endif()
 \ No newline at end of file

--- a/recipes/duckdb/all/patches/001-fix-cmake-targets.patch
+++ b/recipes/duckdb/all/patches/001-fix-cmake-targets.patch
@@ -1,0 +1,83 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9f5dcce..4d6d981 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -527,7 +527,7 @@ endif()
+ 
+ add_subdirectory(src)
+ 
+-add_subdirectory(tools)
++# add_subdirectory(tools)
+ 
+ add_subdirectory(extension)
+ 
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 752e0d6..281b056 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -57,23 +57,25 @@ else()
+       utf8proc
+       hyperloglog)
+ 
+-  add_library(duckdb SHARED ${ALL_OBJECT_FILES})
+-  target_link_libraries(duckdb ${DUCKDB_LINK_LIBS})
+-  link_threads(duckdb)
+-  link_extension_libraries(duckdb)
+-
+-  add_library(duckdb_static STATIC ${ALL_OBJECT_FILES})
+-  target_link_libraries(duckdb_static ${DUCKDB_LINK_LIBS})
+-  link_threads(duckdb_static)
+-  link_extension_libraries(duckdb_static)
+-
+-  target_include_directories(
+-    duckdb PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-                  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+-
+-  target_include_directories(
+-    duckdb_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-                         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++  if (NOT BUILD_STATIC_LIBS)
++    add_library(duckdb SHARED ${ALL_OBJECT_FILES})
++    target_link_libraries(duckdb ${DUCKDB_LINK_LIBS})
++    link_threads(duckdb)
++    link_extension_libraries(duckdb)
++
++    target_include_directories(
++      duckdb PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)  
++  else()
++    add_library(duckdb_static STATIC ${ALL_OBJECT_FILES})
++    target_link_libraries(duckdb_static ${DUCKDB_LINK_LIBS})
++    link_threads(duckdb_static)
++    link_extension_libraries(duckdb_static)
++
++    target_include_directories(
++      duckdb_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)  
++  endif()
+ 
+   install(
+     DIRECTORY "${PROJECT_SOURCE_DIR}/src/include/duckdb"
+@@ -152,8 +154,16 @@ if(BUILD_PYTHON
+   endif()
+ endif()
+ 
+-install(
+-  TARGETS duckdb duckdb_static
+-  EXPORT "${DUCKDB_EXPORT_SET}"
+-  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+-  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
++if (NOT BUILD_STATIC_LIBS)
++  install(
++    TARGETS duckdb
++    EXPORT "${DUCKDB_EXPORT_SET}"
++    LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
++    ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
++else()
++  install(
++    TARGETS duckdb_static
++    EXPORT "${DUCKDB_EXPORT_SET}"
++    LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
++    ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
++endif()
+\ No newline at end of file

--- a/recipes/duckdb/all/test_package/CMakeLists.txt
+++ b/recipes/duckdb/all/test_package/CMakeLists.txt
@@ -6,7 +6,7 @@ conan_basic_setup(TARGETS)
 
 find_package(duckdb CONFIG REQUIRED)
 
-set (CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} duckdb::duckdb)

--- a/recipes/duckdb/all/test_package/CMakeLists.txt
+++ b/recipes/duckdb/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(duckdb CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} duckdb::duckdb)

--- a/recipes/duckdb/all/test_package/CMakeLists.txt
+++ b/recipes/duckdb/all/test_package/CMakeLists.txt
@@ -6,5 +6,7 @@ conan_basic_setup(TARGETS)
 
 find_package(duckdb CONFIG REQUIRED)
 
+set (CMAKE_CXX_STANDARD 11)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} duckdb::duckdb)

--- a/recipes/duckdb/all/test_package/conanfile.py
+++ b/recipes/duckdb/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class DuckdbTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/duckdb/all/test_package/test_package.cpp
+++ b/recipes/duckdb/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+#include "duckdb.hpp"
+
+int main() {
+    duckdb::DuckDB db(nullptr);
+	duckdb::Connection con(db);
+}

--- a/recipes/duckdb/all/test_package/test_package.cpp
+++ b/recipes/duckdb/all/test_package/test_package.cpp
@@ -4,4 +4,6 @@
 int main() {
     duckdb::DuckDB db(nullptr);
 	duckdb::Connection con(db);
+
+    return 0;
 }

--- a/recipes/duckdb/all/test_package/test_package.cpp
+++ b/recipes/duckdb/all/test_package/test_package.cpp
@@ -1,9 +1,9 @@
-#include <iostream>
 #include "duckdb.hpp"
+#include <iostream>
 
 int main() {
     duckdb::DuckDB db(nullptr);
-	duckdb::Connection con(db);
+    duckdb::Connection con(db);
 
     return 0;
 }

--- a/recipes/duckdb/config.yml
+++ b/recipes/duckdb/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.3.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **duckdb/0.3.1**

duckdb is an embedded database engine for olap.
It is required by apache arrow >= 6.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
