### PR TITLE
gtest: improve CMakeDeps & support compiler=msvc

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -1,3 +1,4 @@
+from conan.tools.microsoft import msvc_runtime_flag
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
@@ -13,6 +14,7 @@ class GTestConan(ConanFile):
     homepage = "https://github.com/google/googletest"
     license = "BSD-3-Clause"
     topics = ("testing", "google-testing", "unit-test")
+
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -31,7 +33,6 @@ class GTestConan(ConanFile):
         "hide_symbols": False,
     }
 
-    exports_sources = "CMakeLists.txt", "patches/*"
     generators = "cmake"
 
     @property
@@ -41,6 +42,10 @@ class GTestConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
 
     @property
     def _minimum_cpp_standard(self):
@@ -70,6 +75,11 @@ class GTestConan(ConanFile):
                 "apple-clang": "9.1"
             }
 
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -81,27 +91,29 @@ class GTestConan(ConanFile):
             del self.options.fPIC
 
     def validate(self):
-        if self.settings.get_safe("compiler.cppstd"):
-            tools.check_min_cppstd(self, self._minimum_cpp_standard)
-        min_version = self._minimum_compilers_version.get(
-            str(self.settings.compiler))
-        if self.settings.compiler == "Visual Studio":
-            if self.options.shared and "MT" in self.settings.compiler.runtime:
-                raise ConanInvalidConfiguration("gtest:shared=True with compiler=\"Visual Studio\" is not compatible with compiler.runtime=MT/MTd")
+        if self.options.shared and self._is_msvc and "MT" in msvc_runtime_flag(self):
+            raise ConanInvalidConfiguration(
+                "gtest:shared=True with compiler=\"Visual Studio\" is not "
+                "compatible with compiler.runtime=MT/MTd"
+            )
 
-        def lazy_lt_semver(v1, v2):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, self._minimum_cpp_standard)
+
+        def loose_lt_semver(v1, v2):
             lv1 = [int(v) for v in v1.split(".")]
             lv2 = [int(v) for v in v2.split(".")]
             min_length = min(len(lv1), len(lv2))
             return lv1[:min_length] < lv2[:min_length]
 
-        if not min_version:
-            self.output.warn("{} recipe lacks information about {} compiler support.".format(
-                self.name, self.settings.compiler))
-        else:
-            if lazy_lt_semver(str(self.settings.compiler.version), min_version):
-                raise ConanInvalidConfiguration("{0} requires {1} {2}. The current compiler is {1} {3}.".format(
-                    self.name, self.settings.compiler, min_version, self.settings.compiler.version))
+        min_version = self._minimum_compilers_version.get(str(self.settings.compiler))
+        if min_version and loose_lt_semver(str(self.settings.compiler.version), min_version):
+            raise ConanInvalidConfiguration(
+                "{0} requires {1} {2}. The current compiler is {1} {3}.".format(
+                    self.name, self.settings.compiler,
+                    min_version, self.settings.compiler.version
+                )
+            )
 
     def package_id(self):
         del self.info.options.no_main
@@ -115,8 +127,8 @@ class GTestConan(ConanFile):
         cmake = CMake(self)
         if self.settings.build_type == "Debug":
             cmake.definitions["CUSTOM_DEBUG_POSTFIX"] = self.options.debug_postfix
-        if self.settings.compiler == "Visual Studio":
-            cmake.definitions["gtest_force_shared_crt"] = "MD" in self.settings.compiler.runtime
+        if self._is_msvc:
+            cmake.definitions["gtest_force_shared_crt"] = "MD" in msvc_runtime_flag(self)
         cmake.definitions["BUILD_GMOCK"] = self.options.build_gmock
         if self.settings.os == "Windows" and self.settings.compiler == "gcc":
             cmake.definitions["gtest_disable_pthreads"] = True
@@ -143,56 +155,50 @@ class GTestConan(ConanFile):
         return self.options.debug_postfix if self.settings.build_type == "Debug" else ""
 
     def package_info(self):
-
+        self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_file_name", "GTest")
+
+        # gtest
         self.cpp_info.components["libgtest"].set_property("cmake_target_name", "GTest::gtest")
+        self.cpp_info.components["libgtest"].set_property("cmake_target_aliases", ["GTest::GTest"])
         self.cpp_info.components["libgtest"].set_property("pkg_config_name", "gtest")
         self.cpp_info.components["libgtest"].libs = ["gtest{}".format(self._postfix)]
-
-        self.cpp_info.names["cmake_find_package"] = "GTest"
-        self.cpp_info.names["cmake_find_package_multi"] = "GTest"
-        self.cpp_info.components["libgtest"].names["cmake_find_package"] = "gtest"
-        self.cpp_info.components["libgtest"].names["cmake_find_package_multi"] = "gtest"
-
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libgtest"].system_libs.append("pthread")
-
         if self.settings.os == "Neutrino" and self.settings.os.version == "7.1":
             self.cpp_info.components["libgtest"].system_libs.append("regex")
-
         if self.options.shared:
             self.cpp_info.components["libgtest"].defines.append("GTEST_LINKED_AS_SHARED_LIBRARY=1")
-
         if self.version == "1.8.1":
-            if self.settings.compiler == "Visual Studio":
-                if tools.Version(self.settings.compiler.version) >= "15":
-                    self.cpp_info.components["libgtest"].defines.append("GTEST_LANG_CXX11=1")
-                    self.cpp_info.components["libgtest"].defines.append("GTEST_HAS_TR1_TUPLE=0")
+            if (self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) >= "15") or \
+               (str(self.settings.compiler) == "msvc" and tools.Version(self.settings.compiler.version) >= "191"):
+                self.cpp_info.components["libgtest"].defines.append("GTEST_LANG_CXX11=1")
+                self.cpp_info.components["libgtest"].defines.append("GTEST_HAS_TR1_TUPLE=0")
 
+        # gtest_main
         if not self.options.no_main:
             self.cpp_info.components["gtest_main"].set_property("cmake_target_name", "GTest::gtest_main")
+            self.cpp_info.components["gtest_main"].set_property("cmake_target_aliases", ["GTest::Main"])
             self.cpp_info.components["gtest_main"].set_property("pkg_config_name", "gtest_main")
             self.cpp_info.components["gtest_main"].libs = ["gtest_main{}".format(self._postfix)]
             self.cpp_info.components["gtest_main"].requires = ["libgtest"]
 
-            self.cpp_info.components["gtest_main"].names["cmake_find_package"] = "gtest_main"
-            self.cpp_info.components["gtest_main"].names["cmake_find_package_multi"] = "gtest_main"
-
+        # gmock
         if self.options.build_gmock:
             self.cpp_info.components["gmock"].set_property("cmake_target_name", "GTest::gmock")
             self.cpp_info.components["gmock"].set_property("pkg_config_name", "gmock")
             self.cpp_info.components["gmock"].libs = ["gmock{}".format(self._postfix)]
             self.cpp_info.components["gmock"].requires = ["libgtest"]
 
-            self.cpp_info.components["gmock"].names["cmake_find_package"] = "gmock"
-            self.cpp_info.components["gmock"].names["cmake_find_package_multi"] = "gmock"
-
+            # gmock_main
             if not self.options.no_main:
                 self.cpp_info.components["gmock_main"].set_property("cmake_target_name", "GTest::gmock_main")
                 self.cpp_info.components["gmock_main"].set_property("pkg_config_name", "gmock_main")
                 self.cpp_info.components["gmock_main"].libs = ["gmock_main{}".format(self._postfix)]
                 self.cpp_info.components["gmock_main"].requires = ["gmock"]
 
-                self.cpp_info.components["gmock_main"].names["cmake_find_package"] = "gmock_main"
-                self.cpp_info.components["gmock_main"].names["cmake_find_package_multi"] = "gmock_main"
-
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.names["cmake_find_package"] = "GTest"
+        self.cpp_info.names["cmake_find_package_multi"] = "GTest"
+        self.cpp_info.components["libgtest"].names["cmake_find_package"] = "gtest"
+        self.cpp_info.components["libgtest"].names["cmake_find_package_multi"] = "gtest"


### PR DESCRIPTION
due to https://cmake.org/cmake/help/latest/module/FindGTest.html:
- set `cmake_find_mode` to `both`
- for backwards compatibility add target aliases `GTest::GTest` & `GTest::Main`

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
