### PR TITLE
Remove wrong cmake target for Ofeli

### DIFF
--- a/recipes/ofeli/all/conanfile.py
+++ b/recipes/ofeli/all/conanfile.py
@@ -8,8 +8,8 @@ required_conan_version = ">=1.40.0"
 class OfeliConan(ConanFile):
     name = "ofeli"
     description = "An Object Finite Element Library"
-    topics = ("ofeli", "finite element", "finite element library",
-              "finite element analysis", "finite element solver")
+    topics = ("finite-element", "finite-element-library",
+              "finite-element-analysis", "finite-element-solver")
     license = "LGPL-3.0-or-later"
     homepage = "http://ofeli.org/index.html"
     url = "https://github.com/conan-io/conan-center-index"
@@ -68,8 +68,6 @@ class OfeliConan(ConanFile):
         self.copy("COPYING", dst="licenses", src=self._doc_folder)
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "Ofeli"
-        self.cpp_info.names["cmake_find_package_multi"] = "Ofeli"
         self.cpp_info.libs = ["ofeli"]
         self.env_info.OFELI_PATH_MATERIAL.append(
             os.path.join(self.package_folder, "res"))

--- a/recipes/ofeli/all/test_package/CMakeLists.txt
+++ b/recipes/ofeli/all/test_package/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.4)
 project(test_package LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 11)
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
+find_package(ofeli CONFIG REQUIRED)
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} CONAN_PKG::ofeli)
+target_link_libraries(${PROJECT_NAME} ofeli::ofeli)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)

--- a/recipes/ofeli/all/test_package/conanfile.py
+++ b/recipes/ofeli/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION

Related to #8375

@SpaceIm found a bug in the recipe, the CMake target is not declared on the upstream, so it uses the project name which is `ofeli`, not `Ofeli`.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
