### PR TITLE
cairo: remove cairo-trace component

### DIFF
--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -373,11 +373,6 @@ class CairoConan(ConanFile):
             self.cpp_info.components["cairo-script-interpreter"].libs = ["cairo-script-interpreter"]
             self.cpp_info.components["cairo-script-interpreter"].requires = ["cairo_"]
 
-        if self.options.with_zlib and self.settings.os != "Windows":
-            self.cpp_info.components["cairo-trace"].libs = ["cairo-trace"]
-            self.cpp_info.components["cairo-trace"].requires = ["cairo_"]
-            self.cpp_info.components["cairo-trace"].libdirs.append(os.path.join(self.package_folder, "lib", "cairo"))
-
         if self.options.with_zlib and self.options.tee and self.settings.os != "Windows":
             self.cpp_info.components["cairo-fdr"].libs = ["cairo-fdr"]
             self.cpp_info.components["cairo-fdr"].requires = ["cairo_"]

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -115,7 +115,7 @@ class CairoConan(ConanFile):
             self.requires("egl/system")
 
     def build_requirements(self):
-        self.build_requires("meson/0.59.3")
+        self.build_requires("meson/0.60.2")
         self.build_requires("pkgconf/1.7.4")
 
     def validate(self):

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -113,7 +113,7 @@ class CairoConan(ConanFile):
             self.requires("egl/system")
 
     def build_requirements(self):
-        self.build_requires("meson/0.59.1")
+        self.build_requires("meson/0.59.3")
         self.build_requires("pkgconf/1.7.4")
 
     def validate(self):

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -3,7 +3,6 @@ from conans.errors import ConanInvalidConfiguration
 import contextlib
 import glob
 import os
-import shutil
 
 required_conan_version = ">=1.38.0"
 
@@ -48,7 +47,6 @@ class CairoConan(ConanFile):
         "tee": True,
     }
 
-    exports_sources = "patches/*"
     generators = "pkg_config"
 
     _meson = None
@@ -64,6 +62,10 @@ class CairoConan(ConanFile):
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
+
+    def export_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         del self.settings.compiler.libcxx
@@ -202,12 +204,12 @@ class CairoConan(ConanFile):
             meson.build()
 
     def _fix_library_names(self):
-        if self.settings.compiler == "Visual Studio":
+        if self._is_msvc:
             with tools.chdir(os.path.join(self.package_folder, "lib")):
                 for filename_old in glob.glob("*.a"):
                     filename_new = filename_old[3:-2] + ".lib"
                     self.output.info("rename %s into %s" % (filename_old, filename_new))
-                    shutil.move(filename_old, filename_new)
+                    tools.rename(filename_old, filename_new)
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)


### PR DESCRIPTION
this library is never linked to directly. instead it is loaded dynamically by the cairo-trace utility
cf https://www.cairographics.org/FAQ/#profiling

fixes conan-io/conan-center-index#8667
fixes conan-io/conan-center-index#8818

Specify library name and version:  **cairo/***

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
