### PR TITLE
boost: Fix path finder for python libraries

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -702,7 +702,7 @@ class BoostConan(ConanFile):
                 self.output.info("checking {}".format(python_lib))
                 if os.path.isfile(python_lib):
                     self.output.info("found python library: {}".format(python_lib))
-                    return python_lib.replace("\\", "/")
+                    return libdir.replace("\\", "/")
         raise ConanInvalidConfiguration("couldn't locate python libraries - make sure you have installed python development files")
 
     def _clean(self):


### PR DESCRIPTION
Specify library name and version:  **boost/all**

Fixes #2973

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
