### PR TITLE
msys2: Force uninstall of pkgconf

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -134,7 +134,7 @@ class MSYS2Conan(ConanFile):
             for package in packages:
                 self.run('bash -l -c "pacman -S %s --noconfirm"' % package)
             for package in ['pkgconf']:
-                self.run('bash -l -c "pacman -Rs $(pacman -Qsq %s) --noconfirm"' % package)
+                self.run('bash -l -c "pacman -Rs -d -d $(pacman -Qsq %s) --noconfirm"' % package)
 
         self._kill_pacman()
 


### PR DESCRIPTION
- pkgconf is required by base-devel, so to really make it gone requires ignoring
  dependencies

Specify library name and version:  **msys2/cci.latest**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

`pkgconf` is required by `base-devel`, so for this recipe to delete it, dependencies have to be really ignored.

Avoids this error:

```
(1/1) Updating the info directory file... 
checking dependencies... 
error: failed to prepare transaction (could not satisfy dependencies)
 :: removing pkgconf breaks dependency 'pkgconf' required by base-devel 
msys2/cci.latest: 
msys2/cci.latest: ERROR: Package 'eee3fba89db6d777329de604625af8c30d46f080' build failed 
```

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
