### PR TITLE
simple-yaml: add compatibility for older compilers

### DIFF
--- a/recipes/simple-yaml/all/conandata.yml
+++ b/recipes/simple-yaml/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.2.1":
-    url: "https://github.com/Rechip/simple-yaml/archive/refs/tags/v0.2.1.zip"
-    sha256: "b802b9913d7f112461fcde66419b0c12b794301fe9a5f9d19c3a7716b63c6f97"
+  "0.2.2":
+    url: "https://github.com/Rechip/simple-yaml/archive/refs/tags/v0.2.2.zip"
+    sha256: "7df6a5f15d83dfcff1eac87d14b39cf457e93a6586f888677f408b8884cebada"

--- a/recipes/simple-yaml/all/conandata.yml
+++ b/recipes/simple-yaml/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.2.0":
-    url: "https://github.com/Rechip/simple-yaml/archive/refs/tags/v0.2.0.zip"
-    sha256: "d3fc9e4bd30e7ccce01d2eb1b69710f833043c43456d7be5cad6f83d908aeed5"
+  "0.2.1":
+    url: "https://github.com/Rechip/simple-yaml/archive/refs/tags/v0.2.1.zip"
+    sha256: "b802b9913d7f112461fcde66419b0c12b794301fe9a5f9d19c3a7716b63c6f97"

--- a/recipes/simple-yaml/all/conanfile.py
+++ b/recipes/simple-yaml/all/conanfile.py
@@ -55,6 +55,8 @@ class SimpleYamlConan(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "20")
+        if self.settings.compiler == "clang" and self.settings.compiler.libcxx in ["libstdc++", "libstdc++11"] and self.settings.compiler.version == "11":
+            raise ConanInvalidConfiguration("clang 11 with libstdc++ is not supported due to old libstdc++ missing C++17 support")
         minimum_version = self._minimum_compilers_version.get(
             str(self.settings.compiler), False)
         if not minimum_version:

--- a/recipes/simple-yaml/all/conanfile.py
+++ b/recipes/simple-yaml/all/conanfile.py
@@ -49,7 +49,7 @@ class SimpleYamlConan(ConanFile):
             "Visual Studio": "16.3",
             "gcc": "10",
             "clang": "11",
-            "apple-clang": "12",
+            "apple-clang": "13.3",
         }
 
     def validate(self):

--- a/recipes/simple-yaml/all/conanfile.py
+++ b/recipes/simple-yaml/all/conanfile.py
@@ -33,6 +33,7 @@ class SimpleYamlConan(ConanFile):
     def requirements(self):
         self.requires("pretty-name/1.0.0")
         self.requires("yaml-cpp/0.7.0")
+        self.requires("source_location/0.2.0")
         if self.options.enable_enum:
             self.requires("magic_enum/0.7.3")
 
@@ -45,15 +46,10 @@ class SimpleYamlConan(ConanFile):
     @property
     def _minimum_compilers_version(self):
         return {
-            "Visual Studio": "16.11",
-            "gcc": "11",
-        }
-
-    @property
-    def _unsupported_compilers_version(self):
-        return {
-            "clang": "13",
-            "apple-clang": "13",
+            "Visual Studio": "16.3",
+            "gcc": "10",
+            "clang": "11",
+            "apple-clang": "12",
         }
 
     def validate(self):
@@ -62,11 +58,6 @@ class SimpleYamlConan(ConanFile):
         minimum_version = self._minimum_compilers_version.get(
             str(self.settings.compiler), False)
         if not minimum_version:
-            unsupported_compiler = self._unsupported_compilers_version.get(
-                str(self.settings.compiler), False)
-            if unsupported_compiler and tools.Version(self.settings.compiler.version) <= unsupported_compiler:
-                raise ConanInvalidConfiguration(
-                    "simple-yaml requires C++20. Your compiler does not implement this standard fully.")
             self.output.warn(
                 "simple-yaml requires C++20. Your compiler is unknown. Assuming it fully supports C++20.")
         elif tools.Version(self.settings.compiler.version) < minimum_version:

--- a/recipes/simple-yaml/config.yml
+++ b/recipes/simple-yaml/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.2.0":
+  "0.2.1":
     folder: all

--- a/recipes/simple-yaml/config.yml
+++ b/recipes/simple-yaml/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.2.1":
+  "0.2.2":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **simple-yaml/0.2.1**

The previous PR #8705 didn't generate any packages due to the fact that no compiler in the PR pipeline supported `<source_location>` header. Adding compatibility library `source_location` solves this issue and thus it should generate some packages this time (hopefully). And since there were no packages online, I also bumped the version removing the older one.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
