### PR TITLE
(#9047) boost: Bump build_requires of 'b2' to '4.7.1' (was '4.5.0')

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -92,6 +92,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/1.69.0-type_erasure-no-system.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/1.70.0-boost_build-with-newer-b2.patch"
+      base_path: "source_subfolder"
   1.70.0:
     - patch_file: "patches/0001-beast-fix-moved-from-executor.patch"
       base_path: "source_subfolder"
@@ -117,6 +119,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/1.69.0-type_erasure-no-system.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/1.70.0-boost_build-with-newer-b2.patch"
+      base_path: "source_subfolder"
   1.71.0:
     - patch_file: "patches/bcp_namespace_issues_1_71.patch"
       base_path: "source_subfolder"
@@ -139,6 +143,8 @@ patches:
     - patch_file: "patches/1.69.0-random-no-system.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/1.69.0-type_erasure-no-system.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/1.75.0-boost_build-with-newer-b2.patch"
       base_path: "source_subfolder"
   1.72.0:
     - patch_file: "patches/bcp_namespace_issues_1_72.patch"
@@ -165,6 +171,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/1.69.0-type_erasure-no-system.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/1.75.0-boost_build-with-newer-b2.patch"
+      base_path: "source_subfolder"
   1.73.0:
     - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter.patch"
       base_path: "source_subfolder"
@@ -179,6 +187,8 @@ patches:
     - patch_file: "patches/1.69.0-random-no-system.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/1.69.0-type_erasure-no-system.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/1.75.0-boost_build-with-newer-b2.patch"
       base_path: "source_subfolder"
   1.74.0:
     - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter_since_1_74.patch"
@@ -195,6 +205,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/1.69.0-type_erasure-no-system.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/1.75.0-boost_build-with-newer-b2.patch"
+      base_path: "source_subfolder"
   1.75.0:
     - patch_file: "patches/boost_build_qcc_fix_debug_build_parameter_since_1_74.patch"
       base_path: "source_subfolder"
@@ -208,6 +220,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/1.77.0-type_erasure-no-system.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/1.75.0-boost_build-with-newer-b2.patch"
+      base_path: "source_subfolder"
   1.76.0:
     - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
       base_path: "source_subfolder"
@@ -216,6 +230,8 @@ patches:
     - patch_file: "patches/1.69.0-locale-no-system.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/1.77.0-type_erasure-no-system.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/1.77.0-boost_build-with-newer-b2.patch"
       base_path: "source_subfolder"
   1.77.0:
     - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
@@ -227,6 +243,8 @@ patches:
     - patch_file: "patches/1.77.0-type_erasure-no-system.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/1.77.0-fiber-mingw.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/1.77.0-boost_build-with-newer-b2.patch"
       base_path: "source_subfolder"
   1.78.0:
     - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -445,7 +445,7 @@ class BoostConan(ConanFile):
 
     def build_requirements(self):
         if not self.options.header_only:
-            self.build_requires("b2/4.5.0")
+            self.build_requires("b2/4.7.1")
 
     def _with_dependency(self, dependency):
         """

--- a/recipes/boost/all/patches/1.70.0-boost_build-with-newer-b2.patch
+++ b/recipes/boost/all/patches/1.70.0-boost_build-with-newer-b2.patch
@@ -1,0 +1,51 @@
+--- tools/build/src/build/configure.jam.orig	2019-04-09 15:36:57.000000000 -0400
++++ tools/build/src/build/configure.jam	2022-01-28 20:51:10.924240100 -0500
+@@ -452,7 +452,7 @@
+     return [ find-builds-raw $(p) : $(ps) : $(what) :
+         $(3) : $(4) : $(5) : $(6) : $(7) : $(8) : $(9) :
+         $(10) : $(11) : $(12) : $(13) : $(14) : $(15) :
+-        $(16) : $(17) : $(18) : $(19)  ] ;
++        $(16) : $(17) : $(18) ] ;
+ }
+ 
+ 
+@@ -510,7 +510,7 @@
+     rule __init__ ( message : * )
+     {
+         self.message = $(message) ;
+-        for i in 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
++        for i in 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
+         {
+             local name = [ CALC $(i) - 1 ] ;
+             self.targets.$(name) = $($(i)[1]) ;
+@@ -527,7 +527,7 @@
+     }
+     rule all-properties ( )
+     {
+-        local i = 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ;
++        local i = 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 ;
+         return $(self.props.$(i)) ;
+     }
+     rule check ( properties * )
+@@ -549,9 +549,7 @@
+             : $(self.targets.14) $(self.what.14)
+             : $(self.targets.15) $(self.what.15)
+             : $(self.targets.16) $(self.what.16)
+-            : $(self.targets.17) $(self.what.17)
+-            : $(self.targets.18) $(self.what.18)
+-            : $(self.targets.19) $(self.what.19) ] ;
++            : $(self.targets.17) $(self.what.17) ] ;
+         if $(self.props.$(i))
+         {
+             return [ property.evaluate-conditionals-in-context $(self.props.$(i)) : $(properties) ] ;
+--- tools/build/src/util/indirect.jam.orig	2020-12-03 00:02:49.000000000 -0500
++++ tools/build/src/util/indirect.jam	2022-01-28 20:32:41.249509200 -0500
+@@ -102,7 +102,7 @@
+ {
+     return [ modules.call-in [ get-module $(r) ] : [ get-rule $(r) ] $(args) :
+         $(2) : $(3) : $(4) : $(5) : $(6) : $(7) : $(8) : $(9) : $(10) : $(11) :
+-        $(12) : $(13) : $(14) : $(15) : $(16) : $(17) : $(18) : $(19) ] ;
++        $(12) : $(13) : $(14) : $(15) : $(16) : $(17) : $(18) ] ;
+ }
+ 
+ 

--- a/recipes/boost/all/patches/1.75.0-boost_build-with-newer-b2.patch
+++ b/recipes/boost/all/patches/1.75.0-boost_build-with-newer-b2.patch
@@ -1,0 +1,51 @@
+--- tools/build/src/build/configure.jam.orig	2020-12-03 00:02:49.000000000 -0500
++++ tools/build/src/build/configure.jam	2022-01-28 20:32:41.260634800 -0500
+@@ -454,7 +454,7 @@
+     return [ find-builds-raw $(p) : $(ps) : $(what) :
+         $(3) : $(4) : $(5) : $(6) : $(7) : $(8) : $(9) :
+         $(10) : $(11) : $(12) : $(13) : $(14) : $(15) :
+-        $(16) : $(17) : $(18) : $(19)  ] ;
++        $(16) : $(17) : $(18) ] ;
+ }
+ 
+ 
+@@ -518,7 +518,7 @@
+     {
+         local project = [ project.current ] ;
+         self.message = $(message) ;
+-        for i in 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
++        for i in 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
+         {
+             local name = [ CALC $(i) - 1 ] ;
+             self.targets.$(name) = $($(i)[1]) ;
+@@ -537,7 +537,7 @@
+     }
+     rule all-properties ( )
+     {
+-        local i = 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ;
++        local i = 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 ;
+         return $(self.props.$(i)) ;
+     }
+     rule check ( properties * )
+@@ -559,9 +559,7 @@
+             : $(self.targets.14) $(self.what.14)
+             : $(self.targets.15) $(self.what.15)
+             : $(self.targets.16) $(self.what.16)
+-            : $(self.targets.17) $(self.what.17)
+-            : $(self.targets.18) $(self.what.18)
+-            : $(self.targets.19) $(self.what.19) ] ;
++            : $(self.targets.17) $(self.what.17) ] ;
+         if $(self.props.$(i))
+         {
+             return [ property.evaluate-conditionals-in-context $(self.props.$(i)) : $(properties) ] ;
+--- tools/build/src/util/indirect.jam.orig	2020-12-03 00:02:49.000000000 -0500
++++ tools/build/src/util/indirect.jam	2022-01-28 20:32:41.249509200 -0500
+@@ -102,7 +102,7 @@
+ {
+     return [ modules.call-in [ get-module $(r) ] : [ get-rule $(r) ] $(args) :
+         $(2) : $(3) : $(4) : $(5) : $(6) : $(7) : $(8) : $(9) : $(10) : $(11) :
+-        $(12) : $(13) : $(14) : $(15) : $(16) : $(17) : $(18) : $(19) ] ;
++        $(12) : $(13) : $(14) : $(15) : $(16) : $(17) : $(18) ] ;
+ }
+ 
+ 

--- a/recipes/boost/all/patches/1.77.0-boost_build-with-newer-b2.patch
+++ b/recipes/boost/all/patches/1.77.0-boost_build-with-newer-b2.patch
@@ -1,0 +1,51 @@
+--- tools/build/src/build/configure.jam.orig	2021-08-05 05:42:46.000000000 -0400
++++ tools/build/src/build/configure.jam	2022-01-28 19:55:37.960877600 -0500
+@@ -467,7 +467,7 @@
+     return [ find-builds-raw $(p) : $(ps) : $(what) :
+         $(3) : $(4) : $(5) : $(6) : $(7) : $(8) : $(9) :
+         $(10) : $(11) : $(12) : $(13) : $(14) : $(15) :
+-        $(16) : $(17) : $(18) : $(19)  ] ;
++        $(16) : $(17) : $(18) ] ;
+ }
+ 
+ 
+@@ -531,7 +531,7 @@
+     {
+         local project = [ project.current ] ;
+         self.message = $(message) ;
+-        for i in 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
++        for i in 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
+         {
+             local name = [ CALC $(i) - 1 ] ;
+             self.targets.$(name) = $($(i)[1]) ;
+@@ -550,7 +550,7 @@
+     }
+     rule all-properties ( )
+     {
+-        local i = 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ;
++        local i = 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 ;
+         return $(self.props.$(i)) ;
+     }
+     rule check ( properties * )
+@@ -572,9 +572,7 @@
+             : $(self.targets.14) $(self.what.14)
+             : $(self.targets.15) $(self.what.15)
+             : $(self.targets.16) $(self.what.16)
+-            : $(self.targets.17) $(self.what.17)
+-            : $(self.targets.18) $(self.what.18)
+-            : $(self.targets.19) $(self.what.19) ] ;
++            : $(self.targets.17) $(self.what.17) ] ;
+         if $(self.props.$(i))
+         {
+             return [ property.evaluate-conditionals-in-context $(self.props.$(i)) : $(properties) ] ;
+--- tools/build/src/util/indirect.jam.orig	2021-08-05 05:42:46.000000000 -0400
++++ tools/build/src/util/indirect.jam	2021-12-02 01:48:03.000000000 -0500
+@@ -102,7 +102,7 @@
+ {
+     return [ modules.call-in [ get-module $(r) ] : [ get-rule $(r) ] $(args) :
+         $(2) : $(3) : $(4) : $(5) : $(6) : $(7) : $(8) : $(9) : $(10) : $(11) :
+-        $(12) : $(13) : $(14) : $(15) : $(16) : $(17) : $(18) : $(19) ] ;
++        $(12) : $(13) : $(14) : $(15) : $(16) : $(17) : $(18) ] ;
+ }
+ 
+ .parts_regex = "^([^@]*)@" "([^%]*)%" "([^%]+)$" ;


### PR DESCRIPTION
This fixes #9047 ('build from source fails with MSVC 2022 due to outdated b2 dep')

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
