### PR TITLE
Fix whereami version name

### DIFF
--- a/recipes/whereami/all/conandata.yml
+++ b/recipes/whereami/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "20220112":
+  "cci.20220112":
     url: "https://github.com/gpakosz/whereami/archive/f15606a65908bb097e1887a08a40ae083e9a5c53.tar.gz"
     sha256: "005d51ed0a99845b27ed9df4834b609abfc1811b187aeee1a85929004704dd6d"

--- a/recipes/whereami/config.yml
+++ b/recipes/whereami/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "20220112":
+  "cci.20220112":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **whereami/20220112**

https://github.com/conan-io/conan-center-index/pull/8850#issuecomment-1021290264

/cc @Croydon @jmarrec

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
