### PR TITLE
qt6: enable Quick only if qtshadertools is enabled

### DIFF
--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -76,6 +76,13 @@ sources:
       - "https://www.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/6.2/6.2.2/single/qt-everywhere-src-6.2.2.tar.xz"
       - "https://ftp.fau.de/qtproject/archive/qt/6.2/6.2.2/single/qt-everywhere-src-6.2.2.tar.xz"
     sha256: "907994f78d42b30bdea95e290e91930c2d9b593f3f8dd994f44157e387feee0f"
+  "6.2.3":
+    url:
+      - "https://download.qt.io/archive/qt/6.2/6.2.3/single/qt-everywhere-src-6.2.3.tar.xz"
+      - "https://qt-mirror.dannhauer.de/archive/qt/6.2/6.2.3/single/qt-everywhere-src-6.2.3.tar.xz"
+      - "https://www.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/6.2/6.2.3/single/qt-everywhere-src-6.2.3.tar.xz"
+      - "https://ftp.fau.de/qtproject/archive/qt/6.2/6.2.3/single/qt-everywhere-src-6.2.3.tar.xz"
+    sha256: "f784998a159334d1f47617fd51bd0619b9dbfe445184567d2cd7c820ccb12771"
 patches:
   "6.0.4":
     - base_path: "qt6/qtbase/cmake"
@@ -123,6 +130,15 @@ patches:
     - base_path: "qt6/qtwebengine/src/3rdparty"
       patch_file: "patches/c76d2f6.patch"
   "6.2.2":
+    - base_path: "qt6/qtdeclarative"
+      patch_file: "patches/32451d5.diff"
+    - base_path: "qt6/qtbase/cmake"
+      patch_file: "patches/qt6-pri-helpers-fix.diff"
+    - patch_file: "patches/c72097e.diff"
+      base_path: "qt6/qtwebengine"
+    - patch_file: "patches/138a720.diff"
+      base_path: "qt6/qtwebengine/src/3rdparty"
+  "6.2.3":
     - base_path: "qt6/qtdeclarative"
       patch_file: "patches/32451d5.diff"
     - base_path: "qt6/qtbase/cmake"

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -339,7 +339,7 @@ class QtConan(ConanFile):
             self.requires("dbus/1.12.20")
 
     def build_requirements(self):
-        self.build_requires("cmake/3.21.3")
+        self.build_requires("cmake/3.22.0")
         self.build_requires("ninja/1.10.2")
         self.build_requires("pkgconf/1.7.4")
         if self.settings.compiler == "Visual Studio":

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -280,59 +280,59 @@ class QtConan(ConanFile):
             if tools.is_apple_os(self.settings.os):
                 self.requires("moltenvk/1.1.4")
         if self.options.with_glib:
-            self.requires("glib/2.69.2")
+            self.requires("glib/2.70.1")
         if self.options.with_doubleconversion and not self.options.multiconfiguration:
-            self.requires("double-conversion/3.1.5")
+            self.requires("double-conversion/3.1.7")
         if self.options.get_safe("with_freetype", False) and not self.options.multiconfiguration:
-            self.requires("freetype/2.10.4")
+            self.requires("freetype/2.11.0")
         if self.options.get_safe("with_fontconfig", False):
             self.requires("fontconfig/2.13.93")
         if self.options.get_safe("with_icu", False):
-            self.requires("icu/69.1")
+            self.requires("icu/70.1")
         if self.options.get_safe("with_harfbuzz", False) and not self.options.multiconfiguration:
-            self.requires("harfbuzz/2.8.0")
+            self.requires("harfbuzz/3.2.0")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:
             if self.options.with_libjpeg == "libjpeg-turbo":
-                self.requires("libjpeg-turbo/2.1.1")
+                self.requires("libjpeg-turbo/2.1.2")
             else:
                 self.requires("libjpeg/9d")
         if self.options.get_safe("with_libpng", False) and not self.options.multiconfiguration:
             self.requires("libpng/1.6.37")
         if self.options.with_sqlite3 and not self.options.multiconfiguration:
-            self.requires("sqlite3/3.36.0")
+            self.requires("sqlite3/3.37.2")
             self.options["sqlite3"].enable_column_metadata = True
         if self.options.get_safe("with_mysql", False):
-            self.requires("libmysqlclient/8.0.17")
+            self.requires("libmysqlclient/8.0.25")
         if self.options.with_pq:
-            self.requires("libpq/13.2")
+            self.requires("libpq/13.4")
         if self.options.with_odbc:
             if self.settings.os != "Windows":
                 self.requires("odbc/2.3.9")
         if self.options.get_safe("with_openal", False):
             self.requires("openal/1.21.1")
         if self.options.get_safe("with_libalsa", False):
-            self.requires("libalsa/1.2.4")
+            self.requires("libalsa/1.2.5.1")
         if self.options.gui and self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("xorg/system")
             if not tools.cross_building(self, skip_x64_x86=True):
-                self.requires("xkbcommon/1.3.0")
+                self.requires("xkbcommon/1.3.1")
         if self.settings.os != "Windows" and self.options.get_safe("opengl", "no") != "no":
             self.requires("opengl/system")
         if self.options.with_zstd:
-            self.requires("zstd/1.5.0")
+            self.requires("zstd/1.5.2")
         if self.options.qtwayland:
-            self.requires("wayland/1.19.0")
+            self.requires("wayland/1.20.0")
         if self.options.with_brotli:
             self.requires("brotli/1.0.9")
         if self.options.get_safe("qtwebengine") and self.settings.os == "Linux":
-            self.requires("expat/2.4.1")
+            self.requires("expat/2.4.3")
             self.requires("opus/1.3.1")
             self.requires("xorg-proto/2021.4")
             self.requires("libxshmfence/1.3")
             self.requires("nss/3.72")
             self.requires("libdrm/2.4.109")
         if self.options.get_safe("with_gstreamer", False):
-            self.requires("gst-plugins-base/1.19.1")
+            self.requires("gst-plugins-base/1.19.2")
         if self.options.get_safe("with_pulseaudio", False):
             self.requires("pulseaudio/14.2")
         if self.options.with_dbus:
@@ -351,7 +351,7 @@ class QtConan(ConanFile):
             self.build_requires("gperf/3.1")
             # gperf, bison, flex, python >= 2.7.5 & < 3
             if self.settings.os != "Windows":
-                self.build_requires("bison/3.7.1")
+                self.build_requires("bison/3.7.6")
                 self.build_requires("flex/2.6.4")
             else:
                 self.build_requires("winflexbison/2.5.24")
@@ -392,7 +392,7 @@ class QtConan(ConanFile):
                 raise ConanInvalidConfiguration(msg)
 
         if self.options.qtwayland:
-            self.build_requires("wayland/1.19.0")
+            self.build_requires("wayland/1.20.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -272,7 +272,7 @@ class QtConan(ConanFile):
     def requirements(self):
         self.requires("zlib/1.2.11")
         if self.options.openssl:
-            self.requires("openssl/1.1.1l")
+            self.requires("openssl/1.1.1m")
         if self.options.with_pcre2:
             self.requires("pcre2/10.37")
         if self.options.get_safe("with_vulkan"):
@@ -293,7 +293,7 @@ class QtConan(ConanFile):
             self.requires("harfbuzz/2.8.0")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:
             if self.options.with_libjpeg == "libjpeg-turbo":
-                self.requires("libjpeg-turbo/2.1.0")
+                self.requires("libjpeg-turbo/2.1.1")
             else:
                 self.requires("libjpeg/9d")
         if self.options.get_safe("with_libpng", False) and not self.options.multiconfiguration:

--- a/recipes/qt/6.x.x/qtmodules6.2.3.conf
+++ b/recipes/qt/6.x.x/qtmodules6.2.3.conf
@@ -1,0 +1,299 @@
+[submodule "qtbase"]
+	path = qtbase
+	url = ../qtbase.git
+	branch = 6.2.3
+	status = essential
+[submodule "qtsvg"]
+	depends = qtbase
+	path = qtsvg
+	url = ../qtsvg.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtdeclarative"]
+	depends = qtbase
+	recommends = qtimageformats qtshadertools qtsvg
+	path = qtdeclarative
+	url = ../qtdeclarative.git
+	branch = 6.2.3
+	status = essential
+[submodule "qtactiveqt"]
+	depends = qtbase
+	path = qtactiveqt
+	url = ../qtactiveqt.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtmultimedia"]
+	depends = qtbase qtshadertools
+	recommends = qtdeclarative
+	path = qtmultimedia
+	url = ../qtmultimedia.git
+	branch = 6.2.3
+	status = addon
+[submodule "qttools"]
+	depends = qtbase
+	recommends = qtdeclarative qtactiveqt
+	path = qttools
+	url = ../qttools.git
+	branch = 6.2.3
+	status = essential
+[submodule "qtxmlpatterns"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtxmlpatterns
+	url = ../qtxmlpatterns.git
+	branch = 6.2.3
+	status = ignore
+[submodule "qttranslations"]
+	depends = qttools
+	path = qttranslations
+	url = ../qttranslations.git
+	branch = 6.2.3
+	status = essential
+	priority = 30
+[submodule "qtdoc"]
+	depends = qtdeclarative qttools
+	recommends = qtmultimedia
+	path = qtdoc
+	url = ../qtdoc.git
+	branch = 6.2.3
+	status = essential
+	priority = 40
+[submodule "qtrepotools"]
+	path = qtrepotools
+	url = ../qtrepotools.git
+	branch = master
+	status = essential
+	project = -
+[submodule "qtqa"]
+	depends = qtbase
+	path = qtqa
+	url = ../qtqa.git
+	branch = dev
+	status = essential
+	priority = 50
+[submodule "qtlocation"]
+	depends = qtbase qtpositioning
+	recommends = qtdeclarative
+	path = qtlocation
+	url = ../qtlocation.git
+	branch = 6.2.3
+	status = ignore
+[submodule "qtpositioning"]
+	depends = qtbase
+	recommends = qtdeclarative qtserialport
+	path = qtpositioning
+	url = ../qtpositioning.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtsensors"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtsensors
+	url = ../qtsensors.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtsystems"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtsystems
+	url = ../qtsystems.git
+	branch = dev
+	status = ignore
+[submodule "qtfeedback"]
+	depends = qtdeclarative
+	recommends = qtmultimedia
+	path = qtfeedback
+	url = ../qtfeedback.git
+	branch = master
+	status = ignore
+[submodule "qtpim"]
+	depends = qtdeclarative
+	path = qtpim
+	url = ../qtpim.git
+	branch = dev
+	status = ignore
+[submodule "qtconnectivity"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtconnectivity
+	url = ../qtconnectivity.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtwayland"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtwayland
+	url = ../qtwayland.git
+	branch = 6.2.3
+	status = addon
+[submodule "qt3d"]
+	depends = qtbase
+	recommends = qtdeclarative qtshadertools
+	path = qt3d
+	url = ../qt3d.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtimageformats"]
+	depends = qtbase
+	path = qtimageformats
+	url = ../qtimageformats.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtserialbus"]
+	depends = qtbase
+	recommends = qtserialport
+	path = qtserialbus
+	url = ../qtserialbus.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtserialport"]
+	depends = qtbase
+	path = qtserialport
+	url = ../qtserialport.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtwebsockets"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtwebsockets
+	url = ../qtwebsockets.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtwebchannel"]
+	depends = qtbase
+	recommends = qtdeclarative qtwebsockets
+	path = qtwebchannel
+	url = ../qtwebchannel.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtwebengine"]
+	depends = qtdeclarative
+	recommends = qtwebchannel qttools qtpositioning
+	path = qtwebengine
+	url = ../qtwebengine.git
+	branch = 6.2.3
+	status = addon
+	priority = 10
+[submodule "qtcanvas3d"]
+	depends = qtdeclarative
+	path = qtcanvas3d
+	url = ../qtcanvas3d.git
+	branch = 6.2.3
+	status = ignore
+[submodule "qtwebview"]
+	depends = qtdeclarative
+	recommends = qtwebengine
+	path = qtwebview
+	url = ../qtwebview.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtcharts"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtcharts
+	url = ../qtcharts.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtdatavis3d"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtdatavis3d
+	url = ../qtdatavis3d.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtvirtualkeyboard"]
+	depends = qtbase qtdeclarative qtsvg
+	recommends = qtmultimedia
+	path = qtvirtualkeyboard
+	url = ../qtvirtualkeyboard.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtgamepad"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtgamepad
+	url = ../qtgamepad.git
+	branch = 6.2.3
+	status = ignore
+[submodule "qtscxml"]
+	depends = qtbase qtdeclarative
+	path = qtscxml
+	url = ../qtscxml.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtspeech"]
+	depends = qtbase
+	recommends = qtdeclarative qtmultimedia
+	path = qtspeech
+	url = ../qtspeech.git
+	branch = 6.2.3
+	status = ignore
+[submodule "qtnetworkauth"]
+	depends = qtbase
+	path = qtnetworkauth
+	url = ../qtnetworkauth.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtremoteobjects"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtremoteobjects
+	url = ../qtremoteobjects.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtwebglplugin"]
+	depends = qtbase qtwebsockets
+	recommends = qtdeclarative
+	path = qtwebglplugin
+	url = ../qtwebglplugin.git
+	branch = 6.2.3
+	status = ignore
+[submodule "qtlottie"]
+	depends = qtbase qtdeclarative
+	path = qtlottie
+	url = ../qtlottie.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtquicktimeline"]
+	depends = qtbase qtdeclarative
+	path = qtquicktimeline
+	url = ../qtquicktimeline
+	branch = 6.2.3
+	status = addon
+[submodule "qtquick3d"]
+	depends = qtbase qtdeclarative qtshadertools
+	recommends = qtquicktimeline
+	path = qtquick3d
+	url = ../qtquick3d.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtshadertools"]
+	depends = qtbase
+	path = qtshadertools
+	url = ../qtshadertools.git
+	branch = 6.2.3
+	status = addon
+[submodule "qt5compat"]
+	depends = qtbase qtdeclarative
+	path = qt5compat
+	url = ../qt5compat.git
+	branch = 6.2.3
+	status = deprecated
+[submodule "qtcoap"]
+	depends = qtbase
+	path = qtcoap
+	url = ../qtcoap.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtmqtt"]
+	depends = qtbase qtdeclarative
+	path = qtmqtt
+	url = ../qtmqtt.git
+	branch = 6.2.3
+	status = addon
+[submodule "qtopcua"]
+	depends = qtbase qtdeclarative
+	path = qtopcua
+	url = ../qtopcua.git
+	branch = 6.2.3
+	status = addon

--- a/recipes/qt/6.x.x/test_package/conanfile.py
+++ b/recipes/qt/6.x.x/test_package/conanfile.py
@@ -10,7 +10,7 @@ class TestPackageConan(ConanFile):
     generators = "qt", "cmake", "cmake_find_package_multi", "cmake_find_package", "pkg_config", "qmake"
 
     def build_requirements(self):
-        self.build_requires("cmake/3.21.3")
+        self.build_requires("cmake/3.22.0")
         if self._meson_supported():
             self.build_requires("meson/0.59.3")
 

--- a/recipes/qt/6.x.x/test_package/conanfile.py
+++ b/recipes/qt/6.x.x/test_package/conanfile.py
@@ -12,7 +12,7 @@ class TestPackageConan(ConanFile):
     def build_requirements(self):
         self.build_requires("cmake/3.22.0")
         if self._meson_supported():
-            self.build_requires("meson/0.59.3")
+            self.build_requires("meson/0.60.2")
 
     def _is_mingw(self):
         return self.settings.os == "Windows" and self.settings.compiler == "gcc"

--- a/recipes/qt/6.x.x/test_package/conanfile.py
+++ b/recipes/qt/6.x.x/test_package/conanfile.py
@@ -12,14 +12,14 @@ class TestPackageConan(ConanFile):
     def build_requirements(self):
         self.build_requires("cmake/3.21.3")
         if self._meson_supported():
-            self.build_requires("meson/0.59.0")
+            self.build_requires("meson/0.59.3")
 
     def _is_mingw(self):
         return self.settings.os == "Windows" and self.settings.compiler == "gcc"
 
     def _meson_supported(self):
         return False and self.options["qt"].shared and\
-            not tools.cross_building(self.settings) and\
+            not tools.cross_building(self) and\
             not tools.os_info.is_macos and\
             not self._is_mingw()
 

--- a/recipes/qt/config.yml
+++ b/recipes/qt/config.yml
@@ -23,3 +23,5 @@ versions:
     folder: 6.x.x
   "6.2.2":
     folder: 6.x.x
+  "6.2.3":
+    folder: 6.x.x


### PR DESCRIPTION
fixes conan-io/conan-center-index#9092

Specify library name and version:  **qt/6.*.***

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
