### PR TITLE
ms-gsl: Add version 4.0.0

### DIFF
--- a/recipes/ms-gsl/all/conandata.yml
+++ b/recipes/ms-gsl/all/conandata.yml
@@ -11,3 +11,6 @@ sources:
   "3.1.0":
     url: "https://github.com/microsoft/GSL/archive/v3.1.0.tar.gz"
     sha256: "d3234d7f94cea4389e3ca70619b82e8fb4c2f33bb3a070799f1e18eef500a083"
+  "4.0.0":
+    url: "https://github.com/microsoft/GSL/archive/v4.0.0.tar.gz"
+    sha256: "95a51cd6432b491a71cac92ed279fd07668d1594d8909ea5654fb98156d57a10"

--- a/recipes/ms-gsl/all/test_package/test_package.cpp
+++ b/recipes/ms-gsl/all/test_package/test_package.cpp
@@ -1,8 +1,12 @@
+#include <array>
 #include <gsl/gsl>
 
 int main() 
 {
-	char stack_string[] = "Hello";
-    gsl::string_span<> v = gsl::ensure_z(stack_string);
+	std::array<int, 5> data{{1, 2, 3, 4, 5}};
+	gsl::span<int, 5> span(data); 
+	if (span.size() != 5) {
+		return 1;
+	}
 	return 0;
 }

--- a/recipes/ms-gsl/config.yml
+++ b/recipes/ms-gsl/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "3.1.0":
     folder: all
+  "4.0.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **ms-gsl/4.0.0**

Add the latest version of Microsoft's GSL library, version 4.0.0.
Note that `gsl::string_span` has been deprecated so the `test_package` has been updated not to use it.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
