### PR TITLE
boost: Port patches from 1.77.0 to 1.78.0

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -231,5 +231,13 @@ patches:
   1.78.0:
     - patch_file: "patches/boost_locale_fail_on_missing_backend.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/boost_1_77_mpi_check.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/1.69.0-locale-no-system.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/1.77.0-type_erasure-no-system.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/1.77.0-fiber-mingw.patch"
+      base_path: "source_subfolder"
     - patch_file: "patches/1.78.0-b2-fix-install.patch"
       base_path: "source_subfolder"


### PR DESCRIPTION
Specify library name and version:  **boost/1.78.0**

Fixes #9105 

I've included all the patches that were dropped from `boost/1.77.0` that appear to be still relevant to upstream `boost/1.78.0` (see description of #9105). If I am missing something and a patch no longer applies, I am happy to update the pull request.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
