### PR TITLE
nanosvg: add version cci.20210904

### DIFF
--- a/recipes/nanosvg/all/conandata.yml
+++ b/recipes/nanosvg/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20210904":
+    url: "https://github.com/memononen/nanosvg/archive/ccdb1995134d340a93fb20e3a3d323ccb3838dd0.zip"
+    sha256: "d45fb75b9652f45f3ab4e23e76d77c4a4db02939702d36def6fcd244fb0a44c6"
   "20190405":
     url: "https://github.com/memononen/nanosvg/archive/3e2a632c29c294e83e773cbb53f8af25d2bee15a.zip"
     sha256: "aba32b6de5123480a80ae84dbbb3c08a68bac787e647fd1e1dd5786c3087808a"

--- a/recipes/nanosvg/all/conanfile.py
+++ b/recipes/nanosvg/all/conanfile.py
@@ -2,11 +2,13 @@ import os
 
 from conans import ConanFile, tools
 
+required_conan_version = ">=1.33.0"
+
 class NanosvgConan(ConanFile):
     name = "nanosvg"
     description = "NanoSVG is a simple stupid single-header-file SVG parser."
     license = "Zlib"
-    topics = ("conan", "nanosvg", "svg", "parser", "header-only")
+    topics = ("nanosvg", "svg", "parser", "header-only")
     homepage = "https://github.com/memononen/nanosvg"
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os"
@@ -17,10 +19,8 @@ class NanosvgConan(ConanFile):
         return "source_subfolder"
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        url = self.conan_data["sources"][self.version]["url"]
-        extracted_dir = self.name + "-" + os.path.splitext(os.path.basename(url))[0]
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy("LICENSE.txt", dst="licenses", src=self._source_subfolder)
@@ -31,5 +31,5 @@ class NanosvgConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.includedirs.append(os.path.join("include", "nanosvg"))
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/nanosvg/all/test_package/CMakeLists.txt
+++ b/recipes/nanosvg/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(nanosvg REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} nanosvg::nanosvg)

--- a/recipes/nanosvg/all/test_package/conanfile.py
+++ b/recipes/nanosvg/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,7 +12,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             svg_name = os.path.join(self.source_folder, "nano.svg")
             bin_path = os.path.join("bin", "test_package")
             self.run("{0} {1}".format(bin_path, svg_name), run_environment=True)

--- a/recipes/nanosvg/config.yml
+++ b/recipes/nanosvg/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "cci.20210904":
+    folder: all
   "20190405":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **nanosvg/cci.20210904**

nanosvg/cci.20210904 fixed CVE-2019-1000032(Memory corruption / DoS in nanosvg).

I know previous version "20190405" is illegal in conan-center-index.
But I can't decide if we should change this version number or not.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
