### PR TITLE
cairo: remove fdr component

### DIFF
--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -375,11 +375,6 @@ class CairoConan(ConanFile):
             self.cpp_info.components["cairo-script-interpreter"].libs = ["cairo-script-interpreter"]
             self.cpp_info.components["cairo-script-interpreter"].requires = ["cairo_"]
 
-        if self.options.with_zlib and self.options.tee and self.settings.os != "Windows":
-            self.cpp_info.components["cairo-fdr"].libs = ["cairo-fdr"]
-            self.cpp_info.components["cairo-fdr"].requires = ["cairo_"]
-            self.cpp_info.components["cairo-fdr"].libdirs.append(os.path.join(self.package_folder, "lib", "cairo"))
-
         if self.options.with_glib and self.options.with_png and self.options.with_zlib and self.options.tee and self.settings.os != "Windows":
             self.cpp_info.components["cairo-sphinx"].libs = ["cairo-sphinx"]
             self.cpp_info.components["cairo-sphinx"].requires = ["cairo_"]


### PR DESCRIPTION
it has duplicate symbol with cairo_ component (eg cairo_get_group_target)

Specify library name and version:  **cairo/***

this should unblock https://github.com/conan-io/conan-center-index/pull/8810#issuecomment-1024087073

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
