### PR TITLE
zeromq: fix cmake names + relocatable shared lib on macOS

### DIFF
--- a/recipes/zeromq/all/CMakeLists.txt
+++ b/recipes/zeromq/all/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 if(MSVC)
     add_definitions("-D_NOEXCEPT=noexcept")

--- a/recipes/zeromq/all/conandata.yml
+++ b/recipes/zeromq/all/conandata.yml
@@ -9,8 +9,16 @@ sources:
     url: "https://github.com/zeromq/libzmq/archive/v4.3.2.tar.gz"
     sha256: "02ecc88466ae38cf2c8d79f09cfd2675ba299a439680b64ade733e26a349edeb"
 patches:
+  "4.3.4":
+    - patch_file: "patches/0003-rpath-macos-4.3.3.patch"
+      base_path: "source_subfolder"
+  "4.3.3":
+    - patch_file: "patches/0003-rpath-macos-4.3.3.patch"
+      base_path: "source_subfolder"
   "4.3.2":
     - patch_file: "patches/0001-problem-__try-and-__except-isn-t-universally-supported-on-windows.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0002-problem-invalid-syntax-for-calling-convention-on-function.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0003-rpath-macos-4.3.2.patch"
       base_path: "source_subfolder"

--- a/recipes/zeromq/all/conandata.yml
+++ b/recipes/zeromq/all/conandata.yml
@@ -1,16 +1,16 @@
 sources:
-  "4.3.2":
-    url: "https://github.com/zeromq/libzmq/archive/v4.3.2.tar.gz"
-    sha256: "02ecc88466ae38cf2c8d79f09cfd2675ba299a439680b64ade733e26a349edeb"
-  "4.3.3":
-    url: "https://github.com/zeromq/libzmq/archive/v4.3.3.tar.gz"
-    sha256: "c4fd999d67cd12872a8604162f2b1cf5b5a02fb807a88215f0f96bd50331b166"
   "4.3.4":
     url: "https://github.com/zeromq/libzmq/archive/v4.3.4.tar.gz"
     sha256: "0ff5a531c9ffaf0dfdc7dc78d13d1383088f454896d252934c429b2554d10559"
+  "4.3.3":
+    url: "https://github.com/zeromq/libzmq/archive/v4.3.3.tar.gz"
+    sha256: "c4fd999d67cd12872a8604162f2b1cf5b5a02fb807a88215f0f96bd50331b166"
+  "4.3.2":
+    url: "https://github.com/zeromq/libzmq/archive/v4.3.2.tar.gz"
+    sha256: "02ecc88466ae38cf2c8d79f09cfd2675ba299a439680b64ade733e26a349edeb"
 patches:
   "4.3.2":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0001-problem-__try-and-__except-isn-t-universally-supported-on-windows.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/0002-problem-invalid-syntax-for-calling-convention-on-function.patch"
+    - patch_file: "patches/0001-problem-__try-and-__except-isn-t-universally-supported-on-windows.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-problem-invalid-syntax-for-calling-convention-on-function.patch"
+      base_path: "source_subfolder"

--- a/recipes/zeromq/all/patches/0003-rpath-macos-4.3.2.patch
+++ b/recipes/zeromq/all/patches/0003-rpath-macos-4.3.2.patch
@@ -1,0 +1,24 @@
+Fix for Apple platforms:
+* Ensure install_name with @rpath token
+* Keep rpath clean in installed binaries
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ # CMake build script for ZeroMQ
+ project(ZeroMQ)
+ 
+-if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
++if(1)
+   cmake_minimum_required(VERSION 3.0.2)
+ else()
+   cmake_minimum_required(VERSION 2.8.12)
+@@ -44,7 +44,7 @@ if (ENABLE_INTRINSICS)
+    add_definitions(-DZMQ_HAVE_ATOMIC_INTRINSICS)
+ endif()
+ 
+-if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
++if(0)
+   # Find more information: https://cmake.org/Wiki/CMake_RPATH_handling
+ 
+   # Apply CMP0042: MACOSX_RPATH is enabled by default

--- a/recipes/zeromq/all/patches/0003-rpath-macos-4.3.3.patch
+++ b/recipes/zeromq/all/patches/0003-rpath-macos-4.3.3.patch
@@ -1,0 +1,24 @@
+Fix for Apple platforms:
+* Ensure install_name with @rpath token
+* Keep rpath clean in installed binaries
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ # CMake build script for ZeroMQ
+ project(ZeroMQ)
+ 
+-if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
++if(1)
+   cmake_minimum_required(VERSION 3.0.2)
+ else()
+   cmake_minimum_required(VERSION 2.8.12)
+@@ -94,7 +94,7 @@ set(ZMQ_OUTPUT_BASENAME
+     "zmq"
+     CACHE STRING "Output zmq library base name")
+ 
+-if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
++if(0)
+   # Find more information: https://cmake.org/Wiki/CMake_RPATH_handling
+ 
+   # Apply CMP0042: MACOSX_RPATH is enabled by default

--- a/recipes/zeromq/all/test_package/CMakeLists.txt
+++ b/recipes/zeromq/all/test_package/CMakeLists.txt
@@ -9,11 +9,10 @@ conan_basic_setup(TARGETS)
 find_package(ZeroMQ REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-# TODO: remove ZeroMQ:: namespace when fixed in conanfile.py
 if(ZEROMQ_SHARED)
-  target_link_libraries(${PROJECT_NAME} ZeroMQ::libzmq)
+  target_link_libraries(${PROJECT_NAME} libzmq)
 else()
-  target_link_libraries(${PROJECT_NAME} ZeroMQ::libzmq-static)
+  target_link_libraries(${PROJECT_NAME} libzmq-static)
 endif()
 
 if(WITH_LIBSODIUM)

--- a/recipes/zeromq/config.yml
+++ b/recipes/zeromq/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "4.3.2":
+  "4.3.4":
     folder: all
   "4.3.3":
     folder: all
-  "4.3.4":
+  "4.3.2":
     folder: all


### PR DESCRIPTION
- fix CMake target name in cmake_find_package* generators
- fix CMake config file name in CMakeDeps generator
- generate relocatable shared lib on macOS, with a clean rpath: see https://github.com/conan-io/hooks/issues/376

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
