### PR TITLE
openssl/3.0.1: option no_tests doesn't exist

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -103,7 +103,6 @@ class OpenSSLConan(ConanFile):
             self.options.no_asm = True
             self.options.no_threads = True
             self.options.no_stdio = True
-            self.options.no_tests = True
 
     def configure(self):
         if self.options.shared:


### PR DESCRIPTION
openssl/3.0.1

we use openssl with emscripten, and the 'no_tests' option no longer exists, so the builds fail
---

- [X ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
