### PR TITLE
wt: modernize

### DIFF
--- a/recipes/wt/all/CMakeLists.txt
+++ b/recipes/wt/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 2.8.11)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/wt/all/conandata.yml
+++ b/recipes/wt/all/conandata.yml
@@ -1,20 +1,19 @@
 sources:
-  "4.3.1":
-    url: "https://github.com/emweb/wt/archive/4.3.1.tar.gz"
-    sha256: "6c0130f36c829ed67119679770c2f62d7768a62eaa281bb10070c4cf1b145139"
-  "4.4.0":
-    url: "https://github.com/emweb/wt/archive/4.4.0.tar.gz"
-    sha256: "2eabefea915ecc4deb36f9f67ab30dd3b1f6c73893d76c9d9fa39ac25f4f3690"
-  "4.5.0":
-    url: "https://github.com/emweb/wt/archive/4.5.0.tar.gz"
-    sha256: "119b1eae83285a153b9c901d3f4f25775c7a460d30b1e48242d7d2d649d61deb"
-  "4.5.1":
-    url: "https://github.com/emweb/wt/archive/4.5.1.tar.gz"
-    sha256: "c2820646095af5618fc235705c0108797e3898225fb1826f2c6185c405c21a17"
-
   "4.6.0":
     url: "https://github.com/emweb/wt/archive/4.6.0.tar.gz"
     sha256: "7f709e132d32c4925e6db0a590c7ccc5613344e8b9052676ef891a25ccb550e6"
+  "4.5.1":
+    url: "https://github.com/emweb/wt/archive/4.5.1.tar.gz"
+    sha256: "c2820646095af5618fc235705c0108797e3898225fb1826f2c6185c405c21a17"
+  "4.5.0":
+    url: "https://github.com/emweb/wt/archive/4.5.0.tar.gz"
+    sha256: "119b1eae83285a153b9c901d3f4f25775c7a460d30b1e48242d7d2d649d61deb"
+  "4.4.0":
+    url: "https://github.com/emweb/wt/archive/4.4.0.tar.gz"
+    sha256: "2eabefea915ecc4deb36f9f67ab30dd3b1f6c73893d76c9d9fa39ac25f4f3690"
+  "4.3.1":
+    url: "https://github.com/emweb/wt/archive/4.3.1.tar.gz"
+    sha256: "6c0130f36c829ed67119679770c2f62d7768a62eaa281bb10070c4cf1b145139"
 patches:
   "4.5.0":
     - patch_file: "patches/wt_4_5_0_gcc_11.patch"

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 import os
 import shutil
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class WtConan(ConanFile):
@@ -11,10 +11,8 @@ class WtConan(ConanFile):
     description = "Wt is a C++ library for developing web applications"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/emweb/wt"
-    topics = ("conan", "wt", "web", "webapp")
+    topics = ("wt", "web", "webapp")
     license = "GPL-2.0-only"
-    exports_sources = ["patches/*", "CMakeLists.txt"]
-    generators = "cmake"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -34,7 +32,7 @@ class WtConan(ConanFile):
         "multi_threaded": [True, False],
         "connector_http": [True, False],
         "connector_isapi": [True, False],
-        "connector_fcgi": [True, False]
+        "connector_fcgi": [True, False],
     }
     default_options = {
         "shared": False,
@@ -53,9 +51,10 @@ class WtConan(ConanFile):
         "multi_threaded": True,
         "connector_http": True,
         "connector_isapi": True,
-        "connector_fcgi": False
+        "connector_fcgi": False,
     }
 
+    generators = "cmake"
     _cmake = None
 
     @property
@@ -65,6 +64,11 @@ class WtConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -119,6 +123,17 @@ class WtConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
+
+    def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+        cmakelists = os.path.join(self._source_subfolder, "CMakeLists.txt")
+        tools.replace_in_file(cmakelists, "find_package(OpenSSL)", "#find_package(OpenSSL)")
+        tools.replace_in_file(cmakelists, "INCLUDE(cmake/WtFindMysql.txt)", "#INCLUDE(cmake/WtFindMysql.txt)")
+        tools.replace_in_file(cmakelists, "INCLUDE(cmake/WtFindPostgresql.txt)", "#INCLUDE(cmake/WtFindPostgresql.txt)")
+        if self.settings.os != "Windows":
+            tools.replace_in_file(cmakelists, "INCLUDE(cmake/WtFindOdbc.txt)", "#INCLUDE(cmake/WtFindOdbc.txt)")
 
     def _configure_cmake(self):
         if self._cmake:
@@ -198,16 +213,7 @@ class WtConan(ConanFile):
         return self._cmake
 
     def build(self):
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"), "find_package(OpenSSL)", "#find_package(OpenSSL)")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"), "INCLUDE(cmake/WtFindMysql.txt)", "#INCLUDE(cmake/WtFindMysql.txt)")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"), "INCLUDE(cmake/WtFindPostgresql.txt)", "#INCLUDE(cmake/WtFindPostgresql.txt)")
-        if self.settings.os != "Windows":
-            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"), "INCLUDE(cmake/WtFindOdbc.txt)", "#INCLUDE(cmake/WtFindOdbc.txt)")
-
-
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-
+        self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -221,15 +227,14 @@ class WtConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "wt"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "wt"
-        self.cpp_info.names["cmake_find_package"] = "Wt"
-        self.cpp_info.names["cmake_find_package_multi"] = "Wt"
+        self.cpp_info.set_property("cmake_file_name", "wt")
+
+        suffix = "d" if self.settings.build_type == "Debug" else ""
+
         # wt
-        self.cpp_info.components["wtmain"].names["cmake_find_package"] = "Wt"
-        self.cpp_info.components["wtmain"].names["cmake_find_package_multi"] = "Wt"
-        self.cpp_info.components["wtmain"].libs = [self._lib_name("wt")]
-        if self.settings.os == "Linux":
+        self.cpp_info.components["wtmain"].set_property("cmake_target_name", "Wt::Wt")
+        self.cpp_info.components["wtmain"].libs = ["wt{}".format(suffix)]
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["wtmain"].system_libs = ["m", "rt"]
         elif self.settings.os == "Windows":
             self.cpp_info.components["wtmain"].system_libs = ["ws2_32", "mswsock", "winmm"]
@@ -238,73 +243,103 @@ class WtConan(ConanFile):
             self.cpp_info.components["wtmain"].requires.append("openssl::openssl")
         if self.options.get_safe("with_unwind"):
             self.cpp_info.components["wtmain"].requires.append("libunwind::libunwind")
+
         # wttest
         if self.options.with_test:
-            self.cpp_info.components["wttest"].names["cmake_find_package"] = "Test"
-            self.cpp_info.components["wttest"].names["cmake_find_package_multi"] = "Test"
-            self.cpp_info.components["wttest"].libs = [self._lib_name("wttest")]
+            self.cpp_info.components["wttest"].set_property("cmake_target_name", "Wt::Test")
+            self.cpp_info.components["wttest"].libs = ["wttest{}".format(suffix)]
             self.cpp_info.components["wttest"].requires = ["wtmain"]
+
         # wthttp
         if self.options.connector_http:
-            self.cpp_info.components["wthttp"].names["cmake_find_package"] = "HTTP"
-            self.cpp_info.components["wthttp"].names["cmake_find_package_multi"] = "HTTP"
-            self.cpp_info.components["wthttp"].libs = [self._lib_name("wthttp")]
+            self.cpp_info.components["wthttp"].set_property("cmake_target_name", "Wt::HTTP")
+            self.cpp_info.components["wthttp"].libs = ["wthttp{}".format(suffix)]
             self.cpp_info.components["wthttp"].requires = ["wtmain", "boost::boost", "zlib::zlib"]
             if self.options.with_ssl:
                 self.cpp_info.components["wthttp"].requires.append("openssl::openssl")
+
         # wtisapi
         if self.options.get_safe("connector_isapi"):
-            self.cpp_info.components["wtisapi"].names["cmake_find_package"] = "Isapi"
-            self.cpp_info.components["wtisapi"].names["cmake_find_package_multi"] = "Isapi"
-            self.cpp_info.components["wtisapi"].libs = [self._lib_name("wtisapi")]
+            self.cpp_info.components["wtisapi"].set_property("cmake_target_name", "Wt::Isapi")
+            self.cpp_info.components["wtisapi"].libs = ["wtisapi{}".format(suffix)]
             self.cpp_info.components["wtisapi"].requires = ["wtmain"]
+
         # wtfcgi
         if self.options.get_safe("connector_fcgi"):
-            self.cpp_info.components["wtfcgi"].names["cmake_find_package"] = "FCGI"
-            self.cpp_info.components["wtfcgi"].names["cmake_find_package_multi"] = "FCGI"
-            self.cpp_info.components["wtfcgi"].libs = [self._lib_name("wtfcgi")]
+            self.cpp_info.components["wtfcgi"].set_property("cmake_target_name", "Wt::FCGI")
+            self.cpp_info.components["wtfcgi"].libs = ["wtfcgi{}".format(suffix)]
             self.cpp_info.components["wtfcgi"].requires = ["wtmain"]
             if self.options.with_ssl:
                 self.cpp_info.components["wtfcgi"].requires.append("openssl::openssl")
+
         # wtdbo
         if self.options.with_dbo:
-            self.cpp_info.components["wtdbo"].names["cmake_find_package"] = "Dbo"
-            self.cpp_info.components["wtdbo"].names["cmake_find_package_multi"] = "Dbo"
-            self.cpp_info.components["wtdbo"].libs = [self._lib_name("wtdbo")]
+            self.cpp_info.components["wtdbo"].set_property("cmake_target_name", "Wt::Dbo")
+            self.cpp_info.components["wtdbo"].libs = ["wtdbo{}".format(suffix)]
             if self.options.get_safe("with_unwind"):
                 self.cpp_info.components["wtdbo"].requires.append("libunwind::libunwind")
+
         # wtdbosqlite3
         if self.options.get_safe("with_sqlite"):
-            self.cpp_info.components["wtdbosqlite3"].names["cmake_find_package"] = "DboSqlite3"
-            self.cpp_info.components["wtdbosqlite3"].names["cmake_find_package_multi"] = "DboSqlite3"
-            self.cpp_info.components["wtdbosqlite3"].libs = [self._lib_name("wtdbosqlite3")]
+            self.cpp_info.components["wtdbosqlite3"].set_property("cmake_target_name", "Wt::DboSqlite3")
+            self.cpp_info.components["wtdbosqlite3"].libs = ["wtdbosqlite3{}".format(suffix)]
             self.cpp_info.components["wtdbosqlite3"].requires = ["wtdbo", "sqlite3::sqlite3"]
-            if self.settings.os == "Linux":
+            if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["wtdbosqlite3"].system_libs = ["m"]
+
         # wtdbopostgres
         if self.options.get_safe("with_postgres"):
-            self.cpp_info.components["wtdbopostgres"].names["cmake_find_package"] = "DboPostgres"
-            self.cpp_info.components["wtdbopostgres"].names["cmake_find_package_multi"] = "DboPostgres"
-            self.cpp_info.components["wtdbopostgres"].libs = [self._lib_name("wtdbopostgres")]
+            self.cpp_info.components["wtdbopostgres"].set_property("cmake_target_name", "Wt::DboPostgres")
+            self.cpp_info.components["wtdbopostgres"].libs = ["wtdbopostgres{}".format(suffix)]
             self.cpp_info.components["wtdbopostgres"].requires = ["wtdbo", "libpq::libpq"]
+
         # wtdbomysql
         if self.options.get_safe("with_mysql"):
-            self.cpp_info.components["wtdbomysql"].names["cmake_find_package"] = "DboMySQL"
-            self.cpp_info.components["wtdbomysql"].names["cmake_find_package_multi"] = "DboMySQL"
-            self.cpp_info.components["wtdbomysql"].libs = [self._lib_name("wtdbomysql")]
+            self.cpp_info.components["wtdbomysql"].set_property("cmake_target_name", "Wt::DboMySQL")
+            self.cpp_info.components["wtdbomysql"].libs = ["wtdbomysql{}".format(suffix)]
             self.cpp_info.components["wtdbomysql"].requires = ["wtdbo", "libmysqlclient::libmysqlclient"]
+
         # wtdbomssqlserver
         if self.options.get_safe("with_mssql"):
-            self.cpp_info.components["wtdbomssqlserver"].names["cmake_find_package"] = "DboMSSQLServer"
-            self.cpp_info.components["wtdbomssqlserver"].names["cmake_find_package_multi"] = "DboMSSQLServer"
-            self.cpp_info.components["wtdbomssqlserver"].libs = [self._lib_name("wtdbomssqlserver")]
+            self.cpp_info.components["wtdbomssqlserver"].set_property("cmake_target_name", "Wt::DboMSSQLServer")
+            self.cpp_info.components["wtdbomssqlserver"].libs = ["wtdbomssqlserver{}".format(suffix)]
             self.cpp_info.components["wtdbomssqlserver"].requires = ["wtdbo"]
             if self.settings.os == "Windows":
                 self.cpp_info.components["wtdbomssqlserver"].system_libs.append("odbc32")
             else:
                 self.cpp_info.components["wtdbomssqlserver"].requires.append("odbc::odbc")
 
-    def _lib_name(self, name):
-        if self.settings.build_type == "Debug":
-            return name + "d"
-        return name
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "wt"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "wt"
+        self.cpp_info.names["cmake_find_package"] = "Wt"
+        self.cpp_info.names["cmake_find_package_multi"] = "Wt"
+        self.cpp_info.components["wtmain"].names["cmake_find_package"] = "Wt"
+        self.cpp_info.components["wtmain"].names["cmake_find_package_multi"] = "Wt"
+        if self.options.with_test:
+            self.cpp_info.components["wttest"].names["cmake_find_package"] = "Test"
+            self.cpp_info.components["wttest"].names["cmake_find_package_multi"] = "Test"
+        if self.options.connector_http:
+            self.cpp_info.components["wthttp"].names["cmake_find_package"] = "HTTP"
+            self.cpp_info.components["wthttp"].names["cmake_find_package_multi"] = "HTTP"
+        if self.options.get_safe("connector_isapi"):
+            self.cpp_info.components["wtisapi"].names["cmake_find_package"] = "Isapi"
+            self.cpp_info.components["wtisapi"].names["cmake_find_package_multi"] = "Isapi"
+        if self.options.get_safe("connector_fcgi"):
+            self.cpp_info.components["wtfcgi"].names["cmake_find_package"] = "FCGI"
+            self.cpp_info.components["wtfcgi"].names["cmake_find_package_multi"] = "FCGI"
+        if self.options.with_dbo:
+            self.cpp_info.components["wtdbo"].names["cmake_find_package"] = "Dbo"
+            self.cpp_info.components["wtdbo"].names["cmake_find_package_multi"] = "Dbo"
+        if self.options.get_safe("with_sqlite"):
+            self.cpp_info.components["wtdbosqlite3"].names["cmake_find_package"] = "DboSqlite3"
+            self.cpp_info.components["wtdbosqlite3"].names["cmake_find_package_multi"] = "DboSqlite3"
+        if self.options.get_safe("with_postgres"):
+            self.cpp_info.components["wtdbopostgres"].names["cmake_find_package"] = "DboPostgres"
+            self.cpp_info.components["wtdbopostgres"].names["cmake_find_package_multi"] = "DboPostgres"
+        if self.options.get_safe("with_mysql"):
+            self.cpp_info.components["wtdbomysql"].names["cmake_find_package"] = "DboMySQL"
+            self.cpp_info.components["wtdbomysql"].names["cmake_find_package_multi"] = "DboMySQL"
+        if self.options.get_safe("with_mssql"):
+            self.cpp_info.components["wtdbomssqlserver"].names["cmake_find_package"] = "DboMSSQLServer"
+            self.cpp_info.components["wtdbomssqlserver"].names["cmake_find_package_multi"] = "DboMSSQLServer"

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -138,6 +138,13 @@ class WtConan(ConanFile):
         if self.settings.os != "Windows":
             tools.replace_in_file(cmakelists, "INCLUDE(cmake/WtFindOdbc.txt)", "#INCLUDE(cmake/WtFindOdbc.txt)")
 
+        # Do not pollute rpath of shared libs of the install tree on macOS please
+        tools.replace_in_file(
+            cmakelists,
+            "IF(APPLE)\n  SET(CMAKE_INSTALL_RPATH \"${CMAKE_INSTALL_PREFIX}/lib\")",
+            "if(0)",
+        )
+
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -99,17 +99,20 @@ class WtConan(ConanFile):
         return ["program_options", "filesystem", "thread"]
 
     def requirements(self):
-        self.requires("boost/1.76.0")
+        if tools.Version(self.version) >= "4.6.0":
+            self.requires("boost/1.78.0")
+        else:
+            self.requires("boost/1.76.0")
         if self.options.connector_http:
             self.requires("zlib/1.2.11")
         if self.options.with_ssl:
-            self.requires("openssl/1.1.1k")
+            self.requires("openssl/1.1.1m")
         if self.options.get_safe("with_sqlite"):
-            self.requires("sqlite3/3.35.5")
+            self.requires("sqlite3/3.37.2")
         if self.options.get_safe("with_mysql"):
             self.requires("libmysqlclient/8.0.17")
         if self.options.get_safe("with_postgres"):
-            self.requires("libpq/13.2")
+            self.requires("libpq/13.4")
         if self.options.get_safe("with_mssql") and self.settings.os != "Windows":
             self.requires("odbc/2.3.9")
         if self.options.get_safe("with_unwind"):

--- a/recipes/wt/all/test_package/CMakeLists.txt
+++ b/recipes/wt/all/test_package/CMakeLists.txt
@@ -2,17 +2,18 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
-find_package(wt REQUIRED Wt HTTP CONFIG)
-if(WITH_DBO)
-  find_package(wt REQUIRED Dbo CONFIG)
-endif()
+conan_basic_setup(TARGETS)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
-target_link_libraries(${PROJECT_NAME} Wt::Wt Wt::HTTP)
+
+set(WT_COMPONENTS Wt HTTP)
+set(WT_TARGETS Wt::Wt Wt::HTTP)
 if(WITH_DBO)
-  target_link_libraries(${PROJECT_NAME} Wt::Dbo)
-  target_compile_definitions(${PROJECT_NAME} PRIVATE "WITH_DBO")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE WITH_DBO)
+    list(APPEND WT_COMPONENTS Dbo)
+    list(APPEND WT_TARGETS Wt::Dbo)
 endif()
+
+find_package(wt REQUIRED ${WT_COMPONENTS} CONFIG)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${WT_TARGETS})

--- a/recipes/wt/all/test_package/conanfile.py
+++ b/recipes/wt/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
@@ -13,7 +13,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             args = " --docroot . --http-listen http://127.0.0.1:8080"
             self.run(bin_path + args, run_environment=True)

--- a/recipes/wt/config.yml
+++ b/recipes/wt/config.yml
@@ -1,11 +1,11 @@
 versions:
-  "4.3.1":
-    folder: all
-  "4.4.0":
-    folder: all
-  "4.5.0":
+  "4.6.0":
     folder: all
   "4.5.1":
     folder: all
-  "4.6.0":
+  "4.5.0":
+    folder: all
+  "4.4.0":
+    folder: all
+  "4.3.1":
     folder: all


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- CMakeDeps support
- bump deps. It's worth noting that wt < 4.6.0 doesn't seem to be compatible with boost >= 1.77.0 (compilation errors).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
