### PR TITLE
add tracy

### DIFF
--- a/recipes/tracy/all/CMakeLists.txt
+++ b/recipes/tracy/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/tracy/all/conandata.yml
+++ b/recipes/tracy/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20220130":
+    url: "https://github.com/wolfpld/tracy/archive/361782f3fdbeaefb9697f8fabe9d14e6b5d18f75.tar.gz"
+    sha256: "9267964f39be6bf419318ab5ac01c8a2b8dd921696c18164f133ee7b18bcb00b"

--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -7,7 +7,7 @@ required_conan_version = ">=1.43.0"
 class TracyConan(ConanFile):
     name = "tracy"
     description = "C++ frame profiler"
-    topics = ("tracy", "profiler", "performance", "gamedev")
+    topics = ("profiler", "performance", "gamedev")
     homepage = "https://github.com/wolfpld/tracy"
     url = "https://github.com/conan-io/conan-center-index"
     license = ["BSD 3-clause"]

--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -10,7 +10,7 @@ class TracyConan(ConanFile):
     topics = ("profiler", "performance", "gamedev")
     homepage = "https://github.com/wolfpld/tracy"
     url = "https://github.com/conan-io/conan-center-index"
-    license = ["BSD 3-clause"]
+    license = ["BSD-3-Clause"]
     settings = "os", "compiler", "build_type", "arch"
 
     # Existing CMake tracy options with default value

--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -14,7 +14,7 @@ class TracyConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
 
     # Existing CMake tracy options with default value
-    tracy_options = {
+    _tracy_options = {
         "enable": ([True, False], True),
         "callstack": ([True, False], False),
         "only_localhost": ([True, False], False),
@@ -30,12 +30,12 @@ class TracyConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        **{k: v[0] for k, v in tracy_options.items()},
+        **{k: v[0] for k, v in _tracy_options.items()},
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        **{k: v[1] for k, v in tracy_options.items()},
+        **{k: v[1] for k, v in _tracy_options.items()},
     }
 
     exports_sources = ["CMakeLists.txt"]
@@ -69,7 +69,7 @@ class TracyConan(ConanFile):
 
         # Set all tracy options in the correct form
         # For example, TRACY_NO_EXIT
-        for opt in self.tracy_options.keys():
+        for opt in self._tracy_options.keys():
             switch = getattr(self.options, opt)
             opt = 'TRACY_' + opt.upper()
             self._cmake.definitions[opt] = switch

--- a/recipes/tracy/all/conanfile.py
+++ b/recipes/tracy/all/conanfile.py
@@ -1,0 +1,95 @@
+from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.43.0"
+
+
+class TracyConan(ConanFile):
+    name = "tracy"
+    description = "C++ frame profiler"
+    topics = ("tracy", "profiler", "performance", "gamedev")
+    homepage = "https://github.com/wolfpld/tracy"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = ["BSD 3-clause"]
+    settings = "os", "compiler", "build_type", "arch"
+
+    # Existing CMake tracy options with default value
+    tracy_options = {
+        "enable": ([True, False], True),
+        "callstack": ([True, False], False),
+        "only_localhost": ([True, False], False),
+        "no_broadcast": ([True, False], False),
+        "no_code_transfer": ([True, False], False),
+        "no_context_switch": ([True, False], False),
+        "no_exit": ([True, False], False),
+        "no_frame_image": ([True, False], False),
+        "no_sampling": ([True, False], False),
+        "no_verify": ([True, False], False),
+        "no_vsync_capture": ([True, False], False),
+    }
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        **{k: v[0] for k, v in tracy_options.items()},
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        **{k: v[1] for k, v in tracy_options.items()},
+    }
+
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake"
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+
+        # Set all tracy options in the correct form
+        # For example, TRACY_NO_EXIT
+        for opt in self.tracy_options.keys():
+            switch = getattr(self.options, opt)
+            opt = 'TRACY_' + opt.upper()
+            self._cmake.definitions[opt] = switch
+
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses",
+                  src=self._source_subfolder)
+        self._cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["TracyClient"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.append("dl")

--- a/recipes/tracy/all/test_package/CMakeLists.txt
+++ b/recipes/tracy/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(tracy REQUIRED)
+
+add_executable(test_package example.cpp)
+target_link_libraries(test_package tracy::tracy)

--- a/recipes/tracy/all/test_package/conanfile.py
+++ b/recipes/tracy/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/tracy/all/test_package/example.cpp
+++ b/recipes/tracy/all/test_package/example.cpp
@@ -1,0 +1,7 @@
+#include <Tracy.hpp>
+
+int main(int argc, char **argv) {
+  ZoneScopedN("main")
+
+  return 0;
+}

--- a/recipes/tracy/config.yml
+++ b/recipes/tracy/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20220130":
+    folder: all


### PR DESCRIPTION
**tracy/cci.20220130**

Last published version (0.7.8) didn't have integrated CMake, so I took a recent commit.
Fixes #1708 

This only packages the library to be used in the client program however, not the viewer executable (which is hader and not supported in the project's CMake).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
