### PR TITLE
daw_json_link: add version 2.12.4

### DIFF
--- a/recipes/daw_json_link/all/conandata.yml
+++ b/recipes/daw_json_link/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.12.4":
+    url: "https://github.com/beached/daw_json_link/archive/v2.12.4.tar.gz"
+    sha256: "123dee9eac86b63e13a3233515d3155504fd7a793d7e736ec939646524ac114c"
   "2.11.0":
     url: "https://github.com/beached/daw_json_link/archive/v2.11.0.tar.gz"
     sha256: "e0c616bb647c6fd1d91e614a3512779000689ba68ab9f88fa284e91b6066801e"

--- a/recipes/daw_json_link/config.yml
+++ b/recipes/daw_json_link/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.12.4":
+    folder: "all"
   "2.11.0":
     folder: "all"
   "2.10.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **daw_json_link/2.12.4**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
