### PR TITLE
add new conin-lemon version

### DIFF
--- a/recipes/coin-lemon/all/conandata.yml
+++ b/recipes/coin-lemon/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20211024":
+    url: "https://github.com/MultiFlow/LEMON/archive/57087472162cdbe968516cf94b0cef233d766dd8.tar.gz"
+    sha256: "f2e459855ea0137b0f8a5acdf8b534b50a6c444fb98ddd5c56ad6589c90114d0"
   "1.3.1":
     url: "http://lemon.cs.elte.hu/pub/sources/lemon-1.3.1.tar.gz"
     sha256: "71b7c725f4c0b4a8ccb92eb87b208701586cf7a96156ebd821ca3ed855bad3c8"

--- a/recipes/coin-lemon/config.yml
+++ b/recipes/coin-lemon/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "cci.20211024":
+    folder: "all"
   "1.3.1":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **cci.20211024**

library was recently ported to github. add It's current github version
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
