### PR TITLE
c4core: fix homepage + allow apple-clang + modernize

### DIFF
--- a/recipes/c4core/all/CMakeLists.txt
+++ b/recipes/c4core/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper LANGUAGES CXX)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/c4core/all/conanfile.py
+++ b/recipes/c4core/all/conanfile.py
@@ -2,7 +2,8 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
+
 
 class C4CoreConan(ConanFile):
     name = "c4core"
@@ -14,8 +15,8 @@ class C4CoreConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/biojppm/c4core"
     license = "MIT",
+
     settings = "os", "arch", "compiler", "build_type"
-    exports_sources = ["CMakeLists.txt"]
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -25,8 +26,8 @@ class C4CoreConan(ConanFile):
         "fPIC": True,
     }
 
+    exports_sources = ["CMakeLists.txt"]
     generators = "cmake", "cmake_find_package_multi"
-
     _cmake = None
 
     @property
@@ -41,6 +42,9 @@ class C4CoreConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    def requirements(self):
+        self.requires("fast_float/3.4.0")
+
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "11")
@@ -51,9 +55,6 @@ class C4CoreConan(ConanFile):
                 raise ConanInvalidConfiguration(self, "{}/{} doesn't support clang with libc++".format(self.name, self.version))
             if (self.settings.compiler == "apple-clang" and self.settings.compiler.libcxx == "libc++"):
                 raise ConanInvalidConfiguration(self, "{}/{} doesn't support apple-clang with libc++".format(self.name, self.version))
-
-    def requirements(self):
-        self.requires("fast_float/3.4.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -84,4 +85,6 @@ class C4CoreConan(ConanFile):
         tools.remove_files_by_mask(os.path.join(self.package_folder, "include"), "*.natvis")
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "c4core")
+        self.cpp_info.set_property("cmake_target_name", "c4core::c4core")
         self.cpp_info.libs = ["c4core"]

--- a/recipes/c4core/all/conanfile.py
+++ b/recipes/c4core/all/conanfile.py
@@ -49,12 +49,10 @@ class C4CoreConan(ConanFile):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "11")
 
-        ## clang/apple-clang with libc++ is not supported. It is already fixed at 2022-01-03.
+        ## clang with libc++ is not supported. It is already fixed at 2022-01-03.
         if tools.Version(self.version) <= "0.1.8":
             if (self.settings.compiler == "clang" and self.settings.compiler.libcxx == "libc++"):
                 raise ConanInvalidConfiguration(self, "{}/{} doesn't support clang with libc++".format(self.name, self.version))
-            if (self.settings.compiler == "apple-clang" and self.settings.compiler.libcxx == "libc++"):
-                raise ConanInvalidConfiguration(self, "{}/{} doesn't support apple-clang with libc++".format(self.name, self.version))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/c4core/all/conanfile.py
+++ b/recipes/c4core/all/conanfile.py
@@ -51,8 +51,10 @@ class C4CoreConan(ConanFile):
 
         ## clang with libc++ is not supported. It is already fixed at 2022-01-03.
         if tools.Version(self.version) <= "0.1.8":
-            if (self.settings.compiler == "clang" and self.settings.compiler.libcxx == "libc++"):
-                raise ConanInvalidConfiguration(self, "{}/{} doesn't support clang with libc++".format(self.name, self.version))
+            if (self.settings.compiler == "clang" and self.settings.compiler.get_safe("libcxx") == "libc++"):
+                raise ConanInvalidConfiguration(
+                    "{}/{} doesn't support clang with libc++".format(self.name, self.version),
+                )
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/c4core/all/conanfile.py
+++ b/recipes/c4core/all/conanfile.py
@@ -6,10 +6,13 @@ required_conan_version = ">=1.33.0"
 
 class C4CoreConan(ConanFile):
     name = "c4core"
-    description = "a library of low-level C++ utilities, written with low-latency projects in mind."
+    description = (
+        "c4core is a library of low-level C++ utilities, written with "
+        "low-latency projects in mind."
+    )
     topics = ("utilities", "low-latency", )
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/mutouyun/cpp-ipc"
+    homepage = "https://github.com/biojppm/c4core"
     license = "MIT",
     settings = "os", "arch", "compiler", "build_type"
     exports_sources = ["CMakeLists.txt"]

--- a/recipes/c4core/all/test_package/CMakeLists.txt
+++ b/recipes/c4core/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(c4core REQUIRED CONFIG)
 


### PR DESCRIPTION
- homepage was wrong, probably a copy/paste of another recipe
- allow apple-clang, it builds fine on my mac
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- explicit CMake names of upstream

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
