### PR TITLE
add sentry-crashpad/0.4.14

### DIFF
--- a/recipes/sentry-crashpad/all/conandata.yml
+++ b/recipes/sentry-crashpad/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.4.14":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.14/sentry-native.zip"
+    sha256: "483db8f3bd341fc2f07a6a9678f0eb2d854d1bacafa8d7aeeed15a3bd548de16"
   "0.4.13":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.13/sentry-native.zip"
     sha256: "85e0e15d7fb51388d967ab09e7ee1b95f82330a469a93c65d964ea1afd5e6127"

--- a/recipes/sentry-crashpad/config.yml
+++ b/recipes/sentry-crashpad/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.4.14":
+    folder: all
   "0.4.13":
     folder: all
   "0.4.12":


### PR DESCRIPTION
Specify library name and version:  **sentry-crashpad/0.4.14**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
