### PR TITLE
linter: various fixes

### DIFF
--- a/.github/runlint.py
+++ b/.github/runlint.py
@@ -50,7 +50,7 @@ def main(pr):
         if version:
             shell = bool(platform.system() != "Windows")
             command = "conan export %s %s/%s@" % (os.path.join("recipes", package, folder), package, version)
-            p = subprocess.run(command, shell=shell, check=True)
+            p = subprocess.run(command, shell=shell, check=False)
 
 if __name__ == "__main__":
     # execute only if run as a script

--- a/.github/runlint.py
+++ b/.github/runlint.py
@@ -29,17 +29,21 @@ def main(pr):
     packages = set()
     for line in diff.split("\n"):
         if line.startswith("+++ b/recipes/") or line.startswith("--- a/recipes/"):
-            packages.add(line.split("/")[2])
-    for package in packages:
+            parts = line.split("/")
+            if len(parts) >= 5:
+                packages.add(parts[2] + "/" + parts[3])
+    for line in packages:
+        package = line.split("/")[0]
         version = None
-        folder = ""
+        folder = line.split("/")[1]
         with open(os.path.join("recipes", package, "config.yml"), "r") as file:
             config = yaml.safe_load(file)
             for v in config["versions"]:
+                if config["versions"][v]["folder"] != folder:
+                    continue
                 try:
                     if not version or packaging.version.Version(v) > packaging.version.Version(version):
                         version = v
-                        folder = config["versions"][v]["folder"]
                 except packaging.version.InvalidVersion:
                     print("Error parsing version %s for package %s in pr %s" % (v, package, pr))
 

--- a/.github/runlint.py
+++ b/.github/runlint.py
@@ -31,22 +31,23 @@ def main(pr):
         if line.startswith("+++ b/recipes/") or line.startswith("--- a/recipes/"):
             packages.add(line.split("/")[2])
     for package in packages:
-        version = packaging.version.Version("0.0.0")
+        version = None
         folder = ""
         with open(os.path.join("recipes", package, "config.yml"), "r") as file:
             config = yaml.safe_load(file)
             for v in config["versions"]:
                 try:
                     tmpVer = packaging.version.Version(v)
-                    if tmpVer > version:
+                    if not version or tmpVer > version:
                         version = tmpVer
                         folder = config["versions"][v]["folder"]
                 except packaging.version.InvalidVersion:
                     print("Error parsing version %s for package %s in pr %s" % (v, package, pr))
 
-        shell = bool(platform.system() != "Windows")
-        command = "conan export %s %s/%s@" % (os.path.join("recipes", package, folder), package, version)
-        p = subprocess.run(command, shell=shell, check=True)
+        if version:
+            shell = bool(platform.system() != "Windows")
+            command = "conan export %s %s/%s@" % (os.path.join("recipes", package, folder), package, version)
+            p = subprocess.run(command, shell=shell, check=True)
 
 if __name__ == "__main__":
     # execute only if run as a script

--- a/.github/runlint.py
+++ b/.github/runlint.py
@@ -37,9 +37,8 @@ def main(pr):
             config = yaml.safe_load(file)
             for v in config["versions"]:
                 try:
-                    tmpVer = packaging.version.Version(v)
-                    if not version or tmpVer > version:
-                        version = tmpVer
+                    if not version or packaging.version.Version(v) > packaging.version.Version(version):
+                        version = v
                         folder = config["versions"][v]["folder"]
                 except packaging.version.InvalidVersion:
                     print("Error parsing version %s for package %s in pr %s" % (v, package, pr))

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        hook: [".github/yaml_linter", ".github/recipe_linter"]
+        hook: ["yaml_linter", "recipe_linter"]
     runs-on: ubuntu-latest
 
     steps:
@@ -29,5 +29,5 @@ jobs:
 
       - name: run lint
         run:  |
-          echo "::add-matcher::${{ matrix.hook }}.json"
+          echo "::add-matcher::.github/${{ matrix.hook }}.json"
           python3 .github/runlint.py ${{ github.event.pull_request.number }}


### PR DESCRIPTION
- this fixes the case where there are only cci.* versions in config.yml packages, eg https://github.com/conan-io/conan-center-index/runs/5019322147?check_suite_focus=true
- test the last version of the modified recipe folder (recipes/foo/folder) instead of the last version of the package (recipes/foo)
- fixup the hooks activation (there was a mixup with the .github folder)
- don't make the PR fail if there are some errors reported by the linter. I think we don't want (yet) to prevent merging some PRs only because of the linter's errors.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
