### PR TITLE
zlib-ng: add version 2.0.6

### DIFF
--- a/recipes/zlib-ng/all/conandata.yml
+++ b/recipes/zlib-ng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.6":
+    url: "https://github.com/zlib-ng/zlib-ng/archive/2.0.6.tar.gz"
+    sha256: "8258b75a72303b661a238047cb348203d88d9dddf85d480ed885f375916fcab6"
   "2.0.5":
     sha256: "eca3fe72aea7036c31d00ca120493923c4d5b99fe02e6d3322f7c88dbdcd0085"
     url: "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.5.tar.gz"

--- a/recipes/zlib-ng/config.yml
+++ b/recipes/zlib-ng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.6":
+    folder: all
   "2.0.5":
     folder: all
   "2.0.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **zlib-ng/2.0.6**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
