### PR TITLE
cpuinfo: fix hash of zip

### DIFF
--- a/recipes/cpuinfo/all/conandata.yml
+++ b/recipes/cpuinfo/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "cci.20201217":
     url: "https://github.com/pytorch/cpuinfo/archive/5916273f79a21551890fd3d56fc5375a78d1598d.zip"
-    sha256: "2a160c527d3c58085ce260f34f9e2b161adc009b34186a2baf24e74376e89e6d"
+    sha256: "873961f35200e59cba59416d57f58ad6b53531bfc30e4a55a1b4c9522ac6d02a"


### PR DESCRIPTION
Specify library name and version:  **cpuinfo/cci.20201217**

The hash of the zipfile of cpuinfo has changed.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
