### PR TITLE
mingw-w64:deprecate windows recipe in favor of mingw-builds

### DIFF
--- a/recipes/mingw-w64/all/conanfile.py
+++ b/recipes/mingw-w64/all/conanfile.py
@@ -14,6 +14,8 @@ class MingwConan(ConanFile):
     options = {"threads": ["posix", "win32"], "exception": ["seh", "sjlj"], "gcc": ["10.3.0"]}
     default_options = {"threads": "posix", "exception": "seh", "gcc": "10.3.0"}
     no_copy_source = True
+    
+    deprecated = "mingw-builds"
 
     @property
     def _settings_build(self):


### PR DESCRIPTION
Specify library name and version:  **mingw-w64/8.1**

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
