### PR TITLE
[cpprestsdk] Revert #8856 (thinking a generic solution)

### DIFF
--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -62,9 +62,6 @@ class CppRestSDKConan(ConanFile):
         if self.options.with_websockets:
             self.requires("websocketpp/0.8.2")
 
-    def package_id(self):
-        self.info.requires["boost"].minor_mode()
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 


### PR DESCRIPTION
Revert https://github.com/conan-io/conan-center-index/pull/8856, it breaks `conan-center-index` assumptions.

(I'm gathering feedback about it)

This is a documented Conan feature and it is working properly, but **it breaks the graph of dependencies in `conan-center-index`**: if any consumer declares a different `boost` version, it will modify the package-id of `cpprestsdk` and CI will fail with missing binaries (see #9219)

- [ ] Why was it introduced in the recipe?