### PR TITLE
sqlite3: Mark m as REQUIRED on find_library() so CMake errors out if not found.

### DIFF
--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.18)
 project(sqlite3 C)
 
 include(conanbuildinfo.cmake)
@@ -124,18 +124,16 @@ endif()
 
 if(THREADSAFE)
     find_package(Threads REQUIRED)
-    target_link_libraries(${PROJECT_NAME}  PRIVATE Threads::Threads)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
 endif()
 
 if(NOT OMIT_LOAD_EXTENSION)
-    target_link_libraries(${PROJECT_NAME}  PRIVATE ${CMAKE_DL_LIBS})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
 endif()
 
 if(ENABLE_FTS5 OR ENABLE_MATH_FUNCTIONS)
-    find_library(MATH_LIBRARY m)
-    if(MATH_LIBRARY)
-        target_link_libraries(${PROJECT_NAME}  PRIVATE ${MATH_LIBRARY})
-    endif()
+    find_library(MATH_LIBRARY m REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${MATH_LIBRARY})
 endif()
 
 include(GNUInstallDirs)


### PR DESCRIPTION
`sqlite3` 3.35+ depends on `m` because `ENABLE_MATH_FUNCTIONS` gets enabled.
The current implementation only links `m` if it was found, which results on undefined symbols otherwise.

The `REQUIRED` keyword on `find_library()` is available on CMake 3.18+

See example below
```
[100%] Linking C executable bin/sqlite3
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o): in function `logFunc':
sqlite3.c:(.text+0x1501c): undefined reference to `log'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: sqlite3.c:(.text+0x1503c): undefined reference to `log'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: sqlite3.c:(.text+0x15088): undefined reference to `log'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1598): undefined reference to `trunc'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1748): undefined reference to `exp'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1790): undefined reference to `pow'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x17d8): undefined reference to `pow'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1820): undefined reference to `fmod'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1868): undefined reference to `acos'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x18b0): undefined reference to `asin'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x18f8): undefined reference to `atan'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1940): undefined reference to `atan2'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1988): undefined reference to `cos'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x19d0): undefined reference to `sin'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1a18): undefined reference to `tan'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1a60): undefined reference to `cosh'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1aa8): undefined reference to `sinh'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1af0): undefined reference to `tanh'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1b38): undefined reference to `acosh'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1b80): undefined reference to `asinh'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1bc8): undefined reference to `atanh'
/home/eric/.conan/data/mySDK/1.2/eric/stable/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/sysroots/x86_64-oesdk-linux/usr/libexec/aarch64-oe-linux/gcc/aarch64-oe-linux/8.2.0/real-ld: lib/libsqlite3.a(sqlite3.c.o):(.data.rel+0x1c10): undefined reference to `sqrt'
```
---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
