### PR TITLE
ghc-filesystem: modernize

### DIFF
--- a/recipes/ghc-filesystem/all/conandata.yml
+++ b/recipes/ghc-filesystem/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.4.0":
-    url: "https://github.com/gulrak/filesystem/archive/v1.4.0.tar.gz"
-    sha256: "332fb8afda06671090c755c623da15889b66cfdedcf6f343d38a28a930ea5304"
   "1.5.8":
     url: "https://github.com/gulrak/filesystem/archive/v1.5.8.tar.gz"
     sha256: "726f8ccb2ec844f4c66cc4b572369497327df31b86c04cefad6b311964107139"
+  "1.4.0":
+    url: "https://github.com/gulrak/filesystem/archive/v1.4.0.tar.gz"
+    sha256: "332fb8afda06671090c755c623da15889b66cfdedcf6f343d38a28a930ea5304"

--- a/recipes/ghc-filesystem/all/conanfile.py
+++ b/recipes/ghc-filesystem/all/conanfile.py
@@ -1,49 +1,54 @@
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
+required_conan_version = ">=1.43.0"
 
 
 class GhcFilesystemRecipe(ConanFile):
     name = "ghc-filesystem"
     description = "A header-only single-file std::filesystem compatible helper library"
-    topics = ("conan", "ghc-filesystem", "header-only", "filesystem")
+    topics = ("ghc-filesystem", "header-only", "filesystem")
     homepage = "https://github.com/gulrak/filesystem"
     url = "https://github.com/conan-io/conan-center-index"
     license = "MIT"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
-    _cmake = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "filesystem-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
-
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["GHC_FILESYSTEM_BUILD_TESTING"] = False
-        self._cmake.definitions["GHC_FILESYSTEM_BUILD_EXAMPLES"] = False
-        self._cmake.definitions["GHC_FILESYSTEM_WITH_INSTALL"] = True
-        self._cmake.configure(source_folder=self._source_subfolder)
-        return self._cmake
-
-    def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
-        cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib"))
-
     def package_id(self):
         self.info.header_only()
 
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = CMake(self)
+        cmake.definitions["GHC_FILESYSTEM_BUILD_TESTING"] = False
+        cmake.definitions["GHC_FILESYSTEM_BUILD_EXAMPLES"] = False
+        cmake.definitions["GHC_FILESYSTEM_WITH_INSTALL"] = True
+        cmake.configure(source_folder=self._source_subfolder)
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib"))
+
     def package_info(self):
+        config_file = "ghcFilesystem" if tools.Version(self.version) < "1.5.2" else "ghc_filesystem"
+        self.cpp_info.set_property("cmake_file_name", config_file)
+        self.cpp_info.set_property("cmake_target_name", "ghcFilesystem::ghc_filesystem")
+        # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.components["ghc_filesystem"].bindirs = []
+        self.cpp_info.components["ghc_filesystem"].libdirs = []
+        self.cpp_info.components["ghc_filesystem"].resdirs = []
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = config_file
+        self.cpp_info.filenames["cmake_find_package_multi"] = config_file
         self.cpp_info.names["cmake_find_package"] = "ghcFilesystem"
         self.cpp_info.names["cmake_find_package_multi"] = "ghcFilesystem"
-        self.cpp_info.components["filesystem"].names["cmake_find_package"] = "ghc_filesystem"
-        self.cpp_info.components["filesystem"].names["cmake_find_package_multi"] = "ghc_filesystem"
+        self.cpp_info.components["ghc_filesystem"].names["cmake_find_package"] = "ghc_filesystem"
+        self.cpp_info.components["ghc_filesystem"].names["cmake_find_package_multi"] = "ghc_filesystem"
+        self.cpp_info.components["ghc_filesystem"].set_property("cmake_target_name", "ghcFilesystem::ghc_filesystem")

--- a/recipes/ghc-filesystem/all/test_package/CMakeLists.txt
+++ b/recipes/ghc-filesystem/all/test_package/CMakeLists.txt
@@ -4,7 +4,11 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(ghcFilesystem REQUIRED CONFIG)
+if(GHC_FILESYSTEM_VERSION VERSION_LESS "1.5.2")
+    find_package(ghcFilesystem REQUIRED CONFIG)
+else()
+    find_package(ghc_filesystem REQUIRED CONFIG)
+endif()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ghcFilesystem::ghc_filesystem)

--- a/recipes/ghc-filesystem/all/test_package/conanfile.py
+++ b/recipes/ghc-filesystem/all/test_package/conanfile.py
@@ -1,18 +1,18 @@
-import os
-
 from conans import ConanFile, CMake, tools
+import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["GHC_FILESYSTEM_VERSION"] = self.deps_cpp_info["ghc-filesystem"].version
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/ghc-filesystem/config.yml
+++ b/recipes/ghc-filesystem/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.4.0":
-    folder: "all"
   "1.5.8":
+    folder: "all"
+  "1.4.0":
     folder: "all"


### PR DESCRIPTION
Also fix CMake config filename.
Indeed, upstream has change the name from ghcFilesystemConfig.cmake to ghc_filesystem-config.cmake since 1.5.2:
https://github.com/gulrak/filesystem/blob/v1.5.0/CMakeLists.txt#L57
https://github.com/gulrak/filesystem/blob/v1.5.2/CMakeLists.txt#L64-L65

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
