### PR TITLE
libtins: fix CMake imported target + fix windows build + modernize

### DIFF
--- a/recipes/libtins/all/CMakeLists.txt
+++ b/recipes/libtins/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.1)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/libtins/all/conandata.yml
+++ b/recipes/libtins/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "4.2":
-    sha256: a9fed73e13f06b06a4857d342bb30815fa8c359d00bd69547e567eecbbb4c3a1 
-    url: https://github.com/mfontanini/libtins/archive/v4.2.tar.gz 
   "4.3":
-    sha256: c70bce5a41a27258bf0e3ad535d8238fb747d909a4b87ea14620f25dd65828fd
-    url: https://github.com/mfontanini/libtins/archive/v4.3.tar.gz
+    url: "https://github.com/mfontanini/libtins/archive/v4.3.tar.gz"
+    sha256: "c70bce5a41a27258bf0e3ad535d8238fb747d909a4b87ea14620f25dd65828fd"
+  "4.2":
+    url: "https://github.com/mfontanini/libtins/archive/v4.2.tar.gz"
+    sha256: "a9fed73e13f06b06a4857d342bb30815fa8c359d00bd69547e567eecbbb4c3a1"

--- a/recipes/libtins/all/conanfile.py
+++ b/recipes/libtins/all/conanfile.py
@@ -123,7 +123,7 @@ class LibTinsConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "libtins")
         self.cpp_info.set_property("cmake_target_name", "libtins")
         self.cpp_info.set_property("pkg_config_name", "libtins")
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = ["tins"]
         if self.settings.os == "Windows" and not self.options.shared:
             self.cpp_info.defines.append("TINS_STATIC")
             self.cpp_info.system_libs.extend(["ws2_32", "iphlpapi"])

--- a/recipes/libtins/all/conanfile.py
+++ b/recipes/libtins/all/conanfile.py
@@ -94,6 +94,7 @@ class LibTinsConan(ConanFile):
         self.copy(os.path.join(self._source_subfolder, "LICENSE"), dst="licenses")
         cmake = self._configure_cmake()
         cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "CMake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 

--- a/recipes/libtins/all/conanfile.py
+++ b/recipes/libtins/all/conanfile.py
@@ -50,11 +50,11 @@ class LibTinsConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("libpcap/1.10.0")
+        self.requires("libpcap/1.10.1")
         if self.options.with_ack_tracker:
-            self.requires("boost/1.75.0")
+            self.requires("boost/1.78.0")
         if self.options.with_wpa2:
-            self.requires("openssl/1.1.1j")
+            self.requires("openssl/1.1.1m")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/libtins/all/test_package/CMakeLists.txt
+++ b/recipes/libtins/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(libtins REQUIRED CONFIG)
 
 add_executable(test_package test_package.cpp)
-target_link_libraries(test_package ${CONAN_LIBS})
+target_link_libraries(test_package libtins)

--- a/recipes/libtins/all/test_package/conanfile.py
+++ b/recipes/libtins/all/test_package/conanfile.py
@@ -3,8 +3,8 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/libtins/config.yml
+++ b/recipes/libtins/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "4.2":
-    folder: all
   "4.3":
+    folder: all
+  "4.2":
     folder: all


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- bump dependencies
- CMake imported target is not namespaced
- fix windows build (never tested before, because libpcap was raising InvalidConfiguration for windows).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
