### PR TITLE
[aws-sdk-cpp] Add s3-crt component

### DIFF
--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -228,6 +228,7 @@ class AwsSdkCppConan(ConanFile):
         "route53domains",
         "route53resolver",
         "s3",
+        "s3-crt",
         "s3-encryption",
         "s3control",
         "s3outposts",


### PR DESCRIPTION
Specify library name and version:  **aws-sdk-cpp/1.9**

aws-sdk-cpp v1.9 introduced a new component called `s3-crt`
This component is missing from conan recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
