### PR TITLE
libzen: fix CMake imported target + modernize

### DIFF
--- a/recipes/libzen/all/CMakeLists.txt
+++ b/recipes/libzen/all/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.4)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/recipes/libzen/all/conanfile.py
+++ b/recipes/libzen/all/conanfile.py
@@ -1,5 +1,8 @@
-import os
 from conans import ConanFile, CMake, tools
+import os
+import textwrap
+
+required_conan_version = ">=1.43.0"
 
 
 class LibzenConan(ConanFile):
@@ -8,10 +11,9 @@ class LibzenConan(ConanFile):
     homepage = "https://github.com/MediaArea/ZenLib"
     url = "https://github.com/conan-io/conan-center-index"
     description = "Small C++ derivate classes to have an easier life"
-    topics = ("conan", "libzen", "c++", "helper", "util")
+    topics = ("libzen", "c++", "helper", "util")
+
     settings = "os",  "arch", "compiler", "build_type"
-    exports_sources = "CMakeLists.txt", "patches/**"
-    generators = "cmake"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -25,11 +27,17 @@ class LibzenConan(ConanFile):
         "enable_large_files": True,
     }
 
+    generators = "cmake"
     _cmake = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -40,8 +48,8 @@ class LibzenConan(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("ZenLib", self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:
@@ -53,7 +61,7 @@ class LibzenConan(ConanFile):
         return self._cmake
 
     def _patch_sources(self):
-        for patch in self.conan_data["patches"][self.version]:
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
 
     def build(self):
@@ -69,7 +77,32 @@ class LibzenConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"zen": "ZenLib::ZenLib"}
+        )
+
+    @staticmethod
+    def _create_cmake_module_alias_targets(module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent("""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """.format(alias=alias, aliased=aliased))
+        tools.save(module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", "conan-official-{}-targets.cmake".format(self.name))
+
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "ZenLib")
+        self.cpp_info.set_property("cmake_target_name", "zen")
+        self.cpp_info.set_property("pkg_config_name", "libzen")
         suffix = ""
         if self.settings.build_type == "Debug":
             if self.settings.os == "Windows":
@@ -77,11 +110,15 @@ class LibzenConan(ConanFile):
             elif tools.is_apple_os(self.settings.os):
                 suffix = "_debug"
         self.cpp_info.libs = ["zen{}".format(suffix)]
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["m", "pthread"])
         if self.options.enable_unicode:
             self.cpp_info.defines.extend(["UNICODE", "_UNICODE"])
         if self.options.shared:
             self.cpp_info.defines.append("LIBZEN_SHARED")
+
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.names["cmake_find_package"] = "ZenLib"
         self.cpp_info.names["cmake_find_package_multi"] = "ZenLib"
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/libzen/all/conanfile.py
+++ b/recipes/libzen/all/conanfile.py
@@ -57,6 +57,8 @@ class LibzenConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["ENABLE_UNICODE"] = self.options.enable_unicode
         self._cmake.definitions["LARGE_FILES"] = self.options.enable_large_files
+        # To install relocatable shared libs on Macos
+        self._cmake.definitions["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/libzen/all/test_package/CMakeLists.txt
+++ b/recipes/libzen/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(ZenLib REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} zen)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/libzen/all/test_package/conanfile.py
+++ b/recipes/libzen/all/test_package/conanfile.py
@@ -3,8 +3,8 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
- CMake imported target is `zen`, not `ZenLib::ZenLib` (config file is `ZenLibConfig.cmake`).
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- CMakeDeps support

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
