### PR TITLE
Qt6 use bundled dependencies and option to disable features.

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -57,6 +57,7 @@ class QtConan(ConanFile):
     homepage = "https://www.qt.io"
     license = "LGPL-3.0"
     settings = "os", "arch", "compiler", "build_type"
+    provides = []
 
     options = {
         "shared": [True, False],
@@ -231,6 +232,16 @@ class QtConan(ConanFile):
         for module in self._get_module_tree:
             if self.options.get_safe(module):
                 _enablemodule(module)
+
+        for opt, dep  in [("with_doubleconversion", "double-conversion"),
+                          ("with_freetype", "freetype"),
+                          ("with_harfbuzz", "harfbuzz"),
+                          ("with_libjpeg", "libjpeg"),
+                          ("with_libpng", "libpng"),
+                          ("with_sqlite3", "sqlite3"),
+                          ("with_pcre2", "pcre2")]:
+            if self.options.get_safe(opt, False) == "qt":
+                self.provides.append(dep) 
 
     def validate(self):
         # C++ minimum standard required

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -949,8 +949,8 @@ class QtConan(ConanFile):
                 _create_module("XcbQpaPrivate", ["xkbcommon::libxkbcommon-x11", "xorg::xorg"])
                 _create_plugin("QXcbIntegrationPlugin", "qxcb", "platforms", ["Core", "Gui", "XcbQpaPrivate"])
 
-        if self.options.with_sqlite3 is True:
-            _create_plugin("QSQLiteDriverPlugin", "qsqlite", "sqldrivers", ["sqlite3::sqlite3"])
+        if self.options.with_sqlite3:
+            _create_plugin("QSQLiteDriverPlugin", "qsqlite", "sqldrivers", ["sqlite3::sqlite3"] if self.options.with_sqlite3 is True else [])
         if self.options.with_pq:
             _create_plugin("QPSQLDriverPlugin", "qsqlpsql", "sqldrivers", ["libpq::libpq"])
         if self.options.with_odbc:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -276,7 +276,7 @@ class QtConan(ConanFile):
         if self.settings.os != "Windows" and self.options.get_safe("opengl", "no") == "dynamic":
             raise ConanInvalidConfiguration("Dynamic OpenGL is supported only on Windows.")
 
-        if self.options.get_safe("with_fontconfig", False) and not self._with_system_dependency("with_freetype", False):
+        if self.options.get_safe("with_fontconfig", False) and not self._with_system_dependency("with_freetype"):
             raise ConanInvalidConfiguration("with_fontconfig cannot be enabled if with_freetype is disabled.")
 
         if "MT" in self.settings.get_safe("compiler.runtime", default="") and self.options.shared:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -787,6 +787,9 @@ class QtConan(ConanFile):
         if self.options.gui:
             _create_private_module("Gui", ["CorePrivate", "Gui"])
 
+        if self.options.widgets:
+            _create_private_module("Widgets", ["CorePrivate", "GuiPrivate", "Widgets"])
+
         if self.options.qtdeclarative:
             _create_private_module("Qml", ["CorePrivate", "Qml"])
 
@@ -909,6 +912,9 @@ class QtConan(ConanFile):
                 gui_reqs.append("libjpeg::libjpeg")
             _create_module("Gui", gui_reqs)
 
+            self.cpp_info.components["qtGui"].build_modules["cmake_find_package"].append(self._cmake_qt6_private_file("Gui"))
+            self.cpp_info.components["qtGui"].build_modules["cmake_find_package_multi"].append(self._cmake_qt6_private_file("Gui"))
+
             if self.settings.os == "Windows":
                 _create_plugin("QWindowsIntegrationPlugin", "qwindows", "platforms", ["Core", "Gui"])
                 self.cpp_info.components["qtQWindowsIntegrationPlugin"].system_libs = ["advapi32", "dwmapi", "gdi32", "imm32",
@@ -949,6 +955,8 @@ class QtConan(ConanFile):
         _create_module("Test")
         if self.options.widgets:
             _create_module("Widgets", ["Gui"])
+            self.cpp_info.components["qtWidgets"].build_modules["cmake_find_package"].append(self._cmake_qt6_private_file("Widgets"))
+            self.cpp_info.components["qtWidgets"].build_modules["cmake_find_package_multi"].append(self._cmake_qt6_private_file("Widgets"))
         if self.options.gui and self.options.widgets:
             _create_module("PrintSupport", ["Gui", "Widgets"])
         if self.options.get_safe("opengl", "no") != "no" and self.options.gui:
@@ -1214,9 +1222,6 @@ class QtConan(ConanFile):
         if self.settings.os in ["Windows", "iOS"]:
             self.cpp_info.components["qtCore"].build_modules["cmake_find_package"].append(self._cmake_entry_point_file)
             self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_entry_point_file)
-
-        self.cpp_info.components["qtGui"].build_modules["cmake_find_package"].append(self._cmake_qt6_private_file("Gui"))
-        self.cpp_info.components["qtGui"].build_modules["cmake_find_package_multi"].append(self._cmake_qt6_private_file("Gui"))
 
         for m in os.listdir(os.path.join("lib", "cmake")):
             module = os.path.join("lib", "cmake", m, "%sMacros.cmake" % m)

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -167,7 +167,7 @@ class QtConan(ConanFile):
 
         return self._submodules_tree
 
-    def _with_system_dependency(self, dep):
+    def _with_conan_dependency(self, dep):
         option = self.options.get_safe(dep, False)
         return option and option != "qt"
 
@@ -276,7 +276,7 @@ class QtConan(ConanFile):
         if self.settings.os != "Windows" and self.options.get_safe("opengl", "no") == "dynamic":
             raise ConanInvalidConfiguration("Dynamic OpenGL is supported only on Windows.")
 
-        if self.options.get_safe("with_fontconfig", False) and not self._with_system_dependency("with_freetype"):
+        if self.options.get_safe("with_fontconfig", False) and not self._with_conan_dependency("with_freetype"):
             raise ConanInvalidConfiguration("with_fontconfig cannot be enabled if with_freetype is disabled.")
 
         if "MT" in self.settings.get_safe("compiler.runtime", default="") and self.options.shared:
@@ -290,7 +290,7 @@ class QtConan(ConanFile):
         self.requires("zlib/1.2.11")
         if self.options.openssl:
             self.requires("openssl/1.1.1m")
-        if self._with_system_dependency("with_pcre2"):
+        if self._with_conan_dependency("with_pcre2"):
             self.requires("pcre2/10.37")
         if self.options.get_safe("with_vulkan"):
             self.requires("vulkan-loader/1.2.182")
@@ -298,24 +298,24 @@ class QtConan(ConanFile):
                 self.requires("moltenvk/1.1.4")
         if self.options.with_glib:
             self.requires("glib/2.70.1")
-        if self._with_system_dependency("with_doubleconversion") and not self.options.multiconfiguration:
+        if self._with_conan_dependency("with_doubleconversion") and not self.options.multiconfiguration:
             self.requires("double-conversion/3.1.7")
-        if self._with_system_dependency("with_freetype") and not self.options.multiconfiguration:
+        if self._with_conan_dependency("with_freetype") and not self.options.multiconfiguration:
             self.requires("freetype/2.11.0")
         if self.options.get_safe("with_fontconfig", False):
             self.requires("fontconfig/2.13.93")
         if self.options.get_safe("with_icu", False):
             self.requires("icu/70.1")
-        if self._with_system_dependency("with_harfbuzz") and not self.options.multiconfiguration:
+        if self._with_conan_dependency("with_harfbuzz") and not self.options.multiconfiguration:
             self.requires("harfbuzz/3.2.0")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:
             if self.options.with_libjpeg == "libjpeg-turbo":
                 self.requires("libjpeg-turbo/2.1.2")
             elif self.options.with_libjpeg == "libjpeg":
                 self.requires("libjpeg/9d")
-        if self._with_system_dependency("with_libpng") and not self.options.multiconfiguration:
+        if self._with_conan_dependency("with_libpng") and not self.options.multiconfiguration:
             self.requires("libpng/1.6.37")
-        if self._with_system_dependency("with_sqlite3") and not self.options.multiconfiguration:
+        if self._with_conan_dependency("with_sqlite3") and not self.options.multiconfiguration:
             self.requires("sqlite3/3.37.2")
             self.options["sqlite3"].enable_column_metadata = True
         if self.options.get_safe("with_mysql", False):
@@ -877,9 +877,9 @@ class QtConan(ConanFile):
             self.cpp_info.components[componentname].requires = _get_corrected_reqs(requires)
 
         core_reqs = ["zlib::zlib"]
-        if self._with_system_dependency("with_pcre2"):
+        if self._with_conan_dependency("with_pcre2"):
             core_reqs.append("pcre2::pcre2")
-        if self._with_system_dependency("with_doubleconversion"):
+        if self._with_conan_dependency("with_doubleconversion"):
             core_reqs.append("double-conversion::double-conversion")
         if self.options.get_safe("with_icu", False):
             core_reqs.append("icu::icu")
@@ -901,9 +901,9 @@ class QtConan(ConanFile):
             gui_reqs = []
             if self.options.with_dbus:
                 gui_reqs.append("DBus")
-            if self._with_system_dependency("with_freetype"):
+            if self._with_conan_dependency("with_freetype"):
                 gui_reqs.append("freetype::freetype")
-            if self._with_system_dependency("with_libpng"):
+            if self._with_conan_dependency("with_libpng"):
                 gui_reqs.append("libpng::libpng")
             if self.options.get_safe("with_fontconfig", False):
                 gui_reqs.append("fontconfig::fontconfig")
@@ -917,7 +917,7 @@ class QtConan(ConanFile):
                 gui_reqs.append("vulkan-loader::vulkan-loader")
                 if tools.is_apple_os(self.settings.os):
                     gui_reqs.append("moltenvk::moltenvk")
-            if self._with_system_dependency("with_harfbuzz"):
+            if self._with_conan_dependency("with_harfbuzz"):
                 gui_reqs.append("harfbuzz::harfbuzz")
             if self.options.with_libjpeg == "libjpeg-turbo":
                 gui_reqs.append("libjpeg-turbo::libjpeg-turbo")
@@ -952,7 +952,7 @@ class QtConan(ConanFile):
                 _create_plugin("QXcbIntegrationPlugin", "qxcb", "platforms", ["Core", "Gui", "XcbQpaPrivate"])
 
         if self.options.with_sqlite3:
-            _create_plugin("QSQLiteDriverPlugin", "qsqlite", "sqldrivers", ["sqlite3::sqlite3"] if self._with_system_dependency("with_sqlite3") else [])
+            _create_plugin("QSQLiteDriverPlugin", "qsqlite", "sqldrivers", ["sqlite3::sqlite3"] if self._with_conan_dependency("with_sqlite3") else [])
         if self.options.with_pq:
             _create_plugin("QPSQLDriverPlugin", "qsqlpsql", "sqldrivers", ["libpq::libpq"])
         if self.options.with_odbc:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -91,6 +91,7 @@ class QtConan(ConanFile):
         "cross_compile": "ANY",
         "sysroot": "ANY",
         "multiconfiguration": [True, False],
+        "disabled_features": "ANY",
     }
     options.update({module: [True, False] for module in _submodules})
 
@@ -130,6 +131,7 @@ class QtConan(ConanFile):
         "cross_compile": None,
         "sysroot": None,
         "multiconfiguration": False,
+        "disabled_features": "",
     }
     default_options.update({module: False for module in _submodules})
 
@@ -591,6 +593,9 @@ class QtConan(ConanFile):
             else:
                 self._cmake.definitions["FEATURE_%s" % conf_arg] = "OFF"
                 self._cmake.definitions["FEATURE_system_%s" % feature] = "OFF"
+
+        for feature in str(self.options.disabled_features).split(" "):
+            self._cmake.definitions["FEATURE_%s" % feature] = "OFF"
 
         if self.settings.os == "Macos":
             self._cmake.definitions["FEATURE_framework"] = "OFF"

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -63,16 +63,16 @@ class QtConan(ConanFile):
         "opengl": ["no", "desktop", "dynamic"],
         "with_vulkan": [True, False],
         "openssl": [True, False],
-        "with_pcre2": [True, False],
+        "with_pcre2": [True, False, "qt"],
         "with_glib": [True, False],
-        "with_doubleconversion": [True, False],
-        "with_freetype": [True, False],
+        "with_doubleconversion": [True, False, "qt"],
+        "with_freetype": [True, False, "qt"],
         "with_fontconfig": [True, False],
         "with_icu": [True, False],
-        "with_harfbuzz": [True, False],
-        "with_libjpeg": ["libjpeg", "libjpeg-turbo", False],
-        "with_libpng": [True, False],
-        "with_sqlite3": [True, False],
+        "with_harfbuzz": [True, False, "qt"],
+        "with_libjpeg": ["libjpeg", "libjpeg-turbo", False, "qt"],
+        "with_libpng": [True, False, "qt"],
+        "with_sqlite3": [True, False, "qt"],
         "with_mysql": [True, False],
         "with_pq": [True, False],
         "with_odbc": [True, False],
@@ -259,7 +259,7 @@ class QtConan(ConanFile):
         if self.settings.os != "Windows" and self.options.get_safe("opengl", "no") == "dynamic":
             raise ConanInvalidConfiguration("Dynamic OpenGL is supported only on Windows.")
 
-        if self.options.get_safe("with_fontconfig", False) and not self.options.get_safe("with_freetype", False):
+        if self.options.get_safe("with_fontconfig", False) and not self.options.get_safe("with_freetype", False) is True:
             raise ConanInvalidConfiguration("with_fontconfig cannot be enabled if with_freetype is disabled.")
 
         if "MT" in self.settings.get_safe("compiler.runtime", default="") and self.options.shared:
@@ -273,7 +273,7 @@ class QtConan(ConanFile):
         self.requires("zlib/1.2.11")
         if self.options.openssl:
             self.requires("openssl/1.1.1m")
-        if self.options.with_pcre2:
+        if self.options.with_pcre2 is True:
             self.requires("pcre2/10.37")
         if self.options.get_safe("with_vulkan"):
             self.requires("vulkan-loader/1.2.182")
@@ -281,24 +281,24 @@ class QtConan(ConanFile):
                 self.requires("moltenvk/1.1.4")
         if self.options.with_glib:
             self.requires("glib/2.70.1")
-        if self.options.with_doubleconversion and not self.options.multiconfiguration:
+        if self.options.with_doubleconversion is True and not self.options.multiconfiguration:
             self.requires("double-conversion/3.1.7")
-        if self.options.get_safe("with_freetype", False) and not self.options.multiconfiguration:
+        if self.options.get_safe("with_freetype", False) is True and not self.options.multiconfiguration:
             self.requires("freetype/2.11.0")
         if self.options.get_safe("with_fontconfig", False):
             self.requires("fontconfig/2.13.93")
         if self.options.get_safe("with_icu", False):
             self.requires("icu/70.1")
-        if self.options.get_safe("with_harfbuzz", False) and not self.options.multiconfiguration:
+        if self.options.get_safe("with_harfbuzz", False) is True and not self.options.multiconfiguration:
             self.requires("harfbuzz/3.2.0")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:
             if self.options.with_libjpeg == "libjpeg-turbo":
                 self.requires("libjpeg-turbo/2.1.2")
-            else:
+            elif self.options.with_libjpeg == "libjpeg":
                 self.requires("libjpeg/9d")
-        if self.options.get_safe("with_libpng", False) and not self.options.multiconfiguration:
+        if self.options.get_safe("with_libpng", False) is True and not self.options.multiconfiguration:
             self.requires("libpng/1.6.37")
-        if self.options.with_sqlite3 and not self.options.multiconfiguration:
+        if self.options.with_sqlite3 is True and not self.options.multiconfiguration:
             self.requires("sqlite3/3.37.2")
             self.options["sqlite3"].enable_column_metadata = True
         if self.options.get_safe("with_mysql", False):
@@ -402,7 +402,9 @@ class QtConan(ConanFile):
 
         tools.replace_in_file(os.path.join("qt6", "CMakeLists.txt"),
                         "enable_testing()",
-                        "include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)\nconan_basic_setup(KEEP_RPATHS)\n"
+                        "include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)\n"
+                               "list(REMOVE_ITEM CONAN_INCLUDE_DIRS \"${CONAN_INCLUDE_DIRS_STRAWBERRYPERL}\")\n" # strawberryperl exports includes for jpg, png and many other dependencies that might interfere with the build
+                               "conan_basic_setup(KEEP_RPATHS)\n"
                                "set(QT_EXTRA_INCLUDEPATHS ${CONAN_INCLUDE_DIRS})\n"
                                "set(QT_EXTRA_DEFINES ${CONAN_DEFINES})\n"
                                "set(QT_EXTRA_LIBDIRS ${CONAN_LIB_DIRS})\n"
@@ -572,22 +574,23 @@ class QtConan(ConanFile):
             self._cmake.definitions["FEATURE_%s" % conf_arg] = ("ON" if self.options.get_safe(opt, False) else "OFF")
 
 
-        for opt, conf_arg in [
-                              ("with_doubleconversion", "doubleconversion"),
-                              ("with_freetype", "freetype"),
-                              ("with_harfbuzz", "harfbuzz"),
-                              ("with_libjpeg", "jpeg"),
-                              ("with_libpng", "png"),
-                              ("with_sqlite3", "sqlite"),
-                              ("with_pcre2", "pcre2"),]:
-            if self.options.get_safe(opt, False):
-                if self.options.multiconfiguration:
-                    self._cmake.definitions["FEATURE_%s" % conf_arg] = "ON"
+        for opt, feature, conf_arg in [
+                              ("with_doubleconversion", "doubleconversion", "doubleconversion"),
+                              ("with_freetype", "freetype", "freetype"),
+                              ("with_harfbuzz", "harfbuzz", "harfbuzz"),
+                              ("with_libjpeg", "jpeg", "jpeg"),
+                              ("with_libpng", "png", "png"),
+                              ("with_sqlite3", "sqlite", "sql_sqlite"),
+                              ("with_pcre2", "pcre2", "pcre2"),]:
+            if self.options.get_safe(opt, False) is not False:
+                self._cmake.definitions["FEATURE_%s" % conf_arg] = "ON"
+                if self.options.multiconfiguration or self.options.get_safe(opt, False) == "qt":
+                    self._cmake.definitions["FEATURE_system_%s" % feature] = "OFF"
                 else:
-                    self._cmake.definitions["FEATURE_system_%s" % conf_arg] = "ON"
+                    self._cmake.definitions["FEATURE_system_%s" % feature] = "ON"
             else:
                 self._cmake.definitions["FEATURE_%s" % conf_arg] = "OFF"
-                self._cmake.definitions["FEATURE_system_%s" % conf_arg] = "OFF"
+                self._cmake.definitions["FEATURE_system_%s" % feature] = "OFF"
 
         if self.settings.os == "Macos":
             self._cmake.definitions["FEATURE_framework"] = "OFF"
@@ -853,9 +856,9 @@ class QtConan(ConanFile):
             self.cpp_info.components[componentname].requires = _get_corrected_reqs(requires)
 
         core_reqs = ["zlib::zlib"]
-        if self.options.with_pcre2:
+        if self.options.with_pcre2 is True:
             core_reqs.append("pcre2::pcre2")
-        if self.options.with_doubleconversion:
+        if self.options.with_doubleconversion is True:
             core_reqs.append("double-conversion::double-conversion")
         if self.options.get_safe("with_icu", False):
             core_reqs.append("icu::icu")
@@ -877,9 +880,9 @@ class QtConan(ConanFile):
             gui_reqs = []
             if self.options.with_dbus:
                 gui_reqs.append("DBus")
-            if self.options.with_freetype:
+            if self.options.with_freetype is True:
                 gui_reqs.append("freetype::freetype")
-            if self.options.with_libpng:
+            if self.options.with_libpng is True:
                 gui_reqs.append("libpng::libpng")
             if self.options.get_safe("with_fontconfig", False):
                 gui_reqs.append("fontconfig::fontconfig")
@@ -893,7 +896,7 @@ class QtConan(ConanFile):
                 gui_reqs.append("vulkan-loader::vulkan-loader")
                 if tools.is_apple_os(self.settings.os):
                     gui_reqs.append("moltenvk::moltenvk")
-            if self.options.with_harfbuzz:
+            if self.options.with_harfbuzz is True:
                 gui_reqs.append("harfbuzz::harfbuzz")
             if self.options.with_libjpeg == "libjpeg-turbo":
                 gui_reqs.append("libjpeg-turbo::libjpeg-turbo")
@@ -924,7 +927,7 @@ class QtConan(ConanFile):
                 _create_module("XcbQpaPrivate", ["xkbcommon::libxkbcommon-x11", "xorg::xorg"])
                 _create_plugin("QXcbIntegrationPlugin", "qxcb", "platforms", ["Core", "Gui", "XcbQpaPrivate"])
 
-        if self.options.with_sqlite3:
+        if self.options.with_sqlite3 is True:
             _create_plugin("QSQLiteDriverPlugin", "qsqlite", "sqldrivers", ["sqlite3::sqlite3"])
         if self.options.with_pq:
             _create_plugin("QPSQLDriverPlugin", "qsqlpsql", "sqldrivers", ["libpq::libpq"])


### PR DESCRIPTION
Not sure if this goes against the philosophy of conan but for simplicity and for the sake of using the tested versions of qts dependencies I would like to build with the bundled dependencies instead of using libraries from conan.

I also have a bunch of features disabled which was possible to do with qt5s configure option.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
