### PR TITLE
qt6: don't use strawberryperl

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -342,8 +342,6 @@ class QtConan(ConanFile):
         self.build_requires("cmake/3.22.0")
         self.build_requires("ninja/1.10.2")
         self.build_requires("pkgconf/1.7.4")
-        if self.settings.compiler == "Visual Studio":
-            self.build_requires('strawberryperl/5.30.0.1')
 
         if self.options.get_safe("qtwebengine"):
             self.build_requires("ninja/1.10.2")
@@ -406,6 +404,7 @@ class QtConan(ConanFile):
                                "set(QT_EXTRA_INCLUDEPATHS ${CONAN_INCLUDE_DIRS})\n"
                                "set(QT_EXTRA_DEFINES ${CONAN_DEFINES})\n"
                                "set(QT_EXTRA_LIBDIRS ${CONAN_LIB_DIRS})\n"
+                               "set(HOST_PERL echo CACHE FORCE)\n"
                                "enable_testing()")
 
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -404,7 +404,7 @@ class QtConan(ConanFile):
                                "set(QT_EXTRA_INCLUDEPATHS ${CONAN_INCLUDE_DIRS})\n"
                                "set(QT_EXTRA_DEFINES ${CONAN_DEFINES})\n"
                                "set(QT_EXTRA_LIBDIRS ${CONAN_LIB_DIRS})\n"
-                               "set(HOST_PERL echo CACHE FORCE)\n"
+                               "set(HOST_PERL echo CACHE FILEPATH "" FORCE)\n"
                                "enable_testing()")
 
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -404,7 +404,7 @@ class QtConan(ConanFile):
                                "set(QT_EXTRA_INCLUDEPATHS ${CONAN_INCLUDE_DIRS})\n"
                                "set(QT_EXTRA_DEFINES ${CONAN_DEFINES})\n"
                                "set(QT_EXTRA_LIBDIRS ${CONAN_LIB_DIRS})\n"
-                               "set(HOST_PERL echo CACHE FILEPATH "" FORCE)\n"
+                               "set(HOST_PERL echo CACHE STRING \"Perl binary\")\n"
                                "enable_testing()")
 
         for patch in self.conan_data.get("patches", {}).get(self.version, []):


### PR DESCRIPTION
Specify library name and version:  **qt/6.*.***


---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
