### PR TITLE
mingw-builds: detect conflict with mingw-w64

### DIFF
--- a/recipes/mingw-builds/all/conanfile.py
+++ b/recipes/mingw-builds/all/conanfile.py
@@ -13,6 +13,8 @@ class MingwConan(ConanFile):
     settings = "os", "arch"
     options = {"threads": ["posix", "win32"], "exception": ["seh", "sjlj"]}
     default_options = {"threads": "posix", "exception": "seh"}
+    
+    provides = "mingw-w64"
 
     @property
     def _settings_build(self):


### PR DESCRIPTION
Specify library name and version:  **mingw-builds/***

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
