### PR TITLE
freetype:: enable subpixel

### DIFF
--- a/recipes/freetype/all/conanfile.py
+++ b/recipes/freetype/all/conanfile.py
@@ -23,6 +23,7 @@ class FreetypeConan(ConanFile):
         "with_zlib": [True, False],
         "with_bzip2": [True, False],
         "with_brotli": [True, False],
+        "subpixel": [True, False],
     }
     default_options = {
         "shared": False,
@@ -31,6 +32,7 @@ class FreetypeConan(ConanFile):
         "with_zlib": True,
         "with_bzip2": True,
         "with_brotli": True,
+        "subpixel": False
     }
 
     exports_sources = "CMakeLists.txt"
@@ -101,6 +103,10 @@ class FreetypeConan(ConanFile):
             if not self.options.with_brotli:
                 tools.replace_in_file(cmakelists, "find_package(BrotliDec)", "")
                 tools.replace_in_file(cmakelists, "if (BROTLIDEC_FOUND)", "if(0)")
+
+        config_h = os.path.join(self._source_subfolder, "include", "freetype", "config", "ftoption.h")
+        if self.options.subpixel:
+            tools.replace_in_file(config_h, "/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */", "#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING")
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/freetype/all/test_package/test_package.c
+++ b/recipes/freetype/all/test_package/test_package.c
@@ -118,7 +118,7 @@ main( int     argc,
     FT_Set_Transform( face, &matrix, &pen );
 
     /* load glyph image into the slot (erase previous one) */
-    error = FT_Load_Char( face, text[n], FT_LOAD_RENDER | FT_LOAD_TARGET_LCD);
+    error = FT_Load_Char( face, text[n], FT_LOAD_RENDER);
     if (error) {
         exit(EXIT_FAILURE);
     }

--- a/recipes/freetype/all/test_package/test_package.c
+++ b/recipes/freetype/all/test_package/test_package.c
@@ -69,7 +69,7 @@ main( int     argc,
   int           target_height;
   size_t        n, num_chars;
 
-  if (argv < 2) {
+  if (argc < 2) {
     fprintf(stderr, "Usage: %s FONT\n", argv[0]);
     return EXIT_FAILURE;
   }
@@ -118,7 +118,7 @@ main( int     argc,
     FT_Set_Transform( face, &matrix, &pen );
 
     /* load glyph image into the slot (erase previous one) */
-    error = FT_Load_Char( face, text[n], FT_LOAD_RENDER );
+    error = FT_Load_Char( face, text[n], FT_LOAD_RENDER | FT_LOAD_TARGET_LCD);
     if (error) {
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
Specify library name and version:  **freetype/all**

- add `subpixel` option to control subpixel filter
- fix test_package bug

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
