### PR TITLE
flann: fix CMakeDeps  + relocatable shared libs on macOS

### DIFF
--- a/recipes/flann/all/CMakeLists.txt
+++ b/recipes/flann/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -133,7 +133,7 @@ class FlannConan(ConanFile):
 
         # flann_cpp
         flann_cpp_lib = "flann_cpp" if self.options.shared else "flann_cpp_s"
-        self.cpp_info.components["flann_cpp"].set_property("cmake_file_name", flann_cpp_lib)
+        self.cpp_info.components["flann_cpp"].set_property("cmake_target_name", "flann::{}".format(flann_cpp_lib))
         self.cpp_info.components["flann_cpp"].libs = [flann_cpp_lib]
         if not self.options.shared and tools.stdcpp_library(self):
             self.cpp_info.components["flann_cpp"].system_libs.append(tools.stdcpp_library(self))
@@ -141,7 +141,7 @@ class FlannConan(ConanFile):
 
         # flann
         flann_c_lib = "flann" if self.options.shared else "flann_s"
-        self.cpp_info.components["flann_c"].set_property("cmake_file_name", flann_c_lib)
+        self.cpp_info.components["flann_c"].set_property("cmake_target_name", "flann::{}".format(flann_c_lib))
         self.cpp_info.components["flann_c"].libs = [flann_c_lib]
         if self.settings.os == "Linux":
             self.cpp_info.components["flann_c"].system_libs.append("m")

--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -97,6 +97,9 @@ class FlannConan(ConanFile):
         # OpenMP support can be added later if needed
         self._cmake.definitions["USE_OPENMP"] = False
 
+        # Generate a relocatable shared lib on Macos
+        self._cmake.definitions["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 

--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -143,7 +143,7 @@ class FlannConan(ConanFile):
         flann_c_lib = "flann" if self.options.shared else "flann_s"
         self.cpp_info.components["flann_c"].set_property("cmake_target_name", "flann::{}".format(flann_c_lib))
         self.cpp_info.components["flann_c"].libs = [flann_c_lib]
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["flann_c"].system_libs.append("m")
         if not self.options.shared:
             self.cpp_info.components["flann_c"].defines.append("FLANN_STATIC")


### PR DESCRIPTION
- fix my mistake for CMakeDeps in https://github.com/conan-io/conan-center-index/pull/8959
- relocatable shared libs: see https://github.com/conan-io/hooks/issues/376

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
