### PR TITLE
stb: add version cci.20210910

### DIFF
--- a/recipes/stb/all/conandata.yml
+++ b/recipes/stb/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
-  "cci.20200203":
-    url: "https://github.com/nothings/stb/archive/0224a44a10564a214595797b4c88323f79a5f934.zip"
-    sha256: "5dd9cf8a9a8c0f253fad3e9904923b2dfc740eddbc86415c3f76152bd534f23a"
+  "cci.20210910":
+    url: "https://github.com/nothings/stb/archive/af1a5bc352164740c1cc1354942b1c6b72eacb8a.zip"
+    sha256: "e3d0edbecd356506d3d69b87419de2f9d180a98099134c6343177885f6c2cbef"
   "cci.20210713":
     url: "https://github.com/nothings/stb/archive/3a1174060a7dd4eb652d4e6854bc4cd98c159200.zip"
     sha256: "9313f6871195b97771ce7da1feae0b3d92c7936456f13099edb54a78096ca93c"
+  "cci.20200203":
+    url: "https://github.com/nothings/stb/archive/0224a44a10564a214595797b4c88323f79a5f934.zip"
+    sha256: "5dd9cf8a9a8c0f253fad3e9904923b2dfc740eddbc86415c3f76152bd534f23a"

--- a/recipes/stb/all/test_package/CMakeLists.txt
+++ b/recipes/stb/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(stb REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} stb::stb)

--- a/recipes/stb/all/test_package/conanfile.py
+++ b/recipes/stb/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/stb/config.yml
+++ b/recipes/stb/config.yml
@@ -1,5 +1,7 @@
 versions:
-  "cci.20200203":
+  "cci.20210910":
     folder: all
   "cci.20210713":
+    folder: all
+  "cci.20200203":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **stb/cci.20210910**

Since cci.20210713, stb has fixed bug about stb_truetype.h.
- https://github.com/nothings/stb/issues/1171

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
