### PR TITLE
jasper: clean rpath in installed shared lib

### DIFF
--- a/recipes/jasper/all/CMakeLists.txt
+++ b/recipes/jasper/all/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 set(CMAKE_MODULE_PATH ${CONAN_CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/source_subfolder/build/cmake/modules ${CMAKE_MODULE_PATH})
 


### PR DESCRIPTION
no hardcoded paths in rpath of shared lib: see see https://github.com/conan-io/hooks/issues/376

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
