### PR TITLE
hiredis/1.0.2 Fix AIX with patch from hiredis master.

### DIFF
--- a/recipes/hiredis/all/conandata.yml
+++ b/recipes/hiredis/all/conandata.yml
@@ -9,6 +9,8 @@ patches:
   "1.0.2":
     - patch_file: "patches/fix-cmake.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-aix.patch"
+      base_path: "source_subfolder"
   "1.0.0":
     - patch_file: "patches/fix-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/hiredis/all/patches/fix-aix.patch
+++ b/recipes/hiredis/all/patches/fix-aix.patch
@@ -1,0 +1,15 @@
+diff --git a/fmacros.h b/fmacros.h
+index 3227faa..754a53c 100644
+--- a/fmacros.h
++++ b/fmacros.h
+@@ -1,8 +1,10 @@
+ #ifndef __HIREDIS_FMACRO_H
+ #define __HIREDIS_FMACRO_H
+ 
++#ifndef _AIX
+ #define _XOPEN_SOURCE 600
+ #define _POSIX_C_SOURCE 200112L
++#endif
+ 
+ #if defined(__APPLE__) && defined(__MACH__)
+ /* Enable TCP_KEEPALIVE */


### PR DESCRIPTION
hiredis/1.0.2

AIX upstream contains a #ifdef which fixes the AIX build. This patches 1.0.2 with the fix.
https://github.com/redis/hiredis/issues/1031

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
