### PR TITLE
[nmos-cpp] Latest upstream

### DIFF
--- a/recipes/nmos-cpp/all/conandata.yml
+++ b/recipes/nmos-cpp/all/conandata.yml
@@ -9,3 +9,6 @@ sources:
   "cci.20220120":
     url: "https://github.com/sony/nmos-cpp/archive/46750381f33d19ce6b12a2f760db2f2f5faf2818.tar.gz"
     sha256: "cd6fd81b1a5a10fd0a917fec362aae517a72f13889ec4418c29beb3ec8996df7"
+  "cci.20220208":
+    url: "https://github.com/sony/nmos-cpp/archive/7ca64c4fb5604fb8a3e0c05db2e8f8ffe7ef3857.tar.gz"
+    sha256: "751e7a35501cdada0e3943dcfd23a4e4f5caa02661d7f961204e8f9fea567c42"

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -56,7 +56,7 @@ class NmosCppConan(ConanFile):
 
     def requirements(self):
         # for now, consistent with project's conanfile.txt
-        self.requires("boost/1.77.0")
+        self.requires("boost/1.78.0")
         self.requires("cpprestsdk/2.10.18")
         self.requires("websocketpp/0.8.2")
         self.requires("openssl/1.1.1m")

--- a/recipes/nmos-cpp/config.yml
+++ b/recipes/nmos-cpp/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "cci.20220120":
     folder: all
+  "cci.20220208":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **nmos-cpp/cci.20220208**

* Latest upstream commit, with some bug fixes and new features
* Bumps Boost to 1.78.0 corresponding to upstream
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
