### PR TITLE
imgui: add version 1.87

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -41,3 +41,6 @@ sources:
   "1.86":
     url: "https://github.com/ocornut/imgui/archive/v1.86.tar.gz"
     sha256: "6ba6ae8425a19bc52c5e067702c48b70e4403cd339cba02073a462730a63e825"
+  "1.87":
+    url: "https://github.com/ocornut/imgui/archive/v1.87.tar.gz"
+    sha256: "b54ceb35bda38766e36b87c25edf7a1cd8fd2cb8c485b245aedca6fb85645a20"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -27,3 +27,5 @@ versions:
     folder: all
   "1.86":
     folder: all
+  "1.87":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **imgui/1.87**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
