### PR TITLE
[ruy] Switched fPIC default value to True

### DIFF
--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -22,7 +22,7 @@ class RuyConan(ConanFile):
     }
     default_options = {
         "shared": False,
-        "fPIC": False,
+        "fPIC": True,
     }
 
     _cmake = None


### PR DESCRIPTION
Specify library name and version: ruy/**

The recipe for `ruy` has defined a default value for `fPIC` to `False` and after digging briefly through the commits I coudln't find an obvious justification so I'm assuming it was a slip.

If `fPIC` defaults to False, when building a shared library that depends on `ruy` one has to either:
- set `ruy:shared` to `True` (which is not always desired)
- manually set `ruy:fPIC` to True

a quick search through `conan-center-index` revealed that only three packages, `ruy` included, are defaulting `fPIC` to False:
- `ruy`
- `llvm-openmp`
- `ginkgo`

so I think it's a fair assumption that the default value for `ruy` should also be `True`

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
