### PR TITLE
unleash-client-cpp: fix several issues of initial PR

### DIFF
--- a/recipes/unleash-client-cpp/all/CMakeLists.txt
+++ b/recipes/unleash-client-cpp/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/unleash-client-cpp/all/conandata.yml
+++ b/recipes/unleash-client-cpp/all/conandata.yml
@@ -2,4 +2,7 @@ sources:
   "1.1.1":
     url: "https://github.com/aruizs/unleash-client-cpp/archive/refs/tags/v1.1.1.tar.gz"
     sha256: "2750dc231bf608910d4270ac39d83d46d25b88cc547a9d4d31f7ce4950effa7c"
-
+patches:
+  "1.1.1":
+    - patch_file: "patches/0001-no-conan-cmake.patch"
+      base_path: "source_subfolder"

--- a/recipes/unleash-client-cpp/all/patches/0001-no-conan-cmake.patch
+++ b/recipes/unleash-client-cpp/all/patches/0001-no-conan-cmake.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,8 +25,6 @@ if(DEFINED unleash_SHARED_LIBS)
+ endif()
+ 
+ # External dependencies using Conan.io
+-include(cmake/Conan.cmake)
+-run_conan()
+ 
+ # Create the main unleash library target
+ add_subdirectory(src)

--- a/recipes/unleash-client-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/unleash-client-cpp/all/test_package/CMakeLists.txt
@@ -1,12 +1,11 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(unleash CONFIG REQUIRED)
 
-
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} unleash::unleash)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/unleash-client-cpp/all/test_package/conanfile.py
+++ b/recipes/unleash-client-cpp/all/test_package/conanfile.py
@@ -1,9 +1,9 @@
-import os
 from conans import ConanFile, CMake, tools
+import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):


### PR DESCRIPTION
- don't allow to download `conan.cmake` at build time & remove all logic of upstream `Conan.cmake` module file
- CMakeDeps support
- don't check msvc version, too unstable for the moment in conan (19.10 doesn't mean anything for conan currently, it should be 191).
- properly test target in test package
- allow "unknown" compilers
- relocatable shared lib on macOS
- remove duplicated options & default_options attributes

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
