### PR TITLE
strawberryperl: don't package mingw

### DIFF
--- a/recipes/strawberryperl/all/conanfile.py
+++ b/recipes/strawberryperl/all/conanfile.py
@@ -28,9 +28,6 @@ class StrawberryperlConan(ConanFile):
         self.copy(pattern="*", src=os.path.join("perl", "bin"), dst="bin")
         self.copy(pattern="*", src=os.path.join("perl", "lib"), dst="lib")
         self.copy(pattern="*", src=os.path.join("perl", "vendor", "lib"), dst="lib")
-        self.copy(pattern="*", src=os.path.join("c", "bin"), dst="bin")
-        self.copy(pattern="*", src=os.path.join("c", "lib"), dst="lib")
-        self.copy(pattern="*", src=os.path.join("c", "include"), dst="include")
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):


### PR DESCRIPTION
Specify library name and version:  **strawberryperl/***

`c/bin` contains gcc compiler, linker and tools, `c/include` and `c/lib` contain a lot of headers and libraries. It basically looks like/is a fully fledged mingw distribution. These have a tendency to conflict with package sprovided by conan.
I tried to compile these packages successfully with this lighter strawberryperl:

- makefile-project-workspace-creator/4.1.46@
- verilator/4.034@
- openssl/3.0.1@
- openssl/1.1.1m@
- nasm/2.15.05@
- libaom-av1/3.1.2@
- qt/6.2.3@

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
