### PR TITLE
XNNPACK cci.20211210

### DIFF
--- a/recipes/xnnpack/all/CMakeLists.txt
+++ b/recipes/xnnpack/all/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4)
 project(cmake_wrapper)
 
-include(conanbuildinfo.cmake)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
 add_library(cpuinfo INTERFACE IMPORTED)

--- a/recipes/xnnpack/all/conandata.yml
+++ b/recipes/xnnpack/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "cci.20211026":
     url: "https://github.com/google/XNNPACK/archive/ccbaedf11c70a3ff4db0ef17cfeacd710ffc3492.tar.gz"
     sha256: "9324aea663d21cea4538095c40928572ddb685e0601853f278b7e5ead697fe81"
+  "cci.20211210":
+    url: "https://github.com/google/XNNPACK/archive/113092317754c7dea47bfb3cb49c4f59c3c1fa10.tar.gz"
+    sha256: "065bb9c85438c453f9300251f263118c4d123d79b21acf8f66582a3124d95fb2"

--- a/recipes/xnnpack/all/conanfile.py
+++ b/recipes/xnnpack/all/conanfile.py
@@ -57,8 +57,8 @@ class XnnpackConan(ConanFile):
 
     def requirements(self):
         self.requires("cpuinfo/cci.20201217")
-        self.requires("fp16/cci.20200514")
-        self.requires("fxdiv/cci.20200417")
+        self.requires("fp16/cci.20210320")
+        # Note: using newer version of pthreadpool compared to reference cci.20201205
         self.requires("pthreadpool/cci.20210218")
 
     def _patch_sources(self):
@@ -82,14 +82,19 @@ class XnnpackConan(ConanFile):
             else:
                 # Not defined by Conan for Apple Silicon. See https://github.com/conan-io/conan/pull/8026
                 self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = "arm64"
-        self._cmake.definitions["XNNPACK_LIBRARY_TYPE"] = "default"
+        self._cmake.definitions["XNNPACK_LIBRARY_TYPE"] = "shared" if self.options.shared else "static"
         self._cmake.definitions["XNNPACK_ENABLE_ASSEMBLY"] = self.options.assembly
         self._cmake.definitions["XNNPACK_ENABLE_MEMOPT"] = self.options.memopt
         self._cmake.definitions["XNNPACK_ENABLE_SPARSE"] = self.options.sparse
         self._cmake.definitions["XNNPACK_BUILD_TESTS"] = False
         self._cmake.definitions["XNNPACK_BUILD_BENCHMARKS"] = False
+
+        # Use conan dependencies instead of downloading them during configuration
         self._cmake.definitions["XNNPACK_USE_SYSTEM_LIBS"] = True
+
+        # Install only built targets, in this case just the XNNPACK target
         self._cmake.definitions["CMAKE_SKIP_INSTALL_ALL_DEPENDENCY"] = True
+
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/xnnpack/all/conanfile.py
+++ b/recipes/xnnpack/all/conanfile.py
@@ -76,7 +76,6 @@ class XnnpackConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-        self._cmake.definitions["CONAN_BUILD_FOLDER"] = self.build_folder
         if self.settings.arch == "armv8":
             if self.settings.os == "Linux":
                 self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = "aarch64"

--- a/recipes/xnnpack/all/conanfile.py
+++ b/recipes/xnnpack/all/conanfile.py
@@ -89,12 +89,13 @@ class XnnpackConan(ConanFile):
         self._cmake.definitions["XNNPACK_BUILD_TESTS"] = False
         self._cmake.definitions["XNNPACK_BUILD_BENCHMARKS"] = False
         self._cmake.definitions["XNNPACK_USE_SYSTEM_LIBS"] = True
+        self._cmake.definitions["CMAKE_SKIP_INSTALL_ALL_DEPENDENCY"] = True
         self._cmake.configure()
         return self._cmake
 
     def build(self):
         cmake = self._configure_cmake()
-        cmake.build()
+        cmake.build(target="XNNPACK")
 
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)

--- a/recipes/xnnpack/all/conanfile.py
+++ b/recipes/xnnpack/all/conanfile.py
@@ -76,8 +76,11 @@ class XnnpackConan(ConanFile):
             return self._cmake
         self._cmake = CMake(self)
         if self.settings.arch == "armv8":
-            # Not defined by Conan for Apple Silicon. See https://github.com/conan-io/conan/pull/8026
-            self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = "arm64"
+            if self.settings.os == "Linux":
+                self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = "aarch64"
+            else:
+                # Not defined by Conan for Apple Silicon. See https://github.com/conan-io/conan/pull/8026
+                self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = "arm64"
         self._cmake.definitions["XNNPACK_LIBRARY_TYPE"] = "default"
         self._cmake.definitions["XNNPACK_ENABLE_ASSEMBLY"] = self.options.assembly
         self._cmake.definitions["XNNPACK_ENABLE_MEMOPT"] = self.options.memopt

--- a/recipes/xnnpack/config.yml
+++ b/recipes/xnnpack/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "cci.20211026":
     folder: all
+  "cci.20211210":
+    folder: all


### PR DESCRIPTION
Specify library name and version: xnnpack/cci.20211210

Updated version of xnnpack required by tensorflow-lite/2.8.0

I usually like to test the recipe while developing with a step-by-step approach, meaning:
```bash
conan install . <version>@ -if build [install options]
conan source . -if build -sf source
conan build . -bf build -sf source -pf package
conan package . -bf build -sf source -pf package
```
so added a few tweaks to allow that and make the recipe more robust

This PR depends on #9313 and is a clone of #9315 which seemed to be misbehaving

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
