### PR TITLE
(#9331) Bump version: Perfetto v24.2

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -14,6 +14,9 @@ sources:
   "23.0":
     url: https://github.com/google/perfetto/archive/refs/tags/v23.0.tar.gz
     sha256: 9d2955736ce9d234e0f5153acfefea8facfa762c9167024902ea98f9010207aa
+  "24.2":
+    url: https://github.com/google/perfetto/archive/refs/tags/v24.2.tar.gz
+    sha256: b296d0a939e694fd2e73ed6c6418b774b5ef6809ddf60988989416e5cbf90b41
 
 patches:
   "20.1":

--- a/recipes/perfetto/all/conanfile.py
+++ b/recipes/perfetto/all/conanfile.py
@@ -24,8 +24,8 @@ class PerfettoConan(ConanFile):
             "disable_logging": False,
     }
 
+    short_paths = True
     generators = "cmake"
-
     _cmake = None
 
     @property

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "23.0":
     folder: all
+  "24.2":
+    folder: all


### PR DESCRIPTION
close #9331

Specify library name and version:  **perfetto/v24.2**

```
v24.2 - 2022-02-10:
  SDK:
    * Revert of incremental timestamps, introduced in v24.0.
      Some clients were depending on non-incremental timestamps.
      Future releases will re-enable this but offer an opt-out.


v24.1 - 2022-02-09:
  Tracing service and probes:
    * Fixed build failures on Windows.
  Trace Processor:
    * Fixed build failures on Windows.


v24.0 - 2022-02-08:
  Tracing service and probes:
    * Added "cpufreq_period_ms" in data source "linux.sys_stats" to poll
      /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq periodically.
    * Added support for Trusty TEE workqueue events.
    * Added support for more PMU events in traced_perf.
    * Changed output format of perfetto --query. Made the output more compact
      and added a summary of ongoing tracing sessions for the caller UID.
    * Changed timeout for traced stall detection from 2s to 4s.
    * Changed internal buffer management to split trace filtering in smaller
      tasks and avoid too large memory allocation when filtering.
    * Fixed a bug that could cause producers to see Flush() requests after an
      OnStop() and mis-behave if the tracing session is extremely short.
  Trace Processor:
    * Added support for passing multiple SQL statements to ExecuteQuery(). All
      queries will be executed fully, with the returned iterator yielding rows
      for the final statement.
    * Added support for multi-line SQL comments; previously only single line
      comments were supported.
  UI:
    * Added support for parsing instant events from legacy systrace formats.
    * Added ingestion and visualization for inet_sock_set_state and
      tcp_retransmit_skb events, showing TCP connections on dedicated tracks.
    * Changed HTTP+RPC to use the /websocket endpoint available in newer
      versions of trace_processor --httpd.
    * Changed text selection/copy: now allowed by default for DOM elements.
    * Changed search to also lookup slices by ID when the term is a number.
    * Changed postMessage() API, suppressed confirmation dialog when the opener
      is in the same origin, for cases when the UI is self-hosted.
  SDK:
    * Changed timestamps emitted by the SDK to be incremental by default, using
      ClockSnapshot + TracePacketDefaults.
```

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
