### PR TITLE
cairo: remove sphinx component

### DIFF
--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -375,11 +375,6 @@ class CairoConan(ConanFile):
             self.cpp_info.components["cairo-script-interpreter"].libs = ["cairo-script-interpreter"]
             self.cpp_info.components["cairo-script-interpreter"].requires = ["cairo_"]
 
-        if self.options.with_glib and self.options.with_png and self.options.with_zlib and self.options.tee and self.settings.os != "Windows":
-            self.cpp_info.components["cairo-sphinx"].libs = ["cairo-sphinx"]
-            self.cpp_info.components["cairo-sphinx"].requires = ["cairo_"]
-            self.cpp_info.components["cairo-sphinx"].libdirs.append(os.path.join(self.package_folder, "lib", "cairo"))
-
         # binary tools
         if self.options.with_zlib and self.options.with_png:
             self.cpp_info.components["cairo_util_"].requires.append("expat::expat") # trace-to-xml.c, xml-to-trace.c


### PR DESCRIPTION
the cairo-sphinx library is used only as part of an executable of the same name,
and it is never published as pkg-config
https://gitlab.freedesktop.org/cairo/cairo/-/blob/master/util/cairo-sphinx/meson.build

Specify library name and version:  **cairo/***

I checked all the libraries in https://gitlab.freedesktop.org/cairo/cairo/-/tree/master/util and we should be good this time

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
