### PR TITLE
libmysqlclient: fix few issues with all shared + fix FreeBSD + modernize

### DIFF
--- a/recipes/libmysqlclient/all/CMakeLists.txt
+++ b/recipes/libmysqlclient/all/CMakeLists.txt
@@ -1,8 +1,7 @@
-cmake_minimum_required(VERSION 2.8.12)
-
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
-message(WARNING "Conan libMySQLclient Wrapped CMake")
 
 include(../conanbuildinfo.cmake)
-conan_basic_setup(NO_OUTPUT_DIRS)
+conan_basic_setup(NO_OUTPUT_DIRS KEEP_RPATHS)
+
 include("CMakeListsOriginal.txt")

--- a/recipes/libmysqlclient/all/conandata.yml
+++ b/recipes/libmysqlclient/all/conandata.yml
@@ -1,20 +1,20 @@
 sources:
-  "8.0.17":
-    sha256: c6e3f38199a77bfd8a4925ca00b252d3b6159b90e4980c7232f1c58d6ca759d6
-    url: "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.17.tar.gz"
   "8.0.25":
-    sha256: c16aa9cf621bc028efba2bb11f3c36a323b125fa0d108ff92fab60e46309206e
     url: "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.25.tar.gz"
-patches:
+    sha256: "c16aa9cf621bc028efba2bb11f3c36a323b125fa0d108ff92fab60e46309206e"
   "8.0.17":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0001-find-cmake.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/0002-dont-install-static-libraries+fix-mysql-config.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/0003-msvc-install-no-pdb.patch"
+    url: "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.17.tar.gz"
+    sha256: "c6e3f38199a77bfd8a4925ca00b252d3b6159b90e4980c7232f1c58d6ca759d6"
+patches:
   "8.0.25":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0004-fix-805-cpp17-build.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/0005-fix-macos-12.0.x-version-detection.patch"
+    - patch_file: "patches/0004-fix-805-cpp17-build.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0005-fix-macos-12.0.x-version-detection.patch"
+      base_path: "source_subfolder"
+  "8.0.17":
+    - patch_file: "patches/0001-find-cmake.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-dont-install-static-libraries+fix-mysql-config.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0003-msvc-install-no-pdb.patch"
+      base_path: "source_subfolder"

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -103,6 +103,11 @@ class LibMysqlClientCConan(ConanFile):
            tools.Version(self.settings.compiler.version) >= "13.0":
             raise ConanInvalidConfiguration("libmysqlclient 8.0.17 doesn't support apple-clang >= 13")
 
+    def build_requirements(self):
+        if tools.Version(self.version) >= "8.0.25" and tools.is_apple_os(self.settings.os):
+            # CMake 3.18 or higher is required if Apple, but CI of CCI may run CMake 3.15
+            self.build_requires("cmake/3.22.0")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   strip_root=True, destination=self._source_subfolder)

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -95,13 +95,13 @@ class LibMysqlClientCConan(ConanFile):
         if hasattr(self, "settings_build") and tools.cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross compilation not yet supported by the recipe. contributions are welcome.")
 
-        # FIXME: patch libmysqlclient 8.0.17 to support apple-clang >= 13?
+        # FIXME: patch libmysqlclient 8.0.17 to support apple-clang >= 12?
         #        current errors:
         #             error: expected unqualified-id MYSQL_VERSION_MAJOR=8
         #             error: no member named 'ptrdiff_t' in the global namespace
         if self.version == "8.0.17" and self.settings.compiler == "apple-clang" and \
-           tools.Version(self.settings.compiler.version) >= "13.0":
-            raise ConanInvalidConfiguration("libmysqlclient 8.0.17 doesn't support apple-clang >= 13")
+           tools.Version(self.settings.compiler.version) >= "12.0":
+            raise ConanInvalidConfiguration("libmysqlclient 8.0.17 doesn't support apple-clang >= 12.0")
 
     def build_requirements(self):
         if tools.Version(self.version) >= "8.0.25" and tools.is_apple_os(self.settings.os):

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -31,7 +31,7 @@ class LibMysqlClientCConan(ConanFile):
     }
 
     short_paths = True
-    generators = "cmake"
+    generators = "cmake", "pkg_config"
 
     @property
     def _source_subfolder(self):
@@ -79,6 +79,8 @@ class LibMysqlClientCConan(ConanFile):
             self.requires("zstd/1.5.2")
         if self._with_lz4:
             self.requires("lz4/1.9.3")
+        if self.settings.os == "FreeBSD":
+            self.requires("libunwind/1.5.0")
 
     def validate(self):
         def loose_lt_semver(v1, v2):
@@ -108,6 +110,8 @@ class LibMysqlClientCConan(ConanFile):
         if tools.Version(self.version) >= "8.0.25" and tools.is_apple_os(self.settings.os):
             # CMake 3.18 or higher is required if Apple, but CI of CCI may run CMake 3.15
             self.build_requires("cmake/3.22.0")
+        if self.settings.os == "FreeBSD":
+            self.build_requires("pkgconf/1.7.4")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -94,6 +94,14 @@ class LibMysqlClientCConan(ConanFile):
         if hasattr(self, "settings_build") and tools.cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross compilation not yet supported by the recipe. contributions are welcome.")
 
+        # FIXME: patch libmysqlclient 8.0.17 to support apple-clang >= 13?
+        #        current errors:
+        #             error: expected unqualified-id MYSQL_VERSION_MAJOR=8
+        #             error: no member named 'ptrdiff_t' in the global namespace
+        if self.version == "8.0.17" and self.setting.compiler == "apple-clang" and \
+           tools.Version(self.settings.compiler.version) >= "13.0":
+            raise ConanInvalidConfiguration("libmysqlclient 8.0.17 doesn't support apple-clang >= 13")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   strip_root=True, destination=self._source_subfolder)

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -30,6 +30,7 @@ class LibMysqlClientCConan(ConanFile):
         "with_zlib": True,
     }
 
+    short_paths = True
     generators = "cmake"
 
     @property

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -99,7 +99,7 @@ class LibMysqlClientCConan(ConanFile):
         #        current errors:
         #             error: expected unqualified-id MYSQL_VERSION_MAJOR=8
         #             error: no member named 'ptrdiff_t' in the global namespace
-        if self.version == "8.0.17" and self.setting.compiler == "apple-clang" and \
+        if self.version == "8.0.17" and self.settings.compiler == "apple-clang" and \
            tools.Version(self.settings.compiler.version) >= "13.0":
             raise ConanInvalidConfiguration("libmysqlclient 8.0.17 doesn't support apple-clang >= 13")
 

--- a/recipes/libmysqlclient/all/test_package/CMakeLists.txt
+++ b/recipes/libmysqlclient/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()

--- a/recipes/libmysqlclient/all/test_package/conanfile.py
+++ b/recipes/libmysqlclient/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
 
     def build(self):
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/libmysqlclient/config.yml
+++ b/recipes/libmysqlclient/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "8.0.17":
-    folder: all
   "8.0.25":
+    folder: all
+  "8.0.17":
     folder: all


### PR DESCRIPTION
- fix all shared on macOS (`tools.run_environment()` is not sufficient due to SIP): simply rely on rpath injection by CMake in build tree
- relocatable shared lib on macOS (comes for free with fix above): see https://github.com/conan-io/hooks/issues/376
- avoid to copy shared libs of dependencies to package folder of libmysqlclient
- compiler=msvc support
- bump dependencies

closes https://github.com/conan-io/conan-center-index/issues/5670

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
