### PR TITLE
libpcap: allow macOS M1 & deprecate universal

### DIFF
--- a/recipes/libpcap/all/conanfile.py
+++ b/recipes/libpcap/all/conanfile.py
@@ -21,13 +21,13 @@ class LibPcapConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "enable_libusb": [True, False],
-        "enable_universal": [True, False],
+        "enable_universal": [True, False, "deprecated"],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "enable_libusb": False,
-        "enable_universal": True,
+        "enable_universal": "deprecated",
     }
 
     exports_sources = "CMakeLists.txt"
@@ -57,14 +57,14 @@ class LibPcapConan(ConanFile):
             del self.options.fPIC
         if self.settings.os != "Linux":
             del self.options.enable_libusb
-        if self.settings.os != "Macos":
-            del self.options.enable_universal
 
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+        if self.options.enable_universal != "deprecated":
+            self.output.warn("enable_universal is a deprecated option. Do not use.")
 
     def requirements(self):
         if self.options.get_safe("enable_libusb"):
@@ -73,10 +73,14 @@ class LibPcapConan(ConanFile):
     def validate(self):
         if tools.Version(self.version) < "1.10.0" and self.settings.os == "Macos" and self.options.shared:
             raise ConanInvalidConfiguration("libpcap {} can not be built as shared on OSX.".format(self.version))
-        if self.settings.os == "Macos" and self.settings.arch == "armv8":
-            raise ConanInvalidConfiguration("libpcap can not be built on OSX/armv8.")
+        if hasattr(self, "settings_build") and tools.cross_building(self) and \
+           self.options.shared and tools.is_apple_os(self.settings.os):
+            raise ConanInvalidConfiguration("cross-build of libpcap shared is broken on Apple")
         if tools.Version(self.version) < "1.10.1" and self.settings.os == "Windows" and not self.options.shared:
             raise ConanInvalidConfiguration("libpcap can not be built static on Windows below version 1.10.1.")
+
+    def package_id(self):
+        del self.info.options.enable_universal
 
     def build_requirements(self):
         if self._settings_build.os == "Windows":
@@ -90,27 +94,30 @@ class LibPcapConan(ConanFile):
                   destination=self._source_subfolder, strip_root=True)
 
     def _configure_autotools(self):
-        if not self._autotools:
-            self._autotools = AutoToolsBuildEnvironment(self)
-            self._autotools.libs = []
-            configure_args = ["--enable-shared" if self.options.shared else "--disable-shared"]
-            configure_args.append("--disable-universal" if not self.options.get_safe("enable_universal") else "")
-            configure_args.append("--enable-usb" if self.options.get_safe("enable_libusb") else "--disable-usb")
-            configure_args.extend([
-                "--without-libnl",
-                "--disable-bluetooth",
-                "--disable-packet-ring",
-                "--disable-dbus",
-                "--disable-rdma"
-            ])
-            if tools.cross_building(self):
-                target_os = "linux" if self.settings.os == "Linux" else "null"
-                configure_args.append("--with-pcap=%s" % target_os)
-            elif "arm" in self.settings.arch and self.settings.os == "Linux":
-                configure_args.append("--host=arm-linux")
-            self._autotools.configure(args=configure_args, configure_dir=self._source_subfolder)
-            # Relocatable shared lib on macOS
-            tools.replace_in_file("Makefile", "-install_name $(libdir)/", "-install_name @rpath/")
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self)
+        self._autotools.libs = []
+        yes_no = lambda v: "yes" if v else "no"
+        configure_args = [
+            "--enable-shared={}".format(yes_no(self.options.shared)),
+            "--enable-static={}".format(yes_no(not self.options.shared)),
+            "--enable-usb={}".format(yes_no(self.options.get_safe("enable_libusb"))),
+            "--disable-universal",
+            "--without-libnl",
+            "--disable-bluetooth",
+            "--disable-packet-ring",
+            "--disable-dbus",
+            "--disable-rdma",
+        ]
+        if tools.cross_building(self):
+            target_os = "linux" if self.settings.os == "Linux" else "null"
+            configure_args.append("--with-pcap=%s" % target_os)
+        elif "arm" in self.settings.arch and self.settings.os == "Linux":
+            configure_args.append("--host=arm-linux")
+        self._autotools.configure(args=configure_args, configure_dir=self._source_subfolder)
+        # Relocatable shared lib on macOS
+        tools.replace_in_file("Makefile", "-install_name $(libdir)/", "-install_name @rpath/")
         return self._autotools
 
     def _configure_cmake(self):


### PR DESCRIPTION
- not sure to understand why shared is broken if cross-building (`-arch arm64` is not injected in ld command, only during compilation, maybe a fragile Makefile.in, I don't know). But static is fine. And I'm pretty sure that native build on macOS M1 is fine for static & shared.
- deprecate universal option: universal build on Apple (ie produce binaires with several archs) shouldn't be a recipe option (not even sure that conan profile design can handle this case), and for sure not the default.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
