### PR TITLE
wiringpi: add version 2.61-1

### DIFF
--- a/recipes/wiringpi/all/conandata.yml
+++ b/recipes/wiringpi/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
+  "2.61-1":
+    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/2.61-1.tar.gz"
+    sha256: "b5dc6c6c2ba1349acf602fafd7b58aa81e3fc3216a33b983386264cca0033e12"
   "cci.20210727":
-    sha256: d85f063b1bfe73fd23ed20a3dfb7968be97172a78113d510e2a5f7ddeacc4799
-    url: https://github.com/WiringPi/WiringPi/archive/7f8fe26e4f775abfced43c07657a353f03ddb2d0.tar.gz
+    url: "https://github.com/WiringPi/WiringPi/archive/7f8fe26e4f775abfced43c07657a353f03ddb2d0.tar.gz"
+    sha256: "d85f063b1bfe73fd23ed20a3dfb7968be97172a78113d510e2a5f7ddeacc4799"
   "2.50":
-    sha256: f1ddf17e876f88e074d4597767e365a1b5ef20414a38754884935b38d8c8e932
-    url: https://github.com/WiringPi/WiringPi/archive/final_official_2.50.tar.gz
+    url: "https://github.com/WiringPi/WiringPi/archive/final_official_2.50.tar.gz"
+    sha256: "f1ddf17e876f88e074d4597767e365a1b5ef20414a38754884935b38d8c8e932"

--- a/recipes/wiringpi/all/conanfile.py
+++ b/recipes/wiringpi/all/conanfile.py
@@ -1,4 +1,3 @@
-import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 

--- a/recipes/wiringpi/config.yml
+++ b/recipes/wiringpi/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.61-1":
+    folder: "all"
   "cci.20210727":
     folder: "all"
   "2.50":


### PR DESCRIPTION
Specify library name and version:  **wiringpi/2.61-1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
