### PR TITLE
Leave CMake package-config files in Catch2 package

### DIFF
--- a/recipes/catch2/2.x.x/conanfile.py
+++ b/recipes/catch2/2.x.x/conanfile.py
@@ -94,7 +94,6 @@ class ConanRecipe(ConanFile):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
         for cmake_file in ["ParseAndAddCatchTests.cmake", "Catch.cmake", "CatchAddTests.cmake"]:
             self.copy(


### PR DESCRIPTION
When packaging Catch2 the script removes package config files automatically generated when building Catch2 (Catch2Config.cmake, Catch2ConfigVersion.cmake, Catch2Targets.cmake). Package configuration files are supposed to be a part of the package. 
For example it allows for transparent integration using conan with `cmake_paths` generator (see linked issues below). One can include generated `conan_paths.cmake` file (e.g., with `CMAKE_PROJECT_INCLUDE_BEFORE`) and then use `find_package(Catch2)`.

Linked Issues: 
https://github.com/catchorg/Catch2/issues/2104
https://github.com/conan-io/conan-center-index/issues/6035

Specify library name and version:  **Catch2/2.x.x**
