### PR TITLE
robin-hood-hashing: add version 3.11.5

### DIFF
--- a/recipes/robin-hood-hashing/all/conandata.yml
+++ b/recipes/robin-hood-hashing/all/conandata.yml
@@ -17,3 +17,6 @@ sources:
   "3.11.4":
     url: "https://github.com/martinus/robin-hood-hashing/archive/3.11.4.tar.gz"
     sha256: "99d3624069a0b06df2675b4ba9d2ebac1a1236dbc52326cd6f31ca056c24eb89"
+  "3.11.5":
+    url: "https://github.com/martinus/robin-hood-hashing/archive/3.11.5.tar.gz"
+    sha256: "3693e44dda569e9a8b87ce8263f7477b23af448a3c3600c8ab9004fe79c20ad0"

--- a/recipes/robin-hood-hashing/config.yml
+++ b/recipes/robin-hood-hashing/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: all
   "3.11.4":
     folder: all
+  "3.11.5":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **lib/1.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
