### PR TITLE
linters: don't crash on invalid versions

### DIFF
--- a/.github/runlint.py
+++ b/.github/runlint.py
@@ -25,7 +25,7 @@ def main():
                     if not version or packaging.version.Version(v) > packaging.version.Version(version):
                         version = v
                 except packaging.version.InvalidVersion:
-                    print("Error parsing version %s for package %s in pr %s" % (v, package, pr))
+                    print("Error parsing version %s for package %s" % (v, package))
 
         if version:
             command = ["conan", "export", os.path.join("recipes", package, folder), "%s/%s@" % (package, version)]


### PR DESCRIPTION
https://github.com/conan-io/conan-center-index/runs/5184046172?check_suite_focus=true#step:6:23

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
