### PR TITLE
qt/5.x.x: Fix compilation error for gcc 11

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -24,5 +24,7 @@ patches:
       base_path: "qt5/qtdeclarative"
     - patch_file: "patches/f830b86.diff"
       base_path: "qt5/qtwebengine/src/3rdparty"
+    - patch_file: "patches/fix-gcc-11.diff"
+      base_path: "qt5/qtwebengine/src/3rdparty"
     - patch_file: "patches/dece6f5.diff"
       base_path: "qt5/qtbase"

--- a/recipes/qt/5.x.x/patches/fix-gcc-11.diff
+++ b/recipes/qt/5.x.x/patches/fix-gcc-11.diff
@@ -1,0 +1,10 @@
+--- a/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h
++++ b/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h
+@@ -19,6 +19,7 @@ 
+ 
+ #include <stddef.h>
+ #include <stdint.h>
++#include <limits>
+ 
+ #include <unordered_map>
+ #include <vector>


### PR DESCRIPTION
qt/5.15.2

I use this package and wanted to compile using gcc 11.
I needed this patch to make it work.

Otherwise, I get this error during the compilation:
`
[...]
[5682/29242] /usr/bin/x86_64-pc-linux-gnu-g++ -MMD -MF obj/third_party/perfetto/src/trace_processor/types/types/gfp_flags.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_NSS_CERTS=1 -DUSE_OZONE=1 -DOFFICIAL_BUILD -DTOOLKIT_QT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNO_UNWIND_TABLES -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DPERFETTO_IMPLEMENTATION -Igen -I../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium -I../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto -I../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/include -Igen/third_party/perfetto/build_config -Igen/third_party/perfetto -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -pipe -pthread -m64 -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wno-deprecated-declarations -fno-delete-null-pointer-checks -Wno-comments -Wno-packed-not-aligned -Wno-dangling-else -Wno-missing-field-initializers -Wno-unused-parameter -O2 -fno-ident -fdata-sections -ffunction-sections -fno-omit-frame-pointer -g0 -fvisibility=hidden -std=gnu++14 -Wno-narrowing -Wno-class-memaccess -Wno-attributes -Wno-class-memaccess -Wno-subobject-linkage -Wno-invalid-offsetof -Wno-return-type -Wno-deprecated-copy -fno-exceptions -fno-rtti -fvisibility-inlines-hidden -c ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/types/gfp_flags.cc -o obj/third_party/perfetto/src/trace_processor/types/types/gfp_flags.o
[5683/29242] /usr/bin/x86_64-pc-linux-gnu-g++ -MMD -MF obj/third_party/perfetto/src/trace_processor/types/types/variadic.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_NSS_CERTS=1 -DUSE_OZONE=1 -DOFFICIAL_BUILD -DTOOLKIT_QT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNO_UNWIND_TABLES -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DPERFETTO_IMPLEMENTATION -Igen -I../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium -I../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto -I../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/include -Igen/third_party/perfetto/build_config -Igen/third_party/perfetto -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -pipe -pthread -m64 -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wno-deprecated-declarations -fno-delete-null-pointer-checks -Wno-comments -Wno-packed-not-aligned -Wno-dangling-else -Wno-missing-field-initializers -Wno-unused-parameter -O2 -fno-ident -fdata-sections -ffunction-sections -fno-omit-frame-pointer -g0 -fvisibility=hidden -std=gnu++14 -Wno-narrowing -Wno-class-memaccess -Wno-attributes -Wno-class-memaccess -Wno-subobject-linkage -Wno-invalid-offsetof -Wno-return-type -Wno-deprecated-copy -fno-exceptions -fno-rtti -fvisibility-inlines-hidden -c ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/types/variadic.cc -o obj/third_party/perfetto/src/trace_processor/types/types/variadic.o
FAILED: obj/third_party/perfetto/src/trace_processor/types/types/variadic.o 
/usr/bin/x86_64-pc-linux-gnu-g++ -MMD -MF obj/third_party/perfetto/src/trace_processor/types/types/variadic.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_NSS_CERTS=1 -DUSE_OZONE=1 -DOFFICIAL_BUILD -DTOOLKIT_QT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNO_UNWIND_TABLES -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DPERFETTO_IMPLEMENTATION -Igen -I../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium -I../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto -I../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/include -Igen/third_party/perfetto/build_config -Igen/third_party/perfetto -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -pipe -pthread -m64 -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wno-deprecated-declarations -fno-delete-null-pointer-checks -Wno-comments -Wno-packed-not-aligned -Wno-dangling-else -Wno-missing-field-initializers -Wno-unused-parameter -O2 -fno-ident -fdata-sections -ffunction-sections -fno-omit-frame-pointer -g0 -fvisibility=hidden -std=gnu++14 -Wno-narrowing -Wno-class-memaccess -Wno-attributes -Wno-class-memaccess -Wno-subobject-linkage -Wno-invalid-offsetof -Wno-return-type -Wno-deprecated-copy -fno-exceptions -fno-rtti -fvisibility-inlines-hidden -c ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/types/variadic.cc -o obj/third_party/perfetto/src/trace_processor/types/types/variadic.o
In file included from ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/include/perfetto/ext/base/optional.h:24,
                 from ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h:26,
                 from ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/types/variadic.h:20,
                 from ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/types/variadic.cc:17:
../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h: In static member function ‘static const uint8_t* perfetto::trace_processor::StringPool::ReadSize(const uint8_t*, uint32_t*)’:
../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h:256:34: error: ‘numeric_limits’ is not a member of ‘std’
  256 |     PERFETTO_DCHECK(value < std::numeric_limits<uint32_t>::max());
      |                                  ^~~~~~~~~~~~~~
../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h:256:57: error: expected primary-expression before ‘>’ token
  256 |     PERFETTO_DCHECK(value < std::numeric_limits<uint32_t>::max());
      |                                                         ^
../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h:256:60: error: ‘::max’ has not been declared; did you mean ‘std::max’?
  256 |     PERFETTO_DCHECK(value < std::numeric_limits<uint32_t>::max());
      |                                                            ^~~
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.0.0/include/g++-v11/algorithm:62,
                 from ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/include/perfetto/ext/base/string_view.h:22,
                 from ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/null_term_string_view.h:20,
                 from ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h:29,
                 from ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/types/variadic.h:20,
                 from ../../../../qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/types/variadic.cc:17:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.0.0/include/g++-v11/bits/stl_algo.h:3467:5: note: ‘std::max’ declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
`


