### PR TITLE
ghc-filesystem: use same config file name even before 1.5.2

### DIFF
--- a/recipes/ghc-filesystem/all/conanfile.py
+++ b/recipes/ghc-filesystem/all/conanfile.py
@@ -36,17 +36,17 @@ class GhcFilesystemRecipe(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
-        config_file = "ghcFilesystem" if tools.Version(self.version) < "1.5.2" else "ghc_filesystem"
-        self.cpp_info.set_property("cmake_file_name", config_file)
+        self.cpp_info.set_property("cmake_file_name", "ghc_filesystem")
         self.cpp_info.set_property("cmake_target_name", "ghcFilesystem::ghc_filesystem")
         # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.components["ghc_filesystem"].bindirs = []
+        self.cpp_info.components["ghc_filesystem"].frameworkdirs = []
         self.cpp_info.components["ghc_filesystem"].libdirs = []
         self.cpp_info.components["ghc_filesystem"].resdirs = []
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = config_file
-        self.cpp_info.filenames["cmake_find_package_multi"] = config_file
+        self.cpp_info.filenames["cmake_find_package"] = "ghc_filesystem"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "ghc_filesystem"
         self.cpp_info.names["cmake_find_package"] = "ghcFilesystem"
         self.cpp_info.names["cmake_find_package_multi"] = "ghcFilesystem"
         self.cpp_info.components["ghc_filesystem"].names["cmake_find_package"] = "ghc_filesystem"

--- a/recipes/ghc-filesystem/all/test_package/CMakeLists.txt
+++ b/recipes/ghc-filesystem/all/test_package/CMakeLists.txt
@@ -4,11 +4,7 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-if(GHC_FILESYSTEM_VERSION VERSION_LESS "1.5.2")
-    find_package(ghcFilesystem REQUIRED CONFIG)
-else()
-    find_package(ghc_filesystem REQUIRED CONFIG)
-endif()
+find_package(ghc_filesystem REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ghcFilesystem::ghc_filesystem)

--- a/recipes/ghc-filesystem/all/test_package/conanfile.py
+++ b/recipes/ghc-filesystem/all/test_package/conanfile.py
@@ -8,7 +8,6 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["GHC_FILESYSTEM_VERSION"] = self.deps_cpp_info["ghc-filesystem"].version
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Before 1.5.2, no config file was generated upstream, it was just broken: see https://github.com/gulrak/filesystem/pull/93.
So there is no reason to use a different config file name if version is lower than 1.5.2 in conan generators like I did in https://github.com/conan-io/conan-center-index/pull/9238.
Therefore I propose to use the same config file name to make things simpler and coherent.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
