### PR TITLE
VS 2022 compatibility

### DIFF
--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -87,12 +87,14 @@ class LibsodiumConan(ConanFile):
                 "14": "vs2015",
                 "15": "vs2017",
                 "16": "vs2019",
+                "17": "vs2022",
             }
         else:
             folder = {
                 "190": "vs2015",
                 "191": "vs2017",
                 "192": "vs2019",
+                "193": "vs2022",
             }
         folder.get(str(self.settings.compiler.version))
 


### PR DESCRIPTION
Specify library name and version:  **libsodium/1.0.18**

Libsodium is missing vs 2022 compatibility, hence this PR.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
