### PR TITLE
mpdecimal: modernize

### DIFF
--- a/recipes/mpdecimal/2.4.2/conanfile.py
+++ b/recipes/mpdecimal/2.4.2/conanfile.py
@@ -9,7 +9,7 @@ class MpdecimalConan(ConanFile):
     version = "2.4.2"
     description = "mpdecimal is a package for correctly-rounded arbitrary precision decimal floating point arithmetic."
     license = "BSD-2-Clause"
-    topics = ("conan", "mpdecimal", "multiprecision", "library")
+    topics = ("mpdecimal", "multiprecision", "library")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://www.bytereef.org/mpdecimal"
     settings = "os", "compiler", "build_type", "arch"
@@ -23,14 +23,18 @@ class MpdecimalConan(ConanFile):
         "fPIC": True,
     }
 
+    _autotools = None
+
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
-    _autotools = None
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
 
     def configure(self):
-        if self.settings.os != "Macos" and self.settings.arch not in ("x86", "x86_64"):
+        if self._is_msvc and self.settings.arch not in ("x86", "x86_64"):
             raise ConanInvalidConfiguration("Arch is unsupported")
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
@@ -42,8 +46,8 @@ class MpdecimalConan(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("mpdecimal-{}".format(self.version), self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  strip_root=True, destination=self._source_subfolder)
 
     _shared_ext_mapping = {
         "Linux": ".so",
@@ -54,7 +58,7 @@ class MpdecimalConan(ConanFile):
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
-        if self.settings.compiler != "Visual Studio":
+        if not self._is_msvc:
             """
             Using autotools:
             - Build only shared libraries when shared == True
@@ -170,7 +174,7 @@ class MpdecimalConan(ConanFile):
 
     def build(self):
         self._patch_sources()
-        if self.settings.compiler == "Visual Studio":
+        if self._is_msvc:
             self._build_msvc()
         else:
             with tools.chdir(self._source_subfolder):
@@ -179,7 +183,7 @@ class MpdecimalConan(ConanFile):
 
     def package(self):
         self.copy("LICENSE.txt", src=self._source_subfolder, dst="licenses")
-        if self.settings.compiler == "Visual Studio":
+        if self._is_msvc:
             distfolder = os.path.join(self.build_folder, self._source_subfolder, "vcbuild", "dist{}".format(32 if self.settings.arch == "x86" else 64))
             self.copy("vc*.h", src=os.path.join(self.build_folder, self._source_subfolder, "libmpdec"), dst="include")
             self.copy("*.h", src=distfolder, dst="include")
@@ -192,13 +196,13 @@ class MpdecimalConan(ConanFile):
             tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        if self.settings.compiler == "Visual Studio":
+        if self._is_msvc:
             self.cpp_info.libs = ["libmpdec-{}".format(self.version)]
         else:
             self.cpp_info.libs = ["mpdec"]
         if self.options.shared:
-            if self.settings.compiler == "Visual Studio":
+            if self._is_msvc:
                 self.cpp_info.defines = ["USE_DLL"]
         else:
-            if self.settings.os == "Linux":
+            if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.system_libs = ["m"]


### PR DESCRIPTION
also, enable non x86 archs on linux

Specify library name and version:  **mpdecimal/***

fixes conan-io/conan-center-index#9388

arm linux looks good: https://github.com/eirikb/proof-of-conan/actions/runs/1848526578

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
