### PR TITLE
[PLAT-1605] Update opentdf-client conan-center version to 0.5.3

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.5.3":
+    url: https://github.com/opentdf/client-cpp/archive/refs/tags/0.5.3.zip
+    sha256: "e30b745d7a83cc10a42db9f0e85a06e95d3c8693b274c5b13d1fe205e2725146"
   "0.5.2":
     url: https://github.com/opentdf/client-cpp/archive/refs/tags/0.5.2.zip
     sha256: "dccb61d5fc50b7c56a746ba829b30b4558d9c39619a914f2c6c799bdf86ea915"

--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "0.5.2":
+    url: https://github.com/opentdf/client-cpp/archive/refs/tags/0.5.2.zip
+    sha256: "dccb61d5fc50b7c56a746ba829b30b4558d9c39619a914f2c6c799bdf86ea915"
+  "0.5.1":
+    url: https://github.com/opentdf/client-cpp/archive/refs/tags/0.5.1.zip
+    sha256: "acd7c1d4bc8bddd6920c9bdcd105e3eb22f272b9a248f2cc08f7f2edb2e682bc"
   "0.2.12":
     url: https://github.com/opentdf/client-cpp/archive/refs/tags/0.2.12.zip
     sha256: "eb717e7587e2330666373ab670c1ed79eb3459de0a6d08aea9632ac69881f4e0"

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -60,7 +60,7 @@ class OpenTDFConan(ConanFile):
         self.requires("zlib/1.2.11@")
         self.requires("ms-gsl/2.1.0@")
         self.requires("libxml2/2.9.10@")
-        self.requires("libarchive/3.5.1@")
+        self.requires("libarchive/3.5.2@")
         self.requires("nlohmann_json/3.10.4@")
         self.requires("jwt-cpp/0.4.0@")
 

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -15,7 +15,7 @@ class OpenTDFConan(ConanFile):
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {"build_python": [True, False], "fPIC": [True, False]}
-    default_options = {"build_python": False, "fPIC": True}
+    default_options = {"build_python": False, "fPIC": True, "libzip:with_openssl": False, "libarchive:with_zlib":False}
     exports_sources = ["CMakeLists.txt"]
 
     _cmake = None
@@ -35,10 +35,10 @@ class OpenTDFConan(ConanFile):
     @property
     def _minimum_compilers_version(self):
         return {
-            "Visual Studio": "17",
-            "gcc": "9",
-            "clang": "12",
-            "apple-clang": "12.0.0",
+            "Visual Studio": "15",
+            "gcc": "6",
+            "clang": "11",
+            "apple-clang": "11.0.0",
         }
 
     def validate(self):
@@ -53,10 +53,19 @@ class OpenTDFConan(ConanFile):
                 raise ConanInvalidConfiguration("{} requires C++{} support. The current compiler {} {} does not support it.".format(
                     self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
 
+    def configure(self):
+        if str(self.settings.arch).startswith('arm'):
+            self.options["openssl"].no_asm = True
+            self.options["libxml2"].zlib = False
+            self.options["libxml2"].lzma = False
+            self.options["libxml2"].icu = False
+
     def requirements(self):
         self.requires("openssl/1.1.1l@")
-        self.requires("boost/1.76.0@")
-        self.requires("libiconv/1.16@")
+        if str(self.settings.arch).startswith('arm'):
+            self.requires("boost/1.74.0@")
+        else:
+            self.requires("boost/1.76.0@")
         self.requires("zlib/1.2.11@")
         self.requires("ms-gsl/2.1.0@")
         self.requires("libxml2/2.9.10@")
@@ -95,5 +104,5 @@ class OpenTDFConan(ConanFile):
         self.cpp_info.components["libopentdf"].names["cmake_find_package"] = "opentdf-client"
         self.cpp_info.components["libopentdf"].names["cmake_find_package_multi"] = "opentdf-client"
         self.cpp_info.components["libopentdf"].names["pkg_config"] = "opentdf-client"
-        self.cpp_info.components["libopentdf"].requires = ["openssl::openssl", "boost::boost", "libiconv::libiconv", "zlib::zlib", "ms-gsl::ms-gsl", "libxml2::libxml2", "libarchive::libarchive", "jwt-cpp::jwt-cpp", "nlohmann_json::nlohmann_json"]
+        self.cpp_info.components["libopentdf"].requires = ["openssl::openssl", "boost::boost", "zlib::zlib", "ms-gsl::ms-gsl", "libxml2::libxml2", "libarchive::libarchive", "jwt-cpp::jwt-cpp", "nlohmann_json::nlohmann_json"]
 

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -37,6 +37,7 @@ class OpenTDFConan(ConanFile):
         return {
             "Visual Studio": "15",
             "gcc": "7.5.0",
+            "clang": "12",
             "apple-clang": "11.0.0",
         }
 

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -30,12 +30,12 @@ class OpenTDFConan(ConanFile):
 
     @property
     def _minimum_cpp_standard(self):
-        return 14
+        return 17
 
     @property
     def _minimum_compilers_version(self):
         return {
-            "Visual Studio": "17",
+            "Visual Studio": "15",
             "gcc": "7",
             "clang": "11",
             "apple-clang": "11.0.0",
@@ -69,7 +69,7 @@ class OpenTDFConan(ConanFile):
         self.requires("zlib/1.2.11@")
         self.requires("ms-gsl/2.1.0@")
         self.requires("libxml2/2.9.10@")
-        self.requires("libarchive/3.5.2@")
+        self.requires("libarchive/3.5.1@")
         self.requires("nlohmann_json/3.10.4@")
         self.requires("jwt-cpp/0.4.0@")
 

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -38,7 +38,7 @@ class OpenTDFConan(ConanFile):
             "Visual Studio": "15",
             "gcc": "7.5.0",
             "clang": "12",
-            "apple-clang": "11.0.0",
+            "apple-clang": "12.0.0",
         }
 
     def validate(self):

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -36,7 +36,7 @@ class OpenTDFConan(ConanFile):
     def _minimum_compilers_version(self):
         return {
             "Visual Studio": "15",
-            "gcc": "7",
+            "gcc": "7.5.0",
             "clang": "11",
             "apple-clang": "11.0.0",
         }

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -15,7 +15,7 @@ class OpenTDFConan(ConanFile):
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {"build_python": [True, False], "fPIC": [True, False]}
-    default_options = {"build_python": False, "fPIC": True, "libzip:with_openssl": False, "libarchive:with_zlib":False}
+    default_options = {"build_python": False, "fPIC": True}
     exports_sources = ["CMakeLists.txt"]
 
     _cmake = None

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -53,19 +53,9 @@ class OpenTDFConan(ConanFile):
                 raise ConanInvalidConfiguration("{} requires C++{} support. The current compiler {} {} does not support it.".format(
                     self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
 
-    def configure(self):
-        if str(self.settings.arch).startswith('arm'):
-            self.options["openssl"].no_asm = True
-            self.options["libxml2"].zlib = False
-            self.options["libxml2"].lzma = False
-            self.options["libxml2"].icu = False
-
     def requirements(self):
         self.requires("openssl/1.1.1l@")
-        if str(self.settings.arch).startswith('arm'):
-            self.requires("boost/1.74.0@")
-        else:
-            self.requires("boost/1.76.0@")
+        self.requires("boost/1.76.0@")
         self.requires("zlib/1.2.11@")
         self.requires("ms-gsl/2.1.0@")
         self.requires("libxml2/2.9.10@")

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -35,8 +35,8 @@ class OpenTDFConan(ConanFile):
     @property
     def _minimum_compilers_version(self):
         return {
-            "Visual Studio": "15",
-            "gcc": "6",
+            "Visual Studio": "17",
+            "gcc": "7",
             "clang": "11",
             "apple-clang": "11.0.0",
         }

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -35,7 +35,7 @@ class OpenTDFConan(ConanFile):
     @property
     def _minimum_compilers_version(self):
         return {
-            "Visual Studio": "15",
+            "Visual Studio": "17",
             "gcc": "7.5.0",
             "clang": "12",
             "apple-clang": "12.0.0",

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -37,7 +37,6 @@ class OpenTDFConan(ConanFile):
         return {
             "Visual Studio": "15",
             "gcc": "7.5.0",
-            "clang": "11",
             "apple-clang": "11.0.0",
         }
 

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.5.3":
+    folder: all
   "0.5.2":
     folder: all
   "0.5.1":

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,3 +1,7 @@
 versions:
+  "0.5.2":
+    folder: all
+  "0.5.1":
+    folder: all
   "0.2.12":
     folder: all


### PR DESCRIPTION
Specify library name and version:  opentdf-client/0.5.3

- Update published version to 0.5.3
- Adds support for more OIDC authentication flavors
- Add ARM support
- Update minimum compiler versions to allow more compilers

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
