### PR TITLE
spirv-cross: add 1.3.204.0 + relocatable shared libs on macOS

### DIFF
--- a/recipes/spirv-cross/all/CMakeLists.txt
+++ b/recipes/spirv-cross/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/spirv-cross/all/conandata.yml
+++ b/recipes/spirv-cross/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.204.0":
+    url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/sdk-1.3.204.0.tar.gz"
+    sha256: "1b5a9b5b3b333411164fe29de1969d5b590d83891aad14eb49be3c41eccd9edf"
   "cci.20211113":
     url: "https://github.com/KhronosGroup/SPIRV-Cross/archive/7c3cb0b12c9965497b08403c82ac1b82846fa7be.tar.gz"
     sha256: "5bb6837e2b75db1a9e36e7d6eac40d905e3460ff3b5234f391adc6bdf6aadcdf"

--- a/recipes/spirv-cross/config.yml
+++ b/recipes/spirv-cross/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.204.0":
+    folder: all
   "cci.20211113":
     folder: all
   "cci.20210930":


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- first version aligned with Vulkan versioning, good news !

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
