### PR TITLE
package LinuxPlatformMisc, as it is used for diligent-tools

### DIFF
--- a/recipes/diligent-core/all/conandata.yml
+++ b/recipes/diligent-core/all/conandata.yml
@@ -12,3 +12,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0005-spirv-cross-namespace-override.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0006-install-linux-platform-header.diff"
+      base_path: "source_subfolder"

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -145,9 +145,6 @@ class DiligentCoreConan(ConanFile):
 
         tools.rmdir(os.path.join(self.package_folder, "Licenses"))
         self.copy("License.txt", dst="licenses", src=self._source_subfolder)
-        self.copy("License.txt", dst="licenses", src=self._source_subfolder)
-        if self.settings.os == 'Macos':
-            self.copy("Platforms/Linux/interface/LinuxPlatformMisc.hpp", src=self._source_subfolder, dst="include/DiligentCore", keep_path=True)
 
     def package_info(self):
         if self.settings.build_type == "Debug":

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -145,6 +145,9 @@ class DiligentCoreConan(ConanFile):
 
         tools.rmdir(os.path.join(self.package_folder, "Licenses"))
         self.copy("License.txt", dst="licenses", src=self._source_subfolder)
+        self.copy("License.txt", dst="licenses", src=self._source_subfolder)
+        if self.settings.os == 'Macos':
+            self.copy("Platforms/Linux/interface/LinuxPlatformMisc.hpp", src=self._source_subfolder, dst="include/DiligentCore", keep_path=True)
 
     def package_info(self):
         if self.settings.build_type == "Debug":

--- a/recipes/diligent-core/all/patches/0006-install-linux-platform-header.diff
+++ b/recipes/diligent-core/all/patches/0006-install-linux-platform-header.diff
@@ -1,0 +1,120 @@
+commit 7b5536cfee83af507b9182ca7f8035b69d6af6bd
+Author: assiduous <assiduous@diligentgraphics.com>
+Date:   Thu Feb 17 07:57:41 2022 -0800
+
+    CMake: added install instructions for required Linux platform headers for Apple, Emscriptent and Android (fixed DiligentGraphics/DiligentTools#161)
+
+diff --git a/Platforms/Android/CMakeLists.txt b/Platforms/Android/CMakeLists.txt
+index 8d9ef237f..724e41faa 100644
+--- a/Platforms/Android/CMakeLists.txt
++++ b/Platforms/Android/CMakeLists.txt
+@@ -8,6 +8,7 @@ set(INTERFACE
+     interface/AndroidPlatformDefinitions.h
+     interface/AndroidPlatformMisc.hpp
+     interface/AndroidNativeWindow.h
++    ../Linux/interface/LinuxPlatformMisc.hpp
+ )
+ 
+ set(SOURCE
+@@ -34,8 +35,8 @@ PUBLIC
+ )
+ 
+ source_group("src" FILES ${SOURCE})
+-source_group("include" FILES ${INCLUDE})
+-source_group("interface" FILES ${PLATFORM_INTERFACE_HEADERS})
++source_group("interface\\android" FILES ${INTERFACE})
++source_group("interface\\common" FILES ${PLATFORM_INTERFACE_HEADERS})
+ 
+ set_target_properties(Diligent-AndroidPlatform PROPERTIES
+     FOLDER DiligentCore/Platforms
+@@ -43,4 +44,9 @@ set_target_properties(Diligent-AndroidPlatform PROPERTIES
+ 
+ if(DILIGENT_INSTALL_CORE)
+     install_core_lib(Diligent-AndroidPlatform)
++
++    get_target_relative_dir(Diligent-AndroidPlatform RELATIVE_PATH)
++    install(DIRECTORY    ../Linux/interface
++            DESTINATION  "${CMAKE_INSTALL_INCLUDEDIR}/${RELATIVE_PATH}/../Linux"
++    )
+ endif()
+diff --git a/Platforms/Apple/CMakeLists.txt b/Platforms/Apple/CMakeLists.txt
+index 643c06aac..2d0f19c6d 100644
+--- a/Platforms/Apple/CMakeLists.txt
++++ b/Platforms/Apple/CMakeLists.txt
+@@ -16,6 +16,7 @@ set(INTERFACE
+     interface/AppleFileSystem.hpp
+     interface/ApplePlatformDefinitions.h
+     interface/ApplePlatformMisc.hpp
++    ../Linux/interface/LinuxPlatformMisc.hpp
+     ${APPLE_NATIVE_WINDOW_H}
+ )
+ 
+@@ -61,8 +62,8 @@ elseif(PLATFORM_TVOS)
+ endif()
+ 
+ source_group("src" FILES ${SOURCE})
+-source_group("include" FILES ${INCLUDE})
+-source_group("interface" FILES ${PLATFORM_INTERFACE_HEADERS})
++source_group("interface\\apple" FILES ${INTERFACE})
++source_group("interface\\common" FILES ${PLATFORM_INTERFACE_HEADERS})
+ 
+ set_target_properties(Diligent-ApplePlatform PROPERTIES
+     FOLDER DiligentCore/Platforms
+@@ -70,4 +71,9 @@ set_target_properties(Diligent-ApplePlatform PROPERTIES
+ 
+ if(DILIGENT_INSTALL_CORE)
+     install_core_lib(Diligent-ApplePlatform)
++
++    get_target_relative_dir(Diligent-ApplePlatform RELATIVE_PATH)
++    install(DIRECTORY    ../Linux/interface
++            DESTINATION  "${CMAKE_INSTALL_INCLUDEDIR}/${RELATIVE_PATH}/../Linux"
++    )
+ endif()
+diff --git a/Platforms/Emscripten/CMakeLists.txt b/Platforms/Emscripten/CMakeLists.txt
+index 9d19518d9..4012f6bc3 100644
+--- a/Platforms/Emscripten/CMakeLists.txt
++++ b/Platforms/Emscripten/CMakeLists.txt
+@@ -8,6 +8,7 @@ set(INTERFACE
+     interface/EmscriptenPlatformDefinitions.h
+     interface/EmscriptenPlatformMisc.hpp
+     interface/EmscriptenNativeWindow.h
++    ../Linux/interface/LinuxPlatformMisc.hpp
+ )
+ 
+ set(SOURCE
+@@ -32,8 +33,8 @@ PUBLIC
+ )
+ 
+ source_group("src" FILES ${SOURCE})
+-source_group("include" FILES ${INCLUDE})
+-source_group("interface" FILES ${PLATFORM_INTERFACE_HEADERS})
++source_group("interface\\emscripten" FILES ${INTERFACE})
++source_group("interface\\common" FILES ${PLATFORM_INTERFACE_HEADERS})
+ 
+ set_target_properties(Diligent-EmscriptenPlatform PROPERTIES
+     FOLDER DiligentCore/Platforms
+@@ -41,4 +42,9 @@ set_target_properties(Diligent-EmscriptenPlatform PROPERTIES
+ 
+ if(DILIGENT_INSTALL_CORE)
+     install_core_lib(Diligent-EmscriptenPlatform)
++
++    get_target_relative_dir(Diligent-EmscriptenPlatform RELATIVE_PATH)
++    install(DIRECTORY    ../Linux/interface
++            DESTINATION  "${CMAKE_INSTALL_INCLUDEDIR}/${RELATIVE_PATH}/../Linux"
++    )
+ endif()
+diff --git a/Platforms/Linux/CMakeLists.txt b/Platforms/Linux/CMakeLists.txt
+index 558673dd8..db113331c 100644
+--- a/Platforms/Linux/CMakeLists.txt
++++ b/Platforms/Linux/CMakeLists.txt
+@@ -32,8 +32,8 @@ PUBLIC
+ )
+ 
+ source_group("src" FILES ${SOURCE})
+-source_group("include" FILES ${INCLUDE})
+-source_group("interface" FILES ${PLATFORM_INTERFACE_HEADERS})
++source_group("interface\\linux" FILES ${INTERFACE})
++source_group("interface\\common" FILES ${PLATFORM_INTERFACE_HEADERS})
+ 
+ set_target_properties(Diligent-LinuxPlatform PROPERTIES
+     FOLDER DiligentCore/Platforms


### PR DESCRIPTION
Specify library name and version:  **diligent-core/2.5.1**

this small patch is needed for creation. of diligent-tools in https://github.com/conan-io/conan-center-index/pull/9305#issuecomment-1039008697

I have also reported upstream
https://github.com/DiligentGraphics/DiligentTools/issues/161
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
