### PR TITLE
alac: relocatable macos + small fix to private definitions

### DIFF
--- a/recipes/alac/all/CMakeLists.txt
+++ b/recipes/alac/all/CMakeLists.txt
@@ -4,6 +4,8 @@ project(alac)
 include(conanbuildinfo.cmake)
 conan_basic_setup(KEEP_RPATHS)
 
+include(GNUInstallDirs)
+
 file(GLOB ALAC_LIB_SRCS source_subfolder/codec/*.c source_subfolder/codec/*.cpp)
 file(GLOB ALAC_LIB_PUBLIC_HDRS source_subfolder/codec/ALAC*.h)
 

--- a/recipes/alac/all/CMakeLists.txt
+++ b/recipes/alac/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.8)
 project(alac)
 
 include(conanbuildinfo.cmake)
@@ -10,7 +10,10 @@ file(GLOB ALAC_LIB_PUBLIC_HDRS source_subfolder/codec/ALAC*.h)
 add_library(alac ${ALAC_LIB_SRCS})
 target_include_directories(alac PUBLIC source_subfolder/codec)
 set_property(TARGET alac PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-target_compile_definitions(alac PRIVATE $<$<BOOL:${WIN32}>:TARGET_OS_WIN32>)
+target_compile_definitions(alac
+    PRIVATE
+        $<IF:$<BOOL:${APPLE}>,TARGET_OS_MAC=1,TARGET_OS_MAC=0>
+)
 
 install(FILES ${ALAC_LIB_PUBLIC_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(TARGETS alac
@@ -23,7 +26,10 @@ if(ALAC_BUILD_UTILITY)
 
     add_executable(alacconvert ${ALAC_CONVERTER_SRCS})
     target_link_libraries(alacconvert PRIVATE alac)
-    target_compile_definitions(alacconvert PRIVATE $<$<BOOL:${WIN32}>:TARGET_OS_WIN32>)
+    target_compile_definitions(alacconvert
+        PRIVATE
+            $<IF:$<PLATFORM_ID:Windows>,TARGET_OS_WIN32=1,TARGET_OS_WIN32=0>
+    )
 
     install(TARGETS alacconvert DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/recipes/alac/all/CMakeLists.txt
+++ b/recipes/alac/all/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.4)
 project(alac)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 file(GLOB ALAC_LIB_SRCS source_subfolder/codec/*.c source_subfolder/codec/*.cpp)
 file(GLOB ALAC_LIB_PUBLIC_HDRS source_subfolder/codec/ALAC*.h)

--- a/recipes/alac/all/conanfile.py
+++ b/recipes/alac/all/conanfile.py
@@ -9,7 +9,7 @@ class AlacConan(ConanFile):
     description = "The Apple Lossless Audio Codec (ALAC) is a lossless audio " \
                   "codec developed by Apple and deployed on all of its platforms and devices."
     license = "Apache-2.0"
-    topics = ("conan", "alac", "audio-codec")
+    topics = ("alac", "audio-codec")
     homepage = "https://macosforge.github.io/alac"
     url = "https://github.com/conan-io/conan-center-index"
 

--- a/recipes/alac/all/test_package/CMakeLists.txt
+++ b/recipes/alac/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(alac REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} alac::alac)

--- a/recipes/alac/all/test_package/conanfile.py
+++ b/recipes/alac/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- At build time: 
  - for the lib: `TARGET_OS_MAC=1` should be defined if Apple, and set to 0 otherwise to avoid warnings.
  - utility: `TARGET_OS_WIN32=1` should be defined if Windows, and set to 0 otherwise to avoid warnings.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
