### PR TITLE
libxml2: relocatable shared lib on macOS + improve CMakeDeps

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -352,8 +352,10 @@ class Libxml2Conan(ConanFile):
         return os.path.join("lib", "cmake", "conan-official-{}-variables.cmake".format(self.name))
 
     def package_info(self):
-        # FIXME: cmake creates LibXml2::xmllint imported target for the xmllint executable
-        self.cpp_info.set_property("cmake_file_name", "LibXml2")
+        # FIXME: Provide LibXml2::xmllint & LibXml2::xmlcatalog imported target for executables
+        self.cpp_info.set_property("cmake_find_mode", "both")
+        self.cpp_info.set_property("cmake_module_file_name", "LibXml2")
+        self.cpp_info.set_property("cmake_file_name", "libxml2")
         self.cpp_info.set_property("cmake_target_name", "LibXml2::LibXml2")
         self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
         self.cpp_info.set_property("pkg_config_name", "libxml-2.0")
@@ -377,6 +379,8 @@ class Libxml2Conan(ConanFile):
                 self.cpp_info.system_libs.extend(["ws2_32", "wsock32"])
 
         # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "LibXml2"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "libxml2"
         self.cpp_info.names["cmake_find_package"] = "LibXml2"
         self.cpp_info.names["cmake_find_package_multi"] = "LibXml2"
         self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]

--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -354,10 +354,9 @@ class Libxml2Conan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "LibXml2::LibXml2")
         self.cpp_info.set_property("cmake_build_modules", [self._module_file_rel_path])
         self.cpp_info.set_property("pkg_config_name", "libxml-2.0")
-        if self._is_msvc:
-            self.cpp_info.libs = ["libxml2" if self.options.shared else "libxml2_a"]
-        else:
-            self.cpp_info.libs = ["xml2"]
+        prefix = "lib" if self._is_msvc else ""
+        suffix = "_a" if self._is_msvc and not self.options.shared else ""
+        self.cpp_info.libs = ["{}xml2{}".format(prefix, suffix)]
         self.cpp_info.includedirs.append(os.path.join("include", "libxml2"))
         if not self.options.shared:
             self.cpp_info.defines = ["LIBXML_STATIC"]

--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -307,7 +307,8 @@ class Libxml2Conan(ConanFile):
             if self.options.include_utils:
                 autotools.make(["install", "xmllint", "xmlcatalog", "xml2-config"])
 
-            os.remove(os.path.join(self.package_folder, "lib", "libxml2.la"))
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.sh")
             for prefix in ["run", "test"]:
                 tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), prefix + "*")
             tools.rmdir(os.path.join(self.package_folder, "share"))

--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -262,9 +262,10 @@ class Libxml2Conan(ConanFile):
             tools.replace_in_file(os.path.join(self._source_subfolder, "win32", makefile),
                                                "install-libs : all",
                                                "install-libs :")
-        # fix rpath
-        if self.settings.os == "Macos":
-            tools.replace_in_file(os.path.join(self._source_subfolder, "configure"), r"-install_name \$rpath/", "-install_name ")
+        # relocatable shared lib on macOS
+        tools.replace_in_file(os.path.join(self._source_subfolder, "configure"),
+                              "-install_name \\$rpath/",
+                              "-install_name @rpath/")
 
     def build(self):
         self._patch_sources()

--- a/recipes/libxml2/all/test_package/conanfile.py
+++ b/recipes/libxml2/all/test_package/conanfile.py
@@ -6,6 +6,15 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "cmake_find_package"
 
+    def build_requirements(self):
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            # Workaround for CMake bug with error message:
+            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
+            # set. This could be because you are using a Mac OS X version less than 10.5
+            # or because CMake's platform configuration is corrupt.
+            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
+            self.build_requires("cmake/3.22.0")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
  It's worth noting that there are still hardcoded paths to zlib, icu and lzma in RPATH of libxml2 shared lib for all *nix platform due to pkg-config files generated by conan. It's harmless, but not very neat.
- modernize autotools configuration
- improve CMakeDeps:
  - set cmake_find_mode property to both since CMake has a built-in FindLibXml2.cmake: https://cmake.org/cmake/help/latest/module/FindLibXml2.html
  - libxml2 also provides a CMake config file, and its name is libxml2-config.cmake.
  - Imported targets names in Find and Config files are identical.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
