### PR TITLE
bitmagic: add version 7.10.3

### DIFF
--- a/recipes/bitmagic/all/conandata.yml
+++ b/recipes/bitmagic/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.10.3":
+    url: "https://github.com/tlk00/BitMagic/archive/v7.10.3.tar.gz"
+    sha256: "164aae4f52f35f3a0e4a596611efcd1494a9be5489be494c6a440e5a83f17460"
   "7.9.3":
     url: "https://github.com/tlk00/BitMagic/archive/v7.9.3.tar.gz"
     sha256: "fa1799f702dac47148dc8e2672957b1fc5be440d043ef2c4d275c04b434182e1"

--- a/recipes/bitmagic/config.yml
+++ b/recipes/bitmagic/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.10.3":
+    folder: all
   "7.9.3":
     folder: all
   "7.8.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **bitmagic/7.10.3**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
