### PR TITLE
automake: use /usr/bin/env instead of hard coding perl path

### DIFF
--- a/recipes/automake/all/patches/0002-no-perl-path-in-shebang-0.16.1.patch
+++ b/recipes/automake/all/patches/0002-no-perl-path-in-shebang-0.16.1.patch
@@ -2,12 +2,13 @@
 +++ bin/aclocal.in
 @@ -1,8 +1,8 @@
 -#!@PERL@ -w
-+#!/usr/bin/perl -w
- # -*- perl -*-
+-# -*- perl -*-
++#!/usr/bin/env perl
++# -*- perl -*- -w
  # @configure_input@
  
 -eval 'case $# in 0) exec @PERL@ -S "$0";; *) exec @PERL@ -S "$0" "$@";; esac'
-+eval 'case $# in 0) exec /usr/bin/perl -S "$0";; *) exec /usr/bin/perl -S "$0" "$@";; esac'
++eval 'case $# in 0) exec /usr/bin/env perl -S "$0";; *) exec /usr/bin/env perl -S "$0" "$@";; esac'
      if 0;
  
  # aclocal - create aclocal.m4 by scanning configure.ac
@@ -15,12 +16,13 @@
 +++ bin/automake.in
 @@ -1,8 +1,8 @@
 -#!@PERL@ -w
-+#!/usr/bin/perl -w
- # -*- perl -*-
+-# -*- perl -*-
++#!/usr/bin/env perl
++# -*- perl -*- -w
  # @configure_input@
  
 -eval 'case $# in 0) exec @PERL@ -S "$0";; *) exec @PERL@ -S "$0" "$@";; esac'
-+eval 'case $# in 0) exec /usr/bin/perl -S "$0";; *) exec @PERL@ -S "$0" "$@";; esac'
++eval 'case $# in 0) exec /usr/bin/env perl -S "$0";; *) exec @PERL@ -S "$0" "$@";; esac'
      if 0;
  
  # automake - create Makefile.in from Makefile.am
@@ -31,7 +33,7 @@
  PACKAGE_VERSION = @PACKAGE_VERSION@
  PATH_SEPARATOR = @PATH_SEPARATOR@
 -PERL = @PERL@
-+PERL = /usr/bin/perl
++PERL = /usr/bin/env perl
  RELEASE_YEAR = @RELEASE_YEAR@
  SET_MAKE = @SET_MAKE@
  SHELL = @SHELL@
@@ -42,7 +44,7 @@
  # that automake testsuite, if they are available.
  AWK=${AM_TESTSUITE_AWK-${AWK-'@AWK@'}}
 -PERL=${AM_TESTSUITE_PERL-${PERL-'@PERL@'}}
-+PERL=${AM_TESTSUITE_PERL-${PERL-'/usr/bin/perl'}}
++PERL=${AM_TESTSUITE_PERL-${PERL-'/usr/bin/env perl'}}
  MAKE=${AM_TESTSUITE_MAKE-${MAKE-'make'}}
  YACC=${AM_TESTSUITE_YACC-${YACC-'@YACC@'}}
  LEX=${AM_TESTSUITE_LEX-${LEX-'@LEX@'}}

--- a/recipes/automake/all/patches/0002-no-perl-path-in-shebang-0.16.2.patch
+++ b/recipes/automake/all/patches/0002-no-perl-path-in-shebang-0.16.2.patch
@@ -2,12 +2,14 @@
 +++ bin/aclocal.in
 @@ -1,1 +1,1 @@
 -#!@PERL@ -w
-+#!/usr/bin/perl -w
++#!/usr/bin/env perl
++# -*- perl -*- -w
 --- bin/automake.in
 +++ bin/automake.in
 @@ -1,1 +1,1 @@
 -#!@PERL@ -w
-+#!/usr/bin/perl -w
++#!/usr/bin/env perl
++# -*- perl -*- -w
 --- Makefile.in
 +++ Makefile.in
 @@ -524,7 +524,7 @@
@@ -15,7 +17,7 @@
  PACKAGE_VERSION = @PACKAGE_VERSION@
  PATH_SEPARATOR = @PATH_SEPARATOR@
 -PERL = @PERL@
-+PERL = /usr/bin/perl
++PERL = /usr/bin/env perl
  RELEASE_YEAR = @RELEASE_YEAR@
  SET_MAKE = @SET_MAKE@
  SHELL = @SHELL@
@@ -26,7 +28,7 @@
  # that automake testsuite, if they are available.
  AWK=${AM_TESTSUITE_AWK-${AWK-'@AWK@'}}
 -PERL=${AM_TESTSUITE_PERL-${PERL-'@PERL@'}}
-+PERL=${AM_TESTSUITE_PERL-${PERL-'/usr/bin/perl'}}
++PERL=${AM_TESTSUITE_PERL-${PERL-'/usr/bin/env perl'}}
  MAKE=${AM_TESTSUITE_MAKE-${MAKE-'make'}}
  YACC=${AM_TESTSUITE_YACC-${YACC-'@YACC@'}}
  LEX=${AM_TESTSUITE_LEX-${LEX-'@LEX@'}}

--- a/recipes/automake/all/patches/0002-no-perl-path-in-shebang-0.16.3.patch
+++ b/recipes/automake/all/patches/0002-no-perl-path-in-shebang-0.16.3.patch
@@ -2,12 +2,12 @@
 +++ bin/aclocal.in
 @@ -1,1 +1,1 @@
 -#!@PERL@
-+#!/usr/bin/perl
++#!/usr/bin/env perl
 --- bin/automake.in
 +++ bin/automake.in
 @@ -1,1 +1,1 @@
 -#!@PERL@
-+#!/usr/bin/perl
++#!/usr/bin/env perl
 --- Makefile.in
 +++ Makefile.in
 @@ -535,7 +535,7 @@
@@ -15,7 +15,7 @@
  PACKAGE_VERSION = @PACKAGE_VERSION@
  PATH_SEPARATOR = @PATH_SEPARATOR@
 -PERL = @PERL@
-+PERL = /usr/bin/perl
++PERL = /usr/bin/env perl
  RELEASE_YEAR = @RELEASE_YEAR@
  SET_MAKE = @SET_MAKE@
  SHELL = @SHELL@
@@ -26,7 +26,7 @@
  # that automake testsuite, if they are available.
  AWK=${AM_TESTSUITE_AWK-${AWK-'@AWK@'}}
 -PERL=${AM_TESTSUITE_PERL-${PERL-'@PERL@'}}
-+PERL=${AM_TESTSUITE_PERL-${PERL-'/usr/bin/perl'}}
++PERL=${AM_TESTSUITE_PERL-${PERL-'/usr/bin/env perl'}}
  MAKE=${AM_TESTSUITE_MAKE-${MAKE-'make'}}
  YACC=${AM_TESTSUITE_YACC-${YACC-'@YACC@'}}
  LEX=${AM_TESTSUITE_LEX-${LEX-'@LEX@'}}

--- a/recipes/automake/all/patches/0002-no-perl-path-in-shebang-0.16.4.patch
+++ b/recipes/automake/all/patches/0002-no-perl-path-in-shebang-0.16.4.patch
@@ -2,12 +2,12 @@
 +++ bin/aclocal.in
 @@ -1,1 +1,1 @@
 -#!@PERL@
-+#!/usr/bin/perl
++#!/usr/bin/env perl
 --- bin/automake.in
 +++ bin/automake.in
 @@ -1,1 +1,1 @@
 -#!@PERL@
-+#!/usr/bin/perl
++#!/usr/bin/env perl
 --- Makefile.in
 +++ Makefile.in
 @@ -527,7 +527,7 @@
@@ -15,7 +15,7 @@
  PACKAGE_VERSION = @PACKAGE_VERSION@
  PATH_SEPARATOR = @PATH_SEPARATOR@
 -PERL = @PERL@
-+PERL = /usr/bin/perl
++PERL = /usr/bin/env perl
  RELEASE_YEAR = @RELEASE_YEAR@
  SET_MAKE = @SET_MAKE@
  SHELL = @SHELL@
@@ -26,7 +26,7 @@
  # that automake testsuite, if they are available.
  AWK=${AM_TESTSUITE_AWK-${AWK-'@AWK@'}}
 -PERL=${AM_TESTSUITE_PERL-${PERL-'@PERL@'}}
-+PERL=${AM_TESTSUITE_PERL-${PERL-'/usr/bin/perl'}}
++PERL=${AM_TESTSUITE_PERL-${PERL-'/usr/bin/env perl'}}
  MAKE=${AM_TESTSUITE_MAKE-${MAKE-'make'}}
  YACC=${AM_TESTSUITE_YACC-${YACC-'@YACC@'}}
  LEX=${AM_TESTSUITE_LEX-${LEX-'@LEX@'}}


### PR DESCRIPTION
Not all systems have perl at /usr/bin/perl and the build fails for all
systems that don't.

Specify library name and version:  **automake/all**

/cc @madebr as previous contributor to that file.

See also #8315 where this was implemented for autoconf already.


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
