### PR TITLE
add cctag/1.0.1

### DIFF
--- a/recipes/cctag/all/CMakeLists.txt
+++ b/recipes/cctag/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.13)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(KEEP_RPATHS)
+
+add_subdirectory(source_subfolder)

--- a/recipes/cctag/all/conandata.yml
+++ b/recipes/cctag/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "1.0.1":
     url: "https://github.com/alicevision/CCTag/archive/refs/tags/v1.0.1.tar.gz"
     sha256: "ae8a819bc978eb13bb1061a204c214da835e56c9b7dc775237ed6b2191011dec"
+patches:
+  "1.0.1":
+    - patch_file: "patches/0001-honor-vc-runtime.patch"
+      base_path: "source_subfolder"

--- a/recipes/cctag/all/conandata.yml
+++ b/recipes/cctag/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.1":
+    url: "https://github.com/alicevision/CCTag/archive/refs/tags/v1.0.1.tar.gz"
+    sha256: "ae8a819bc978eb13bb1061a204c214da835e56c9b7dc775237ed6b2191011dec"

--- a/recipes/cctag/all/conanfile.py
+++ b/recipes/cctag/all/conanfile.py
@@ -33,12 +33,16 @@ class CCTagConan(ConanFile):
         "with_cuda": False,
     }
 
-    exports_sources = "CMakeLists.txt"
     generators = "cmake", "cmake_find_package"
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -85,6 +89,8 @@ class CCTagConan(ConanFile):
                   destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         # Cleanup RPATH if Apple in shared lib of install tree
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)",

--- a/recipes/cctag/all/conanfile.py
+++ b/recipes/cctag/all/conanfile.py
@@ -133,11 +133,15 @@ class CCTagConan(ConanFile):
             self.cpp_info.system_libs.extend(["dl", "pthread"])
         self.cpp_info.requires = [
             "boost::atomic", "boost::chrono", "boost::date_time", "boost::exception",
-            "boost::filesystem", "boost::serialization", "boost::stacktrace",
-            "boost::system", "boost::thread", "boost::timer", "boost::math_c99",
-            "eigen::eigen", "tbb::tbb", "opencv::opencv_core", "opencv::opencv_videoio",
+            "boost::filesystem", "boost::serialization", "boost::system",
+            "boost::thread", "boost::timer", "boost::math_c99", "eigen::eigen",
+            "tbb::tbb", "opencv::opencv_core", "opencv::opencv_videoio",
             "opencv::opencv_imgproc", "opencv::opencv_imgcodecs",
         ]
+        if self.settings.os == "Windows":
+            self.cpp_info.requires.append("boost::stacktrace_windbg")
+        else:
+            self.cpp_info.requires.append("boost::stacktrace_basic")
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.names["cmake_find_package"] = "CCTag"

--- a/recipes/cctag/all/conanfile.py
+++ b/recipes/cctag/all/conanfile.py
@@ -19,11 +19,17 @@ class CCTagConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "serialize": [True, False],
+        "visual_debug": [True, False],
+        "no_cout": [True, False],
         "with_cuda": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "serialize": False,
+        "visual_debug": False,
+        "no_cout": True,
         "with_cuda": False,
     }
 
@@ -91,9 +97,9 @@ class CCTagConan(ConanFile):
     @functools.lru_cache(1)
     def _configure_cmake(self):
         cmake = CMake(self)
-        cmake.definitions["CCTAG_SERIALIZE"] = False
-        cmake.definitions["CCTAG_VISUAL_DEBUG"] = False
-        cmake.definitions["CCTAG_NO_COUT"] = True
+        cmake.definitions["CCTAG_SERIALIZE"] = self.options.serialize
+        cmake.definitions["CCTAG_VISUAL_DEBUG"] = self.options.visual_debug
+        cmake.definitions["CCTAG_NO_COUT"] = self.options.no_cout
         cmake.definitions["CCTAG_WITH_CUDA"] = self.options.with_cuda
         cmake.definitions["CCTAG_BUILD_APPS"] = False
         cmake.definitions["CCTAG_CUDA_CC_CURRENT_ONLY"] = False

--- a/recipes/cctag/all/conanfile.py
+++ b/recipes/cctag/all/conanfile.py
@@ -1,0 +1,138 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import functools
+import os
+
+required_conan_version = ">=1.43.0"
+
+
+class CCTagConan(ConanFile):
+    name = "cctag"
+    description = "Detection of CCTag markers made up of concentric circles."
+    license = "MPL-2.0"
+    topics = ("cctag", "computer-vision", "detection", "image-processing",
+              "markers", "fiducial-markers", "concentric-circles")
+    homepage = "https://github.com/alicevision/CCTag"
+    url = "https://github.com/conan-io/conan-center-index"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_cuda": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_cuda": False,
+    }
+
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake", "cmake_find_package"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def requirements(self):
+        self.requires("boost/1.78.0")
+        self.requires("eigen/3.4.0")
+        self.requires("tbb/2020.3")
+        self.requires("opencv/4.5.3")
+
+    @property
+    def _required_boost_components(self):
+        return [
+            "atomic", "chrono", "date_time", "exception", "filesystem",
+            "math", "serialization", "stacktrace", "system", "thread", "timer",
+        ]
+
+    def validate(self):
+        miss_boost_required_comp = \
+            any(getattr(self.options["boost"],
+                        "without_{}".format(boost_comp),
+                        True) for boost_comp in self._required_boost_components)
+        if self.options["boost"].header_only or miss_boost_required_comp:
+            raise ConanInvalidConfiguration(
+                "{0} requires non header-only boost with these components: {1}".format(
+                    self.name, ", ".join(self._required_boost_components),
+                )
+            )
+
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 14)
+
+        # FIXME: add cuda support
+        if self.options.with_cuda:
+            raise ConanInvalidConfiguration("CUDA not supported yet")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def _patch_sources(self):
+        # Cleanup RPATH if Apple in shared lib of install tree
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              "SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)",
+                              "")
+        # Link to OpenCV targets
+        tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
+                              "${OpenCV_LIBS}",
+                              "opencv_core opencv_videoio opencv_imgproc opencv_imgcodecs")
+
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["CCTAG_SERIALIZE"] = False
+        cmake.definitions["CCTAG_VISUAL_DEBUG"] = False
+        cmake.definitions["CCTAG_NO_COUT"] = True
+        cmake.definitions["CCTAG_WITH_CUDA"] = self.options.with_cuda
+        cmake.definitions["CCTAG_BUILD_APPS"] = False
+        cmake.definitions["CCTAG_CUDA_CC_CURRENT_ONLY"] = False
+        cmake.definitions["CCTAG_NVCC_WARNINGS"] = False
+        cmake.definitions["CCTAG_EIGEN_NO_ALIGN"] = True
+        cmake.definitions["CCTAG_USE_POSITION_INDEPENDENT_CODE"] = self.options.get_safe("fPIC", True)
+        cmake.definitions["CCTAG_ENABLE_SIMD_AVX2"] = False
+        cmake.definitions["CCTAG_BUILD_TESTS"] = False
+        cmake.definitions["CCTAG_BUILD_DOC"] = False
+        cmake.definitions["CCTAG_NO_THRUST_COPY_IF"] = False
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        self._patch_sources()
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("COPYING.md", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "CCTag")
+        self.cpp_info.set_property("cmake_target_name", "CCTag::CCTag")
+        suffix = "d" if self.settings.build_type == "Debug" else ""
+        self.cpp_info.libs = ["CCTag{}".format(suffix)]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["dl", "pthread"])
+        self.cpp_info.requires = [
+            "boost::atomic", "boost::chrono", "boost::date_time", "boost::exception",
+            "boost::filesystem", "boost::serialization", "boost::stacktrace",
+            "boost::system", "boost::thread", "boost::timer", "boost::math_c99",
+            "eigen::eigen", "tbb::tbb", "opencv::opencv_core", "opencv::opencv_videoio",
+            "opencv::opencv_imgproc", "opencv::opencv_imgcodecs",
+        ]
+
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.names["cmake_find_package"] = "CCTag"
+        self.cpp_info.names["cmake_find_package_multi"] = "CCTag"

--- a/recipes/cctag/all/conanfile.py
+++ b/recipes/cctag/all/conanfile.py
@@ -56,7 +56,7 @@ class CCTagConan(ConanFile):
         self.requires("boost/1.78.0")
         self.requires("eigen/3.4.0")
         self.requires("onetbb/2020.3")
-        self.requires("opencv/4.5.3")
+        self.requires("opencv/4.5.5")
 
     @property
     def _required_boost_components(self):

--- a/recipes/cctag/all/conanfile.py
+++ b/recipes/cctag/all/conanfile.py
@@ -55,7 +55,7 @@ class CCTagConan(ConanFile):
     def requirements(self):
         self.requires("boost/1.78.0")
         self.requires("eigen/3.4.0")
-        self.requires("tbb/2020.3")
+        self.requires("onetbb/2020.3")
         self.requires("opencv/4.5.3")
 
     @property
@@ -141,7 +141,7 @@ class CCTagConan(ConanFile):
             "boost::atomic", "boost::chrono", "boost::date_time", "boost::exception",
             "boost::filesystem", "boost::serialization", "boost::system",
             "boost::thread", "boost::timer", "boost::math_c99", "eigen::eigen",
-            "tbb::tbb", "opencv::opencv_core", "opencv::opencv_videoio",
+            "onetbb::onetbb", "opencv::opencv_core", "opencv::opencv_videoio",
             "opencv::opencv_imgproc", "opencv::opencv_imgcodecs",
         ]
         if self.settings.os == "Windows":

--- a/recipes/cctag/all/patches/0001-honor-vc-runtime.patch
+++ b/recipes/cctag/all/patches/0001-honor-vc-runtime.patch
@@ -1,0 +1,18 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,6 +41,7 @@ else()
+   message(STATUS "Building in ${CMAKE_BUILD_TYPE} configuration")
+ endif()
+ 
++if(0)
+ # ensure the proper linker flags when building the static version on MSVC
+ if(MSVC AND NOT BUILD_SHARED_LIBS)
+   foreach(config "DEBUG" "RELEASE" "MINSIZEREL" "RELWITHDEBINFO")
+@@ -64,6 +65,7 @@ if(MSVC AND CMAKE_GENERATOR MATCHES "Ninja")
+   endif()
+   list(APPEND CUDA_NVCC_FLAGS   -Xcompiler ${CCTAG_MVSC_LINKER})
+ endif()
++endif()
+ 
+ set(CCTAG_CXX_STANDARD 14)
+ set(CMAKE_CXX_STANDARD ${CCTAG_CXX_STANDARD})

--- a/recipes/cctag/all/test_package/CMakeLists.txt
+++ b/recipes/cctag/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(CCTag REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} CCTag::CCTag)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/cctag/all/test_package/conanfile.py
+++ b/recipes/cctag/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/cctag/all/test_package/test_package.cpp
+++ b/recipes/cctag/all/test_package/test_package.cpp
@@ -1,0 +1,6 @@
+#include <cctag/CCTag.hpp>
+
+int main() {
+    cctag::EdgePointCollection(1024, 1024);
+    return 0;
+}

--- a/recipes/cctag/config.yml
+++ b/recipes/cctag/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.1":
+    folder: all


### PR DESCRIPTION
This library depends on Boost Math.
Therefore it won't build out of the box in conan-center if default C++ standard of the compiler is not at least C++11.
Why?
- Boost Math requires C++11
- Boost recipe is not modularized
- Few components (not related to Math component) of Boost have API/ABI breakage depending on C++ standard
=> In consequence, unlike current "policy" of all other conan-center recipes, boost recipe doesn't build C++11 components if compiler.cppstd is not explicitly set to 11 or higher, or if default C++ standard of the compiler is not 11 or higher.

Since default C++ standard of apple-clang is still C++98 => no build for macOS in CCI.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
