### PR TITLE
Add vc143 (visual studio 2022) as an option to b2

### DIFF
--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -23,7 +23,7 @@ class B2Conan(ConanFile):
     'acc', 'borland', 'clang', 'como', 'gcc-nocygwin', 'gcc',
     'intel-darwin', 'intel-linux', 'intel-win32', 'kcc', 'kylix',
     'mingw', 'mipspro', 'pathscale', 'pgi', 'qcc', 'sun', 'sunpro',
-    'tru64cxx', 'vacpp', 'vc12', 'vc14', 'vc141', 'vc142'
+    'tru64cxx', 'vacpp', 'vc12', 'vc14', 'vc141', 'vc142', 'vc143'
 
     Specifies the toolset to use for building. The default of 'auto' detects
     a usable compiler for building and should be preferred. The 'cxx' toolset
@@ -39,7 +39,7 @@ class B2Conan(ConanFile):
             'acc', 'borland', 'clang', 'como', 'gcc-nocygwin', 'gcc',
             'intel-darwin', 'intel-linux', 'intel-win32', 'kcc', 'kylix',
             'mingw', 'mipspro', 'pathscale', 'pgi', 'qcc', 'sun', 'sunpro',
-            'tru64cxx', 'vacpp', 'vc12', 'vc14', 'vc141', 'vc142']
+            'tru64cxx', 'vacpp', 'vc12', 'vc14', 'vc141', 'vc142', 'vc143']
     }
     default_options = {
         'use_cxx_env': False,

--- a/recipes/b2/standard/conanfile.py
+++ b/recipes/b2/standard/conanfile.py
@@ -23,7 +23,7 @@ class B2Conan(ConanFile):
     'acc', 'borland', 'clang', 'como', 'gcc-nocygwin', 'gcc',
     'intel-darwin', 'intel-linux', 'intel-win32', 'kcc', 'kylix',
     'mingw', 'mipspro', 'pathscale', 'pgi', 'qcc', 'sun', 'sunpro',
-    'tru64cxx', 'vacpp', 'vc12', 'vc14', 'vc141', 'vc142'
+    'tru64cxx', 'vacpp', 'vc12', 'vc14', 'vc141', 'vc142', 'vc143'
 
     Specifies the toolset to use for building. The default of 'auto' detects
     a usable compiler for building and should be preferred. The 'cxx' toolset
@@ -39,7 +39,7 @@ class B2Conan(ConanFile):
             'acc', 'borland', 'clang', 'como', 'gcc-nocygwin', 'gcc',
             'intel-darwin', 'intel-linux', 'intel-win32', 'kcc', 'kylix',
             'mingw', 'mipspro', 'pathscale', 'pgi', 'qcc', 'sun', 'sunpro',
-            'tru64cxx', 'vacpp', 'vc12', 'vc14', 'vc141', 'vc142']
+            'tru64cxx', 'vacpp', 'vc12', 'vc14', 'vc141', 'vc142', 'vc143']
     }
     default_options = {
         'use_cxx_env': False,


### PR DESCRIPTION
Specify library name and version:  **b2/4.7.1**

Upstream b2 has added support for compiling with Visual Studio 2022, aka vc143. This PR just adds that as a valid option for the b2 conan package. I have tested the "standard" version, but not the "portable" version. But I see no reason that it should work any differently.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
