### PR TITLE
pugixml: add version 1.12.1

### DIFF
--- a/recipes/pugixml/all/conandata.yml
+++ b/recipes/pugixml/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.12.1":
+    url: "https://github.com/zeux/pugixml/archive/v1.12.1.tar.gz"
+    sha256: "1e28ab24b6e04e013d96f45d25e9f2d04c921dc68c613fd010ecaaad3892c14d"
   "1.11":
     url: "https://github.com/zeux/pugixml/archive/v1.11.tar.gz"
     sha256: "79b5e3a50dca0c150ab5fd282e23dd1da00760073a7040ca8dde4e031330add2"

--- a/recipes/pugixml/config.yml
+++ b/recipes/pugixml/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.12.1":
+    folder: "all"
   "1.11":
     folder: "all"
   "1.10":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **pugixml/1.12.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
