### PR TITLE
leveldb: relocatable shared lib on macOS + ensure to honor options

### DIFF
--- a/recipes/leveldb/all/CMakeLists.txt
+++ b/recipes/leveldb/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.9)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/leveldb/all/CMakeLists.txt
+++ b/recipes/leveldb/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.9)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
+conan_basic_setup(TARGETS KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/leveldb/all/conanfile.py
+++ b/recipes/leveldb/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import CMake, ConanFile, tools
+import functools
 import os
 
 required_conan_version = ">=1.43.0"
@@ -30,7 +31,6 @@ class LevelDBCppConan(ConanFile):
     }
 
     generators = "cmake", "cmake_find_package_multi"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -66,16 +66,15 @@ class LevelDBCppConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["LEVELDB_BUILD_TESTS"] = False
-        self._cmake.definitions["LEVELDB_BUILD_BENCHMARKS"] = False
-        self._cmake.definitions["LEVELDB_WITH_SNAPPY"] = self.options.with_snappy
-        self._cmake.definitions["LEVELDB_WITH_CRC32C"] = self.options.with_crc32c
-        self._cmake.configure()
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["LEVELDB_BUILD_TESTS"] = False
+        cmake.definitions["LEVELDB_BUILD_BENCHMARKS"] = False
+        cmake.definitions["LEVELDB_WITH_SNAPPY"] = self.options.with_snappy
+        cmake.definitions["LEVELDB_WITH_CRC32C"] = self.options.with_crc32c
+        cmake.configure()
+        return cmake
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/leveldb/all/conanfile.py
+++ b/recipes/leveldb/all/conanfile.py
@@ -29,7 +29,7 @@ class LevelDBCppConan(ConanFile):
         "with_crc32c": True,
     }
 
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package_multi"
     _cmake = None
 
     @property
@@ -72,6 +72,8 @@ class LevelDBCppConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["LEVELDB_BUILD_TESTS"] = False
         self._cmake.definitions["LEVELDB_BUILD_BENCHMARKS"] = False
+        self._cmake.definitions["LEVELDB_WITH_SNAPPY"] = self.options.with_snappy
+        self._cmake.definitions["LEVELDB_WITH_CRC32C"] = self.options.with_crc32c
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/leveldb/all/conanfile.py
+++ b/recipes/leveldb/all/conanfile.py
@@ -71,8 +71,8 @@ class LevelDBCppConan(ConanFile):
         cmake = CMake(self)
         cmake.definitions["LEVELDB_BUILD_TESTS"] = False
         cmake.definitions["LEVELDB_BUILD_BENCHMARKS"] = False
-        cmake.definitions["LEVELDB_WITH_SNAPPY"] = self.options.with_snappy
-        cmake.definitions["LEVELDB_WITH_CRC32C"] = self.options.with_crc32c
+        cmake.definitions["HAVE_SNAPPY"] = self.options.with_snappy
+        cmake.definitions["HAVE_CRC32C"] = self.options.with_crc32c
         cmake.configure()
         return cmake
 

--- a/recipes/leveldb/all/patches/check_library_exists.1.22.patch
+++ b/recipes/leveldb/all/patches/check_library_exists.1.22.patch
@@ -10,15 +10,15 @@ index 1409c06..7a6a109 100644
 -check_library_exists(snappy snappy_compress "" HAVE_SNAPPY)
  check_library_exists(tcmalloc malloc "" HAVE_TCMALLOC)
  
-+find_package(Crc32c)
-+if (Crc32c_FOUND)
++if(LEVELDB_WITH_CRC32C)
++  find_package(Crc32c REQUIRED CONFIG)
 +  set(HAVE_CRC32C ON)
-+endif (Crc32c_FOUND)
++endif()
 +
-+find_package(Snappy)
-+if (Snappy_FOUND)
++if(LEVELDB_WITH_SNAPPY)
++  find_package(Snappy REQUIRED CONFIG)
 +  set(HAVE_SNAPPY ON)
-+endif (Snappy_FOUND)
++endif()
 +
  include(CheckCXXSymbolExists)
  # Using check_cxx_symbol_exists() instead of check_c_symbol_exists() because

--- a/recipes/leveldb/all/patches/check_library_exists.1.22.patch
+++ b/recipes/leveldb/all/patches/check_library_exists.1.22.patch
@@ -1,25 +1,30 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1409c06..7a6a109 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -35,10 +35,18 @@ include(CheckIncludeFile)
+@@ -35,8 +35,12 @@ include(CheckIncludeFile)
  check_include_file("unistd.h" HAVE_UNISTD_H)
  
  include(CheckLibraryExists)
 -check_library_exists(crc32c crc32c_value "" HAVE_CRC32C)
 -check_library_exists(snappy snappy_compress "" HAVE_SNAPPY)
++if(HAVE_CRC32C)
++  find_package(Crc32c REQUIRED CONFIG)
++endif()
++if(HAVE_SNAPPY)
++  find_package(Snappy REQUIRED CONFIG)
++endif()
  check_library_exists(tcmalloc malloc "" HAVE_TCMALLOC)
  
-+if(LEVELDB_WITH_CRC32C)
-+  find_package(Crc32c REQUIRED CONFIG)
-+  set(HAVE_CRC32C ON)
-+endif()
-+
-+if(LEVELDB_WITH_SNAPPY)
-+  find_package(Snappy REQUIRED CONFIG)
-+  set(HAVE_SNAPPY ON)
-+endif()
-+
  include(CheckCXXSymbolExists)
- # Using check_cxx_symbol_exists() instead of check_c_symbol_exists() because
- # we're including the header from C++, and feature detection should use the same
+@@ -246,10 +250,10 @@ if(HAVE_CLANG_THREAD_SAFETY)
+ endif(HAVE_CLANG_THREAD_SAFETY)
+ 
+ if(HAVE_CRC32C)
+-  target_link_libraries(leveldb crc32c)
++  target_link_libraries(leveldb Crc32c::crc32c)
+ endif(HAVE_CRC32C)
+ if(HAVE_SNAPPY)
+-  target_link_libraries(leveldb snappy)
++  target_link_libraries(leveldb Snappy::snappy)
+ endif(HAVE_SNAPPY)
+ if(HAVE_TCMALLOC)
+   target_link_libraries(leveldb tcmalloc)

--- a/recipes/leveldb/all/patches/check_library_exists.1.23.patch
+++ b/recipes/leveldb/all/patches/check_library_exists.1.23.patch
@@ -10,15 +10,15 @@ index f8285b8..55258e7 100644
 -check_library_exists(snappy snappy_compress "" HAVE_SNAPPY)
  check_library_exists(tcmalloc malloc "" HAVE_TCMALLOC)
  
-+find_package(Crc32c)
-+if (Crc32c_FOUND)
++if(LEVELDB_WITH_CRC32C)
++  find_package(Crc32c REQUIRED CONFIG)
 +  set(HAVE_CRC32C ON)
-+endif (Crc32c_FOUND)
++endif()
 +
-+find_package(Snappy)
-+if (Snappy_FOUND)
++if(LEVELDB_WITH_SNAPPY)
++  find_package(Snappy REQUIRED CONFIG)
 +  set(HAVE_SNAPPY ON)
-+endif (Snappy_FOUND)
++endif()
 +
  include(CheckCXXSymbolExists)
  # Using check_cxx_symbol_exists() instead of check_c_symbol_exists() because

--- a/recipes/leveldb/all/patches/check_library_exists.1.23.patch
+++ b/recipes/leveldb/all/patches/check_library_exists.1.23.patch
@@ -1,25 +1,30 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f8285b8..55258e7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -38,10 +38,18 @@ include(CheckIncludeFile)
+@@ -38,8 +38,12 @@ include(CheckIncludeFile)
  check_include_file("unistd.h" HAVE_UNISTD_H)
  
  include(CheckLibraryExists)
 -check_library_exists(crc32c crc32c_value "" HAVE_CRC32C)
 -check_library_exists(snappy snappy_compress "" HAVE_SNAPPY)
++if(HAVE_CRC32C)
++  find_package(Crc32c REQUIRED CONFIG)
++endif()
++if(HAVE_SNAPPY)
++  find_package(Snappy REQUIRED CONFIG)
++endif()
  check_library_exists(tcmalloc malloc "" HAVE_TCMALLOC)
  
-+if(LEVELDB_WITH_CRC32C)
-+  find_package(Crc32c REQUIRED CONFIG)
-+  set(HAVE_CRC32C ON)
-+endif()
-+
-+if(LEVELDB_WITH_SNAPPY)
-+  find_package(Snappy REQUIRED CONFIG)
-+  set(HAVE_SNAPPY ON)
-+endif()
-+
  include(CheckCXXSymbolExists)
- # Using check_cxx_symbol_exists() instead of check_c_symbol_exists() because
- # we're including the header from C++, and feature detection should use the same
+@@ -268,10 +272,10 @@ if(HAVE_CLANG_THREAD_SAFETY)
+ endif(HAVE_CLANG_THREAD_SAFETY)
+ 
+ if(HAVE_CRC32C)
+-  target_link_libraries(leveldb crc32c)
++  target_link_libraries(leveldb Crc32c::crc32c)
+ endif(HAVE_CRC32C)
+ if(HAVE_SNAPPY)
+-  target_link_libraries(leveldb snappy)
++  target_link_libraries(leveldb Snappy::snappy)
+ endif(HAVE_SNAPPY)
+ if(HAVE_TCMALLOC)
+   target_link_libraries(leveldb tcmalloc)


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- add CMake options to ensure that leveldb doesn't accidentally find snappy or crc32c if related options are disabled

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
