### PR TITLE
hidapi: relocatable shared lib on macOS + modernize

### DIFF
--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -84,9 +84,12 @@ class HidapiConan(ConanFile):
         else:
             with tools.chdir(self._source_subfolder):
                 self.run("./bootstrap")
-            if self.settings.os == "Macos":
-                tools.replace_in_file(os.path.join(self._source_subfolder, "configure"),
-                                      r"-install_name \$rpath/", "-install_name ")
+                # relocatable shared lib on macOS
+                tools.replace_in_file(
+                    "configure",
+                    "-install_name \\$rpath/",
+                    "-install_name @rpath/",
+                )
             autotools = self._configure_autotools()
             autotools.make()
 

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -83,13 +83,9 @@ class HidapiConan(ConanFile):
             self._build_msvc()
         else:
             with tools.chdir(self._source_subfolder):
-                self.run("./bootstrap")
+                self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows)
                 # relocatable shared lib on macOS
-                tools.replace_in_file(
-                    "configure",
-                    "-install_name \\$rpath/",
-                    "-install_name @rpath/",
-                )
+                tools.replace_in_file("configure", "-install_name \\$rpath/", "-install_name @rpath/")
             autotools = self._configure_autotools()
             autotools.make()
 

--- a/recipes/hidapi/all/conanfile.py
+++ b/recipes/hidapi/all/conanfile.py
@@ -1,8 +1,10 @@
-import os
 from conans import ConanFile, AutoToolsBuildEnvironment, MSBuild, tools
 from conans.errors import ConanInvalidConfiguration
+import functools
+import os
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.36.0"
+
 
 class HidapiConan(ConanFile):
     name = "hidapi"
@@ -12,7 +14,8 @@ class HidapiConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/libusb/hidapi"
     license = "GPL-3-or-later", "BSD-3-Clause"
-    settings = "os", "compiler", "build_type", "arch"
+
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
         "shared": [True, False],
@@ -21,61 +24,69 @@ class HidapiConan(ConanFile):
         "fPIC": True,
         "shared": False,
     }
+
     generators = "pkg_config"
-    _autotools = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if self.settings.compiler == "Visual Studio":
+        if self._is_msvc:
             self.options.shared = True
 
     def configure(self):
-        if self.settings.compiler == "Visual Studio" and not self.options.shared:
-            raise ConanInvalidConfiguration("Static libraries for Visual Studio are currently not available")
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
-
-    def build_requirements(self):
-        if self.settings.compiler != "Visual Studio":
-            self.build_requires("libtool/2.4.6")
-
     def requirements(self):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("libusb/1.0.24")
+
+    def validate(self):
+        if self._is_msvc and not self.options.shared:
+            raise ConanInvalidConfiguration("Static libraries for Visual Studio are currently not available")
+
+    def build_requirements(self):
+        if not self._is_msvc:
+            self.build_requires("libtool/2.4.6")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def _patch_sources(self):
         tools.replace_in_file(os.path.join(self._source_subfolder, "configure.ac"),
                               "AC_CONFIG_MACRO_DIR", "dnl AC_CONFIG_MACRO_DIR")
 
+    @functools.lru_cache(1)
     def _configure_autotools(self):
-        if self._autotools:
-            return self._autotools
-        with tools.chdir(self._source_subfolder):
-            self.run("./bootstrap")
-        if self.settings.os == "Macos":
-            tools.replace_in_file(os.path.join(self._source_subfolder, "configure"),
-                                  r"-install_name \$rpath/", "-install_name ")
-        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        args = ["--enable-shared" if self.options.shared else "--disable-shared",
-                "--enable-static" if not self.options.shared else "--disable-static"]
-        self._autotools.configure(configure_dir=self._source_subfolder, args=args)
-        return self._autotools
+        autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        yes_no = lambda v: "yes" if v else "no"
+        args = [
+            "--enable-shared={}".format(yes_no(self.options.shared)),
+            "--enable-static={}".format(yes_no(not self.options.shared)),
+        ]
+        autotools.configure(configure_dir=self._source_subfolder, args=args)
+        return autotools
 
     def build(self):
         self._patch_sources()
-        if self.settings.compiler == "Visual Studio":
+        if self._is_msvc:
             self._build_msvc()
         else:
+            with tools.chdir(self._source_subfolder):
+                self.run("./bootstrap")
+            if self.settings.os == "Macos":
+                tools.replace_in_file(os.path.join(self._source_subfolder, "configure"),
+                                      r"-install_name \$rpath/", "-install_name ")
             autotools = self._configure_autotools()
             autotools.make()
 
@@ -99,13 +110,11 @@ class HidapiConan(ConanFile):
 
     def package_info(self):
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["libusb"].names["pkg_config"] = "hidapi-libusb"
             self.cpp_info.components["libusb"].set_property("pkg_config_name", "hidapi-libusb")
             self.cpp_info.components["libusb"].libs = ["hidapi-libusb"]
             self.cpp_info.components["libusb"].requires = ["libusb::libusb"]
             self.cpp_info.components["libusb"].system_libs = ["pthread", "dl", "rt"]
 
-            self.cpp_info.components["hidraw"].names["pkg_config"] = "hidapi-hidraw"
             self.cpp_info.components["hidraw"].set_property("pkg_config_name", "hidapi-hidraw")
             self.cpp_info.components["hidraw"].libs = ["hidapi-hidraw"]
             self.cpp_info.components["hidraw"].system_libs = ["pthread", "dl"]

--- a/recipes/hidapi/all/test_package/conanfile.py
+++ b/recipes/hidapi/all/test_package/conanfile.py
@@ -6,6 +6,15 @@ class HidapiTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "cmake_find_package_multi"
 
+    def build_requirements(self):
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            # Workaround for CMake bug with error message:
+            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
+            # set. This could be because you are using a Mac OS X version less than 10.5
+            # or because CMake's platform configuration is corrupt.
+            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
+            self.build_requires("cmake/3.22.0")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- compiler=msvc support
- explicitly call autoreconf from our autoconf recipe (instead of obfuscating the call through upstream bootstrap script). Also call it in `build()` instead of `_configure_autotools()` (otherwise it could be called again with `conan -kb`)
- conan 1.36 is sufficient for this recipe

I'm pretty sure that MinGW is broken by design in this recipe, but I won't fix it here.
It's also quite strange to see `pkg_config` in generators for the build, without `pkgconf` in `build_requirements()` (since there is a dependency if Linux or FreeBSD, I guess it breaks or build is fragile if build machine doesn't have pkg-config installed).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
