### PR TITLE
libdeflate: add version 1.10

### DIFF
--- a/recipes/libdeflate/all/conandata.yml
+++ b/recipes/libdeflate/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.10":
+    url: "https://github.com/ebiggers/libdeflate/archive/v1.10.tar.gz"
+    sha256: "5c1f75c285cd87202226f4de49985dcb75732f527eefba2b3ddd70a8865f2533"
   "1.9":
     url: "https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.9.tar.gz"
     sha256: "a537ab6125c226b874c02b166488b326aece954930260dbf682d88fc339137e3"

--- a/recipes/libdeflate/config.yml
+++ b/recipes/libdeflate/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.10":
+    folder: all
   "1.9":
     folder: all
   "1.8":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libdeflate/1.10**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
