### PR TITLE
openssl: ensure install_name_tool works on MacOS #5308

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -612,6 +612,9 @@ class OpenSSLConan(ConanFile):
         if self.settings.os == "Windows":
             includes = includes.replace('\\', '/') # OpenSSL doesn't like backslashes
 
+        lflags = env_build.link_flags
+        if self.settings.os == "Macos":
+            lflags.append("-headerpad_max_install_names")
         if self._asm_target:
             ancestor = '[ "%s", asm("%s") ]' % (self._ancestor_target, self._asm_target)
         else:
@@ -641,7 +644,7 @@ class OpenSSLConan(ConanFile):
                                         shared_target=shared_target,
                                         shared_extension=shared_extension,
                                         shared_cflag=shared_cflag,
-                                        lflags=" ".join(env_build.link_flags))
+                                        lflags=" ".join(lflags))
         self.output.info("using target: %s -> %s" % (self._target, self._ancestor_target))
         self.output.info(config)
 

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -588,9 +588,11 @@ class OpenSSLConan(ConanFile):
 """
         cflags = []
         cxxflags = []
+        lflags = []
         env_build = self._get_env_build()
         cflags.extend(env_build.vars_dict["CFLAGS"])
         cxxflags.extend(env_build.vars_dict["CXXFLAGS"])
+        lflags.extend(env_build.vars_dict["LDFLAGS"])
 
         cc = self._tool("CC", "cc")
         cxx = self._tool("CXX", "cxx")
@@ -612,7 +614,6 @@ class OpenSSLConan(ConanFile):
         if self.settings.os == "Windows":
             includes = includes.replace('\\', '/') # OpenSSL doesn't like backslashes
 
-        lflags = env_build.link_flags
         if self.settings.os == "Macos":
             lflags.append("-headerpad_max_install_names")
         if self._asm_target:

--- a/recipes/openssl/1.x.x/test_package/conanfile.py
+++ b/recipes/openssl/1.x.x/test_package/conanfile.py
@@ -35,4 +35,12 @@ class TestPackageConan(ConanFile):
         if not self._skip_test and not tools.cross_building(self):
             bin_path = os.path.join("bin", "digest")
             self.run(bin_path, run_environment=True)
+            if self.settings.os == 'Macos' and self.options["openssl"].shared:
+                # Ensure we can run install_name_tool on the libraries
+                libssl_dylib = 'libssl.dylib'
+                libssl = os.path.join(self.deps_cpp_info["openssl"].rootpath, 'lib', libssl_dylib)
+                self.run(f'rm -f {libssl_dylib}')
+                self.run(f'cp {libssl} {libssl_dylib}')
+                long_rpath = 'poijfpeoifjperwonfjpnocjpnqoefjpneojntvqpeonijtpqeonrvtijpqvneoitjvqpneoitjnvpqeonijtvpqoeijrtvpqoeritjvpqeoijtqpevnoitjpqenotijqepo'
+                self.run(f'install_name_tool -add_rpath {long_rpath} {libssl_dylib}')
         assert os.path.exists(os.path.join(self.deps_cpp_info["openssl"].rootpath, "licenses", "LICENSE"))


### PR DESCRIPTION
Specify library name and version:  **openssl/1.1.1k**

Adds a test to validate that users can effectively run install_name_tool on the generated library when shared=True on MacOS

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
