### PR TITLE
qt5: add missing package_info

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -6,7 +6,6 @@ import configparser
 import glob
 import itertools
 import os
-import shutil
 import textwrap
 
 required_conan_version = ">=1.43.0"
@@ -887,7 +886,7 @@ Examples = bin/datadir/examples""")
                 requires.append("Core")
             self.cpp_info.components[componentname].requires = _get_corrected_reqs(requires)
 
-        def _create_plugin(pluginname, libname, type, requires):
+        def _create_plugin(pluginname, libname, plugintype, requires):
             componentname = "qt%s" % pluginname
             assert componentname not in self.cpp_info.components, "Plugin %s already present in self.cpp_info.components" % pluginname
             self.cpp_info.components[componentname].set_property("cmake_target_name", "Qt5::{}".format(pluginname))
@@ -895,7 +894,7 @@ Examples = bin/datadir/examples""")
             self.cpp_info.components[componentname].names["cmake_find_package_multi"] = pluginname
             if not self.options.shared:
                 self.cpp_info.components[componentname].libs = [libname + libsuffix]
-            self.cpp_info.components[componentname].libdirs = [os.path.join("bin", "archdatadir", "plugins", type)]
+            self.cpp_info.components[componentname].libdirs = [os.path.join("bin", "archdatadir", "plugins", plugintype)]
             self.cpp_info.components[componentname].includedirs = []
             if "Core" not in requires:
                 requires.append("Core")
@@ -1192,7 +1191,7 @@ Examples = bin/datadir/examples""")
             _create_module("MacExtras")
 
         if self.options.qtxmlpatterns:
-             _create_module("XmlPatterns", ["Network"])
+            _create_module("XmlPatterns", ["Network"])
 
         if self.options.qtactiveqt:
             _create_module("AxBase", ["Gui", "Widgets"])

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1205,6 +1205,23 @@ Examples = bin/datadir/examples""")
             _create_module("AxServer", ["Core", "Gui", "Widgets", "AxBase"])
             self.cpp_info.components["qtAxServer"].includedirs = [os.path.join("include", "ActiveQt")]
             self.cpp_info.components["qtAxServer"].system_libs.append("shell32")
+        
+        if self.options.qtscript:
+            _create_module("Script")
+            if self.options.widgets:
+                _create_module("ScriptTools", ["Gui", "Widgets", "Script"])
+        
+        if self.options.qtandroidextras:
+            _create_module("AndroidExtras")
+            
+        if self.options.qtwebview:
+            _create_module("WebView", ["Gui", "Quick"])
+            
+        if self.options.qtvirtualkeyboard:
+            _create_module("VirtualKeyboard", ["Qml", "Quick", "Gui"])
+        
+        if self.options.qtspeech:
+            _create_module("TextToSpeech")
 
         if not self.options.shared:
             if self.settings.os == "Windows":

--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -17,7 +17,7 @@ class TestPackageConan(ConanFile):
         if self._settings_build.os == "Windows" and self.settings.compiler == "Visual Studio":
             self.build_requires("jom/1.1.3")
         if self._meson_supported():
-            self.build_requires("meson/0.59.0")
+            self.build_requires("meson/0.59.3")
 
     def _is_mingw(self):
         return self.settings.os == "Windows" and self.settings.compiler == "gcc"


### PR DESCRIPTION
for qt modules:
- Script
- ScriptTools
- AndroidExtras
- WebView
- VirtualKeyboard
- TextToSpeech

fixes conan-io/conan-center-index#9453

Specify library name and version:  **qt/5.15.2**

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
