### PR TITLE
Corrected compiler version check, disabled MySQL on Macos/ARM

### DIFF
--- a/recipes/ncbi-cxx-toolkit-public/26/conanfile.py
+++ b/recipes/ncbi-cxx-toolkit-public/26/conanfile.py
@@ -62,8 +62,6 @@ class NcbiCxxToolkit(ConanFile):
                 return None
             if key == "NGHTTP2" and self.settings.os == "Windows":
                 return None
-            if key == "MySQL" and self.settings.os == "Macos" and "arm" in self.settings.arch:
-                return None
             return self.NCBI_to_Conan_requires[key]
         return None
 
@@ -94,6 +92,8 @@ class NcbiCxxToolkit(ConanFile):
             raise ConanInvalidConfiguration("This configuration is not supported")
         if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "7":
             raise ConanInvalidConfiguration("This version of GCC is not supported")
+        if hasattr(self, "settings_build") and tools.cross_building(self, skip_x64_x86=True):
+            raise ConanInvalidConfiguration("Cross compilation is not supported")
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/ncbi-cxx-toolkit-public/26/conanfile.py
+++ b/recipes/ncbi-cxx-toolkit-public/26/conanfile.py
@@ -7,7 +7,7 @@ class NcbiCxxToolkit(ConanFile):
     license = "CC0-1.0"
     homepage = "https://ncbi.github.io/cxx-toolkit"
     url = "https://github.com/conan-io/conan-center-index"
-    description = "NCBI C++ Toolkit"
+    description = "NCBI C++ Toolkit -- a cross-platform application framework and a collection of libraries for working with biological data."
     topics = ("ncbi", "biotechnology", "bioinformatics", "genbank", "gene",
               "genome", "genetic", "sequence", "alignment", "blast",
               "biological", "toolkit", "c++")
@@ -62,6 +62,8 @@ class NcbiCxxToolkit(ConanFile):
                 return None
             if key == "NGHTTP2" and self.settings.os == "Windows":
                 return None
+            if key == "MySQL" and self.settings.os == "Macos" and "arm" in self.settings.arch:
+                return None
             return self.NCBI_to_Conan_requires[key]
         return None
 
@@ -86,11 +88,11 @@ class NcbiCxxToolkit(ConanFile):
             tools.check_min_cppstd(self, 17)
         if self.settings.os not in ["Linux", "Macos", "Windows"]:   
             raise ConanInvalidConfiguration("This operating system is not supported")
-        if self.settings.compiler == "Visual Studio" and str(self.settings.compiler.version) < "15":
+        if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) < "16":
             raise ConanInvalidConfiguration("This version of Visual Studio is not supported")
         if self.settings.compiler == "Visual Studio" and self.options.shared and "MT" in self.settings.compiler.runtime:
             raise ConanInvalidConfiguration("This configuration is not supported")
-        if self.settings.compiler == "gcc" and str(self.settings.compiler.version) < "7":
+        if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "7":
             raise ConanInvalidConfiguration("This version of GCC is not supported")
 
     def config_options(self):
@@ -119,9 +121,8 @@ class NcbiCxxToolkit(ConanFile):
         cmake.configure(source_folder=self._source_subfolder)
 # Visual Studio sometimes runs "out of heap space"
         if self.settings.compiler == "Visual Studio":
-            self.run("cmake --build . %s -j 1" % cmake.build_config)
-        else:
-            cmake.build()
+            cmake.parallel = False
+        cmake.build()
 
 #----------------------------------------------------------------------------
     def package(self):


### PR DESCRIPTION
Specify library name and version:  **ncbi-cxx-toolkit-public/26.0.1**

This fixes compiler version checks and disables dependency on MySQL on Macos/ARM
---

- [ x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ -] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
