### PR TITLE
msgpack-cxx: add version 4.1.0

### DIFF
--- a/recipes/msgpack-cxx/all/conandata.yml
+++ b/recipes/msgpack-cxx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.1.0":
+    url: "https://github.com/msgpack/msgpack-c/archive/cpp-4.1.0.tar.gz"
+    sha256: "634762502a192026bd5db773f9e18d900ad04cfc312b52faee350a5c76e5ccfb"
   "4.0.3":
     url: "https://github.com/msgpack/msgpack-c/archive/cpp-4.0.3.tar.gz"
     sha256: "23d737b1e959dfb6ca420564563f098e758adacc0b18003c56abf1b945bd1d4a"

--- a/recipes/msgpack-cxx/config.yml
+++ b/recipes/msgpack-cxx/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "4.1.0":
+    folder: all
   "4.0.3":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **msgpack-cxx/4.1.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
