### PR TITLE
qt: add qtmain library, make CMake policy CMP0020 work, fix asserts

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -811,19 +811,10 @@ Examples = bin/datadir/examples""")
                     set(_isWin32 $<BOOL:$<TARGET_PROPERTY:WIN32_EXECUTABLE>>)
                     set(_isNotExcluded $<NOT:$<BOOL:$<TARGET_PROPERTY:Qt5_NO_LINK_QTMAIN>>>)
                     set(_isPolicyNEW $<TARGET_POLICY:CMP0020>)
-                    get_target_property(_configs Qt5::Core IMPORTED_CONFIGURATIONS)
                     set_property(TARGET Qt5::Core APPEND PROPERTY
                         INTERFACE_LINK_LIBRARIES
                             $<$<AND:${_isExe},${_isWin32},${_isNotExcluded},${_isPolicyNEW}>:Qt5::WinMain>
                     )
-                    # For backward compatibility with CMake < 2.8.12
-                    foreach(_config ${_configs})
-                        set_property(TARGET Qt5::Core APPEND PROPERTY
-                            IMPORTED_LINK_INTERFACE_LIBRARIES_${_config}
-                                $<$<AND:${_isExe},${_isWin32},${_isNotExcluded},${_isPolicyNEW}>:Qt5::WinMain>
-                        )
-                    endforeach()
-                    unset(_configs)
                     unset(_isExe)
                     unset(_isWin32)
                     unset(_isNotExcluded)

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -728,8 +728,8 @@ class QtConan(ConanFile):
                         self.run(self._make_program(), run_environment=True)
 
     @property
-    def _cmake_executables_file(self):
-        return os.path.join("lib", "cmake", "Qt5Core", "conan_qt_executables_variables.cmake")
+    def _cmake_core_extras_file(self):
+        return os.path.join("lib", "cmake", "Qt5Core", "conan_qt_core_extras.cmake")
 
     def _cmake_qt5_private_file(self, module):
         return os.path.join("lib", "cmake", "Qt5{0}".format(module), "conan_qt_qt5_{0}private.cmake".format(module.lower()))
@@ -803,7 +803,35 @@ Examples = bin/datadir/examples""")
                     endif()
                     """.format(target=target, ext=extension, namespace=namespace, uppercase_target=target.upper()))
 
-        tools.save(os.path.join(self.package_folder, self._cmake_executables_file), filecontents)
+        if self.settings.os == "Windows":
+            filecontents += textwrap.dedent("""\
+                set(Qt5Core_QTMAIN_LIBRARIES Qt5::WinMain)
+                if (NOT Qt5_NO_LINK_QTMAIN)
+                    set(_isExe $<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>)
+                    set(_isWin32 $<BOOL:$<TARGET_PROPERTY:WIN32_EXECUTABLE>>)
+                    set(_isNotExcluded $<NOT:$<BOOL:$<TARGET_PROPERTY:Qt5_NO_LINK_QTMAIN>>>)
+                    set(_isPolicyNEW $<TARGET_POLICY:CMP0020>)
+                    get_target_property(_configs Qt5::Core IMPORTED_CONFIGURATIONS)
+                    set_property(TARGET Qt5::Core APPEND PROPERTY
+                        INTERFACE_LINK_LIBRARIES
+                            $<$<AND:${_isExe},${_isWin32},${_isNotExcluded},${_isPolicyNEW}>:Qt5::WinMain>
+                    )
+                    # For backward compatibility with CMake < 2.8.12
+                    foreach(_config ${_configs})
+                        set_property(TARGET Qt5::Core APPEND PROPERTY
+                            IMPORTED_LINK_INTERFACE_LIBRARIES_${_config}
+                                $<$<AND:${_isExe},${_isWin32},${_isNotExcluded},${_isPolicyNEW}>:Qt5::WinMain>
+                        )
+                    endforeach()
+                    unset(_configs)
+                    unset(_isExe)
+                    unset(_isWin32)
+                    unset(_isNotExcluded)
+                    unset(_isPolicyNEW)
+                endif()
+                """)
+
+        tools.save(os.path.join(self.package_folder, self._cmake_core_extras_file), filecontents)
 
         def _create_private_module(module, dependencies=[]):
             if "Core" not in dependencies:
@@ -914,8 +942,15 @@ Examples = bin/datadir/examples""")
             core_reqs.append("glib::glib-2.0")
 
         _create_module("Core", core_reqs)
-        if self._is_msvc:
-            self.cpp_info.components["qtCore"].exelinkflags.append("-ENTRY:mainCRTStartup")
+        if self.settings.os == "Windows":
+            module = "WinMain"
+            componentname = "qt%s" % module
+            self.cpp_info.components[componentname].set_property("cmake_target_name", "Qt5::{}".format(module))
+            self.cpp_info.components[componentname].names["cmake_find_package"] = module
+            self.cpp_info.components[componentname].names["cmake_find_package_multi"] = module
+            self.cpp_info.components[componentname].libs = ["qtmain%s" % libsuffix]
+            self.cpp_info.components[componentname].includedirs = []
+            self.cpp_info.components[componentname].defines = []
 
         if self.options.gui:
             gui_reqs = []
@@ -1230,9 +1265,9 @@ Examples = bin/datadir/examples""")
                 self.cpp_info.components["qtNetwork"].frameworks.append("GSS")
 
         self.cpp_info.components["qtCore"].builddirs.append(os.path.join("bin","archdatadir","bin"))
-        build_modules.append(self._cmake_executables_file)
-        self.cpp_info.components["qtCore"].build_modules["cmake_find_package"].append(self._cmake_executables_file)
-        self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_executables_file)
+        build_modules.append(self._cmake_core_extras_file)
+        self.cpp_info.components["qtCore"].build_modules["cmake_find_package"].append(self._cmake_core_extras_file)
+        self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_core_extras_file)
         build_modules.append(self._cmake_qt5_private_file("Core"))
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package"].append(self._cmake_qt5_private_file("Core"))
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_qt5_private_file("Core"))

--- a/recipes/qt/5.x.x/test_package/CMakeLists.txt
+++ b/recipes/qt/5.x.x/test_package/CMakeLists.txt
@@ -4,6 +4,8 @@ set(CMAKE_CXX_STANDARD 11)
 
 project(test_package)
 
+cmake_policy(SET CMP0020 NEW)
+
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_set_vs_runtime()
 conan_set_libcxx()

--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -90,7 +90,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         self._build_with_qmake()
-        #self._build_with_meson()
+        self._build_with_meson()
         self._build_with_cmake_find_package_multi()
 
     def _test_with_qmake(self):
@@ -115,5 +115,5 @@ class TestPackageConan(ConanFile):
     def test(self):
         if not tools.cross_building(self, skip_x64_x86=True):
             self._test_with_qmake()
-            #self._test_with_meson()
+            self._test_with_meson()
             self._test_with_cmake_find_package_multi()

--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -89,8 +89,8 @@ class TestPackageConan(ConanFile):
             cmake.build()
 
     def build(self):
-        self._build_with_qmake()
-        self._build_with_meson()
+        #self._build_with_qmake()
+        #self._build_with_meson()
         self._build_with_cmake_find_package_multi()
 
     def _test_with_qmake(self):

--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -89,7 +89,7 @@ class TestPackageConan(ConanFile):
             cmake.build()
 
     def build(self):
-        #self._build_with_qmake()
+        self._build_with_qmake()
         #self._build_with_meson()
         self._build_with_cmake_find_package_multi()
 
@@ -115,5 +115,5 @@ class TestPackageConan(ConanFile):
     def test(self):
         if not tools.cross_building(self, skip_x64_x86=True):
             self._test_with_qmake()
-            self._test_with_meson()
+            #self._test_with_meson()
             self._test_with_cmake_find_package_multi()


### PR DESCRIPTION
Specify library name and version:  **qt/5.15.2**

Fixes #9557 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
