### PR TITLE
[gh-action] TOC: use branch starting with `bot/`

### DIFF
--- a/.github/workflows/on-push-do-doco.yml
+++ b/.github/workflows/on-push-do-doco.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:
-        branch: action-doc-toc
+        branch: bot/action-doc-toc
         commit-message: "[docs] Regenerate tables of contents"
         title: "[docs] Regenerate tables of contents"
         body: "Automatic update of the documentation TOCs."


### PR DESCRIPTION
CI will skip the branches inside the repository that starts with `bot/` and it won't run for them (still they run in pull-requests). This is the same strategy we use for the [PR related to _"supported platforms"_](https://github.com/conan-io/conan-center-index/pulls?q=is%3Apr+author%3Aconan-center-bot+).

With this change they shouldn't appear as broken in the commit history (if you check the link, the broken ones come from the branch).
![image](https://user-images.githubusercontent.com/1406456/156402709-474ec6dc-5453-4b9c-a9b7-917230682781.png)
