### PR TITLE
librasterlite: fix "all shared" on macOS + modernize

### DIFF
--- a/recipes/librasterlite/all/conanfile.py
+++ b/recipes/librasterlite/all/conanfile.py
@@ -60,7 +60,7 @@ class LibrasterliteConan(ConanFile):
         self.requires("libpng/1.6.37")
         self.requires("libspatialite/5.0.1")
         self.requires("libtiff/4.3.0")
-        self.requires("sqlite3/3.38.0")
+        self.requires("sqlite3/3.38.1")
 
     def build_requirements(self):
         if not self._is_msvc:

--- a/recipes/librasterlite/all/conanfile.py
+++ b/recipes/librasterlite/all/conanfile.py
@@ -49,7 +49,7 @@ class LibrasterliteConan(ConanFile):
         self.requires("libpng/1.6.37")
         self.requires("libspatialite/5.0.1")
         self.requires("libtiff/4.3.0")
-        self.requires("sqlite3/3.36.0")
+        self.requires("sqlite3/3.38.0")
 
     @property
     def _settings_build(self):

--- a/recipes/librasterlite/all/conanfile.py
+++ b/recipes/librasterlite/all/conanfile.py
@@ -90,6 +90,14 @@ class LibrasterliteConan(ConanFile):
     def _build_autotools(self):
         with tools.chdir(self._source_subfolder):
             self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows)
+            # avoid SIP issues on macOS when dependencies are shared
+            if tools.is_apple_os(self.settings.os):
+                libpaths = ":".join(self.deps_cpp_info.lib_paths)
+                tools.replace_in_file(
+                    "configure",
+                    "#! /bin/sh\n",
+                    "#! /bin/sh\nexport DYLD_LIBRARY_PATH={}:$DYLD_LIBRARY_PATH\n".format(libpaths),
+                )
             with tools.run_environment(self):
                 autotools = self._configure_autotools()
                 autotools.make()

--- a/recipes/librasterlite/all/conanfile.py
+++ b/recipes/librasterlite/all/conanfile.py
@@ -1,7 +1,8 @@
 from conans import ConanFile, AutoToolsBuildEnvironment, VisualStudioBuildEnvironment, tools
+import functools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
 
 
 class LibrasterliteConan(ConanFile):
@@ -25,13 +26,23 @@ class LibrasterliteConan(ConanFile):
         "fPIC": True,
     }
 
-    exports_sources = "patches/**"
     generators = "pkg_config"
-    _autotools = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def export_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -51,12 +62,8 @@ class LibrasterliteConan(ConanFile):
         self.requires("libtiff/4.3.0")
         self.requires("sqlite3/3.38.0")
 
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
     def build_requirements(self):
-        if self.settings.compiler != "Visual Studio":
+        if not self._is_msvc:
             self.build_requires("libtool/2.4.6")
             self.build_requires("pkgconf/1.7.4")
             if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
@@ -87,30 +94,29 @@ class LibrasterliteConan(ConanFile):
                 autotools = self._configure_autotools()
                 autotools.make()
 
+    @functools.lru_cache(1)
     def _configure_autotools(self):
-        if self._autotools:
-            return self._autotools
         yes_no = lambda v: "yes" if v else "no"
         args = [
             "--enable-static={}".format(yes_no(not self.options.shared)),
             "--enable-shared={}".format(yes_no(self.options.shared)),
             "--disable-gcov",
         ]
-        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        self._autotools.configure(args=args)
-        return self._autotools
+        autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        autotools.configure(args=args)
+        return autotools
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
-        if self.settings.compiler == "Visual Studio":
+        if self._is_msvc:
             self._build_msvc()
         else:
             self._build_autotools()
 
     def package(self):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)
-        if self.settings.compiler == "Visual Studio":
+        if self._is_msvc:
             self.copy("rasterlite.h", dst="include", src=os.path.join(self._source_subfolder, "headers"))
             self.copy("*.lib", dst="lib", src=self._source_subfolder)
             self.copy("*.dll", dst="bin", src=self._source_subfolder)
@@ -123,6 +129,9 @@ class LibrasterliteConan(ConanFile):
             tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.names["pkg_config"] = "rasterlite"
-        suffix = "_i" if self.settings.compiler == "Visual Studio" and self.options.shared else ""
+        self.cpp_info.set_property("pkg_config_name", "rasterlite")
+        suffix = "_i" if self._is_msvc and self.options.shared else ""
         self.cpp_info.libs = ["rasterlite{}".format(suffix)]
+
+        # TODO: to remove in conan v2 once pkg_config generator removed
+        self.cpp_info.names["pkg_config"] = "rasterlite"

--- a/recipes/librasterlite/all/conanfile.py
+++ b/recipes/librasterlite/all/conanfile.py
@@ -90,6 +90,8 @@ class LibrasterliteConan(ConanFile):
     def _build_autotools(self):
         with tools.chdir(self._source_subfolder):
             self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows)
+            # relocatable shared libs on macOS
+            tools.replace_in_file("configure", "-install_name \\$rpath/", "-install_name @rpath/")
             # avoid SIP issues on macOS when dependencies are shared
             if tools.is_apple_os(self.settings.os):
                 libpaths = ":".join(self.deps_cpp_info.lib_paths)

--- a/recipes/librasterlite/all/test_package/CMakeLists.txt
+++ b/recipes/librasterlite/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(librasterlite REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} librasterlite::librasterlite)

--- a/recipes/librasterlite/all/test_package/conanfile.py
+++ b/recipes/librasterlite/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/librasterlite/all/test_package/conanfile.py
+++ b/recipes/librasterlite/all/test_package/conanfile.py
@@ -6,6 +6,15 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
+    def build_requirements(self):
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            # Workaround for CMake bug with error message:
+            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
+            # set. This could be because you are using a Mac OS X version less than 10.5
+            # or because CMake's platform configuration is corrupt.
+            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
+            self.build_requires("cmake/3.22.3")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
- fix all shared on macOS (see https://github.com/conan-io/conan/issues/10668)
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- bump dependencies
- `compiler=msvc` support
- `PkgConfigDeps` support

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
