### PR TITLE
[libx264] Fix error when building on ARM / MAC M1

### DIFF
--- a/recipes/libx264/all/conanfile.py
+++ b/recipes/libx264/all/conanfile.py
@@ -96,6 +96,7 @@ class LibX264Conan(ConanFile):
             # bitstream-a.S:29:18: error: unknown token in expression
             args.append("--extra-asflags=-arch arm64")
             args.append("--extra-ldflags=-arch arm64")
+            args.append("--host=aarch64-apple-darwin")
 
         if self._with_nasm:
             # FIXME: get using user_build_info


### PR DESCRIPTION
Specify library name and version:  **libx264/20191217**

Fixes #8195 

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
