### PR TITLE
dbus: Fix with_x11 swith for autotools

### DIFF
--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -63,6 +63,7 @@ class DbusConan(ConanFile):
             args.append("--disable-doxygen-docs")
             args.append("--disable-xml-docs")
 
+            args.append("--with-x=%s" % ("yes" if self.options.get_safe("with_x11", False) else "no"))
             args.append("--%s-x11-autolaunch" % ("enable" if self.options.get_safe("with_x11", False) else "disable"))
             args.append("--disable-asserts")
             args.append("--disable-checks")


### PR DESCRIPTION
dbus/1.12.20

It fixes the #9563 issue.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
