### PR TITLE
xorg/system: Add -luuid to sm component link flags

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -64,7 +64,7 @@ class ConanXOrg(ConanFile):
                             "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXScrnSaver-devel", "libXvMC-devel",
                             "xorg-x11-xtrans-devel", "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                             "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
-                            "xkeyboard-config-devel", "xcb-util-devel", "uuid-devel"]
+                            "xkeyboard-config-devel", "xcb-util-devel", "libuuid-devel"]
             elif tools.os_info.with_pacman:
                 packages = ["libxcb", "libfontenc", "libice", "libsm", "libxaw", "libxcomposite", "libxcursor",
                             "libxdamage", "libxdmcp", "libxft", "libxtst", "libxinerama", "libxkbfile", "libxrandr", "libxres",
@@ -72,7 +72,7 @@ class ConanXOrg(ConanFile):
                             "libxxf86vm", "libxv", "xkeyboard-config", "xcb-util", "util-linux-libs"]
             elif tools.os_info.with_zypper:
                 packages = ["xorg-x11-devel", "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
-                            "xcb-util-renderutil-devel", "xkeyboard-config", "xcb-util-devel", "uuid-devel"]
+                            "xcb-util-renderutil-devel", "xkeyboard-config", "xcb-util-devel", "libuuid-devel"]
             else:
                 self.output.warn("Do not know how to install 'xorg' for {}.".format(tools.os_info.linux_distro))
         
@@ -93,7 +93,7 @@ class ConanXOrg(ConanFile):
                      "xcb-xkb", "xcb-icccm", "xcb-image", "xcb-keysyms", "xcb-randr", "xcb-render",
                      "xcb-renderutil", "xcb-shape", "xcb-shm", "xcb-sync", "xcb-xfixes",
                      "xcb-xinerama", "xcb", "xkeyboard-config", "xcb-atom", "xcb-aux", "xcb-event", "xcb-util",
-                     "xcb-dri3", "uuid"]:
+                     "xcb-dri3"] + ([] if self.settings.os == "FreeBSD" else ["uuid"]):
             self._fill_cppinfo_from_pkgconfig(name)
         if self.settings.os == "Linux":
             self.cpp_info.components["sm"].requires.append("uuid")

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -10,7 +10,7 @@ class ConanXOrg(ConanFile):
     homepage = "https://www.x.org/wiki/"
     description = "The X.Org project provides an open source implementation of the X Window System."
     settings = "os"
-    topics = ("conan", "x11", "xorg")
+    topics = ("x11", "xorg")
 
     def configure(self):
         if self.settings.os not in ["Linux", "FreeBSD"]:
@@ -51,7 +51,7 @@ class ConanXOrg(ConanFile):
                             "libxv-dev", "libxvmc-dev", "libxxf86vm-dev", "xtrans-dev", "libxcb-render0-dev",
                             "libxcb-render-util0-dev", "libxcb-xkb-dev", "libxcb-icccm4-dev", "libxcb-image0-dev",
                             "libxcb-keysyms1-dev", "libxcb-randr0-dev", "libxcb-shape0-dev", "libxcb-sync-dev", "libxcb-xfixes0-dev",
-                            "libxcb-xinerama0-dev", "xkb-data", "libxcb-dri3-dev"]
+                            "libxcb-xinerama0-dev", "xkb-data", "libxcb-dri3-dev", "uuid-dev"]
                 if (tools.os_info.linux_distro == "ubuntu" and tools.os_info.os_version < "15") or\
                    (tools.os_info.linux_distro == "debian" and tools.os_info.os_version < "12") or\
                    (tools.os_info.linux_distro == "raspbian" and tools.os_info.os_version < "12"):
@@ -64,15 +64,15 @@ class ConanXOrg(ConanFile):
                             "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXScrnSaver-devel", "libXvMC-devel",
                             "xorg-x11-xtrans-devel", "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                             "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
-                            "xkeyboard-config-devel", "xcb-util-devel"]
+                            "xkeyboard-config-devel", "xcb-util-devel", "uuid-devel"]
             elif tools.os_info.with_pacman:
                 packages = ["libxcb", "libfontenc", "libice", "libsm", "libxaw", "libxcomposite", "libxcursor",
                             "libxdamage", "libxdmcp", "libxft", "libxtst", "libxinerama", "libxkbfile", "libxrandr", "libxres",
                             "libxss", "libxvmc", "xtrans", "xcb-util-wm", "xcb-util-image","xcb-util-keysyms", "xcb-util-renderutil",
-                            "libxxf86vm", "libxv", "xkeyboard-config", "xcb-util"]
+                            "libxxf86vm", "libxv", "xkeyboard-config", "xcb-util", "util-linux-libs"]
             elif tools.os_info.with_zypper:
                 packages = ["xorg-x11-devel", "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
-                            "xcb-util-renderutil-devel", "xkeyboard-config", "xcb-util-devel"]
+                            "xcb-util-renderutil-devel", "xkeyboard-config", "xcb-util-devel", "uuid-devel"]
             else:
                 self.output.warn("Do not know how to install 'xorg' for {}.".format(tools.os_info.linux_distro))
         
@@ -95,3 +95,9 @@ class ConanXOrg(ConanFile):
                      "xcb-xinerama", "xcb", "xkeyboard-config", "xcb-atom", "xcb-aux", "xcb-event", "xcb-util",
                      "xcb-dri3"]:
             self._fill_cppinfo_from_pkgconfig(name)
+        if self.settings.os == "Linux":
+            if "-luuid" not in self.cpp_info.components["sm"].sharedlinkflags:
+                self.cpp_info.components["sm"].sharedlinkflags.append("-luuid")
+            if "-luuid" not in self.cpp_info.components["sm"].exelinkflags:
+                self.cpp_info.components["sm"].exelinkflags.append("-luuid")
+

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -93,11 +93,8 @@ class ConanXOrg(ConanFile):
                      "xcb-xkb", "xcb-icccm", "xcb-image", "xcb-keysyms", "xcb-randr", "xcb-render",
                      "xcb-renderutil", "xcb-shape", "xcb-shm", "xcb-sync", "xcb-xfixes",
                      "xcb-xinerama", "xcb", "xkeyboard-config", "xcb-atom", "xcb-aux", "xcb-event", "xcb-util",
-                     "xcb-dri3"]:
+                     "xcb-dri3", "uuid"]:
             self._fill_cppinfo_from_pkgconfig(name)
         if self.settings.os == "Linux":
-            if "-luuid" not in self.cpp_info.components["sm"].sharedlinkflags:
-                self.cpp_info.components["sm"].sharedlinkflags.append("-luuid")
-            if "-luuid" not in self.cpp_info.components["sm"].exelinkflags:
-                self.cpp_info.components["sm"].exelinkflags.append("-luuid")
+            self.cpp_info.components["sm"].requires.append("uuid")
 

--- a/recipes/xorg/all/test_package/conanfile.py
+++ b/recipes/xorg/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/xorg/all/test_package/test_package.c
+++ b/recipes/xorg/all/test_package/test_package.c
@@ -3,6 +3,8 @@
 
 #include <X11/Xauth.h>
 
+#include <X11/SM/SMlib.h>
+
 #include <stdio.h>
 
 int main() {
@@ -20,4 +22,5 @@ int main() {
     }
 
     XCloseDisplay(display);
+    SmcSetErrorHandler(NULL);
 }


### PR DESCRIPTION
closes conan-io#9580

Specify library name and version:  **xorg/system**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): I'm trying to build qt with qtwebengine. qtwebengine depends on nss. nss depends on libSM from xorg/system. After investigating, I found out that libSM depends on libuuid. uuid isn't exported as a link flag by the pkgconfig recipe. Without this change, building nss (using a shared libsqlite provided by conan) fails


---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
