### PR TITLE
[thrust] Remove default options from test package

### DIFF
--- a/recipes/thrust/all/conandata.yml
+++ b/recipes/thrust/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.9.5":
     url: "https://github.com/thrust/thrust/archive/1.9.5.tar.gz"
     sha256: "d155dc2a260fe0c75c63c185fa4c4b4c6c5b7c444fcdac7109bb71941c9603f1"
+  "1.16.0":
+    url: "https://github.com/thrust/thrust/archive/1.16.0.tar.gz"
+    sha256: "93b9553e3ee544e05395022bea67e6d600f8f3eb680950ec7cf73c0f55162487"

--- a/recipes/thrust/all/conanfile.py
+++ b/recipes/thrust/all/conanfile.py
@@ -19,16 +19,14 @@ class ThrustConan(ConanFile):
 
     def requirements(self):
         if self.options.device_system == "tbb":
-            self.requires("tbb/2020.1")
+            self.requires("tbb/2020.3")
         elif self.options.device_system != "cpp":
             self.output.warn('Conan package for {0} is not available,'
                              ' this package will use {0} from system.'
                              .format(str(self.options.device_system).upper()))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def package(self):
         self.copy(pattern="LICENSE", src=self._source_subfolder, dst="licenses")

--- a/recipes/thrust/all/conanfile.py
+++ b/recipes/thrust/all/conanfile.py
@@ -11,7 +11,7 @@ class ThrustConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     no_copy_source = True
     options = {"device_system": ["cuda", "cpp", "omp", "tbb"]}
-    default_options = {"device_system": "cuda"}
+    default_options = {"device_system": "tbb"}
 
     @property
     def _source_subfolder(self):

--- a/recipes/thrust/all/conanfile.py
+++ b/recipes/thrust/all/conanfile.py
@@ -33,9 +33,7 @@ class ThrustConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE", src=self._source_subfolder, dst="licenses")
-        self.copy("*.h", src=os.path.join(self._source_subfolder, "thrust"),
-                      dst=os.path.join("include", "thrust"))
-        self.copy("*.inl", src=os.path.join(self._source_subfolder, "thrust"),
+        self.copy("*[.h|.inl]", src=os.path.join(self._source_subfolder, "thrust"),
                       dst=os.path.join("include", "thrust"))
 
     def package_id(self):

--- a/recipes/thrust/all/conanfile.py
+++ b/recipes/thrust/all/conanfile.py
@@ -33,8 +33,10 @@ class ThrustConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE", src=self._source_subfolder, dst="licenses")
-        self.copy("*", src=os.path.join(self._source_subfolder, "thrust"),
-                  dst=os.path.join("include", "thrust"))
+        self.copy("*.h", src=os.path.join(self._source_subfolder, "thrust"),
+                      dst=os.path.join("include", "thrust"))
+        self.copy("*.inl", src=os.path.join(self._source_subfolder, "thrust"),
+                      dst=os.path.join("include", "thrust"))
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/thrust/all/conanfile.py
+++ b/recipes/thrust/all/conanfile.py
@@ -1,6 +1,9 @@
 from conans import ConanFile, tools
 import os
 
+required_conan_version = ">=1.33.0"
+
+
 class ThrustConan(ConanFile):
     name = "thrust"
     license = "Apache-2.0"

--- a/recipes/thrust/all/test_package/CMakeLists.txt
+++ b/recipes/thrust/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(thrust CONFIG REQUIRED)
 
 add_executable(test_package test_package.cpp)
-target_link_libraries(test_package ${CONAN_LIBS})
+target_link_libraries(test_package thrust::thrust)
 set_target_properties(test_package PROPERTIES CXX_STANDARD 11)

--- a/recipes/thrust/all/test_package/conanfile.py
+++ b/recipes/thrust/all/test_package/conanfile.py
@@ -5,7 +5,6 @@ from conans import ConanFile, CMake, tools
 class ThrustTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
-    default_options = {"thrust:device_system": "tbb"}
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/thrust/all/test_package/conanfile.py
+++ b/recipes/thrust/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 
 class ThrustTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class ThrustTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/thrust/config.yml
+++ b/recipes/thrust/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.9.5":
     folder: all
+  "1.16.0"
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **thrust/1.9.5**

Related to https://github.com/conan-io/hooks/issues/287

- Use TBB by default, then we don't need default_options on test package
- Add version 1.16.0
- Update TBB version. OneTBB is incompatible due tbb thread

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
