### PR TITLE
daw_header_libraries: add version 2.23.0

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.23.0":
+    url: "https://github.com/beached/header_libraries/archive/v2.23.0.tar.gz"
+    sha256: "5619830ff745319615736036bfd3437577d6a8438ea9f34023208599fdf2cdda"
   "2.15.1":
     url: "https://github.com/beached/header_libraries/archive/v2.15.1.tar.gz"
     sha256: "3ddfc484448a762fcf13c6143b0fcff643cbd98dabc639e043bcf493235fc54d"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.23.0":
+    folder: all
   "2.15.1":
     folder: all
   "2.5.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **daw_header_libraries/2.23.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
