### PR TITLE
ms-gsl/4.0.0: fix checksum

### DIFF
--- a/recipes/ms-gsl/all/conandata.yml
+++ b/recipes/ms-gsl/all/conandata.yml
@@ -13,4 +13,4 @@ sources:
     sha256: "d3234d7f94cea4389e3ca70619b82e8fb4c2f33bb3a070799f1e18eef500a083"
   "4.0.0":
     url: "https://github.com/microsoft/GSL/archive/v4.0.0.tar.gz"
-    sha256: "95a51cd6432b491a71cac92ed279fd07668d1594d8909ea5654fb98156d57a10"
+    sha256: "f0e32cb10654fea91ad56bde89170d78cfbf4363ee0b01d8f097de2ba49f6ce9"

--- a/recipes/ms-gsl/all/test_package/conanfile.py
+++ b/recipes/ms-gsl/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
The version was re-tagged

From the release page:

> Update 1/28/2022: Bumped the release forward to hotfix microsoft/GSL@a353456

https://github.com/microsoft/GSL/releases/tag/v4.0.0

Fixes #9603