### PR TITLE
dlib: added OpenBLAS dependency

### DIFF
--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -23,7 +23,8 @@ class DlibConan(ConanFile):
         "with_png": [True, False],
         "with_sse2": [True, False, "auto"],
         "with_sse4": [True, False, "auto"],
-        "with_avx": [True, False, "auto"]
+        "with_avx": [True, False, "auto"],
+        "with_openblas": [True, False]
     }
     default_options = {
         "shared": False,
@@ -33,7 +34,10 @@ class DlibConan(ConanFile):
         "with_png": True,
         "with_sse2": "auto",
         "with_sse4": "auto",
-        "with_avx": "auto"
+        "with_avx": "auto",
+        "with_openblas": True,
+
+        "openblas:shared": False
     }
 
     _cmake = None
@@ -67,6 +71,8 @@ class DlibConan(ConanFile):
             self.requires("libjpeg/9d")
         if self.options.with_png:
             self.requires("libpng/1.6.37")
+        if self.options.with_openblas:
+            self.requires("openblas/0.3.17")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Added OpenBLAS dependency to build using a high-performacnce BLAS library instead of falling back to internal BLAS implementation.

See also #9281 

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
