### PR TITLE
libnghttp2: add components + fix dependencies + relocatable shared libs on macOS

### DIFF
--- a/recipes/libnghttp2/all/CMakeLists.txt
+++ b/recipes/libnghttp2/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -109,7 +109,7 @@ class Nghttp2Conan(ConanFile):
 
         if tools.is_apple_os(self.settings.os):
             # workaround for: install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
-            self._cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False
+            cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False
 
         cmake.configure()
         return cmake

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -107,6 +107,10 @@ class Nghttp2Conan(ConanFile):
             # backward-incompatible change in 1.42.0
             cmake.definitions["STATIC_LIB_SUFFIX"] = "_static"
 
+        if tools.is_apple_os(self.settings.os):
+            # workaround for: install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
+            self._cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False
+
         cmake.configure()
         return cmake
 

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -26,8 +26,8 @@ class Nghttp2Conan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_app": True,
-        "with_hpack": True,
+        "with_app": False,
+        "with_hpack": False,
         "with_jemalloc": False,
         "with_asio": False,
     }

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -58,8 +58,8 @@ class Nghttp2Conan(ConanFile):
     def requirements(self):
         self.requires("zlib/1.2.11")
         if self.options.with_app:
-            self.requires("openssl/1.1.1l")
-            self.requires("c-ares/1.17.1")
+            self.requires("openssl/1.1.1m")
+            self.requires("c-ares/1.18.1")
             self.requires("libev/4.33")
             self.requires("libevent/2.1.12")
             self.requires("libxml2/2.9.12")
@@ -68,7 +68,7 @@ class Nghttp2Conan(ConanFile):
         if self.options.with_jemalloc:
             self.requires("jemalloc/5.2.1")
         if self.options.with_asio:
-            self.requires("boost/1.77.0")
+            self.requires("boost/1.78.0")
 
     def validate(self):
         if self.options.with_asio and self._is_msvc:

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -32,7 +32,7 @@ class Nghttp2Conan(ConanFile):
         "with_asio": False,
     }
 
-    generators = "cmake", "pkg_config"
+    generators = "cmake", "cmake_find_package", "pkg_config"
 
     @property
     def _source_subfolder(self):
@@ -106,12 +106,6 @@ class Nghttp2Conan(ConanFile):
         if tools.Version(self.version) >= "1.42.0":
             # backward-incompatible change in 1.42.0
             cmake.definitions["STATIC_LIB_SUFFIX"] = "_static"
-
-        if self.options.with_app:
-            cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath
-        if self.options.with_asio:
-            cmake.definitions["BOOST_ROOT"] = self.deps_cpp_info["boost"].rootpath
-        cmake.definitions["ZLIB_ROOT"] = self.deps_cpp_info["zlib"].rootpath
 
         cmake.configure()
         return cmake

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -54,6 +54,9 @@ class Nghttp2Conan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        if not (self.options.with_app or self.options.with_hpack or self.options.with_asio):
+            del self.settings.compiler.cppstd
+            del self.settings.compiler.libcxx
 
     def requirements(self):
         self.requires("zlib/1.2.11")

--- a/recipes/libnghttp2/all/test_package/CMakeLists.txt
+++ b/recipes/libnghttp2/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(libnghttp2 REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} libnghttp2::libnghttp2)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)

--- a/recipes/libnghttp2/all/test_package/conanfile.py
+++ b/recipes/libnghttp2/all/test_package/conanfile.py
@@ -6,6 +6,15 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
+    def build_requirements(self):
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            # Workaround for CMake bug with error message:
+            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
+            # set. This could be because you are using a Mac OS X version less than 10.5
+            # or because CMake's platform configuration is corrupt.
+            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
+            self.build_requires("cmake/3.22.0")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()

--- a/recipes/libnghttp2/all/test_package/conanfile.py
+++ b/recipes/libnghttp2/all/test_package/conanfile.py
@@ -1,12 +1,10 @@
-# -*- coding: utf-8 -*-
-
 from conans import ConanFile, CMake, tools
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- `pkg_config_name` of `nghttp2_asio` was missing in `package_info()`, this is why components are needed.
- there were few mistakes in requirements:
  - `zlib` is not a dependency of `nghttp2` lib, but apps only.
  - `openssl` is also a dependency of `nghttp2_asio` lib, not only of apps.
  - `with_jemalloc` is for apps only.
- add `cmake_find_package` generator (upstream relies on official Find modules for zlib, openssl & libxml2). Yet, it's still quite fragile for several dependencies: for example there is a custom `FindLibevent.cmake` having precedence over the one generate by conan, and it may find system `libevent` instead of conan one (tested on my mac). So this PR doesn't fix everything regarding proper discovery of conan dependencies (because it takes time to check/fix everything), but it's an improvement at least.
- `nghttp2` lib is pure C. `nghttp2_asio` is a C++ lib, and apps/hpack utilities are C++ executables. Therefore `compiler.cppstd` & `compiler.libcxx` are deleted if we don't build `nghttp2_asio`, apps and hpack. I'm also wondering if apps & hpack shouldn't be disabled by default, since it drags lot of dependencies not needed by `nghttp2` lib.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
