### PR TITLE
libgettext: finer grained packaging + no -FS for Visual Studio < 2013

### DIFF
--- a/recipes/libgettext/all/conanfile.py
+++ b/recipes/libgettext/all/conanfile.py
@@ -124,7 +124,9 @@ class GetTextConan(ConanFile):
                 with tools.chdir(os.path.join(self._source_subfolder, self._gettext_folder)):
                     env_build = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
                     if self._is_msvc:
-                        env_build.flags.append("-FS")
+                        if not (self.settings.compiler == "Visual Studio" and
+                                tools.Version(self.settings.compiler.version) < "12"):
+                            env_build.flags.append("-FS")
                     env_build.configure(args=args, build=build, host=host)
                     env_build.make(self._make_args)
 

--- a/recipes/libgettext/all/conanfile.py
+++ b/recipes/libgettext/all/conanfile.py
@@ -130,12 +130,12 @@ class GetTextConan(ConanFile):
 
     def package(self):
         self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="*.dll", dst="bin", src=self._source_subfolder, keep_path=False, symlinks=True)
-        self.copy(pattern="*.lib", dst="lib", src=self._source_subfolder, keep_path=False, symlinks=True)
-        self.copy(pattern="*.a", dst="lib", src=self._source_subfolder, keep_path=False, symlinks=True)
-        self.copy(pattern="*.so*", dst="lib", src=self._source_subfolder, keep_path=False, symlinks=True)
-        self.copy(pattern="*.dylib*", dst="lib", src=self._source_subfolder, keep_path=False, symlinks=True)
-        self.copy(pattern="*libgnuintl.h", dst="include", src=self._source_subfolder, keep_path=False, symlinks=True)
+        self.copy(pattern="*gnuintl*.dll", dst="bin", src=self._source_subfolder, keep_path=False)
+        self.copy(pattern="*gnuintl*.lib", dst="lib", src=self._source_subfolder, keep_path=False)
+        self.copy(pattern="*gnuintl*.a", dst="lib", src=self._source_subfolder, keep_path=False)
+        self.copy(pattern="*gnuintl*.so*", dst="lib", src=self._source_subfolder, keep_path=False, symlinks=True)
+        self.copy(pattern="*gnuintl*.dylib", dst="lib", src=self._source_subfolder, keep_path=False, symlinks=True)
+        self.copy(pattern="*libgnuintl.h", dst="include", src=self._source_subfolder, keep_path=False)
         tools.rename(os.path.join(self.package_folder, "include", "libgnuintl.h"),
                      os.path.join(self.package_folder, "include", "libintl.h"))
         if self._is_msvc and self.options.shared:


### PR DESCRIPTION
Minor fixes:

- COPYING.LIB was packaged into lib folder
- `-FS` is not a valid flag for Visual Studio < 2013

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
