### PR TITLE
nspr: relocatable shared libs on macOS + various fixes

### DIFF
--- a/recipes/nspr/all/conandata.yml
+++ b/recipes/nspr/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
-  "4.29":
-    sha256: 22286bdb8059d74632cc7c2865c139e63953ecfb33bf4362ab58827e86e92582
-    url: https://ftp.mozilla.org/pub/nspr/releases/v4.29/src/nspr-4.29.tar.gz
   "4.32":
-    sha256: bb6bf4f534b9559cf123dcdc6f9cd8167de950314a90a88b2a329c16836e7f6c
-    url: https://ftp.mozilla.org/pub/nspr/releases/v4.32/src/nspr-4.32.tar.gz
+    url: "https://ftp.mozilla.org/pub/nspr/releases/v4.32/src/nspr-4.32.tar.gz"
+    sha256: "bb6bf4f534b9559cf123dcdc6f9cd8167de950314a90a88b2a329c16836e7f6c"
+  "4.29":
+    url: "https://ftp.mozilla.org/pub/nspr/releases/v4.29/src/nspr-4.29.tar.gz"
+    sha256: "22286bdb8059d74632cc7c2865c139e63953ecfb33bf4362ab58827e86e92582"
   "4.27":
     url: "https://ftp.mozilla.org/pub/nspr/releases/v4.27/src/nspr-4.27.tar.gz"
     sha256: "6d495192b6ab00a3c28db053492cf794329f7c0351a5728db198111a1816e89b"

--- a/recipes/nspr/all/conanfile.py
+++ b/recipes/nspr/all/conanfile.py
@@ -123,6 +123,12 @@ class NsprConan(ConanFile):
 
     def build(self):
         with tools.chdir(self._source_subfolder):
+            # relocatable shared libs on macOS
+            tools.replace_in_file(
+                "configure",
+                "-install_name @executable_path/",
+                "-install_name @rpath/"
+            )
             with self._build_context():
                 autotools = self._configure_autotools()
                 autotools.make()

--- a/recipes/nspr/all/conanfile.py
+++ b/recipes/nspr/all/conanfile.py
@@ -189,7 +189,7 @@ class NsprConan(ConanFile):
             elif self.settings.arch == "x86_64":
                 self.cpp_info.defines.append("_M_X64")
         self.cpp_info.includedirs.append(os.path.join("include", "nspr"))
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["dl", "pthread"])
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs.extend(["winmm", "ws2_32"])

--- a/recipes/nspr/all/conanfile.py
+++ b/recipes/nspr/all/conanfile.py
@@ -1,3 +1,4 @@
+from conan.tools.microsoft import msvc_runtime_flag
 from conans import ConanFile, tools, AutoToolsBuildEnvironment
 from conans.errors import ConanInvalidConfiguration
 import os
@@ -97,8 +98,8 @@ class NsprConan(ConanFile):
         if self._is_msvc:
             conf_args.extend([
                 "{}-pc-mingw32".format("x86_64" if self.settings.arch == "x86_64" else "x86"),
-                "--enable-static-rtl={}".format(yes_no("MT" in self.settings.compiler.runtime)),
-                "--enable-debug-rtl={}".format(yes_no("d" in self.settings.compiler.runtime)),
+                "--enable-static-rtl={}".format(yes_no("MT" in msvc_runtime_flag(self))),
+                "--enable-debug-rtl={}".format(yes_no("d" in msvc_runtime_flag(self))),
             ])
         elif self.settings.os == "Android":
             conf_args.extend([

--- a/recipes/nspr/all/conanfile.py
+++ b/recipes/nspr/all/conanfile.py
@@ -1,10 +1,11 @@
 from conan.tools.microsoft import msvc_runtime_flag
 from conans import ConanFile, tools, AutoToolsBuildEnvironment
 from conans.errors import ConanInvalidConfiguration
-import os
 import contextlib
+import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
+
 
 class NsprConan(ConanFile):
     name = "nspr"
@@ -177,6 +178,7 @@ class NsprConan(ConanFile):
         return ["plds4", "plc4", "nspr4"]
 
     def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "nspr")
         libs = self._library_names
         if self.settings.os == "Windows" and not self.options.shared:
             libs = list("{}_s".format(l) for l in libs)

--- a/recipes/nspr/all/conanfile.py
+++ b/recipes/nspr/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan.tools.microsoft import msvc_runtime_flag
+from conan.tools.files import rename
 from conans import ConanFile, tools, AutoToolsBuildEnvironment
 from conans.errors import ConanInvalidConfiguration
 import contextlib
@@ -71,7 +72,7 @@ class NsprConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination="tmp", strip_root=True)
-        os.rename(os.path.join("tmp", "nspr"), self._source_subfolder)
+        rename(self, os.path.join("tmp", "nspr"), self._source_subfolder)
         tools.rmdir("tmp")
 
     @contextlib.contextmanager
@@ -150,8 +151,8 @@ class NsprConan(ConanFile):
                 libprefix = "" if self._is_msvc else "lib"
                 if self.options.shared:
                     os.unlink(os.path.join(self.package_folder, "lib", "{}{}_s.{}".format(libprefix, lib, libsuffix)))
-                    os.rename(os.path.join(self.package_folder, "lib", "{}.dll".format(lib)),
-                              os.path.join(self.package_folder, "bin", "{}.dll".format(lib)))
+                    rename(self, os.path.join(self.package_folder, "lib", "{}.dll".format(lib)),
+                                 os.path.join(self.package_folder, "bin", "{}.dll".format(lib)))
                 else:
                     os.unlink(os.path.join(self.package_folder, "lib", "{}{}.{}".format(libprefix, lib, libsuffix)))
                     os.unlink(os.path.join(self.package_folder, "lib", "{}.dll".format(lib)))

--- a/recipes/nspr/all/conanfile.py
+++ b/recipes/nspr/all/conanfile.py
@@ -53,7 +53,7 @@ class NsprConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
-    
+
     def validate(self):
         # https://bugzilla.mozilla.org/show_bug.cgi?id=1658671
         if tools.Version(self.version) < "4.29":
@@ -93,9 +93,6 @@ class NsprConan(ConanFile):
             "--enable-debug={}".format(yes_no(self.settings.build_type == "Debug")),
             "--datarootdir={}".format(tools.unix_path(os.path.join(self.package_folder, "res"))),
             "--disable-cplus",
-            "--enable-64bit" if self.settings.arch in ("armv8", "x86_64") else "--disable-64bit",
-            "--disable-strip" if self.settings.build_type == "RelWithDebInfo" else "--enable-strip",
-            "--enable-debug" if self.settings.build_type == "Debug" else "--disable-debug",
         ]
         if self._is_msvc:
             conf_args.extend([

--- a/recipes/nspr/all/conanfile.py
+++ b/recipes/nspr/all/conanfile.py
@@ -33,7 +33,7 @@ class NsprConan(ConanFile):
 
     @property
     def _is_msvc(self):
-        return self.settings.compiler in ["Visual Studio", "msvc"]
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
 
     @property
     def _source_subfolder(self):
@@ -163,7 +163,7 @@ class NsprConan(ConanFile):
                 else:
                     os.unlink(os.path.join(self.package_folder, "lib", "lib{}.{}".format(lib, shared_ext)))
 
-        if self.settings.compiler == "Visual Studio":
+        if self._is_msvc:
             if self.settings.build_type == "Debug":
                 for lib in self._library_names:
                     os.unlink(os.path.join(self.package_folder, "lib", "{}.pdb".format(lib)))

--- a/recipes/nspr/all/conanfile.py
+++ b/recipes/nspr/all/conanfile.py
@@ -61,17 +61,17 @@ class NsprConan(ConanFile):
             if self.settings.os == "Macos" and self.settings.arch == "armv8":
                 raise ConanInvalidConfiguration("NSPR does not support mac M1 before 4.29")
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination="tmp", strip_root=True)
-        os.rename(os.path.join("tmp", "nspr"), self._source_subfolder)
-        tools.rmdir("tmp")
-
     def build_requirements(self):
         if self._settings_build.os == "Windows":
             self.build_requires("mozilla-build/3.3")
             if not tools.get_env("CONAN_BASH_PATH"):
                 self.build_requires("msys2/cci.latest")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination="tmp", strip_root=True)
+        os.rename(os.path.join("tmp", "nspr"), self._source_subfolder)
+        tools.rmdir("tmp")
 
     @contextlib.contextmanager
     def _build_context(self):

--- a/recipes/nspr/all/test_package/conanfile.py
+++ b/recipes/nspr/all/test_package/conanfile.py
@@ -6,6 +6,15 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "cmake_find_package_multi"
 
+    def build_requirements(self):
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            # Workaround for CMake bug with error message:
+            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
+            # set. This could be because you are using a Mac OS X version less than 10.5
+            # or because CMake's platform configuration is corrupt.
+            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
+            self.build_requires("cmake/3.22.0")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- improve compiler=msvc support
- remove duplicated options passed to configure: see https://github.com/conan-io/conan-center-index/pull/7212#discussion_r820503608
- explicit pkg_config_name
- add system libs for FreeBSD

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
