### PR TITLE
- [libmysqlclient] bump deps

### DIFF
--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -33,12 +33,12 @@ class LibMysqlClientCConan(ConanFile):
 
     def requirements(self):
         if self.options.with_ssl:
-            self.requires("openssl/1.1.1k")
+            self.requires("openssl/1.1.1m")
 
         if self.options.with_zlib:
             self.requires("zlib/1.2.11")
         if self._with_zstd:
-            self.requires("zstd/1.5.0")
+            self.requires("zstd/1.5.2")
         if self._with_lz4:
             self.requires("lz4/1.9.3")
 


### PR DESCRIPTION
from #9609 :
```
WARN: libmysqlclient/8.0.25: requirement openssl/1.1.1k overridden by qt/5.15.3 to openssl/1.1.1m 
WARN: libmysqlclient/8.0.25: requirement zstd/1.5.0 overridden by qt/5.15.3 to zstd/1.5.2 
```

Specify library name and version:  **libmysqlclient/all**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
