### PR TITLE
Bump version of expat library to support 2.4.7

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.4.7":
+    sha256: "9875621085300591f1e64c18fd3da3a0eeca4a74f884b9abac2758ad1bd07a7d"
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_7/expat-2.4.7.tar.xz"
   "2.4.6":
     sha256: "de55794b7a9bc214852fdc075beaaecd854efe1361597e6268ee87946951289b"
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_6/expat-2.4.6.tar.xz"

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.4.7":
+    folder: all
   "2.4.6":
     folder: all
   "2.4.5":


### PR DESCRIPTION
Specify library name and version:  **expat/2.4.7**

Support expat 2.4.7

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
