### PR TITLE
duktape: add version 2.7.0

### DIFF
--- a/recipes/duktape/all/CMakeLists.txt
+++ b/recipes/duktape/all/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(duktape C)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder/src/*.c)
 file(GLOB HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder/src/*.h)

--- a/recipes/duktape/all/conandata.yml
+++ b/recipes/duktape/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
+  "2.7.0":
+    url: "https://github.com/svaarala/duktape/releases/download/v2.7.0/duktape-2.7.0.tar.xz"
+    sha256: "90f8d2fa8b5567c6899830ddef2c03f3c27960b11aca222fa17aa7ac613c2890"
   "2.6.0":
-    sha256: 96f4a05a6c84590e53b18c59bb776aaba80a205afbbd92b82be609ba7fe75fa7
-    url: https://github.com/svaarala/duktape/releases/download/v2.6.0/duktape-2.6.0.tar.xz
+    url: "https://github.com/svaarala/duktape/releases/download/v2.6.0/duktape-2.6.0.tar.xz"
+    sha256: "96f4a05a6c84590e53b18c59bb776aaba80a205afbbd92b82be609ba7fe75fa7"
   "2.5.0":
-    sha256: 83d411560a1cd36ea132bd81d8d9885efe9285c6bc6685c4b71e69a0c4329616
-    url: https://github.com/svaarala/duktape/releases/download/v2.5.0/duktape-2.5.0.tar.xz
+    url: "https://github.com/svaarala/duktape/releases/download/v2.5.0/duktape-2.5.0.tar.xz"
+    sha256: "83d411560a1cd36ea132bd81d8d9885efe9285c6bc6685c4b71e69a0c4329616"

--- a/recipes/duktape/all/test_package/conanfile.py
+++ b/recipes/duktape/all/test_package/conanfile.py
@@ -13,5 +13,5 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             self.run(os.path.join("bin", "test_package"), run_environment=True)

--- a/recipes/duktape/config.yml
+++ b/recipes/duktape/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.7.0":
+    folder: "all"
   "2.6.0":
     folder: "all"
   "2.5.0":


### PR DESCRIPTION
Specify library name and version:  **duktape/2.7.0**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
