### PR TITLE
s2n: backport build fix

### DIFF
--- a/recipes/s2n/all/conandata.yml
+++ b/recipes/s2n/all/conandata.yml
@@ -11,3 +11,11 @@ sources:
   "1.0.11":
     url: "https://github.com/awslabs/s2n/archive/v1.0.11.tar.gz"
     sha256: "dbe886cf8cd6658cce571cdaba81e9a93d8c914fd1eba0d3233fec64ed53224b"
+patches:
+  "1.1.0":
+    - patch_file: "patches/1.1.0/001-try-compile.patch"
+      base_path: "source_subfolder"
+  "1.0.11":
+    - patch_file: "patches/1.0.11/001-try-compile.patch"
+      base_path: "source_subfolder"
+

--- a/recipes/s2n/all/conandata.yml
+++ b/recipes/s2n/all/conandata.yml
@@ -18,4 +18,3 @@ patches:
   "1.0.11":
     - patch_file: "patches/1.0.11/001-try-compile.patch"
       base_path: "source_subfolder"
-

--- a/recipes/s2n/all/conanfile.py
+++ b/recipes/s2n/all/conanfile.py
@@ -23,13 +23,17 @@ class S2n(ConanFile):
         "fPIC": True,
     }
 
-    exports_sources = "CMakeLists.txt", "patches/**"
     generators = "cmake", "cmake_find_package"
     _cmake = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def configure(self):
         if self.options.shared:

--- a/recipes/s2n/all/conanfile.py
+++ b/recipes/s2n/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+from conan.tools.files import apply_conandata_patches
 import os
 
 required_conan_version = ">=1.43.0"
@@ -12,7 +13,6 @@ class S2n(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/aws/s2n-tls"
     license = "Apache-2.0",
-
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -23,7 +23,7 @@ class S2n(ConanFile):
         "fPIC": True,
     }
 
-    exports_sources = "CMakeLists.txt"
+    exports_sources = "CMakeLists.txt", "patches/**"
     generators = "cmake", "cmake_find_package"
     _cmake = None
 
@@ -58,6 +58,7 @@ class S2n(ConanFile):
         return self._cmake
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/s2n/all/patches/1.0.11/001-try-compile.patch
+++ b/recipes/s2n/all/patches/1.0.11/001-try-compile.patch
@@ -1,0 +1,115 @@
+commit f6da121bc248974e70ced3bfc690b4652a4cb056
+Author: dvirtz <dvirtz@gmail.com>
+Date:   Fri Mar 4 16:23:00 2022 +0200
+
+    Fix BIKE Round 3 try_compile statements
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b72effbe..cc298a13 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -147,28 +147,49 @@ else()
+         # First, check if the compiler supports the specific instruction set
+         # extensions. For example, gcc-4 doesn't fully support AVX-512, while
+         # gcc-7 doesn't support VPCLMUL extension.
+-        try_compile(BIKE_R3_AVX2_SUPPORTED
+-            ${CMAKE_BINARY_DIR}
+-            "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
+-            COMPILE_DEFINITIONS "-mavx2")
++        set(BIKE_R3_AVX2_FLAGS "-mavx2")
++        try_compile(
++                BIKE_R3_AVX2_SUPPORTED
++                ${CMAKE_BINARY_DIR}
++                SOURCES
++                "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
++                "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/bike_r3/gf2x_mul_avx2.c"
++                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_SOURCE_DIR}"
++                COMPILE_DEFINITIONS "${BIKE_R3_AVX2_FLAGS} -DS2N_BIKE_R3_AVX2"
++        )
+ 
+         set(BIKE_R3_AVX512_FLAGS "-mavx512f -mavx512bw -mavx512dq")
+-        try_compile(BIKE_R3_AVX512_SUPPORTED
+-            ${CMAKE_BINARY_DIR}
+-            "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
+-            COMPILE_DEFINITIONS ${BIKE_R3_AVX512_FLAGS})
++        try_compile(
++                BIKE_R3_AVX512_SUPPORTED
++                ${CMAKE_BINARY_DIR}
++                SOURCES
++                "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
++                "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/bike_r3/gf2x_mul_avx512.c"
++                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_SOURCE_DIR}"
++                COMPILE_DEFINITIONS "${BIKE_R3_AVX512_FLAGS} -DS2N_BIKE_R3_AVX512"
++        )
+ 
+         set(BIKE_R3_PCLMUL_FLAGS "-mpclmul -msse2")
+-        try_compile(BIKE_R3_PCLMUL_SUPPORTED
+-            ${CMAKE_BINARY_DIR}
+-            "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
+-            COMPILE_DEFINITIONS ${BIKE_R3_PCLMUL_FLAGS})
++        try_compile(
++                BIKE_R3_PCLMUL_SUPPORTED
++                ${CMAKE_BINARY_DIR}
++                SOURCES
++                "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
++                "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/bike_r3/gf2x_mul_base_pclmul.c"
++                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_SOURCE_DIR}"
++                COMPILE_DEFINITIONS "${BIKE_R3_PCLMUL_FLAGS} -DS2N_BIKE_R3_PCLMUL"
++        )
+ 
+         set(BIKE_R3_VPCLMUL_FLAGS "-mvpclmulqdq -mavx512f -mavx512bw -mavx512dq")
+-        try_compile(BIKE_R3_VPCLMUL_SUPPORTED
+-            ${CMAKE_BINARY_DIR}
+-            "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
+-            COMPILE_DEFINITIONS ${BIKE_R3_VPCLMUL_FLAGS})
++        try_compile(
++                BIKE_R3_VPCLMUL_SUPPORTED
++                ${CMAKE_BINARY_DIR}
++                SOURCES
++                "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
++                "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/bike_r3/gf2x_mul_base_vpclmul.c"
++                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_SOURCE_DIR}"
++                COMPILE_DEFINITIONS "${BIKE_R3_VPCLMUL_FLAGS} -DS2N_BIKE_R3_VPCLMUL"
++        )
+ 
+         if(BIKE_R3_AVX2_SUPPORTED OR BIKE_R3_AVX512_SUPPORTED OR BIKE_R3_PCLMUL_SUPPORTED OR BIKE_R3_VPCLMUL_SUPPORTED)
+             set(BIKE_R3_X86_64_OPT_SUPPORTED ON)
+@@ -277,31 +298,36 @@ if(BIKE_R3_X86_64_OPT_SUPPORTED)
+     # If any of the BIKE_R3 x86_64 optimizations is supported (this was checked
+     # earlier in the file), we add the required compile flags to files that
+     # contain the optimized code.
++
++    message(STATUS "Enabling BIKE_R3 x86_64 optimizations")
++
+     if(BIKE_R3_AVX2_SUPPORTED)
++        message(STATUS "\t Enabling BIKE_R3_AVX2")
+         FILE(GLOB BIKE_R3_AVX2_SRCS "pq-crypto/bike_r3/*_avx2.c")
+         set_source_files_properties(${BIKE_R3_AVX2_SRCS} PROPERTIES COMPILE_FLAGS -mavx2)
+         target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BIKE_R3_AVX2)
+     endif()
+ 
+     if(BIKE_R3_AVX512_SUPPORTED)
++        message(STATUS "\t Enabling BIKE_R3_AVX512")
+         FILE(GLOB BIKE_R3_AVX512_SRCS "pq-crypto/bike_r3/*_avx512.c")
+         set_source_files_properties(${BIKE_R3_AVX512_SRCS} PROPERTIES COMPILE_FLAGS ${BIKE_R3_AVX512_FLAGS})
+         target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BIKE_R3_AVX512)
+     endif()
+ 
+     if(BIKE_R3_PCLMUL_SUPPORTED)
++        message(STATUS "\t Enabling BIKE_R3_PCLMUL")
+         FILE(GLOB BIKE_R3_PCLMUL_SRCS "pq-crypto/bike_r3/*_pclmul.c")
+         set_source_files_properties(${BIKE_R3_PCLMUL_SRCS} PROPERTIES COMPILE_FLAGS ${BIKE_R3_PCLMUL_FLAGS})
+         target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BIKE_R3_PCLMUL)
+     endif()
+ 
+     if(BIKE_R3_VPCLMUL_SUPPORTED)
++        message(STATUS "\t Enabling BIKE_R3_VPCLMUL")
+         FILE(GLOB BIKE_R3_VPCLMUL_SRCS "pq-crypto/bike_r3/*_vpclmul.c")
+         set_source_files_properties(${BIKE_R3_VPCLMUL_SRCS} PROPERTIES COMPILE_FLAGS ${BIKE_R3_VPCLMUL_FLAGS})
+         target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BIKE_R3_VPCLMUL)
+     endif()
+-
+-    message(STATUS "Enabling BIKE_R3 x86_64 optimizations")
+ endif()
+ 
+ if(ADX_SUPPORTED)

--- a/recipes/s2n/all/patches/1.1.0/001-try-compile.patch
+++ b/recipes/s2n/all/patches/1.1.0/001-try-compile.patch
@@ -1,0 +1,115 @@
+commit b1fae56bd3537a3d89dd42a479dbdc1dc2e2f862
+Author: dvirtz <dvirtz@gmail.com>
+Date:   Fri Mar 4 16:23:00 2022 +0200
+
+    Fix BIKE Round 3 try_compile statements
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f58303a6..98800345 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -159,28 +159,49 @@ else()
+         # First, check if the compiler supports the specific instruction set
+         # extensions. For example, gcc-4 doesn't fully support AVX-512, while
+         # gcc-7 doesn't support VPCLMUL extension.
+-        try_compile(BIKE_R3_AVX2_SUPPORTED
+-            ${CMAKE_BINARY_DIR}
+-            "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
+-            COMPILE_DEFINITIONS "-mavx2")
++        set(BIKE_R3_AVX2_FLAGS "-mavx2")
++        try_compile(
++                BIKE_R3_AVX2_SUPPORTED
++                ${CMAKE_BINARY_DIR}
++                SOURCES
++                "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
++                "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/bike_r3/gf2x_mul_avx2.c"
++                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_SOURCE_DIR}"
++                COMPILE_DEFINITIONS "${BIKE_R3_AVX2_FLAGS} -DS2N_BIKE_R3_AVX2"
++        )
+ 
+         set(BIKE_R3_AVX512_FLAGS "-mavx512f -mavx512bw -mavx512dq")
+-        try_compile(BIKE_R3_AVX512_SUPPORTED
+-            ${CMAKE_BINARY_DIR}
+-            "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
+-            COMPILE_DEFINITIONS ${BIKE_R3_AVX512_FLAGS})
++        try_compile(
++                BIKE_R3_AVX512_SUPPORTED
++                ${CMAKE_BINARY_DIR}
++                SOURCES
++                "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
++                "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/bike_r3/gf2x_mul_avx512.c"
++                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_SOURCE_DIR}"
++                COMPILE_DEFINITIONS "${BIKE_R3_AVX512_FLAGS} -DS2N_BIKE_R3_AVX512"
++        )
+ 
+         set(BIKE_R3_PCLMUL_FLAGS "-mpclmul -msse2")
+-        try_compile(BIKE_R3_PCLMUL_SUPPORTED
+-            ${CMAKE_BINARY_DIR}
+-            "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
+-            COMPILE_DEFINITIONS ${BIKE_R3_PCLMUL_FLAGS})
++        try_compile(
++                BIKE_R3_PCLMUL_SUPPORTED
++                ${CMAKE_BINARY_DIR}
++                SOURCES
++                "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
++                "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/bike_r3/gf2x_mul_base_pclmul.c"
++                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_SOURCE_DIR}"
++                COMPILE_DEFINITIONS "${BIKE_R3_PCLMUL_FLAGS} -DS2N_BIKE_R3_PCLMUL"
++        )
+ 
+         set(BIKE_R3_VPCLMUL_FLAGS "-mvpclmulqdq -mavx512f -mavx512bw -mavx512dq")
+-        try_compile(BIKE_R3_VPCLMUL_SUPPORTED
+-            ${CMAKE_BINARY_DIR}
+-            "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
+-            COMPILE_DEFINITIONS ${BIKE_R3_VPCLMUL_FLAGS})
++        try_compile(
++                BIKE_R3_VPCLMUL_SUPPORTED
++                ${CMAKE_BINARY_DIR}
++                SOURCES
++                "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
++                "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/bike_r3/gf2x_mul_base_vpclmul.c"
++                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES:STRING=${CMAKE_SOURCE_DIR}"
++                COMPILE_DEFINITIONS "${BIKE_R3_VPCLMUL_FLAGS} -DS2N_BIKE_R3_VPCLMUL"
++        )
+ 
+         if(BIKE_R3_AVX2_SUPPORTED OR BIKE_R3_AVX512_SUPPORTED OR BIKE_R3_PCLMUL_SUPPORTED OR BIKE_R3_VPCLMUL_SUPPORTED)
+             set(BIKE_R3_X86_64_OPT_SUPPORTED ON)
+@@ -312,31 +333,36 @@ if(BIKE_R3_X86_64_OPT_SUPPORTED)
+     # If any of the BIKE_R3 x86_64 optimizations is supported (this was checked
+     # earlier in the file), we add the required compile flags to files that
+     # contain the optimized code.
++
++    message(STATUS "Enabling BIKE_R3 x86_64 optimizations")
++
+     if(BIKE_R3_AVX2_SUPPORTED)
++        message(STATUS "\t Enabling BIKE_R3_AVX2")
+         FILE(GLOB BIKE_R3_AVX2_SRCS "pq-crypto/bike_r3/*_avx2.c")
+         set_source_files_properties(${BIKE_R3_AVX2_SRCS} PROPERTIES COMPILE_FLAGS -mavx2)
+         target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BIKE_R3_AVX2)
+     endif()
+ 
+     if(BIKE_R3_AVX512_SUPPORTED)
++        message(STATUS "\t Enabling BIKE_R3_AVX512")
+         FILE(GLOB BIKE_R3_AVX512_SRCS "pq-crypto/bike_r3/*_avx512.c")
+         set_source_files_properties(${BIKE_R3_AVX512_SRCS} PROPERTIES COMPILE_FLAGS ${BIKE_R3_AVX512_FLAGS})
+         target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BIKE_R3_AVX512)
+     endif()
+ 
+     if(BIKE_R3_PCLMUL_SUPPORTED)
++        message(STATUS "\t Enabling BIKE_R3_PCLMUL")
+         FILE(GLOB BIKE_R3_PCLMUL_SRCS "pq-crypto/bike_r3/*_pclmul.c")
+         set_source_files_properties(${BIKE_R3_PCLMUL_SRCS} PROPERTIES COMPILE_FLAGS ${BIKE_R3_PCLMUL_FLAGS})
+         target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BIKE_R3_PCLMUL)
+     endif()
+ 
+     if(BIKE_R3_VPCLMUL_SUPPORTED)
++        message(STATUS "\t Enabling BIKE_R3_VPCLMUL")
+         FILE(GLOB BIKE_R3_VPCLMUL_SRCS "pq-crypto/bike_r3/*_vpclmul.c")
+         set_source_files_properties(${BIKE_R3_VPCLMUL_SRCS} PROPERTIES COMPILE_FLAGS ${BIKE_R3_VPCLMUL_FLAGS})
+         target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BIKE_R3_VPCLMUL)
+     endif()
+-
+-    message(STATUS "Enabling BIKE_R3 x86_64 optimizations")
+ endif()
+ 
+ if(KYBER512R3_AVX2_BMI2_OPT_SUPPORTED)


### PR DESCRIPTION
Specify library name and version:  **s2n/1.1.0** and **s2n/1.0.11**

backport upstream fix from https://github.com/aws/s2n-tls/pull/3219 to solve #8876

fixes #8876

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
