### PR TITLE
Downgrade tesseract recipe minimum gcc to >=7

### DIFF
--- a/recipes/tesseract/all/conanfile.py
+++ b/recipes/tesseract/all/conanfile.py
@@ -82,7 +82,7 @@ class TesseractConan(ConanFile):
             # 5.0.0 requires C++-17 compiler
             minimal_version = {
                 "Visual Studio": "16",
-                "gcc": "9",
+                "gcc": "7",
                 "clang": "7",
                 "apple-clang": "11"
             }


### PR DESCRIPTION
Specify library name and version:  **tesseract/5.0 + tesseract/5.1**

[Submitting this PR to address issue I created.](https://github.com/conan-io/conan-center-index/issues/9678)

closes #9678

---

- [ X ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ X ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ X ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ X ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
