### PR TITLE
minizip-ng: add version 3.0.5

### DIFF
--- a/recipes/minizip-ng/all/conandata.yml
+++ b/recipes/minizip-ng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.5":
+    url: "https://github.com/zlib-ng/minizip-ng/archive/3.0.5.tar.gz"
+    sha256: "1a248c378fdf4ef6c517024bb65577603d5146cffaebe81900bec9c0a5035d4d"
   "3.0.4":
     url: "https://github.com/zlib-ng/minizip-ng/archive/3.0.4.tar.gz"
     sha256: "2ab219f651901a337a7d3c268128711b80330a99ea36bdc528c76b591a624c3c"

--- a/recipes/minizip-ng/config.yml
+++ b/recipes/minizip-ng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.5":
+    folder: all
   "3.0.4":
     folder: all
   "3.0.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **minizip-ng/3.0.5**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
