### PR TITLE
Add shared and static flags to diligent core

### DIFF
--- a/recipes/diligent-core/all/CMakeLists.txt
+++ b/recipes/diligent-core/all/CMakeLists.txt
@@ -4,10 +4,4 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-get_cmake_property(_variableNames VARIABLES)
-list (SORT _variableNames)
-foreach (_variableName ${_variableNames})
-message(STATUS "${_variableName}=${${_variableName}}")
-endforeach()
-
 add_subdirectory(source_subfolder)

--- a/recipes/diligent-core/all/CMakeLists.txt
+++ b/recipes/diligent-core/all/CMakeLists.txt
@@ -4,6 +4,6 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(glslang)
+find_package(glslang CONFIG REQUIRED)
 
 add_subdirectory(source_subfolder)

--- a/recipes/diligent-core/all/CMakeLists.txt
+++ b/recipes/diligent-core/all/CMakeLists.txt
@@ -4,4 +4,6 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
+find_package(glslang)
+
 add_subdirectory(source_subfolder)

--- a/recipes/diligent-core/all/CMakeLists.txt
+++ b/recipes/diligent-core/all/CMakeLists.txt
@@ -4,4 +4,10 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
+get_cmake_property(_variableNames VARIABLES)
+list (SORT _variableNames)
+foreach (_variableName ${_variableNames})
+message(STATUS "${_variableName}=${${_variableName}}")
+endforeach()
+
 add_subdirectory(source_subfolder)

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -158,7 +158,8 @@ class DiligentCoreConan(ConanFile):
             self.copy(pattern="*.so", dst="lib", keep_path=False)
             self.copy(pattern="*.dll", dst="bin", keep_path=False)
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.a")
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.lib")
+            if self.settings.os is not "Windows":
+                tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.lib")
         else:
             self.copy(pattern="*.a", dst="lib", keep_path=False)
             self.copy(pattern="*.lib", dst="lib", keep_path=False)

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -21,7 +21,7 @@ class DiligentCoreConan(ConanFile):
         "shared": False	,
         "fPIC": True,
     }
-    generators = "cmake_find_package", "cmake"
+    generators = "cmake_find_package", "cmake", "cmake_find_package_multi"
     _cmake = None
     exports_sources = ["CMakeLists.txt", "patches/**"]
     short_paths = True

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -18,7 +18,7 @@ class DiligentCoreConan(ConanFile):
         "fPIC":   [True, False],
     }
     default_options = {
-        "shared": False,
+        "shared": False	,
         "fPIC": True,
     }
     generators = "cmake_find_package", "cmake"
@@ -72,7 +72,7 @@ class DiligentCoreConan(ConanFile):
                 self.info.settings.compiler.runtime = "MT/MTd"
 
     def config_options(self):
-        if self.settings.os == "Windows":
+        if self.settings.os == "Windows" or self.options.shared:
             del self.options.fPIC
 
     def _patch_sources(self):

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -14,9 +14,11 @@ class DiligentCoreConan(ConanFile):
     topics = ("graphics")
     settings = "os", "compiler", "build_type", "arch"
     options = {
-        "fPIC": [True, False],
+        "shared": [True, False],
+        "fPIC":   [True, False],
     }
     default_options = {
+        "shared": True,
         "fPIC": True,
     }
     generators = "cmake_find_package", "cmake"
@@ -148,11 +150,14 @@ class DiligentCoreConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "bin"))
         self.copy("License.txt", dst="licenses", src=self._source_subfolder)
 
-        self.copy(pattern="*.a", dst="lib", keep_path=False)
-        self.copy(pattern="*.lib", dst="lib", keep_path=False)
-        self.copy(pattern="*.dylib", dst="lib", keep_path=False)
-        self.copy(pattern="*.so", dst="lib", keep_path=False)
-        self.copy(pattern="*.dll", dst="bin", keep_path=False)
+        if self.options.shared:
+            self.copy(pattern="*.dylib", dst="lib", keep_path=False)
+            self.copy(pattern="*.so", dst="lib", keep_path=False)
+            self.copy(pattern="*.dll", dst="bin", keep_path=False)
+        else:
+            self.copy(pattern="*.a", dst="lib", keep_path=False)
+            self.copy(pattern="*.lib", dst="lib", keep_path=False)
+
         self.copy(pattern="*.fxh", dst="res", keep_path=False)
 
         self.copy("File2String*", src=os.path.join(self._build_subfolder, "bin"), dst="bin", keep_path=False)

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -154,9 +154,14 @@ class DiligentCoreConan(ConanFile):
             self.copy(pattern="*.dylib", dst="lib", keep_path=False)
             self.copy(pattern="*.so", dst="lib", keep_path=False)
             self.copy(pattern="*.dll", dst="bin", keep_path=False)
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.a")
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.lib")
         else:
             self.copy(pattern="*.a", dst="lib", keep_path=False)
             self.copy(pattern="*.lib", dst="lib", keep_path=False)
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.dylib")
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.so")
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.dll")
 
         self.copy(pattern="*.fxh", dst="res", keep_path=False)
 

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -130,6 +130,7 @@ class DiligentCoreConan(ConanFile):
         self._cmake.definitions["DILIGENT_BUILD_TESTS"] = False
         self._cmake.definitions["DILIGENT_NO_DXC"] = True
         self._cmake.definitions["SPIRV_CROSS_NAMESPACE_OVERRIDE"] = self.options["spirv-cross"].namespace
+        self._cmake.definitions["BUILD_SHARED_LIBS"] = False
 
         self._cmake.definitions["ENABLE_RTTI"] = True
         self._cmake.definitions["ENABLE_EXCEPTIONS"] = True

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -97,8 +97,6 @@ class DiligentCoreConan(ConanFile):
         self.requires("vulkan-headers/1.2.198")
         self.requires("volk/1.2.198")
         self.requires("glslang/11.7.0")
-        if self.settings.compiler == "apple-clang":
-            self.options["glslang"].shared = True
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("xorg/system")

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -18,7 +18,7 @@ class DiligentCoreConan(ConanFile):
         "fPIC":   [True, False],
     }
     default_options = {
-        "shared": True,
+        "shared": False,
         "fPIC": True,
     }
     generators = "cmake_find_package", "cmake"

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -71,8 +71,12 @@ class DiligentCoreConan(ConanFile):
             else:
                 self.info.settings.compiler.runtime = "MT/MTd"
 
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
     def config_options(self):
-        if self.settings.os == "Windows" or self.options.shared:
+        if self.settings.os == "Windows":
             del self.options.fPIC
 
     def _patch_sources(self):

--- a/recipes/diligent-core/all/patches/0002-use_conan_dependencies.patch
+++ b/recipes/diligent-core/all/patches/0002-use_conan_dependencies.patch
@@ -37,7 +37,7 @@ index 00e634263..a7519f23e 100644
 -            SPIRV
 -            glslang
 +            CONAN_PKG::spirv-tools
-+            CONAN_PKG::glslang
++            glslang::glslang
          )
  
          target_include_directories(Diligent-ShaderTools
@@ -119,7 +119,7 @@ index e329495f4..f2adeccdd 100644
 -            target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:DEBUG>:/Ob1>")
 -        endforeach()
 -    endif()
-+    list(APPEND THIRD_PARTY_LIBS CONAN_PKG::spirv-tools CONAN_PKG::spirv-cross CONAN_PKG::glslang)
++    list(APPEND THIRD_PARTY_LIBS CONAN_PKG::spirv-tools CONAN_PKG::spirv-cross glslang::glslang)
  
      # Make sure that symbols do not leak out when third-party
      # libs are linked into shared libraries

--- a/recipes/diligent-core/all/patches/0002-use_conan_dependencies.patch
+++ b/recipes/diligent-core/all/patches/0002-use_conan_dependencies.patch
@@ -37,7 +37,7 @@ index 00e634263..a7519f23e 100644
 -            SPIRV
 -            glslang
 +            spirv-tools::SPIRV-Tools-opt
-+            glslang::glslang
++            glslang::SPIRV glslang::glslang glslang::MachineIndependent glslang::GenericCodeGen glslang::OSDependent glslang::OGLCompiler glslang::HLSL
          )
  
          target_include_directories(Diligent-ShaderTools
@@ -119,7 +119,7 @@ index e329495f4..f2adeccdd 100644
 -            target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:DEBUG>:/Ob1>")
 -        endforeach()
 -    endif()
-+    list(APPEND THIRD_PARTY_LIBS spirv-tools::SPIRV-Tools-opt CONAN_PKG::spirv-cross glslang::glslang)
++    list(APPEND THIRD_PARTY_LIBS spirv-tools::SPIRV-Tools-opt CONAN_PKG::spirv-cross glslang::SPIRV glslang::glslang glslang::MachineIndependent glslang::GenericCodeGen glslang::OSDependent glslang::OGLCompiler glslang::HLSL)
  
      # Make sure that symbols do not leak out when third-party
      # libs are linked into shared libraries

--- a/recipes/diligent-core/all/patches/0002-use_conan_dependencies.patch
+++ b/recipes/diligent-core/all/patches/0002-use_conan_dependencies.patch
@@ -7,7 +7,7 @@ index 387b3b019..e760513de 100644
      message("HLSL support is disabled. Vulkan backend will not be able to consume SPIRV bytecode generated from HLSL.")
  else()
 -    list(APPEND PRIVATE_DEPENDENCIES SPIRV-Tools-opt)
-+    list(APPEND PRIVATE_DEPENDENCIES CONAN_PKG::spirv-tools)
++    list(APPEND PRIVATE_DEPENDENCIES spirv-tools::SPIRV-Tools-opt)
  endif()
  
  # Use DirectX shader compiler for SPIRV.
@@ -27,7 +27,7 @@ index 00e634263..a7519f23e 100644
          target_link_libraries(Diligent-ShaderTools
          PRIVATE
 -            SPIRV-Tools-opt
-+            CONAN_PKG::spirv-tools
++            spirv-tools::SPIRV-Tools-opt
          )
      endif()
  
@@ -36,7 +36,7 @@ index 00e634263..a7519f23e 100644
          PRIVATE
 -            SPIRV
 -            glslang
-+            CONAN_PKG::spirv-tools
++            spirv-tools::SPIRV-Tools-opt
 +            glslang::glslang
          )
  
@@ -119,7 +119,7 @@ index e329495f4..f2adeccdd 100644
 -            target_compile_options(${TARGET} PRIVATE "$<$<CONFIG:DEBUG>:/Ob1>")
 -        endforeach()
 -    endif()
-+    list(APPEND THIRD_PARTY_LIBS CONAN_PKG::spirv-tools CONAN_PKG::spirv-cross glslang::glslang)
++    list(APPEND THIRD_PARTY_LIBS spirv-tools::SPIRV-Tools-opt CONAN_PKG::spirv-cross glslang::glslang)
  
      # Make sure that symbols do not leak out when third-party
      # libs are linked into shared libraries


### PR DESCRIPTION
Specify library name and version:  **diligent-core/2.5.1**

introduce shared flag for diligent-core.
The lib always produce two sets of libs: static and dynamic. All we need, is to delete another set in package method

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
