### PR TITLE
mpg123: Add version 1.29.3

### DIFF
--- a/recipes/mpg123/all/conandata.yml
+++ b/recipes/mpg123/all/conandata.yml
@@ -2,7 +2,15 @@ sources:
   "1.26.4":
     url: "https://sourceforge.net/projects/mpg123/files/mpg123/1.26.4/mpg123-1.26.4.tar.bz2"
     sha256: "081991540df7a666b29049ad870f293cfa28863b36488ab4d58ceaa7b5846454"
+  "1.29.3":
+    url: "https://sourceforge.net/projects/mpg123/files/mpg123/1.29.3/mpg123-1.29.3.tar.bz2"
+    sha256: "963885d8cc77262f28b77187c7d189e32195e64244de2530b798ddf32183e847"
 patches:
   "1.26.4":
     - patch_file: "patches/0001-msvc-export-symbols.patch"
+      base_path: "source_subfolder"
+  "1.29.3":
+    - patch_file: "patches/0001-msvc-export-symbols.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-cmake-read_api_version-fix.patch"
       base_path: "source_subfolder"

--- a/recipes/mpg123/all/conanfile.py
+++ b/recipes/mpg123/all/conanfile.py
@@ -116,6 +116,7 @@ class Mpg123Conan(ConanFile):
             "--enable-layer2={}".format(yes_no(self.options.layer2)),
             "--enable-layer3={}".format(yes_no(self.options.layer3)),
             "--with-audio={}".format(self._audio_module),
+            "--with-default-audio={}".format(self._audio_module),
             "--with-seektable={}".format(self.options.seektable),
             "--enable-modules=no",
             "--enable-shared={}".format(yes_no(self.options.shared)),

--- a/recipes/mpg123/all/patches/0002-cmake-read_api_version-fix.patch
+++ b/recipes/mpg123/all/patches/0002-cmake-read_api_version-fix.patch
@@ -1,0 +1,10 @@
+--- a/ports/cmake/cmake/read_api_version.cmake
++++ b/ports/cmake/cmake/read_api_version.cmake
+@@ -1,6 +1,6 @@
+ function(read_api_version project_version api_version outapi_version synapi_version )
+ 
+-    file( READ "${CMAKE_SOURCE_DIR}/../../configure.ac" configure_ac )
++    file( READ "${CMAKE_CURRENT_SOURCE_DIR}/../../configure.ac" configure_ac )
+ 
+     string( REGEX MATCH "AC_INIT\\(\\[mpg123\\], \\[([0-9\\.]+)" result ${configure_ac} )
+     set( ${project_version} ${CMAKE_MATCH_1} PARENT_SCOPE )

--- a/recipes/mpg123/config.yml
+++ b/recipes/mpg123/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.26.4":
     folder: "all"
+  "1.29.3":
+    folder: "all"


### PR DESCRIPTION
**mpg123/1.29.3**

* Added the latest version 1.29.3 to recipe.
* Fixed build error according to suggestion from [https://sourceforge.net/p/mpg123/bugs/333/](https://sourceforge.net/p/mpg123/bugs/333/). Double checked that it doesn't break the build of the previous version 1.26.4.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
