### PR TITLE
[hana] Bump version boost-1.78.0

### DIFF
--- a/recipes/hana/all/conandata.yml
+++ b/recipes/hana/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "boost-1.78.0":
+    url: "https://github.com/boostorg/hana/archive/boost-1.78.0.tar.gz"
+    sha256: "f713c2888e849f66b90c01fecb69924538a2d1440bfa432d92c8f600bc98ad49"
   "boost-1.74.0":
     url: "https://github.com/boostorg/hana/archive/boost-1.74.0.tar.gz"
     sha256: "d50b366aca035b7fbeaf1cadc3bad0edd9d68d98b297dcf9473bbfb0f52408b8"

--- a/recipes/hana/config.yml
+++ b/recipes/hana/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "boost-1.78.0":
+    folder: all
   "boost-1.74.0":
     folder: all
   "1.6.0":


### PR DESCRIPTION
Specify library name and version:  **hana/boost-1.78.0**

Bump package version

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
