### PR TITLE
opentdf-client: add version 0.6.0

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.0":
+    url: "https://github.com/opentdf/client-cpp/archive/0.6.0.tar.gz"
+    sha256: "4237bc8e60624255c2778225aef6a88cd9045fb2850a0c685f0d2492a00a51b2"
   "0.5.3":
     url: https://github.com/opentdf/client-cpp/archive/refs/tags/0.5.3.zip
     sha256: "e30b745d7a83cc10a42db9f0e85a06e95d3c8693b274c5b13d1fe205e2725146"

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.0":
+    folder: all
   "0.5.3":
     folder: all
   "0.5.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **opentdf-client/0.6.0**

- Updated network provider interface to support PKI
- Added more diagnostics

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
