### PR TITLE
xmlsec: relocatable shared libs on macOS + reproducible build

### DIFF
--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -226,7 +226,7 @@ class XmlSecConan(ConanFile):
         else:
             self.cpp_info.components["libxmlsec"].defines.append("XMLSEC_NO_XSLT=1")
         self.cpp_info.components["libxmlsec"].defines.extend(["XMLSEC_NO_SIZE_T", "XMLSEC_NO_GOST=1", "XMLSEC_NO_CRYPTO_DYNAMIC_LOADING=1"])
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libxmlsec"].system_libs = ["m", "dl", "pthread"]
         if self.settings.os == "Windows":
             self.cpp_info.components["libxmlsec"].system_libs = ["crypt32", "ws2_32", "advapi32", "user32", "bcrypt"]

--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -183,6 +183,8 @@ class XmlSecConan(ConanFile):
         else:
             with tools.chdir(self._source_subfolder):
                 self.run("{} -fiv".format(tools.get_env("AUTORECONF")), run_environment=True, win_bash=tools.os_info.is_windows)
+                # relocatable shared lib on macOS
+                tools.replace_in_file("configure", "-install_name \\$rpath/", "-install_name @rpath/")
             autotools = self._configure_autotools()
             autotools.make()
 

--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -21,11 +21,17 @@ class XmlSecConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_openssl": [True, False],
+        "with_nss": [True, False],
+        "with_gcrypt": [True, False],
+        "with_gnutls": [True, False],
         "with_xslt": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_nss": False,
+        "with_gcrypt": False,
+        "with_gnutls": False,
         "with_openssl": True,
         "with_xslt": False,
     }
@@ -62,7 +68,13 @@ class XmlSecConan(ConanFile):
             self.requires("libxslt/1.1.34")
 
     def validate(self):
-        if not self.options.with_openssl:
+        if self.options.with_nss:
+            raise ConanInvalidConfiguration("xmlsec with nss not supported yet in this recice")
+        if self.options.with_gcrypt:
+            raise ConanInvalidConfiguration("xmlsec with gcrypt not supported yet in this recice")
+        if self.options.with_gnutls:
+            raise ConanInvalidConfiguration("xmlsec with gnutls not supported yet in this recice")
+        if not (self.options.with_openssl or self.options.with_nss or self.options.with_gcrypt or self.options.with_gnutls):
             raise ConanInvalidConfiguration("At least one crypto engine needs to be enabled")
 
     def build_requirements(self):
@@ -150,6 +162,10 @@ class XmlSecConan(ConanFile):
             "--enable-apps-crypto-dl={}".format(yes_no(False)),
             "--with-libxslt={}".format(yes_no(self.options.with_xslt)),
             "--with-openssl={}".format(yes_no(self.options.with_openssl)),
+            "--with-nss={}".format(yes_no(self.options.with_nss)),
+            "--with-nspr={}".format(yes_no(self.options.with_nss)),
+            "--with-gcrypt={}".format(yes_no(self.options.with_gcrypt)),
+            "--with-gnutls={}".format(yes_no(self.options.with_gnutls)),
             "--enable-mscrypto={}".format(yes_no(False)),   # Built on mingw
             "--enable-mscng={}".format(yes_no(False)),      # Build on mingw
             "--enable-docs=no",

--- a/recipes/xmlsec/all/test_package/CMakeLists.txt
+++ b/recipes/xmlsec/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-CONAN_BASIC_SETUP(TARGETS)
+conan_basic_setup(TARGETS)
+
+find_package(xmlsec REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} sign1.c)
-target_link_libraries(${PROJECT_NAME} CONAN_PKG::xmlsec)
+target_link_libraries(${PROJECT_NAME} xmlsec::xmlsec)

--- a/recipes/xmlsec/all/test_package/conanfile.py
+++ b/recipes/xmlsec/all/test_package/conanfile.py
@@ -3,8 +3,8 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/xmlsec/all/test_package/conanfile.py
+++ b/recipes/xmlsec/all/test_package/conanfile.py
@@ -6,6 +6,15 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
+    def build_requirements(self):
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            # Workaround for CMake bug with error message:
+            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
+            # set. This could be because you are using a Mac OS X version less than 10.5
+            # or because CMake's platform configuration is corrupt.
+            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
+            self.build_requires("cmake/3.22.0")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- reproducible build by adding options with_nss, with_gcrypt and with_gnutls (otherwise the build is free to build more libs depending on what is found on the build machine).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
