### PR TITLE
add enhex-generic_serialization recipe

### DIFF
--- a/recipes/enhex-generic_serialization/all/conandata.yml
+++ b/recipes/enhex-generic_serialization/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0":
+    url: "https://github.com/Enhex/generic_serialization/archive/refs/tags/v1.0.0.zip"
+    sha256: a3a09fb0c026662a06075fbcf993458d9611db03cb8fdc6db31268afa9314400

--- a/recipes/enhex-generic_serialization/all/conanfile.py
+++ b/recipes/enhex-generic_serialization/all/conanfile.py
@@ -1,0 +1,50 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+class EnhexGenericserializationConan(ConanFile):
+    name = "enhex-generic_serialization"
+    license = "MIT"
+    description = "Lightweight and extensible generic serialization library"
+    topics = ("serialization")
+    homepage = "https://github.com/Enhex/generic_serialization"
+    url = "https://github.com/conan-io/conan-center-index"
+    no_copy_source = True
+    settings = ("compiler")
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 17)
+
+        minimal_version = {
+            "Visual Studio": "15",
+            "gcc": "7",
+            "clang": "5.0",
+            "apple-clang": "9.1"
+        }
+        compiler = str(self.settings.compiler)
+        compiler_version = tools.Version(self.settings.compiler.version)
+
+        if compiler not in minimal_version:
+            self.output.info("{} requires a compiler that supports at least C++17".format(self.name))
+            return
+
+        # Exclude compilers not supported
+        if compiler_version < minimal_version[compiler]:
+            raise ConanInvalidConfiguration("{} requires a compiler that supports at least C++17. {} {} is not".format(
+                self.name, compiler, tools.Version(self.settings.compiler.version.value)))
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/enhex-generic_serialization/all/test_package/CMakeLists.txt
+++ b/recipes/enhex-generic_serialization/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(enhex-generic_serialization CONFIG REQUIRED)
+
+add_executable(example example.cpp)
+target_link_libraries(example enhex-generic_serialization::enhex-generic_serialization)
+set_target_properties(example PROPERTIES CXX_STANDARD 17)

--- a/recipes/enhex-generic_serialization/all/test_package/conanfile.py
+++ b/recipes/enhex-generic_serialization/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class EnhexGenericserializationTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/enhex-generic_serialization/all/test_package/example.cpp
+++ b/recipes/enhex-generic_serialization/all/test_package/example.cpp
@@ -1,0 +1,131 @@
+#define _CRT_SECURE_NO_WARNINGS
+
+#include <gs/binary.h>
+#include <cassert>
+#include <iostream>
+
+using namespace std;
+
+
+// Example for serializing a POD type (without references/pointers since memory addresses change)
+struct Vector3 {
+	float x, y, z;
+
+	void print() const {
+		std::cout <<
+			"x: " << x << '\n' <<
+			"x: " << y << '\n' <<
+			"y: " << z << '\n';
+	}
+};
+
+namespace gs
+{
+template<typename Stream>
+void serialize(Stream& stream, Vector3& value) {
+	gs::read_or_write_bytes(stream, value);
+}
+}
+
+
+// example class
+struct A
+{
+	int x = 0;
+	float y = 0;
+	char z[3];
+	Vector3 vec3;
+
+	void print() const {
+		cout
+			<< "x: " << x << '\n'
+			<< "x: " << y << '\n'
+			<< "z: " << z << '\n'
+			<< "vec3:\n";
+		vec3.print();
+
+	}
+};
+
+namespace gs
+{
+	//TODO alternatively can be a member function so we don't have to pass A and we can access members directly. Requires using SFINAE to check if the method is available.
+	template<typename Stream>
+	void serialize(Stream& stream, A& value) {
+		// choose which members to serialize
+		gs::serializer(stream, value.x, value.y, value.z, value.vec3);	// members' types' already have serialization implemented
+	}
+}
+
+
+#include <gs/serializer.h>
+
+
+namespace test
+{
+	void serialization()
+	{
+		A a;
+
+		a.x = 5;
+		a.y = 7.5;
+		a.z[0] = 'a';
+		a.z[1] = 'b';
+		a.z[2] = '\0';
+		a.vec3 = { 1,2,3 };
+
+		puts("writing:");
+		puts("========");
+		a.print();
+		putchar('\n');
+
+		// serialize to file
+		{
+			ofstream f("test", ofstream::binary);
+			//auto& f = *static_cast<gs::oFile*>(fopen("test", "wb"));
+			
+			gs::serializer(f, a);
+
+			//fclose(&f);
+		}
+
+		a.x = 0;
+		a.y = 0;
+		a.z[0] = '0';
+		a.z[1] = '0';
+		a.vec3 = { 0,0,0 };
+
+		// read back from file
+		{
+			ifstream f("test", ios::binary);
+			//auto& f = *static_cast<gs::iFile*>(fopen("test", "rb"));
+
+			gs::serializer(f, a);
+
+			//fclose(&f);
+		}
+
+		puts("reading:");
+		puts("========");
+		a.print();
+		putchar('\n');
+
+		assert(a.x == 5);
+		assert(a.y == 7.5);
+		assert(a.z[0] == 'a');
+		assert(a.z[1] == 'b');
+		assert(a.z[2] == '\0');
+		assert(a.vec3.x == 1);
+		assert(a.vec3.y == 2);
+		assert(a.vec3.z == 3);
+	}
+}
+
+
+int main()
+{
+	puts("Serialization test");
+	puts("==================");
+
+	test::serialization();
+}

--- a/recipes/enhex-generic_serialization/config.yml
+++ b/recipes/enhex-generic_serialization/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **enhex-generic_serialization/1.0.0**

This is a library of mine.
It's the second and last dependency for adding a recipe for https://github.com/Enhex/Deco

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
