### PR TITLE
vk-bootstrap: relocatable shared lib on macOS + bump vulkan-headers

### DIFF
--- a/recipes/vk-bootstrap/all/CMakeLists.txt
+++ b/recipes/vk-bootstrap/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.10)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/vk-bootstrap/all/conanfile.py
+++ b/recipes/vk-bootstrap/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import functools
 
 required_conan_version = ">=1.33.0"
 
@@ -23,7 +24,6 @@ class VkBootstrapConan(ConanFile):
     }
 
     generators = "cmake"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -77,17 +77,16 @@ class VkBootstrapConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["VK_BOOTSTRAP_TEST"] = False
+        cmake = CMake(self)
+        cmake.definitions["VK_BOOTSTRAP_TEST"] = False
         if tools.Version(self.version) >= "0.3.0":
-            self._cmake.definitions["VK_BOOTSTRAP_VULKAN_HEADER_DIR"] = ";".join(self.deps_cpp_info["vulkan-headers"].include_paths)
+            cmake.definitions["VK_BOOTSTRAP_VULKAN_HEADER_DIR"] = ";".join(self.deps_cpp_info["vulkan-headers"].include_paths)
         if tools.Version(self.version) >= "0.4.0":
-            self._cmake.definitions["VK_BOOTSTRAP_WERROR"] = False
-        self._cmake.configure()
-        return self._cmake
+            cmake.definitions["VK_BOOTSTRAP_WERROR"] = False
+        cmake.configure()
+        return cmake
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/vk-bootstrap/all/conanfile.py
+++ b/recipes/vk-bootstrap/all/conanfile.py
@@ -29,6 +29,10 @@ class VkBootstrapConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+
     def export_sources(self):
         self.copy("CMakeLists.txt")
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -70,7 +74,7 @@ class VkBootstrapConan(ConanFile):
         elif lazy_lt_semver(str(self.settings.compiler.version), minimum_version):
             raise ConanInvalidConfiguration("vk-bootstrap requires C++14, which your compiler does not support.")
 
-        if self.settings.compiler == "Visual Studio" and self.options.shared:
+        if self._is_msvc and self.options.shared:
             raise ConanInvalidConfiguration("vk-boostrap shared not supported with Visual Studio")
 
     def source(self):

--- a/recipes/vk-bootstrap/all/conanfile.py
+++ b/recipes/vk-bootstrap/all/conanfile.py
@@ -43,7 +43,7 @@ class VkBootstrapConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("vulkan-headers/1.2.198.0")
+        self.requires("vulkan-headers/1.3.204.1")
 
     @property
     def _compilers_minimum_version(self):

--- a/recipes/vk-bootstrap/all/test_package/CMakeLists.txt
+++ b/recipes/vk-bootstrap/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(vk-bootstrap REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} vk-bootstrap::vk-bootstrap)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)

--- a/recipes/vk-bootstrap/all/test_package/conanfile.py
+++ b/recipes/vk-bootstrap/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- bump `vulkan-headers` to 1.3.204.1
- cache CMake configuration with lru_cache
- use cmake_find_package_multi in test package

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
