### PR TITLE
c-dbg-macro: A set of dbg(…) macros for C

### DIFF
--- a/recipes/c-dbg-macro/all/conandata.yml
+++ b/recipes/c-dbg-macro/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.12.1":
+    url: https://github.com/eerimoq/dbg-macro/archive/0.12.1.tar.gz
+    sha256: 8567730747c8f18cf01748819ebd178bcd9f9ca54431e124b9fda9f0616db751

--- a/recipes/c-dbg-macro/all/conanfile.py
+++ b/recipes/c-dbg-macro/all/conanfile.py
@@ -24,9 +24,7 @@ class DbgMacroConan(ConanFile):
             raise ConanInvalidConfiguration("This library is not compatible with Windows")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "dbg-macro-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy("include/dbg.h", dst=".", src=self._source_subfolder)

--- a/recipes/c-dbg-macro/all/conanfile.py
+++ b/recipes/c-dbg-macro/all/conanfile.py
@@ -1,0 +1,34 @@
+import os
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+
+
+class DbgMacroConan(ConanFile):
+    name = "c-dbg-macro"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/eerimoq/dbg-macro"
+    license = "MIT"
+    description = "A dbg(...) macro for C"
+    topics = ("conan", "debugging", "macro", "pretty-printing", "header-only")
+    settings = ("compiler",  "build_type", "os", "arch")
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def validate(self):
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration("This library is not compatible with Windows")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "dbg-macro-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def package(self):
+        self.copy("include/dbg.h", dst=".", src=self._source_subfolder)
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/c-dbg-macro/all/conanfile.py
+++ b/recipes/c-dbg-macro/all/conanfile.py
@@ -1,4 +1,3 @@
-import os
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 

--- a/recipes/c-dbg-macro/all/conanfile.py
+++ b/recipes/c-dbg-macro/all/conanfile.py
@@ -3,6 +3,8 @@ from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 
 
+required_conan_version = ">=1.33.0"
+
 class DbgMacroConan(ConanFile):
     name = "c-dbg-macro"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/c-dbg-macro/all/test_package/CMakeLists.txt
+++ b/recipes/c-dbg-macro/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(test_package test_package.c)

--- a/recipes/c-dbg-macro/all/test_package/conanfile.py
+++ b/recipes/c-dbg-macro/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/c-dbg-macro/all/test_package/conanfile.py
+++ b/recipes/c-dbg-macro/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+    
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/c-dbg-macro/all/test_package/test_package.c
+++ b/recipes/c-dbg-macro/all/test_package/test_package.c
@@ -1,0 +1,30 @@
+#include <errno.h>
+#include <dbg.h>
+
+static int factorial(int n)
+{
+    if (dbgb(n <= 1)) {
+        return dbg(1);
+    } else {
+        return dbg(n * factorial(n - 1));
+    }
+}
+
+int main()
+{
+    char message[] = "hello";
+    dbg(message);  // main.c:15: message = "hello"
+    dbgh(message, sizeof(message));
+
+    const int a = 2;
+    const int b = dbg(3 * a) + 1;  // main.c:19: 3 * a = 6 (0x6)
+
+    int numbers[2] = { b, 13 };
+    dbga(numbers, 2);  // main.c:22: numbers = [7, 13] (length: 2)
+
+    dbg(factorial(4));
+    dbge(-EINVAL);
+    dbgbt();
+
+    return 0;
+}

--- a/recipes/c-dbg-macro/config.yml
+++ b/recipes/c-dbg-macro/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.12.1":
+    folder: "all"


### PR DESCRIPTION
Add version 0.12.1.

A few macros that prints and returns the value of a given expression
for quick and dirty debugging, inspired by Rusts dbg!(…) macro and its
C++ variant.

* dbg(expr) for primitive data types (int, float, etc.), strings and pointers.

* dbgb(expr) to force boolean true/false output.

* dbga(expr, length) for array of primitive data types.

* dbgh(expr, size) for hexdump output.

* dbge(expr) for negative error codes.

* dbgbt() for a backtrace.

Just include dbg.h in your project to use it.
