### PR TITLE
harfbuzz: add version 4.0.1

### DIFF
--- a/recipes/harfbuzz/all/CMakeLists.txt
+++ b/recipes/harfbuzz/all/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 set(THIRD_PARTY_LIBS ${CONAN_LIBS})
 

--- a/recipes/harfbuzz/all/conandata.yml
+++ b/recipes/harfbuzz/all/conandata.yml
@@ -27,23 +27,26 @@ sources:
     url: "https://github.com/harfbuzz/harfbuzz/releases/download/2.9.0/harfbuzz-2.9.0.tar.xz"
     sha256: "3e1c2e1d2c65d56364fd16d1c41a06b2a35795496f78dfff635c2b7414b54c5a"
   "2.9.1":
-    url: "https://github.com/harfbuzz/harfbuzz/archive/2.9.1.tar.gz"
-    sha256: "f997abd0e3b90647408bfb01af2383b5fc9557af20137e7c2deaf2fa13705dc8"
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/2.9.1/harfbuzz-2.9.1.tar.xz"
+    sha256: "0edcc980f526a338452180e701d6aba6323aef457b6686976a7d17ccbddc51cf"
   "3.0.0":
     url: "https://github.com/harfbuzz/harfbuzz/releases/download/3.0.0/harfbuzz-3.0.0.tar.xz"
     sha256: "036b0ee118451539783ec7864148bb4106be42a2eb964df4e83e6703ec46f3d9"
   "3.1.0":
-    url: "https://github.com/harfbuzz/harfbuzz/archive/3.1.0.tar.gz"
-    sha256: "df48973da20110a7c1da4ef2746e7dc460bb171166dc3df1deb825f6d18982a0"
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/3.1.0/harfbuzz-3.1.0.tar.xz"
+    sha256: "2359390944a74a933d2b1bd214754a5b3f817916a09c6d4ca3d263473cf19b8e"
   "3.1.1":
-    url: "https://github.com/harfbuzz/harfbuzz/archive/3.1.1.tar.gz"
-    sha256: "5283c7f5f1f06ddb5e2e88319f6946ea37d2eb3a574e0f73f6000de8f9aa34e6"
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/3.1.1/harfbuzz-3.1.1.tar.xz"
+    sha256: "f3f3247bdeabf36765acc237a5f651e651e4e9706582b9cc2cf6c9b8102dfa93"
   "3.1.2":
-    url: "https://github.com/harfbuzz/harfbuzz/archive/3.1.2.tar.gz"
-    sha256: "c27d2640e70e95bdbc2fbeca2f9cc212ee583da1149c9f6dacf1316217652e56"
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/3.1.2/harfbuzz-3.1.2.tar.xz"
+    sha256: "4056b1541dd8bbd8ec29207fe30e568805c0705515632d7fec53a94399bc7945"
   "3.2.0":
-    url: "https://github.com/harfbuzz/harfbuzz/archive/3.2.0.tar.gz"
-    sha256: "41b38daa13ebdba39fae3b5fb2abbf5f9ccd9121bfa7f47b18d51aa733f80aad"
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/3.2.0/harfbuzz-3.2.0.tar.xz"
+    sha256: "0ada50a1c199bb6f70843ab893c55867743a443b84d087d54df08ad883ebc2cd"
+  "4.0.1":
+    url: "https://github.com/harfbuzz/harfbuzz/releases/download/4.0.1/harfbuzz-4.0.1.tar.xz"
+    sha256: "98f68777272db6cd7a3d5152bac75083cd52a26176d87bc04c8b3929d33bce49"
 patches:
   "2.6.8":
     - patch_file: "patches/icu.patch"
@@ -89,4 +92,7 @@ patches:
       base_path: "source_subfolder"
   "3.2.0":
     - patch_file: "patches/icu-3.0.x.patch"
+      base_path: "source_subfolder"
+  "4.0.1":
+    - patch_file: "patches/icu-4.0.x.patch"
       base_path: "source_subfolder"

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -66,9 +66,9 @@ class HarfbuzzConan(ConanFile):
         if self.options.with_freetype:
             self.requires("freetype/2.11.1")
         if self.options.with_icu:
-            self.requires("icu/69.1")
+            self.requires("icu/70.1")
         if self.options.with_glib:
-            self.requires("glib/2.70.1")
+            self.requires("glib/2.71.3")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/harfbuzz/all/patches/icu-4.0.x.patch
+++ b/recipes/harfbuzz/all/patches/icu-4.0.x.patch
@@ -1,0 +1,31 @@
+diff --git a/a/CMakeLists.txt b/b/CMakeLists.txt
+index 3259ca9..8168bb4 100644
+--- a/a/CMakeLists.txt
++++ b/b/CMakeLists.txt
+@@ -246,19 +246,19 @@ if (HB_HAVE_ICU)
+   add_definitions(-DHAVE_ICU)
+ 
+   # https://github.com/WebKit/webkit/blob/fdd7733f2f30eab7fe096a9791f98c60f62f49c0/Source/cmake/FindICU.cmake
+-  find_package(PkgConfig)
+-  pkg_check_modules(PC_ICU QUIET icu-uc)
++  # find_package(PkgConfig)
++  # pkg_check_modules(PC_ICU QUIET icu-uc)
+ 
+-  find_path(ICU_INCLUDE_DIR NAMES unicode/utypes.h HINTS ${PC_ICU_INCLUDE_DIRS} ${PC_ICU_INCLUDEDIR})
+-  find_library(ICU_LIBRARY NAMES libicuuc cygicuuc cygicuuc32 icuuc HINTS ${PC_ICU_LIBRARY_DIRS} ${PC_ICU_LIBDIR})
++  # find_path(ICU_INCLUDE_DIR NAMES unicode/utypes.h HINTS ${PC_ICU_INCLUDE_DIRS} ${PC_ICU_INCLUDEDIR})
++  # find_library(ICU_LIBRARY NAMES libicuuc cygicuuc cygicuuc32 icuuc HINTS ${PC_ICU_LIBRARY_DIRS} ${PC_ICU_LIBDIR})
+ 
+-  include_directories(${ICU_INCLUDE_DIR})
++  # include_directories(${ICU_INCLUDE_DIR})
+ 
+   list(APPEND project_headers ${PROJECT_SOURCE_DIR}/src/hb-icu.h)
+ 
+-  list(APPEND THIRD_PARTY_LIBS ${ICU_LIBRARY})
++  # list(APPEND THIRD_PARTY_LIBS ${ICU_LIBRARY})
+ 
+-  mark_as_advanced(ICU_INCLUDE_DIR ICU_LIBRARY)
++  # mark_as_advanced(ICU_INCLUDE_DIR ICU_LIBRARY)
+ endif ()
+ 
+ if (APPLE AND HB_HAVE_CORETEXT)

--- a/recipes/harfbuzz/config.yml
+++ b/recipes/harfbuzz/config.yml
@@ -29,5 +29,5 @@ versions:
     folder: all
   "3.2.0":
     folder: all
-  "4.0.0":
+  "4.0.1":
     folder: all

--- a/recipes/harfbuzz/config.yml
+++ b/recipes/harfbuzz/config.yml
@@ -29,3 +29,5 @@ versions:
     folder: all
   "3.2.0":
     folder: all
+  "4.0.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **harfbuzz/4.0.1**

urls in conandata.yml are fixed too except 2.7.0 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
