### PR TITLE
pdal: improve CMake Find/Config generators + bump deps + modernize

### DIFF
--- a/recipes/pdal/all/CMakeLists.txt
+++ b/recipes/pdal/all/CMakeLists.txt
@@ -4,4 +4,6 @@ project(cmake_wrapper)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(KEEP_RPATHS)
 
+find_package(Boost REQUIRED filesystem)
+
 add_subdirectory("source_subfolder")

--- a/recipes/pdal/all/CMakeLists.txt
+++ b/recipes/pdal/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/pdal/all/conanfile.py
+++ b/recipes/pdal/all/conanfile.py
@@ -151,7 +151,7 @@ class PdalConan(ConanFile):
         # remove vendored boost
         tools.rmdir(os.path.join(self._source_subfolder, "vendor", "pdalboost"))
         tools.replace_in_file(top_cmakelists, "add_subdirectory(vendor/pdalboost)", "")
-        tools.replace_in_file(util_cmakelists, "${PDAL_BOOST_LIB_NAME}", "${CONAN_LIBS}")
+        tools.replace_in_file(util_cmakelists, "${PDAL_BOOST_LIB_NAME}", "Boost::filesystem")
         tools.replace_in_file(os.path.join(self._source_subfolder, "pdal", "util", "FileUtils.cpp"),
                               "pdalboost::", "boost::")
         # No rpath manipulation

--- a/recipes/pdal/all/conanfile.py
+++ b/recipes/pdal/all/conanfile.py
@@ -240,32 +240,33 @@ class PdalConan(ConanFile):
         # pdal_base
         self.cpp_info.components["pdal_base"].set_property("cmake_target_name", self._pdal_base_name)
         self.cpp_info.components["pdal_base"].libs = [self._pdal_base_name]
-        self.cpp_info.components["pdal_base"].requires = ["pdal_util"]
+        if not self.options.shared:
+            self.cpp_info.components["pdal_base"].libs.extend(["pdal_arbiter", "pdal_kazhdan"])
+            if self.settings.os == "Windows":
+                # dependency of pdal_arbiter
+                self.cpp_info.components["pdal_base"].system_libs.append("shlwapi")
+        self.cpp_info.components["pdal_base"].requires = [
+            "pdal_util", "eigen::eigen", "gdal::gdal", "libcurl::libcurl",
+            "libgeotiff::libgeotiff", "nanoflann::nanoflann"
+        ]
+        if self.options.with_xml:
+            self.cpp_info.components["pdal_base"].requires.append("libxml2::libxml2")
+        if self.options.with_zstd:
+            self.cpp_info.components["pdal_base"].requires.append("zstd::zstd")
+        if self.options.with_laszip:
+            self.cpp_info.components["pdal_base"].requires.append("laszip::laszip")
+        if self.options.with_zlib:
+            self.cpp_info.components["pdal_base"].requires.append("zlib::zlib")
+        if self.options.with_lzma:
+            self.cpp_info.components["pdal_base"].requires.append("xz_utils::xz_utils")
 
         # pdal_util
         self.cpp_info.components["pdal_util"].set_property("cmake_target_name", "pdal_util")
         self.cpp_info.components["pdal_util"].libs = ["pdal_util"]
         if not self.options.shared:
-            self.cpp_info.components["pdal_util"].libs.extend(["pdal_arbiter", "pdal_kazhdan"])
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["pdal_util"].system_libs.extend(["dl", "m"])
-            elif self.settings.os == "Windows":
-                # dependency of pdal_arbiter
-                self.cpp_info.components["pdal_util"].system_libs.append("shlwapi")
-        self.cpp_info.components["pdal_util"].requires = [
-            "boost::filesystem", "eigen::eigen", "gdal::gdal",
-            "libcurl::libcurl", "libgeotiff::libgeotiff", "nanoflann::nanoflann"
-        ]
-        if self.options.with_xml:
-            self.cpp_info.components["pdal_util"].requires.append("libxml2::libxml2")
-        if self.options.with_zstd:
-            self.cpp_info.components["pdal_util"].requires.append("zstd::zstd")
-        if self.options.with_laszip:
-            self.cpp_info.components["pdal_util"].requires.append("laszip::laszip")
-        if self.options.with_zlib:
-            self.cpp_info.components["pdal_util"].requires.append("zlib::zlib")
-        if self.options.with_lzma:
-            self.cpp_info.components["pdal_util"].requires.append("xz_utils::xz_utils")
+        self.cpp_info.components["pdal_util"].requires = ["boost::filesystem"]
         if self.options.get_safe("with_unwind"):
             self.cpp_info.components["pdal_util"].requires.append("libunwind::libunwind")
 

--- a/recipes/pdal/all/conanfile.py
+++ b/recipes/pdal/all/conanfile.py
@@ -1,8 +1,11 @@
+from conan.tools.microsoft import msvc_runtime_flag
 from conans import ConanFile, tools, CMake
 from conans.errors import ConanInvalidConfiguration
+import functools
 import os
+import textwrap
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class PdalConan(ConanFile):
@@ -38,11 +41,14 @@ class PdalConan(ConanFile):
     }
 
     generators = "cmake", "cmake_find_package"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
 
     def export_sources(self):
         self.copy("CMakeLists.txt")
@@ -89,11 +95,11 @@ class PdalConan(ConanFile):
         return ["filesystem"]
 
     def validate(self):
-        if self.settings.compiler.cppstd:
+        if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, 11)
         if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < 5:
             raise ConanInvalidConfiguration ("This compiler version is unsupported")
-        if self.options.shared and self.settings.compiler == "Visual Studio" and "MT" in str(self.settings.compiler.runtime):
+        if self.options.shared and self._is_msvc and "MT" in msvc_runtime_flag(self):
             raise ConanInvalidConfiguration("pdal shared doesn't support MT runtime with Visual Studio")
         miss_boost_required_comp = any(getattr(self.options["boost"], "without_{}".format(boost_comp), True) for boost_comp in self._required_boost_components)
         if self.options["boost"].header_only or miss_boost_required_comp:
@@ -105,22 +111,21 @@ class PdalConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["PDAL_BUILD_STATIC"] = not self.options.shared
-        self._cmake.definitions["WITH_TESTS"] = False
-        self._cmake.definitions["WITH_LAZPERF"] = self.options.with_lazperf
-        self._cmake.definitions["WITH_LASZIP"] = self.options.with_laszip
-        self._cmake.definitions["WITH_STATIC_LASZIP"] = True # doesn't really matter but avoids to inject useless definition
-        self._cmake.definitions["WITH_ZSTD"] = self.options.with_zstd
-        self._cmake.definitions["WITH_ZLIB"] = self.options.with_zlib
-        self._cmake.definitions["WITH_LZMA"] = self.options.with_lzma
+        cmake = CMake(self)
+        cmake.definitions["PDAL_BUILD_STATIC"] = not self.options.shared
+        cmake.definitions["WITH_TESTS"] = False
+        cmake.definitions["WITH_LAZPERF"] = self.options.with_lazperf
+        cmake.definitions["WITH_LASZIP"] = self.options.with_laszip
+        cmake.definitions["WITH_STATIC_LASZIP"] = True # doesn't really matter but avoids to inject useless definition
+        cmake.definitions["WITH_ZSTD"] = self.options.with_zstd
+        cmake.definitions["WITH_ZLIB"] = self.options.with_zlib
+        cmake.definitions["WITH_LZMA"] = self.options.with_lzma
         # disable plugin that requires postgresql
-        self._cmake.definitions["BUILD_PLUGIN_PGPOINTCLOUD"] = False
-        self._cmake.configure()
-        return self._cmake
+        cmake.definitions["BUILD_PLUGIN_PGPOINTCLOUD"] = False
+        cmake.configure()
+        return cmake
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -180,33 +185,98 @@ class PdalConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "pdal-config*")
+        self._create_cmake_module_variables(
+            os.path.join(self.package_folder, self._module_vars_file)
+        )
+
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_target_file),
+            {
+                f"{self._pdal_base_name}": f"PDAL::{self._pdal_base_name}",
+                "pdal_util": "PDAL::pdal_util",
+            }
+        )
+
+    def _create_cmake_module_variables(self, module_file):
+        pdal_version = tools.Version(self.version)
+        content = textwrap.dedent(f"""\
+            set(PDAL_LIBRARIES {self._pdal_base_name} pdal_util)
+            set(PDAL_VERSION_MAJOR {pdal_version.major})
+            set(PDAL_VERSION_MINOR {pdal_version.minor})
+            set(PDAL_VERSION_PATCH {pdal_version.patch})
+        """)
+        tools.save(module_file, content)
+
+    @property
+    def _module_vars_file(self):
+        return os.path.join("lib", "cmake", "conan-official-{}-variables.cmake".format(self.name))
+
+    @staticmethod
+    def _create_cmake_module_alias_targets(module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent("""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """.format(alias=alias, aliased=aliased))
+        tools.save(module_file, content)
+
+    @property
+    def _module_target_file(self):
+        return os.path.join("lib", "cmake", "conan-official-{}-targets.cmake".format(self.name))
+
+    @property
+    def _pdal_base_name(self):
+        return "pdalcpp" if self.settings.os == "Windows" or tools.is_apple_os(self.settings.os) else "pdal_base"
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "PDAL"
-        self.cpp_info.names["cmake_find_package_multi"] = "PDAL"
-        self.cpp_info.names["pkg_config"] = "pdal"
-        pdal_base_name = "pdalcpp" if self.settings.os == "Windows" or tools.is_apple_os(self.settings.os) else "pdal_base"
-        self.cpp_info.libs = [pdal_base_name, "pdal_util"]
+        self.cpp_info.set_property("cmake_file_name", "PDAL")
+        self.cpp_info.set_property("cmake_build_modules", [self._module_vars_file])
+        self.cpp_info.set_property("pkg_config_name", "pdal")
+
+        # pdal_base
+        self.cpp_info.components["pdal_base"].set_property("cmake_target_name", self._pdal_base_name)
+        self.cpp_info.components["pdal_base"].libs = [self._pdal_base_name]
+        self.cpp_info.components["pdal_base"].requires = ["pdal_util"]
+
+        # pdal_util
+        self.cpp_info.components["pdal_util"].set_property("cmake_target_name", "pdal_util")
+        self.cpp_info.components["pdal_util"].libs = ["pdal_util"]
         if not self.options.shared:
-            self.cpp_info.libs.extend(["pdal_arbiter", "pdal_kazhdan"])
+            self.cpp_info.components["pdal_util"].libs.extend(["pdal_arbiter", "pdal_kazhdan"])
             if self.settings.os in ["Linux", "FreeBSD"]:
-                self.cpp_info.system_libs.extend(["dl", "m"])
+                self.cpp_info.components["pdal_util"].system_libs.extend(["dl", "m"])
             elif self.settings.os == "Windows":
                 # dependency of pdal_arbiter
-                self.cpp_info.system_libs.append("shlwapi")
-        self.cpp_info.requires = [
+                self.cpp_info.components["pdal_util"].system_libs.append("shlwapi")
+        self.cpp_info.components["pdal_util"].requires = [
             "boost::filesystem", "eigen::eigen", "gdal::gdal",
             "libcurl::libcurl", "libgeotiff::libgeotiff", "nanoflann::nanoflann"
         ]
         if self.options.with_xml:
-            self.cpp_info.requires.append("libxml2::libxml2")
+            self.cpp_info.components["pdal_util"].requires.append("libxml2::libxml2")
         if self.options.with_zstd:
-            self.cpp_info.requires.append("zstd::zstd")
+            self.cpp_info.components["pdal_util"].requires.append("zstd::zstd")
         if self.options.with_laszip:
-            self.cpp_info.requires.append("laszip::laszip")
+            self.cpp_info.components["pdal_util"].requires.append("laszip::laszip")
         if self.options.with_zlib:
-            self.cpp_info.requires.append("zlib::zlib")
+            self.cpp_info.components["pdal_util"].requires.append("zlib::zlib")
         if self.options.with_lzma:
-            self.cpp_info.requires.append("xz_utils::xz_utils")
+            self.cpp_info.components["pdal_util"].requires.append("xz_utils::xz_utils")
         if self.options.get_safe("with_unwind"):
-            self.cpp_info.requires.append("libunwind::libunwind")
+            self.cpp_info.components["pdal_util"].requires.append("libunwind::libunwind")
+
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.names["cmake_find_package"] = "PDAL"
+        self.cpp_info.names["cmake_find_package_multi"] = "PDAL"
+        self.cpp_info.components["pdal_base"].names["cmake_find_package"] = self._pdal_base_name
+        self.cpp_info.components["pdal_base"].names["cmake_find_package_multi"] = self._pdal_base_name
+        self.cpp_info.components["pdal_base"].build_modules["cmake_find_package"] = [
+            self._module_target_file, self._module_vars_file,
+        ]
+        self.cpp_info.components["pdal_base"].build_modules["cmake_find_package_multi"] = [
+            self._module_target_file, self._module_vars_file,
+        ]

--- a/recipes/pdal/all/conanfile.py
+++ b/recipes/pdal/all/conanfile.py
@@ -69,18 +69,16 @@ class PdalConan(ConanFile):
         # TODO package improvements:
         # - switch from vendored arbiter (not in CCI). disabled openssl and curl are deps of arbiter
         # - switch from vendor/nlohmann to nlohmann_json (in CCI)
-        self.requires("boost/1.77.0")
+        self.requires("boost/1.78.0")
         self.requires("eigen/3.4.0")
-        self.requires("gdal/3.3.3")
-        self.requires("libcurl/7.79.1.0") # mandatory dependency of arbiter (to remove if arbiter is unvendored)
+        self.requires("gdal/3.4.1")
+        self.requires("libcurl/7.80.0") # mandatory dependency of arbiter (to remove if arbiter is unvendored)
         self.requires("libgeotiff/1.7.0")
-        self.requires("nanoflann/1.3.2")
+        self.requires("nanoflann/1.4.2")
         if self.options.with_xml:
             self.requires("libxml2/2.9.12")
         if self.options.with_zstd:
-            self.requires("zstd/1.5.0")
-        if self.options.with_lazperf:
-            raise ConanInvalidConfiguration("lazperf recipe not yet available in CCI")
+            self.requires("zstd/1.5.2")
         if self.options.with_laszip:
             self.requires("laszip/3.4.3")
         if self.options.with_zlib:
@@ -106,6 +104,8 @@ class PdalConan(ConanFile):
             raise ConanInvalidConfiguration("{0} requires non header-only boost with these components: {1}".format(self.name, ", ".join(self._required_boost_components)))
         if hasattr(self, "settings_build") and tools.cross_building(self):
             raise ConanInvalidConfiguration("pdal doesn't support cross-build yet")
+        if self.options.with_lazperf:
+            raise ConanInvalidConfiguration("lazperf recipe not yet available in CCI")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/pdal/all/test_package/CMakeLists.txt
+++ b/recipes/pdal/all/test_package/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 # keep close to the upstream example docs
-find_package(PDAL 2.0.0 REQUIRED)
+find_package(PDAL REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${PDAL_LIBRARIES})

--- a/recipes/pdal/all/test_package/conanfile.py
+++ b/recipes/pdal/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- `CMakeDeps` support.
- improve generators to stick to CMake config file of upstream:
  - components: provide `pdalcpp` (or `pdal_base` if not Windows or Macos) and `pdal_util` targets.
  - variables: define `PDAL_LIBRARIES`, `PDAL_VERSION_MAJOR`, `PDAL_VERSION_MINOR` & `PDAL_VERSION_PATCH`.
- cache CMake configuration with `functools.lru_cache`.
- handle `compiler=msvc`.
- bump dependencies.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
