### PR TITLE
laszip: relocatable shared lib on macOS + modernize

### DIFF
--- a/recipes/laszip/all/CMakeLists.txt
+++ b/recipes/laszip/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/laszip/all/conandata.yml
+++ b/recipes/laszip/all/conandata.yml
@@ -2,3 +2,9 @@ sources:
   "3.4.3":
     url: "https://github.com/LASzip/LASzip/archive/3.4.3.tar.gz"
     sha256: "862715affa00609b78b4f469ab5529fee659c597efd40b5006b4305dd56c22d3"
+patches:
+  "3.4.3":
+    - patch_file: "patches/0001-no-build-laszip-api.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-no-rpath-and-relocatable-macos.patch"
+      base_path: "source_subfolder"

--- a/recipes/laszip/all/conanfile.py
+++ b/recipes/laszip/all/conanfile.py
@@ -68,7 +68,8 @@ class LaszipConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = ["laszip"]
+        suffix = tools.Version(self.version).major if self.settings.os == "Windows" else ""
+        self.cpp_info.libs = [f"laszip{suffix}"]
         if self.options.shared:
             self.cpp_info.defines.append("LASZIP_DYN_LINK")
         else:

--- a/recipes/laszip/all/patches/0001-no-build-laszip-api.patch
+++ b/recipes/laszip/all/patches/0001-no-build-laszip-api.patch
@@ -1,0 +1,9 @@
+--- a/dll/CMakeLists.txt
++++ b/dll/CMakeLists.txt
+@@ -3,6 +3,5 @@ set(LASZIP_API_SOURCES
+     laszip_api.c
+ )
+ 
+-LASZIP_ADD_LIBRARY(${LASZIP_API_LIB_NAME} ${LASZIP_API_SOURCES})
+ LASZIP_ADD_INCLUDES("laszip" "${LASZIP_HEADERS_DIR}/laszip_api.h" ${LASZIP_API_VERSION_H})
+ 

--- a/recipes/laszip/all/patches/0002-no-rpath-and-relocatable-macos.patch
+++ b/recipes/laszip/all/patches/0002-no-rpath-and-relocatable-macos.patch
@@ -1,0 +1,29 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -80,15 +80,11 @@ file(MAKE_DIRECTORY "${LASZIP_OUTPUT_BIN_DIR}")
+ # per http://www.cmake.org/Wiki/CMake_RPATH_handling
+ SET(CMAKE_SKIP_BUILD_RPATH FALSE)
+ SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+-SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+ IF (APPLE)
+     SET(MACOSX_RPATH ON)
+ endif()
+ LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
+     "${CMAKE_INSTALL_PREFIX}/${LASZIP_LIB_INSTALL_DIR}" isSystemDir)
+-IF("${isSystemDir}" STREQUAL "-1")
+-    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LASZIP_LIB_INSTALL_DIR}")
+-ENDIF("${isSystemDir}" STREQUAL "-1")
+ 
+ # wipe lib/ drectory on clean. It will have plugins that could be out of date
+ # in the next build
+--- a/cmake/macros.cmake
++++ b/cmake/macros.cmake
+@@ -71,8 +71,6 @@ macro(LASZIP_ADD_LIBRARY _name)
+         LIBRARY DESTINATION ${LASZIP_LIB_INSTALL_DIR}
+         ARCHIVE DESTINATION ${LASZIP_LIB_INSTALL_DIR})
+     if (APPLE)
+-        set_target_properties(${_name} PROPERTIES INSTALL_NAME_DIR
+-            "@executable_path/../lib")
+     endif()
+ endmacro(LASZIP_ADD_LIBRARY)
+ 

--- a/recipes/laszip/all/test_package/CMakeLists.txt
+++ b/recipes/laszip/all/test_package/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(laszip REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(${PROJECT_NAME} laszip::laszip)

--- a/recipes/laszip/all/test_package/conanfile.py
+++ b/recipes/laszip/all/test_package/conanfile.py
@@ -1,10 +1,10 @@
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- no absolute path into RUNPATH/LC_RPATH of shared lib on *nix platforms
- propagate libcxx since it's a C++ lib with a C API
- delete fPIC if shared

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
