### PR TITLE
libusb should not decide about libudev

### DIFF
--- a/recipes/libusb/all/conanfile.py
+++ b/recipes/libusb/all/conanfile.py
@@ -61,8 +61,6 @@ class LibUSBConan(ConanFile):
         if self.options.get_safe("enable_udev"):
             if self.settings.os == "Android":
                 raise ConanInvalidConfiguration("udev can't be enabled for Android yet, since libudev recipe is missing in CCI.")
-            if tools.cross_building(self):
-                raise ConanInvalidConfiguration("udev can't be enabled yet if cross-compiling")
 
     def build_requirements(self):
         if self._settings_build.os == "Windows" and not self._is_msvc and not tools.get_env("CONAN_BASH_PATH"):

--- a/recipes/libusb/all/conanfile.py
+++ b/recipes/libusb/all/conanfile.py
@@ -57,11 +57,6 @@ class LibUSBConan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
-    def validate(self):
-        if self.options.get_safe("enable_udev"):
-            if self.settings.os == "Android":
-                raise ConanInvalidConfiguration("udev can't be enabled for Android yet, since libudev recipe is missing in CCI.")
-
     def build_requirements(self):
         if self._settings_build.os == "Windows" and not self._is_msvc and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")


### PR DESCRIPTION
The libusb is managing what libudev can and can not do. However, libudev has a package now, where all those limitations should be managed. It was a leftover when moving the SystemPackageTool from libusb to libudev package.

Specify library name and version:  **libusb/1.0.24**

Related to #9773

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
