### PR TITLE
libxml2: add 2.9.13

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.9.13":
+    url: "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.13.tar.xz"
+    sha256: "276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e"
   "2.9.12":
     url: "http://xmlsoft.org/sources/libxml2-2.9.12.tar.gz"
     sha256: "c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92"

--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, tools, AutoToolsBuildEnvironment, VisualStudioBuildEnvironment
 from contextlib import contextmanager
+from conan.tools.files import rename
 import functools
 import itertools
 import os
@@ -12,8 +13,8 @@ class Libxml2Conan(ConanFile):
     name = "libxml2"
     url = "https://github.com/conan-io/conan-center-index"
     description = "libxml2 is a software library for parsing XML documents"
-    topics = ("XML", "parser", "validation")
-    homepage = "https://xmlsoft.org"
+    topics = ("xml", "parser", "validation")
+    homepage = "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/"
     license = "MIT"
 
     settings = "os", "arch", "compiler", "build_type"
@@ -106,7 +107,7 @@ class Libxml2Conan(ConanFile):
         # can't use strip_root here because if fails since 2.9.10 with:
         # KeyError: "linkname 'libxml2-2.9.1x/test/relaxng/ambig_name-class.xml' not found"
         tools.get(**self.conan_data["sources"][self.version])
-        tools.rename("libxml2-{}".format(self.version), self._source_subfolder)
+        rename(self, "libxml2-{}".format(self.version), self._source_subfolder)
 
     @contextmanager
     def _msvc_build_environment(self):

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.9.13":
+    folder: all
   "2.9.12":
     folder: all
   "2.9.10":


### PR DESCRIPTION
Specify library name and version:  **libxml2/2.9.13**

This version fixes the following bugs (most importantly the CVE):

- [CVE-2022-23308] Use-after-free of ID and IDREF attributes
   (Thanks to Shinji Sato for the report)
- Use-after-free in xmlXIncludeCopyRange (David Kilzer)
- Fix null deref in xmlSchemaGetComponentTargetNs (huangduirong)
- Fix memory leak in xmlXPathCompNodeTest
- Fix null pointer deref in xmlStringGetNodeList
- Fix several memory leaks found by Coverity (David King)
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
