### PR TITLE
[imgui] Add docking branch

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -29,9 +29,6 @@ sources:
   "1.83":
     url: "https://github.com/ocornut/imgui/archive/v1.83.tar.gz"
     sha256: "ccf3e54b8d1fa30dd35682fc4f50f5d2fe340b8e29e08de71287d0452d8cc3ff"
-  # "1.84.1":
-  #   url: "https://github.com/ocornut/imgui/archive/v1.84.1.tar.gz"
-  #   sha256: "292ab54cfc328c80d63a3315a242a4785d7c1cf7689fbb3d70da39b34db071ea"
   "1.84.2":
     url: "https://github.com/ocornut/imgui/archive/v1.84.2.tar.gz"
     sha256: "35cb5ca0fb42cb77604d4f908553f6ef3346ceec4fcd0189675bdfb764f62b9b"

--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -29,9 +29,9 @@ sources:
   "1.83":
     url: "https://github.com/ocornut/imgui/archive/v1.83.tar.gz"
     sha256: "ccf3e54b8d1fa30dd35682fc4f50f5d2fe340b8e29e08de71287d0452d8cc3ff"
-  "1.84.1":
-    url: "https://github.com/ocornut/imgui/archive/v1.84.1.tar.gz"
-    sha256: "292ab54cfc328c80d63a3315a242a4785d7c1cf7689fbb3d70da39b34db071ea"
+  # "1.84.1":
+  #   url: "https://github.com/ocornut/imgui/archive/v1.84.1.tar.gz"
+  #   sha256: "292ab54cfc328c80d63a3315a242a4785d7c1cf7689fbb3d70da39b34db071ea"
   "1.84.2":
     url: "https://github.com/ocornut/imgui/archive/v1.84.2.tar.gz"
     sha256: "35cb5ca0fb42cb77604d4f908553f6ef3346ceec4fcd0189675bdfb764f62b9b"
@@ -44,3 +44,6 @@ sources:
   "1.87":
     url: "https://github.com/ocornut/imgui/archive/v1.87.tar.gz"
     sha256: "b54ceb35bda38766e36b87c25edf7a1cd8fd2cb8c485b245aedca6fb85645a20"
+  "cci.20220207+docking":
+    url: "https://github.com/ocornut/imgui/archive/1ee252772ae9c0a971d06257bb5c89f628fa696a.tar.gz"
+    sha256: "c50e263660e1deb6e85b10a0382bf8a6fc861645e44b7012bd32da5460829ae0"

--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -44,6 +44,10 @@ sources:
   "1.87":
     url: "https://github.com/ocornut/imgui/archive/v1.87.tar.gz"
     sha256: "b54ceb35bda38766e36b87c25edf7a1cd8fd2cb8c485b245aedca6fb85645a20"
-  "cci.20220207+docking":
+
+  # These versions belong to the docking branch in ImGUI repository. This branch is declared stable and production ready, and
+  # it is synced with `master` regularly. These versions are taken from that branch using the commit where `master` was synced
+  # after a regular release
+  "cci.20220207+1.87.docking":
     url: "https://github.com/ocornut/imgui/archive/1ee252772ae9c0a971d06257bb5c89f628fa696a.tar.gz"
     sha256: "c50e263660e1deb6e85b10a0382bf8a6fc861645e44b7012bd32da5460829ae0"

--- a/recipes/imgui/all/conanfile.py
+++ b/recipes/imgui/all/conanfile.py
@@ -55,9 +55,10 @@ class IMGUIConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
+        use_backends = 'docking' in self.version or tools.Version(self.version) >= "1.80"
         backends_folder = os.path.join(
             self._source_subfolder,
-            "backends" if tools.Version(self.version) >= "1.80" else "examples"
+            "backends" if use_backends else "examples"
         )
         self.copy(pattern="imgui_impl_*",
                   dst=os.path.join("res", "bindings"),

--- a/recipes/imgui/all/conanfile.py
+++ b/recipes/imgui/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 import os
+import re
 
 required_conan_version = ">=1.33.0"
 
@@ -55,10 +56,11 @@ class IMGUIConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
-        use_backends = 'docking' in self.version or tools.Version(self.version) >= "1.80"
+        m = re.match(r'cci\.\d{8}\+(?P<version>\d+\.\d+)\.docking', str(self.version))
+        version = tools.Version(m.group('version')) if m else tools.Version(self.version)
         backends_folder = os.path.join(
             self._source_subfolder,
-            "backends" if use_backends else "examples"
+            "backends" if version >= "1.80" else "examples"
         )
         self.copy(pattern="imgui_impl_*",
                   dst=os.path.join("res", "bindings"),

--- a/recipes/imgui/all/test_package/CMakeLists.txt
+++ b/recipes/imgui/all/test_package/CMakeLists.txt
@@ -10,3 +10,6 @@ set(CMAKE_CXX_STANDARD 11)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} imgui::imgui)
+if (DOCKING)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -DDOCKING)
+endif()

--- a/recipes/imgui/all/test_package/conanfile.py
+++ b/recipes/imgui/all/test_package/conanfile.py
@@ -4,9 +4,14 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["DOCKING"] = 'docking' in self.tested_reference_str
         cmake.configure()
         cmake.build()
 

--- a/recipes/imgui/all/test_package/test_package.cpp
+++ b/recipes/imgui/all/test_package/test_package.cpp
@@ -1,4 +1,8 @@
 #include <imgui.h>
+#ifdef DOCKING
+    #include <imgui_internal.h>
+#endif
+
 #include <stdio.h>
 
 int main(int, char**)
@@ -20,6 +24,13 @@ int main(int, char**)
         io.DisplaySize = ImVec2(1920, 1080);
         io.DeltaTime = 1.0f / 60.0f;
         ImGui::NewFrame();
+
+#ifdef DOCKING
+        auto dockspaceID = ImGui::GetID("MyDockSpace");
+        static ImGuiDockNodeFlags dockspace_flags = ImGuiDockNodeFlags_None;
+        ImGui::DockSpace(dockspaceID, ImVec2(0.0f, 0.0f), dockspace_flags);
+        printf("  with docking\n");
+#endif
 
         static float f = 0.0f;
         ImGui::Text("Hello, world!");

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -19,8 +19,8 @@ versions:
     folder: all
   "1.83":
     folder: all
-  "1.84.1":
-    folder: all
+  # "1.84.1":
+  #   folder: all
   "1.84.2":
     folder: all
   "1.85":

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -29,5 +29,9 @@ versions:
     folder: all
   "1.87":
     folder: all
-  "cci.20220207+docking":
+
+  # These versions belong to the docking branch in ImGUI repository. This branch is declared stable and production ready, and
+  # it is synced with `master` regularly. These versions are taken from that branch using the commit where `master` was synced
+  # after a regular release
+  "cci.20220207+1.87.docking":
     folder: all

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -29,3 +29,5 @@ versions:
     folder: all
   "1.87":
     folder: all
+  "cci.20220207+docking":
+    folder: all

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -19,8 +19,6 @@ versions:
     folder: all
   "1.83":
     folder: all
-  # "1.84.1":
-  #   folder: all
   "1.84.2":
     folder: all
   "1.85":


### PR DESCRIPTION
close #7557 


We proposed versions like `cci.20220207+docking` for the docking branch, but I'm thinking that it would be useful to include some reference to the `1.87` version, which is the matching one. Something like `cci.20220207+1.87.docking`, wdyt?

cc/ @uilianries @SSE4 

- [x] Better parser for `self.version`
- [x] Add something extra to test this branch