### PR TITLE
Update jfalcou-eve requirements as of v2022.03.0

### DIFF
--- a/recipes/jfalcou-eve/all/conandata.yml
+++ b/recipes/jfalcou-eve/all/conandata.yml
@@ -5,6 +5,6 @@ sources:
   "v2021.10.0":
     url: "https://github.com/jfalcou/eve/archive/refs/tags/v2021.10.0.tar.gz"
     sha256: "580c40a8244039a700b93ea49fb0affc1c8d3c100eb6dc66368e101753f51e5c"
-  "v2021.10.0":
+  "v2022.03.0":
     url: "https://github.com/jfalcou/eve/archive/refs/tags/v2022.03.0.tar.gz"
     sha256: "8bf9faea516806e7dd468e778dcedc81c51f0b2c6a70b9c75987ce12bb759911"

--- a/recipes/jfalcou-eve/all/conandata.yml
+++ b/recipes/jfalcou-eve/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "v2021.10.0":
     url: "https://github.com/jfalcou/eve/archive/refs/tags/v2021.10.0.tar.gz"
     sha256: "580c40a8244039a700b93ea49fb0affc1c8d3c100eb6dc66368e101753f51e5c"
+  "v2021.10.0":
+    url: "https://github.com/jfalcou/eve/archive/refs/tags/v2022.03.0.tar.gz"
+    sha256: "8bf9faea516806e7dd468e778dcedc81c51f0b2c6a70b9c75987ce12bb759911"

--- a/recipes/jfalcou-eve/all/conandata.yml
+++ b/recipes/jfalcou-eve/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "cci.20210823":
-    url: "https://github.com/jfalcou/eve/archive/30e7a7f6bcc5cf524a6c2cc624234148eee847be.tar.gz"
-    sha256: "c267135f7215197ef6859b2aa1c5b6a7fc45ca8333933beda56c96b0d0400ef1"
   "v2021.10.0":
     url: "https://github.com/jfalcou/eve/archive/refs/tags/v2021.10.0.tar.gz"
     sha256: "580c40a8244039a700b93ea49fb0affc1c8d3c100eb6dc66368e101753f51e5c"

--- a/recipes/jfalcou-eve/all/conanfile.py
+++ b/recipes/jfalcou-eve/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile, tools
+from conan.tools.scm import Version
 from conans.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.33.0"
@@ -26,20 +27,11 @@ class JfalcouEveConan(ConanFile):
 
     @property
     def _compilers_minimum_version(self):
-        if  tools.scm.Version(self.version) >= "2022.03.0":
-                return {
-                    "gcc": "11",
-                    "Visual Studio": "16.9",
-                    "clang": "13",
-                    "apple-clang": "13",
-                    }
-        else:
-                return {
-                    "gcc": "10.2",
-                    "Visual Studio": "16.9",
-                    "clang": "12",
-                    "apple-clang": "13",
-                    }
+        return {"gcc": "11",
+                "Visual Studio": "16.9",
+                "clang": "13",
+                "apple-clang": "13",
+                }
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -65,7 +57,7 @@ class JfalcouEveConan(ConanFile):
         self.info.header_only()
 
     def source(self):
-        tools.files.get(**self.conan_data["sources"][self.version], strip_root=True,
+        tools.files.get(self, **self.conan_data["sources"][self.version], strip_root=True,
                 destination=self._source_subfolder)
 
     def package(self):

--- a/recipes/jfalcou-eve/all/conanfile.py
+++ b/recipes/jfalcou-eve/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, tools
+from conan import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.33.0"
@@ -26,7 +26,7 @@ class JfalcouEveConan(ConanFile):
 
     @property
     def _compilers_minimum_version(self):
-        if  tools.Version(self.version) >= "2022.03.0":
+        if  tools.scm.Version(self.version) >= "2022.03.0":
                 return {
                     "gcc": "11",
                     "Visual Studio": "16.9",
@@ -43,7 +43,7 @@ class JfalcouEveConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, self._min_cppstd)
+            tools.build.check_min_cppstd(self, self._min_cppstd)
         if self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration("EVE does not support MSVC yet (https://github.com/jfalcou/eve/issues/1022).")
         if self.settings.compiler == "apple-clang":
@@ -65,7 +65,7 @@ class JfalcouEveConan(ConanFile):
         self.info.header_only()
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True,
+        tools.files.get(**self.conan_data["sources"][self.version], strip_root=True,
                 destination=self._source_subfolder)
 
     def package(self):

--- a/recipes/jfalcou-eve/all/conanfile.py
+++ b/recipes/jfalcou-eve/all/conanfile.py
@@ -41,7 +41,7 @@ class JfalcouEveConan(ConanFile):
         if self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration("EVE does not support MSVC yet (https://github.com/jfalcou/eve/issues/1022).")
         if self.settings.compiler == "apple-clang":
-            raise ConanInvalidConfiguration("EVE does not support apple Clang due to an incomple libcpp.")
+            raise ConanInvalidConfiguration("EVE does not support apple Clang due to an incomplete libcpp.")
 
         def lazy_lt_semver(v1, v2):
             lv1 = [int(v) for v in v1.split(".")]

--- a/recipes/jfalcou-eve/all/conanfile.py
+++ b/recipes/jfalcou-eve/all/conanfile.py
@@ -31,7 +31,7 @@ class JfalcouEveConan(ConanFile):
         return {
             "gcc": "10.2",
             "Visual Studio": "16.9",
-            "clang": "12",
+            "clang": "13",
             "apple-clang": "13",
         }
 

--- a/recipes/jfalcou-eve/all/conanfile.py
+++ b/recipes/jfalcou-eve/all/conanfile.py
@@ -40,6 +40,8 @@ class JfalcouEveConan(ConanFile):
             tools.check_min_cppstd(self, self._min_cppstd)
         if self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration("EVE does not support MSVC yet (https://github.com/jfalcou/eve/issues/1022).")
+        if self.settings.compiler == "apple-clang":
+            raise ConanInvalidConfiguration("EVE does not support apple Clang due to an incomple libcpp.")
 
         def lazy_lt_semver(v1, v2):
             lv1 = [int(v) for v in v1.split(".")]

--- a/recipes/jfalcou-eve/all/conanfile.py
+++ b/recipes/jfalcou-eve/all/conanfile.py
@@ -1,9 +1,7 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
-import os
 
 required_conan_version = ">=1.33.0"
-
 
 class JfalcouEveConan(ConanFile):
     name = "jfalcou-eve"
@@ -28,12 +26,20 @@ class JfalcouEveConan(ConanFile):
 
     @property
     def _compilers_minimum_version(self):
-        return {
-            "gcc": "11",
-            "Visual Studio": "16.9",
-            "clang": "13",
-            "apple-clang": "13",
-        }
+        if tools.Version(self.version) >= "2022.03.0":
+                return {
+                    "gcc": "11",
+                    "Visual Studio": "16.9",
+                    "clang": "13",
+                    "apple-clang": "13",
+                    }
+        else:
+                return {
+                    "gcc": "10.2",
+                    "Visual Studio": "16.9",
+                    "clang": "12",
+                    "apple-clang": "13",
+                    }
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/jfalcou-eve/all/conanfile.py
+++ b/recipes/jfalcou-eve/all/conanfile.py
@@ -29,7 +29,7 @@ class JfalcouEveConan(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            "gcc": "10.2",
+            "gcc": "11",
             "Visual Studio": "16.9",
             "clang": "13",
             "apple-clang": "13",

--- a/recipes/jfalcou-eve/all/conanfile.py
+++ b/recipes/jfalcou-eve/all/conanfile.py
@@ -26,7 +26,7 @@ class JfalcouEveConan(ConanFile):
 
     @property
     def _compilers_minimum_version(self):
-        if not self.version.startswith("cci.") and  tools.Version(self.version) >= "2022.03.0":
+        if  tools.Version(self.version) >= "2022.03.0":
                 return {
                     "gcc": "11",
                     "Visual Studio": "16.9",

--- a/recipes/jfalcou-eve/all/conanfile.py
+++ b/recipes/jfalcou-eve/all/conanfile.py
@@ -26,7 +26,7 @@ class JfalcouEveConan(ConanFile):
 
     @property
     def _compilers_minimum_version(self):
-        if tools.Version(self.version) >= "2022.03.0":
+        if not self.version.startswith("cci.") and  tools.Version(self.version) >= "2022.03.0":
                 return {
                     "gcc": "11",
                     "Visual Studio": "16.9",

--- a/recipes/jfalcou-eve/config.yml
+++ b/recipes/jfalcou-eve/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "v2021.10.0":
     folder: all
+  "v2022.03.0":
+    folder: all

--- a/recipes/jfalcou-eve/config.yml
+++ b/recipes/jfalcou-eve/config.yml
@@ -1,6 +1,4 @@
 versions:
-  "cci.20210823":
-    folder: all
   "v2021.10.0":
     folder: all
   "v2022.03.0":


### PR DESCRIPTION
**jfalcou-eve/v2022.03.0**

Latest version of EVE now requires clang 13 and g++ 11 on Linux

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
