### PR TITLE
libvpx: modernize a little bit more

### DIFF
--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -1,10 +1,11 @@
 from conan.tools.microsoft import msvc_runtime_flag
+from conan.tools.microsoft.visual import msvc_version_to_vs_ide_version
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 import re
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class LibVPXConan(ConanFile):
@@ -129,12 +130,7 @@ class LibVPXConan(ConanFile):
             if self.settings.compiler == "Visual Studio":
                 vc_version = self.settings.compiler.version
             else:
-                vc_version = {
-                    "190": "14",
-                    "191": "15",
-                    "192": "16",
-                    "193": "17",
-                }[str(self.settings.compiler.version)]
+                vc_version = msvc_version_to_vs_ide_version(self.settings.compiler.version)
             compiler = "vs{}".format(vc_version)
         elif self.settings.compiler in ["gcc", "clang", "apple-clang"]:
             compiler = 'gcc'


### PR DESCRIPTION
Some minor improvements, mainly for maintenance purpose:
- there is a `msvc_version_to_vs_ide_version()` function since conan 1.43.0, I guess it will scale better than a manual handling in the recipe.
- cache configure with functools.lru_cache
- don't call `tools.vcvars()` twice

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
