### PR TITLE
bullet3: fix libs ordering + improve cmake generators + modernize

### DIFF
--- a/recipes/bullet3/all/CMakeLists.txt
+++ b/recipes/bullet3/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.0)
 project(cmake_wrapper)
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/bullet3/all/conandata.yml
+++ b/recipes/bullet3/all/conandata.yml
@@ -1,22 +1,22 @@
 sources:
-  "2.89":
-    url: "https://github.com/bulletphysics/bullet3/archive/2.89.tar.gz"
-    sha256: "621b36e91c0371933f3c2156db22c083383164881d2a6b84636759dc4cbb0bb8"
-  "3.06":
-    url: "https://github.com/bulletphysics/bullet3/archive/3.06.tar.gz"
-    sha256: "217c1d198ee00be7e40d4cb4d79882e37ef4a06cbfbe11f5fbc207c347a57020"
-  "3.07":
-    url: "https://github.com/bulletphysics/bullet3/archive/3.07.tar.gz"
-    sha256: "068ecf8acbf256d3976eebee75d7d6f5af16c049f10f6b2d8ba28bb638bef3b0"
-  "3.08":
-    url: "https://github.com/bulletphysics/bullet3/archive/3.08.tar.gz"
-    sha256: "05826c104b842bcdd1339b86894cb44c84ac2525ac296689d34b38a14bbba0dd"
-  "3.09":
-    url: "https://github.com/bulletphysics/bullet3/archive/3.09.tar.gz"
-    sha256: "f2feef9322329c0571d9066fede2db0ede92b19f7f7fdf54def3b4651f02af03"
-  "3.17":
-    url: "https://github.com/bulletphysics/bullet3/archive/3.17.tar.gz"
-    sha256: "baa642c906576d4d98d041d0acb80d85dd6eff6e3c16a009b1abf1ccd2bc0a61"
   "3.21":
     url: "https://github.com/bulletphysics/bullet3/archive/3.21.tar.gz"
     sha256: "49d1ee47aa8cbb0bc6bb459f0a4cfb9579b40e28f5c7d9a36c313e3031fb3965"
+  "3.17":
+    url: "https://github.com/bulletphysics/bullet3/archive/3.17.tar.gz"
+    sha256: "baa642c906576d4d98d041d0acb80d85dd6eff6e3c16a009b1abf1ccd2bc0a61"
+  "3.09":
+    url: "https://github.com/bulletphysics/bullet3/archive/3.09.tar.gz"
+    sha256: "f2feef9322329c0571d9066fede2db0ede92b19f7f7fdf54def3b4651f02af03"
+  "3.08":
+    url: "https://github.com/bulletphysics/bullet3/archive/3.08.tar.gz"
+    sha256: "05826c104b842bcdd1339b86894cb44c84ac2525ac296689d34b38a14bbba0dd"
+  "3.07":
+    url: "https://github.com/bulletphysics/bullet3/archive/3.07.tar.gz"
+    sha256: "068ecf8acbf256d3976eebee75d7d6f5af16c049f10f6b2d8ba28bb638bef3b0"
+  "3.06":
+    url: "https://github.com/bulletphysics/bullet3/archive/3.06.tar.gz"
+    sha256: "217c1d198ee00be7e40d4cb4d79882e37ef4a06cbfbe11f5fbc207c347a57020"
+  "2.89":
+    url: "https://github.com/bulletphysics/bullet3/archive/2.89.tar.gz"
+    sha256: "621b36e91c0371933f3c2156db22c083383164881d2a6b84636759dc4cbb0bb8"

--- a/recipes/bullet3/all/conanfile.py
+++ b/recipes/bullet3/all/conanfile.py
@@ -44,6 +44,7 @@ class Bullet3Conan(ConanFile):
         "extras": False,
     }
 
+    short_paths = True
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
 

--- a/recipes/bullet3/all/conanfile.py
+++ b/recipes/bullet3/all/conanfile.py
@@ -104,31 +104,32 @@ class Bullet3Conan(ConanFile):
     def package_info(self):
         libs = []
         if self.options.bullet3:
-            libs += [
-                "Bullet2FileLoader",
-                "Bullet3Collision",
-                "Bullet3Dynamics",
+            libs.extend([
+                "Bullet3OpenCL_clew", # depends on LinearMath Bullet3Dynamics (and libdl on Linux)
+                "Bullet3Dynamics", # depends on Bullet3Collision
+                "Bullet3Collision", # depends on Bullet3Geometry
                 "Bullet3Geometry",
-                "Bullet3OpenCL_clew",
-            ]
-        libs += [
-            "BulletDynamics",
-            "BulletCollision",
-            "LinearMath",
-            "BulletSoftBody",
-            "Bullet3Common",
-            "BulletInverseDynamics",
-        ]
+                "Bullet2FileLoader", # depends on Bullet3Common
+            ])
         if self.options.extras:
-            libs += [   "BulletInverseDynamicsUtils",
-                        "BulletRobotics",
-                        "BulletFileLoader",
-                        "BulletXmlWorldImporter",
-                        "BulletWorldImporter",
-                        "ConvexDecomposition",
-                        "HACD",
-                        "GIMPACTUtils"
-                    ]
+            libs.extend([
+                "BulletRobotics", # depends on BulletInverseDynamicsUtils BulletWorldImporter BulletFileLoader BulletSoftBody BulletDynamics BulletCollision BulletInverseDynamics LinearMath Bullet3Common
+                "BulletInverseDynamicsUtils", # depends on BulletInverseDynamics BulletDynamics BulletCollision Bullet3Common LinearMath
+                "BulletXmlWorldImporter", # depends on BulletWorldImporter BulletDynamics BulletCollision BulletFileLoader LinearMath
+                "BulletWorldImporter", # depends on BulletDynamics BulletCollision BulletFileLoader LinearMath
+                "BulletFileLoader", # depends on LinearMath
+                "GIMPACTUtils", # depends on ConvexDecomposition BulletCollision
+                "ConvexDecomposition", # depends on BulletCollision LinearMath
+                "HACD",
+            ])
+        libs.extend([
+            "BulletSoftBody", # depends on BulletDynamics
+            "BulletDynamics", # depends on BulletCollision & LinearMath
+            "BulletCollision", # depends on LinearMath
+            "BulletInverseDynamics", # depends on Bullet3Common & LinearMath
+            "LinearMath",
+            "Bullet3Common",
+        ])
         if self.settings.os == "Windows" and self.settings.build_type in ("Debug", "MinSizeRel", "RelWithDebInfo"):
             lib_suffix = "RelWithDebugInfo" if self.settings.build_type == "RelWithDebInfo" else self.settings.build_type
             libs = [lib + "_{}".format(lib_suffix) for lib in libs]

--- a/recipes/bullet3/all/conanfile.py
+++ b/recipes/bullet3/all/conanfile.py
@@ -79,7 +79,7 @@ class Bullet3Conan(ConanFile):
         cmake.definitions["INSTALL_LIBS"] = True
         cmake.definitions["USE_GRAPHICAL_BENCHMARK"] = self.options.graphical_benchmark
         cmake.definitions["USE_DOUBLE_PRECISION"] = self.options.double_precision
-        cmake.definitions["BULLET2_USE_THREAD_LOCKS"] = self.options.bt2_thread_locks
+        cmake.definitions["BULLET2_MULTITHREADING"] = self.options.bt2_thread_locks
         cmake.definitions["USE_SOFT_BODY_MULTI_BODY_DYNAMICS_WORLD"] = self.options.soft_body_multi_body_dynamics_world
         cmake.definitions["BUILD_ENET"] = self.options.network_support
         cmake.definitions["BUILD_CLSOCKET"] = self.options.network_support
@@ -190,6 +190,8 @@ class Bullet3Conan(ConanFile):
         if self.options.extras:
             self.cpp_info.includedirs.append(os.path.join("include", "bullet_robotics"))
         self.cpp_info.defines = self._bullet_definitions
+        if self.options.bt2_thread_locks and self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.names["cmake_find_package"] = "Bullet"

--- a/recipes/bullet3/all/conanfile.py
+++ b/recipes/bullet3/all/conanfile.py
@@ -35,7 +35,7 @@ class Bullet3Conan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "bullet3": False,
+        "bullet3": True,
         "graphical_benchmark": False,
         "double_precision": False,
         "bt2_thread_locks": False,

--- a/recipes/bullet3/all/test_package/CMakeLists.txt
+++ b/recipes/bullet3/all/test_package/CMakeLists.txt
@@ -5,6 +5,7 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
 find_package(Bullet REQUIRED CONFIG)
+include(${BULLET_ROOT_DIR}/${BULLET_USE_FILE})
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} Bullet::Bullet)
+target_link_libraries(${PROJECT_NAME} ${BULLET_LIBRARIES})

--- a/recipes/bullet3/all/test_package/CMakeLists.txt
+++ b/recipes/bullet3/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(Bullet REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} Bullet::Bullet)

--- a/recipes/bullet3/all/test_package/conanfile.py
+++ b/recipes/bullet3/all/test_package/conanfile.py
@@ -3,8 +3,8 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/bullet3/config.yml
+++ b/recipes/bullet3/config.yml
@@ -1,15 +1,15 @@
 versions:
-  "2.89":
-    folder: all
-  "3.06":
-    folder: all
-  "3.07":
-    folder: all
-  "3.08":
-    folder: all
-  "3.09":
+  "3.21":
     folder: all
   "3.17":
     folder: all
-  "3.21":
+  "3.09":
+    folder: all
+  "3.08":
+    folder: all
+  "3.07":
+    folder: all
+  "3.06":
+    folder: all
+  "2.89":
     folder: all


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- CMakeDeps support
- provide official CMake variables from upstream config file
- keep `UseBullet.cmake`
- fix libs ordering, there were several issues
- enable `bullet3` option by default to honor default upstream value
- compiler=msvc support

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
