### PR TITLE
cpuinfo: add cci.20220228 + modernize

### DIFF
--- a/recipes/cpuinfo/all/CMakeLists.txt
+++ b/recipes/cpuinfo/all/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
+
+if(NOT CMAKE_SYSTEM_PROCESSOR)
+    set(CMAKE_SYSTEM_PROCESSOR ${CONAN_CPUINFO_SYSTEM_PROCESSOR})
+endif()
 
 add_subdirectory(source_subfolder)

--- a/recipes/cpuinfo/all/conandata.yml
+++ b/recipes/cpuinfo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20220228":
+    url: "https://github.com/pytorch/cpuinfo/archive/6288930068efc8dff4f3c0b95f062fc5ddceba04.tar.gz"
+    sha256: "9e9e937b3569320d23d8b1c8c26ed3603affe55c3e4a3e49622e8a2c6d6e1696"
   "cci.20201217":
-    url: "https://github.com/pytorch/cpuinfo/archive/5916273f79a21551890fd3d56fc5375a78d1598d.zip"
-    sha256: "2a160c527d3c58085ce260f34f9e2b161adc009b34186a2baf24e74376e89e6d"
+    url: "https://github.com/pytorch/cpuinfo/archive/5916273f79a21551890fd3d56fc5375a78d1598d.tar.gz"
+    sha256: "f3c16d5d393d6d1fa6b6ed8621dd0a535552df9bc88cbba739375dde38a93142"

--- a/recipes/cpuinfo/all/conanfile.py
+++ b/recipes/cpuinfo/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 import functools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
 
 
 class CpuinfoConan(ConanFile):
@@ -94,8 +94,10 @@ class CpuinfoConan(ConanFile):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "libcpuinfo")
         self.cpp_info.libs = ["cpuinfo", "clog"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread"]

--- a/recipes/cpuinfo/all/conanfile.py
+++ b/recipes/cpuinfo/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import functools
 import os
 
 required_conan_version = ">=1.33.0"
@@ -10,7 +11,7 @@ class CpuinfoConan(ConanFile):
     description = "cpuinfo is a library to detect essential for performance " \
                   "optimization information about host CPU."
     license = "BSD-2-Clause"
-    topics = ("conan", "cpuinfo", "cpu", "cpuid", "cpu-cache", "cpu-model",
+    topics = ("cpuinfo", "cpu", "cpuid", "cpu-cache", "cpu-model",
               "instruction-set", "cpu-topology")
     homepage = "https://github.com/pytorch/cpuinfo"
     url = "https://github.com/conan-io/conan-center-index"
@@ -29,7 +30,6 @@ class CpuinfoConan(ConanFile):
 
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -58,33 +58,32 @@ class CpuinfoConan(ConanFile):
                               "SET_PROPERTY(TARGET clog PROPERTY POSITION_INDEPENDENT_CODE ON)",
                               "")
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
+        cmake = CMake(self)
         # cpuinfo
-        self._cmake.definitions["CPUINFO_LIBRARY_TYPE"] = "default"
-        self._cmake.definitions["CPUINFO_RUNTIME_TYPE"] = "default"
-        self._cmake.definitions["CPUINFO_LOG_LEVEL"] = self.options.log_level
-        self._cmake.definitions["CPUINFO_BUILD_TOOLS"] = False
-        self._cmake.definitions["CPUINFO_BUILD_UNIT_TESTS"] = False
-        self._cmake.definitions["CPUINFO_BUILD_MOCK_TESTS"] = False
-        self._cmake.definitions["CPUINFO_BUILD_BENCHMARKS"] = False
+        cmake.definitions["CPUINFO_LIBRARY_TYPE"] = "default"
+        cmake.definitions["CPUINFO_RUNTIME_TYPE"] = "default"
+        cmake.definitions["CPUINFO_LOG_LEVEL"] = self.options.log_level
+        cmake.definitions["CPUINFO_BUILD_TOOLS"] = False
+        cmake.definitions["CPUINFO_BUILD_UNIT_TESTS"] = False
+        cmake.definitions["CPUINFO_BUILD_MOCK_TESTS"] = False
+        cmake.definitions["CPUINFO_BUILD_BENCHMARKS"] = False
         # clog (always static)
-        self._cmake.definitions["CLOG_RUNTIME_TYPE"] = "default"
-        self._cmake.definitions["CLOG_BUILD_TESTS"] = False
-        self._cmake.definitions["CMAKE_POSITION_INDEPENDENT_CODE"] = self.options.get_safe("fPIC", True)
+        cmake.definitions["CLOG_RUNTIME_TYPE"] = "default"
+        cmake.definitions["CLOG_BUILD_TESTS"] = False
+        cmake.definitions["CMAKE_POSITION_INDEPENDENT_CODE"] = self.options.get_safe("fPIC", True)
 
         # CMAKE_SYSTEM_PROCESSOR must be manually set if cross-building
-        if tools.cross_building(self.settings):
+        if tools.cross_building(self):
             cmake_system_processor = {
                 "armv8": "arm64",
                 "armv8.3": "arm64",
             }.get(str(self.settings.arch), str(self.settings.arch))
-            self._cmake.definitions["CMAKE_SYSTEM_PROCESSOR"] = cmake_system_processor
+            cmake.definitions["CONAN_CPUINFO_SYSTEM_PROCESSOR"] = cmake_system_processor
 
-        self._cmake.configure()
-        return self._cmake
+        cmake.configure()
+        return cmake
 
     def build(self):
         self._patch_sources()
@@ -98,5 +97,5 @@ class CpuinfoConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["cpuinfo", "clog"]
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread"]

--- a/recipes/cpuinfo/all/test_package/CMakeLists.txt
+++ b/recipes/cpuinfo/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(cpuinfo REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} cpuinfo::cpuinfo)
 set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)

--- a/recipes/cpuinfo/all/test_package/conanfile.py
+++ b/recipes/cpuinfo/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/cpuinfo/config.yml
+++ b/recipes/cpuinfo/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "cci.20220228":
+    folder: all
   "cci.20201217":
     folder: all


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- honor `CMAKE_SYSTEM_PROCESSOR` if already set by user
- cpuinfo now provides a pkg-config file, so it's defined in package_info()

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
