### PR TITLE
avcpp: add recipe

### DIFF
--- a/recipes/avcpp/all/CMakeLists.txt
+++ b/recipes/avcpp/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.4)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/avcpp/all/CMakeLists.txt
+++ b/recipes/avcpp/all/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(KEEP_RPATHS)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(AVCPP_NOT_SUBPROJECT ON)
+
+add_subdirectory(source_subfolder)

--- a/recipes/avcpp/all/conandata.yml
+++ b/recipes/avcpp/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "cci.20220301":
+    url: "https://github.com/h4tr3d/avcpp/archive/fd4bc4662eb39853de8fcac4a663bebd0eea30b8.tar.gz"
+    sha256: "e48eae2ec154bc69aed16159c8b18c9ffb4925ba672b022e94a3c9b96782a4bf"
+
+patches:
+  "cci.20220301":
+    - base_path: "source_subfolder"
+      patch_file: "patches/fix-ffmpeg-package.patch"

--- a/recipes/avcpp/all/conanfile.py
+++ b/recipes/avcpp/all/conanfile.py
@@ -1,0 +1,101 @@
+import os
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.43.0"
+
+class AvcppConan(ConanFile):
+    name = "avcpp"
+    description = "C++ wrapper for FFmpeg"
+    topics = ("ffmpeg", "cpp")
+    license = "LGPL-2.1 or BSD"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/h4tr3d/avcpp/"
+    settings = "os", "arch", "compiler", "build_type"
+    options = { "fPIC": [True, False], "shared": [True, False], }
+    default_options = { "fPIC": True, "shared": False, }
+    generators = "cmake", "cmake_find_package_multi"
+
+    _cmake = None
+
+    @property
+    def _compiler_required_cpp17(self):
+        return {
+            "Visual Studio": "16",
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "12.0",
+        }
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def validate(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            tools.check_min_cppstd(self, "17")
+
+        minimum_version = self._compiler_required_cpp17.get(str(self.settings.compiler), False)
+        if minimum_version:
+            if tools.Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration("{} requires C++17, which your compiler does not support.".format(self.name))
+        else:
+            self.output.warn("{0} requires C++17. Your compiler is unknown. Assuming it supports C++17.".format(self.name))
+
+    def requirements(self):
+        self.requires("ffmpeg/5.0")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["AV_ENABLE_SHARED"] = self.options.shared
+        self._cmake.definitions["AV_ENABLE_STATIC"] = not self.options.shared
+        self._cmake.definitions["AV_BUILD_EXAMPLES"] = False
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE*", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        target_name = "avcpp" if self.options.shared else "avcpp-static"
+
+        self.cpp_info.set_property("cmake_file_name", "avcpp")
+        self.cpp_info.set_property("cmake_target_name", "avcpp::{}".format(target_name))
+
+        self.cpp_info.filenames["cmake_find_package"] = "avcpp"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "avcpp"
+        self.cpp_info.names["cmake_find_package"] = "avcpp"
+        self.cpp_info.names["cmake_find_package_multi"] = "avcpp"
+
+        self.cpp_info.components["AvCpp"].names["cmake_find_package"] = target_name
+        self.cpp_info.components["AvCpp"].names["cmake_find_package_multi"] = target_name
+        self.cpp_info.components["AvCpp"].set_property("cmake_target_name", "avcpp::{}".format(target_name))
+        self.cpp_info.components["AvCpp"].libs = ["avcpp", ]
+        self.cpp_info.components["AvCpp"].requires = ["ffmpeg::ffmpeg", ]

--- a/recipes/avcpp/all/patches/fix-ffmpeg-package.patch
+++ b/recipes/avcpp/all/patches/fix-ffmpeg-package.patch
@@ -1,0 +1,46 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a5fed05..d077b96 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,7 +6,7 @@ endif()
+ 
+ project(AvCpp LANGUAGES CXX VERSION 2.0.99)
+ 
+-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
++# set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+ 
+ set(FFMPEG_PKG_CONFIG_SUFFIX "" CACHE STRING "This suffix uses for FFmpeg component names searches by pkg-config")
+ set(AV_ENABLE_STATIC On CACHE BOOL "Enable static library build (On)")
+@@ -28,8 +28,8 @@ set (AVCPP_WARNING_OPTIONS
+ set(THREADS_PREFER_PTHREAD_FLAG ON)
+ find_package(Threads)
+ 
+-find_package(FFmpeg
+-    COMPONENTS AVCODEC AVFORMAT AVUTIL AVDEVICE AVFILTER SWSCALE SWRESAMPLE REQUIRED)
++find_package(ffmpeg
++    COMPONENTS avcodec avformat avutil avdevice avfilter swscale swresample REQUIRED)
+ 
+ add_subdirectory(src)
+ 
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 80c6faa..262c16c 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -24,7 +24,7 @@ foreach(TARGET ${AV_TARGETS})
+     add_library(${TARGET} ${TYPE} ${AV_SOURCES} ${AV_HEADERS})
+ 
+     target_compile_options(${TARGET} PRIVATE ${AVCPP_WARNING_OPTIONS})
+-    target_link_libraries(${TARGET} PRIVATE Threads::Threads PUBLIC FFmpeg::FFmpeg)
++    target_link_libraries(${TARGET} PRIVATE Threads::Threads PUBLIC ffmpeg::ffmpeg)
+     target_include_directories(${TARGET}
+         PUBLIC
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+@@ -53,7 +53,7 @@ if (AVCPP_NOT_SUBPROJECT)
+     #    APPEND
+     #    FILE ${CMAKE_CURRENT_BINARY_DIR}/avcpp-targets.cmake)
+ 
+-    install(TARGETS ${AV_TARGETS} FFmpeg
++    install(TARGETS ${AV_TARGETS}
+         EXPORT avcpp-targets
+         LIBRARY DESTINATION        ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION        ${CMAKE_INSTALL_LIBDIR}

--- a/recipes/avcpp/all/test_package/CMakeLists.txt
+++ b/recipes/avcpp/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/avcpp/all/test_package/CMakeLists.txt
+++ b/recipes/avcpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(avcpp CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+if (TARGET avcpp::avcpp)
+    target_link_libraries(${PROJECT_NAME} avcpp::avcpp)
+else()
+    target_link_libraries(${PROJECT_NAME} avcpp::avcpp-static)
+endif()
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)

--- a/recipes/avcpp/all/test_package/conanfile.py
+++ b/recipes/avcpp/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class TestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/avcpp/all/test_package/test_package.cpp
+++ b/recipes/avcpp/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+#include "avcpp/av.h"
+#include "avcpp/avutils.h"
+
+int main() {
+    av::init();
+    av::setFFmpegLoggingLevel(AV_LOG_DEBUG);
+
+    return 0;
+}

--- a/recipes/avcpp/config.yml
+++ b/recipes/avcpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20220301":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **avcpp/cci.20220301**

The latest version of avcpp is 0.2, released in 2018.
avcpp is still under development in 2022, which is why this recipe is only available in a snapshot version.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
