### PR TITLE
[ci] Conan linter: match version running in CI

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.8"
 
-      - run: "pip3 install conan yamllint packaging pylint==2.10.2 astroid"
+      - run: "pip3 install conan==1.44.1 yamllint packaging pylint==2.10.2 astroid"
 
       - name: install hook
         run: |


### PR DESCRIPTION
The linter should match the version we are running in the CI, otherwise it might report errors (or suggestions) that might not work.

Note.- Pylint plugin is here: https://github.com/conan-io/conan/blob/develop/conans/pylint_plugin.py