### PR TITLE
opencv: Fixed correspondence not requiring version on Windows.

### DIFF
--- a/recipes/opencv/3.x/conanfile.py
+++ b/recipes/opencv/3.x/conanfile.py
@@ -404,7 +404,7 @@ class OpenCVConan(ConanFile):
 
         def get_lib_name(module):
             if module in ("correspondence", "multiview", "numeric"):
-                return "%s%s" % (module, debug)
+                return module
             else:
                 return "opencv_%s%s%s" % (module, version, debug)
 

--- a/recipes/opencv/3.x/conanfile.py
+++ b/recipes/opencv/3.x/conanfile.py
@@ -403,8 +403,10 @@ class OpenCVConan(ConanFile):
         debug = "d" if self.settings.build_type == "Debug" and self._is_msvc else ""
 
         def get_lib_name(module):
-            prefix = "" if module in ("correspondence", "multiview", "numeric") else "opencv_"
-            return "%s%s%s%s" % (prefix, module, version, debug)
+            if module in ("correspondence", "multiview", "numeric"):
+                return "%s%s" % (module, debug)
+            else:
+                return "opencv_%s%s%s" % (module, version, debug)
 
         def add_components(components):
             for component in components:

--- a/recipes/opencv/3.x/conanfile.py
+++ b/recipes/opencv/3.x/conanfile.py
@@ -147,6 +147,17 @@ class OpenCVConan(ConanFile):
                               "")
         tools.replace_in_file(install_layout_file, "set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)", "")
 
+        if self.options.contrib and tools.Version(self.version) <= "3.4.12":
+            sfm_cmake = os.path.join(self._contrib_folder, "modules", "sfm", "CMakeLists.txt")
+            search = '  find_package(Glog QUIET)\nendif()'
+            tools.replace_in_file(sfm_cmake, search, """{}
+            if(NOT GFLAGS_LIBRARIES AND TARGET gflags::gflags)
+              set(GFLAGS_LIBRARIES gflags::gflags)
+            endif()
+            if(NOT GLOG_LIBRARIES AND TARGET glog::glog)
+              set(GLOG_LIBRARIES glog::glog)
+            endif()""".format(search))
+
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake

--- a/recipes/opencv/3.x/test_package/CMakeLists.txt
+++ b/recipes/opencv/3.x/test_package/CMakeLists.txt
@@ -6,5 +6,10 @@ conan_basic_setup(TARGETS)
 
 find_package(OpenCV REQUIRED core imgproc CONFIG)
 
+option(built_contrib "Enabled if opencv is built contrib sfm" OFF)
+if(built_contrib)
+    add_definitions(-DBUILT_CONTRIB)
+endif()
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} opencv_core opencv_imgproc)
+target_link_libraries(${PROJECT_NAME} opencv_core opencv_imgproc $<TARGET_NAME_IF_EXISTS:opencv_sfm>)

--- a/recipes/opencv/3.x/test_package/conanfile.py
+++ b/recipes/opencv/3.x/test_package/conanfile.py
@@ -8,6 +8,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.definitions["built_contrib"] = self.options["opencv"].contrib
         cmake.configure()
         cmake.build()
 

--- a/recipes/opencv/3.x/test_package/test_package.cpp
+++ b/recipes/opencv/3.x/test_package/test_package.cpp
@@ -7,6 +7,9 @@
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc.hpp>
+#ifdef BUILT_CONTRIB
+#include <opencv2/sfm.hpp>
+#endif
 
 #define w 400
 
@@ -17,6 +20,7 @@ void MyEllipse( Mat img, double angle );
 void MyFilledCircle( Mat img, Point center );
 void MyPolygon( Mat img );
 void MyLine( Mat img, Point start, Point end );
+void TestSFM();
 
 /**
  * @function main
@@ -63,6 +67,7 @@ int main( void ){
   MyLine( rook_image, Point( w/4, 7*w/8 ), Point( w/4, w ) );
   MyLine( rook_image, Point( w/2, 7*w/8 ), Point( w/2, w ) );
   MyLine( rook_image, Point( 3*w/4, 7*w/8 ), Point( 3*w/4, w ) );
+  TestSFM();
 
   return(0);
 }
@@ -162,4 +167,13 @@ void MyLine( Mat img, Point start, Point end )
     Scalar( 0, 0, 0 ),
     thickness,
     lineType );
+}
+
+void TestSFM()
+{
+#ifdef BUILT_CONTRIB
+  Vec3f a;
+  a << 1,2,3;
+  Matx33f ax = sfm::skew(a);
+#endif
 }

--- a/recipes/opencv/4.x/CMakeLists.txt
+++ b/recipes/opencv/4.x/CMakeLists.txt
@@ -5,6 +5,7 @@ if (WITH_OPENEXR)
     set(CMAKE_CXX_STANDARD 11)
 endif()
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
 include(conanbuildinfo.cmake)
 conan_basic_setup(KEEP_RPATHS)
 

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -711,8 +711,10 @@ class OpenCVConan(ConanFile):
         debug = "d" if self.settings.build_type == "Debug" and self.settings.os == "Windows" else ""
 
         def get_lib_name(module):
-            if module in ("ippiw", "correspondence", "multiview", "numeric"):
+            if module == "ippiw":
                 return "%s%s" % (module, debug)
+            elif module in ("correspondence", "multiview", "numeric"):
+                return module
             else:
                 return "opencv_%s%s%s" % (module, version, debug)
 

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -298,6 +298,21 @@ class OpenCVConan(ConanFile):
             gapi_cmake = os.path.join(self._source_subfolder, "modules", "gapi", "CMakeLists.txt")
             tools.replace_in_file(gapi_cmake, " ade)", " ade::ade)")
 
+        if self.options.contrib and self.options.contrib_sfm and tools.Version(self.version) <= "4.5.2":
+            sfm_cmake = os.path.join(self._contrib_folder, "modules", "sfm", "CMakeLists.txt")
+            ver = tools.Version(self.version)
+            if ver <= "4.5.0":
+                search = '  find_package(Glog QUIET)\nendif()'
+            else:
+                search = '  set(GLOG_INCLUDE_DIRS "${GLOG_INCLUDE_DIR}")\nendif()'
+            tools.replace_in_file(sfm_cmake, search, """{}
+            if(NOT GFLAGS_LIBRARIES AND TARGET gflags::gflags)
+              set(GFLAGS_LIBRARIES gflags::gflags)
+            endif()
+            if(NOT GLOG_LIBRARIES AND TARGET glog::glog)
+              set(GLOG_LIBRARIES glog::glog)
+            endif()""".format(search))
+
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -711,10 +711,10 @@ class OpenCVConan(ConanFile):
         debug = "d" if self.settings.build_type == "Debug" and self.settings.os == "Windows" else ""
 
         def get_lib_name(module):
-            if module == "ippiw":
+            if module in ("ippiw", "correspondence", "multiview", "numeric"):
                 return "%s%s" % (module, debug)
-            prefix = "" if module in ("correspondence", "multiview", "numeric") else "opencv_"
-            return "%s%s%s%s" % (prefix, module, version, debug)
+            else:
+                return "opencv_%s%s%s" % (module, version, debug)
 
         def add_components(components):
             for component in components:

--- a/recipes/opencv/4.x/test_package/CMakeLists.txt
+++ b/recipes/opencv/4.x/test_package/CMakeLists.txt
@@ -11,11 +11,23 @@ if(built_with_ade)
     add_definitions(-DBUILT_WITH_ADE)
 endif()
 
-option(built_with_ade "Enabled if opencv is built with ffmpeg" OFF)
+option(built_with_ffmpeg "Enabled if opencv is built with ffmpeg" OFF)
 if(built_with_ffmpeg)
     add_definitions(-DBUILT_WITH_FFMPEG)
 endif()
 
+option(built_contrib_sfm "Enabled if opencv is built contrib sfm" OFF)
+if(built_contrib_sfm)
+    add_definitions(-DBUILT_CONTRIB_SFM)
+endif()
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} opencv_imgcodecs opencv_highgui opencv_objdetect $<TARGET_NAME_IF_EXISTS:opencv_gapi> $<TARGET_NAME_IF_EXISTS:opencv_videoio>)
+target_link_libraries(${PROJECT_NAME}
+    opencv_imgcodecs
+    opencv_highgui
+    opencv_objdetect
+    $<TARGET_NAME_IF_EXISTS:opencv_gapi>
+    $<TARGET_NAME_IF_EXISTS:opencv_videoio>
+    $<TARGET_NAME_IF_EXISTS:opencv_sfm>
+)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/opencv/4.x/test_package/conanfile.py
+++ b/recipes/opencv/4.x/test_package/conanfile.py
@@ -10,7 +10,7 @@ class TestPackageConan(ConanFile):
         cmake = CMake(self)
         cmake.definitions["built_with_ade"] = self.options["opencv"].with_ade
         cmake.definitions["built_with_ffmpeg"] = self.options["opencv"].with_ffmpeg
-        cmake.definitions["built_contrib_sfm"] = self.options["opencv"].contrib_sfm
+        cmake.definitions["built_contrib_sfm"] = self.options["opencv"].contrib and self.options["opencv"].contrib_sfm
         cmake.configure()
         cmake.build()
 

--- a/recipes/opencv/4.x/test_package/conanfile.py
+++ b/recipes/opencv/4.x/test_package/conanfile.py
@@ -10,6 +10,7 @@ class TestPackageConan(ConanFile):
         cmake = CMake(self)
         cmake.definitions["built_with_ade"] = self.options["opencv"].with_ade
         cmake.definitions["built_with_ffmpeg"] = self.options["opencv"].with_ffmpeg
+        cmake.definitions["built_contrib_sfm"] = self.options["opencv"].contrib_sfm
         cmake.configure()
         cmake.build()
 

--- a/recipes/opencv/4.x/test_package/test_package.cpp
+++ b/recipes/opencv/4.x/test_package/test_package.cpp
@@ -15,6 +15,9 @@
 #ifdef BUILD_WITH_FFMPEF
 #include <opencv2/videoio.hpp>
 #endif
+#ifdef BUILT_CONTRIB_SFM
+#include <opencv2/sfm.hpp>
+#endif
 
 #define w 400
 
@@ -28,6 +31,7 @@ void MyLine( Mat img, Point start, Point end );
 // to test `with_ade` option
 void TestGAPI();
 void TestVideo();
+void TestSFM();
 
 /**
  * @function main
@@ -84,6 +88,7 @@ int main( void ){
   //![draw_rook]
   TestGAPI();
   TestVideo();
+  TestSFM();
 
   return(0);
 }
@@ -216,5 +221,14 @@ void TestVideo()
 #ifdef BUILD_WITH_FFMPEG
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
         throw std::runtime_error("FFmpeg backend was not found");
+#endif
+}
+
+void TestSFM()
+{
+#ifdef BUILT_CONTRIB_SFM
+  Vec3f a;
+  a << 1,2,3;
+  Matx33f ax = sfm::skew(a);
 #endif
 }


### PR DESCRIPTION
Specify library name and version:  **opencv/3.4.17**

In Windows, there is no need for version correspondence, multiview and numeric libraries.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
