### PR TITLE
llvm-core: Add option to use cmake official config files + Keep TableGen binary

### DIFF
--- a/recipes/llvm-core/all/CMakeLists.txt
+++ b/recipes/llvm-core/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.13.4)
 project(conanllvm)
 
 include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source")

--- a/recipes/llvm-core/all/conanfile.py
+++ b/recipes/llvm-core/all/conanfile.py
@@ -47,7 +47,8 @@ class LLVMCoreConan(ConanFile):
         ],
         'with_ffi': [True, False],
         'with_zlib': [True, False],
-        'with_xml2': [True, False]
+        'with_xml2': [True, False],
+        'use_llvm_cmake_files': [True, False],
     }
     default_options = {
         'shared': False,
@@ -65,7 +66,8 @@ class LLVMCoreConan(ConanFile):
         'use_sanitizer': 'None',
         'with_ffi': False,
         'with_zlib': True,
-        'with_xml2': True
+        'with_xml2': True,
+        'use_llvm_cmake_files': False,
     }
 
     # Older cmake versions may have issues generating the graphviz output used
@@ -201,6 +203,9 @@ class LLVMCoreConan(ConanFile):
         if self.options.get_safe('with_xml2', False):
             self.requires('libxml2/2.9.10')
 
+    def package_id(self):
+        del self.info.options.use_llvm_cmake_files
+
     def validate(self):
         if self.options.shared:  # Shared builds disabled just due to the CI
             message = 'Shared builds not currently supported'
@@ -322,8 +327,20 @@ class LLVMCoreConan(ConanFile):
                 old_alias_targets
             )
 
-        tools.rmdir(os.path.join(self.package_folder, 'bin'))
         tools.rmdir(os.path.join(self.package_folder, 'share'))
+
+        tools.remove_files_by_mask(self.package_folder, "LLVMExports*.cmake")
+        tools.rename(os.path.join(self.package_folder, self._module_subfolder, 'LLVM-Config.cmake'),
+                     os.path.join(self.package_folder, self._module_subfolder, 'LLVM-ConfigInternal.cmake'))
+        tools.rename(os.path.join(self.package_folder, self._module_subfolder, 'LLVMConfig.cmake'),
+                     os.path.join(self.package_folder, self._module_subfolder, 'LLVMConfigInternal.cmake'))
+
+        tools.replace_in_file(os.path.join(self.package_folder, self._module_subfolder, 'AddLLVM.cmake'),
+                              "include(LLVM-Config)",
+                              "include(LLVM-ConfigInternal)")
+        tools.replace_in_file(os.path.join(self.package_folder, self._module_subfolder, 'LLVMConfigInternal.cmake'),
+                              "LLVM-Config.cmake",
+                              "LLVM-ConfigInternal.cmake")
 
         for mask in ["Find*.cmake", "*Config.cmake", "*-config.cmake"]:
             tools.remove_files_by_mask(self.package_folder, mask)
@@ -396,6 +413,14 @@ class LLVMCoreConan(ConanFile):
                 self._alias_module_file_rel_path,
                 self._old_alias_module_file_rel_path,
             ])
+
+            if self.options.use_llvm_cmake_files:
+                self.cpp_info.components[component].build_modules["cmake_find_package"].append(
+                    os.path.join(self._module_subfolder, "LLVMConfigInternal.cmake")
+                )
+                self.cpp_info.components[component].build_modules["cmake_find_package_multi"].append(
+                    os.path.join(self._module_subfolder, "LLVMConfigInternal.cmake")
+                )
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.names["cmake_find_package"] = "LLVM"


### PR DESCRIPTION
Specify library name and version:  **llvm-core/all**

These changes are mandatory for packaging llvm tools like clang:
- Keep TableGen binary
- Add option (disabled by default) to use cmake official config files

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
