### PR TITLE
snappy: add a patch and option to enable rtti

### DIFF
--- a/recipes/snappy/all/conandata.yml
+++ b/recipes/snappy/all/conandata.yml
@@ -16,3 +16,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/1.1.9-0003-fix-clobber-list-older-llvm.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/1.1.9-0004-add-option-to-enable-rtti.patch"
+      base_path: "source_subfolder"

--- a/recipes/snappy/all/conanfile.py
+++ b/recipes/snappy/all/conanfile.py
@@ -16,10 +16,12 @@ class SnappyConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "rtti": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "rtti": False
     }
 
     generators = "cmake"
@@ -65,6 +67,7 @@ class SnappyConan(ConanFile):
             self._cmake.definitions["SNAPPY_INSTALL"] = True
         if tools.Version(self.version) >= "1.1.9":
             self._cmake.definitions["SNAPPY_BUILD_BENCHMARKS"] = False
+            self._cmake.definitions["SNAPPY_ENABLE_RTTI"] = self.options.rtti
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 

--- a/recipes/snappy/all/patches/1.1.9-0004-add-option-to-enable-rtti.patch
+++ b/recipes/snappy/all/patches/1.1.9-0004-add-option-to-enable-rtti.patch
@@ -1,0 +1,38 @@
+allow building package with rtti enabled
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -53,8 +53,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   add_definitions(-D_HAS_EXCEPTIONS=0)
+ 
+   # Disable RTTI.
+-  string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
++  if(NOT SNAPPY_ENABLE_RTTI)
++    string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
++  endif(SNAPPY_ENABLE_RTTI)
+ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   # Use -Wall for clang and gcc.
+   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
+@@ -78,8 +80,10 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+ 
+   # Disable RTTI.
+-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
++  if(NOT SNAPPY_ENABLE_RTTI)
++    string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
++  endif(SNAPPY_ENABLE_RTTI)
+ endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+ 
+ # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make
+@@ -98,6 +102,8 @@ option(SNAPPY_REQUIRE_AVX2 "Target processors with AVX2 support." OFF)
+ 
+ option(SNAPPY_INSTALL "Install Snappy's header and library" ON)
+ 
++option(SNAPPY_ENABLE_RTTI "Enable RTTI for Snappy's library" OFF)
++
+ include(TestBigEndian)
+ test_big_endian(SNAPPY_IS_BIG_ENDIAN)
+ 


### PR DESCRIPTION
Specify library name and version:  snappy/1.1.9

Add a patch file to allow the use of rtti with the snappy library
Add a package option to enable the cmake option, False by default to maintain current behavior

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
