### PR TITLE
protobuf: relocatable shared libs on macOS + modernize

### DIFF
--- a/recipes/protobuf/all/CMakeLists.txt
+++ b/recipes/protobuf/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include("conanbuildinfo.cmake")
-conan_basic_setup(TARGETS)
+conan_basic_setup(TARGETS KEEP_RPATHS)
 
 add_subdirectory(source_subfolder/cmake)

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -1,5 +1,8 @@
+from conan.tools.files import rename
+from conan.tools.microsoft import msvc_runtime_flag
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import functools
 import os
 import textwrap
 
@@ -31,9 +34,7 @@ class ProtobufConan(ConanFile):
     }
 
     short_paths = True
-
     generators = "cmake"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -42,6 +43,10 @@ class ProtobufConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
 
     @property
     def _is_clang_x86(self):
@@ -96,21 +101,21 @@ class ProtobufConan(ConanFile):
     def _cmake_install_base_path(self):
         return os.path.join("lib", "cmake", "protobuf")
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if not self._cmake:
-            self._cmake = CMake(self)
-            self._cmake.definitions["CMAKE_INSTALL_CMAKEDIR"] = self._cmake_install_base_path.replace("\\", "/")
-            self._cmake.definitions["protobuf_WITH_ZLIB"] = self.options.with_zlib
-            self._cmake.definitions["protobuf_BUILD_TESTS"] = False
-            self._cmake.definitions["protobuf_BUILD_PROTOC_BINARIES"] = True
-            if tools.Version(self.version) >= "3.14.0":
-                self._cmake.definitions["protobuf_BUILD_LIBPROTOC"] = True
-            if self._can_disable_rtti:
-                self._cmake.definitions["protobuf_DISABLE_RTTI"] = not self.options.with_rtti
-            if self.settings.compiler.get_safe("runtime"):
-                self._cmake.definitions["protobuf_MSVC_STATIC_RUNTIME"] = str(self.settings.compiler.runtime) in ["MT", "MTd", "static"]
-            self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["CMAKE_INSTALL_CMAKEDIR"] = self._cmake_install_base_path.replace("\\", "/")
+        cmake.definitions["protobuf_WITH_ZLIB"] = self.options.with_zlib
+        cmake.definitions["protobuf_BUILD_TESTS"] = False
+        cmake.definitions["protobuf_BUILD_PROTOC_BINARIES"] = True
+        if tools.Version(self.version) >= "3.14.0":
+            cmake.definitions["protobuf_BUILD_LIBPROTOC"] = True
+        if self._can_disable_rtti:
+            cmake.definitions["protobuf_DISABLE_RTTI"] = not self.options.with_rtti
+        if self._is_msvc:
+            cmake.definitions["protobuf_MSVC_STATIC_RUNTIME"] = "MT" in msvc_runtime_flag(self)
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -195,7 +200,7 @@ class ProtobufConan(ConanFile):
         os.unlink(os.path.join(self.package_folder, self._cmake_install_base_path, "protobuf-config-version.cmake"))
         os.unlink(os.path.join(self.package_folder, self._cmake_install_base_path, "protobuf-targets.cmake"))
         os.unlink(os.path.join(self.package_folder, self._cmake_install_base_path, "protobuf-targets-{}.cmake".format(str(self.settings.build_type).lower())))
-        tools.rename(os.path.join(self.package_folder, self._cmake_install_base_path, "protobuf-config.cmake"),
+        rename(self, os.path.join(self.package_folder, self._cmake_install_base_path, "protobuf-config.cmake"),
                      os.path.join(self.package_folder, self._cmake_install_base_path, "protobuf-generate.cmake"))
 
         if not self.options.lite:
@@ -215,7 +220,7 @@ class ProtobufConan(ConanFile):
         ]
         self.cpp_info.set_property("cmake_build_modules", build_modules)
 
-        lib_prefix = "lib" if self.settings.compiler == "Visual Studio" else ""
+        lib_prefix = "lib" if self._is_msvc else ""
         lib_suffix = "d" if self.settings.build_type == "Debug" else ""
 
         # libprotobuf


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- cache CMake configuration with functools.lru_cache
- rely on `conan.tools.microsoft.msvc_runtime_flag` to set vc runtime

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
