### PR TITLE
mcap: add version 0.1.0

### DIFF
--- a/recipes/mcap/all/conandata.yml
+++ b/recipes/mcap/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  0.1.1:
-    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.1.tar.gz
-    sha256: 162144ec9c6bcb6299f66fcc27dc796307b6445f403c71587310ec6cea30ade2
+  0.1.0:
+    url: https://github.com/foxglove/mcap/archive/33bddb9c3009478d09fa516e6293b962932967da.tar.gz
+    sha256: 1375c1f8ee5e84c27bad1b4b8cd477728bfb4c2d48f2cf84229de873166a2800

--- a/recipes/mcap/all/conandata.yml
+++ b/recipes/mcap/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   0.1.0:
-    url: https://github.com/foxglove/mcap/archive/33bddb9c3009478d09fa516e6293b962932967da.tar.gz
-    sha256: 1375c1f8ee5e84c27bad1b4b8cd477728bfb4c2d48f2cf84229de873166a2800
+    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.0/main.tar.gz
+    sha256: a936abb1493b0d189d7909a79c45bdc6703b6016801e10b5cd129ba39642d2b2

--- a/recipes/mcap/all/conandata.yml
+++ b/recipes/mcap/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  0.1.1:
+    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.1.tar.gz
+    sha256: 162144ec9c6bcb6299f66fcc27dc796307b6445f403c71587310ec6cea30ade2

--- a/recipes/mcap/all/conanfile.py
+++ b/recipes/mcap/all/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 

--- a/recipes/mcap/all/conanfile.py
+++ b/recipes/mcap/all/conanfile.py
@@ -24,7 +24,7 @@ class McapConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "17")
-        if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 8:
+        if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 11:
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
         if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) <= "16.8":
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")

--- a/recipes/mcap/all/conanfile.py
+++ b/recipes/mcap/all/conanfile.py
@@ -1,0 +1,37 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class McapConan(ConanFile):
+    name = "mcap"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/foxglove/mcap"
+    description = "A C++ implementation of the MCAP file format"
+    license = "Apache-2.0"
+    topics = ("mcap", "serialization", "deserialization", "recording")
+
+    settings = ("os", "compiler", "build_type", "arch")
+    requires = ("fmt/8.1.1", "lz4/1.9.3", "zstd/1.5.2")
+    generators = ("cmake", "cmake_find_package")
+
+    _source_root = "source_root"
+    _source_package_path = os.path.join(_source_root, "cpp", "mcap")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_root)
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, "17")
+        if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 8:
+            raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
+        if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) <= "16.8":
+            raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_package_path)
+        self.copy("include/*", src=self._source_package_path)
+
+    def package_id(self):
+        self.info.header_only()

--- a/recipes/mcap/all/conanfile.py
+++ b/recipes/mcap/all/conanfile.py
@@ -24,7 +24,9 @@ class McapConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "17")
-        if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 11:
+        if self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) <= 11:
+            raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
+        if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 8:
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
         if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) <= "16.8":
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")

--- a/recipes/mcap/all/conanfile.py
+++ b/recipes/mcap/all/conanfile.py
@@ -15,11 +15,16 @@ class McapConan(ConanFile):
     requires = ("fmt/8.1.1", "lz4/1.9.3", "zstd/1.5.2")
     generators = ("cmake", "cmake_find_package")
 
-    _source_root = "source_root"
-    _source_package_path = os.path.join(_source_root, "cpp", "mcap")
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _source_package_path(self):
+        return os.path.join(self._source_subfolder, "cpp", "mcap")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_root)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/mcap/all/test_package/CMakeLists.txt
+++ b/recipes/mcap/all/test_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(mcap REQUIRED CONFIG)
+
+add_compile_options(-O0 -g)
+
+add_executable(test_package test_package.cpp)
+set_target_properties(test_package PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+target_link_libraries(test_package mcap::mcap)

--- a/recipes/mcap/all/test_package/CMakeLists.txt
+++ b/recipes/mcap/all/test_package/CMakeLists.txt
@@ -6,8 +6,6 @@ conan_basic_setup(TARGETS)
 
 find_package(mcap REQUIRED CONFIG)
 
-add_compile_options(-O0 -g)
-
 add_executable(test_package test_package.cpp)
 set_target_properties(test_package PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 target_link_libraries(test_package mcap::mcap)

--- a/recipes/mcap/all/test_package/conanfile.py
+++ b/recipes/mcap/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = ("os", "arch", "compiler", "build_type")
+    generators = ("cmake", "cmake_find_package_multi")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/mcap/all/test_package/test_package.cpp
+++ b/recipes/mcap/all/test_package/test_package.cpp
@@ -1,0 +1,101 @@
+#define MCAP_IMPLEMENTATION
+#include <mcap/reader.hpp>
+#include <mcap/writer.hpp>
+
+#include <algorithm>
+#include <chrono>
+
+struct Buffer : mcap::IReadable, mcap::IWritable {
+  std::vector<std::byte> buffer;
+
+  virtual uint64_t size() const {
+    return buffer.size();
+  }
+
+  // IWritable
+  virtual void end() {}
+  virtual void handleWrite(const std::byte* data, uint64_t size) {
+    buffer.insert(buffer.end(), data, data + size);
+  }
+
+  // IReadable
+  virtual uint64_t read(std::byte** output, uint64_t offset, uint64_t size) {
+    if (offset + size > buffer.size()) {
+      return 0;
+    }
+    *output = buffer.data() + offset;
+    return size;
+  }
+};
+
+void assertOk(const mcap::Status& status) {
+  if (!status.ok()) {
+    throw std::runtime_error(status.message);
+  }
+}
+
+void expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+int main() {
+  Buffer buffer;
+  mcap::McapWriter writer;
+
+  auto options = mcap::McapWriterOptions("example");
+  options.compression = mcap::Compression::Zstd;
+
+  writer.open(buffer, options);
+
+  mcap::Schema schema("Example", "jsonschema",
+                      R"({ "type": "object", "properties": { "foo": { "type": "string" } } })");
+  writer.addSchema(schema);
+
+  mcap::Channel channel("example", "json", schema.id);
+  writer.addChannel(channel);
+
+  auto now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+               .count();
+
+  std::string payload = R"({"foo": "bar"})";
+  mcap::Message msg;
+  msg.channelId = channel.id;
+  msg.sequence = 0;
+  msg.publishTime = now;
+  msg.logTime = msg.publishTime;
+  msg.data = reinterpret_cast<const std::byte*>(payload.data());
+  msg.dataSize = payload.size();
+  assertOk(writer.write(msg));
+
+  writer.close();
+
+  mcap::McapReader reader;
+  assertOk(reader.open(buffer));
+  assertOk(reader.readSummary(mcap::ReadSummaryMethod::NoFallbackScan, assertOk));
+  expect(reader.statistics().value().schemaCount == 1, "incorrect schemaCount");
+  expect(reader.statistics().value().channelCount == 1, "incorrect channelCount");
+  expect(reader.statistics().value().messageCount == 1, "incorrect messageCount");
+  expect(reader.statistics().value().chunkCount == 1, "incorrect chunkCount");
+  for (const auto& msgView : reader.readMessages()) {
+    expect(msgView.channel->id == channel.id, "incorrect channel id");
+    expect(msgView.channel->topic == channel.topic, "incorrect channel topic");
+    expect(msgView.channel->messageEncoding == channel.messageEncoding,
+           "incorrect channel messageEncoding");
+    expect(msgView.schema->id == schema.id, "incorrect schema id");
+    expect(msgView.schema->name == schema.name, "incorrect schema name");
+    expect(msgView.schema->encoding == schema.encoding, "incorrect schema encoding");
+    expect(msgView.message.sequence == msg.sequence, "incorrect message sequence");
+    expect(msgView.message.logTime == msg.logTime, "incorrect message logTime");
+    expect(msgView.message.publishTime == msg.publishTime, "incorrect message publishTime");
+    expect(msgView.message.dataSize == msg.dataSize, "incorrect message dataSize");
+    expect(msgView.message.data != msg.data, "data should be copied");
+    expect(std::equal(msgView.message.data, msgView.message.data + msgView.message.dataSize,
+                      msg.data, msg.data + msg.dataSize),
+           "incorrect data");
+  }
+  std::cout << "MCAP roundtrip succeeded!" << std::endl;
+  return 0;
+}

--- a/recipes/mcap/config.yml
+++ b/recipes/mcap/config.yml
@@ -1,0 +1,3 @@
+versions:
+  0.1.1:
+    folder: all

--- a/recipes/mcap/config.yml
+++ b/recipes/mcap/config.yml
@@ -1,3 +1,3 @@
 versions:
-  0.1.1:
+  0.1.0:
     folder: all


### PR DESCRIPTION
Hello 👋

I'm part of a team developing a file format, [MCAP](https://github.com/foxglove/mcap), and we would like the C++ reader/writer libraries to be available on ConanCenter. This is the first published version of the package, which is a header-only library, with dependencies on `fmt`, `lz4`, and `zstd`.

Closes https://github.com/foxglove/mcap/issues/201

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
