### PR TITLE
libepoxy: add version 1.5.10

### DIFF
--- a/recipes/libepoxy/all/conandata.yml
+++ b/recipes/libepoxy/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.10":
+    url: "https://github.com/anholt/libepoxy/archive/1.5.10.tar.gz"
+    sha256: "a7ced37f4102b745ac86d6a70a9da399cc139ff168ba6b8002b4d8d43c900c15"
   "1.5.9":
     url: "https://github.com/anholt/libepoxy/archive/1.5.9.tar.gz"
     sha256: "ee8048d20179a2e86156ac842ddb6428732d9cd7a2cfc2eca905165bf24887a2"

--- a/recipes/libepoxy/config.yml
+++ b/recipes/libepoxy/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.10":
+    folder: all
   "1.5.9":
     folder: all
   "1.5.8":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libepoxy1.5.10**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
