### PR TITLE
Add Imath 3.1.4

### DIFF
--- a/recipes/imath/all/CMakeLists.txt
+++ b/recipes/imath/all/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(imath)
+
+include("conanbuildinfo.cmake")
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/imath/all/conandata.yml
+++ b/recipes/imath/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.1.4":
+    url: "https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.1.4.tar.gz"
+    sha256: "fcca5fbb37d375a252bacd8a29935569bdc28b888f01ef1d9299ca0c9e87c17a"

--- a/recipes/imath/all/conanfile.py
+++ b/recipes/imath/all/conanfile.py
@@ -1,0 +1,87 @@
+from conans import ConanFile, CMake, tools
+import os, functools
+
+required_conan_version = ">=1.33.0"
+
+class ImathConan(ConanFile):
+    name = "imath"
+    description = "Imath is a C++ and python library of 2D and 3D vector, matrix, and math operations for computer graphics."
+    license = "BSD-3-Clause"
+    homepage = "https://github.com/AcademySoftwareFoundation/Imath"
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    generators = "cmake", "cmake_find_package"
+    exports_sources = ["CMakeLists.txt"]
+    topics = ("computer-graphics", "matrix", "openexr", "3d-vector")
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+    
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build(self):
+        cm = self._configure_cmake()
+        cm.build()
+
+    def package(self):
+        cm = self._configure_cmake()
+        cm.install()
+
+        tools.rmdir(os.path.join(self.package_folder, "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+
+        self.copy("LICENSE.md", src=self._source_subfolder, dst="licenses")
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "Imath"
+        self.cpp_info.names["cmake_find_package_multi"] = "Imath"
+        self.cpp_info.names["pkg_config"] = "Imath"
+
+        # Imath::ImathConfig - header only library
+        imath_config = self.cpp_info.components["imath_config"]
+        imath_config.names["cmake_find_package"] = "ImathConfig"
+        imath_config.names["cmake_find_package_multi"] = "ImathConfig"
+        imath_config.names["pkg_config"] = "ImathConfig"
+        imath_config.includedirs.append(os.path.join("include", "Imath"))
+
+        # Imath::Imath - linkable library
+        imath_lib = self.cpp_info.components["imath_lib"]
+        imath_lib.names["cmake_find_package"] = "Imath"
+        imath_lib.names["cmake_find_package_multi"] = "Imath"
+        imath_lib.names["pkg_config"] = "Imath"
+        imath_lib.libs = tools.collect_libs(self)
+        imath_lib.requires = ["imath_config"]

--- a/recipes/imath/all/test_package/CMakeLists.txt
+++ b/recipes/imath/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(Imath REQUIRED)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} Imath::Imath Imath::ImathConfig)

--- a/recipes/imath/all/test_package/conanfile.py
+++ b/recipes/imath/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/imath/all/test_package/test_package.cpp
+++ b/recipes/imath/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include <Imath/half.h>
+#include <iostream>
+
+int main()
+{
+    std::cout << Imath::half(1.0) << "\n";
+    return 0;
+}

--- a/recipes/imath/config.yml
+++ b/recipes/imath/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.1.4":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **Imath/3.1.4**

Imath is a library of utilities for working with vectors, matrices, half precision floating point numbers and alike.

Formerly, Imath was part of OpenEXR. Starting with OpenEXR 3.0, these two libraries are released independently. 
This PR is adds only Imath, [another one](https://github.com/p-podsiadly/conan-center-index/tree/openexr3) will add OpenEXR 3.1.4.

Note: the separation of OpenEXR and Imath and changes to exported CMake targets in OpenEXR 3 mean that bugs #2219 and #3464 will not affect OpenEXR 3 packages.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
