### PR TITLE
added cryptopp-8.6.0

### DIFF
--- a/recipes/cryptopp/all/conandata.yml
+++ b/recipes/cryptopp/all/conandata.yml
@@ -1,4 +1,11 @@
 sources:
+  "8.6.0":
+    url:
+      "source": "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_6_0.tar.gz"
+      "cmake": "https://github.com/noloader/cryptopp-cmake/archive/CRYPTOPP_8_6_0.tar.gz"
+    sha256:
+      "source": "9304625f4767a13e0a5f26d0f019d78cf9375604a33e5391c3bf2e81399dfeb8"
+      "cmake": "970b20d55dbf9d6335485e72c9f8967d878bf64bbd3de6aa28436beb6799c493"
   "8.5.0":
     url:
       "source": "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_5_0.tar.gz"
@@ -21,6 +28,9 @@ sources:
       "source": "e3bcd48a62739ad179ad8064b523346abb53767bcbefc01fe37303412292343e"
       "cmake": "f41f6a32b1177c094c3ef97423916713c902d0ac26cbee30ec70b1e8ab0e6fba"
 patches:
+  "8.6.0":
+    - patch_file: "patches/fix-cmake-8.6.0.patch"
+      base_path: "source_subfolder"
   "8.2.0":
     - patch_file: "patches/fix-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/cryptopp/all/patches/fix-cmake-8.6.0.patch
+++ b/recipes/cryptopp/all/patches/fix-cmake-8.6.0.patch
@@ -1,0 +1,13 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1024,8 +1024,8 @@
+   # https://stackoverflow.com/q/61250087
+   add_definitions("${CMAKE_CPP_FLAGS}" "${CMAKE_CXX_FLAGS}" "${CRYPTOPP_COMPILE_DEFINITIONS}" "${CRYPTOPP_COMPILE_OPTIONS}")
+ else()
+-  add_compile_definitions("${CMAKE_CPP_FLAGS}" "${CRYPTOPP_COMPILE_DEFINITIONS}")
+-  add_compile_options("${CMAKE_CXX_FLAGS}" "${CRYPTOPP_COMPILE_OPTIONS}")
++  add_compile_definitions(${CRYPTOPP_COMPILE_DEFINITIONS})
++  add_compile_options(${CRYPTOPP_COMPILE_OPTIONS})
+ endif()
+ 
+ #============================================================================

--- a/recipes/cryptopp/config.yml
+++ b/recipes/cryptopp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.6.0":
+    folder: "all"
   "8.5.0":
     folder: "all"
   "8.4.0":


### PR DESCRIPTION
**cryptopp/8.6.0**

added cryptopp-8.6.0, given patch of CMakeLists.txt to make it compile

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
