### PR TITLE
Add sentry-native performance option

### DIFF
--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -36,7 +36,7 @@ class SentryNativeConan(ConanFile):
         "qt": False,
         "with_crashpad": "sentry",
         "with_breakpad": "sentry",
-        "performance": True,
+        "performance": False,
     }
 
     generators = "cmake", "cmake_find_package", "cmake_find_package_multi", "pkg_config"

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -26,6 +26,7 @@ class SentryNativeConan(ConanFile):
         "qt": [True, False],
         "with_crashpad": ["google", "sentry"],
         "with_breakpad": ["google", "sentry"],
+        "performance": [True, False],
     }
     default_options = {
         "shared": False,
@@ -35,7 +36,7 @@ class SentryNativeConan(ConanFile):
         "qt": False,
         "with_crashpad": "sentry",
         "with_breakpad": "sentry",
-
+        "performance": True,
     }
 
     generators = "cmake", "cmake_find_package", "cmake_find_package_multi", "pkg_config"
@@ -129,6 +130,9 @@ class SentryNativeConan(ConanFile):
         if self.options.backend == "crashpad" and tools.Version(self.version) < "0.4.7" and self.settings.os == "Macos" and self.settings.arch == "armv8":
             raise ConanInvalidConfiguration("This version doesn't support ARM compilation")
 
+        if self.options.performance and tools.Version(self.version) < "0.4.14":
+            raise ConanInvalidConfiguration("Performance monitoring was introduced in 0.4.14")
+
     def build_requirements(self):
         if tools.Version(self.version) >= "0.4.0" and self.settings.os == "Windows":
             self.build_requires("cmake/3.22.0")
@@ -149,6 +153,7 @@ class SentryNativeConan(ConanFile):
         self._cmake.definitions["SENTRY_TRANSPORT"] = self.options.transport
         self._cmake.definitions["SENTRY_PIC"] = self.options.get_safe("fPIC", True)
         self._cmake.definitions["SENTRY_INTEGRATION_QT"] = self.options.qt
+        self._cmake.definitions["SENTRY_PERFORMANCE_MONITORING"] = self.options.performance
         self._cmake.configure()
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **sentry-native/0.4.15**

Adding a new option for native performance monitoring.
The option is currently set to true but I will change it to false before merging.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
