### PR TITLE
clove-unit: add version 2.2.3

### DIFF
--- a/recipes/clove-unit/all/conandata.yml
+++ b/recipes/clove-unit/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.2.3":
+    url: "https://github.com/fdefelici/clove-unit/archive/v2.2.3.tar.gz"
+    sha256: 65f80d600ddec35f7ba70370f10e2df268d68c589e5cddbdcad815b6dbb61dfd

--- a/recipes/clove-unit/all/conanfile.py
+++ b/recipes/clove-unit/all/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, tools
-import os
 
 required_conan_version = ">=1.43.0"
 

--- a/recipes/clove-unit/all/conanfile.py
+++ b/recipes/clove-unit/all/conanfile.py
@@ -17,7 +17,7 @@ class CloveUnitConan(ConanFile):
         return "source_subfolder"
 
     def source(self):
-       tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)

--- a/recipes/clove-unit/all/conanfile.py
+++ b/recipes/clove-unit/all/conanfile.py
@@ -1,0 +1,32 @@
+from conans import ConanFile, tools
+import os
+
+required_conan_version = ">=1.43.0"
+
+
+class CloveUnitConan(ConanFile):
+    name = "clove-unit"
+    description = "Single-header Unit Testing framework for C (mainly, but also C++) with test autodiscovery feature"
+    topics = ("clove-unit", "unit-testing", "testing", "unit testing", "test")
+    homepage = "https://github.com/fdefelici/clove-unit"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "MIT"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+       tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="clove-unit.h", dst="include", src=self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "CloveUnit"
+        self.cpp_info.names["cmake_find_package_multi"] = "CloveUnit"

--- a/recipes/clove-unit/all/test_package/CMakeLists.txt
+++ b/recipes/clove-unit/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/clove-unit/all/test_package/CMakeLists.txt
+++ b/recipes/clove-unit/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(CloveUnit CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} CloveUnit::CloveUnit)

--- a/recipes/clove-unit/all/test_package/CMakeLists.txt
+++ b/recipes/clove-unit/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.18)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/clove-unit/all/test_package/conanfile.py
+++ b/recipes/clove-unit/all/test_package/conanfile.py
@@ -11,6 +11,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/clove-unit/all/test_package/conanfile.py
+++ b/recipes/clove-unit/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/clove-unit/all/test_package/conanfile.py
+++ b/recipes/clove-unit/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestPackageConan(ConanFile):
+#    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/clove-unit/all/test_package/conanfile.py
+++ b/recipes/clove-unit/all/test_package/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 import os
 
 class TestPackageConan(ConanFile):
-#    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 
     def build(self):

--- a/recipes/clove-unit/all/test_package/test_package.cpp
+++ b/recipes/clove-unit/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+#define CLOVE_IMPLEMENTATION
+#define CLOVE_SUITE_NAME Suite01
+#include <clove-unit.h>
+
+CLOVE_RUNNER()
+
+CLOVE_TEST(Test1) {
+    CLOVE_PASS();
+}
+
+

--- a/recipes/clove-unit/all/test_package/test_package.cpp
+++ b/recipes/clove-unit/all/test_package/test_package.cpp
@@ -1,11 +1,11 @@
 #define CLOVE_IMPLEMENTATION
-#define CLOVE_SUITE_NAME Suite01
 #include <clove-unit.h>
 
-CLOVE_RUNNER()
-
-CLOVE_TEST(Test1) {
-    CLOVE_PASS();
+char * __clove_exec_path;
+char * __clove_exec_base_path;
+int main() {
+    __clove_report_console_setup_ansi();
+    return 0;
 }
 
 

--- a/recipes/clove-unit/config.yml
+++ b/recipes/clove-unit/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.2.3":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **clove-unit/2.2.3**

I'm the author of the library. It is a single-header unit testing librarary for both C and C++

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
