### PR TITLE
funchook: Add recipe (version 1.1.0)

### DIFF
--- a/recipes/funchook/all/CMakeLists.txt
+++ b/recipes/funchook/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/funchook/all/conandata.yml
+++ b/recipes/funchook/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "1.1.0":
+    url: "https://github.com/kubo/funchook/releases/download/v1.1.0/funchook-1.1.0.tar.gz"
+    sha256: "676d5818d9cbb68e318dfb00acc3b81bc988af7ca6410812ced02a148086dbe0"
+patches:
+  "1.1.0":
+    - patch_file: "patches/1.1.0-disable-direct-cmake-external-proj.patch"
+      base_path: "source_subfolder"

--- a/recipes/funchook/all/conanfile.py
+++ b/recipes/funchook/all/conanfile.py
@@ -108,7 +108,6 @@ class FunchookConan(ConanFile):
         self.cpp_info.libs = funchook_libs + self.cpp_info.libs
 
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs.append('m')
-            self.cpp_info.system_libs.extend(["dl"])
+            self.cpp_info.system_libs.extend(["m", "dl"])
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs.extend(["psapi"])

--- a/recipes/funchook/all/conanfile.py
+++ b/recipes/funchook/all/conanfile.py
@@ -1,0 +1,114 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.33.0"
+
+
+class FunchookConan(ConanFile):
+    name = "funchook"
+    homepage = "https://github.com/kubo/funchook"
+    description = " Hook function calls by inserting jump instructions at runtime"
+    topics = ("function", "hooking")
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "GPL-2.0-or-later-linking-exception"
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "disassembler": ["diStorm3", "zydis", "capstone"],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "disassembler": "diStorm3",
+    }
+
+    _cmake = None
+
+    def export_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def package_id(self):
+        self.info.shared_library_package_id()
+
+    def requirements(self):
+        if self.options.disassembler == "capstone":
+            self.requires("capstone/4.0.2")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def validate(self):
+        if self.options.disassembler == "zydis":
+            raise ConanInvalidConfiguration("disassembler 'zydis' currently not supported by this Conan recipe")
+        if 'arm' in str(self.settings.arch):
+            if self.options.disassembler != "capstone":
+                raise ConanInvalidConfiguration("disassembler must be 'capstone' for arm arch")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["FUNCHOOK_BUILD_TESTS"] = False
+        self._cmake.definitions["FUNCHOOK_BUILD_SHARED"] = self.options.shared
+        self._cmake.definitions["FUNCHOOK_BUILD_STATIC"] = not self.options.shared
+        if self.options.disassembler == "diStorm3":
+            self._cmake.definitions["FUNCHOOK_DISASM"] = "distorm"
+        else:
+            self._cmake.definitions["FUNCHOOK_DISASM"] = self.options.disassembler
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy("*.h", dst="include", src=(self._source_subfolder + "/include"))
+        self.copy("*.lib", dst="lib", keep_path=False)
+        self.copy("*.dll", dst="bin", keep_path=False)
+        if self.options.shared:
+            self.copy("*.so", dst="lib", keep_path=False)
+            self.copy("*.dylib*", dst="lib", keep_path=False)
+        else:
+            self.copy("*.a", dst="lib", keep_path=False)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+
+        # in case of static linking, funchook needs to be at the start (before other .a files)
+        funchook_libs = [i for i in self.cpp_info.libs if i.startswith('funchook')]
+        self.cpp_info.libs = [i for i in self.cpp_info.libs if i not in funchook_libs]
+        self.cpp_info.libs = funchook_libs + self.cpp_info.libs
+
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.append('m')
+            self.cpp_info.system_libs.extend(["dl"])
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["psapi"])

--- a/recipes/funchook/all/conanfile.py
+++ b/recipes/funchook/all/conanfile.py
@@ -100,12 +100,7 @@ class FunchookConan(ConanFile):
             self.copy("*.a", dst="lib", keep_path=False)
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
-
-        # in case of static linking, funchook needs to be at the start (before other .a files)
-        funchook_libs = [i for i in self.cpp_info.libs if i.startswith('funchook')]
-        self.cpp_info.libs = [i for i in self.cpp_info.libs if i not in funchook_libs]
-        self.cpp_info.libs = funchook_libs + self.cpp_info.libs
+        self.cpp_info.libs = ["funkhook"]
 
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.extend(["m", "dl"])

--- a/recipes/funchook/all/conanfile.py
+++ b/recipes/funchook/all/conanfile.py
@@ -39,9 +39,6 @@ class FunchookConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
-    def package_id(self):
-        self.info.shared_library_package_id()
-
     def requirements(self):
         if self.options.disassembler == "capstone":
             self.requires("capstone/4.0.2")

--- a/recipes/funchook/all/conanfile.py
+++ b/recipes/funchook/all/conanfile.py
@@ -60,6 +60,8 @@ class FunchookConan(ConanFile):
         if self.options.disassembler == "zydis":
             raise ConanInvalidConfiguration("disassembler 'zydis' currently not supported by this Conan recipe")
         if 'arm' in str(self.settings.arch):
+            if self.settings.os == "Macos":
+                raise ConanInvalidConfiguration("Funchook does not support ARM on MacOS")
             if self.options.disassembler != "capstone":
                 raise ConanInvalidConfiguration("disassembler must be 'capstone' for arm arch")
 

--- a/recipes/funchook/all/conanfile.py
+++ b/recipes/funchook/all/conanfile.py
@@ -94,12 +94,10 @@ class FunchookConan(ConanFile):
         self.copy("*.lib", dst="lib", keep_path=False)
         self.copy("*.dll", dst="bin", keep_path=False)
         if self.options.shared:
-            self.copy("*.so", dst="lib", keep_path=False)
+            self.copy("*.so*", dst="lib", keep_path=False)
             self.copy("*.dylib*", dst="lib", keep_path=False)
         else:
             self.copy("*.a", dst="lib", keep_path=False)
-        cmake = self._configure_cmake()
-        cmake.install()
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/funchook/all/conanfile.py
+++ b/recipes/funchook/all/conanfile.py
@@ -90,14 +90,8 @@ class FunchookConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy("*.h", dst="include", src=(self._source_subfolder + "/include"))
-        self.copy("*.lib", dst="lib", keep_path=False)
-        self.copy("*.dll", dst="bin", keep_path=False)
-        if self.options.shared:
-            self.copy("*.so*", dst="lib", keep_path=False)
-            self.copy("*.dylib*", dst="lib", keep_path=False)
-        else:
-            self.copy("*.a", dst="lib", keep_path=False)
+        cmake = self._configure_cmake()
+        cmake.install()
 
     def package_info(self):
         self.cpp_info.libs = ["funkhook"]

--- a/recipes/funchook/all/patches/1.1.0-disable-direct-cmake-external-proj.patch
+++ b/recipes/funchook/all/patches/1.1.0-disable-direct-cmake-external-proj.patch
@@ -1,0 +1,58 @@
+--- CMakeLists.txt.orig	2022-03-14 20:29:13.938536330 -0400
++++ CMakeLists.txt	2022-03-14 20:30:18.213519229 -0400
+@@ -70,43 +70,6 @@
+ # capstone
+ #
+ if (DISASM_CAPSTONE)
+-  set(CAPSTONE_arm64_SUPPORT OFF)
+-  set(CAPSTONE_x86_SUPPORT OFF)
+-  set(CAPSTONE_${FUNCHOOK_CPU}_SUPPORT ON)
+-
+-  include(ExternalProject)
+-  ExternalProject_Add(capstone_src
+-    GIT_REPOSITORY    https://github.com/aquynh/capstone.git
+-    GIT_TAG           4.0.1
+-    GIT_SHALLOW       TRUE
+-    CMAKE_ARGS        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+-                      -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}
+-                      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+-                      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+-                      -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}
+-                      -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+-                      -DCAPSTONE_BUILD_SHARED=OFF
+-                      -DCAPSTONE_BUILD_STATIC_RUNTIME=OFF
+-                      -DCAPSTONE_BUILD_TESTS=OFF
+-                      -DCAPSTONE_BUILD_CSTOOL=OFF
+-                      -DCAPSTONE_ARM_SUPPORT=OFF
+-                      -DCAPSTONE_ARM64_SUPPORT=${CAPSTONE_arm64_SUPPORT}
+-                      -DCAPSTONE_EVM_SUPPORT=OFF
+-                      -DCAPSTONE_M680X_SUPPORT=OFF
+-                      -DCAPSTONE_M68K_SUPPORT=OFF
+-                      -DCAPSTONE_MIPS_SUPPORT=OFF
+-                      -DCAPSTONE_PPC_SUPPORT=OFF
+-                      -DCAPSTONE_SPARC_SUPPORT=OFF
+-                      -DCAPSTONE_SYSZ_SUPPORT=OFF
+-                      -DCAPSTONE_TMS320C64X_SUPPORT=OFF
+-                      -DCAPSTONE_XCORE_SUPPORT=OFF
+-                      -DCAPSTONE_X86_SUPPORT=${CAPSTONE_x86_SUPPORT}
+-    INSTALL_COMMAND   ""
+-  )
+-  ExternalProject_Get_Property(capstone_src SOURCE_DIR)
+-  include_directories(${SOURCE_DIR}/include)
+-  ExternalProject_Get_Property(capstone_src BINARY_DIR)
+-  link_directories(${BINARY_DIR})
+   set(DISASM capstone)
+ endif ()
+
+--- CMakeLists.txt.orig	2022-03-14 20:49:01.771518389 -0400
++++ CMakeLists.txt	2022-03-14 20:49:11.791305406 -0400
+@@ -149,9 +149,6 @@
+ 
+ function (add_funchook_library target_name target_type)
+   add_library(${target_name} ${target_type} ${FUNCHOOK_SOURCES})
+-  if (NOT DISASM STREQUAL distorm)
+-    add_dependencies(${target_name} ${DISASM}_src)
+-  endif ()
+   set_target_properties(${target_name} PROPERTIES ${FUNCHOOK_PROPERTIES})
+   target_include_directories(${target_name} PUBLIC include)
+   target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}) # to include config.h

--- a/recipes/funchook/all/test_package/CMakeLists.txt
+++ b/recipes/funchook/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(src)

--- a/recipes/funchook/all/test_package/conanfile.py
+++ b/recipes/funchook/all/test_package/conanfile.py
@@ -8,10 +8,6 @@ class TestPackageConan(ConanFile):
 
     _cmake = None
 
-    def configure(self):
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
-
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake

--- a/recipes/funchook/all/test_package/conanfile.py
+++ b/recipes/funchook/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package"
+
+    _cmake = None
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/funchook/all/test_package/conanfile.py
+++ b/recipes/funchook/all/test_package/conanfile.py
@@ -25,5 +25,8 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+            # Funchook author reports hooking on x86_64 MacOS *can* work but only in shared libs
+            #    as I don't have an easy way to still test this, I have skipped the tests for MacOS
+            if self.settings.os != "Macos":
+                bin_path = os.path.join("bin", "test_package")
+                self.run(bin_path, run_environment=True)

--- a/recipes/funchook/all/test_package/src/CMakeLists.txt
+++ b/recipes/funchook/all/test_package/src/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.1)
+SET(SOURCES test_package.c)
+
+ADD_EXECUTABLE(${CMAKE_PROJECT_NAME} ${SOURCES})
+
+conan_target_link_libraries(${CMAKE_PROJECT_NAME})

--- a/recipes/funchook/all/test_package/src/test_package.c
+++ b/recipes/funchook/all/test_package/src/test_package.c
@@ -1,0 +1,65 @@
+#include <stdio.h>
+#include <funchook.h>
+
+#ifdef __GNUC__
+#define NOINLINE __attribute__((noinline))
+#endif
+#ifdef _MSC_VER
+#define NOINLINE __declspec(noinline)
+#endif
+
+void target();
+int installHook();
+void hook();
+int main();
+
+int hook_invoked = 0;
+void (*original_target)() = target;
+
+NOINLINE void target() {
+  printf("Target invoked\n");
+}
+
+int installHook() {
+  funchook_t *funchook = funchook_create();
+  int rv;
+
+  rv = funchook_prepare(funchook, (void **)&original_target, hook);
+  if (rv != 0) {
+    return 1;
+  }
+
+  rv = funchook_install(funchook, 0);
+  if (rv != 0) {
+    return 1;
+  }
+
+  return 0;
+}
+
+void hook() {
+  printf("Hook invoked\n");
+  hook_invoked=1;
+  original_target();
+}
+
+int main() {
+  funchook_set_debug_file("funchook_debug.txt");
+
+  if (installHook() == 1) {
+    printf("Failed to install hook\n");
+    return 1;
+  }
+
+  printf("Hook installed, invoking...\n");
+
+  target();
+
+  if (hook_invoked == 1) {
+    printf("Test passed!\n");
+    return 0;
+  } else {
+    printf("Test failed...hook was not invoked...\n");
+    return 1;
+  }
+}

--- a/recipes/funchook/config.yml
+++ b/recipes/funchook/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.0":
+    folder: all


### PR DESCRIPTION
Library name and version:  **funchook/1.1.0**  (entirely new recipe)

Funchook is a lightweight and simple detours-like function-call hooking library.  

Disclaimer:  I am not the author (just a user of the lib); I wrote a recipe for Funchook a while back and figured I should share it.  I think it **should hopefully** be pretty reasonable now that I've cleaned it up a lot and tested on various platforms.  

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
