### PR TITLE
libavrocpp: add version 1.11.0

### DIFF
--- a/recipes/libavrocpp/all/CMakeLists.txt
+++ b/recipes/libavrocpp/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder/lang/c++)

--- a/recipes/libavrocpp/all/conandata.yml
+++ b/recipes/libavrocpp/all/conandata.yml
@@ -1,20 +1,23 @@
 sources:
-  "1.10.1":
-    url: "https://github.com/apache/avro/archive/release-1.10.1.tar.gz"
-    sha256: "8fd1f850ce37e60835e6d8335c0027a959aaa316773da8a9660f7d33a66ac142"
+  "1.11.0":
+    url: "https://github.com/apache/avro/archive/release-1.11.0.tar.gz"
+    sha256: "c205140e7936d552286ba7131122a34e522d66f601ee912f272109d801f89773"
   "1.10.2":
     url: "https://github.com/apache/avro/archive/release-1.10.2.tar.gz"
     sha256: "c849ef7f7af58ce66e7b999b8d9815507d69ae434e7e058a44f7818515455a03"
-patches:
   "1.10.1":
+    url: "https://github.com/apache/avro/archive/release-1.10.1.tar.gz"
+    sha256: "8fd1f850ce37e60835e6d8335c0027a959aaa316773da8a9660f7d33a66ac142"
+patches:
+  "1.11.0":
     - base_path: "source_subfolder"
-      patch_file: "patches/0001-add-iterator-include.patch"
+      patch_file: "patches/0001-add-iterator-include-1-11-0.patch"
     - base_path: "source_subfolder"
-      patch_file: "patches/0002-disable-tests-1-10-1.patch"
+      patch_file: "patches/0002-disable-tests-1-11-0.patch"
     - base_path: "source_subfolder"
-      patch_file: "patches/0003-allow-static-boost-linkage.patch"
+      patch_file: "patches/0003-allow-static-boost-linkage-1-11-0.patch"
     - base_path: "source_subfolder"
-      patch_file: "patches/0004-fix-windows-shared-installation-1-10-1.patch"
+      patch_file: "patches/0004-fix-windows-shared-installation-1-11-0.patch"
   "1.10.2":
     - base_path: "source_subfolder"
       patch_file: "patches/0001-add-iterator-include.patch"
@@ -24,3 +27,12 @@ patches:
       patch_file: "patches/0003-allow-static-boost-linkage.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/0004-fix-windows-shared-installation-1-10-2.patch"
+  "1.10.1":
+    - base_path: "source_subfolder"
+      patch_file: "patches/0001-add-iterator-include.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0002-disable-tests-1-10-1.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0003-allow-static-boost-linkage.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/0004-fix-windows-shared-installation-1-10-1.patch"

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -31,7 +31,7 @@ class LibavrocppConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
-▽g
+
     def export_sources(self):
         self.copy("CMakeLists.txt")
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -1,8 +1,9 @@
 import os
+import functools
 
 from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.33.0"
 
 class LibavrocppConan(ConanFile):
     name = "libavrocpp"
@@ -11,21 +12,29 @@ class LibavrocppConan(ConanFile):
     description = "Avro is a data serialization system."
     homepage = "https://avro.apache.org/"
     topics = ("serialization", "deserialization")
-    exports_sources = ["CMakeLists.txt", "patches/*.patch"]
     generators = "cmake", "cmake_find_package"
-    settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
-
-    _cmake = None
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False], 
+        "fPIC": [True, False]
+    }
+    default_options = {
+        "shared": False, 
+        "fPIC": True
+    }
 
     @property
     def _source_subfolder(self):
-        return os.path.join("source_subfolder", "lang", "c++")
+        return "source_subfolder"
 
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -34,31 +43,33 @@ class LibavrocppConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+
+    def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, "11")
 
     def requirements(self):
-        self.requires("boost/1.75.0")
-        self.requires("snappy/1.1.8")
+        self.requires("boost/1.78.0")
+        self.requires("snappy/1.1.9")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("avro-release-" + self.version, "source_subfolder")
+        tools.get(**self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         tools.replace_in_file(
-            os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            os.path.join(os.path.join(self._source_subfolder, "lang", "c++"), "CMakeLists.txt"),
             "${SNAPPY_LIBRARIES}", "${Snappy_LIBRARIES}"
         )
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if not self._cmake:
-            self._cmake = CMake(self)
-            self._cmake.definitions["SNAPPY_ROOT_DIR"] = self.deps_cpp_info["snappy"].rootpath.replace("\\", "/")
-            self._cmake.configure()
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["SNAPPY_ROOT_DIR"] = self.deps_cpp_info["snappy"].rootpath.replace("\\", "/")
+        cmake.configure()
+        return cmake
 
     def build(self):
         self._patch_sources()
@@ -66,8 +77,8 @@ class LibavrocppConan(ConanFile):
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy("NOTICE", dst="licenses", src=self._source_subfolder)
+        self.copy("LICENSE*", dst="licenses", src=self._source_subfolder)
+        self.copy("NOTICE*", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
 

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -82,6 +82,10 @@ class LibavrocppConan(ConanFile):
         self.copy("NOTICE*", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
+        if os.settings.os == "Windows":
+            tools.remove_from_path(os.path.join(self.package_folder, "bin", "concrt140.dll"))
+            tools.remove_from_path(os.path.join(self.package_folder, "bin", "msvcp140.dll"))
+            tools.remove_from_path(os.path.join(self.package_folder, "bin", "vcruntime140.dll"))
 
     def package_info(self):
         # FIXME: avro does not install under a CMake namespace https://github.com/apache/avro/blob/351f589913b9691322966fb77fe72269a0a2ec82/lang/c%2B%2B/CMakeLists.txt#L193

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -22,6 +22,7 @@ class LibavrocppConan(ConanFile):
         "shared": False, 
         "fPIC": True
     }
+    short_paths = True
 
     @property
     def _source_subfolder(self):

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -31,7 +31,7 @@ class LibavrocppConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
-
+▽g
     def export_sources(self):
         self.copy("CMakeLists.txt")
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -82,10 +82,10 @@ class LibavrocppConan(ConanFile):
         self.copy("NOTICE*", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
+
         if self.settings.os == "Windows":
-            tools.remove_from_path(os.path.join(self.package_folder, "bin", "concrt140.dll"))
-            tools.remove_from_path(os.path.join(self.package_folder, "bin", "msvcp140.dll"))
-            tools.remove_from_path(os.path.join(self.package_folder, "bin", "vcruntime140.dll"))
+            for dll_pattern_to_remove in ["concrt*.dll", "msvcp*.dll", "vcruntime*.dll"]:
+                tools.remove_files_by_mask(self.package_folder, dll_pattern_to_remove)
 
     def package_info(self):
         # FIXME: avro does not install under a CMake namespace https://github.com/apache/avro/blob/351f589913b9691322966fb77fe72269a0a2ec82/lang/c%2B%2B/CMakeLists.txt#L193

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -82,7 +82,7 @@ class LibavrocppConan(ConanFile):
         self.copy("NOTICE*", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        if os.settings.os == "Windows":
+        if self.settings.os == "Windows":
             tools.remove_from_path(os.path.join(self.package_folder, "bin", "concrt140.dll"))
             tools.remove_from_path(os.path.join(self.package_folder, "bin", "msvcp140.dll"))
             tools.remove_from_path(os.path.join(self.package_folder, "bin", "vcruntime140.dll"))

--- a/recipes/libavrocpp/all/patches/0001-add-iterator-include-1-11-0.patch
+++ b/recipes/libavrocpp/all/patches/0001-add-iterator-include-1-11-0.patch
@@ -1,0 +1,96 @@
+diff --git a/lang/c++/api/buffer/detail/BufferDetail.hh b/lang/c++/api/buffer/detail/BufferDetail.hh
+index b487cdb..89783fb 100644
+--- a/lang/c++/api/buffer/detail/BufferDetail.hh
++++ b/lang/c++/api/buffer/detail/BufferDetail.hh
+@@ -30,6 +30,7 @@
+ #endif
+ #include <cassert>
+ #include <deque>
++#include <iterator>
+ #include <exception>
+ 
+ /**
+diff --git a/lang/c++/impl/DataFile.cc b/lang/c++/impl/DataFile.cc
+index 18fb3f6..f8679a2 100644
+--- a/lang/c++/impl/DataFile.cc
++++ b/lang/c++/impl/DataFile.cc
+@@ -20,6 +20,7 @@
+ #include "Compiler.hh"
+ #include "Exception.hh"
+ 
++#include <iterator>
+ #include <sstream>
+ 
+ #include <boost/crc.hpp> // for boost::crc_32_type
+diff --git a/lang/c++/impl/Stream.cc b/lang/c++/impl/Stream.cc
+index 63a8b4e..39556d1 100644
+--- a/lang/c++/impl/Stream.cc
++++ b/lang/c++/impl/Stream.cc
+@@ -17,6 +17,7 @@
+  */
+ 
+ #include "Stream.hh"
++#include <iterator>
+ #include <vector>
+ 
+ namespace avro {
+diff --git a/lang/c++/impl/parsing/JsonCodec.cc b/lang/c++/impl/parsing/JsonCodec.cc
+index 4fd0481..3de5150 100644
+--- a/lang/c++/impl/parsing/JsonCodec.cc
++++ b/lang/c++/impl/parsing/JsonCodec.cc
+@@ -20,6 +20,7 @@
+ #include <boost/math/special_functions/fpclassify.hpp>
+ #include <map>
+ #include <memory>
++#include <iterator>
+ #include <string>
+ 
+ #include "Decoder.hh"
+diff --git a/lang/c++/impl/parsing/ResolvingDecoder.cc b/lang/c++/impl/parsing/ResolvingDecoder.cc
+index d86f6e5..3b961ea 100644
+--- a/lang/c++/impl/parsing/ResolvingDecoder.cc
++++ b/lang/c++/impl/parsing/ResolvingDecoder.cc
+@@ -21,6 +21,7 @@
+ #include <memory>
+ #include <string>
+ #include <utility>
++#include <iterator>
+ 
+ #include "Decoder.hh"
+ #include "Encoder.hh"
+diff --git a/lang/c++/impl/parsing/ValidatingCodec.cc b/lang/c++/impl/parsing/ValidatingCodec.cc
+index cfb8222..8a0817a 100644
+--- a/lang/c++/impl/parsing/ValidatingCodec.cc
++++ b/lang/c++/impl/parsing/ValidatingCodec.cc
+@@ -19,6 +19,7 @@
+ #include "ValidatingCodec.hh"
+ 
+ #include <algorithm>
++#include <iterator>
+ #include <boost/any.hpp>
+ #include <map>
+ #include <memory>
+diff --git a/lang/c++/test/CodecTests.cc b/lang/c++/test/CodecTests.cc
+index a99cdd6..07f560c 100644
+--- a/lang/c++/test/CodecTests.cc
++++ b/lang/c++/test/CodecTests.cc
+@@ -25,6 +25,7 @@
+ #include "Specific.hh"
+ #include "ValidSchema.hh"
+ 
++#include <iterator>
+ #include <boost/bind.hpp>
+ #include <cstdint>
+ #include <functional>
+diff --git a/lang/c++/test/DataFileTests.cc b/lang/c++/test/DataFileTests.cc
+index fec7f31..aced825 100644
+--- a/lang/c++/test/DataFileTests.cc
++++ b/lang/c++/test/DataFileTests.cc
+@@ -24,6 +24,7 @@
+ #include <boost/test/unit_test.hpp>
+ 
+ #include <chrono>
++#include <iterator>
+ #include <thread>
+ 
+ #include <sstream>

--- a/recipes/libavrocpp/all/patches/0002-disable-tests-1-11-0.patch
+++ b/recipes/libavrocpp/all/patches/0002-disable-tests-1-11-0.patch
@@ -1,0 +1,30 @@
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index 4a37931..f371590 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -168,10 +168,6 @@ target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIE
+ enable_testing()
+ 
+ macro (unittest name)
+-    add_executable (${name} test/${name}.cc)
+-    target_link_libraries (${name} avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+-    add_test (NAME ${name} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${name})
+ endmacro (unittest)
+ 
+ unittest (buffertest)
+@@ -187,14 +183,6 @@ unittest (AvrogencppTests)
+ unittest (CompilerTests)
+ unittest (AvrogencppTestReservedWords)
+ 
+-add_dependencies (AvrogencppTestReservedWords cpp_reserved_words_hh)
+-
+-add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
+-    tweet_hh
+-    union_array_union_hh union_map_union_hh union_conflict_hh
+-    recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
+-    primitivetypes_hh empty_record_hh)
+-
+ include (InstallRequiredSystemLibraries)
+ 
+ set (CPACK_PACKAGE_FILE_NAME "avrocpp-${AVRO_VERSION_MAJOR}")

--- a/recipes/libavrocpp/all/patches/0003-allow-static-boost-linkage-1-11-0.patch
+++ b/recipes/libavrocpp/all/patches/0003-allow-static-boost-linkage-1-11-0.patch
@@ -1,0 +1,18 @@
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index f371590..7f8c09a 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -55,12 +55,7 @@ if (WIN32 AND NOT CYGWIN AND NOT MSYS)
+     add_definitions (/EHa)
+     add_definitions (
+         -DNOMINMAX
+-        -DBOOST_REGEX_DYN_LINK
+-        -DBOOST_FILESYSTEM_DYN_LINK
+-        -DBOOST_SYSTEM_DYN_LINK
+-        -DBOOST_IOSTREAMS_DYN_LINK
+-        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
+-        -DBOOST_ALL_NO_LIB)
++    )
+ endif()
+ 
+ if (CMAKE_COMPILER_IS_GNUCXX)

--- a/recipes/libavrocpp/all/patches/0004-fix-windows-shared-installation-1-11-0.patch
+++ b/recipes/libavrocpp/all/patches/0004-fix-windows-shared-installation-1-11-0.patch
@@ -1,0 +1,13 @@
+diff --git a/lang/c++/CMakeLists.txt b/lang/c++/CMakeLists.txt
+index 7f8c09a..aff0447 100644
+--- a/lang/c++/CMakeLists.txt
++++ b/lang/c++/CMakeLists.txt
+@@ -187,7 +187,7 @@ include (CPack)
+ install (TARGETS avrocpp avrocpp_s
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib
+-    RUNTIME DESTINATION lib)
++    RUNTIME DESTINATION bin)
+ 
+ install (TARGETS avrogencpp RUNTIME DESTINATION bin)
+ 

--- a/recipes/libavrocpp/all/test_package/CMakeLists.txt
+++ b/recipes/libavrocpp/all/test_package/CMakeLists.txt
@@ -2,14 +2,14 @@ cmake_minimum_required(VERSION 3.8)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(libavrocpp REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
 
-if(AVROCPP_SHARED)
+if(TARGET libavrocpp::avrocpp)
     target_link_libraries(${PROJECT_NAME} libavrocpp::avrocpp)
 else()
     target_link_libraries(${PROJECT_NAME} libavrocpp::avrocpp_s)

--- a/recipes/libavrocpp/all/test_package/conanfile.py
+++ b/recipes/libavrocpp/all/test_package/conanfile.py
@@ -9,12 +9,10 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.verbose = True
-        cmake.definitions["AVROCPP_SHARED"] = self.options["libavrocpp"].shared
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/libavrocpp/config.yml
+++ b/recipes/libavrocpp/config.yml
@@ -1,5 +1,7 @@
 versions:
-  1.10.1:
+  1.11.0:
     folder: all
   1.10.2:
+    folder: all
+  1.10.1:
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libavrocpp/1.11.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
