### PR TITLE
Add libpqxx/7.7.2

### DIFF
--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -173,10 +173,14 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/fix-inline-constexpr-local-variable-problem-7.6.0.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-remove-unlikely-annotation-before-return-7.6.0_to_7.6.1.patch"
+      base_path: "source_subfolder"
   "7.6.1":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/fix-inline-constexpr-local-variable-problem-7.6.0.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-remove-unlikely-annotation-before-return-7.6.0_to_7.6.1.patch"
       base_path: "source_subfolder"
   "7.7.0":
     - patch_file: "patches/0001-cmake-fix-module.patch"

--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -80,32 +80,48 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/fix-missing-limits-include.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch"
+      base_path: "source_subfolder"
   "7.0.2":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/fix-missing-limits-include.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch"
       base_path: "source_subfolder"
   "7.0.3":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/fix-missing-limits-include.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch"
+      base_path: "source_subfolder"
   "7.0.4":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/fix-missing-limits-include.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch"
+      base_path: "source_subfolder"
   "7.0.5":
     - patch_file: "patches/0001-cmake-fix-module.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch"
       base_path: "source_subfolder"
   "7.0.6":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.6_to_7.0.7.patch"
+      base_path: "source_subfolder"
   "7.0.7":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.6_to_7.0.7.patch"
+      base_path: "source_subfolder"
   "7.1.1":
     - patch_file: "patches/0001-cmake-fix-module.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.1.1.patch"
       base_path: "source_subfolder"
   "7.1.2":
     - patch_file: "patches/0001-cmake-fix-module.patch"

--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -170,3 +170,5 @@ patches:
   "7.7.2":
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-install-library-symlink-7.7.2.patch"
+      base_path: "source_subfolder"

--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -71,6 +71,9 @@ sources:
   "7.7.0":
     url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.7.0.tar.gz"
     sha256: "2d99de960aa3016915bc69326b369fcee04425e57fbe9dad48dd3fa6203879fb"
+  "7.7.2":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.7.2.tar.gz"
+    sha256: "4b7a0b67cbd75d1c31e1e8a07c942ffbe9eec4e32c29b15d71cc225dc737e243"
 patches:
   "7.0.1":
     - patch_file: "patches/0001-cmake-fix-module.patch"
@@ -163,4 +166,7 @@ patches:
     - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/fix-clang-compilation-7.7.0.patch"
+      base_path: "source_subfolder"
+  "7.7.2":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
       base_path: "source_subfolder"

--- a/recipes/libpqxx/all/patches/fix-install-library-symlink-7.7.2.patch
+++ b/recipes/libpqxx/all/patches/fix-install-library-symlink-7.7.2.patch
@@ -1,0 +1,14 @@
+Fix install library symlink error 7.7.2 (https://github.com/jtv/libpqxx/pull/552)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 6eafd7b3..1d697ab7 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -58,7 +58,7 @@ macro(library_target_setup tgt)
+             VERBATIM
+             COMMAND_EXPAND_LISTS
+         )
+-        install(FILES $<TARGET_FILE_DIR:${tgt}>/${library_prefix}${name}${library_suffix}
++        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${library_prefix}${name}${library_suffix}
+             DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         )
+     endif()

--- a/recipes/libpqxx/all/patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch
+++ b/recipes/libpqxx/all/patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch
@@ -1,0 +1,21 @@
+Fix 'dumb_stringstream' was not declared (https://github.com/jtv/libpqxx/commit/0e81d36f522093d7215b3792f1c62dcd06a34ad1)
+diff --git a/src/strconv.cxx b/src/strconv.cxx
+index 66276802..390192ac 100644
+--- a/src/strconv.cxx
++++ b/src/strconv.cxx
+@@ -587,6 +587,7 @@ template char *
+ float_traits<long double>::into_buf(char *, char *, long double const &);
+ 
+ 
++#if !defined(PQXX_HAVE_CHARCONV_FLOAT)
+ template<typename F>
+ inline std::string to_dumb_stringstream(dumb_stringstream<F> &s, F value)
+ {
+@@ -594,6 +595,7 @@ inline std::string to_dumb_stringstream(dumb_stringstream<F> &s, F value)
+   s << value;
+   return s.str();
+ }
++#endif
+ 
+ 
+ /// Floating-point implementations for @c pqxx::to_string().

--- a/recipes/libpqxx/all/patches/fix-not-declared-dumb_stringstream-7.0.6_to_7.0.7.patch
+++ b/recipes/libpqxx/all/patches/fix-not-declared-dumb_stringstream-7.0.6_to_7.0.7.patch
@@ -1,0 +1,21 @@
+Fix 'dumb_stringstream' was not declared (https://github.com/jtv/libpqxx/commit/0e81d36f522093d7215b3792f1c62dcd06a34ad1)
+diff --git a/src/strconv.cxx b/src/strconv.cxx
+index 72217455..b34bd394 100644
+--- a/src/strconv.cxx
++++ b/src/strconv.cxx
+@@ -591,6 +591,7 @@ template char *
+ float_traits<long double>::into_buf(char *, char *, long double const &);
+ 
+ 
++#if !defined(PQXX_HAVE_CHARCONV_FLOAT)
+ template<typename F>
+ inline std::string to_dumb_stringstream(dumb_stringstream<F> &s, F value)
+ {
+@@ -598,6 +599,7 @@ inline std::string to_dumb_stringstream(dumb_stringstream<F> &s, F value)
+   s << value;
+   return s.str();
+ }
++#endif
+ 
+ 
+ /// Floating-point implementations for @c pqxx::to_string().

--- a/recipes/libpqxx/all/patches/fix-not-declared-dumb_stringstream-7.1.1.patch
+++ b/recipes/libpqxx/all/patches/fix-not-declared-dumb_stringstream-7.1.1.patch
@@ -1,0 +1,21 @@
+Fix 'dumb_stringstream' was not declared (https://github.com/jtv/libpqxx/commit/0e81d36f522093d7215b3792f1c62dcd06a34ad1)
+diff --git a/src/strconv.cxx b/src/strconv.cxx
+index 13b0b9ab..c0b7510d 100644
+--- a/src/strconv.cxx
++++ b/src/strconv.cxx
+@@ -591,6 +591,7 @@ template char *
+ float_traits<long double>::into_buf(char *, char *, long double const &);
+ 
+ 
++#if !defined(PQXX_HAVE_CHARCONV_FLOAT)
+ template<typename F>
+ inline std::string to_dumb_stringstream(dumb_stringstream<F> &s, F value)
+ {
+@@ -598,6 +599,7 @@ inline std::string to_dumb_stringstream(dumb_stringstream<F> &s, F value)
+   s << value;
+   return s.str();
+ }
++#endif
+ 
+ 
+ /// Floating-point implementations for @c pqxx::to_string().

--- a/recipes/libpqxx/all/patches/fix-remove-unlikely-annotation-before-return-7.6.0_to_7.6.1.patch
+++ b/recipes/libpqxx/all/patches/fix-remove-unlikely-annotation-before-return-7.6.0_to_7.6.1.patch
@@ -1,0 +1,13 @@
+fix: Remove `unlikely` annotation before `return` (https://github.com/jtv/libpqxx/pull/476)
+diff --git a/src/robusttransaction.cxx b/src/robusttransaction.cxx
+index ba110b12..88d8bd32 100644
+--- a/src/robusttransaction.cxx
++++ b/src/robusttransaction.cxx
+@@ -64,7 +64,6 @@ constexpr tx_stat parse_status(std::string_view text) noexcept
+       PQXX_LIKELY return tx_in_progress;
+     break;
+   }
+-  PQXX_UNLIKELY
+   return tx_unknown;
+ }
+ 

--- a/recipes/libpqxx/config.yml
+++ b/recipes/libpqxx/config.yml
@@ -47,3 +47,5 @@ versions:
     folder: all
   "7.7.0":
     folder: all
+  "7.7.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libpqxx/7.7.2**

Add libpqxx new version (bugfix release).

**NOTE:** libpqxx version 7.7.1 was skipped because it is an incomplete version due to several missing commits.

This release fixes conan-io/conan-center-index#9852

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
