### PR TITLE
ffmpeg include advanced linking flags for clang

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -534,7 +534,7 @@ class FFMpegConan(ConanFile):
             if self.options.postproc:
                 self.cpp_info.components["postproc"].system_libs = ["m"]
             if self.options.get_safe("fPIC"):
-                if self.settings.compiler in ("gcc", ):
+                if self.settings.compiler in ("gcc", "clang"):
                     # https://trac.ffmpeg.org/ticket/1713
                     # https://ffmpeg.org/platform.html#Advanced-linking-configuration
                     # https://ffmpeg.org/pipermail/libav-user/2014-December/007719.html


### PR DESCRIPTION
Add advanced linker flags for clang too

Specify library name and version:  **ffmpeg/all**

Fixes #9903
---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
