### PR TITLE
Support openssl using python 3.5

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -151,11 +151,11 @@ class OpenSSLConan(ConanFile):
 
     @property
     def _target(self):
-        target = f"conan-{self.settings.build_type}-{self.settings.os}-{self.settings.arch}-{self.settings.compiler}-{self.settings.compiler.version}"
+        target = "conan-{}-{}-{}-{}-{}".format(self.settings.build_type, self.settings.os, self.settings.arch, self.settings.compiler, self.settings.compiler.version)
         if self._use_nmake:
-            target = f"VC-{target}"  # VC- prefix is important as it's checked by Configure
+            target = "VC-{}".format(target)  # VC- prefix is important as it's checked by Configure
         if self._is_mingw:
-            target = f"mingw-{target}"
+            target = "mingw-{}".format(target)
         return target
 
     @property
@@ -319,13 +319,13 @@ class OpenSSLConan(ConanFile):
         if "CONAN_OPENSSL_CONFIGURATION" in os.environ:
             return os.environ["CONAN_OPENSSL_CONFIGURATION"]
         compiler = "Visual Studio" if self.settings.compiler == "msvc" else self.settings.compiler
-        query = f"{self.settings.os}-{self.settings.arch}-{compiler}"
+        query = "{}-{}-{}".format(self.settings.os, self.settings.arch, compiler)
         ancestor = next((self._targets[i] for i in self._targets if fnmatch.fnmatch(query, i)), None)
         if not ancestor:
             raise ConanInvalidConfiguration(
-                f"Unsupported configuration ({self.settings.os}/{self.settings.arch}/{self.settings.compiler}).\n"
-                f"Please open an issue at {self.url}.\n"
-                f"Alternatively, set the CONAN_OPENSSL_CONFIGURATION environment variable into your conan profile."
+                "Unsupported configuration ({}/{}/{}).\n".format(self.settings.os, self.settings.arch, self.settings.compiler) +
+                "Please open an issue at {}.\n".format(self.url) +
+                "Alternatively, set the CONAN_OPENSSL_CONFIGURATION environment variable into your conan profile."
             )
         return ancestor
 
@@ -435,7 +435,7 @@ class OpenSSLConan(ConanFile):
 
         for option_name in self.options.values.fields:
             if self.options.get_safe(option_name, False) and option_name not in ("shared", "fPIC", "openssldir", "capieng_dialog", "enable_capieng", "zlib", "no_fips"):
-                self.output.info(f"Activated option: {option_name}")
+                self.output.info("Activated option: {}".format(option_name))
                 args.append(option_name.replace("_", "-"))
         return args
 


### PR DESCRIPTION
Format strings give syntax errors on Ubuntu 16.04
```
    target = f"conan-{self.settings.build_type}-{self.settings.os}-{self.settings.arch}-{self.settings.compiler}-{self.settings.compiler.version}"
                                                                                                                                                ^
SyntaxError: invalid syntax
```

Specify library name and version:  **opencv/3.0.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
