### PR TITLE
fix header only spdlog iOS build error

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -150,3 +150,5 @@ class SpdlogConan(ConanFile):
             self.cpp_info.components["libspdlog"].defines.append("SPDLOG_NO_EXCEPTIONS")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libspdlog"].system_libs = ["pthread"]
+        if self.options.header_only and self.settings.os in ("iOS", "tvOS", "watchOS"):
+            self.cpp_info.components["libspdlog"].defines.append("SPDLOG_NO_TLS")


### PR DESCRIPTION
Specify library name and version:  **spdlog**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

when use `spdlog` with option `header_only=True` for iOS, compiler produce errors.
```
In file included from /Users/xyz1001/.conan/data/spdlog/1.9.2/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/spdlog/details/os.h:117:
/Users/xyz1001/.conan/data/spdlog/1.9.2/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/include/spdlog/details/os-inl.h:362:12: error: thread-local storage
is not supported for the current target
    static thread_local const size_t tid = _thread_id();
 ```

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
