### PR TITLE
tinyspline: add 0.4.0 + fix several issues

### DIFF
--- a/recipes/tinyspline/all/CMakeLists.txt
+++ b/recipes/tinyspline/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.4)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/tinyspline/all/conandata.yml
+++ b/recipes/tinyspline/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.4.0":
+    url: "https://github.com/msteinbeck/tinyspline/archive/refs/tags/v0.4.0.tar.gz"
+    sha256: "819db7f8b09c68b701b54232f08d35210599353703934c61e03555c3c059a0db"
   "0.3.0":
     url: "https://github.com/msteinbeck/tinyspline/archive/v0.3.0.tar.gz"
     sha256: "3e89ec449799b00c66a5f3d26b9960d74a1e238132093424ba35c793a3bd3cd7"

--- a/recipes/tinyspline/all/conandata.yml
+++ b/recipes/tinyspline/all/conandata.yml
@@ -1,14 +1,14 @@
 sources:
-  "0.2.0":
-    url: "https://github.com/msteinbeck/tinyspline/archive/0.2.0.tar.gz"
-    sha256: "7e0776abfc2ab7e485ec5cdac0ad37774aa9362f81303ceb5584e983582a38d2"
   "0.3.0":
     url: "https://github.com/msteinbeck/tinyspline/archive/v0.3.0.tar.gz"
     sha256: "3e89ec449799b00c66a5f3d26b9960d74a1e238132093424ba35c793a3bd3cd7"
-patches:
   "0.2.0":
-    - patch_file: "patches/0.2.0-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
+    url: "https://github.com/msteinbeck/tinyspline/archive/0.2.0.tar.gz"
+    sha256: "7e0776abfc2ab7e485ec5cdac0ad37774aa9362f81303ceb5584e983582a38d2"
+patches:
   "0.3.0":
     - patch_file: "patches/0.3.0-0001-fix-cmake.patch"
+      base_path: "source_subfolder"
+  "0.2.0":
+    - patch_file: "patches/0.2.0-0001-fix-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/tinyspline/all/conanfile.py
+++ b/recipes/tinyspline/all/conanfile.py
@@ -64,20 +64,35 @@ class TinysplineConan(ConanFile):
         cmake.definitions["TINYSPLINE_BUILD_DOCS"] = False
         cmake.definitions["TINYSPLINE_BUILD_EXAMPLES"] = False
         cmake.definitions["TINYSPLINE_BUILD_TESTS"] = False
-        cmake.definitions["TINYSPLINE_DISABLE_CXX"] = not self.options.cxx
-        cmake.definitions["TINYSPLINE_DISABLE_CSHARP"] = True
-        cmake.definitions["TINYSPLINE_DISABLE_D"] = True
-        cmake.definitions["TINYSPLINE_DISABLE_GOLANG"] = True
-        cmake.definitions["TINYSPLINE_DISABLE_JAVA"] = True
-        cmake.definitions["TINYSPLINE_DISABLE_LUA"] = True
-        cmake.definitions["TINYSPLINE_DISABLE_OCTAVE"] = True
-        cmake.definitions["TINYSPLINE_DISABLE_PHP"] = True
-        cmake.definitions["TINYSPLINE_DISABLE_PYTHON"] = True
-        cmake.definitions["TINYSPLINE_DISABLE_R"] = True
-        cmake.definitions["TINYSPLINE_DISABLE_RUBY"] = True
         cmake.definitions["TINYSPLINE_FLOAT_PRECISION"] = self.options.floating_point_precision == "single"
         cmake.definitions["TINYSPLINE_INSTALL_BINARY_DIR"] = "bin"
         cmake.definitions["TINYSPLINE_INSTALL_LIBRARY_DIR"] = "lib"
+        if tools.Version(self.version) < "0.3.0":
+            cmake.definitions["TINYSPLINE_DISABLE_CXX"] = not self.options.cxx
+            cmake.definitions["TINYSPLINE_DISABLE_CSHARP"] = True
+            cmake.definitions["TINYSPLINE_DISABLE_D"] = True
+            cmake.definitions["TINYSPLINE_DISABLE_GOLANG"] = True
+            cmake.definitions["TINYSPLINE_DISABLE_JAVA"] = True
+            cmake.definitions["TINYSPLINE_DISABLE_LUA"] = True
+            cmake.definitions["TINYSPLINE_DISABLE_OCTAVE"] = True
+            cmake.definitions["TINYSPLINE_DISABLE_PHP"] = True
+            cmake.definitions["TINYSPLINE_DISABLE_PYTHON"] = True
+            cmake.definitions["TINYSPLINE_DISABLE_R"] = True
+            cmake.definitions["TINYSPLINE_DISABLE_RUBY"] = True
+        else:
+            cmake.definitions["TINYSPLINE_WARNINGS_AS_ERRORS"] = False
+            cmake.definitions["TINYSPLINE_ENABLE_CXX"] = self.options.cxx
+            cmake.definitions["TINYSPLINE_ENABLE_CSHARP"] = False
+            cmake.definitions["TINYSPLINE_ENABLE_DLANG"] = False
+            cmake.definitions["TINYSPLINE_ENABLE_GO"] = False
+            cmake.definitions["TINYSPLINE_ENABLE_JAVA"] = False
+            cmake.definitions["TINYSPLINE_ENABLE_LUA"] = False
+            cmake.definitions["TINYSPLINE_ENABLE_OCTAVE"] = False
+            cmake.definitions["TINYSPLINE_ENABLE_PHP"] = False
+            cmake.definitions["TINYSPLINE_ENABLE_PYTHON"] = False
+            cmake.definitions["TINYSPLINE_ENABLE_R"] = False
+            cmake.definitions["TINYSPLINE_ENABLE_RUBY"] = False
+            cmake.definitions["TINYSPLINE_ENABLE_ALL_INTERFACES"] = False
         cmake.configure()
         return cmake
 
@@ -105,18 +120,21 @@ class TinysplineConan(ConanFile):
             cpp_prefix = "cxx"
 
         self.cpp_info.set_property("cmake_file_name", "tinyspline")
-        self.cpp_info.set_property("cmake_target_name", "tinyspline-do-not-use")
-        self.cpp_info.set_property("pkg_config_name", "tinyspline-do-not-use")
 
         self.cpp_info.components["libtinyspline"].set_property("cmake_target_name", "tinyspline::tinyspline")
         self.cpp_info.components["libtinyspline"].set_property("pkg_config_name", "tinyspline")
         self.cpp_info.components["libtinyspline"].libs = ["{}tinyspline{}".format(lib_prefix, lib_suffix)]
-
-        # FIXME: should live in tinysplinecxx-config.cmake (see https://github.com/conan-io/conan/issues/9000)
-        self.cpp_info.components["libtinysplinecxx"].set_property("cmake_target_name", "tinysplinecxx::tinysplinecxx")
-        self.cpp_info.components["libtinysplinecxx"].set_property("pkg_config_name", "tinysplinecxx")
-        self.cpp_info.components["libtinysplinecxx"].libs = ["{}tinyspline{}{}".format(lib_prefix, cpp_prefix, lib_suffix)]
-
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libtinyspline"].system_libs = ["m"]
-            self.cpp_info.components["libtinysplinecxx"].system_libs = ["m"]
+
+        if self.options.cxx:
+            # FIXME: should live in tinysplinecxx-config.cmake (see https://github.com/conan-io/conan/issues/9000)
+            self.cpp_info.components["libtinysplinecxx"].set_property("cmake_target_name", "tinysplinecxx::tinysplinecxx")
+            self.cpp_info.components["libtinysplinecxx"].set_property("pkg_config_name", "tinysplinecxx")
+            self.cpp_info.components["libtinysplinecxx"].libs = ["{}tinyspline{}{}".format(lib_prefix, cpp_prefix, lib_suffix)]
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                self.cpp_info.components["libtinysplinecxx"].system_libs = ["m"]
+
+            # Workaround to always provide a global target or pkg-config file with all components
+            self.cpp_info.set_property("cmake_target_name", "tinyspline-do-not-use")
+            self.cpp_info.set_property("pkg_config_name", "tinyspline-do-not-use")

--- a/recipes/tinyspline/all/conanfile.py
+++ b/recipes/tinyspline/all/conanfile.py
@@ -1,36 +1,47 @@
+from conans import ConanFile, CMake, tools
+import functools
 import os
 
-from conans import ConanFile, CMake, tools
+required_conan_version = ">=1.36.0"
+
 
 class TinysplineConan(ConanFile):
     name = "tinyspline"
     description = "Library for interpolating, transforming, and querying " \
                   "arbitrary NURBS, B-Splines, and Bezier curves."
     license = "MIT"
-    topics = ("conan", "tinyspline ", "nurbs", "b-splines", "bezier")
+    topics = ("tinyspline ", "nurbs", "b-splines", "bezier")
     homepage = "https://github.com/msteinbeck/tinyspline"
     url = "https://github.com/conan-io/conan-center-index"
-    exports_sources = ["CMakeLists.txt", "patches/**"]
-    generators = "cmake"
+
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
         "cxx": [True, False],
-        "floating_point_precision": ["double", "single"]
+        "floating_point_precision": ["double", "single"],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "cxx": True,
-        "floating_point_precision": "double"
+        "floating_point_precision": "double",
     }
 
-    _cmake = None
+    generators = "cmake"
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -44,32 +55,31 @@ class TinysplineConan(ConanFile):
             del self.settings.compiler.cppstd
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename(self.name + "-" + self.version, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["TINYSPLINE_BUILD_DOCS"] = False
-        self._cmake.definitions["TINYSPLINE_BUILD_EXAMPLES"] = False
-        self._cmake.definitions["TINYSPLINE_BUILD_TESTS"] = False
-        self._cmake.definitions["TINYSPLINE_DISABLE_CXX"] = not self.options.cxx
-        self._cmake.definitions["TINYSPLINE_DISABLE_CSHARP"] = True
-        self._cmake.definitions["TINYSPLINE_DISABLE_D"] = True
-        self._cmake.definitions["TINYSPLINE_DISABLE_GOLANG"] = True
-        self._cmake.definitions["TINYSPLINE_DISABLE_JAVA"] = True
-        self._cmake.definitions["TINYSPLINE_DISABLE_LUA"] = True
-        self._cmake.definitions["TINYSPLINE_DISABLE_OCTAVE"] = True
-        self._cmake.definitions["TINYSPLINE_DISABLE_PHP"] = True
-        self._cmake.definitions["TINYSPLINE_DISABLE_PYTHON"] = True
-        self._cmake.definitions["TINYSPLINE_DISABLE_R"] = True
-        self._cmake.definitions["TINYSPLINE_DISABLE_RUBY"] = True
-        self._cmake.definitions["TINYSPLINE_FLOAT_PRECISION"] = self.options.floating_point_precision == "single"
-        self._cmake.definitions["TINYSPLINE_INSTALL_BINARY_DIR"] = "bin"
-        self._cmake.definitions["TINYSPLINE_INSTALL_LIBRARY_DIR"] = "lib"
-        self._cmake.configure()
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["TINYSPLINE_BUILD_DOCS"] = False
+        cmake.definitions["TINYSPLINE_BUILD_EXAMPLES"] = False
+        cmake.definitions["TINYSPLINE_BUILD_TESTS"] = False
+        cmake.definitions["TINYSPLINE_DISABLE_CXX"] = not self.options.cxx
+        cmake.definitions["TINYSPLINE_DISABLE_CSHARP"] = True
+        cmake.definitions["TINYSPLINE_DISABLE_D"] = True
+        cmake.definitions["TINYSPLINE_DISABLE_GOLANG"] = True
+        cmake.definitions["TINYSPLINE_DISABLE_JAVA"] = True
+        cmake.definitions["TINYSPLINE_DISABLE_LUA"] = True
+        cmake.definitions["TINYSPLINE_DISABLE_OCTAVE"] = True
+        cmake.definitions["TINYSPLINE_DISABLE_PHP"] = True
+        cmake.definitions["TINYSPLINE_DISABLE_PYTHON"] = True
+        cmake.definitions["TINYSPLINE_DISABLE_R"] = True
+        cmake.definitions["TINYSPLINE_DISABLE_RUBY"] = True
+        cmake.definitions["TINYSPLINE_FLOAT_PRECISION"] = self.options.floating_point_precision == "single"
+        cmake.definitions["TINYSPLINE_INSTALL_BINARY_DIR"] = "bin"
+        cmake.definitions["TINYSPLINE_INSTALL_LIBRARY_DIR"] = "lib"
+        cmake.configure()
+        return cmake
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -81,27 +91,32 @@ class TinysplineConan(ConanFile):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         if tools.Version(self.version) < "0.3.0":
-            lib_prefix = "lib" if self.settings.compiler == "Visual Studio" and not self.options.shared else ""
-            lib_suffix = "d" if self.settings.compiler == "Visual Studio" and self.settings.build_type == "Debug" else ""
+            lib_prefix = "lib" if self._is_msvc and not self.options.shared else ""
+            lib_suffix = "d" if self._is_msvc and self.settings.build_type == "Debug" else ""
             cpp_prefix = "cpp"
         else:
             lib_prefix = ""
             lib_suffix = ""
             cpp_prefix = "cxx"
 
+        self.cpp_info.set_property("cmake_file_name", "tinyspline")
+        self.cpp_info.set_property("cmake_target_name", "tinyspline-do-not-use")
+        self.cpp_info.set_property("pkg_config_name", "tinyspline-do-not-use")
+
+        self.cpp_info.components["libtinyspline"].set_property("cmake_target_name", "tinyspline::tinyspline")
+        self.cpp_info.components["libtinyspline"].set_property("pkg_config_name", "tinyspline")
         self.cpp_info.components["libtinyspline"].libs = ["{}tinyspline{}".format(lib_prefix, lib_suffix)]
-        self.cpp_info.components["libtinyspline"].names["pkg_config"] = "tinyspline"
 
-        # FIXME: create tinysplinecxx::tinysplinecxx in tinycplinecxx-config.cmake
+        # FIXME: should live in tinysplinecxx-config.cmake (see https://github.com/conan-io/conan/issues/9000)
+        self.cpp_info.components["libtinysplinecxx"].set_property("cmake_target_name", "tinysplinecxx::tinysplinecxx")
+        self.cpp_info.components["libtinysplinecxx"].set_property("pkg_config_name", "tinysplinecxx")
         self.cpp_info.components["libtinysplinecxx"].libs = ["{}tinyspline{}{}".format(lib_prefix, cpp_prefix, lib_suffix)]
-        self.cpp_info.components["libtinysplinecxx"].names["pkg_config"] = "tinyspline{}".format(cpp_prefix)
 
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libtinyspline"].system_libs = ["m"]
             self.cpp_info.components["libtinysplinecxx"].system_libs = ["m"]

--- a/recipes/tinyspline/all/conanfile.py
+++ b/recipes/tinyspline/all/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 import functools
 import os
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.43.0"
 
 
 class TinysplineConan(ConanFile):

--- a/recipes/tinyspline/all/conanfile.py
+++ b/recipes/tinyspline/all/conanfile.py
@@ -150,6 +150,8 @@ class TinysplineConan(ConanFile):
         self.cpp_info.components["libtinyspline"].libs = ["{}tinyspline{}".format(lib_prefix, lib_suffix)]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libtinyspline"].system_libs = ["m"]
+        if tools.Version(self.version) >= "0.3.0" and self.options.shared and self.settings.os == "Windows":
+            self.cpp_info.components["libtinyspline"].defines.append("TINYSPLINE_SHARED")
 
         if self.options.cxx:
             # FIXME: should live in tinysplinecxx-config.cmake (see https://github.com/conan-io/conan/issues/9000)
@@ -158,6 +160,8 @@ class TinysplineConan(ConanFile):
             self.cpp_info.components["libtinysplinecxx"].libs = ["{}tinyspline{}{}".format(lib_prefix, cpp_prefix, lib_suffix)]
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["libtinysplinecxx"].system_libs = ["m"]
+            if tools.Version(self.version) >= "0.3.0" and self.options.shared and self.settings.os == "Windows":
+                self.cpp_info.components["libtinysplinecxx"].defines.append("TINYSPLINE_SHARED")
 
             # Workaround to always provide a global target or pkg-config file with all components
             self.cpp_info.set_property("cmake_target_name", "tinyspline-do-not-use")

--- a/recipes/tinyspline/all/test_package/CMakeLists.txt
+++ b/recipes/tinyspline/all/test_package/CMakeLists.txt
@@ -2,15 +2,18 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 if(TINYSPLINE_API_0_3)
   add_definitions(-DTINYSPLINE_API_0_3)
 endif()
+
+find_package(tinyspline REQUIRED CONFIG)
 add_executable(${PROJECT_NAME}_c test_package.c)
-target_link_libraries(${PROJECT_NAME}_c ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME}_c tinyspline::tinyspline)
 
 if(TINYSPLINE_CXX)
-  add_executable(${PROJECT_NAME}_cpp test_package.cpp)
-  target_link_libraries(${PROJECT_NAME}_cpp ${CONAN_LIBS})
+    # FIXME: we should have to call find_package(tinysplinecxx REQUIRED CONFIG)
+    add_executable(${PROJECT_NAME}_cpp test_package.cpp)
+    target_link_libraries(${PROJECT_NAME}_cpp tinysplinecxx::tinysplinecxx)
 endif()

--- a/recipes/tinyspline/all/test_package/conanfile.py
+++ b/recipes/tinyspline/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/tinyspline/all/test_package/conanfile.py
+++ b/recipes/tinyspline/all/test_package/conanfile.py
@@ -1,9 +1,9 @@
+from conans import ConanFile, CMake, tools
 import os
 
-from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
 
     def build(self):
@@ -14,7 +14,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_c_path = os.path.join("bin", "test_package_c")
             self.run(bin_c_path, run_environment=True)
             if self.options["tinyspline"].cxx:

--- a/recipes/tinyspline/all/test_package/test_package.cpp
+++ b/recipes/tinyspline/all/test_package/test_package.cpp
@@ -5,7 +5,7 @@
 #endif
 
 int main() {
-  tinyspline::BSpline spline(6, 3, 3, TS_OPENED);
+  tinyspline::BSpline spline(6, 3, 3);
 
   return 0;
 }

--- a/recipes/tinyspline/config.yml
+++ b/recipes/tinyspline/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.4.0":
+    folder: all
   "0.3.0":
     folder: all
   "0.2.0":

--- a/recipes/tinyspline/config.yml
+++ b/recipes/tinyspline/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.2.0":
-    folder: all
   "0.3.0":
+    folder: all
+  "0.2.0":
     folder: all


### PR DESCRIPTION
- add tinyspline/0.4.0
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- honor `tinyspline:cxx=False` at build time when version >= 0.3.0
- fix `package_info()` when cxx option disabled
- no warnings as errors
- fix CMake targets names
- add interface definition `TINYSPLINE_SHARED` if windows, shared and version >= 0.3.0 (you can look at `tinyspline.h` header).
- modernize

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
