### PR TITLE
Android NDK r24

### DIFF
--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -1,4 +1,18 @@
 sources:
+  "r24":
+    url:
+      "Windows":
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r24-windows.zip"
+          sha256: "b2a9fab1481c3c21df0b78608747dde0747b50890134a62a81c983a5250066d6"
+      "Linux":
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r24-linux.zip"
+          sha256: "caac638f060347c9aae994e718ba00bb18413498d8e0ad4e12e1482964032997"
+      "Macos":
+        "x86_64":
+          url: "https://dl.google.com/android/repository/android-ndk-r24-darwin.dmg"
+          sha256: "9b67b1aec07aaf707ca167332982d3d86eff901df0843cefa2a3b347fb463333"
   "r23b":
     url:
       "Windows":

--- a/recipes/android-ndk/config.yml
+++ b/recipes/android-ndk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "r24":
+    folder: all
   "r23b":
     folder: all
   "r23":


### PR DESCRIPTION
Specify library name and version:  **NDK r24**

close #9955

I know I have to use NDK 24 to have arm64 support on Apple Silicon, but the latest from conan is 23b

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
