### PR TITLE
Fix defines for termcap

### DIFF
--- a/recipes/termcap/all/conanfile.py
+++ b/recipes/termcap/all/conanfile.py
@@ -89,7 +89,7 @@ class TermcapConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "Termcap"
         self.cpp_info.libs = tools.collect_libs(self)
         if self.options.shared:
-            self.cpp_info.definitions = ["TERMCAP_SHARED"]
+            self.cpp_info.defines = ["TERMCAP_SHARED"]
 
         self.output.info("Setting TERMCAP environment variable: {}".format(self._termcap_path))
         self.env_info.TERMCAP = self._termcap_path


### PR DESCRIPTION
I happened to find this misnamed identifier in the termcap port. I am not sure why the mistake hasn't been caught in any tests.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
