### PR TITLE
New version of expat, 2.4.8

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.4.8":
+    sha256: "f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df479dcaf25"
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_8/expat-2.4.8.tar.xz"
   "2.4.7":
     sha256: "9875621085300591f1e64c18fd3da3a0eeca4a74f884b9abac2758ad1bd07a7d"
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_7/expat-2.4.7.tar.xz"

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.4.8":
+    folder: all
   "2.4.7":
     folder: all
   "2.4.6":


### PR DESCRIPTION
Specify library name and version:  **expat/2.4.8**

Package the latest version of the expat library, version 2.4.8

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
