### PR TITLE
fix windows clang compilation for ffi

### DIFF
--- a/recipes/libffi/all/conanfile.py
+++ b/recipes/libffi/all/conanfile.py
@@ -87,13 +87,16 @@ class LibffiConan(ConanFile):
     @contextlib.contextmanager
     def _build_context(self):
         extra_env_vars = {}
-        if self._is_msvc:
+        if tools.os_info.is_windows:
             msvcc = tools.unix_path(os.path.join(self.source_folder, self._source_subfolder, "msvcc.sh"))
             msvcc_args = []
             if self.settings.arch == "x86_64":
                 msvcc_args.append("-m64")
             elif self.settings.arch == "x86":
                 msvcc_args.append("-m32")
+            if self.settings.compiler == "clang":
+                msvcc_args.append("-clang-cl")
+
             if msvcc_args:
                 msvcc = "{} {}".format(msvcc, " ".join(msvcc_args))
             extra_env_vars.update(tools.vcvars_dict(self.settings))
@@ -178,3 +181,4 @@ class LibffiConan(ConanFile):
         self.cpp_info.libs = ["{}ffi".format("lib" if self._is_msvc else "")]
         if not self.options.shared:
             self.cpp_info.defines = ["FFI_BUILDING"]
+

--- a/recipes/libffi/all/conanfile.py
+++ b/recipes/libffi/all/conanfile.py
@@ -87,14 +87,15 @@ class LibffiConan(ConanFile):
     @contextlib.contextmanager
     def _build_context(self):
         extra_env_vars = {}
-        if tools.os_info.is_windows:
+        if tools.os_info.is_windows and (self._is_msvc or self.settings.compiler == "clang") :
             msvcc = tools.unix_path(os.path.join(self.source_folder, self._source_subfolder, "msvcc.sh"))
             msvcc_args = []
-            if self.settings.arch == "x86_64":
-                msvcc_args.append("-m64")
-            elif self.settings.arch == "x86":
-                msvcc_args.append("-m32")
-            if self.settings.compiler == "clang":
+            if self._is_msvc:
+                if self.settings.arch == "x86_64":
+                    msvcc_args.append("-m64")
+                elif self.settings.arch == "x86":
+                    msvcc_args.append("-m32")
+            elif self.settings.compiler == "clang":
                 msvcc_args.append("-clang-cl")
 
             if msvcc_args:


### PR DESCRIPTION
Specify library name and version:  **libffi/3.4.2@**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

closes: #9954

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
