### PR TITLE
clipper: fix download of 4.8.8 tarball + relocatable shared lib on macOS

### DIFF
--- a/recipes/clipper/all/CMakeLists.txt
+++ b/recipes/clipper/all/CMakeLists.txt
@@ -6,6 +6,6 @@ if(WIN32 AND BUILD_SHARED_LIBS)
 endif()
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder/cpp")

--- a/recipes/clipper/all/conandata.yml
+++ b/recipes/clipper/all/conandata.yml
@@ -6,8 +6,10 @@ sources:
     url: "https://github.com/skyrpex/clipper/archive/5.1.6.tar.gz"
     sha256: "34e1b8dacac09f3732772e9c0dd4034d584fde3a15e8c05dfed52d24e9ad4cb3"
   "4.8.8":
-    url: "https://sourceforge.net/code-snapshots/svn/p/po/polyclipping/code/polyclipping-code-r585-tags-4.8.8.zip"
-    sha256: "777eb8931b750cc03dbbb5c30db5a6dd20def3e940e25cda6746287cbfc758db"
+    url:
+      post: "https://sourceforge.net/p/polyclipping/code/HEAD/tree/tags/4.8.8/tarball"
+      archive: "https://sourceforge.net/code-snapshots/svn/p/po/polyclipping/code/polyclipping-code-r585-tags-4.8.8.zip"
+    sha256: "dc5d526446f0899e61f7e8fc3d9f33335622f8b5adcbe3464d1b51b674034b96"
 patches:
   "6.4.2":
     - patch_file: "patches/0001-include-install-directory-6.x.patch"

--- a/recipes/clipper/all/conanfile.py
+++ b/recipes/clipper/all/conanfile.py
@@ -1,5 +1,7 @@
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanException
 import os
+import requests
 
 required_conan_version = ">=1.36.0"
 
@@ -46,9 +48,34 @@ class ClipperConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    @staticmethod
+    def _generate_git_tag_archive_sourceforge(url, timeout=10, retry=2):
+        def try_post(retry_count):
+            try:
+                requests.post(url, timeout=timeout)
+            except:
+                if retry_count < retry:
+                    try_post(retry_count + 1)
+                else:
+                    raise ConanException("All the attempt to generate archive url have failed.")
+        try_post(0)
+
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        conan_data_version = self.conan_data["sources"][self.version]
+        if "post" in conan_data_version["url"]:
+            # Generate the archive download link
+            self._generate_git_tag_archive_sourceforge(
+                conan_data_version["url"]["post"],
+            )
+
+            # Download archive
+            archive_url = conan_data_version["url"]["archive"]
+            sha256 = conan_data_version["sha256"]
+            tools.get(url=archive_url, sha256=sha256,
+                      destination=self._source_subfolder, strip_root=True)
+        else:
+            tools.get(**conan_data_version,
+                      destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/clipper/all/conanfile.py
+++ b/recipes/clipper/all/conanfile.py
@@ -81,6 +81,8 @@ class ClipperConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        # To install relocatable shared libs on Macos
+        self._cmake.definitions["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- url of tarball of 4.8.8 is not persistent, it may or may not exist at a given time.  So we must force sourceforge to generate the link prior to download attempt. 

closes https://github.com/conan-io/conan-center-index/issues/9991

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
