### PR TITLE
aws-c-http: add version 0.6.13 with updating dependencies

### DIFF
--- a/recipes/aws-c-http/all/conandata.yml
+++ b/recipes/aws-c-http/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.13":
+    url: "https://github.com/awslabs/aws-c-http/archive/v0.6.13.tar.gz"
+    sha256: "8c69f8fc58b7073039e598383da3e1fd9b23f392cb992dbe769a7b80f342dbaf"
   "0.6.10":
     url: "https://github.com/awslabs/aws-c-http/archive/v0.6.10.tar.gz"
     sha256: "4413faf2b8f6a83c898bb535cf83542fa548d7ecc1acf681dc79b7959a07231a"

--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -39,9 +39,9 @@ class AwsCHttp(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.15")
+        self.requires("aws-c-common/0.6.19")
         self.requires("aws-c-compression/0.2.14")
-        self.requires("aws-c-io/0.10.13")
+        self.requires("aws-c-io/0.10.20")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/aws-c-http/config.yml
+++ b/recipes/aws-c-http/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.13":
+    folder: all
   "0.6.10":
     folder: all
   "0.6.7":


### PR DESCRIPTION
Specify library name and version:  **aws-c-http/0.6.13**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
