### PR TITLE
opencv: Fix incorrectly including libelf header files.

### DIFF
--- a/recipes/opencv/3.x/conanfile.py
+++ b/recipes/opencv/3.x/conanfile.py
@@ -158,6 +158,14 @@ class OpenCVConan(ConanFile):
               set(GLOG_LIBRARIES glog::glog)
             endif()""".format(search))
 
+        if self.options.contrib and self._is_msvc:
+            videoio_cmake = os.path.join(self._source_subfolder, "modules", "videoio", "CMakeLists.txt")
+            tools.replace_in_file(videoio_cmake, "ocv_module_include_directories()", """ocv_module_include_directories()
+            get_directory_property(temp_include_dirs INCLUDE_DIRECTORIES)
+            string(REPLACE "%s" "" temp_new_include_dirs "${temp_include_dirs}")
+            set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES "${temp_new_include_dirs}")
+            """ % os.path.join(self.deps_cpp_info["libelf"].rootpath, "include", "libelf").replace("\\", "/"))
+
     def _configure_cmake(self):
         if self._cmake:
             return self._cmake


### PR DESCRIPTION
Specify library name and version:  **opencv/3.x**

Both libelf and the Windows SDK have the errors.h header file. The header file for libelf was incorrectly included.
2.x and 4.x versions do not have this problem.

![image](https://user-images.githubusercontent.com/3735828/160795478-ce6fdd49-0e64-4d54-9b31-b8f458a245d8.png)


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
