### PR TITLE
poco: bump dependencies + modernize

### DIFF
--- a/recipes/poco/all/CMakeLists.txt
+++ b/recipes/poco/all/CMakeLists.txt
@@ -23,4 +23,4 @@ if ("${CONAN_PACKAGE_VERSION}" VERSION_GREATER "1.10")
 endif()
 
 
-add_subdirectory(source_subfolder)
+add_subdirectory(src)

--- a/recipes/poco/all/CMakeLists.txt
+++ b/recipes/poco/all/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 if(MYSQL_ROOT_DIR)
   find_package(MySQL REQUIRED)

--- a/recipes/poco/all/conandata.yml
+++ b/recipes/poco/all/conandata.yml
@@ -23,32 +23,32 @@ sources:
 patches:
   "1.11.1":
     - patch_file: patches/1.11.1.patch
-      base_path: source_subfolder
+      base_path: src
     - patch_file: patches/0002-mysql-include.patch
-      base_path: source_subfolder
+      base_path: src
   "1.11.0":
     - patch_file: patches/1.11.0.patch
-      base_path: source_subfolder
+      base_path: src
     - patch_file: patches/0002-mysql-include.patch
-      base_path: source_subfolder
+      base_path: src
   "1.10.1":
     - patch_file: patches/1.10.1.patch
-      base_path: source_subfolder
+      base_path: src
   "1.10.0":
     - patch_file: patches/1.10.0.patch
-      base_path: source_subfolder
+      base_path: src
     - patch_file: patches/1.10.0-set-missing-cmake-variable.patch
-      base_path: source_subfolder
+      base_path: src
   "1.9.4":
     - patch_file: patches/1.9.2.patch
-      base_path: source_subfolder
+      base_path: src
     - patch_file: patches/1.9.2-2.patch
-      base_path: source_subfolder
+      base_path: src
   "1.9.3":
     - patch_file: patches/1.9.2.patch
-      base_path: source_subfolder
+      base_path: src
     - patch_file: patches/1.9.2-2.patch
-      base_path: source_subfolder
+      base_path: src
   "1.8.1":
     - patch_file: patches/1.8.1.patch
-      base_path: source_subfolder
+      base_path: src

--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -1,6 +1,8 @@
+from conan.tools.microsoft import msvc_runtime_flag
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 from collections import namedtuple
+import functools
 import os
 
 required_conan_version = ">=1.43.0"
@@ -12,8 +14,11 @@ class PocoConan(ConanFile):
     homepage = "https://pocoproject.org"
     topics = ("building", "networking", "server", "mobile", "embedded")
     license = "BSL-1.0"
-    description = "Modern, powerful open source C++ class libraries for building network- and internet-based " \
-                  "applications that run on desktop, server, mobile and embedded systems."
+    description = (
+        "Modern, powerful open source C++ class libraries for building "
+        "network- and internet-based applications that run on desktop, server, "
+        "mobile and embedded systems."
+    )
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -66,7 +71,6 @@ class PocoConan(ConanFile):
     del comp
 
     generators = "cmake", "cmake_find_package"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -75,6 +79,10 @@ class PocoConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
 
     def export_sources(self):
         self.copy("CMakeLists.txt")
@@ -134,9 +142,8 @@ class PocoConan(ConanFile):
     def validate(self):
         if self.options.enable_apacheconnector:
             raise ConanInvalidConfiguration("Apache connector not supported: https://github.com/pocoproject/poco/issues/1764")
-        if self.settings.compiler == "Visual Studio":
-            if self.options.shared and "MT" in str(self.settings.compiler.runtime):
-                raise ConanInvalidConfiguration("Cannot build shared poco libraries with MT(d) runtime")
+        if self._is_msvc and self.options.shared and "MT" in msvc_runtime_flag(self):
+            raise ConanInvalidConfiguration("Cannot build shared poco libraries with MT(d) runtime")
         for compopt in self._poco_component_tree.values():
             if not compopt.option:
                 continue
@@ -160,45 +167,42 @@ class PocoConan(ConanFile):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["CMAKE_BUILD_TYPE"] = self.settings.build_type
+        cmake = CMake(self)
+        cmake.definitions["CMAKE_BUILD_TYPE"] = self.settings.build_type
         if tools.Version(self.version) < "1.10.1":
-            self._cmake.definitions["POCO_STATIC"] = not self.options.shared
+            cmake.definitions["POCO_STATIC"] = not self.options.shared
         for comp in self._poco_component_tree.values():
-            if not comp.option:
-                continue
-            self._cmake.definitions[comp.option.upper()] = self.options.get_safe(comp.option, False)
-        self._cmake.definitions["POCO_UNBUNDLED"] = True
-        self._cmake.definitions["CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP"] = True
-        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":  # MT or MTd
-            self._cmake.definitions["POCO_MT"] = "ON" if "MT" in str(self.settings.compiler.runtime) else "OFF"
+            if comp.option:
+                cmake.definitions[comp.option.upper()] = self.options.get_safe(comp.option, False)
+        cmake.definitions["POCO_UNBUNDLED"] = True
+        cmake.definitions["CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP"] = True
+        if self._is_msvc:
+            cmake.definitions["POCO_MT"] = "MT" in msvc_runtime_flag(self)
         if self.options.get_safe("enable_data_postgresql", False):
-            self._cmake.definitions["PostgreSQL_ROOT_DIR"] = self.deps_cpp_info["libpq"].rootpath
-            self._cmake.definitions["PostgreSQL_ROOT_INCLUDE_DIRS"] = ";".join(self.deps_cpp_info["libpq"].include_paths)
-            self._cmake.definitions["PostgreSQL_ROOT_LIBRARY_DIRS"] = ";".join(self.deps_cpp_info["libpq"].lib_paths)
+            cmake.definitions["PostgreSQL_ROOT_DIR"] = self.deps_cpp_info["libpq"].rootpath
+            cmake.definitions["PostgreSQL_ROOT_INCLUDE_DIRS"] = ";".join(self.deps_cpp_info["libpq"].include_paths)
+            cmake.definitions["PostgreSQL_ROOT_LIBRARY_DIRS"] = ";".join(self.deps_cpp_info["libpq"].lib_paths)
         if self.options.get_safe("enable_data_mysql", False):
-            self._cmake.definitions["MYSQL_ROOT_DIR"] = self.deps_cpp_info["libmysqlclient"].rootpath
-            self._cmake.definitions["MYSQL_ROOT_INCLUDE_DIRS"] = ";".join(self.deps_cpp_info["libmysqlclient"].include_paths)
-            self._cmake.definitions["MYSQL_INCLUDE_DIR"] = ";".join(self.deps_cpp_info["libmysqlclient"].include_paths)
-            self._cmake.definitions["MYSQL_ROOT_LIBRARY_DIRS"] = ";".join(self.deps_cpp_info["libmysqlclient"].lib_paths)
-            self._cmake.definitions["APR_ROOT_DIR"] = self.deps_cpp_info["apr"].rootpath
-            self._cmake.definitions["APR_ROOT_INCLUDE_DIRS"] = ";".join(self.deps_cpp_info["apr"].include_paths)
-            self._cmake.definitions["APR_ROOT_LIBRARY_DIRS"] = ";".join(self.deps_cpp_info["apr"].lib_paths)
-            self._cmake.definitions["APRUTIL_ROOT_DIR"] = self.deps_cpp_info["apr-util"].rootpath
-            self._cmake.definitions["APRUTIL_ROOT_INCLUDE_DIRS"] = ";".join(self.deps_cpp_info["apr-util"].include_paths)
-            self._cmake.definitions["APRUTIL_ROOT_LIBRARY_DIRS"] = ";".join(self.deps_cpp_info["apr-util"].lib_paths)
+            cmake.definitions["MYSQL_ROOT_DIR"] = self.deps_cpp_info["libmysqlclient"].rootpath
+            cmake.definitions["MYSQL_ROOT_INCLUDE_DIRS"] = ";".join(self.deps_cpp_info["libmysqlclient"].include_paths)
+            cmake.definitions["MYSQL_INCLUDE_DIR"] = ";".join(self.deps_cpp_info["libmysqlclient"].include_paths)
+            cmake.definitions["MYSQL_ROOT_LIBRARY_DIRS"] = ";".join(self.deps_cpp_info["libmysqlclient"].lib_paths)
+            cmake.definitions["APR_ROOT_DIR"] = self.deps_cpp_info["apr"].rootpath
+            cmake.definitions["APR_ROOT_INCLUDE_DIRS"] = ";".join(self.deps_cpp_info["apr"].include_paths)
+            cmake.definitions["APR_ROOT_LIBRARY_DIRS"] = ";".join(self.deps_cpp_info["apr"].lib_paths)
+            cmake.definitions["APRUTIL_ROOT_DIR"] = self.deps_cpp_info["apr-util"].rootpath
+            cmake.definitions["APRUTIL_ROOT_INCLUDE_DIRS"] = ";".join(self.deps_cpp_info["apr-util"].include_paths)
+            cmake.definitions["APRUTIL_ROOT_LIBRARY_DIRS"] = ";".join(self.deps_cpp_info["apr-util"].lib_paths)
 
-        self.output.info(self._cmake.definitions)
         # Disable fork
         if not self.options.get_safe("enable_fork", True):
-            self._cmake.definitions["POCO_NO_FORK_EXEC"] = True
+            cmake.definitions["POCO_NO_FORK_EXEC"] = True
         # On Windows, Poco needs a message (MC) compiler.
-        with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
-            self._cmake.configure(build_dir=self._build_subfolder)
-        return self._cmake
+        with tools.vcvars(self.settings) if self._is_msvc else tools.no_op():
+            cmake.configure(build_dir=self._build_subfolder)
+        return cmake
 
     def build(self):
         self._patch_sources()
@@ -222,8 +226,8 @@ class PocoConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "Poco"
         self.cpp_info.names["cmake_find_package_multi"] = "Poco"
 
-        suffix = str(self.settings.compiler.runtime).lower()  \
-                 if self.settings.compiler == "Visual Studio" and not self.options.shared \
+        suffix = msvc_runtime_flag(self).lower() \
+                 if self._is_msvc and not self.options.shared \
                  else ("d" if self.settings.build_type == "Debug" else "")
 
         for compname, comp in self._poco_component_tree.items():
@@ -241,7 +245,7 @@ class PocoConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["poco_foundation"].system_libs.extend(["pthread", "dl", "rt"])
 
-        if self.settings.compiler == "Visual Studio":
+        if self._is_msvc:
             self.cpp_info.components["poco_foundation"].defines.append("POCO_NO_AUTOMATIC_LIBS")
         if not self.options.shared:
             self.cpp_info.components["poco_foundation"].defines.append("POCO_STATIC=ON")

--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -116,7 +116,7 @@ class PocoConan(ConanFile):
 
     def requirements(self):
         self.requires("pcre/8.45")
-        self.requires("zlib/1.2.11")
+        self.requires("zlib/1.2.12")
         if self.options.enable_xml:
             self.requires("expat/2.4.8")
         if self.options.enable_data_sqlite:

--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -74,11 +74,11 @@ class PocoConan(ConanFile):
 
     @property
     def _source_subfolder(self):
-        return "source_subfolder"
+        return "src"
 
     @property
     def _build_subfolder(self):
-        return "build_subfolder"
+        return "build"
 
     @property
     def _is_msvc(self):

--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -118,9 +118,9 @@ class PocoConan(ConanFile):
         self.requires("pcre/8.45")
         self.requires("zlib/1.2.11")
         if self.options.enable_xml:
-            self.requires("expat/2.4.1")
+            self.requires("expat/2.4.8")
         if self.options.enable_data_sqlite:
-            self.requires("sqlite3/3.36.0")
+            self.requires("sqlite3/3.38.1")
         if self.options.enable_apacheconnector:
             self.requires("apr/1.7.0")
             self.requires("apr-util/1.6.1")
@@ -129,11 +129,11 @@ class PocoConan(ConanFile):
         if self.options.enable_netssl or \
                 self.options.enable_crypto or \
                 self.options.get_safe("enable_jwt", False):
-            self.requires("openssl/1.1.1l")
+            self.requires("openssl/1.1.1n")
         if self.options.enable_data_odbc and self.settings.os != "Windows":
             self.requires("odbc/2.3.9")
         if self.options.get_safe("enable_data_postgresql", False):
-            self.requires("libpq/13.4")
+            self.requires("libpq/14.2")
         if self.options.get_safe("enable_data_mysql", False):
             self.requires("apr/1.7.0")
             self.requires("apr-util/1.6.1")

--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -121,26 +121,22 @@ class PocoConan(ConanFile):
             self.requires("expat/2.4.8")
         if self.options.enable_data_sqlite:
             self.requires("sqlite3/3.38.1")
-        if self.options.enable_apacheconnector:
-            self.requires("apr/1.7.0")
-            self.requires("apr-util/1.6.1")
-            # FIXME: missing apache2 recipe
-            raise ConanInvalidConfiguration("apache2 is not (yet) available on CCI")
-        if self.options.enable_netssl or \
-                self.options.enable_crypto or \
-                self.options.get_safe("enable_jwt", False):
+        if self.options.enable_netssl or self.options.enable_crypto or \
+           self.options.get_safe("enable_jwt"):
             self.requires("openssl/1.1.1n")
         if self.options.enable_data_odbc and self.settings.os != "Windows":
             self.requires("odbc/2.3.9")
-        if self.options.get_safe("enable_data_postgresql", False):
+        if self.options.get_safe("enable_data_postgresql"):
             self.requires("libpq/14.2")
-        if self.options.get_safe("enable_data_mysql", False):
+        if self.options.get_safe("enable_data_mysql") or self.options.enable_apacheconnector:
             self.requires("apr/1.7.0")
             self.requires("apr-util/1.6.1")
+        if self.options.get_safe("enable_data_mysql"):
             self.requires("libmysqlclient/8.0.25")
 
     def validate(self):
         if self.options.enable_apacheconnector:
+            # FIXME: missing apache2 recipe + few issues
             raise ConanInvalidConfiguration("Apache connector not supported: https://github.com/pocoproject/poco/issues/1764")
         if self._is_msvc and self.options.shared and "MT" in msvc_runtime_flag(self):
             raise ConanInvalidConfiguration("Cannot build shared poco libraries with MT(d) runtime")

--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -39,7 +39,7 @@ class PocoConan(ConanFile):
         # "CppUnit": _PocoComponent("enable_cppunit", False, ["Foundation"], [], False)),
         "Crypto": _PocoComponent("enable_crypto", True, ["Foundation"], ["openssl::openssl"], True),
         "Data": _PocoComponent("enable_data", True, ["Foundation"], [], True),
-        "DataMySQL": _PocoComponent("enable_data_mysql", True, ["Data"], ["apr::apr", "apr-util::apr-util", "libmysqlclient::libmysqlclient"], True),
+        "DataMySQL": _PocoComponent("enable_data_mysql", True, ["Data"], ["libmysqlclient::libmysqlclient"], True),
         "DataODBC": _PocoComponent("enable_data_odbc", False, ["Data"], [], True), # requires odbc but conditional, see package_info()
         "DataPostgreSQL": _PocoComponent("enable_data_postgresql", True, ["Data"], ["libpq::libpq"], True),
         "DataSQLite": _PocoComponent("enable_data_sqlite", True, ["Data"], ["sqlite3::sqlite3"], True),
@@ -121,6 +121,9 @@ class PocoConan(ConanFile):
             self.requires("expat/2.4.8")
         if self.options.enable_data_sqlite:
             self.requires("sqlite3/3.38.1")
+        if self.options.enable_apacheconnector:
+            self.requires("apr/1.7.0")
+            self.requires("apr-util/1.6.1")
         if self.options.enable_netssl or self.options.enable_crypto or \
            self.options.get_safe("enable_jwt"):
             self.requires("openssl/1.1.1n")
@@ -128,9 +131,6 @@ class PocoConan(ConanFile):
             self.requires("odbc/2.3.9")
         if self.options.get_safe("enable_data_postgresql"):
             self.requires("libpq/14.2")
-        if self.options.get_safe("enable_data_mysql") or self.options.enable_apacheconnector:
-            self.requires("apr/1.7.0")
-            self.requires("apr-util/1.6.1")
         if self.options.get_safe("enable_data_mysql"):
             self.requires("libmysqlclient/8.0.25")
 
@@ -185,6 +185,7 @@ class PocoConan(ConanFile):
             cmake.definitions["MYSQL_ROOT_INCLUDE_DIRS"] = ";".join(self.deps_cpp_info["libmysqlclient"].include_paths)
             cmake.definitions["MYSQL_INCLUDE_DIR"] = ";".join(self.deps_cpp_info["libmysqlclient"].include_paths)
             cmake.definitions["MYSQL_ROOT_LIBRARY_DIRS"] = ";".join(self.deps_cpp_info["libmysqlclient"].lib_paths)
+        if self.options.enable_apacheconnector:
             cmake.definitions["APR_ROOT_DIR"] = self.deps_cpp_info["apr"].rootpath
             cmake.definitions["APR_ROOT_INCLUDE_DIRS"] = ";".join(self.deps_cpp_info["apr"].include_paths)
             cmake.definitions["APR_ROOT_LIBRARY_DIRS"] = ";".join(self.deps_cpp_info["apr"].lib_paths)


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- `compiler=msvc` support
- cache CMake configuration with `functools.lru_cache`
- bump dependencies
- remove `apr` & `apr-util` from requirements of DataMySQL component. /cc @SSE4 since you added these requirements in https://github.com/conan-io/conan-center-index/pull/1917, but I don't understand why.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
