### PR TITLE
[qt6] use msvc-clang by default

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -477,7 +477,7 @@ class QtConan(ConanFile):
                 "Visual Studio": "win32-msvc",
                 "msvc": "win32-msvc",
                 "gcc": "win32-g++",
-                "clang": "win32-clang-g++",
+                "clang": "win32-clang-msvc",
             }.get(str(self.settings.compiler))
 
         elif self.settings.os == "WindowsStore":


### PR DESCRIPTION
Specify library name and version:  **qt/all**

use msvc-clang by default
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
