### PR TITLE
(#10037) Bump libusb to 1.0.25

### DIFF
--- a/recipes/libusb/all/conandata.yml
+++ b/recipes/libusb/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "1.0.24":
     sha256: 7efd2685f7b327326dcfb85cee426d9b871fd70e22caa15bb68d595ce2a2b12a
     url: https://github.com/libusb/libusb/releases/download/v1.0.24/libusb-1.0.24.tar.bz2
+  "1.0.25":
+    sha256: 8a28ef197a797ebac2702f095e81975e2b02b2eeff2774fa909c78a74ef50849
+    url: https://github.com/libusb/libusb/releases/download/v1.0.25/libusb-1.0.25.tar.bz2

--- a/recipes/libusb/all/conanfile.py
+++ b/recipes/libusb/all/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile, AutoToolsBuildEnvironment, MSBuild, tools
-from conans.errors import ConanInvalidConfiguration
 import os
 import re
 

--- a/recipes/libusb/all/conanfile.py
+++ b/recipes/libusb/all/conanfile.py
@@ -152,6 +152,6 @@ class LibUSBConan(ConanFile):
             self.cpp_info.system_libs.append("pthread")
         elif self.settings.os == "Macos":
             self.cpp_info.system_libs = ["objc"]
-            self.cpp_info.frameworks = ["IOKit", "CoreFoundation"]
+            self.cpp_info.frameworks = ["IOKit", "CoreFoundation", "Security"]
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs = ["advapi32"]

--- a/recipes/libusb/all/test_package/CMakeLists.txt
+++ b/recipes/libusb/all/test_package/CMakeLists.txt
@@ -1,12 +1,8 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
-
-if (APPLE)
-    add_link_options(-framework Security)
-endif(APPLE)
 
 add_executable(${CMAKE_PROJECT_NAME} test_package.c)
 target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/libusb/all/test_package/CMakeLists.txt
+++ b/recipes/libusb/all/test_package/CMakeLists.txt
@@ -1,8 +1,12 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
+
+if (APPLE)
+    add_link_options(-framework Security)
+endif(APPLE)
 
 add_executable(${CMAKE_PROJECT_NAME} test_package.c)
 target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/libusb/config.yml
+++ b/recipes/libusb/config.yml
@@ -4,3 +4,5 @@ versions:
     folder: all
   "1.0.24":
     folder: all
+  "1.0.25":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libusb/1.0.25**

2022-01-31: v1.0.25

* Linux: Fix regression with some particular devices
* Linux: Fix regression with libusb_handle_events_timeout_completed()
* Linux: Fix regression with cpu usage in libusb_bulk_transfer
* Darwin (macOS): Add support for detaching kernel drivers with authorization.
* Darwin (macOS): Do not drop partial data on timeout.
* Darwin (macOS): Silence pipe error in set_interface_alt_setting().
* Windows: Fix HID backend missing byte
* Windows: Fix segfault with libusbk driver
* Windows: Fix regression when using libusb0 driver
* Windows: Support LIBUSB_TRANSFER_ADD_ZERO_PACKET on winusb
* New NO_DEVICE_DISCOVERY option replaces WEAK_AUTHORITY option
* Various other bug fixes and improvements

closes #10037

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
