### PR TITLE
quazip/1.3.0: Add qt6 support

### DIFF
--- a/recipes/quazip/all/conanfile.py
+++ b/recipes/quazip/all/conanfile.py
@@ -26,9 +26,13 @@ class QuaZIPConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    @property
+    def _qt_major_version(self):
+        return tools.Version(self.deps_cpp_info["qt"].version).major
+
     def requirements(self):
         self.requires("zlib/1.2.12")
-        self.requires("qt/5.15.3")
+        self.requires("qt/6.2.3")
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -46,6 +50,7 @@ class QuaZIPConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        self._cmake.definitions["QUAZIP_QT_MAJOR_VERSION"] = self._qt_major_version
         self._cmake.configure()
         return self._cmake
 
@@ -62,11 +67,11 @@ class QuaZIPConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
-        self.cpp_info.includedirs=[os.path.join('include', 'QuaZip-Qt5-{}'.format(self.version))]
+        self.cpp_info.includedirs=[os.path.join('include', 'QuaZip-Qt{}-{}'.format(self._qt_major_version, self.version))]
         if not self.options.shared:
             self.cpp_info.defines.append("QUAZIP_STATIC")
 
-        self.cpp_info.filenames["cmake_find_package"] = "QuaZip-Qt5"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "QuaZip-Qt5"
+        self.cpp_info.filenames["cmake_find_package"] = 'QuaZip-Qt{}'.format(self._qt_major_version, self.version)
+        self.cpp_info.filenames["cmake_find_package_multi"] = 'QuaZip-Qt{}'.format(self._qt_major_version, self.version)
         self.cpp_info.names["cmake_find_package"] = "QuaZip"
         self.cpp_info.names["cmake_find_package_multi"] = "QuaZip"

--- a/recipes/quazip/all/conanfile.py
+++ b/recipes/quazip/all/conanfile.py
@@ -32,7 +32,7 @@ class QuaZIPConan(ConanFile):
 
     def requirements(self):
         self.requires("zlib/1.2.12")
-        self.requires("qt/6.2.3")
+        self.requires("qt/6.3.0")
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/quazip/all/conanfile.py
+++ b/recipes/quazip/all/conanfile.py
@@ -32,7 +32,10 @@ class QuaZIPConan(ConanFile):
 
     def requirements(self):
         self.requires("zlib/1.2.12")
-        self.requires("qt/6.3.0")
+        if tools.Version(self.version) < "1.3":
+            self.requires("qt/5.15.3")
+        else:
+            self.requires("qt/6.3.0")
 
     def config_options(self):
         if self.settings.os == "Windows":


### PR DESCRIPTION
Specify library name and version:  **quazip/1.2.0**

I currently put qt6 as default for CI testing but we might revert it to qt5 if needed
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
