### PR TITLE
opentdf-client: add version 0.6.3

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.3":
+    url: "https://github.com/opentdf/client-cpp/archive/0.6.3.tar.gz"
+    sha256: "02853b536ec94ee830cece960169d55249322c6e76fa52c8a484453e233ee7ca"
   "0.6.1":
     url: "https://github.com/opentdf/client-cpp/archive/0.6.1.tar.gz"
     sha256: "4f4017efad3ef013822c92673f89fcef7f6553f5c78cee930e382a09adad0f23"

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.6.3":
+    folder: all
   "0.6.1":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version: opentdf-client/0.6.3

 - Fixed the regression caused by not using the right network provider interface

---

- [x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
