### PR TITLE
Add onnx 1.11.0

### DIFF
--- a/recipes/onnx/all/conandata.yml
+++ b/recipes/onnx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.11.0":
+    url: "https://github.com/onnx/onnx/archive/refs/tags/v1.11.0.tar.gz"
+    sha256: "a20f2d9df805b16ac75ab4da0a230d3d1c304127d719e5c66a4e6df514e7f6c0"
   "1.10.2":
     url: "https://github.com/onnx/onnx/archive/refs/tags/v1.10.2.tar.gz"
     sha256: "520b3aa34272cc215e2eb41385f58adf01750d88858d4722563edca8410c5dc9"
@@ -9,6 +12,9 @@ sources:
     url: "https://github.com/onnx/onnx/archive/v1.8.1.tar.gz"
     sha256: "0054c7eeed97e8ee43921c3f944b0450782a081d910a14b3b6e662bc87065192"
 patches:
+  "1.11.0":
+    - patch_file: "patches/0001-fix-concurrent-proto3-remove-1.11.0.patch"
+      base_path: "source_subfolder"
   "1.10.2":
     - patch_file: "patches/0001-fix-concurrent-proto3-remove-1.9.0.patch"
       base_path: "source_subfolder"

--- a/recipes/onnx/all/conanfile.py
+++ b/recipes/onnx/all/conanfile.py
@@ -125,11 +125,11 @@ class OnnxConan(ConanFile):
 
     @property
     def _onnx_components(self):
-        return {
+        components = {
             "libonnx": {
                 "target": "onnx",
                 "libs": ["onnx"],
-                "defines": ["ONNX_NAMESPACE=onnx", "ONNX_ML=1", "__STDC_FORMAT_MACROS"],
+                "defines": ["ONNX_NAMESPACE=onnx", "ONNX_ML=1"],
                 "requires": ["onnx_proto"]
             },
             "onnx_proto": {
@@ -155,6 +155,9 @@ class OnnxConan(ConanFile):
                 "target": "onnxifi_wrapper"
             }
         }
+        if tools.Version(self.version) >= "1.11.0":
+            components["libonnx"]["defines"].append("__STDC_FORMAT_MACROS")
+        return components
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "ONNX"

--- a/recipes/onnx/all/conanfile.py
+++ b/recipes/onnx/all/conanfile.py
@@ -129,7 +129,7 @@ class OnnxConan(ConanFile):
             "libonnx": {
                 "target": "onnx",
                 "libs": ["onnx"],
-                "defines": ["ONNX_NAMESPACE=onnx", "ONNX_ML=1"],
+                "defines": ["ONNX_NAMESPACE=onnx", "ONNX_ML=1", "__STDC_FORMAT_MACROS"],
                 "requires": ["onnx_proto"]
             },
             "onnx_proto": {

--- a/recipes/onnx/all/patches/0001-fix-concurrent-proto3-remove-1.11.0.patch
+++ b/recipes/onnx/all/patches/0001-fix-concurrent-proto3-remove-1.11.0.patch
@@ -1,0 +1,11 @@
+--- a/onnx/gen_proto.py
++++ b/onnx/gen_proto.py
+@@ -165,7 +165,7 @@ def convert(stem, package_name, output, do_onnx_ml=False, lite=False, protoc_pat
+             porto3_dir = os.path.dirname(proto3)
+             base_dir = os.path.dirname(porto3_dir)
+             gen_proto3_code(protoc_path, proto3, base_dir, base_dir, base_dir)
+-            pb3_files = glob.glob(os.path.join(porto3_dir, '*.proto3.*'))
++            pb3_files = glob.glob(os.path.join(porto3_dir, '{}.proto3.*'.format(proto_base)))
+             for pb3_file in pb3_files:
+                 print("Removing {}".format(pb3_file))
+                 os.remove(pb3_file)

--- a/recipes/onnx/config.yml
+++ b/recipes/onnx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.11.0":
+    folder: all
   "1.10.2":
     folder: all
   "1.9.0":


### PR DESCRIPTION
Specify library name and version:  **onnx/1.11.0**

This adds support for the latest version 1.11.0 of onnx.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
