### PR TITLE
folly: bump dependencies + modernize

### DIFF
--- a/recipes/folly/all/CMakeLists.txt
+++ b/recipes/folly/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -67,7 +67,7 @@ class FollyConan(ConanFile):
         self.requires("bzip2/1.0.8")
         self.requires("double-conversion/3.2.0")
         self.requires("gflags/2.2.2")
-        self.requires("glog/0.5.0")
+        self.requires("glog/0.4.0")
         self.requires("libevent/2.1.12")
         self.requires("openssl/1.1.1n")
         self.requires("lz4/1.9.3")

--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -63,17 +63,17 @@ class FollyConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("boost/1.76.0")
+        self.requires("boost/1.78.0")
         self.requires("bzip2/1.0.8")
-        self.requires("double-conversion/3.1.5")
+        self.requires("double-conversion/3.2.0")
         self.requires("gflags/2.2.2")
-        self.requires("glog/0.4.0")
+        self.requires("glog/0.5.0")
         self.requires("libevent/2.1.12")
         self.requires("openssl/1.1.1n")
         self.requires("lz4/1.9.3")
-        self.requires("snappy/1.1.8")
-        self.requires("zlib/1.2.11")
-        self.requires("zstd/1.4.9")
+        self.requires("snappy/1.1.9")
+        self.requires("zlib/1.2.12")
+        self.requires("zstd/1.5.2")
         if not is_msvc(self):
             self.requires("libdwarf/20191104")
         self.requires("libsodium/1.0.18")


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- fine-grained export of patches
- `CMakeDeps` support
- `compiler=msvc` support
- cache CMake configuration with `functools.lru_cache`
- reorder methods by order of execution
- bump dependencies

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
