### PR TITLE
assimp: bump clipper, minizip & zlib + modernize

### DIFF
--- a/recipes/assimp/5.x/CMakeLists.txt
+++ b/recipes/assimp/5.x/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 if(WIN32)
   add_definitions(-DNOMINMAX)

--- a/recipes/assimp/5.x/conanfile.py
+++ b/recipes/assimp/5.x/conanfile.py
@@ -186,7 +186,7 @@ class Assimp(ConanFile):
         if self._depends_on_rapidjson:
             self.requires("rapidjson/cci.20211112")
         if self._depends_on_zlib:
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.12")
         if self._depends_on_draco:
             self.requires("draco/1.5.2")
         if self._depends_on_clipper:

--- a/recipes/assimp/5.x/conanfile.py
+++ b/recipes/assimp/5.x/conanfile.py
@@ -177,7 +177,7 @@ class Assimp(ConanFile):
         else:
             self.requires("pugixml/1.12.1")
 
-        self.requires("minizip/1.2.11")
+        self.requires("minizip/1.2.12")
         self.requires("utfcpp/3.2.1")
         if self._depends_on_kuba_zip:
             self.requires("kuba-zip/0.2.2")

--- a/recipes/assimp/5.x/conanfile.py
+++ b/recipes/assimp/5.x/conanfile.py
@@ -6,7 +6,7 @@ import functools
 required_conan_version = ">=1.43.0"
 
 
-class Assimp(ConanFile):
+class AssimpConan(ConanFile):
     name = "assimp"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/assimp/assimp"

--- a/recipes/assimp/5.x/conanfile.py
+++ b/recipes/assimp/5.x/conanfile.py
@@ -186,7 +186,7 @@ class Assimp(ConanFile):
         if self._depends_on_draco:
             self.requires("draco/1.5.2")
         if self._depends_on_clipper:
-            self.requires("clipper/4.8.8")  # Only 4.x supported
+            self.requires("clipper/4.10.0")  # Only 4.x supported
         if self._depends_on_stb:
             self.requires("stb/cci.20210910")
         if self._depends_on_openddlparser:

--- a/recipes/assimp/5.x/test_package/conanfile.py
+++ b/recipes/assimp/5.x/test_package/conanfile.py
@@ -1,9 +1,9 @@
-import os
 from conans import ConanFile, CMake, tools
+import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
@@ -12,7 +12,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             obj_path = os.path.join(self.source_folder, "box.obj")
 
             bin_path = os.path.join("bin", "test_package")


### PR DESCRIPTION
- bump clipper to 4.10.0: sha256 of clipper/4.8.8 tarball always changes, the one of 4.10.0 is stable.
- bump minizip & zlib
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- `compiler=msvc` support

closes https://github.com/conan-io/conan-center-index/issues/10032

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
