### PR TITLE
aws-c-s3: add version 0.1.37

### DIFF
--- a/recipes/aws-c-s3/all/conandata.yml
+++ b/recipes/aws-c-s3/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.37":
+    url: "https://github.com/awslabs/aws-c-s3/archive/v0.1.37.tar.gz"
+    sha256: "2c35100c1739300e438d47f49aaa2c374001416a79fe3c6f27d79371fb2ac90b"
   "0.1.29":
     url: "https://github.com/awslabs/aws-c-s3/archive/v0.1.29.tar.gz"
     sha256: "bcbc38d091ad994fec2789bffd1d99e157c5e29a60685e836f028006e531bc60"

--- a/recipes/aws-c-s3/all/conanfile.py
+++ b/recipes/aws-c-s3/all/conanfile.py
@@ -40,10 +40,12 @@ class AwsCS3(ConanFile):
         del self.settings.compiler.libcxx
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.15")
-        self.requires("aws-c-io/0.10.13")
-        self.requires("aws-c-http/0.6.10")
-        self.requires("aws-c-auth/0.6.8")
+        self.requires("aws-c-common/0.6.19")
+        self.requires("aws-c-io/0.10.20")
+        self.requires("aws-c-http/0.6.13")
+        self.requires("aws-c-auth/0.6.11")
+        if tools.Version(self.version) >= "0.1.36":
+            self.requires("aws-checksums/0.1.12")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -86,3 +88,5 @@ class AwsCS3(ConanFile):
             "aws-c-http::aws-c-http-lib",
             "aws-c-auth::aws-c-auth-lib"
         ]
+        if tools.Version(self.version) >= "0.1.36":
+            self.cpp_info.components["aws-c-s3-lib"].requires.append("aws-checksums::aws-checksums-lib")

--- a/recipes/aws-c-s3/config.yml
+++ b/recipes/aws-c-s3/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.1.37":
+    folder: all
   "0.1.29":
     folder: all
   "0.1.27":


### PR DESCRIPTION
Specify library name and version:  **aws-c-s3/0.1.37**

Since aws-c-s3/0.1.36, this recipe requires aws-checksums.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
