### PR TITLE
gdal: fix GEOS in autotools build + bump dependencies

### DIFF
--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -252,7 +252,7 @@ class GdalConan(ConanFile):
         if tools.Version(self.version) >= "3.1.0":
             self.requires("flatbuffers/2.0.5")
         if self.options.get_safe("with_zlib", True):
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.12")
         if self.options.get_safe("with_libdeflate"):
             self.requires("libdeflate/1.10")
         if self.options.with_libiconv:
@@ -264,7 +264,7 @@ class GdalConan(ConanFile):
         if self.options.get_safe("with_lz4"):
             self.requires("lz4/1.9.3")
         if self.options.with_pg:
-            self.requires("libpq/13.6")
+            self.requires("libpq/14.2")
         # if self.options.with_libgrass:
         #     self.requires("libgrass/x.x.x")
         if self.options.with_cfitsio:
@@ -314,7 +314,7 @@ class GdalConan(ConanFile):
         if self.options.with_xerces:
             self.requires("xerces-c/3.2.3")
         if self.options.with_expat:
-            self.requires("expat/2.4.7")
+            self.requires("expat/2.4.8")
         if self.options.with_libkml:
             self.requires("libkml/1.3.0")
         if self.options.with_odbc and self.settings.os != "Windows":

--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -245,7 +245,7 @@ class GdalConan(ConanFile):
 
     def requirements(self):
         self.requires("json-c/0.15")
-        self.requires("libgeotiff/1.7.0")
+        self.requires("libgeotiff/1.7.1")
         # self.requires("libopencad/0.0.2") # TODO: use conan recipe when available instead of internal one
         self.requires("libtiff/4.3.0")
         self.requires("proj/9.0.0")

--- a/recipes/gdal/all/patches/3.1.x/fix-autotools-3.1.4.patch
+++ b/recipes/gdal/all/patches/3.1.x/fix-autotools-3.1.4.patch
@@ -205,13 +205,14 @@
  
      if test "$HAVE_SQLITE3" = "yes"; then
          LIBS="$SQLITE3_LDFLAGS $LIBS"
-@@ -4597,8 +4586,12 @@ dnl ---------------------------------------------------------------------------
+@@ -4597,8 +4586,13 @@ dnl ---------------------------------------------------------------------------
  dnl Check if geos library is available.
  dnl ---------------------------------------------------------------------------
  
 -GEOS_INIT(3.1.0)
 +AC_ARG_WITH(geos, AS_HELP_STRING([--with-geos[=ARG]], [Include GEOS support (ARG=yes or no)]),,)
  HAVE_GEOS_RESULT="no"
++HAVE_GEOS=no
 +if test x"$with_geos" = x"no" ; then
 +  AC_MSG_RESULT([GEOS support disabled])
 +else
@@ -219,15 +220,16 @@
  if test "${HAVE_GEOS}" = "yes" ; then
  
    AC_MSG_NOTICE([Using C API from GEOS $GEOS_VERSION])
-@@ -4607,6 +4600,7 @@ if test "${HAVE_GEOS}" = "yes" ; then
+@@ -4607,6 +4601,8 @@ if test "${HAVE_GEOS}" = "yes" ; then
    LIBS="${GEOS_LIBS} ${LIBS}"
    HAVE_GEOS_RESULT="yes"
  fi
 +fi
++AC_SUBST(HAVE_GEOS, $HAVE_GEOS)
  
  dnl ---------------------------------------------------------------------------
  dnl Check if SFCGAL library is available.
-@@ -4641,20 +4635,18 @@ elif test "$with_qhull" = "yes" -o "$with_qhull" = "" ; then
+@@ -4641,20 +4637,18 @@ elif test "$with_qhull" = "yes" -o "$with_qhull" = "" ; then
    # qhull/qhull.h
    AC_CHECK_HEADERS([qhull/libqhull.h])
    if test "$ac_cv_header_qhull_libqhull_h" = "yes"; then
@@ -250,7 +252,7 @@
      fi
    fi
  
-@@ -4741,7 +4733,9 @@ AC_MSG_CHECKING([for FreeXL support])
+@@ -4741,7 +4735,9 @@ AC_MSG_CHECKING([for FreeXL support])
  HAVE_FREEXL=no
  FREEXL_INCLUDE=
  
@@ -261,7 +263,7 @@
    AC_CHECK_HEADERS(freexl.h)
    AC_CHECK_LIB(freexl,freexl_open,FREEXL_LIBS="-lfreexl",FREEXL_LIBS=missing)
  
-@@ -4847,8 +4841,7 @@ if test "$with_libjson_c" = "external" -o "$with_libjson_c" = "" -o "$with_libjs
+@@ -4847,8 +4843,7 @@ if test "$with_libjson_c" = "external" -o "$with_libjson_c" = "" -o "$with_libjs
  elif test "$with_libjson_c" = "internal" ; then
    LIBJSONC_SETTING=internal
  elif test "$with_libjson_c" != "no"; then
@@ -271,7 +273,7 @@
  else
    AC_MSG_ERROR([libjson-c (internal or external) is required])
  fi
-@@ -5952,7 +5945,6 @@ else
+@@ -5952,7 +5947,6 @@ else
      # Test that the package found is for the right architecture
      saved_LIBS="$LIBS"
      LIBS="$EXR_LIBS"

--- a/recipes/gdal/all/patches/3.2.x/fix-autotools.patch
+++ b/recipes/gdal/all/patches/3.2.x/fix-autotools.patch
@@ -226,13 +226,14 @@
      LIBS="${SAVED_LIBS}"
    fi
  
-@@ -4567,8 +4559,12 @@ dnl ---------------------------------------------------------------------------
+@@ -4567,8 +4559,13 @@ dnl ---------------------------------------------------------------------------
  dnl Check if geos library is available.
  dnl ---------------------------------------------------------------------------
  
 -GEOS_INIT(3.1.0)
 +AC_ARG_WITH(geos, AS_HELP_STRING([--with-geos[=ARG]], [Include GEOS support (ARG=yes or no)]),,)
  HAVE_GEOS_RESULT="no"
++HAVE_GEOS=no
 +if test x"$with_geos" = x"no" ; then
 +  AC_MSG_RESULT([GEOS support disabled])
 +else
@@ -240,15 +241,16 @@
  if test "${HAVE_GEOS}" = "yes" ; then
  
    AC_MSG_NOTICE([Using C API from GEOS $GEOS_VERSION])
-@@ -4577,6 +4573,7 @@ if test "${HAVE_GEOS}" = "yes" ; then
+@@ -4577,6 +4574,8 @@ if test "${HAVE_GEOS}" = "yes" ; then
    LIBS="${GEOS_LIBS} ${LIBS}"
    HAVE_GEOS_RESULT="yes"
  fi
 +fi
++AC_SUBST(HAVE_GEOS, $HAVE_GEOS)
  
  dnl ---------------------------------------------------------------------------
  dnl Check if SFCGAL library is available.
-@@ -4611,20 +4608,18 @@ elif test "$with_qhull" = "yes" -o "$with_qhull" = "" ; then
+@@ -4611,20 +4610,18 @@ elif test "$with_qhull" = "yes" -o "$with_qhull" = "" ; then
    # qhull/qhull.h
    AC_CHECK_HEADERS([qhull/libqhull.h])
    if test "$ac_cv_header_qhull_libqhull_h" = "yes"; then
@@ -271,7 +273,7 @@
      fi
    fi
  
-@@ -4711,7 +4706,9 @@ AC_MSG_CHECKING([for FreeXL support])
+@@ -4711,7 +4708,9 @@ AC_MSG_CHECKING([for FreeXL support])
  HAVE_FREEXL=no
  FREEXL_INCLUDE=
  
@@ -282,7 +284,7 @@
    AC_CHECK_HEADERS(freexl.h)
    AC_CHECK_LIB(freexl,freexl_open,FREEXL_LIBS="-lfreexl",FREEXL_LIBS=missing)
  
-@@ -4817,8 +4814,7 @@ if test "$with_libjson_c" = "external" -o "$with_libjson_c" = "" -o "$with_libjs
+@@ -4817,8 +4816,7 @@ if test "$with_libjson_c" = "external" -o "$with_libjson_c" = "" -o "$with_libjs
  elif test "$with_libjson_c" = "internal" ; then
    LIBJSONC_SETTING=internal
  elif test "$with_libjson_c" != "no"; then
@@ -292,7 +294,7 @@
  else
    AC_MSG_ERROR([libjson-c (internal or external) is required])
  fi
-@@ -5928,7 +5924,6 @@ else
+@@ -5928,7 +5926,6 @@ else
      # Test that the package found is for the right architecture
      saved_LIBS="$LIBS"
      LIBS="$EXR_LIBS"

--- a/recipes/gdal/all/patches/3.3.x/fix-autotools-3.3.3.patch
+++ b/recipes/gdal/all/patches/3.3.x/fix-autotools-3.3.3.patch
@@ -226,12 +226,13 @@
      LIBS="${SAVED_LIBS}"
    fi
  
-@@ -4550,13 +4542,16 @@ dnl ---------------------------------------------------------------------------
+@@ -4550,13 +4542,18 @@ dnl ---------------------------------------------------------------------------
  dnl Check if geos library is available.
  dnl ---------------------------------------------------------------------------
  
 -GEOS_INIT(3.1.0)
 +AC_ARG_WITH(geos, AS_HELP_STRING([--with-geos[=ARG]], [Include GEOS support (ARG=yes or no)]),,)
++HAVE_GEOS=no
 +if test x"$with_geos" = x"no" ; then
 +  AC_MSG_RESULT([GEOS support disabled])
 +else
@@ -243,10 +244,11 @@
    LIBS="${GEOS_LIBS} ${LIBS}"
  fi
 +fi
++AC_SUBST(HAVE_GEOS, $HAVE_GEOS)
  
  dnl ---------------------------------------------------------------------------
  dnl Check if SFCGAL library is available.
-@@ -4588,20 +4583,18 @@ elif test "$with_qhull" = "yes" -o "$with_qhull" = "" ; then
+@@ -4588,20 +4585,18 @@ elif test "$with_qhull" = "yes" -o "$with_qhull" = "" ; then
    # qhull/qhull.h
    AC_CHECK_HEADERS([qhull/libqhull.h])
    if test "$ac_cv_header_qhull_libqhull_h" = "yes"; then
@@ -269,7 +271,7 @@
      fi
    fi
  
-@@ -4688,7 +4681,9 @@ AC_MSG_CHECKING([for FreeXL support])
+@@ -4688,7 +4683,9 @@ AC_MSG_CHECKING([for FreeXL support])
  HAVE_FREEXL=no
  FREEXL_INCLUDE=
  
@@ -280,7 +282,7 @@
    AC_CHECK_HEADERS(freexl.h)
    AC_CHECK_LIB(freexl,freexl_open,FREEXL_LIBS="-lfreexl",FREEXL_LIBS=missing)
  
-@@ -4794,8 +4789,7 @@ if test "$with_libjson_c" = "external" -o "$with_libjson_c" = "" -o "$with_libjs
+@@ -4794,8 +4791,7 @@ if test "$with_libjson_c" = "external" -o "$with_libjson_c" = "" -o "$with_libjs
  elif test "$with_libjson_c" = "internal" ; then
    LIBJSONC_SETTING=internal
  elif test "$with_libjson_c" != "no"; then
@@ -290,7 +292,7 @@
  else
    AC_MSG_ERROR([libjson-c (internal or external) is required])
  fi
-@@ -5953,7 +5947,6 @@ else
+@@ -5953,7 +5949,6 @@ else
      # Test that the package found is for the right architecture
      saved_LIBS="$LIBS"
      LIBS="$EXR_LIBS"

--- a/recipes/gdal/all/patches/3.4.x/fix-autotools.patch
+++ b/recipes/gdal/all/patches/3.4.x/fix-autotools.patch
@@ -267,12 +267,13 @@
          else
              if test "$with_pcre" = "yes"; then
                  AC_MSG_ERROR([cannot find libpcre])
-@@ -4648,13 +4641,16 @@ dnl ---------------------------------------------------------------------------
+@@ -4648,13 +4641,18 @@ dnl ---------------------------------------------------------------------------
  dnl Check if geos library is available.
  dnl ---------------------------------------------------------------------------
  
 -GEOS_INIT(3.1.0)
 +AC_ARG_WITH(geos, AS_HELP_STRING([--with-geos[=ARG]], [Include GEOS support (ARG=yes or no)]),,)
++HAVE_GEOS=no
 +if test x"$with_geos" = x"no" ; then
 +  AC_MSG_RESULT([GEOS support disabled])
 +else
@@ -284,10 +285,11 @@
    LIBS="${GEOS_LIBS} ${LIBS}"
  fi
 +fi
++AC_SUBST(HAVE_GEOS, $HAVE_GEOS)
  
  dnl ---------------------------------------------------------------------------
  dnl Check if SFCGAL library is available.
-@@ -4684,11 +4680,10 @@ elif test "$with_qhull" = "yes" -o "$with_qhull" = "" ; then
+@@ -4684,11 +4682,10 @@ elif test "$with_qhull" = "yes" -o "$with_qhull" = "" ; then
  
    AC_CHECK_HEADERS([libqhull_r/libqhull_r.h])
    if test "$ac_cv_header_libqhull_r_libqhull_r_h" = "yes"; then
@@ -300,7 +302,7 @@
      fi
    else
      # Only qhull 2012 is reliable on certain datasets. Older Ubuntu have
-@@ -4798,7 +4793,9 @@ AC_MSG_CHECKING([for FreeXL support])
+@@ -4798,7 +4795,9 @@ AC_MSG_CHECKING([for FreeXL support])
  HAVE_FREEXL=no
  FREEXL_INCLUDE=
  
@@ -311,7 +313,7 @@
    AC_CHECK_HEADERS(freexl.h)
    AC_CHECK_LIB(freexl,freexl_open,FREEXL_LIBS="-lfreexl",FREEXL_LIBS=missing)
  
-@@ -4904,8 +4901,7 @@ if test "$with_libjson_c" = "external" -o "$with_libjson_c" = "" -o "$with_libjs
+@@ -4904,8 +4903,7 @@ if test "$with_libjson_c" = "external" -o "$with_libjson_c" = "" -o "$with_libjs
  elif test "$with_libjson_c" = "internal" ; then
    LIBJSONC_SETTING=internal
  elif test "$with_libjson_c" != "no"; then
@@ -321,7 +323,7 @@
  else
    AC_MSG_ERROR([libjson-c (internal or external) is required])
  fi
-@@ -6079,7 +6075,6 @@ else
+@@ -6079,7 +6077,6 @@ else
      # Test that the package found is for the right architecture
      saved_LIBS="$LIBS"
      LIBS="$EXR_LIBS"


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/10077

Explanation:
- gdal recipe doesn' trust custom GEOS_INIT m4 macro which is fragile, so we patch configure.ac to rely on pkg-conf
- GEOS_INIT macro substitutes HAVE_GEOS in Makefiles, and based on this value Makefiles inject a definition to enable geos during compilation, but this substitution was missing in our patch of configure.ac

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
