### PR TITLE
lexbor: add recipe

### DIFF
--- a/recipes/lexbor/all/CMakeLists.txt
+++ b/recipes/lexbor/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper LANGUAGES C)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(KEEP_RPATHS)
+
+add_subdirectory(source_subfolder)

--- a/recipes/lexbor/all/conandata.yml
+++ b/recipes/lexbor/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.1.0":
+    url: "https://github.com/lexbor/lexbor/archive/v2.1.0.zip"
+    sha256: "58d684d19cec689e40d8d443b3b953697cfa677a0ca59a2cf1fc14cd37ac2404"

--- a/recipes/lexbor/all/conandata.yml
+++ b/recipes/lexbor/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "cci.20220301":
-    url: "https://github.com/lexbor/lexbor/archive/9c6915b98b0c33ac140bc85cc2c9b9eb0a93751b.tar.gz"
-    sha256: "4bcc2ee1c50f3c39c1393b0644c26b741fa723b34ef859135012f4b519ccf5f3"
   "2.1.0":
     url: "https://github.com/lexbor/lexbor/archive/v2.1.0.zip"
     sha256: "58d684d19cec689e40d8d443b3b953697cfa677a0ca59a2cf1fc14cd37ac2404"

--- a/recipes/lexbor/all/conandata.yml
+++ b/recipes/lexbor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20220301":
+    url: "https://github.com/lexbor/lexbor/archive/9c6915b98b0c33ac140bc85cc2c9b9eb0a93751b.tar.gz"
+    sha256: "4bcc2ee1c50f3c39c1393b0644c26b741fa723b34ef859135012f4b519ccf5f3"
   "2.1.0":
     url: "https://github.com/lexbor/lexbor/archive/v2.1.0.zip"
     sha256: "58d684d19cec689e40d8d443b3b953697cfa677a0ca59a2cf1fc14cd37ac2404"

--- a/recipes/lexbor/all/conanfile.py
+++ b/recipes/lexbor/all/conanfile.py
@@ -47,6 +47,7 @@ class LexborConan(ConanFile):
         del self.settings.compiler.libcxx
 
     def validate(self):
+        # static build on Windows will be support by future release. (https://github.com/lexbor/lexbor/issues/69)
         if str(self.version) == "2.1.0" and self.options.shared == False and (self._is_msvc or self._is_mingw):
             raise tools.ConanInvalidConfiguration("{}/{} doesn't support static build on Windows(please use cci.20220301).".format(self.name, self.version))
 

--- a/recipes/lexbor/all/conanfile.py
+++ b/recipes/lexbor/all/conanfile.py
@@ -44,7 +44,7 @@ class LexborConan(ConanFile):
 
     def validate(self):
         # static build on Windows will be support by future release. (https://github.com/lexbor/lexbor/issues/69)
-        if str(self.version) == "2.1.0" and self.options.shared == False and (self._is_msvc or self._is_mingw):
+        if str(self.version) == "2.1.0" and self.options.shared == False and (is_msvc(self) or self._is_mingw):
             raise tools.ConanInvalidConfiguration("{}/{} doesn't support static build on Windows(please use cci.20220301).".format(self.name, self.version))
 
         if self.options.build_separately:

--- a/recipes/lexbor/all/conanfile.py
+++ b/recipes/lexbor/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conan.tools.microsoft import is_msvc
 import functools
 
 required_conan_version = ">=1.43.0"

--- a/recipes/lexbor/all/conanfile.py
+++ b/recipes/lexbor/all/conanfile.py
@@ -29,10 +29,6 @@ class LexborConan(ConanFile):
         return "source_subfolder"
 
     @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
-
-    @property
     def _is_mingw(self):
         return self.settings.os == "Windows" and self.settings.compiler == "gcc"
 

--- a/recipes/lexbor/all/conanfile.py
+++ b/recipes/lexbor/all/conanfile.py
@@ -92,3 +92,4 @@ class LexborConan(ConanFile):
         self.cpp_info.components["_lexbor"].names["cmake_find_package_multi"] = target
 
         self.cpp_info.components["_lexbor"].libs = [target]
+        self.cpp_info.components["_lexbor"].defines = ["LEXBOR_BUILD_SHARED" if self.options.shared else "LEXBOR_BUILD_STATIC"]

--- a/recipes/lexbor/all/conanfile.py
+++ b/recipes/lexbor/all/conanfile.py
@@ -1,0 +1,76 @@
+from conans import ConanFile, CMake, tools
+import functools
+
+required_conan_version = ">=1.43.0"
+
+class LexborConan(ConanFile):
+    name = "lexbor"
+    license = "Apache-2.0"
+    homepage = "https://github.com/lexbor/lexbor/"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "Lexbor is development of an open source HTML Renderer library"
+    topics = ("html5", "css", "parser", "renderer")
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+    exports_sources = ["CMakeLists.txt", ]
+    options = {
+        "shared": [True, False], 
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False, 
+        "fPIC": True,
+    }
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.cppstd
+        del self.settings.compiler.libcxx
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
+
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+
+        cmake.definitions["LEXBOR_BUILD_SHARED"] = self.options.shared
+        cmake.definitions["LEXBOR_BUILD_STATIC"] = not self.options.shared
+        cmake.definitions["LEXBOR_TESTS_CPP"] = False
+        # TODO: enable build_separately option
+        cmake.definitions["LEXBOR_BUILD_SEPARATELY"] = False
+        cmake.definitions["LEXBOR_INSTALL_HEADERS"] = True
+
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        target = "lexbor" if self.options.shared else "lexbor_static"
+        self.cpp_info.set_property("cmake_file_name", "lexbor")
+        self.cpp_info.set_property("cmake_target_name", "lexbor::{}".format(target))
+        self.cpp_info.components["_lexbor"].libs = [target]
+
+        self.cpp_info.names["cmake_find_package"] = "lexbor"
+        self.cpp_info.names["cmake_find_package_multi"] = "lexbor"
+        self.cpp_info.components["_lexbor"].names["cmake_find_package"] = target
+        self.cpp_info.components["_lexbor"].names["cmake_find_package_multi"] = target
+        self.cpp_info.components["_lexbor"].set_property("cmake_target_name", "lexbor::{}".format(target))

--- a/recipes/lexbor/all/conanfile.py
+++ b/recipes/lexbor/all/conanfile.py
@@ -28,6 +28,14 @@ class LexborConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+
+    @property
+    def _is_mingw(self):
+        return self.settings.os == "Windows" and self.settings.compiler == "gcc"
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -39,6 +47,9 @@ class LexborConan(ConanFile):
         del self.settings.compiler.libcxx
 
     def validate(self):
+        if str(self.version) == "2.1.0" and self.options.shared == False and (self._is_msvc or self._is_mingw):
+            raise tools.ConanInvalidConfiguration("{}/{} doesn't support static build on Windows(please use cci.20220301).".format(self.name, self.version))
+
         if self.options.build_separately:
             raise tools.ConanInvalidConfiguration("{}/{} doesn't support build_separately option(yet).".format(self.name, self.version))
 

--- a/recipes/lexbor/all/test_package/CMakeLists.txt
+++ b/recipes/lexbor/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+conan_basic_setup()
 
 find_package(lexbor CONFIG REQUIRED)
 

--- a/recipes/lexbor/all/test_package/CMakeLists.txt
+++ b/recipes/lexbor/all/test_package/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(lexbor CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.c)
+
+if(TARGET lexbor::lexbor_static)
+    target_link_libraries(${PROJECT_NAME} lexbor::lexbor_static)
+else()
+    target_link_libraries(${PROJECT_NAME} lexbor::lexbor)
+endif()

--- a/recipes/lexbor/all/test_package/conanfile.py
+++ b/recipes/lexbor/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class LexborTestConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/lexbor/all/test_package/test_package.c
+++ b/recipes/lexbor/all/test_package/test_package.c
@@ -1,0 +1,11 @@
+#include <lexbor/core/base.h>
+#include <lexbor/core/types.h>
+#include <lexbor/html/parser.h>
+#include <lexbor/html/serialize.h>
+
+int main() {
+    lxb_html_document_t* document = lxb_html_document_create();
+    lxb_html_document_destroy(document);
+
+    return 0;
+}

--- a/recipes/lexbor/config.yml
+++ b/recipes/lexbor/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.1.0":
+    folder: "all"

--- a/recipes/lexbor/config.yml
+++ b/recipes/lexbor/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "cci.20220301":
+    folder: "all"
   "2.1.0":
     folder: "all"

--- a/recipes/lexbor/config.yml
+++ b/recipes/lexbor/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "cci.20220301":
-    folder: "all"
   "2.1.0":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **lexbor/2.1.0**

lexbor is an html parser and rendering library.
It is being developed as the successor library to myhtml.

lexbor supports the option to build modules separately.
However, this recipe is not yet supported.

lexbor/2.1.0 doen't support for Windows with static build.
(see https://github.com/lexbor/lexbor/issues/69)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
