### PR TITLE
cli11: add version 2.2.0

### DIFF
--- a/recipes/cli11/all/conandata.yml
+++ b/recipes/cli11/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.0":
+    url: "https://github.com/CLIUtils/CLI11/archive/v2.2.0.tar.gz"
+    sha256: "d60440dc4d43255f872d174e416705f56ba40589f6eb07727f76376fb8378fd6"
   "2.1.2":
     url: "https://github.com/CLIUtils/CLI11/archive/v2.1.2.tar.gz"
     sha256: "26291377e892ba0e5b4972cdfd4a2ab3bf53af8dac1f4ea8fe0d1376b625c8cb"

--- a/recipes/cli11/config.yml
+++ b/recipes/cli11/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.0":
+    folder: all
   "2.1.2":
     folder: all
   "2.1.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cli11/2.2.0**

Version bump.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
