### PR TITLE
pcre: Bump requirement zlib/1.2.11 to zlib/1.2.12

### DIFF
--- a/recipes/pcre/all/conanfile.py
+++ b/recipes/pcre/all/conanfile.py
@@ -82,7 +82,7 @@ class PCREConan(ConanFile):
         if self.options.get_safe("with_bzip2"):
             self.requires("bzip2/1.0.8")
         if self.options.get_safe("with_zlib"):
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.12")
 
     def validate(self):
         if not self.options.build_pcre_8 and not self.options.build_pcre_16 and not self.options.build_pcre_32:


### PR DESCRIPTION
Specify library name and version:  **pcre/8.45**

I'm getting a conflict in one of my recipes.  Weirdly it occurs on mac and msvc, but not on gcc.

https://github.com/jmarrec/conan-openstudio-ruby/runs/5822256011?check_suite_focus=true#step:5:404

```
    'pcre/8.45' requires 'zlib/1.2.11' while 'minizip/1.2.12' requires 'zlib/1.2.12'.
```

My conanfile.py has `self.requires("zlib/1.2.12")`. My t`est_package/conanfile.py` has `self.requires("minizip/1.2.12")` (and I tried adding `self.requires("zlib/1.2.12")` in the `test_package/conanfile.py` too)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
