### PR TITLE
qcustomplot: add version 1.3.2

### DIFF
--- a/recipes/qcustomplot/all/CMakeLists.txt
+++ b/recipes/qcustomplot/all/CMakeLists.txt
@@ -9,8 +9,13 @@ set_target_properties(${PROJECT_NAME}
     PROPERTIES
         AUTOMOC ON
         DEBUG_POSTFIX "d"
+        VERSION ${CONAN_PACKAGE_VERSION}
 )
 if(BUILD_SHARED_LIBS)
+    # get major version via 'conanbuildinfo.cmake'
+    string(REPLACE "." ";" VERSION_LIST ${CONAN_PACKAGE_VERSION})
+    list(GET VERSION_LIST 0 CONAN_PACKAGE_VERSION_MAJOR)
+
     target_compile_definitions(${PROJECT_NAME}
         PRIVATE QCUSTOMPLOT_COMPILE_LIBRARY
         INTERFACE QCUSTOMPLOT_USE_LIBRARY
@@ -19,6 +24,7 @@ if(BUILD_SHARED_LIBS)
         PROPERTIES
             CXX_VISIBILITY_PRESET hidden
             VISIBILITY_INLINES_HIDDEN ON
+            SOVERSION ${CONAN_PACKAGE_VERSION_MAJOR}
     )
 endif()
 

--- a/recipes/qcustomplot/all/conandata.yml
+++ b/recipes/qcustomplot/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "2.1.0":
     url: "https://www.qcustomplot.com/release/2.1.0fixed/QCustomPlot-source.tar.gz"
     sha256: "357b78be0f52b2d01c17ec3e2e1271255761810af7e8a9476cef51fccf1a0f44"
+  "1.3.2":
+    url: "https://www.qcustomplot.com/release/1.3.2/QCustomPlot.tar.gz"
+    sha256: "ea2ed5712c2020b25f40eacabd0926ef71a7f07e2a3771c32d53ace1f47123eb"
 patches:
   "2.1.0":
     - patch_file: "patches/0001-fix-for-qt6.2.patch"

--- a/recipes/qcustomplot/all/conanfile.py
+++ b/recipes/qcustomplot/all/conanfile.py
@@ -47,7 +47,10 @@ class QcustomplotConan(ConanFile):
         self.options["qt"].shared = True
 
     def requirements(self):
-        self.requires("qt/6.2.3")
+        if int(tools.Version(self.version).major) >= 2:
+            self.requires("qt/6.2.4")
+        else:
+            self.requires("qt/5.15.3")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -63,10 +66,11 @@ class QcustomplotConan(ConanFile):
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
-        # allow static qcustomplot with shared qt, and vice versa
-        tools.replace_in_file(os.path.join(self._source_subfolder, "qcustomplot.h"),
-                              "#if defined(QT_STATIC_BUILD)",
-                              "#if 0" if self.options.shared else "#if 1")
+        if int(tools.Version(self.version).major) >= 2:
+            # allow static qcustomplot with shared qt, and vice versa
+            tools.replace_in_file(os.path.join(self._source_subfolder, "qcustomplot.h"),
+                                "#if defined(QT_STATIC_BUILD)",
+                                "#if 0" if self.options.shared else "#if 1")
 
     @functools.lru_cache(1)
     def _configure_cmake(self):

--- a/recipes/qcustomplot/all/conanfile.py
+++ b/recipes/qcustomplot/all/conanfile.py
@@ -48,7 +48,7 @@ class QcustomplotConan(ConanFile):
 
     def requirements(self):
         if int(tools.Version(self.version).major) >= 2:
-            self.requires("qt/6.2.4")
+            self.requires("qt/6.3.0")
         else:
             self.requires("qt/5.15.3")
 

--- a/recipes/qcustomplot/all/conanfile.py
+++ b/recipes/qcustomplot/all/conanfile.py
@@ -69,8 +69,8 @@ class QcustomplotConan(ConanFile):
         if int(tools.Version(self.version).major) >= 2:
             # allow static qcustomplot with shared qt, and vice versa
             tools.replace_in_file(os.path.join(self._source_subfolder, "qcustomplot.h"),
-                                "#if defined(QT_STATIC_BUILD)",
-                                "#if 0" if self.options.shared else "#if 1")
+                                  "#if defined(QT_STATIC_BUILD)",
+                                  "#if 0" if self.options.shared else "#if 1")
 
     @functools.lru_cache(1)
     def _configure_cmake(self):

--- a/recipes/qcustomplot/config.yml
+++ b/recipes/qcustomplot/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.1.0":
     folder: all
+  "1.3.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **qcustomplot/1.3.2**

Due to the possibility of commercial licenses, I think it makes sense 
to add the old major version of QCustomPlot as a Conan recipe.

Since the old major version of QCustomPlot only support Qt5, we use
`qt/5.15.3`.

Add also CMake's `VERSION` and `SOVERSION` for creating correct 
library version details.

Also bump requirement for `qcustomplot/2.1.0` to `qt/6.3.0`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
