### PR TITLE
wolfssl: add version 5.2.0

### DIFF
--- a/recipes/wolfssl/all/conandata.yml
+++ b/recipes/wolfssl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.2.0":
+    url: "https://github.com/wolfSSL/wolfssl/archive/v5.2.0-stable.tar.gz"
+    sha256: "409b4646c5f54f642de0e9f3544c3b83de7238134f5b1ff93fb44527bf119d05"
   "5.1.1":
     url: "https://github.com/wolfSSL/wolfssl/archive/v5.1.1-stable.tar.gz"
     sha256: "d3e0544dbe7e9587c0f6538cdc671b6492663bb7a4281819538abe6c99cdbd92"

--- a/recipes/wolfssl/config.yml
+++ b/recipes/wolfssl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.2.0":
+    folder: all
   "5.1.1":
     folder: all
   "5.0.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **wolfssl/5.2.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
