### PR TITLE
(#10125) perfetto: bump version to v25.0

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -34,3 +34,6 @@ patches:
   "22.1":
     - patch_file: "patches/v22.x/0001-Fix-perfetto-logging-when-PERFETTO_DISABLE_LOG-activ.patch"
       base_path: "source_subfolder"
+  "25.0":
+    - patch_file: "patches/v25.0/0001-MSVC-Fix-narrowing-conversion-error.patch"
+      base_path: "source_subfolder"

--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -17,6 +17,9 @@ sources:
   "24.2":
     url: https://github.com/google/perfetto/archive/refs/tags/v24.2.tar.gz
     sha256: b296d0a939e694fd2e73ed6c6418b774b5ef6809ddf60988989416e5cbf90b41
+  "25.0":
+    url: https://github.com/google/perfetto/archive/refs/tags/v25.0.tar.gz
+    sha256: 73a4b895df9222ddb231b8d903099d6da08cd079f27983f540e89156fa88ba67
 
 patches:
   "20.1":

--- a/recipes/perfetto/all/patches/v25.0/0001-MSVC-Fix-narrowing-conversion-error.patch
+++ b/recipes/perfetto/all/patches/v25.0/0001-MSVC-Fix-narrowing-conversion-error.patch
@@ -1,0 +1,13 @@
+diff --git a/sdk/perfetto.h b/sdk/perfetto.h
+index 677e0e2..df0de12 100644
+--- a/sdk/perfetto.h
++++ b/sdk/perfetto.h
+@@ -16140,7 +16140,7 @@ template <>
+ struct TraceTimestampTraits<uint64_t> {
+   static inline TraceTimestamp ConvertTimestampToTraceTimeNs(
+       const uint64_t& timestamp) {
+-    return {internal::TrackEventInternal::GetClockId(), timestamp};
++    return {static_cast<uint32_t>(internal::TrackEventInternal::GetClockId()), timestamp};
+   }
+ };
+

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: all
   "24.2":
     folder: all
+  "25.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **perfetto/v25.0**

```
v25.0 - 2022-04-01:
  Tracing service and probes:
    * Added prebuilts for mac-arm64.
    * Removed merged trace and config protos from Bazel. Embedder should
      instead depend on the non-merged proto targets.
    * Added FtraceConfig.disable_generic_events. If set, the ftrace data source
      will not emit events for which it doesn't have a compile-time proto
      message.
    * Added ingestion support for cros_ec (CrOS sensors) ftrace events.
    * Added ingestion support for kvm trace events.
    * Added reporting of atrace failures. Now they are bubbled up to the UI
      rather than causing atrace data to be silently missing.
  Trace Processor:
    * Added prebuilts for mac-arm64.
    * Changed LIKE comparisions to be case-insenstive. This reverts the change
      introduced in v22. GLOB should be used where case senstive searches are
      desired; built-in metrics continue to require the use of GLOB.
    * Added an optional dependency from trace processor onto a subset of
      sources from llvm-project for function name demangling. Bazel embedders
      might need to update their PERFETTO_CONFIG in perfetto_cfg.bzl to opt in
      or out of the new dependency. See
      perfetto/bazel/standalone/perfetto_cfg.bzl for details.
  UI:
    * Added flow arrows between binder transaction pairs (request/reply
      and async send/async recv).
  SDK:
    * Added support for writing typed proto messages inside DebugAnnotations.
    * Added support for delta encoding of timestamps for TrackEvents.
      To disable it, refer to `disable_incremental_timestamps` flag in
      `track_event_config.proto`.
  Tools:
    * Added support of gzip-compressed traces to traceconv.
    * Changed `traceconv text` to use an internal proto->pbtx converter rather
      than relying on libprotobuf. It could cause some small divergencies in the
      output format vs past releases.
    * Added tools/cpu_profile helper script to capture traces with callstack
      samples.
```

Closes #10125

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
