### PR TITLE
aws-crt-cpp: add version 0.17.23 with updating dependencies

### DIFF
--- a/recipes/aws-crt-cpp/all/conandata.yml
+++ b/recipes/aws-crt-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.17.23":
+    url: "https://github.com/awslabs/aws-crt-cpp/archive/v0.17.23.tar.gz"
+    sha256: "28061c3efa493519cfae46e4ea96389f03a81eeec7613d7da861dd8c5f4f6598"
   "0.17.12":
     url: "https://github.com/awslabs/aws-crt-cpp/archive/v0.17.12.tar.gz"
     sha256: "acdd8b83198c5a471f92702bc4101828fe55361005764143704c39acd6f80ffc"
@@ -6,6 +9,9 @@ sources:
     url: "https://github.com/awslabs/aws-crt-cpp/archive/v0.14.3.tar.gz"
     sha256: "3ea16c43e691bab0c373ba1ad072f6535390c516ebda658dfaf4d074d920e0fb"
 patches:
+  "0.17.23":
+    - base_path: "source_subfolder"
+      patch_file: "patches/0.17.23-fix-cast-error.patch"
   "0.17.12":
     - base_path: "source_subfolder"
       patch_file: "patches/0.17.12-fix-cast-error.patch"

--- a/recipes/aws-crt-cpp/all/conanfile.py
+++ b/recipes/aws-crt-cpp/all/conanfile.py
@@ -46,12 +46,12 @@ class AwsCrtCpp(ConanFile):
 
     def requirements(self):
         self.requires("aws-c-event-stream/0.2.7")
-        self.requires("aws-c-common/0.6.15")
-        self.requires("aws-c-io/0.10.13")
-        self.requires("aws-c-http/0.6.10")
-        self.requires("aws-c-auth/0.6.8")
-        self.requires("aws-c-mqtt/0.7.9")
-        self.requires("aws-c-s3/0.1.29")
+        self.requires("aws-c-common/0.6.19")
+        self.requires("aws-c-io/0.10.20")
+        self.requires("aws-c-http/0.6.13")
+        self.requires("aws-c-auth/0.6.11")
+        self.requires("aws-c-mqtt/0.7.10")
+        self.requires("aws-c-s3/0.1.37")
         self.requires("aws-checksums/0.1.12")
 
     def source(self):

--- a/recipes/aws-crt-cpp/all/patches/0.17.23-fix-cast-error.patch
+++ b/recipes/aws-crt-cpp/all/patches/0.17.23-fix-cast-error.patch
@@ -1,0 +1,13 @@
+diff --git a/source/io/TlsOptions.cpp b/source/io/TlsOptions.cpp
+index 3018e4c..eb5e129 100644
+--- a/source/io/TlsOptions.cpp
++++ b/source/io/TlsOptions.cpp
+@@ -213,7 +213,7 @@ namespace Aws
+ 
+                 if (m_slotId)
+                 {
+-                    options.slot_id = &(*m_slotId);
++                    options.slot_id = const_cast<uint64_t*>(&(*m_slotId));
+                 }
+ 
+                 if (m_userPin)

--- a/recipes/aws-crt-cpp/config.yml
+++ b/recipes/aws-crt-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.17.23":
+    folder: all
   "0.17.12":
     folder: all
   "0.14.3":


### PR DESCRIPTION
Specify library name and version:  **aws-crt-cpp/0.17.23**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
