### PR TITLE
Fix compiling issue with latest FlatBuffers recipe

### DIFF
--- a/recipes/tensorflow-lite/all/conanfile.py
+++ b/recipes/tensorflow-lite/all/conanfile.py
@@ -32,7 +32,7 @@ class TensorflowLiteConan(ConanFile):
         "with_mmap": True,
         "with_xnnpack": True,
     }
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
     exports_sources = ["CMakeLists.txt", "patches/**"]
 
     _cmake = None


### PR DESCRIPTION
Specify library name and version:  **tensorflow-lite/2.6.0**

Fix issue with latest FlatBuffer recipe which generates FindFlatBuffers.cmake while the tensorflow-lite's recipe is searching for Flatbuffer package

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
