### PR TITLE
yasm: Do not require devenv

### DIFF
--- a/recipes/yasm/all/conanfile.py
+++ b/recipes/yasm/all/conanfile.py
@@ -53,7 +53,7 @@ class YASMConan(ConanFile):
             elif self.settings.arch == "x86_64":
                 msbuild.build_env.link_flags.append("/SAFESEH:NO /MACHINE:X64")
             build_type = "Debug" if self.settings.build_type == "Debug" else "Release"
-            msbuild.build(project_file="yasm.sln", build_type=build_type,
+            msbuild.build(project_file="yasm.sln", build_type=build_type, upgrade_project=False,
                           targets=["yasm"], platforms={"x86": "Win32"}, force_vcvars=True)
 
     def _configure_autotools(self):


### PR DESCRIPTION
yasm/1.3.0

This fixes #9198

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
