### PR TITLE
glslang: add include path as needed in diligent-core

### DIFF
--- a/recipes/glslang/all/conanfile.py
+++ b/recipes/glslang/all/conanfile.py
@@ -174,6 +174,7 @@ class GlslangConan(ConanFile):
         # glslang
         self.cpp_info.components["glslang-core"].names["cmake_find_package"] = "glslang"
         self.cpp_info.components["glslang-core"].names["cmake_find_package_multi"] = "glslang"
+        self.cpp_info.components["glslang-core"].includedirs.append(os.path.join("include", "glslang"))
         self.cpp_info.components["glslang-core"].libs = ["glslang" + lib_suffix]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["glslang-core"].system_libs.extend(["m", "pthread"])


### PR DESCRIPTION
Specify library name and version:  **glslang/all**

This PR is only needed for https://github.com/conan-io/conan-center-index/pull/10093#issuecomment-1090306975
I would really apreciate if someone tries it locally, as it works for me even without this change

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
