### PR TITLE
(#10167) libbacktrace: Bug when using Conan 2 profile mode

### DIFF
--- a/recipes/libbacktrace/all/conanfile.py
+++ b/recipes/libbacktrace/all/conanfile.py
@@ -65,15 +65,23 @@ class LibbacktraceConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @property
+    def _user_info_build(self):
+        # If using the experimental feature with different context for host and
+        # build, the 'user_info' attributes of the 'build_requires' packages
+        # will be located into the 'user_info_build' object. In other cases they
+        # will be located into the 'deps_user_info' object.
+        return getattr(self, "user_info_build", None) or self.deps_user_info
+
     @contextlib.contextmanager
     def _build_context(self):
         if self._is_msvc:
             with tools.vcvars(self):
                 env = {
-                    "CC": "{} cl -nologo".format(tools.unix_path(self.deps_user_info["automake"].compile)),
-                    "CXX": "{} cl -nologo".format(tools.unix_path(self.deps_user_info["automake"].compile)),
-                    "LD": "{} link -nologo".format(tools.unix_path(self.deps_user_info["automake"].compile)),
-                    "AR": "{} lib".format(tools.unix_path(self.deps_user_info["automake"].ar_lib)),
+                    "CC": "{} cl -nologo".format(tools.unix_path(self._user_info_build["automake"].compile)),
+                    "CXX": "{} cl -nologo".format(tools.unix_path(self._user_info_build["automake"].compile)),
+                    "LD": "{} link -nologo".format(tools.unix_path(self._user_info_build["automake"].compile)),
+                    "AR": "{} lib".format(tools.unix_path(self._user_info_build["automake"].ar_lib)),
                 }
                 with tools.environment_append(env):
                     yield

--- a/recipes/libbacktrace/all/conanfile.py
+++ b/recipes/libbacktrace/all/conanfile.py
@@ -67,10 +67,6 @@ class LibbacktraceConan(ConanFile):
 
     @property
     def _user_info_build(self):
-        # If using the experimental feature with different context for host and
-        # build, the 'user_info' attributes of the 'build_requires' packages
-        # will be located into the 'user_info_build' object. In other cases they
-        # will be located into the 'deps_user_info' object.
         return getattr(self, "user_info_build", None) or self.deps_user_info
 
     @contextlib.contextmanager

--- a/recipes/libbacktrace/all/conanfile.py
+++ b/recipes/libbacktrace/all/conanfile.py
@@ -67,7 +67,7 @@ class LibbacktraceConan(ConanFile):
 
     @property
     def _user_info_build(self):
-        return getattr(self, "user_info_build", None) or self.deps_user_info
+        return getattr(self, "user_info_build", self.deps_user_info)
 
     @contextlib.contextmanager
     def _build_context(self):


### PR DESCRIPTION
Make libbacktrace build work in Conan's 2 profile mode (host and build profile).

Specify library name and version:  **libbacktrace/cci.20210118**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
