### PR TITLE
fix: Warning message in grpc package.

### DIFF
--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -98,7 +98,7 @@ class grpcConan(ConanFile):
             # libabsl_time.a(duration.cc.o): undefined reference to symbol '_ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7compareEPKc@@GLIBCXX_3.4.21'
             if (self.settings.os == "Linux" and self.settings.compiler == "gcc") and not self.options["abseil"].shared:
                 raise ConanInvalidConfiguration(
-                    "gRPC shared not supported yet without abseil shared"
+                    "gRPC shared not supported yet without abseil static"
                 )
 
             if self._is_msvc:


### PR DESCRIPTION
fix: Wrong warning message, typo.

Specify library name and version:  **grpc/1.44**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
