### PR TITLE
yaml-cpp: Fix CMake target name for the CMakeDeps generator

### DIFF
--- a/recipes/yaml-cpp/all/conanfile.py
+++ b/recipes/yaml-cpp/all/conanfile.py
@@ -1,7 +1,7 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
 import os
 import textwrap
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.43.0"
 
@@ -121,7 +121,7 @@ class YamlCppConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "yaml-cpp")
-        self.cpp_info.set_property("cmake_target_name", "yaml-cpp")
+        self.cpp_info.set_property("cmake_target_name", "yaml-cpp::yaml-cpp")
         self.cpp_info.set_property("pkg_config_name", "yaml-cpp")
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os in ("Linux", "FreeBSD"):


### PR DESCRIPTION
Specify library name and version:  **yaml-cpp/0.7.0**

The CMake target for yaml-cpp should be `yaml-cpp::yaml-cpp`.
This target name is available for the old CMake generators.
Currently, the `yaml-cpp::yaml-cpp` target is missing for CMakeDeps.
This PR rectifies this issue.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
