### PR TITLE
[hdf5] Bump dependencies and add missing versions

### DIFF
--- a/recipes/hdf5/all/conandata.yml
+++ b/recipes/hdf5/all/conandata.yml
@@ -5,12 +5,21 @@ sources:
   "1.12.0":
     url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_12_0.tar.gz"
     sha256: "c64ffec2539ae6b6041f97952a40b0893c3c0df4d5b1c0177fb8aba567808158"
+  "1.10.8":
+    url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_10_8.tar.gz"
+    sha256: "6fcaf2e5f10bb758d2d5fafa7bd0fd560d4047faf6b397fe1278c06e4e9f3564   "
+  "1.10.7":
+    url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_10_7.tar.gz"
+    sha256: "a1b7c2a477090508365d79bb1356d995a90d5c75e9e3ff0f2bd09d54d8a225d0"
   "1.10.6":
     url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_10_6.tar.gz"
     sha256: "e524b374b1c6f14f1aa87595c0761608c861fe7838549dab84639ae564ff48e8"
   "1.10.5":
     url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_10_5.tar.gz"
     sha256: "22a4a48f94b013e9fd482c0bb0251de02ff9963787a107c5dde26a3f903b3b90"
+  "1.8.22":
+    url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_8_22.tar.gz"
+    sha256: "afad23abf0935a39840745222adb71ca08d59db12b2a7eb3679e15b2aac52ec4"
   "1.8.21":
     url: "https://github.com/HDFGroup/hdf5/archive/hdf5-1_8_21.tar.gz"
     sha256: "753520e34a576a64809b8e02d9c015d6126f7974f678c7417a60492d835a88f4"
@@ -19,6 +28,20 @@ patches:
     - patch_file: "patches/conanize-link-szip-1.12.1+.patch"
       base_path: "source_subfolder"
   "1.12.0":
+    - patch_file: "patches/conanize-link-szip-1.10.5+.patch"
+      base_path: "source_subfolder"
+  "1.10.8":
+    - patch_file: "patches/fix-missing-function-prototypes-1.10.5+.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-missing-function-prototypes-1.10.6.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/conanize-link-szip-1.10.5+.patch"
+      base_path: "source_subfolder"
+  "1.10.7":
+    - patch_file: "patches/fix-missing-function-prototypes-1.10.5+.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-missing-function-prototypes-1.10.6.patch"
+      base_path: "source_subfolder"
     - patch_file: "patches/conanize-link-szip-1.10.5+.patch"
       base_path: "source_subfolder"
   "1.10.6":
@@ -40,6 +63,15 @@ patches:
     - patch_file: "patches/mingw-fix-prefix-lib.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/mingw-unused-ellipses.patch"
+      base_path: "source_subfolder"
+  "1.8.22":
+    - patch_file: "patches/conanize-link-szip-1.8.21.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/build-either-static-or-shared-1.8.21.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/mingw-cmake-size-type-checks-1.8.21.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/mingw-fix-prefix-lib.patch"
       base_path: "source_subfolder"
   "1.8.21":
     - patch_file: "patches/conanize-link-szip-1.8.21.patch"

--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -89,9 +89,9 @@ class Hdf5Conan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.12")
         if self.options.szip_support == "with_libaec":
-            self.requires("libaec/1.0.4")
+            self.requires("libaec/1.0.6")
         elif self.options.szip_support == "with_szip":
             self.requires("szip/2.1.1")
         if self.options.parallel:

--- a/recipes/hdf5/config.yml
+++ b/recipes/hdf5/config.yml
@@ -3,9 +3,15 @@ versions:
     folder: all
   "1.12.0":
     folder: all
+  "1.10.8":
+    folder: all
+  "1.10.7":
+    folder: all
   "1.10.6":
     folder: all
   "1.10.5":
+    folder: all
+  "1.8.22":
     folder: all
   "1.8.21":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **hdf5/1.12.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
