### PR TITLE
Add glog/0.6.0

### DIFF
--- a/recipes/glog/all/conandata.yml
+++ b/recipes/glog/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.0":
+    sha256: 8a83bf982f37bb70825df71a9709fa90ea9f4447fb3c099e1d720a439d88bad6
+    url: https://github.com/google/glog/archive/refs/tags/v0.6.0.tar.gz
   "0.5.0":
     sha256: eede71f28371bf39aa69b45de23b329d37214016e2055269b3b5e7cfd40b59f5
     url: https://github.com/google/glog/archive/refs/tags/v0.5.0.tar.gz

--- a/recipes/glog/all/conanfile.py
+++ b/recipes/glog/all/conanfile.py
@@ -48,6 +48,10 @@ class GlogConan(ConanFile):
         if self.options.with_gflags:
             self.requires("gflags/2.2.2")
 
+    def build_requirements(self):
+        if tools.Version(self.version) >= "0.6.0":
+            self.build_requires("cmake/3.22.3")
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
@@ -56,9 +60,10 @@ class GlogConan(ConanFile):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         # do not force PIC
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              "set_target_properties (glog PROPERTIES POSITION_INDEPENDENT_CODE ON)",
-                              "")
+        if tools.Version(self.version) <= "0.5.0":
+            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                                  "set_target_properties (glog PROPERTIES POSITION_INDEPENDENT_CODE ON)",
+                                  "")
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/glog/config.yml
+++ b/recipes/glog/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.0":
+    folder: all
   "0.5.0":
     folder: all
   "0.4.0":


### PR DESCRIPTION
Specify library name and version:  **glog/0.6.0**


[patch](https://github.com/conan-io/conan-center-index/blob/master/recipes/glog/all/patches/0001-fix-msvc-snprintf.patch) from 0.5.0 is not needed anymore. Problem was [fixed](https://github.com/google/glog/commit/9c1a25b9310b0bb73a605aecb72463bab5901721) in upstream. 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
