### PR TITLE
freeimage: bump zlib + C++17 handling

### DIFF
--- a/recipes/freeimage/all/conandata.yml
+++ b/recipes/freeimage/all/conandata.yml
@@ -30,3 +30,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/013_use-typedef-as-already-declared.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/014_no_auto_ptr.patch"
+      base_path: "source_subfolder"

--- a/recipes/freeimage/all/conanfile.py
+++ b/recipes/freeimage/all/conanfile.py
@@ -72,7 +72,7 @@ class FreeImageConan(ConanFile):
                 self.options["libtiff"].jpeg = self.options.with_jpeg
 
     def requirements(self):
-        self.requires("zlib/1.2.11")
+        self.requires("zlib/1.2.12")
         if self.options.with_jpeg == "libjpeg":
             self.requires("libjpeg/9d")
         elif self.options.with_jpeg == "libjpeg-turbo":

--- a/recipes/freeimage/all/conanfile.py
+++ b/recipes/freeimage/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
 import functools
 import os
 
@@ -94,6 +95,8 @@ class FreeImageConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "11")
+            if tools.valid_min_cppstd(self, "17"):
+                raise ConanInvalidConfiguration("freeimage relies on auto_ptr, removed in C++17")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -110,6 +113,9 @@ class FreeImageConan(ConanFile):
         cmake.definitions["FREEIMAGE_WITH_RAW"] = self.options.with_raw
         cmake.definitions["FREEIMAGE_WITH_JXR"] = self.options.with_jxr
         cmake.definitions["FREEIMAGE_WITH_TIFF"] = self.options.with_tiff
+        if tools.valid_min_cppstd(self, "17"):
+            # If default C++ standard of the compiler is C++17 or higher, force C++14 instead
+            cmake.definitions["CMAKE_CXX_STANDARD"] = 14
         cmake.configure(build_dir=self._build_subfolder)
         return cmake
 

--- a/recipes/freeimage/all/conanfile.py
+++ b/recipes/freeimage/all/conanfile.py
@@ -95,8 +95,6 @@ class FreeImageConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "11")
-            if tools.valid_min_cppstd(self, "17"):
-                raise ConanInvalidConfiguration("freeimage relies on auto_ptr, removed in C++17")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -113,9 +111,6 @@ class FreeImageConan(ConanFile):
         cmake.definitions["FREEIMAGE_WITH_RAW"] = self.options.with_raw
         cmake.definitions["FREEIMAGE_WITH_JXR"] = self.options.with_jxr
         cmake.definitions["FREEIMAGE_WITH_TIFF"] = self.options.with_tiff
-        if tools.valid_min_cppstd(self, "17"):
-            # If default C++ standard of the compiler is C++17 or higher, force C++14 instead
-            cmake.definitions["CMAKE_CXX_STANDARD"] = 14
         cmake.configure(build_dir=self._build_subfolder)
         return cmake
 

--- a/recipes/freeimage/all/patches/014_no_auto_ptr.patch
+++ b/recipes/freeimage/all/patches/014_no_auto_ptr.patch
@@ -1,0 +1,24 @@
+--- /Source/FreeImage/MultiPage.cpp
++++ /Source/FreeImage/MultiPage.cpp
+@@ -271,8 +271,8 @@ FreeImage_OpenMultiBitmap(FREE_IMAGE_FORMAT fif, const char *filename, BOOL crea
+ 					}
+ 				}
+ 
+-				std::auto_ptr<FIMULTIBITMAP> bitmap (new FIMULTIBITMAP);
+-				std::auto_ptr<MULTIBITMAPHEADER> header (new MULTIBITMAPHEADER);
++				std::unique_ptr<FIMULTIBITMAP> bitmap (new FIMULTIBITMAP);
++				std::unique_ptr<MULTIBITMAPHEADER> header (new MULTIBITMAPHEADER);
+ 				header->m_filename = filename;
+ 				// io is default
+ 				header->node = node;
+@@ -337,8 +337,8 @@ FreeImage_OpenMultiBitmapFromHandle(FREE_IMAGE_FORMAT fif, FreeImageIO *io, fi_h
+ 				PluginNode *node = list->FindNodeFromFIF(fif);
+ 			
+ 				if (node) {
+-					std::auto_ptr<FIMULTIBITMAP> bitmap (new FIMULTIBITMAP);
+-					std::auto_ptr<MULTIBITMAPHEADER> header (new MULTIBITMAPHEADER);
++					std::unique_ptr<FIMULTIBITMAP> bitmap (new FIMULTIBITMAP);
++					std::unique_ptr<MULTIBITMAPHEADER> header (new MULTIBITMAPHEADER);
+ 					header->io = *io;
+ 					header->node = node;
+ 					header->fif = fif;


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/10171

freeimage uses `auto_ptr`, therefore it can't work in C++17 or higher.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
