### PR TITLE
add ccache/4.6.0

### DIFF
--- a/recipes/ccache/all/conandata.yml
+++ b/recipes/ccache/all/conandata.yml
@@ -1,8 +1,14 @@
 sources:
+  "4.6.0":
+    url: "https://github.com/ccache/ccache/releases/download/v4.6/ccache-4.6.tar.xz"
+    sha256: "3d2bb860f4359169e640f60cf7cc11da5fab5fb9aed55230d78141e49c3945e9"
   "4.5.1":
     url: "https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.xz"
     sha256: "51186ebe0326365f4e6131e1caa8911de7da4aa6718efc00680322d63a759517"
 patches:
+  "4.6.0":
+    - patch_file: "patches/0001-fix-cmake-4.6.0.patch"
+      base_path: "source_subfolder"
   "4.5.1":
     - patch_file: "patches/0001-fix-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/ccache/all/patches/0001-fix-cmake-4.6.0.patch
+++ b/recipes/ccache/all/patches/0001-fix-cmake-4.6.0.patch
@@ -1,0 +1,63 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -96,12 +96,12 @@ if(MSVC AND NOT CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg|conan")
+ endif()
+ 
+ option(ZSTD_FROM_INTERNET "Download and use libzstd from the Internet" ${ZSTD_FROM_INTERNET_DEFAULT})
+-find_package(zstd 1.1.2 REQUIRED)
++find_package(zstd REQUIRED CONFIG)
+ 
+ option(REDIS_STORAGE_BACKEND "Enable Redis secondary storage" ON)
+ if(REDIS_STORAGE_BACKEND)
+   option(HIREDIS_FROM_INTERNET "Download and use libhiredis from the Internet" ${HIREDIS_FROM_INTERNET_DEFAULT})
+-  find_package(hiredis 0.13.3 REQUIRED)
++  find_package(hiredis REQUIRED CONFIG)
+ endif()
+ 
+ #
+--- a/cmake/GenerateConfigurationFile.cmake
++++ b/cmake/GenerateConfigurationFile.cmake
+@@ -106,5 +106,5 @@ if(HAVE_SYS_MMAN_H AND HAVE_PTHREAD_MUTEXATTR_SETPSHARED)
+   set(INODE_CACHE_SUPPORTED 1)
+ endif()
+ 
+-configure_file(${CMAKE_SOURCE_DIR}/cmake/config.h.in
++configure_file(${PROJECT_SOURCE_DIR}/cmake/config.h.in
+                ${CMAKE_BINARY_DIR}/config.h @ONLY)
+--- a/cmake/GenerateVersionFile.cmake
++++ b/cmake/GenerateVersionFile.cmake
+@@ -1,4 +1,4 @@
+ configure_file(
+-  ${CMAKE_SOURCE_DIR}/cmake/version.cpp.in
++  ${PROJECT_SOURCE_DIR}/cmake/version.cpp.in
+   ${CMAKE_BINARY_DIR}/src/version.cpp
+   @ONLY)
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -26,7 +26,7 @@ set(
+   execute.cpp
+   hashutil.cpp
+   language.cpp
+-  version.cpp
++  ${CMAKE_BINARY_DIR}/src/version.cpp
+ )
+ 
+ if(INODE_CACHE_SUPPORTED)
+@@ -64,7 +64,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
+ find_package(Threads REQUIRED)
+ target_link_libraries(
+   ccache_framework
+-  PRIVATE standard_settings standard_warnings ZSTD::ZSTD Threads::Threads third_party
++  PRIVATE standard_settings standard_warnings $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static> Threads::Threads third_party
+ )
+ 
+ target_include_directories(ccache_framework PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+@@ -73,7 +73,7 @@ if(REDIS_STORAGE_BACKEND)
+   target_compile_definitions(ccache_framework PRIVATE -DHAVE_REDIS_STORAGE_BACKEND)
+   target_link_libraries(
+     ccache_framework
+-    PUBLIC standard_settings standard_warnings HIREDIS::HIREDIS third_party
++    PUBLIC standard_settings standard_warnings hiredis::hiredis third_party
+   )
+ endif()
+ 

--- a/recipes/ccache/config.yml
+++ b/recipes/ccache/config.yml
@@ -1,3 +1,5 @@
 versions:
   "4.5.1":
     folder: all
+  "4.6.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **ccache/4.6.0**

Adds the latest version of ccache that introduces second-level cache.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
