### PR TITLE
libsodium for github stable branch

### DIFF
--- a/recipes/libsodium/config.yml
+++ b/recipes/libsodium/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.0.18":
     folder: all
+  "git-stable":
+    folder: git-stable

--- a/recipes/libsodium/git-stable/conanfile.py
+++ b/recipes/libsodium/git-stable/conanfile.py
@@ -1,0 +1,200 @@
+from conan.tools.microsoft import msvc_runtime_flag
+from conans import ConanFile, AutoToolsBuildEnvironment, tools, MSBuild
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.43.0"
+
+
+class LibsodiumConan(ConanFile):
+    name = "libsodium"
+    description = "A modern and easy-to-use crypto library."
+    license = "ISC"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://doc.libsodium.org/"
+    topics = ("sodium", "libsodium", "encryption", "signature", "hashing")
+
+    scm = {
+        "type": "git",
+        "subfolder": ".",
+        "url": "https://github.com/jedisct1/libsodium.git",
+        "revision": "stable", # for the head of stable, whatever it is at the time
+    }
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "use_soname": [True, False],
+        "PIE": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "use_soname": True,
+        "PIE": False,
+    }
+
+    short_paths = True
+
+    _autotools = None
+
+    @property
+    def _source_subfolder(self):
+        return "."
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    @property
+    def _is_msvc(self):
+        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+
+    @property
+    def _is_mingw(self):
+        return self.settings.os == "Windows" and self.settings.compiler == "gcc"
+
+    # def export_sources(self):
+        # for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            # self.copy(patch["patch_file"])
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def validate(self):
+        if self.options.shared and self._is_msvc and "MT" in msvc_runtime_flag(self):
+            raise ConanInvalidConfiguration("Cannot build shared libsodium libraries with static runtime")
+
+    def build_requirements(self):
+        if not self._is_msvc:
+            if self._is_mingw:
+                self.build_requires("libtool/2.4.6")
+            if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+                self.build_requires("msys2/cci.latest")
+
+    # def source(self):
+        # tools.get(**self.conan_data["sources"][self.version],
+                  # destination=self._source_subfolder, strip_root=True)
+
+    @property
+    def _msvc_sln_folder(self):
+        if self.settings.compiler == "Visual Studio":
+            folder = {
+                "10": "vs2010",
+                "11": "vs2012",
+                "12": "vs2013",
+                "14": "vs2015",
+                "15": "vs2017",
+                "16": "vs2019",
+                "17": "vs2022",
+            }
+        else:
+            folder = {
+                "190": "vs2015",
+                "191": "vs2017",
+                "192": "vs2019",
+                "193": "vs2022",
+            }
+        return folder.get(str(self.settings.compiler.version))
+
+    def _build_msvc(self):
+        msvc_sln_folder = self._msvc_sln_folder or "vs2022"
+        upgrade_project = self._msvc_sln_folder is None
+        sln_path = os.path.join(self.build_folder, self._source_subfolder, "builds", "msvc", msvc_sln_folder, "libsodium.sln")
+        build_type = "{}{}".format(
+            "Dyn" if self.options.shared else "Static",
+            "Debug" if self.settings.build_type == "Debug" else "Release",
+        )
+        msbuild = MSBuild(self)
+        msbuild.build(sln_path, upgrade_project=upgrade_project, platforms={"x86": "Win32"}, build_type=build_type)
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        if self._is_mingw:
+            self._autotools.libs.append("ssp")
+
+        if self.settings.os == "Emscripten":
+            self.output.warn("os=Emscripten is not tested/supported by this recipe")
+            # FIXME: ./dist-build/emscripten.sh does not respect options of this recipe
+
+        yes_no = lambda v: "yes" if v else "no"
+        args = [
+            "--enable-shared={}".format(yes_no(self.options.shared)),
+            "--enable-static={}".format(yes_no(not self.options.shared)),
+            "--enable-soname-versions={}".format(yes_no(self.options.use_soname)),
+            "--enable-pie={}".format(yes_no(self.options.PIE)),
+        ]
+
+        self._autotools.configure(args=args, configure_dir=self._source_subfolder)
+        return self._autotools
+
+    def build(self):
+        # for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            # tools.patch(**patch)
+        if self._is_msvc:
+            self._build_msvc()
+        else:
+            if self._is_mingw:
+                self.run("{} -fiv".format(tools.get_env("AUTORECONF")), cwd=self._source_subfolder, win_bash=tools.os_info.is_windows)
+            if tools.is_apple_os(self.settings.os):
+                # Relocatable shared lib for Apple platforms
+                tools.replace_in_file(
+                    os.path.join(self._source_subfolder, "configure"),
+                    "-install_name \\$rpath/",
+                    "-install_name @rpath/"
+                )
+            autotools = self._configure_autotools()
+            autotools.make()
+
+    def package(self):
+        self.copy("*LICENSE", dst="licenses", keep_path=False)
+        if self._is_msvc:
+            self.copy("*.lib", dst="lib", keep_path=False)
+            self.copy("*.dll", dst="bin", keep_path=False)
+            inc_src = os.path.join(self._source_subfolder, "src", self.name, "include")
+            self.copy("*.h", src=inc_src, dst="include", keep_path=True, excludes=("*/private/*"))
+        else:
+            autotools = self._configure_autotools()
+            autotools.install()
+            tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+
+    def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "libsodium")
+        self.cpp_info.libs = ["{}sodium".format("lib" if self._is_msvc else "")]
+        if not self.options.shared:
+            self.cpp_info.defines = ["SODIUM_STATIC"]
+        if self.settings.os in ("FreeBSD", "Linux"):
+            self.cpp_info.system_libs.append("pthread")
+        if self._is_mingw:
+            self.cpp_info.system_libs.append("ssp")
+
+        # This makes 'editable packages work',
+        # but, only if you build in a folder called "build"
+        # I'm not sure how to make this better according to conan design...
+        # mkdir build
+        # cd build
+        # conan install ..
+        # conan source ..
+        # conan build ..
+        # conan editable add .. libsodium/VERSION@USER/CHANNEL
+        # (where you, the user, choose what version, user, and channel to call it
+        #
+        # Then to test the editable package:
+        # cd .. # back to the recipe folder
+        # conan test test_package/ libsodium/VERSION@USER/CHANNEL
+        # --> should show OK
+        #
+        self.cpp_info.includedirs.append("build/src/libsodium/include")
+        self.cpp_info.libdirs.append("build/src/libsodium/.libs")
+

--- a/recipes/libsodium/git-stable/readme.txt
+++ b/recipes/libsodium/git-stable/readme.txt
@@ -1,0 +1,23 @@
+This will always pull the latest version from the github stable branch,
+it is up to you, the package maker, to decide what version to stamp on it.
+
+This also supports the package in "editable" mode,
+see 'hack notes' in conanfile.py, def package_info(self)
+copied here:
+
+# The next two self.cpp_info lines help 'editable packages' work correctly,
+# but, only if you build in a folder called "build"
+# I'm not sure how to make this better according to conan design...
+# mkdir build
+# cd build
+# conan install ..
+# conan source ..
+# conan build ..
+# conan editable add .. libsodium/VERSION@USER/CHANNEL
+# (where you, the user, choose what version, user, and channel to call it
+#
+# Then to test the editable package:
+# cd .. # back to the recipe folder
+# conan test test_package/ libsodium/VERSION@USER/CHANNEL
+# --> should show OK
+#

--- a/recipes/libsodium/git-stable/test_package/CMakeLists.txt
+++ b/recipes/libsodium/git-stable/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/libsodium/git-stable/test_package/conanfile.py
+++ b/recipes/libsodium/git-stable/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "arch", "build_type"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libsodium/git-stable/test_package/test_package.c
+++ b/recipes/libsodium/git-stable/test_package/test_package.c
@@ -1,0 +1,13 @@
+#include <sodium.h>
+#include <stdio.h>
+
+int main() {
+    printf("************* Testing libsodium ***************\n");
+    if (sodium_init() == -1) {
+        printf("\tFAIL\n");
+        return 1;
+    }
+    printf("\tOK\n");
+    printf("***********************************************\n");
+    return 0;
+}


### PR DESCRIPTION
NOTE - This pull request will likely require work from people more experienced at conan than myself to make it acceptable to the conans.

For a start, there is no particular release version for this recipe.
Perhaps this is a good start, but requires some magic to be able to specify the commit ID to match a particular version number.  I don't know enough to make this extra step.

----

I've only tested on Linux (GCC).
Note that this has notes on how to make this package work in "editable" mode,
as that wasn't working for me with version 1.0.18, perhaps due to my lack of conan knowledge.

I'm happy for this PR to be rejected if it isn't appropriate for CCI, I spent some time on this for my own ends and I thought I should share it.
Perhaps it will help contribute to the conversation about dealing with rolling release libraries.

----

An attempt to make a recipe to build a package for whatever is at the
HEAD of libsodium's "stable" branch on github.

libsodium hasn't done a tagged release for a few years now, it seems
that library users are supposed to just use whatever is at the tip of
the stable branch.

----

Specify library name and version:  **lib/1.0.18.????**

I imagine users will use this with
conan create . libsodium/1.0.18.yyyymmdd
as it will be whatever is the current TIP of the stable branch on github.

If that version is uploaded to CCI / elsewhere, then consumers will be using that particular version.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.

I don't think it is ready for this step:
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
