### PR TITLE
Update rapidcsv to 8.62

### DIFF
--- a/recipes/rapidcsv/all/conandata.yml
+++ b/recipes/rapidcsv/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.62":
+    url: "https://github.com/d99kris/rapidcsv/archive/refs/tags/v8.62.tar.gz"
+    sha256: a7efda6324420f2b69d3448672a9553dc91520632409661f9f83ac0425faa31d
   "8.53":
     url: "https://github.com/d99kris/rapidcsv/archive/refs/tags/v8.53.tar.gz"
     sha256: 27cc1d6b924e91b99640aae5c6c286bb60494d0bee1ec10e1bfd39698d30007b

--- a/recipes/rapidcsv/config.yml
+++ b/recipes/rapidcsv/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "8.62":
+    folder: "all"
   "8.53":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **rapidcsv/8.62**

This updates the rapidcsv recipe to the latest version.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
