### PR TITLE
pagmo2: relocatable shared lib on macOS + depend on onetbb instead of tbb

### DIFF
--- a/recipes/pagmo2/all/CMakeLists.txt
+++ b/recipes/pagmo2/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/pagmo2/all/conanfile.py
+++ b/recipes/pagmo2/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import functools
 import os
 
 required_conan_version = ">=1.43.0"
@@ -31,7 +32,6 @@ class Pagmo2Conan(ConanFile):
 
     exports_sources = "CMakeLists.txt"
     generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -105,20 +105,19 @@ class Pagmo2Conan(ConanFile):
         tools.replace_in_file(yacma_cmake, "_YACMA_CHECK_ENABLE_DEBUG_CXX_FLAG(/W4)", "")
         tools.replace_in_file(yacma_cmake, "_YACMA_CHECK_ENABLE_DEBUG_CXX_FLAG(/WX)", "")
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["PAGMO_BUILD_TESTS"] = False
-        self._cmake.definitions["PAGMO_BUILD_BENCHMARKS"] = False
-        self._cmake.definitions["PAGMO_BUILD_TUTORIALS"] = False
-        self._cmake.definitions["PAGMO_WITH_EIGEN3"] = self.options.with_eigen
-        self._cmake.definitions["PAGMO_WITH_NLOPT"] = self.options.with_nlopt
-        self._cmake.definitions["PAGMO_WITH_IPOPT"] = self.options.with_ipopt
-        self._cmake.definitions["PAGMO_ENABLE_IPO"] = False
-        self._cmake.definitions["PAGMO_BUILD_STATIC_LIBRARY"] = not self.options.shared
-        self._cmake.configure()
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["PAGMO_BUILD_TESTS"] = False
+        cmake.definitions["PAGMO_BUILD_BENCHMARKS"] = False
+        cmake.definitions["PAGMO_BUILD_TUTORIALS"] = False
+        cmake.definitions["PAGMO_WITH_EIGEN3"] = self.options.with_eigen
+        cmake.definitions["PAGMO_WITH_NLOPT"] = self.options.with_nlopt
+        cmake.definitions["PAGMO_WITH_IPOPT"] = self.options.with_ipopt
+        cmake.definitions["PAGMO_ENABLE_IPO"] = False
+        cmake.definitions["PAGMO_BUILD_STATIC_LIBRARY"] = not self.options.shared
+        cmake.configure()
+        return cmake
 
     def build(self):
         self._patch_sources()

--- a/recipes/pagmo2/all/conanfile.py
+++ b/recipes/pagmo2/all/conanfile.py
@@ -47,7 +47,7 @@ class Pagmo2Conan(ConanFile):
 
     def requirements(self):
         self.requires("boost/1.78.0")
-        self.requires("tbb/2020.3")
+        self.requires("onetbb/2020.3")
         if self.options.with_eigen:
             self.requires("eigen/3.4.0")
         if self.options.with_nlopt:
@@ -136,7 +136,7 @@ class Pagmo2Conan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "Pagmo::pagmo")
         # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.components["_pagmo"].libs = ["pagmo"]
-        self.cpp_info.components["_pagmo"].requires = ["boost::headers", "boost::serialization", "tbb::tbb"]
+        self.cpp_info.components["_pagmo"].requires = ["boost::headers", "boost::serialization", "onetbb::onetbb"]
         if self.options.with_eigen:
             self.cpp_info.components["_pagmo"].requires.append("eigen::eigen")
         if self.options.with_nlopt:


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- cache CMake configuration with `functools.lru_cache`
- depend on onetbb instead of deprecated tbb recipe

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
