### PR TITLE
mariadb-connector-c: bump dependencies + relocatable shared lib on macOS

### DIFF
--- a/recipes/mariadb-connector-c/all/CMakeLists.txt
+++ b/recipes/mariadb-connector-c/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/mariadb-connector-c/all/conanfile.py
+++ b/recipes/mariadb-connector-c/all/conanfile.py
@@ -106,6 +106,8 @@ class MariadbConnectorcConan(ConanFile):
         self._cmake.definitions["INSTALL_BINDIR"] = "bin"
         self._cmake.definitions["INSTALL_LIBDIR"] = "lib"
         self._cmake.definitions["INSTALL_PLUGINDIR"] = os.path.join("lib", "plugin").replace("\\", "/")
+        # To install relocatable shared libs on Macos
+        self._cmake.definitions["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         self._cmake.configure()
         return self._cmake
 

--- a/recipes/mariadb-connector-c/all/conanfile.py
+++ b/recipes/mariadb-connector-c/all/conanfile.py
@@ -57,13 +57,13 @@ class MariadbConnectorcConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def requirements(self):
-        self.requires("zlib/1.2.11")
+        self.requires("zlib/1.2.12")
         if self.options.get_safe("with_iconv"):
             self.requires("libiconv/1.16")
         if self.options.with_curl:
-            self.requires("libcurl/7.79.1")
+            self.requires("libcurl/7.80.0")
         if self.options.with_ssl == "openssl":
-            self.requires("openssl/1.1.1l")
+            self.requires("openssl/1.1.1n")
 
     def validate(self):
         if self.settings.os != "Windows" and self.options.with_ssl == "schannel":


### PR DESCRIPTION
relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
