### PR TITLE
tree-sitter: add version 0.20.6

### DIFF
--- a/recipes/tree-sitter/all/conandata.yml
+++ b/recipes/tree-sitter/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.20.6":
+    url: "https://github.com/tree-sitter/tree-sitter/archive/v0.20.6.tar.gz"
+    sha256: "4d37eaef8a402a385998ff9aca3e1043b4a3bba899bceeff27a7178e1165b9de"
   "0.20.0":
     url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.20.0.tar.gz"
     sha256: "4a8070b9de17c3b8096181fe8530320ab3e8cca685d8bee6a3e8d164b5fb47da"

--- a/recipes/tree-sitter/config.yml
+++ b/recipes/tree-sitter/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.20.6":
+    folder: all
   "0.20.0":
     folder: all
   "0.17.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **tree-sitter/0.20.6**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
