### PR TITLE
ghc-filesystem: add version 1.5.12

### DIFF
--- a/recipes/ghc-filesystem/all/conandata.yml
+++ b/recipes/ghc-filesystem/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.12":
+    url: "https://github.com/gulrak/filesystem/archive/v1.5.12.tar.gz"
+    sha256: "7d62c5746c724d28da216d9e11827ba4e573df15ef40720292827a4dfd33f2e9"
   "1.5.8":
     url: "https://github.com/gulrak/filesystem/archive/v1.5.8.tar.gz"
     sha256: "726f8ccb2ec844f4c66cc4b572369497327df31b86c04cefad6b311964107139"

--- a/recipes/ghc-filesystem/config.yml
+++ b/recipes/ghc-filesystem/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.12":
+    folder: "all"
   "1.5.8":
     folder: "all"
   "1.4.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **ghc-filesystem/1.5.12**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
