### PR TITLE
[minizip] Keep compatibility with older compilers

### DIFF
--- a/recipes/minizip/all/conandata.yml
+++ b/recipes/minizip/all/conandata.yml
@@ -9,6 +9,8 @@ patches:
   "1.2.12":
     - patch_file: "patches/minizip.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/ioapi.patch"
+      base_path: "source_subfolder"
   "1.2.11":
     - patch_file: "patches/minizip.patch"
       base_path: "source_subfolder"

--- a/recipes/minizip/all/patches/ioapi.patch
+++ b/recipes/minizip/all/patches/ioapi.patch
@@ -1,0 +1,102 @@
+--- a/contrib/minizip/ioapi.c
++++ b/contrib/minizip/ioapi.c
+@@ -94,9 +94,9 @@ static int     ZCALLBACK ferror_file_func OF((voidpf opaque, voidpf stream));
+ 
+ static voidpf ZCALLBACK fopen_file_func (voidpf opaque, const char* filename, int mode)
+ {
+-    (void)opaque;
+     FILE* file = NULL;
+     const char* mode_fopen = NULL;
++    (void)opaque;
+     if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
+         mode_fopen = "rb";
+     else
+@@ -113,9 +113,9 @@ static voidpf ZCALLBACK fopen_file_func (voidpf opaque, const char* filename, in
+ 
+ static voidpf ZCALLBACK fopen64_file_func (voidpf opaque, const void* filename, int mode)
+ {
+-    (void)opaque;
+     FILE* file = NULL;
+     const char* mode_fopen = NULL;
++    (void)opaque;
+     if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
+         mode_fopen = "rb";
+     else
+@@ -133,24 +133,24 @@ static voidpf ZCALLBACK fopen64_file_func (voidpf opaque, const void* filename,
+ 
+ static uLong ZCALLBACK fread_file_func (voidpf opaque, voidpf stream, void* buf, uLong size)
+ {
+-    (void)opaque;
+     uLong ret;
++    (void)opaque;
+     ret = (uLong)fread(buf, 1, (size_t)size, (FILE *)stream);
+     return ret;
+ }
+ 
+ static uLong ZCALLBACK fwrite_file_func (voidpf opaque, voidpf stream, const void* buf, uLong size)
+ {
+-    (void)opaque;
+     uLong ret;
++    (void)opaque;
+     ret = (uLong)fwrite(buf, 1, (size_t)size, (FILE *)stream);
+     return ret;
+ }
+ 
+ static long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
+ {
+-    (void)opaque;
+     long ret;
++    (void)opaque;
+     ret = ftell((FILE *)stream);
+     return ret;
+ }
+@@ -158,17 +158,17 @@ static long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
+ 
+ static ZPOS64_T ZCALLBACK ftell64_file_func (voidpf opaque, voidpf stream)
+ {
+-    (void)opaque;
+     ZPOS64_T ret;
++    (void)opaque;
+     ret = (ZPOS64_T)FTELLO_FUNC((FILE *)stream);
+     return ret;
+ }
+ 
+ static long ZCALLBACK fseek_file_func (voidpf  opaque, voidpf stream, uLong offset, int origin)
+ {
+-    (void)opaque;
+     int fseek_origin=0;
+     long ret;
++    (void)opaque;
+     switch (origin)
+     {
+     case ZLIB_FILEFUNC_SEEK_CUR :
+@@ -190,9 +190,9 @@ static long ZCALLBACK fseek_file_func (voidpf  opaque, voidpf stream, uLong offs
+ 
+ static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T offset, int origin)
+ {
+-    (void)opaque;
+     int fseek_origin=0;
+     long ret;
++    (void)opaque;
+     switch (origin)
+     {
+     case ZLIB_FILEFUNC_SEEK_CUR :
+@@ -217,16 +217,16 @@ static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T
+ 
+ static int ZCALLBACK fclose_file_func (voidpf opaque, voidpf stream)
+ {
+-    (void)opaque;
+     int ret;
++    (void)opaque;
+     ret = fclose((FILE *)stream);
+     return ret;
+ }
+ 
+ static int ZCALLBACK ferror_file_func (voidpf opaque, voidpf stream)
+ {
+-    (void)opaque;
+     int ret;
++    (void)opaque;
+     ret = ferror((FILE *)stream);
+     return ret;
+ }


### PR DESCRIPTION
Specify library name and version:  **minizip/1.2.12**

Whereas `conan.exe install minizip/1.2.11@ --build -s compiler.version=11` worked with MSVC it got broken by v1.2.12. This PR introduces the patch from https://github.com/madler/zlib/pull/624 to keep compatibiliy with VS2010 or VS2012.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
