### PR TITLE
libnghttp2: add version 1.47.0

### DIFF
--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.47.0":
+    url: "https://github.com/nghttp2/nghttp2/archive/v1.47.0.tar.gz"
+    sha256: "db98735b30f1586edf3212ada57f85feaceff483a1c0f1c1c8285abcf37e3444"
   "1.46.0":
     url: "https://github.com/nghttp2/nghttp2/archive/v1.46.0.tar.gz"
     sha256: "0875a638d319cd28b06dcc410e6dc2add1a52f7cab6f62b26025c448f8ae8f43"
@@ -18,6 +21,11 @@ sources:
     url: "https://github.com/nghttp2/nghttp2/releases/download/v1.39.2/nghttp2-1.39.2.tar.bz2"
     sha256: "92a23e4522328c8565028ee0c7270e74add7990614fd1148f2a79d873bc2a1d0"
 patches:
+  "1.47.0":
+    - patch_file: "patches/fix-findJemalloc.cmake"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix-findLibevent.cmake"
+      base_path: "source_subfolder"
   "1.46.0":
     - patch_file: "patches/fix-findJemalloc.cmake"
       base_path: "source_subfolder"

--- a/recipes/libnghttp2/config.yml
+++ b/recipes/libnghttp2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.47.0":
+    folder: all
   "1.46.0":
     folder: all
   "1.45.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libnghttp2/1.47.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
