### PR TITLE
[automake] Empty includedirs

### DIFF
--- a/recipes/automake/all/conanfile.py
+++ b/recipes/automake/all/conanfile.py
@@ -106,6 +106,7 @@ class AutomakeConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libdirs = []
+        self.cpp_info.includedirs = []
 
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable:: {}".format(bin_path))


### PR DESCRIPTION
Specify library name and version:  **automake**

This is (sometimes) a transitive requirement via `libtool`. New generators are not removing empty directories, and these folders are added by default (https://docs.conan.io/en/latest/migrating_to_2.0/recipes.html#the-package-info-method), so CMake complains about not-existing directory.