### PR TITLE
log4cplus 2.0.6 + 2.0.7

### DIFF
--- a/recipes/log4cplus/all/conandata.yml
+++ b/recipes/log4cplus/all/conandata.yml
@@ -5,3 +5,9 @@ sources:
   "2.0.5":
     url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_5/log4cplus-2.0.5.tar.bz2"
     sha256: "b38dbfc68ef6d771e4de7de0be3544bc51bd3f7d5b75c5f6500d10e23203eb15"
+  "2.0.6":
+    url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_6/log4cplus-2.0.6.tar.bz2"
+    sha256: "1a963afd0f883d62de946b18927d238051fd47936e415eabeffe2b1397f16eca"
+  "2.0.7":
+    url: "https://github.com/log4cplus/log4cplus/releases/download/REL_2_0_7/log4cplus-2.0.7.tar.bz2"
+    sha256: "8fadbafee2ba4e558a0f78842613c9fb239c775d83f23340d091084c0e1b12ab"        

--- a/recipes/log4cplus/config.yml
+++ b/recipes/log4cplus/config.yml
@@ -3,3 +3,7 @@ versions:
     folder: all
   "2.0.5":
     folder: all
+  "2.0.6":
+    folder: all
+  "2.0.7":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **log4cplus/2.0.6+2.0.7**

Two new releases of log4cplus has been issued since last recipe update

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
