### PR TITLE
No __stdcall converntions for Windows x86 build

### DIFF
--- a/recipes/sqlcipher/all/conanfile.py
+++ b/recipes/sqlcipher/all/conanfile.py
@@ -123,7 +123,11 @@ class SqlcipherConan(ConanFile):
             nmake_flags.append("USE_CRT_DLL=1")
         if self.settings.build_type == "Debug":
             nmake_flags.append("DEBUG=2")
-        nmake_flags.append("FOR_WIN10=1")
+        # It is very unlikely that __stdcall convetions are really wanted for 32bit windows
+        # It would also not work with tcl extensions are enabled, so deactivate it
+        # Ff someone really needs that, please feel free to add it as on option for 32bit msvc builds only
+        if self.settings.arch != "x86":
+            nmake_flags.append("FOR_WIN10=1")
         platforms = {"x86": "x86", "x86_64": "x64"}
         nmake_flags.append("PLATFORM=%s" % platforms[str(self.settings.arch)])
         vcvars = tools.vcvars_command(self.settings)

--- a/recipes/sqlcipher/all/conanfile.py
+++ b/recipes/sqlcipher/all/conanfile.py
@@ -66,7 +66,7 @@ class SqlcipherConan(ConanFile):
 
     def requirements(self):
         if self.options.crypto_library == "openssl":
-            self.requires("openssl/1.1.1n")
+            self.requires("openssl/1.1.1o")
         elif self.options.crypto_library == "libressl":
             self.requires("libressl/3.4.3")
 


### PR DESCRIPTION
Without this change, symbols on for win32 x86 builds will look like this

dumpbin.exe /SYMBOLS .\sqlcipher.lib | findstr("_sqlite3_") | findstr("close")
96A 00000000 SECT2FF notype ()    External    | _sqlite3_close@4
96D 00000000 SECT300 notype ()    External    | _sqlite3_close_v2@4
D1F 00000000 SECT41B notype ()    External    | _sqlite3_blob_close@4

This makes even the conan test package failing, and is usually unwanted.
For example, the tcl extension can not work with this calling
convention.

With this patch, symobls are as expected (plain C) and have no '@4' at the end.


---
Target: **sqlcipher/all**


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
