### PR TITLE
FIX: zlib package need to rename library

### DIFF
--- a/recipes/zlib/all/conanfile.py
+++ b/recipes/zlib/all/conanfile.py
@@ -91,8 +91,8 @@ class ZlibConan(ConanFile):
         cmake.build()
 
     def _rename_libraries(self):
+        lib_path = os.path.join(self.package_folder, "lib")
         if self.settings.os == "Windows":
-            lib_path = os.path.join(self.package_folder, "lib")
             suffix = "d" if self.settings.build_type == "Debug" else ""
 
             if self.options.shared:
@@ -107,6 +107,11 @@ class ZlibConan(ConanFile):
                     if not self.settings.os.subsystem:
                         current_lib = os.path.join(lib_path, "libzlibstatic.a")
                         tools.rename(current_lib, os.path.join(lib_path, "libzlib.a"))
+        if self.settings.os == "Linux":
+            fullname = os.path.join(lib_path, "libzlibstatic.a")
+            shortname = os.path.join(lib_path, "libz.a")
+            if os.path.exists(fullname) and not os.path.exists(shortname):
+                tools.rename(fullname, shortname)
 
     def _extract_license(self):
         with tools.chdir(os.path.join(self.source_folder, self._source_subfolder)):


### PR DESCRIPTION
On Linux with static compiler there is only zlibstatic.a in package. It causes problems because standard way of linking is `-lz`. There already exists logic for renaming the lib. But it works only on Windows.

Specify library name and version:  **zlib** all versions

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
