### PR TITLE
spdlog: Bump fmt version

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -51,7 +51,9 @@ class SpdlogConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        if tools.Version(self.version) >= "1.9.0":
+        if tools.Version(self.version) >= "1.10.0":
+            self.requires("fmt/8.1.1")
+        elif tools.Version(self.version) >= "1.9.0":
             self.requires("fmt/8.0.1")
         elif tools.Version(self.version) >= "1.7.0":
             self.requires("fmt/7.1.3")


### PR DESCRIPTION
Specify library name and version:  **spdlog/1.10.0**

Spdlog switched to fmt/8.1.1 internally, it's better if we use the same version externally too. See: https://github.com/gabime/spdlog/releases/tag/v1.10.0

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
