### PR TITLE
[yasm/all] Fix RelWithDebInfo

### DIFF
--- a/recipes/yasm/all/conanfile.py
+++ b/recipes/yasm/all/conanfile.py
@@ -85,7 +85,8 @@ class YASMConan(ConanFile):
                 "x86_64": "x64",
             }[str(self.settings.arch)]
             tools.mkdir(os.path.join(self.package_folder, "bin"))
-            shutil.copy(os.path.join(self._msvc_subfolder, arch, str(self.settings.build_type), "yasm.exe"),
+            build_type = "Debug" if self.settings.build_type == "Debug" else "Release"
+            shutil.copy(os.path.join(self._msvc_subfolder, arch, build_type, "yasm.exe"),
                         os.path.join(self.package_folder, "bin", "yasm.exe"))
             self.copy(pattern="yasm.exe*", src=self._source_subfolder, dst="bin", keep_path=False)
         else:


### PR DESCRIPTION
Specify library name and version:  **yasm/all**

The recipe is broken when trying to compile with `RelWithDebInfo`:

```
FileNotFoundError: [Errno 2] No such file or directory: 'source_subfolder\\Mkfiles\\vc10\\x64\\RelWithDebInfo\\yasm.exe'
```

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
