### PR TITLE
grpc: Update zlib to 1.2.12

### DIFF
--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -79,7 +79,7 @@ class grpcConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires('zlib/1.2.11')
+        self.requires('zlib/1.2.12')
         self.requires('openssl/1.1.1m')
         self.requires('protobuf/3.19.2')
         self.requires('c-ares/1.17.2')


### PR DESCRIPTION
library name and version:  **grpc/all**

This updates the zlib dependency to 1.2.12.

fixes #10262



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
