### PR TITLE
thrift: bump zlib version

### DIFF
--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -85,7 +85,7 @@ class ThriftConan(ConanFile):
         if self.options.with_openssl:
             self.requires("openssl/1.1.1m")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.12")
         if self.options.with_libevent:
             self.requires("libevent/2.1.12")
 


### PR DESCRIPTION
thrift packages are currently broken due to the new zlib 1.2.12 version. For instance:
````bash
WARN: boost/1.78.0: requirement zlib/1.2.12 overridden by thrift/0.15.0 to zlib/1.2.11
ERROR: Conflict in c-blosc/1.20.1:
    'c-blosc/1.20.1' requires 'zlib/1.2.12' while 'thrift/0.15.0' requires 'zlib/1.2.11'.
    To fix this conflict you need to override the package 'zlib' in your root package.
````

Specify library name and version:  **thrift/0.13.0** / **thrift/0.15.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
