### PR TITLE
Add drmp3/0.6.32

### DIFF
--- a/recipes/drmp3/all/CMakeLists.txt
+++ b/recipes/drmp3/all/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.4)
+project(dr_mp3 C)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(KEEP_RPATHS)
+
+option(NO_SIMD "Build with define DR_MP3_NO_SIMD" OFF)
+option(NO_STDIO "Build with define DR_MP3_NO_STDIO" OFF)
+
+add_library(${CMAKE_PROJECT_NAME} dr_mp3.c)
+
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE source_subfolder)
+
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES 
+    PUBLIC_HEADER source_subfolder/dr_mp3.h
+    C_STANDARD 99
+)
+
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDRMP3_DLL)
+endif()
+if(NO_SIMD)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDR_MP3_NO_SIMD)
+endif()
+if(NO_STDIO)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDR_MP3_NO_STDIO)
+endif()
+
+install(TARGETS ${CMAKE_PROJECT_NAME}
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    PUBLIC_HEADER DESTINATION include
+)

--- a/recipes/drmp3/all/conandata.yml
+++ b/recipes/drmp3/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  # NOTE: https://github.com/mackron/dr_libs/blob/9497270f581f43e6b795ce5d98d8764861fb6a50/dr_mp3.h#L3
+  "0.6.32":
+    url: https://github.com/mackron/dr_libs/archive/9497270f581f43e6b795ce5d98d8764861fb6a50.zip
+    sha256: "572b59ec9719cf8f4938f982bc1f2e52689a3fbf6cceb4f27478942d7e35456b"

--- a/recipes/drmp3/all/conanfile.py
+++ b/recipes/drmp3/all/conanfile.py
@@ -71,3 +71,7 @@ class Drmp3Conan(ConanFile):
         self.cpp_info.libs = ["dr_mp3"]
         if self.options.shared:
             self.cpp_info.defines.append("DRMP3_DLL")
+        if self.options.no_simd:
+            self.cpp_info.defines.append("DR_MP3_NO_SIMD")
+        if self.options.no_stdio:
+            self.cpp_info.defines.append("DR_MP3_NO_STDIO")

--- a/recipes/drmp3/all/conanfile.py
+++ b/recipes/drmp3/all/conanfile.py
@@ -1,0 +1,73 @@
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.33.0"
+
+
+class Drmp3Conan(ConanFile):
+    name = "drmp3"
+    description = "MP3 audio decoder."
+    homepage = "https://mackron.github.io/"
+    topics = ("audio", "mp3", "sound")
+    license = ("Unlicense", "MIT-0")
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False], 
+        "fPIC": [True, False],
+        "no_simd": [True, False],
+        "no_stdio": [True, False]
+    }
+    default_options = {
+        "shared": False, 
+        "fPIC": True,
+        "no_simd": False,
+        "no_stdio": False
+    }
+    generators = "cmake"
+    exports_sources = ["CMakeLists.txt", "dr_mp3.c"]
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.cppstd
+        del self.settings.compiler.libcxx
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["NO_SIMD"] = self.options.no_simd
+        self._cmake.definitions["NO_STDIO"] = self.options.no_stdio
+        self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["dr_mp3"]
+        if self.options.shared:
+            self.cpp_info.defines.append("DRMP3_DLL")

--- a/recipes/drmp3/all/dr_mp3.c
+++ b/recipes/drmp3/all/dr_mp3.c
@@ -1,0 +1,3 @@
+#define DR_MP3_IMPLEMENTATION
+
+#include "dr_mp3.h"

--- a/recipes/drmp3/all/test_package/CMakeLists.txt
+++ b/recipes/drmp3/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(drmp3 CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} drmp3::drmp3)
+set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)

--- a/recipes/drmp3/all/test_package/conanfile.py
+++ b/recipes/drmp3/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class Drmp3TestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/drmp3/all/test_package/test_package.c
+++ b/recipes/drmp3/all/test_package/test_package.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include "dr_mp3.h"
+
+int main(void) {
+    const char *version = drmp3_version_string();
+    printf("dr_mp3 version: %s\n", version);
+
+    return 0;
+}

--- a/recipes/drmp3/config.yml
+++ b/recipes/drmp3/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.6.32":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **drmp3/0.6.32**

This adds a new recipe for the [dr_mp3](https://github.com/mackron/dr_libs/tree/master) library.

See also the existing PRs for the very similar [dr_wav](https://github.com/mackron/dr_libs/tree/master) and [dr_flac](https://github.com/mackron/dr_libs/tree/master) libraries. Apart from naming, there is no difference to the drwav recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
