### PR TITLE
visit_struct: add recipe

### DIFF
--- a/recipes/visit_struct/all/conandata.yml
+++ b/recipes/visit_struct/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "1.0":
+    url: "https://github.com/garbageslam/visit_struct/archive/refs/tags/v1.0.tar.gz"
+    sha256: "7e5d727bd9fbe444d182840625f5eb21f2cf67f06f3aeab27a2d7c4724b3c09c"
+

--- a/recipes/visit_struct/all/conandata.yml
+++ b/recipes/visit_struct/all/conandata.yml
@@ -2,4 +2,3 @@ sources:
   "1.0":
     url: "https://github.com/garbageslam/visit_struct/archive/refs/tags/v1.0.tar.gz"
     sha256: "7e5d727bd9fbe444d182840625f5eb21f2cf67f06f3aeab27a2d7c4724b3c09c"
-

--- a/recipes/visit_struct/all/conanfile.py
+++ b/recipes/visit_struct/all/conanfile.py
@@ -1,0 +1,49 @@
+import os
+from conans import ConanFile, tools
+
+required_conan_version = ">=1.33.0"
+
+class VisitStructConan(ConanFile):
+    name = "visit_struct"
+    description = "A miniature library for struct-field reflection in C++"
+    topics = ("reflection", "introspection", "visitor", "struct-field-visitor",)
+    homepage = "https://github.com/garbageslam/visit_struct"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "BSL-1.0"
+    settings = "os", "arch", "compiler", "build_type",
+    options = {
+        "with_boost_fusion": [True, False],
+        "with_boost_hana": [True, False],
+    }
+    default_options = {
+        "with_boost_fusion": False,
+        "with_boost_hana": False,
+    }
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def requirements(self):
+        if self.options.with_boost_fusion or self.options.with_boost_hana:
+            self.requires("boost/1.78.0")
+
+    def package_id(self):
+        self.info.header_only()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, "11")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def package(self):
+        self.copy(pattern="LICENSE", src=self._source_subfolder, dst="licenses")
+        self.copy(pattern="*visit_struct.hpp", src=os.path.join(self._source_subfolder, "include"), dst="include")
+        self.copy(pattern="*visit_struct_intrusive.hpp", src=os.path.join(self._source_subfolder, "include"), dst="include")
+        if self.options.with_boost_fusion:
+            self.copy(pattern="*visit_struct_boost_fusion.hpp", src=os.path.join(self._source_subfolder, "include"), dst="include")
+        if self.options.with_boost_hana:
+            self.copy(pattern="*visit_struct_boost_hana.hpp", src=os.path.join(self._source_subfolder, "include"), dst="include")

--- a/recipes/visit_struct/all/test_package/CMakeLists.txt
+++ b/recipes/visit_struct/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(visit_struct REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} visit_struct::visit_struct)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/visit_struct/all/test_package/conanfile.py
+++ b/recipes/visit_struct/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type",
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/visit_struct/all/test_package/test_package.cpp
+++ b/recipes/visit_struct/all/test_package/test_package.cpp
@@ -1,0 +1,26 @@
+#include <visit_struct/visit_struct.hpp>
+
+#include <iostream>
+
+struct my_type {
+    int         a;
+    float       b;
+    std::string c;
+};
+
+VISITABLE_STRUCT(my_type, a, b, c);
+
+struct debug_printer {
+    template <typename T>
+    void operator()(const char* name, const T& value) {
+        std::cerr << name << ": " << value << std::endl;
+    }
+};
+
+int main(int argc, char* argv[]) {
+    auto val = my_type{1, 2.0f, "three"};
+
+    visit_struct::for_each(val, debug_printer{});
+
+    return 0;
+}

--- a/recipes/visit_struct/all/test_package/test_package.cpp
+++ b/recipes/visit_struct/all/test_package/test_package.cpp
@@ -1,5 +1,6 @@
 #include <visit_struct/visit_struct.hpp>
 
+#include <string>
 #include <iostream>
 
 struct my_type {

--- a/recipes/visit_struct/config.yml
+++ b/recipes/visit_struct/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **visit_struct**

visit_struct is used by structopt internally.
I want to separate it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
