### PR TITLE
libtiff: fix build of libtiff < 4.3.0 when jbig or zstd disabled

### DIFF
--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -120,15 +120,13 @@ class LibtiffConan(ConanFile):
             tools.patch(**patch)
 
         # Rename the generated Findjbig.cmake and Findzstd.cmake to avoid case insensitive conflicts with FindJBIG.cmake and FindZSTD.cmake on Windows
-        if self.options.jbig:
-            rename(self, os.path.join(self.build_folder, "Findjbig.cmake"),
-                         os.path.join(self.build_folder, "ConanFindjbig.cmake"))
-        else:
-            os.remove(os.path.join(self.build_folder, self._source_subfolder, "cmake", "FindJBIG.cmake"))
-        if self._has_zstd_option:
+        if tools.Version(self.version) >= "4.3.0":
+            if self.options.jbig:
+                rename(self, "Findjbig.cmake", "ConanFindjbig.cmake")
+            else:
+                os.remove(os.path.join(self.build_folder, self._source_subfolder, "cmake", "FindJBIG.cmake"))
             if self.options.zstd:
-                rename(self, os.path.join(self.build_folder, "Findzstd.cmake"),
-                             os.path.join(self.build_folder, "ConanFindzstd.cmake"))
+                rename(self, "Findzstd.cmake", "ConanFindzstd.cmake")
             else:
                 os.remove(os.path.join(self.build_folder, self._source_subfolder, "cmake", "FindZSTD.cmake"))
 


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/10268

Before https://github.com/conan-io/conan-center-index/pull/7278, build of libtiff with disabled jbig or zstd was ok for versions < 4.3.0 , but broken for 4.3.0. After, it was the opposite.

Current PR should satisfy all versions.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
