### PR TITLE
civetweb: bump dependencies + relocatable shared libs on macOS

### DIFF
--- a/recipes/civetweb/all/CMakeLists.txt
+++ b/recipes/civetweb/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/civetweb/all/conanfile.py
+++ b/recipes/civetweb/all/conanfile.py
@@ -85,9 +85,9 @@ class CivetwebConan(ConanFile):
 
     def requirements(self):
         if self.options.with_ssl:
-            self.requires("openssl/1.1.1m")
+            self.requires("openssl/1.1.1n")
         if self.options.get_safe("with_zlib"):
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.12")
 
     def validate(self):
         if self.options.get_safe("ssl_dynamic_loading") and not self.options["openssl"].shared:

--- a/recipes/civetweb/all/conanfile.py
+++ b/recipes/civetweb/all/conanfile.py
@@ -1,6 +1,6 @@
-import os
 from conans import ConanFile, tools, CMake
 from conans.errors import ConanInvalidConfiguration
+import os
 
 required_conan_version = ">=1.43.0"
 
@@ -12,8 +12,8 @@ class CivetwebConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     description = "Embedded C/C++ web server"
     topics = ("civetweb", "web-server", "embedded")
-    generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
-    settings = "os", "compiler", "build_type", "arch"
+
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
         "shared": [True, False],
@@ -49,6 +49,7 @@ class CivetwebConan(ConanFile):
         "with_zlib": False,
     }
 
+    generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
     _cmake = None
 
     @property

--- a/recipes/civetweb/all/conanfile.py
+++ b/recipes/civetweb/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conans import ConanFile, tools, CMake
 from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class CivetwebConan(ConanFile):


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- also bump `required_conan_version` to 1.43.0 since explicit target name is used in `set_property()`

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
