### PR TITLE
Bump vulkan-headers/1.3.211

### DIFF
--- a/recipes/vulkan-headers/all/conandata.yml
+++ b/recipes/vulkan-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.211":
+    url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.3.211.tar.gz"
+    sha256: "67ab69142f69389dfdf5f1c7922e62aa4a03ba286b9229dd7f7f3e827232463c"
   "1.3.204.1":
     url: "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/sdk-1.3.204.1.tar.gz"
     sha256: "9c4d33f71467c915749fbf48c0c3a8ee7833f15babf398e3463cd88791fb592e"

--- a/recipes/vulkan-headers/config.yml
+++ b/recipes/vulkan-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.211":
+    folder: all
   "1.3.204.1":
     folder: all
   "1.3.204.0":


### PR DESCRIPTION
Latest Vulkan SDK will be based on 1.3.211 (MoltenVK has already released its last version based on 1.3.211).
SDK version is not available yet, but volk recipe relies on non-sdk version.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
