### PR TITLE
Updated recipe for yasm/1.3.0

### DIFF
--- a/recipes/yasm/all/conandata.yml
+++ b/recipes/yasm/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
   "1.3.0":
-    - url: "http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz"
+    - url: "https://github.com/yasm/yasm/releases/download/v1.3.0/yasm-1.3.0.tar.gz"
       sha256: "3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f"
     - url: "https://raw.githubusercontent.com/yasm/yasm/bcc01c59d8196f857989e6ae718458c296ca20e3/YASM-VERSION-GEN.bat"
       sha256: "b976cb97d2f7bb00e78e5db0da0978659acbdd60b52998cd2983145d8d75f141"

--- a/recipes/yasm/all/conandata.yml
+++ b/recipes/yasm/all/conandata.yml
@@ -1,6 +1,9 @@
 sources:
   "1.3.0":
-    - url: "https://github.com/yasm/yasm/releases/download/v1.3.0/yasm-1.3.0.tar.gz"
+    - url: [
+      "http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz",
+      "https://github.com/yasm/yasm/releases/download/v1.3.0/yasm-1.3.0.tar.gz",
+    ]
       sha256: "3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f"
     - url: "https://raw.githubusercontent.com/yasm/yasm/bcc01c59d8196f857989e6ae718458c296ca20e3/YASM-VERSION-GEN.bat"
       sha256: "b976cb97d2f7bb00e78e5db0da0978659acbdd60b52998cd2983145d8d75f141"

--- a/recipes/yasm/all/conandata.yml
+++ b/recipes/yasm/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.3.0":
     - url: [
-      "http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz",
+      "https://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz",
       "https://github.com/yasm/yasm/releases/download/v1.3.0/yasm-1.3.0.tar.gz",
     ]
       sha256: "3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f"


### PR DESCRIPTION
www.tortall.net is inaccessable, the github version from the yasm public repo however has the same checksum and builds correctly

Specify library name and version:  **yasm/1.3.0**