### PR TITLE
opentelemetry-proto: add version 0.16.0

### DIFF
--- a/recipes/opentelemetry-proto/all/conandata.yml
+++ b/recipes/opentelemetry-proto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.16.0":
+    url: "https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v0.16.0.tar.gz"
+    sha256: "22763df2020d4e16a411b249f86dda8fa1bea69a9592915bf0b1dab6d7005190"
   "0.11.0":
-    sha256: "985367f8905e91018e636cbf0d83ab3f834b665c4f5899a27d10cae9657710e2"
     url: "https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v0.11.0.tar.gz"
+    sha256: "985367f8905e91018e636cbf0d83ab3f834b665c4f5899a27d10cae9657710e2"

--- a/recipes/opentelemetry-proto/config.yml
+++ b/recipes/opentelemetry-proto/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.16.0":
+    folder: all
   "0.11.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **opentelemetry-proto/0.16.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
