### PR TITLE
taglib: bump zlib + modernize

### DIFF
--- a/recipes/taglib/all/CMakeLists.txt
+++ b/recipes/taglib/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/taglib/all/conanfile.py
+++ b/recipes/taglib/all/conanfile.py
@@ -1,14 +1,15 @@
 from conans import ConanFile, CMake, tools
+import functools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
 
 
 class TaglibConan(ConanFile):
     name = "taglib"
     description = "TagLib is a library for reading and editing the metadata of several popular audio formats."
     license = ("LGPL-2.1-or-later", "MPL-1.1")
-    topics = ("conan", "taglib", "audio", "metadata")
+    topics = ("taglib", "audio", "metadata")
     homepage = "https://taglib.org"
     url = "https://github.com/conan-io/conan-center-index"
 
@@ -24,13 +25,16 @@ class TaglibConan(ConanFile):
         "bindings": True,
     }
 
-    exports_sources = "CMakeLists.txt", "patches/*"
     generators = "cmake", "cmake_find_package"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -47,17 +51,16 @@ class TaglibConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["ENABLE_CCACHE"] = False
-        self._cmake.definitions["VISIBILITY_HIDDEN"] = True
-        self._cmake.definitions["BUILD_TESTS"] = False
-        self._cmake.definitions["BUILD_EXAMPLES"] = False
-        self._cmake.definitions["BUILD_BINDINGS"] = self.options.bindings
-        self._cmake.configure()
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["ENABLE_CCACHE"] = False
+        cmake.definitions["VISIBILITY_HIDDEN"] = True
+        cmake.definitions["BUILD_TESTS"] = False
+        cmake.definitions["BUILD_EXAMPLES"] = False
+        cmake.definitions["BUILD_BINDINGS"] = self.options.bindings
+        cmake.configure()
+        return cmake
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -73,9 +76,9 @@ class TaglibConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.names["pkg_config"] = "taglib_full_package" # unofficial, to avoid conflicts in pkg_config generator
+        self.cpp_info.set_property("pkg_config_name", "taglib_full_package") # unofficial, to avoid conflicts in pkg_config generator
 
-        self.cpp_info.components["tag"].names["pkg_config"] = "taglib"
+        self.cpp_info.components["tag"].set_property("pkg_config_name", "taglib")
         self.cpp_info.components["tag"].includedirs.append(os.path.join("include", "taglib"))
         self.cpp_info.components["tag"].libs = ["tag"]
         self.cpp_info.components["tag"].requires = ["zlib::zlib"]
@@ -83,7 +86,7 @@ class TaglibConan(ConanFile):
             self.cpp_info.components["tag"].defines.append("TAGLIB_STATIC")
 
         if self.options.bindings:
-            self.cpp_info.components["tag_c"].names["pkg_config"] = "taglib_c"
+            self.cpp_info.components["tag_c"].set_property("pkg_config_name", "taglib_c")
             self.cpp_info.components["tag_c"].libs = ["tag_c"]
             self.cpp_info.components["tag_c"].requires = ["tag"]
             if not self.options.shared:

--- a/recipes/taglib/all/conanfile.py
+++ b/recipes/taglib/all/conanfile.py
@@ -41,7 +41,7 @@ class TaglibConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("zlib/1.2.11")
+        self.requires("zlib/1.2.12")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/taglib/all/test_package/CMakeLists.txt
+++ b/recipes/taglib/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(taglib REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} taglib::taglib)

--- a/recipes/taglib/all/test_package/conanfile.py
+++ b/recipes/taglib/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- cache CMake configuration with `functools.lru_cache`
- use `cmake_find_package_multi` in test package
- fine-grained export of patches
- `PkgConfigDeps` support
- bump zlib to 1.2.12

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
