### PR TITLE
glib: declare the system libraries required by gio

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -266,6 +266,13 @@ class GLibConan(ConanFile):
         self.cpp_info.components["gthread-2.0"].requires.append("glib-2.0")
 
         self.cpp_info.components["gio-2.0"].libs = ["gio-2.0"]
+        if self.settings.os == "Windows":
+            # See source "gio/meson.build"
+            self.cpp_info.components["gio-2.0"].system_libs.extend([
+                "shlwapi",
+                "dnsapi",
+                "iphlpapi",
+            ])
         if self.settings.os == "Linux":
             self.cpp_info.components["gio-2.0"].system_libs.append("resolv")
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/glib/all/test_package/test_package.c
+++ b/recipes/glib/all/test_package/test_package.c
@@ -43,6 +43,9 @@ void test_gio()
     GInetAddress *add = g_inet_address_new_any(G_SOCKET_FAMILY_IPV4);
     printf("Any ipv4 address: %s\n", g_inet_address_to_string(add));
     g_object_unref(add);
+
+    GSocket *socket = g_socket_new(G_SOCKET_FAMILY_IPV4, G_SOCKET_TYPE_DATAGRAM, 0, NULL);
+    g_object_unref(socket);
 }
 
 void test_gthread()


### PR DESCRIPTION
Specify library name and version:  **glib/***

The old version does not declare all the `system_lib`s used by gio, thus something that statically links to the glib package and uses `GSocket` (as the updated test_package does) will fail. The PR declared required `system_lib`s according to [meson.build from goi](https://github.com/GNOME/glib/blob/d987146fe1c304ef88b0de5846db32913169bbc1/gio/meson.build#L421), except that winsock is already linked by default.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
