### PR TITLE
coin-cbc : enable parallel mode (non-Windows os only)

### DIFF
--- a/recipes/coin-cbc/all/conandata.yml
+++ b/recipes/coin-cbc/all/conandata.yml
@@ -6,3 +6,5 @@ patches:
   "2.10.5":
     - patch_file: "patches/0001-no-pkg-config-check.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0002-pthreads4w.patch"
+      base_path: "source_subfolder"

--- a/recipes/coin-cbc/all/conanfile.py
+++ b/recipes/coin-cbc/all/conanfile.py
@@ -153,6 +153,8 @@ class CoinCbcConan(ConanFile):
         self.cpp_info.components["libcbc"].includedirs.append(os.path.join("include", "coin"))
         self.cpp_info.components["libcbc"].requires = ["coin-clp::osi-clp", "coin-utils::coin-utils", "coin-osi::coin-osi", "coin-cgl::coin-cgl"]
         self.cpp_info.components["libcbc"].names["pkg_config"] = "cbc"
+        if self.settings.os in ["Linux", "FreeBSD"] and self.options.parallel:
+            self.cpp_info.components["libcbc"].system_libs.append("pthread")
 
         self.cpp_info.components["osi-cbc"].libs = ["OsiCbc"]
         self.cpp_info.components["osi-cbc"].requires = ["libcbc"]

--- a/recipes/coin-cbc/all/conanfile.py
+++ b/recipes/coin-cbc/all/conanfile.py
@@ -105,11 +105,11 @@ class CoinCbcConan(ConanFile):
         yes_no = lambda v: "yes" if v else "no"
         configure_args = [
             "--enable-shared={}".format(yes_no(self.options.shared)),
-            "--without-blas"
-            "--without-lapack"
+            "--without-blas",
+            "--without-lapack",
         ]
         if self.settings.os != "Windows":
-            configure_args = [
+            configure_args += [
                 "--enable-cbc-parallel={}".format(yes_no(self.options.parallel))
             ]
         if self.settings.compiler == "Visual Studio":

--- a/recipes/coin-cbc/all/conanfile.py
+++ b/recipes/coin-cbc/all/conanfile.py
@@ -17,10 +17,12 @@ class CoinCbcConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "parallel": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "parallel": False,
     }
     generators = "pkg_config"
 
@@ -41,6 +43,7 @@ class CoinCbcConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+            del self.options.parallel
 
     def configure(self):
         if self.options.shared:
@@ -105,6 +108,10 @@ class CoinCbcConan(ConanFile):
             "--without-blas"
             "--without-lapack"
         ]
+        if self.settings.os != "Windows":
+            configure_args = [
+                "--enable-cbc-parallel={}".format(yes_no(self.options.parallel))
+            ]
         if self.settings.compiler == "Visual Studio":
             self._autotools.cxx_flags.append("-EHsc")
             configure_args.append("--enable-msvc={}".format(self.settings.compiler.runtime))

--- a/recipes/coin-cbc/all/patches/0002-pthreads4w.patch
+++ b/recipes/coin-cbc/all/patches/0002-pthreads4w.patch
@@ -1,0 +1,11 @@
+--- a/Cbc/configure
++++ b/Cbc/configure
+@@ -30970,7 +30970,7 @@ cat >>confdefs.h <<\_ACEOF
+ #define CBC_THREAD 1
+ _ACEOF
+ 
+-  if test $coin_cxx_is_cl = true ;
++  if test "${with_pthreadsw32_lib+set}" = set ;
+   then
+     # TODO we should check whether the library works and pthread.h is indeed there
+ 


### PR DESCRIPTION
**coin-cbc/2.10.5**

Allows consumers to enable parallel mode on non-Windows platforms
---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
