### PR TITLE
podofo: bump zlib & openssl + few fixes

### DIFF
--- a/recipes/podofo/all/CMakeLists.txt
+++ b/recipes/podofo/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include("conanbuildinfo.cmake")
-conan_basic_setup(TARGETS)
+conan_basic_setup(TARGETS KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -1,7 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.36.0"
 
 
 class PodofoConan(ConanFile):

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+import functools
 import os
 
 required_conan_version = ">=1.36.0"
@@ -37,7 +38,6 @@ class PodofoConan(ConanFile):
     }
 
     generators = "cmake", "cmake_find_package"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -94,29 +94,27 @@ class PodofoConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-
-        self._cmake = CMake(self)
-        self._cmake.definitions["PODOFO_BUILD_LIB_ONLY"] = True
-        self._cmake.definitions["PODOFO_BUILD_SHARED"] = self.options.shared
-        self._cmake.definitions["PODOFO_BUILD_STATIC"] = not self.options.shared
+        cmake = CMake(self)
+        cmake.definitions["PODOFO_BUILD_LIB_ONLY"] = True
+        cmake.definitions["PODOFO_BUILD_SHARED"] = self.options.shared
+        cmake.definitions["PODOFO_BUILD_STATIC"] = not self.options.shared
         if not self.options.threadsafe:
-            self._cmake.definitions["PODOFO_NO_MULTITHREAD"] = True
+            cmake.definitions["PODOFO_NO_MULTITHREAD"] = True
         if not tools.valid_min_cppstd(self, 11) and tools.Version(self.version) >= "0.9.7":
-            self._cmake.definitions["CMAKE_CXX_STANDARD"] = 11
+            cmake.definitions["CMAKE_CXX_STANDARD"] = 11
 
         # Custom CMake options injected in our patch, required to ensure reproducible builds
-        self._cmake.definitions["PODOFO_WITH_OPENSSL"] = self.options.with_openssl
-        self._cmake.definitions["PODOFO_WITH_LIBIDN"] = self.options.with_libidn
-        self._cmake.definitions["PODOFO_WITH_LIBJPEG"] = self.options.with_jpeg
-        self._cmake.definitions["PODOFO_WITH_TIFF"] = self.options.with_tiff
-        self._cmake.definitions["PODOFO_WITH_PNG"] = self.options.with_png
-        self._cmake.definitions["PODOFO_WITH_UNISTRING"] = self.options.with_unistring
+        cmake.definitions["PODOFO_WITH_OPENSSL"] = self.options.with_openssl
+        cmake.definitions["PODOFO_WITH_LIBIDN"] = self.options.with_libidn
+        cmake.definitions["PODOFO_WITH_LIBJPEG"] = self.options.with_jpeg
+        cmake.definitions["PODOFO_WITH_TIFF"] = self.options.with_tiff
+        cmake.definitions["PODOFO_WITH_PNG"] = self.options.with_png
+        cmake.definitions["PODOFO_WITH_UNISTRING"] = self.options.with_unistring
 
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -105,6 +105,9 @@ class PodofoConan(ConanFile):
         if not tools.valid_min_cppstd(self, 11) and tools.Version(self.version) >= "0.9.7":
             cmake.definitions["CMAKE_CXX_STANDARD"] = 11
 
+        # To install relocatable shared lib on Macos
+        cmake.definitions["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+
         # Custom CMake options injected in our patch, required to ensure reproducible builds
         cmake.definitions["PODOFO_WITH_OPENSSL"] = self.options.with_openssl
         cmake.definitions["PODOFO_WITH_LIBIDN"] = self.options.with_libidn

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -70,11 +70,11 @@ class PodofoConan(ConanFile):
 
     def requirements(self):
         self.requires("freetype/2.11.1")
-        self.requires("zlib/1.2.11")
+        self.requires("zlib/1.2.12")
         if self.settings.os != "Windows":
             self.requires("fontconfig/2.13.93")
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1m")
+            self.requires("openssl/1.1.1n")
         if self.options.with_libidn:
             self.requires("libidn/1.36")
         if self.options.with_jpeg:

--- a/recipes/podofo/all/conanfile.py
+++ b/recipes/podofo/all/conanfile.py
@@ -132,8 +132,10 @@ class PodofoConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.set_property("pkg_config_name", "libpodofo-{}".format(tools.Version(self.version).major))
-        self.cpp_info.names["pkg_config"] = "libpodofo-{}".format(tools.Version(self.version).major)
+        podofo_version = tools.Version(self.version)
+        pkg_config_name = f"libpodofo-{podofo_version.major}" if podofo_version < "0.9.7" else "libpodofo"
+        self.cpp_info.set_property("pkg_config_name", pkg_config_name)
+        self.cpp_info.names["pkg_config"] = pkg_config_name
         self.cpp_info.libs = ["podofo"]
         if self.settings.os == "Windows" and self.options.shared:
             self.cpp_info.defines.append("USING_SHARED_PODOFO")


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- cache CMake configuration with `functools.lru_cache`
- fix pkg_config_name for podofo >= 0.9.7. Indeed upstream has changed this file name, it's `libpodofo.pc` now (instead of `libpodofo-0.pc`)
- bump zlib & openssl

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
