### PR TITLE
cppcheck: add version 2.7.5

### DIFF
--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.7.5":
+    url: "https://github.com/danmar/cppcheck/archive/2.7.5.tar.gz"
+    sha256: "6c7ac29e57fa8b3ac7be224510200e579d5a90217e2152591ef46ffc947d8f78"
   "2.7.4":
     url: "https://github.com/danmar/cppcheck/archive/2.7.4.tar.gz"
     sha256: "f0558c497b7807763325f3a821f1c72b743e5d888b037b8d32157dd07d6c26e1"
@@ -27,6 +30,11 @@ sources:
     url: "https://github.com/danmar/cppcheck/archive/2.2.tar.gz"
     sha256: "ad96290a1842c5934bf9c4268cb270953f3078d4ce33a9a53922d6cb6daf61aa"
 patches:
+  "2.7.5":
+    - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-htmlreport-python3.patch"
+      base_path: "source_subfolder"
   "2.7.4":
     - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
       base_path: "source_subfolder"

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.7.5":
+    folder: all
   "2.7.4":
     folder: all
   "2.7.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cppcheck/2.7.5**

Trying @qchateau automatic PR generation.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
