### PR TITLE
[abseil] Work around check_cxx_source_compiles/CMP0067 build issue

### DIFF
--- a/recipes/abseil/all/CMakeLists.txt
+++ b/recipes/abseil/all/CMakeLists.txt
@@ -4,6 +4,11 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
+# Note: This must appear before adding the Abseil source subdirectory because
+# Abseil's minimum CMake version is 3.5 so it may cause the definition of
+# check_cxx_source_compiles() to have CMP0067 unset
+include(CheckCXXSourceCompiles)
+
 if(MSVC)
     add_definitions("-D_HAS_DEPRECATED_RESULT_OF")
 endif()
@@ -13,8 +18,6 @@ if(NOT CMAKE_SYSTEM_PROCESSOR)
 endif()
 
 add_subdirectory(source_subfolder)
-
-include(CheckCXXSourceCompiles)
 
 get_target_property(ABSL_INCLUDES absl::config INTERFACE_INCLUDE_DIRECTORIES)
 set(CMAKE_REQUIRED_INCLUDES ${ABSL_INCLUDES})


### PR DESCRIPTION
Specify library name and version:  **abseil/all**

Reason for this PR: https://github.com/conan-io/conan-center-index/pull/9703#issuecomment-1101278361
In short: build breakage on CMake versions which share code between `check_c_source_compiles` and `check_cxx_source_compiles` due to older CMake policy settings baked into their definitions by Abseil's policy settings.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
