### PR TITLE
[binutils] Update to 2.38, expose target, remove overconstrained validation

### DIFF
--- a/recipes/binutils/all/conandata.yml
+++ b/recipes/binutils/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "2.37":
     url: "https://ftp.gnu.org/gnu/binutils/binutils-2.37.tar.gz"
     sha256: "c44968b97cd86499efbc4b4ab7d98471f673e5414c554ef54afa930062dbbfcb"
+  "2.38":
+    url: "https://ftp.gnu.org/gnu/binutils/binutils-2.38.tar.gz"
+    sha256: "b3f1dc5b17e75328f19bd88250bee2ef9f91fc8cbb7bd48bdb31390338636052"    

--- a/recipes/binutils/all/conanfile.py
+++ b/recipes/binutils/all/conanfile.py
@@ -19,18 +19,16 @@ class BinutilsConan(ConanFile):
     license = "GPL-2.0-or-later"
 
     settings = "os", "arch", "compiler", "build_type"
+    options = { "target": "ANY" }
+    default_options = { "target": "None" }
 
     _source_subfolder = "source_subfolder"
-
-    def validate(self):
-        if self.settings.os not in ["Linux", "FreeBSD"]:
-            raise ConanInvalidConfiguration("This recipes supports only Linux and FreeBSD")
-
+            
     def package_id(self):
         del self.info.settings.compiler
 
     def requirements(self):
-        self.requires("zlib/1.2.11")
+        self.requires("zlib/1.2.12")
         self.requires("readline/8.0")
 
     def generate(self):
@@ -43,6 +41,9 @@ class BinutilsConan(ConanFile):
         ac = AutotoolsToolchain(self)
         ac.default_configure_install_args = True
         ac.configure_args.extend(["--with-system-zlib", "--with-system-readline"])
+        target = self.options.get_safe("target", None)
+        if target:
+            ac.configure_args.extend(["--target=" + str(target)])
         ac.generate()
 
     def source(self):

--- a/recipes/binutils/config.yml
+++ b/recipes/binutils/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.37":
     folder: all
+  "2.38":
+    folder: all


### PR DESCRIPTION
binutils/2.38

I have updated the recipe to version 2.38 and exposed the "target" option of binutils to generate cross-assemblers.
Also I removed the validation-function which constrained the package to linux and FreeBSD as binutils compiles fine on MacOs and there also are mingw builds out there (though I didn't test those). This change in the current form would be up to discussion - maybe what was meant initially was to constrain to certain compilers (gcc/clang? Dunno if msvc would work).

---

- [x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
