### PR TITLE
bison: remove useless linking to libreadline

### DIFF
--- a/recipes/bison/all/conandata.yml
+++ b/recipes/bison/all/conandata.yml
@@ -23,6 +23,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0005-gnulib-limit-search-range-of-_setmaxstdio.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0006-dont-link-bison-against-libreadline.patch"
+      base_path: "source_subfolder"
   "3.5.3":
     - patch_file: "patches/0001-create_pipe-uses-O_TEXT-not-O_BINARY-mode.patch"
       base_path: "source_subfolder"

--- a/recipes/bison/all/patches/0006-dont-link-bison-against-libreadline.patch
+++ b/recipes/bison/all/patches/0006-dont-link-bison-against-libreadline.patch
@@ -1,0 +1,14 @@
+build: don't link bison against libreadline
+Reported by Paul Smith <psmith@gnu.org>.
+https://lists.gnu.org/r/bug-bison/2020-10/msg00001.html
+
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -3456,7 +3456,6 @@
+   $(LIB_SETLOCALE_NULL)                         \
+   $(LIBICONV)                                   \
+   $(LIBINTL)                                    \
+-  $(LIBREADLINE)                                \
+   $(LIBTEXTSTYLE)
+
+ @ENABLE_YACC_TRUE@nodist_bin_SCRIPTS = src/yacc


### PR DESCRIPTION
Specify library name and version:  **bison/3.7.1**

Bison does not need libradline but linked to it on some versions. It has been fixed since official bison/3.7.3. This PR fixes this for current versions on CCI.

Fix #4443

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
