### PR TITLE
thrift: disable libthrift_nb component when libevent is disabled

### DIFF
--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -129,6 +129,7 @@ class ThriftConan(ConanFile):
             self._cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath
         if self.options.with_zlib:
             self._cmake.definitions["ZLIB_ROOT"] = self.deps_cpp_info["zlib"].rootpath
+        self._cmake.definitions["WITH_LIBEVENT"] = self.options.with_libevent
         if self.options.with_libevent:
             self._cmake.definitions["LIBEVENT_ROOT"] = self.deps_cpp_info["libevent"].rootpath
 
@@ -155,9 +156,11 @@ class ThriftConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        targets = {"thriftnb::thriftnb": "thrift::thriftnb"}
+        targets = {}
         if self.options.with_zlib:
             targets.update({"thriftz::thriftz": "thrift::thriftz"})
+        if self.options.with_libevent:
+            targets.update({"thriftnb::thriftnb": "thrift::thriftnb"})
         if self.options.with_qt:
             targets.update({"thriftqt5::thriftqt5": "thrift::thriftqt5"})
         self._create_cmake_module_alias_targets(
@@ -202,8 +205,6 @@ class ThriftConan(ConanFile):
         self.cpp_info.components["libthrift"].requires.append("boost::headers")
         if self.options.with_openssl:
             self.cpp_info.components["libthrift"].requires.append("openssl::openssl")
-        if self.options.with_libevent:
-            self.cpp_info.components["libthrift"].requires.append("libevent::libevent")
 
         if self.options.with_zlib:
             self.cpp_info.components["libthrift_z"].set_property("cmake_target_name", "thriftz::thriftz")
@@ -211,10 +212,12 @@ class ThriftConan(ConanFile):
             self.cpp_info.components["libthrift_z"].libs = ["thriftz" + libsuffix]
             self.cpp_info.components["libthrift_z"].requires = ["libthrift", "zlib::zlib"]
 
-        self.cpp_info.components["libthrift_nb"].set_property("cmake_target_name", "thriftnb::thriftnb")
-        self.cpp_info.components["libthrift_nb"].set_property("pkg_config_name", "thrift-nb")
-        self.cpp_info.components["libthrift_nb"].libs = ["thriftnb" + libsuffix]
-        self.cpp_info.components["libthrift_nb"].requires = ["libthrift"]
+
+        if self.options.with_libevent:
+            self.cpp_info.components["libthrift_nb"].set_property("cmake_target_name", "thriftnb::thriftnb")
+            self.cpp_info.components["libthrift_nb"].set_property("pkg_config_name", "thrift-nb")
+            self.cpp_info.components["libthrift_nb"].libs = ["thriftnb" + libsuffix]
+            self.cpp_info.components["libthrift_nb"].requires = ["libthrift", "libevent::libevent"]
 
         if self.options.with_qt:
             self.cpp_info.components["libthrift_qt5"].set_property("cmake_target_name", "thriftqt5::thriftqt5")
@@ -239,10 +242,11 @@ class ThriftConan(ConanFile):
             self.cpp_info.components["libthrift_z"].names["cmake_find_package_multi"] = "thriftz"
             self.cpp_info.components["libthrift_z"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
             self.cpp_info.components["libthrift_z"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
-        self.cpp_info.components["libthrift_nb"].names["cmake_find_package"] = "thriftnb"
-        self.cpp_info.components["libthrift_nb"].names["cmake_find_package_multi"] = "thriftnb"
-        self.cpp_info.components["libthrift_nb"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.components["libthrift_nb"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+        if self.options.with_libevent:
+            self.cpp_info.components["libthrift_nb"].names["cmake_find_package"] = "thriftnb"
+            self.cpp_info.components["libthrift_nb"].names["cmake_find_package_multi"] = "thriftnb"
+            self.cpp_info.components["libthrift_nb"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+            self.cpp_info.components["libthrift_nb"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
         if self.options.with_qt:
             self.cpp_info.components["libthrift_qt5"].names["cmake_find_package"] = "thriftqt5"
             self.cpp_info.components["libthrift_qt5"].names["cmake_find_package_multi"] = "thriftqt5"

--- a/recipes/thrift/all/test_package/CMakeLists.txt
+++ b/recipes/thrift/all/test_package/CMakeLists.txt
@@ -12,5 +12,5 @@ add_executable(${PROJECT_NAME}
     Calculator.cpp
     test_package.cpp
 )
-target_link_libraries(${PROJECT_NAME} thriftnb::thriftnb)
+target_link_libraries(${PROJECT_NAME} thrift::thrift)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)

--- a/recipes/thrift/all/test_package/test_package.cpp
+++ b/recipes/thrift/all/test_package/test_package.cpp
@@ -7,12 +7,10 @@
 #include <thrift/server/TSimpleServer.h>
 #include <thrift/server/TThreadPoolServer.h>
 #include <thrift/server/TThreadedServer.h>
-#include "thrift/server/TNonblockingServer.h"
 
 #include <thrift/concurrency/ThreadManager.h>
 #include <thrift/concurrency/ThreadFactory.h>
 #include <thrift/protocol/TBinaryProtocol.h>
-#include "thrift/transport/TNonblockingServerSocket.h"
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/transport/TServerSocket.h>
 #include <thrift/transport/TSocket.h>
@@ -48,12 +46,10 @@ int main(int argc, char **argv) {
     std::shared_ptr<TTransportFactory> transportFactory(new TBufferedTransportFactory());
     std::shared_ptr<TProtocolFactory> protocolFactory(new TBinaryProtocolFactory());
 
-    std::shared_ptr<TNonblockingServerSocket> nonBlockingserverTransport(new TNonblockingServerSocket(port));
 
     TSimpleServer server1(processor, serverTransport, transportFactory, protocolFactory);
     TThreadedServer server2(processor, serverTransport, transportFactory, protocolFactory);
     TThreadPoolServer server3(processor, serverTransport, transportFactory, protocolFactory);
-    TNonblockingServer server4(processor, nonBlockingserverTransport);
 
     const int workerCount = 4;
     std::shared_ptr<ThreadManager> threadManager = ThreadManager::newSimpleThreadManager(workerCount);


### PR DESCRIPTION
* specify explicit WITH_LIBEVENT cmake variable
* remove optional non-blocking code from test_package example

Fixes #10384

Specify library name and version:  **thrift/0.15.0**, **thrift/0.14.2**, **thrift/0.14.1**, **thrift/0.13.0**
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
