### PR TITLE
automake: fix test_package build for compiler=msvc

### DIFF
--- a/recipes/automake/all/test_package/conanfile.py
+++ b/recipes/automake/all/test_package/conanfile.py
@@ -1,9 +1,10 @@
 from conans import AutoToolsBuildEnvironment, ConanFile, tools
+from conan.tools.microsoft import is_msvc
 from contextlib import contextmanager
 import os
 import shutil
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.45.0"
 
 
 class TestPackageConan(ConanFile):
@@ -26,7 +27,7 @@ class TestPackageConan(ConanFile):
 
     @contextmanager
     def _build_context(self):
-        if self.settings.compiler == "Visual Studio":
+        if is_msvc(self):
             with tools.vcvars(self):
                 with tools.environment_append({"CC": "cl -nologo", "CXX": "cl -nologo",}):
                     yield
@@ -59,7 +60,7 @@ class TestPackageConan(ConanFile):
         assert os.path.isfile(compile_script)
 
         if self._system_cc:
-            with tools.vcvars(self) if self.settings.compiler == "Visual Studio" else tools.no_op():
+            with tools.vcvars(self) if is_msvc(self) else tools.no_op():
                 self.run("{} {} test_package_1.c -o script_test".format(tools.unix_path(compile_script), self._system_cc), win_bash=tools.os_info.is_windows)
 
     def _build_autotools(self):


### PR DESCRIPTION
Specify library name and version:  **automake/any**

Fixes **automake** test_package build with `compiler=msvc` in profile

```
[settings]
os=Windows
arch=x86_64
compiler=msvc
compiler.version=193
compiler.cppstd=17
compiler.runtime=dynamic
build_type=Release
[options]
[conf]
[build_requires]
[env]
```


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
