### PR TITLE
argh: add version 1.3.2

### DIFF
--- a/recipes/argh/all/conandata.yml
+++ b/recipes/argh/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.2":
+    url: "https://github.com/adishavit/argh/archive/v1.3.2.tar.gz"
+    sha256: "4b76d8c55e97cc0752feee4f00b99dc58464dd030dea9ba257c0a7d24a84f9dd"
   "1.3.1":
     url: "https://github.com/adishavit/argh/archive/refs/tags/v1.3.1.tar.gz"
     sha256: "48e09999f2768afbe90ef98864980933cf0ed5323dce3593c3f2f44b0ffda3de"

--- a/recipes/argh/config.yml
+++ b/recipes/argh/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.3.2":
+    folder: all
   "1.3.1":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **argh/1.3.2**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
