### PR TITLE
Create hooks-warnings.yml

### DIFF
--- a/.github/workflows/hooks-warnings.yml
+++ b/.github/workflows/hooks-warnings.yml
@@ -47,7 +47,7 @@ jobs:
             {
               comment = "<details>\n"
               comment += "<summary>Hooks produced the following warnings"
-              const shaRegex = /(All green|Failure) in build \d+ \((?<sha>(\d|[a-z])+)\):/g;
+              const shaRegex = /(All green|Failure) in build \d+ \(`(?<sha>(\d|[a-z])+)`\):/g;
               const shaMatch = shaRegex.exec(context.payload.comment.body)
               if(shaMatch)
               {

--- a/.github/workflows/hooks-warnings.yml
+++ b/.github/workflows/hooks-warnings.yml
@@ -36,9 +36,11 @@ jobs:
                 if(!warnings_map.has(job.reference))
                   warnings_map.set(job.reference, new Set())
                 for(const warning of warnings)
+                {
                   msg = warning.slice(prefix.length)
                   warnings_map.get(job.reference).add(msg)
                   core.warning(msg)
+                }
               }
             }
             if(warnings_map.size > 0)

--- a/.github/workflows/hooks-warnings.yml
+++ b/.github/workflows/hooks-warnings.yml
@@ -46,14 +46,21 @@ jobs:
             if(warnings_map.size > 0)
             {
               comment = "<details>\n"
-              comment += "<summary>Hooks produced the following warnings</summary>\n\n"
+              comment += "<summary>Hooks produced the following warnings"
+              const shaRegex = /(All green|Failure) in build \d+ \((?<sha>(\d|[a-z])+)\):/g;
+              const shaMatch = shaRegex.exec(context.payload.comment.body)
+              if(shaMatch)
+              {
+                comment += " for commit " + shaMatch.groups.sha
+              }
+              comment += "</summary>\n\n"
               for (const [ref, warnings] of warnings_map)
               {
                 comment += "<details>\n"
                 comment += "<summary>" + ref + "</summary>\n\n```\n"
                 for(const warning of warnings)
                   comment += warning + "\n"
-                comment += "\n```\n</details>\n"
+                comment += "```\n</details>\n"
               }
               comment += "</details>\n"
               github.rest.issues.createComment({

--- a/.github/workflows/hooks-warnings.yml
+++ b/.github/workflows/hooks-warnings.yml
@@ -1,0 +1,63 @@
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  comment:
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            warnings_map = new Map()
+            const link_regex = /\[All logs\]\((?<url>https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*))\)/g;
+            for (const match of context.payload.comment.body.matchAll(link_regex))
+            {
+              prefix = "https://c3i.jfrog.io/c3i/misc/summary.html?json="
+              if(!match.groups.url.startsWith(prefix))
+                 continue;
+              url = match.groups.url.slice(prefix.length)
+              const result = await github.request({
+                url: url,
+              });
+              for (const job of result.data)
+              {
+                if (job.build == null)
+                  continue;
+                const log = await github.request({
+                  baseUrl: "https://c3i.jfrog.io/c3i/misc/",
+                  url: job.build,
+                });
+                prefix = "[HOOK - conan-center.py] "
+                warnings = log.data.split("\n").filter(line => line.startsWith(prefix) && line.includes(" WARN: "))
+                if(warnings.length == 0)
+                  continue
+                if(!warnings_map.has(job.reference))
+                  warnings_map.set(job.reference, new Set())
+                for(const warning of warnings)
+                  msg = warning.slice(prefix.length)
+                  warnings_map.get(job.reference).add(msg)
+                  core.warning(msg)
+              }
+            }
+            if(warnings_map.size > 0)
+            {
+              comment = "<details>\n"
+              comment += "<summary>Hooks produced the following warnings</summary>\n\n"
+              for (const [ref, warnings] of warnings_map)
+              {
+                comment += "<details>\n"
+                comment += "<summary>" + ref + "</summary>\n\n```\n"
+                for(const warning of warnings)
+                  comment += warning + "\n"
+                comment += "\n```\n</details>\n"
+              }
+              comment += "</details>\n"
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              })
+            }

--- a/.github/workflows/hooks-warnings.yml
+++ b/.github/workflows/hooks-warnings.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   comment:
-    if: ${{ github.event.issue.pull_request }}
+    if: ${{ github.event.issue.pull_request && github.event.sender.login == 'conan-center-bot' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6


### PR DESCRIPTION
This hooks processes the pull request comments, in order to find build logs posted by @conan-center-bot, and extract all the conan-center hooks warnings, and reports them (after deduplication) as a comment on the PR.
You can play with it by copy/pasting any message from @conan-center-bot on this [PR](https://github.com/ericLemanissier/conan-center-index/pull/15) and see what the @github-actions bot posts afterwards.

In the current state of this PR, the bot does not check for the author of the comment, and it checks all the links having text `All logs` and url starting with `https://c3i.jfrog.io/c3i/misc/summary.html?json=`

One of the limitations is that @conan-center-bot does not always provide a link to the build log (eg if the recipe was not modified since the last build)

All suggestions are welcome

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
