### PR TITLE
Version bump zlib/1.2.12 in doxygen packages

### DIFF
--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -55,7 +55,7 @@ class DoxygenConan(ConanFile):
     def requirements(self):
         if self.options.enable_search:
             self.requires("xapian-core/1.4.18")
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.12")
 
     def build_requirements(self):
         if self._settings_build.os == "Windows":


### PR DESCRIPTION
Specify library name and version:  **doxygen/***

Version bump zlib dependency to version 1.2.12

Since to zlib update to 1.2.12, using the doxygen package throws a diamond conflict with boost. 

![image](https://user-images.githubusercontent.com/44053930/164245727-cbbf0763-15a9-429f-b121-df796eccec01.png)


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
