### PR TITLE
Add libcurl version 7.82.0

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.82.0":
+    sha256: 910cc5fe279dc36e2cca534172c94364cf3fcf7d6494ba56e6c61a390881ddce
+    url: https://curl.se/download/curl-7.82.0.tar.gz
   "7.80.0":
     sha256: dab997c9b08cb4a636a03f2f7f985eaba33279c1c52692430018fae4a4878dc7
     url: https://curl.se/download/curl-7.80.0.tar.gz

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -490,19 +490,29 @@ class LibcurlConan(ConanFile):
         self._cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
         self._cmake.definitions["CURL_STATICLIB"] = not self.options.shared
         self._cmake.definitions["CMAKE_DEBUG_POSTFIX"] = ""
-        if tools.Version(self.version) >= "7.72.0":
+        if tools.Version(self.version) >= "7.81.0":
+            self._cmake.definitions["CURL_USE_SCHANNEL"] = self.options.with_ssl == "schannel"
+        elif tools.Version(self.version) >= "7.72.0":
             self._cmake.definitions["CMAKE_USE_SCHANNEL"] = self.options.with_ssl == "schannel"
         else:
             self._cmake.definitions["CMAKE_USE_WINSSL"] = self.options.with_ssl == "schannel"
-        self._cmake.definitions["CMAKE_USE_OPENSSL"] = self.options.with_ssl == "openssl"
-        if tools.Version(self.version) >= "7.70.0":
+        if tools.Version(self.version) >= "7.81.0":
+            self._cmake.definitions["CURL_USE_OPENSSL"] = self.options.with_ssl == "openssl"
+        else:
+            self._cmake.definitions["CMAKE_USE_OPENSSL"] = self.options.with_ssl == "openssl"
+        if tools.Version(self.version) >= "7.81.0":
+            self._cmake.definitions["CURL_USE_WOLFSSL"] = self.options.with_ssl == "wolfssl"
+        elif tools.Version(self.version) >= "7.70.0":
             self._cmake.definitions["CMAKE_USE_WOLFSSL"] = self.options.with_ssl == "wolfssl"
         self._cmake.definitions["USE_NGHTTP2"] = self.options.with_nghttp2
         self._cmake.definitions["CURL_ZLIB"] = self.options.with_zlib
         self._cmake.definitions["CURL_BROTLI"] = self.options.with_brotli
         if self._has_zstd_option:
             self._cmake.definitions["CURL_ZSTD"] = self.options.with_zstd
-        self._cmake.definitions["CMAKE_USE_LIBSSH2"] = self.options.with_libssh2
+        if tools.Version(self.version) >= "7.81.0":
+            self._cmake.definitions["CURL_USE_LIBSSH2"] = self.options.with_libssh2
+        else:
+            self._cmake.definitions["CMAKE_USE_LIBSSH2"] = self.options.with_libssh2
         self._cmake.definitions["ENABLE_ARES"] = self.options.with_c_ares
         self._cmake.definitions["CURL_DISABLE_PROXY"] = not self.options.with_proxy
         self._cmake.definitions["USE_LIBRTMP"] = self.options.with_librtmp

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.82.0":
+    folder: all
   "7.80.0":
     folder: all
   "7.79.1":


### PR DESCRIPTION
Specify library name and version:  **libcurl/7.82.0**

- Add libcurl version 7.82.0
- Adapt recipe to upstream renaming of cmake identifiers, starting with version 7.81.0: https://github.com/curl/curl/issues/7988

Closes #10418

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
