### PR TITLE
cppcheck/*: Test against dummy file fix #5831

### DIFF
--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -2,18 +2,8 @@ sources:
   "2.7.5":
     url: "https://github.com/danmar/cppcheck/archive/2.7.5.tar.gz"
     sha256: "6c7ac29e57fa8b3ac7be224510200e579d5a90217e2152591ef46ffc947d8f78"
-  "2.7.4":
-    url: "https://github.com/danmar/cppcheck/archive/2.7.4.tar.gz"
-    sha256: "f0558c497b7807763325f3a821f1c72b743e5d888b037b8d32157dd07d6c26e1"
 patches:
   "2.7.5":
-    - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0002-htmlreport-python3.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0003-handle-exename-on-macos.patch"
-      base_path: "source_subfolder"
-  "2.7.4":
     - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0002-htmlreport-python3.patch"

--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -8,27 +8,6 @@ sources:
   "2.7.3":
     url: "https://github.com/danmar/cppcheck/archive/2.7.3.tar.gz"
     sha256: "edda6dc9627ccb2b0132a2e43e7b7deff47e479ae3dc3af1c1fbc8a66699a113"
-  "2.7.1":
-    url: "https://github.com/danmar/cppcheck/archive/2.7.1.tar.gz"
-    sha256: "f4d4ec42eb214b113c6a7ca7aaf6bafa92c33029560223049b46ac12f17f54b8"
-  "2.6":
-    url: "https://github.com/danmar/cppcheck/archive/2.6.tar.gz"
-    sha256: "99f0c5cf58a0072876c4deb114f3f5f798c933b8e459cddb00a061c8bb4dd765"
-  "2.5":
-    url: "https://github.com/danmar/cppcheck/archive/2.5.tar.gz"
-    sha256: "dc27154d799935c96903dcc46653c526c6f4148a6912b77d3a50cb35dabd82e1"
-  "2.4.1":
-    url: "https://github.com/danmar/cppcheck/archive/2.4.1.tar.gz"
-    sha256: "11a9d9fe5305a105561655c45d2cd83cb30fbc87b41d0569de1b00a1a314867f"
-  "2.4":
-    url: "https://github.com/danmar/cppcheck/archive/2.4.tar.gz"
-    sha256: "d1ac6a1eaf24f2f54df5a164c7e37d1e0624cc094a4622e226a73b53ede1eeb8"
-  "2.3":
-    url: "https://github.com/danmar/cppcheck/archive/2.3.tar.gz"
-    sha256: "3c622628ebf46f68909c7a96743b07b6207894a0772fbe802603732152ab1035"
-  "2.2":
-    url: "https://github.com/danmar/cppcheck/archive/2.2.tar.gz"
-    sha256: "ad96290a1842c5934bf9c4268cb270953f3078d4ce33a9a53922d6cb6daf61aa"
 patches:
   "2.7.5":
     - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
@@ -42,41 +21,6 @@ patches:
       base_path: "source_subfolder"
   "2.7.3":
     - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0002-htmlreport-python3.patch"
-      base_path: "source_subfolder"
-  "2.7.1":
-    - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0002-htmlreport-python3.patch"
-      base_path: "source_subfolder"
-  "2.6":
-    - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0002-htmlreport-python3.patch"
-      base_path: "source_subfolder"
-  "2.5":
-    - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0002-htmlreport-python3.patch"
-      base_path: "source_subfolder"
-  "2.4.1":
-    - patch_file: "patches/0001-cmake-source-dir.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0002-htmlreport-python3.patch"
-      base_path: "source_subfolder"
-  "2.4":
-    - patch_file: "patches/0001-cmake-source-dir.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0002-htmlreport-python3.patch"
-      base_path: "source_subfolder"
-  "2.3":
-    - patch_file: "patches/0001-cmake-source-dir.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0002-htmlreport-python3.patch"
-      base_path: "source_subfolder"
-  "2.2":
-    - patch_file: "patches/0001-cmake-source-dir.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0002-htmlreport-python3.patch"
       base_path: "source_subfolder"

--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -2,8 +2,18 @@ sources:
   "2.7.5":
     url: "https://github.com/danmar/cppcheck/archive/2.7.5.tar.gz"
     sha256: "6c7ac29e57fa8b3ac7be224510200e579d5a90217e2152591ef46ffc947d8f78"
+  "2.7.4":
+    url: "https://github.com/danmar/cppcheck/archive/2.7.4.tar.gz"
+    sha256: "f0558c497b7807763325f3a821f1c72b743e5d888b037b8d32157dd07d6c26e1"
 patches:
   "2.7.5":
+    - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-htmlreport-python3.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0003-handle-exename-on-macos.patch"
+      base_path: "source_subfolder"
+  "2.7.4":
     - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0002-htmlreport-python3.patch"

--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -14,6 +14,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0002-htmlreport-python3.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0003-handle-exename-on-macos.patch"
+      base_path: "source_subfolder"
   "2.7.4":
     - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
       base_path: "source_subfolder"

--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -5,9 +5,6 @@ sources:
   "2.7.4":
     url: "https://github.com/danmar/cppcheck/archive/2.7.4.tar.gz"
     sha256: "f0558c497b7807763325f3a821f1c72b743e5d888b037b8d32157dd07d6c26e1"
-  "2.7.3":
-    url: "https://github.com/danmar/cppcheck/archive/2.7.3.tar.gz"
-    sha256: "edda6dc9627ccb2b0132a2e43e7b7deff47e479ae3dc3af1c1fbc8a66699a113"
 patches:
   "2.7.5":
     - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
@@ -17,11 +14,6 @@ patches:
     - patch_file: "patches/0003-handle-exename-on-macos.patch"
       base_path: "source_subfolder"
   "2.7.4":
-    - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0002-htmlreport-python3.patch"
-      base_path: "source_subfolder"
-  "2.7.3":
     - patch_file: "patches/0001-cmake-source-dir-2.5.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0002-htmlreport-python3.patch"

--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -18,3 +18,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0002-htmlreport-python3.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0003-handle-exename-on-macos.patch"
+      base_path: "source_subfolder"

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -17,6 +17,7 @@ class CppcheckConan(ConanFile):
     options = {"with_z3": [True, False], "have_rules": [True, False]}
     default_options = {"with_z3": True, "have_rules": True}
     exports_sources = ["CMakeLists.txt", "patches/**"]
+    build_policy = "always"
 
     @property
     def _source_subfolder(self):

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+import functools
 import os
 
 required_conan_version = ">=1.33.0"
@@ -16,8 +17,6 @@ class CppcheckConan(ConanFile):
     options = {"with_z3": [True, False], "have_rules": [True, False]}
     default_options = {"with_z3": True, "have_rules": True}
     exports_sources = ["CMakeLists.txt", "patches/**"]
-
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -44,16 +43,16 @@ class CppcheckConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["USE_Z3"] = self.options.with_z3
-        self._cmake.definitions["HAVE_RULES"] = self.options.have_rules
-        self._cmake.definitions["USE_MATCHCOMPILER"] = "Auto"
-        self._cmake.definitions["ENABLE_OSS_FUZZ"] = False
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["USE_Z3"] = self.options.with_z3
+        cmake.definitions["HAVE_RULES"] = self.options.have_rules
+        cmake.definitions["USE_MATCHCOMPILER"] = "Auto"
+        cmake.definitions["ENABLE_OSS_FUZZ"] = False
+        cmake.definitions["FILESDIR"] = os.path.join(self.package_folder, "bin")
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
 
     def build(self):
         self._patch_sources()

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -50,7 +50,6 @@ class CppcheckConan(ConanFile):
         cmake.definitions["HAVE_RULES"] = self.options.have_rules
         cmake.definitions["USE_MATCHCOMPILER"] = "Auto"
         cmake.definitions["ENABLE_OSS_FUZZ"] = False
-        cmake.definitions["FILESDIR"] = os.path.join(self.package_folder, "bin")
         cmake.configure(build_folder=self._build_subfolder)
         return cmake
 

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -17,7 +17,6 @@ class CppcheckConan(ConanFile):
     options = {"with_z3": [True, False], "have_rules": [True, False]}
     default_options = {"with_z3": True, "have_rules": True}
     exports_sources = ["CMakeLists.txt", "patches/**"]
-    build_policy = "always"
 
     @property
     def _source_subfolder(self):

--- a/recipes/cppcheck/all/patches/0003-handle-exename-on-macos.patch
+++ b/recipes/cppcheck/all/patches/0003-handle-exename-on-macos.patch
@@ -1,11 +1,11 @@
-commit efa44a75124859cf980ea68ff91620e6711d076c
+commit 3b54e7610c8e512432fefd02c047ade142cde19a
 Author: Martin Delille <martin@delille.org>
 Date:   Sun May 1 19:32:12 2022 +0200
 
     Handle exename on macos
 
 diff --git a/cli/main.cpp b/cli/main.cpp
-index ca48497d2..5cf5b6d78 100644
+index ca48497d2..dae782ce6 100644
 --- a/cli/main.cpp
 +++ b/cli/main.cpp
 @@ -76,6 +76,12 @@
@@ -21,13 +21,14 @@ index ca48497d2..5cf5b6d78 100644
  /**
   * Main function of cppcheck
   *
-@@ -95,6 +101,10 @@ int main(int argc, char* argv[])
+@@ -95,6 +101,11 @@ int main(int argc, char* argv[])
      GetModuleFileNameA(nullptr, exename, sizeof(exename)/sizeof(exename[0])-1);
      argv[0] = exename;
  #endif
 +#if defined(__APPLE__)
-+	uint32_t size = sizeof(exename);
-+	_NSGetExecutablePath(exename, &size);
++    uint32_t size = sizeof(exename);
++    _NSGetExecutablePath(exename, &size);
++    argv[0] = exename;
 +#endif
  // *INDENT-OFF*
  #ifdef NDEBUG

--- a/recipes/cppcheck/all/patches/0003-handle-exename-on-macos.patch
+++ b/recipes/cppcheck/all/patches/0003-handle-exename-on-macos.patch
@@ -1,0 +1,34 @@
+commit efa44a75124859cf980ea68ff91620e6711d076c
+Author: Martin Delille <martin@delille.org>
+Date:   Sun May 1 19:32:12 2022 +0200
+
+    Handle exename on macos
+
+diff --git a/cli/main.cpp b/cli/main.cpp
+index ca48497d2..5cf5b6d78 100644
+--- a/cli/main.cpp
++++ b/cli/main.cpp
+@@ -76,6 +76,12 @@
+ static char exename[1024] = {0};
+ #endif
+ 
++#if defined(__APPLE__)
++#include <mach-o/dyld.h>
++
++static char exename[1024] = {0};
++#endif
++
+ /**
+  * Main function of cppcheck
+  *
+@@ -95,6 +101,10 @@ int main(int argc, char* argv[])
+     GetModuleFileNameA(nullptr, exename, sizeof(exename)/sizeof(exename[0])-1);
+     argv[0] = exename;
+ #endif
++#if defined(__APPLE__)
++	uint32_t size = sizeof(exename);
++	_NSGetExecutablePath(exename, &size);
++#endif
+ // *INDENT-OFF*
+ #ifdef NDEBUG
+     try {

--- a/recipes/cppcheck/all/test_package/conanfile.py
+++ b/recipes/cppcheck/all/test_package/conanfile.py
@@ -1,13 +1,17 @@
 from conans import ConanFile, tools
 import sys
+import os
+import shutil
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch"
 
     def test(self):
+        shutil.copy(os.path.join(self.source_folder, "file_to_check.cpp"),
+                    os.path.join(self.build_folder, "file_to_check.cpp"))
         if not tools.cross_building(self.settings):
-            self.run("cppcheck --enable=warning,style,performance --std=c++11 ./file_to_check.cpp",
+            self.run("cppcheck --enable=warning,style,performance --std=c++11 .",
                     cwd=self.source_folder, run_environment=True)
             # On windows we need to explicitly use python to run the python script
             if self.settings.os == 'Windows':

--- a/recipes/cppcheck/all/test_package/conanfile.py
+++ b/recipes/cppcheck/all/test_package/conanfile.py
@@ -1,17 +1,14 @@
 from conans import ConanFile, tools
-import os
-import shutil
 import sys
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch"
-    exports_sources = "file_to_check.cpp"
 
     def test(self):
-        shutil.copy(os.path.join(self.source_folder, "file_to_check.cpp"), self.build_folder)
         if not tools.cross_building(self.settings):
-            self.run("cppcheck .", run_environment=True)
+            self.run("cppcheck  --enable=warning,style,performance --std=c++11 ./file_to_check.cpp",
+                    cwd=self.source_folder, run_environment=True)
             # On windows we need to explicitly use python to run the python script
             if self.settings.os == 'Windows':
                 self.run("{} {} -h".format(sys.executable, tools.get_env("CPPCHECK_HTMLREPORT")))

--- a/recipes/cppcheck/all/test_package/conanfile.py
+++ b/recipes/cppcheck/all/test_package/conanfile.py
@@ -1,13 +1,17 @@
 from conans import ConanFile, tools
+import os
+import shutil
 import sys
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch"
+    exports_sources = "file_to_check.cpp"
 
     def test(self):
+        shutil.copy(os.path.join(self.source_folder, "file_to_check.cpp"), self.build_folder)
         if not tools.cross_building(self.settings):
-            self.run("cppcheck --version", run_environment=True)
+            self.run("cppcheck .", run_environment=True)
             # On windows we need to explicitly use python to run the python script
             if self.settings.os == 'Windows':
                 self.run("{} {} -h".format(sys.executable, tools.get_env("CPPCHECK_HTMLREPORT")))

--- a/recipes/cppcheck/all/test_package/conanfile.py
+++ b/recipes/cppcheck/all/test_package/conanfile.py
@@ -7,7 +7,7 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self.settings):
-            self.run("cppcheck  --enable=warning,style,performance --std=c++11 ./file_to_check.cpp",
+            self.run("cppcheck --enable=warning,style,performance --std=c++11 ./file_to_check.cpp",
                     cwd=self.source_folder, run_environment=True)
             # On windows we need to explicitly use python to run the python script
             if self.settings.os == 'Windows':

--- a/recipes/cppcheck/all/test_package/file_to_check.cpp
+++ b/recipes/cppcheck/all/test_package/file_to_check.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -5,17 +5,3 @@ versions:
     folder: all
   "2.7.3":
     folder: all
-  "2.7.1":
-    folder: all
-  "2.6":
-    folder: all
-  "2.5":
-    folder: all
-  "2.4.1":
-    folder: all
-  "2.4":
-    folder: all
-  "2.3":
-    folder: all
-  "2.2":
-    folder: all

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -19,4 +19,3 @@ versions:
     folder: all
   "2.2":
     folder: all
-

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.7.5":
     folder: all
+  "2.7.4":
+    folder: all

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -1,5 +1,3 @@
 versions:
   "2.7.5":
     folder: all
-  "2.7.4":
-    folder: all

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -3,5 +3,3 @@ versions:
     folder: all
   "2.7.4":
     folder: all
-  "2.7.3":
-    folder: all


### PR DESCRIPTION
Specify library name and version:  **cppcheck/...**

This test hightlights an issue in the current cppcheck recipe which fails to detect std.cfg.
Any idea how to fix this ?

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
