### PR TITLE
Add sentry-breakpad/0.4.17

### DIFF
--- a/recipes/sentry-breakpad/all/conandata.yml
+++ b/recipes/sentry-breakpad/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.4.16":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.16/sentry-native.zip"
-    sha256: "abf2f6e0e0221f4aa42f7a68e70dab3a9750777504633d50f3954ab8f7fde483"
+  "0.4.17":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.17/sentry-native.zip"
+    sha256: "38c9e180c29b6561c5f91ada154e191eabe9d7c270734cff81e55532878ec273"
   "0.4.15":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.15/sentry-native.zip"
     sha256: "ae3ac4efa76d431d8734d7b0b1bf9bbedaf2cbdb18dfc5c95e2411a67808cf29"

--- a/recipes/sentry-breakpad/all/conandata.yml
+++ b/recipes/sentry-breakpad/all/conandata.yml
@@ -5,9 +5,9 @@ sources:
   "0.4.15":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.15/sentry-native.zip"
     sha256: "ae3ac4efa76d431d8734d7b0b1bf9bbedaf2cbdb18dfc5c95e2411a67808cf29"
-  "0.4.14":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.14/sentry-native.zip"
-    sha256: "483db8f3bd341fc2f07a6a9678f0eb2d854d1bacafa8d7aeeed15a3bd548de16"
+  "0.4.13":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.13/sentry-native.zip"
+    sha256: "85e0e15d7fb51388d967ab09e7ee1b95f82330a469a93c65d964ea1afd5e6127"
   "0.2.6":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.2.6/sentry-native-0.2.6.zip"
     sha256: "0d93bd77f70a64f3681d4928dfca6b327374218a84d33ee31489114d8e4716c0"

--- a/recipes/sentry-breakpad/all/conandata.yml
+++ b/recipes/sentry-breakpad/all/conandata.yml
@@ -1,34 +1,13 @@
 sources:
+  "0.4.16":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.16/sentry-native.zip"
+    sha256: "abf2f6e0e0221f4aa42f7a68e70dab3a9750777504633d50f3954ab8f7fde483"
   "0.4.15":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.15/sentry-native.zip"
     sha256: "ae3ac4efa76d431d8734d7b0b1bf9bbedaf2cbdb18dfc5c95e2411a67808cf29"
   "0.4.14":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.14/sentry-native.zip"
     sha256: "483db8f3bd341fc2f07a6a9678f0eb2d854d1bacafa8d7aeeed15a3bd548de16"
-  "0.4.13":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.13/sentry-native.zip"
-    sha256: "85e0e15d7fb51388d967ab09e7ee1b95f82330a469a93c65d964ea1afd5e6127"
-  "0.4.12":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.12/sentry-native.zip"
-    sha256: "d7fa804995124c914a3abe077a73307960bbcadfbba9021e8ccbd05c7ba45f88"
-  "0.4.11":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.11/sentry-native.zip"
-    sha256: "4a0dae61ab718ac23fc7041de3236a2929a12a5a6594b7ec375dc55fb33aabce"
-  "0.4.10":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.10/sentry-native.zip"
-    sha256: "8926735b5c27ad2ae0e40098c53f45a031cdc584cb4519ffc93d04de28df6a7a"
-  "0.4.9":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.9/sentry-native.zip"
-    sha256: "559344bad846b7868c182b22df0cd9869c31ebf46a222ac7a6588aab0211af7d"
-  "0.4.8":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.8/sentry-native.zip"
-    sha256: "35afb62eecc5e719187c81f5c89b4e3d3c45c7b3c1597836202989fa40c79178"
-  "0.4.7":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.7/sentry-native.zip"
-    sha256: "fb16658b250c342ed05e4d2edeff8ec806d9db758dfa188b78070bdfaf54f598"
-  "0.4.1":
-    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.1/sentry-native.zip"
-    sha256: "ffeec2a8aa6d2f274123cd16c62ad6d5d4c6f993e44e9e2f88210261ccb51fcc"
   "0.2.6":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.2.6/sentry-native-0.2.6.zip"
     sha256: "0d93bd77f70a64f3681d4928dfca6b327374218a84d33ee31489114d8e4716c0"

--- a/recipes/sentry-breakpad/all/conanfile.py
+++ b/recipes/sentry-breakpad/all/conanfile.py
@@ -1,8 +1,9 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import functools
 import os
 
-required_conan_version = ">=1.28.0"
+required_conan_version = ">=1.45.0"
 
 
 class SentryBreakpadConan(ConanFile):
@@ -22,8 +23,6 @@ class SentryBreakpadConan(ConanFile):
     }
     exports_sources = "CMakeLists.txt", "patches/*"
     generators = "cmake"
-
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -51,12 +50,11 @@ class SentryBreakpadConan(ConanFile):
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.configure()
-        return self._cmake
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/sentry-breakpad/config.yml
+++ b/recipes/sentry-breakpad/config.yml
@@ -1,23 +1,9 @@
 versions:
+  "0.4.16":
+    folder: all
   "0.4.15":
     folder: all
   "0.4.14":
-    folder: all
-  "0.4.13":
-    folder: all
-  "0.4.12":
-    folder: all
-  "0.4.11":
-    folder: all
-  "0.4.10":
-    folder: all
-  "0.4.9":
-    folder: all
-  "0.4.8":
-    folder: all
-  "0.4.7":
-    folder: all
-  "0.4.1":
     folder: all
   "0.2.6":
     folder: all

--- a/recipes/sentry-breakpad/config.yml
+++ b/recipes/sentry-breakpad/config.yml
@@ -3,7 +3,7 @@ versions:
     folder: all
   "0.4.15":
     folder: all
-  "0.4.14":
+  "0.4.13":
     folder: all
   "0.2.6":
     folder: all

--- a/recipes/sentry-breakpad/config.yml
+++ b/recipes/sentry-breakpad/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.4.16":
+  "0.4.17":
     folder: all
   "0.4.15":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **sentry-breakpad/0.4.17**

I also clean old versions including 0.4.14 since sentry-native doesn't handle it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
