### PR TITLE
draco: fix CMake config file & target name

### DIFF
--- a/recipes/draco/all/conanfile.py
+++ b/recipes/draco/all/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake, tools
 import functools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class DracoConan(ConanFile):
@@ -157,9 +157,9 @@ class DracoConan(ConanFile):
                 )
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "Draco"
-        self.cpp_info.names["cmake_find_package_multi"] = "Draco"
-        self.cpp_info.names["pkg_config"] = "draco"
+        self.cpp_info.set_property("cmake_file_name", "draco")
+        self.cpp_info.set_property("cmake_target_name", "draco::draco")
+        self.cpp_info.set_property("pkg_config_name", "draco")
         self.cpp_info.libs = ["draco"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/draco/all/test_package/CMakeLists.txt
+++ b/recipes/draco/all/test_package/CMakeLists.txt
@@ -1,9 +1,11 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(draco REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} draco::draco)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/draco/all/test_package/conanfile.py
+++ b/recipes/draco/all/test_package/conanfile.py
@@ -3,8 +3,8 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Since 1.4.0, config file is `draco-config.cmake` (but without an imported target). Before 1.4.0 it was `DracoConfig.cmake` but the file was broken.
In master branch, `draco::draco` import target is now available (since https://github.com/google/draco/pull/840). 

Therefore I think it's better to unconditionally change CMake names defined in this recipe.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
