### PR TITLE
(#10437) Bump libusb to 1.0.26

### DIFF
--- a/recipes/libusb/all/conandata.yml
+++ b/recipes/libusb/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   "1.0.25":
     sha256: 8a28ef197a797ebac2702f095e81975e2b02b2eeff2774fa909c78a74ef50849
     url: https://github.com/libusb/libusb/releases/download/v1.0.25/libusb-1.0.25.tar.bz2
+  "1.0.26":
+    sha256: 12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5
+    url: https://github.com/libusb/libusb/releases/download/v1.0.26/libusb-1.0.26.tar.bz2

--- a/recipes/libusb/config.yml
+++ b/recipes/libusb/config.yml
@@ -6,3 +6,5 @@ versions:
     folder: all
   "1.0.25":
     folder: all
+  "1.0.26":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libusb/1.0.26**

2022-04-10: v1.0.26
* Fix regression with transfer free's after closing device
* Fix regression with destroyed context if API is misused
* Workaround for applications using missing default context
* Fix hotplog enumeration regression
* Fix Windows isochronous transfer regression since 1.0.24
* Fix macOS exit crash in some multi-context cases
* Build fixes for various platforms and configurations
* Fix Windows HID multi-interface product string retrieval
* Update isochronous OUT packet actual lengths on Windows
* Add interface bound checking for broken devices
* Add umockdev tests on Linux

closes #10437 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
