### PR TITLE
websocketpp: bump dependencies + modernize

### DIFF
--- a/recipes/websocketpp/all/conandata.yml
+++ b/recipes/websocketpp/all/conandata.yml
@@ -1,11 +1,11 @@
 sources:
-  "0.8.1":
-    url: "https://github.com/zaphoyd/websocketpp/archive/0.8.1.tar.gz"
-    sha256: "178899de48c02853b55b1ea8681599641cedcdfce59e56beaff3dd0874bf0286"
   "0.8.2":
     url: "https://github.com/zaphoyd/websocketpp/archive/0.8.2.tar.gz"
     sha256: "6ce889d85ecdc2d8fa07408d6787e7352510750daa66b5ad44aacb47bea76755"
+  "0.8.1":
+    url: "https://github.com/zaphoyd/websocketpp/archive/0.8.1.tar.gz"
+    sha256: "178899de48c02853b55b1ea8681599641cedcdfce59e56beaff3dd0874bf0286"
 patches:
   "0.8.1":
-    - base_path: "source_subfolder"
-      patch_file: "patches/websocket_boost_support_1_7_x.patch"
+    - patch_file: "patches/websocket_boost_support_1_7_x.patch"
+      base_path: "source_subfolder"

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -30,15 +30,15 @@ class WebsocketPPConan(ConanFile):
 
     def requirements(self):
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1l")
+            self.requires("openssl/1.1.1n")
 
         if self.options.with_zlib:
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.12")
 
         if self.options.asio == "standalone":
-            self.requires("asio/1.21.0")
+            self.requires("asio/1.22.1")
         elif self.options.asio == "boost":
-            self.requires("boost/1.77.0")
+            self.requires("boost/1.78.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -1,7 +1,7 @@
-import os
 from conans import ConanFile, tools
+import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class WebsocketPPConan(ConanFile):
@@ -11,8 +11,8 @@ class WebsocketPPConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/zaphoyd/websocketpp"
     license = "BSD-3-Clause"
+
     settings = "os", "arch", "compiler", "build_type"
-    exports_sources = ["patches/*"]
     options = {
         "asio": ["boost", "standalone", False],
         "with_openssl": [True, False],
@@ -28,6 +28,10 @@ class WebsocketPPConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
+    def export_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
     def requirements(self):
         if self.options.with_openssl:
             self.requires("openssl/1.1.1n")
@@ -39,6 +43,9 @@ class WebsocketPPConan(ConanFile):
             self.requires("asio/1.22.1")
         elif self.options.asio == "boost":
             self.requires("boost/1.78.0")
+
+    def package_id(self):
+        self.info.header_only()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -54,8 +61,7 @@ class WebsocketPPConan(ConanFile):
         self.copy(pattern=os.path.join("websocketpp","*.hpp"), dst="include", src=self._source_subfolder)
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "websocketpp")
+        self.cpp_info.set_property("cmake_target_name", "websocketpp::websocketpp")
         if self.options.asio == "standalone":
             self.cpp_info.defines.extend(["ASIO_STANDALONE", "_WEBSOCKETPP_CPP11_STL_"])
-
-    def package_id(self):
-        self.info.header_only()

--- a/recipes/websocketpp/all/test_package/CMakeLists.txt
+++ b/recipes/websocketpp/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(websocketpp REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} websocketpp::websocketpp)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/websocketpp/all/test_package/conanfile.py
+++ b/recipes/websocketpp/all/test_package/conanfile.py
@@ -1,10 +1,10 @@
-import os
 from conans import ConanFile, CMake, tools
+import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/websocketpp/config.yml
+++ b/recipes/websocketpp/config.yml
@@ -1,6 +1,5 @@
----
 versions:
-  "0.8.1":
-    folder: all
   "0.8.2":
+    folder: all
+  "0.8.1":
     folder: all


### PR DESCRIPTION
I've added explicit config & imported target names (from https://github.com/zaphoyd/websocketpp/blob/1b11fd301531e6df35a6107c1e8665b1e77a2d8e/CMakeLists.txt#L266-L281 + https://github.com/zaphoyd/websocketpp/blob/1b11fd301531e6df35a6107c1e8665b1e77a2d8e/websocketpp-config.cmake.in)

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
