### PR TITLE
stringtoolbox: add recipe

### DIFF
--- a/recipes/stringtoolbox/all/conandata.yml
+++ b/recipes/stringtoolbox/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.4":
+    url: "https://github.com/chrberger/stringtoolbox/archive/refs/tags/v0.0.4.tar.gz"
+    sha256: "5778bc508f880e9f9d139446059766047108f941cd08f8fba102464289ebb967"

--- a/recipes/stringtoolbox/all/conanfile.py
+++ b/recipes/stringtoolbox/all/conanfile.py
@@ -1,0 +1,31 @@
+from conans import ConanFile, tools
+
+required_conan_version = ">=1.33.0"
+
+class DawHeaderLibrariesConan(ConanFile):
+    name = "stringtoolbox"
+    license = "MIT"
+    description = "A simple header-only, single-file string toolbox library for C++."
+    topics = ("string", "header-only",)
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/chrberger/stringtoolbox"
+    settings = "os", "arch", "compiler", "build_type",
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def validate(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            tools.check_min_cppstd(self, "11")
+
+    def package_id(self):
+        self.info.header_only()
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy("LICENSE*", "licenses", self._source_subfolder)
+        self.copy("stringtoolbox.hpp", "include", self._source_subfolder)

--- a/recipes/stringtoolbox/all/test_package/CMakeLists.txt
+++ b/recipes/stringtoolbox/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(stringtoolbox CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} stringtoolbox::stringtoolbox)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/stringtoolbox/all/test_package/conanfile.py
+++ b/recipes/stringtoolbox/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class DawHeaderLibrariesTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/stringtoolbox/all/test_package/test_package.cpp
+++ b/recipes/stringtoolbox/all/test_package/test_package.cpp
@@ -1,0 +1,15 @@
+#include "stringtoolbox.hpp"
+
+#include <iostream>
+
+int main() {
+    std::string target = "  ABC ";
+
+    std::cout << target << std::endl;
+
+    stringtoolbox::trim(target);
+
+    std::cout << target << std::endl;
+
+    return 0;
+}

--- a/recipes/stringtoolbox/config.yml
+++ b/recipes/stringtoolbox/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.0.4":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **stringtoolbox/0.0.4**

stringtoolbox is reqiured by libcluon which I am going to add recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
