### PR TITLE
tmx: bump dependencies + relocatable shared lib on macOS

### DIFF
--- a/recipes/tmx/all/CMakeLists.txt
+++ b/recipes/tmx/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper C)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/tmx/all/conanfile.py
+++ b/recipes/tmx/all/conanfile.py
@@ -46,11 +46,11 @@ class TmxConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def requirements(self):
-        self.requires("libxml2/2.9.12")
+        self.requires("libxml2/2.9.13")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.12")
         if self.options.with_zstd:
-            self.requires("zstd/1.5.1")
+            self.requires("zstd/1.5.2")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/tmx/all/conanfile.py
+++ b/recipes/tmx/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+import functools
 import os
 import textwrap
 
@@ -29,7 +30,6 @@ class TmxConan(ConanFile):
 
     exports_sources = "CMakeLists.txt"
     generators = "cmake", "cmake_find_package"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -60,16 +60,15 @@ class TmxConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "${CMAKE_BINARY_DIR}", "${CMAKE_CURRENT_BINARY_DIR}")
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["WANT_ZLIB"] = self.options.with_zlib
-        self._cmake.definitions["WANT_ZSTD"] = self.options.with_zstd
+        cmake = CMake(self)
+        cmake.definitions["WANT_ZLIB"] = self.options.with_zlib
+        cmake.definitions["WANT_ZSTD"] = self.options.with_zstd
         if self.options.with_zstd:
-            self._cmake.definitions["ZSTD_PREFER_STATIC"] = not self.options["zstd"].shared
-        self._cmake.configure()
-        return self._cmake
+            cmake.definitions["ZSTD_PREFER_STATIC"] = not self.options["zstd"].shared
+        cmake.configure()
+        return cmake
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- bump dependencies
- cache CMake configuration with `functools.lru_cache`

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
