### PR TITLE
aruco: bump dependencies + modernize

### DIFF
--- a/recipes/aruco/3.x.x/CMakeLists.txt
+++ b/recipes/aruco/3.x.x/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/aruco/3.x.x/conandata.yml
+++ b/recipes/aruco/3.x.x/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  3.1.12:
-    url: https://downloads.sourceforge.net/project/aruco/3.1.12/aruco-3.1.12.zip
-    sha256: 70b9ec8aa8eac6fe3f622201747a3e32c77bbb5f015e28a95c1c7c91f8ee8a09
+  "3.1.12":
+    url: "https://downloads.sourceforge.net/project/aruco/3.1.12/aruco-3.1.12.zip"
+    sha256: "70b9ec8aa8eac6fe3f622201747a3e32c77bbb5f015e28a95c1c7c91f8ee8a09"

--- a/recipes/aruco/3.x.x/conanfile.py
+++ b/recipes/aruco/3.x.x/conanfile.py
@@ -77,4 +77,5 @@ class ArucoConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "aruco")
+        self.cpp_info.includedirs.append(os.path.join("include", "aruco"))
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/aruco/3.x.x/conanfile.py
+++ b/recipes/aruco/3.x.x/conanfile.py
@@ -1,21 +1,30 @@
 from conans import ConanFile, tools, CMake
+import functools
 import os
 
+required_conan_version = ">=1.36.0"
 
-class LibnameConan(ConanFile):
+
+class ArucoConan(ConanFile):
     name = "aruco"
     description = "Augmented reality library based on OpenCV "
-    topics = ("conan", "aruco", "augmented reality")
+    topics = ("aruco", "augmented reality")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.uco.es/investiga/grupos/ava/node/26"
     license = "GPL-3.0-only"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [False, True],
+        "fPIC": [False, True],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
     exports_sources = "CMakeLists.txt"
     generators = "cmake", "cmake_find_package"
-    _cmake = None
-
-    settings = "os", "compiler", "arch", "build_type"
-    options = {"shared": [False, True], "fPIC": [False, True]}
-    default_options = {"shared": False, "fPIC": True}
 
     @property
     def _source_subfolder(self):
@@ -39,42 +48,35 @@ class LibnameConan(ConanFile):
         self.requires("zlib/1.2.11")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["ARUCO_DEVINSTALL"] = "ON"
-        self._cmake.definitions["BUILD_TESTS"] = "OFF"
-        self._cmake.definitions["BUILD_GLSAMPLES"] = "OFF"
-        self._cmake.definitions["BUILD_UTILS"] = "OFF"
-        self._cmake.definitions["BUILD_DEBPACKAGE"] = "OFF"
-        self._cmake.definitions["BUILD_SVM"] = "OFF"
-        self._cmake.definitions["INSTALL_DOC"] = "OFF"
-        self._cmake.definitions["USE_OWN_EIGEN3"] = "OFF"
-        self._cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["ARUCO_DEVINSTALL"] = True
+        cmake.definitions["BUILD_TESTS"] = False
+        cmake.definitions["BUILD_GLSAMPLES"] = False
+        cmake.definitions["BUILD_UTILS"] = False
+        cmake.definitions["BUILD_DEBPACKAGE"] = False
+        cmake.definitions["BUILD_SVM"] = False
+        cmake.definitions["INSTALL_DOC"] = False
+        cmake.definitions["USE_OWN_EIGEN3"] = False
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
 
     def build(self):
         cmake = self._configure_cmake()
         cmake.build()
 
     def package(self):
-        self.copy(
-            pattern="LICENSE", dst="licenses", src=self._source_subfolder
-        )
-
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.includedirs.append("include")
+        self.cpp_info.set_property("pkg_config_name", "aruco")
         self.cpp_info.includedirs.append(os.path.join("include", "aruco"))
         self.cpp_info.libs = tools.collect_libs(self)
-        self.cpp_info.names["pkg_config"] = "aruco"

--- a/recipes/aruco/3.x.x/conanfile.py
+++ b/recipes/aruco/3.x.x/conanfile.py
@@ -43,9 +43,9 @@ class ArucoConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("opencv/4.5.1")
-        self.requires("eigen/3.3.9")
-        self.requires("zlib/1.2.11")
+        self.requires("opencv/4.5.5")
+        self.requires("eigen/3.4.0")
+        self.requires("zlib/1.2.12")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/aruco/3.x.x/conanfile.py
+++ b/recipes/aruco/3.x.x/conanfile.py
@@ -78,5 +78,4 @@ class ArucoConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "aruco")
-        self.cpp_info.includedirs.append(os.path.join("include", "aruco"))
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/aruco/3.x.x/conanfile.py
+++ b/recipes/aruco/3.x.x/conanfile.py
@@ -45,7 +45,6 @@ class ArucoConan(ConanFile):
     def requirements(self):
         self.requires("opencv/4.5.5")
         self.requires("eigen/3.4.0")
-        self.requires("zlib/1.2.12")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/aruco/3.x.x/test_package/CMakeLists.txt
+++ b/recipes/aruco/3.x.x/test_package/CMakeLists.txt
@@ -1,12 +1,11 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
-set(CMAKE_CXX_STANDARD 11)
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-find_package(aruco REQUIRED)
+find_package(aruco REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} aruco::aruco)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/aruco/3.x.x/test_package/conanfile.py
+++ b/recipes/aruco/3.x.x/test_package/conanfile.py
@@ -3,10 +3,8 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
-
-    settings = "os", "compiler", "arch", "build_type"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -14,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/aruco/config.yml
+++ b/recipes/aruco/config.yml
@@ -1,3 +1,3 @@
 versions:
-  3.1.12:
+  "3.1.12":
     folder: 3.x.x


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- bump dependencies
- remove zlib from requirements (not a direct dependency)
- `PkgConfigDeps` support
- cache CMake configuration with `functools.lru_cache`

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
