### PR TITLE
zint: bump dependencies + modernize

### DIFF
--- a/recipes/zint/all/CMakeLists.txt
+++ b/recipes/zint/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+conan_basic_setup(TARGETS KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/zint/all/conanfile.py
+++ b/recipes/zint/all/conanfile.py
@@ -55,9 +55,9 @@ class ZintConan(ConanFile):
             del self.settings.compiler.cppstd
 
     def requirements(self):
-        self.requires("zlib/1.2.12")
         if self.options.with_libpng:
             self.requires("libpng/1.6.37")
+            self.requires("zlib/1.2.12")
         if self.options.with_qt:
             self.requires("qt/5.15.3")
 
@@ -106,11 +106,10 @@ class ZintConan(ConanFile):
 
         self.cpp_info.components["libzint"].set_property("cmake_target_name", "Zint::Zint")
         self.cpp_info.components["libzint"].libs = ["zint" if self.options.shared else "zint-static"]
-        self.cpp_info.components["libzint"].requires = ["zlib::zlib"]
         if self.settings.os == "Windows" and self.options.shared:
             self.cpp_info.components["libzint"].defines = ["ZINT_DLL"]
         if self.options.with_libpng:
-            self.cpp_info.components["libzint"].requires.append("libpng::libpng")
+            self.cpp_info.components["libzint"].requires.extend(["libpng::libpng", "zlib::zlib"])
 
         if self.options.with_qt:
             self.cpp_info.components["libqzint"].set_property("cmake_target_name", "Zint::QZint")

--- a/recipes/zint/all/conanfile.py
+++ b/recipes/zint/all/conanfile.py
@@ -38,11 +38,11 @@ class ZintConan(ConanFile):
         return "build_subfolder"
 
     def requirements(self):
-        self.requires("zlib/1.2.11")
+        self.requires("zlib/1.2.12")
         if self.options.with_libpng:
             self.requires("libpng/1.6.37")
         if self.options.with_qt:
-            self.requires("qt/5.15.2")
+            self.requires("qt/5.15.3")
 
     def validate(self):
         if self.options.with_qt:

--- a/recipes/zint/all/conanfile.py
+++ b/recipes/zint/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 import functools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class ZintConan(ConanFile):
@@ -13,8 +13,7 @@ class ZintConan(ConanFile):
     homepage = "https://sourceforge.net/p/zint/code"
     license = "GPL-3.0"
     topics = ("barcode", "qt")
-    exports_sources = ["CMakeLists.txt", "patches/*"]
-    generators = "cmake", "cmake_find_package_multi", "cmake_find_package"
+
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -29,6 +28,8 @@ class ZintConan(ConanFile):
         "with_qt": False,
     }
 
+    generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
+
     @property
     def _source_subfolder(self):
         return "source_subfolder"
@@ -36,6 +37,19 @@ class ZintConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
 
     def requirements(self):
         self.requires("zlib/1.2.12")
@@ -45,17 +59,8 @@ class ZintConan(ConanFile):
             self.requires("qt/5.15.3")
 
     def validate(self):
-        if self.options.with_qt:
-            if not self.options["qt"].gui:
-                raise ConanInvalidConfiguration(f"{self.name} needs qt:gui=True")
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            del self.options.fPIC
+        if self.options.with_qt and not self.options["qt"].gui:
+            raise ConanInvalidConfiguration(f"{self.name} needs qt:gui=True")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -82,29 +87,37 @@ class ZintConan(ConanFile):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "Zint"
-        self.cpp_info.names["cmake_find_package_multi"] = "Zint"
+        self.cpp_info.set_property("cmake_file_name", "Zint")
+
+        self.cpp_info.components["libzint"].set_property("cmake_target_name", "Zint::Zint")
         self.cpp_info.components["libzint"].libs = ["zint" if self.options.shared else "zint-static"]
-        self.cpp_info.components["libzint"].names["cmake_find_package"] = "Zint"
-        self.cpp_info.components["libzint"].names["cmake_find_package_multi"] = "Zint"
         self.cpp_info.components["libzint"].requires = ["zlib::zlib"]
         if self.settings.os == "Windows" and self.options.shared:
             self.cpp_info.components["libzint"].defines = ["ZINT_DLL"]
-
         if self.options.with_libpng:
             self.cpp_info.components["libzint"].requires.append("libpng::libpng")
 
         if self.options.with_qt:
+            self.cpp_info.components["libqzint"].set_property("cmake_target_name", "Zint::QZint")
             self.cpp_info.components["libqzint"].libs = ["QZint"]
-            self.cpp_info.components["libqzint"].names["cmake_find_package"] = "QZint"
-            self.cpp_info.components["libqzint"].names["cmake_find_package_multi"] = "QZint"
             self.cpp_info.components["libqzint"].requires.extend([
                 "libzint",
                 "qt::qtGui",
             ])
             if self.settings.os == "Windows" and self.options.shared:
                 self.cpp_info.components["libqzint"].defines = ["QZINT_DLL"]
+
+        # Trick to only define Zint::QZint and Zint::Zint in CMakeDeps generator
+        self.cpp_info.set_property("cmake_target_name", "Zint::QZint" if self.options.with_qt else "Zint::Zint")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.names["cmake_find_package"] = "Zint"
+        self.cpp_info.names["cmake_find_package_multi"] = "Zint"
+        self.cpp_info.components["libzint"].names["cmake_find_package"] = "Zint"
+        self.cpp_info.components["libzint"].names["cmake_find_package_multi"] = "Zint"
+        if self.options.with_qt:
+            self.cpp_info.components["libqzint"].names["cmake_find_package"] = "QZint"
+            self.cpp_info.components["libqzint"].names["cmake_find_package_multi"] = "QZint"

--- a/recipes/zint/all/conanfile.py
+++ b/recipes/zint/all/conanfile.py
@@ -50,6 +50,9 @@ class ZintConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        if not self.options.with_qt:
+            del self.settings.compiler.libcxx
+            del self.settings.compiler.cppstd
 
     def requirements(self):
         self.requires("zlib/1.2.12")

--- a/recipes/zint/all/test_package/CMakeLists.txt
+++ b/recipes/zint/all/test_package/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(Zint REQUIRED)
+find_package(Zint REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE Zint::Zint)

--- a/recipes/zint/all/test_package/conanfile.py
+++ b/recipes/zint/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- bump dependencies
- `CMakeDeps` support
- remove hardcoded `CMAKE_OSX_SYSROOT` in upstream CMakeLists :sweat:

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
