### PR TITLE
libssh2: bump dependencies + relocatable shared lib on macOS

### DIFF
--- a/recipes/libssh2/all/CMakeLists.txt
+++ b/recipes/libssh2/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(cmake_wrapper)
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper C)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -87,6 +87,8 @@ class Libssh2Conan(ConanFile):
             cmake.definitions["CRYPTO_BACKEND"] = "mbedTLS"
         cmake.definitions["BUILD_EXAMPLES"] = False
         cmake.definitions["BUILD_TESTING"] = False
+        # To install relocatable shared lib on Macos by default
+        cmake.definitions["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         cmake.configure()
         return cmake
 

--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -56,9 +56,9 @@ class Libssh2Conan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.12")
         if self.options.crypto_backend == "openssl":
-            self.requires("openssl/1.1.1m")
+            self.requires("openssl/1.1.1n")
         elif self.options.crypto_backend == "mbedtls":
             self.requires("mbedtls/2.25.0")
 


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- bump zlib & openssl
- cache CMake configuration with `functools.lru_cache`

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
