### PR TITLE
http_parser: modernize

### DIFF
--- a/recipes/http_parser/all/CMakeLists.txt
+++ b/recipes/http_parser/all/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.4)
-project(cmake_wrapper LANGUAGES C)
+project(http_parser LANGUAGES C)
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/recipes/http_parser/all/conandata.yml
+++ b/recipes/http_parser/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
-  "2.9.2":
-    url: https://github.com/nodejs/http-parser/archive/v2.9.2.tar.gz
-    sha256: "5199500e352584852c95c13423edc5f0cb329297c81dd69c3c8f52a75496da08"
-  "2.9.3":
-    url: https://github.com/nodejs/http-parser/archive/v2.9.3.tar.gz
-    sha256: "8fa0ab8770fd8425a9b431fdbf91623c4d7a9cdb842b9339289bd2b0b01b0d3d"
   "2.9.4":
-    url: https://github.com/nodejs/http-parser/archive/v2.9.4.tar.gz
+    url: "https://github.com/nodejs/http-parser/archive/v2.9.4.tar.gz"
     sha256: "467b9e30fd0979ee301065e70f637d525c28193449e1b13fbcb1b1fab3ad224f"
+  "2.9.3":
+    url: "https://github.com/nodejs/http-parser/archive/v2.9.3.tar.gz"
+    sha256: "8fa0ab8770fd8425a9b431fdbf91623c4d7a9cdb842b9339289bd2b0b01b0d3d"
+  "2.9.2":
+    url: "https://github.com/nodejs/http-parser/archive/v2.9.2.tar.gz"
+    sha256: "5199500e352584852c95c13423edc5f0cb329297c81dd69c3c8f52a75496da08"

--- a/recipes/http_parser/all/test_package/CMakeLists.txt
+++ b/recipes/http_parser/all/test_package/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+find_package(http_parser REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} http_parser::http_parser)

--- a/recipes/http_parser/all/test_package/conanfile.py
+++ b/recipes/http_parser/all/test_package/conanfile.py
@@ -3,8 +3,8 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/http_parser/all/test_package/test_package.c
+++ b/recipes/http_parser/all/test_package/test_package.c
@@ -1,6 +1,6 @@
-#include "http_parser.h"
+#include <http_parser.h>
 
-#include <cstdio>
+#include <stdio.h>
 
 int main()
 {

--- a/recipes/http_parser/config.yml
+++ b/recipes/http_parser/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "2.9.2":
+  "2.9.4":
     folder: all
   "2.9.3":
     folder: all
-  "2.9.4":
+  "2.9.2":
     folder: all


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- C test package
- use `strip_root` in `source()`
- cache CMake configuration with `functools.lru_cache()`

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
