### PR TITLE
fix: #10477 Do not set -moutline-atomics under iOS arm64

### DIFF
--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -30,3 +30,6 @@ patches:
   "0.4.25":
     - patch_file: "patches/0001-disable-fPIC.patch"
       base_path: "source_subfolder"
+  "0.6.19":
+    - patch_file: "patches/0002-fix-902-Do-not-set-moutline-atomics-flag-under-iOS-a.patch"
+      base_path: "source_subfolder"

--- a/recipes/aws-c-common/all/patches/0002-fix-902-Do-not-set-moutline-atomics-flag-under-iOS-a.patch
+++ b/recipes/aws-c-common/all/patches/0002-fix-902-Do-not-set-moutline-atomics-flag-under-iOS-a.patch
@@ -1,0 +1,29 @@
+From e852ec2ef647fdb080f9b07d96688a53da69ab1e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E9=82=93=E4=BD=B3=E4=BD=B3?= <dengjiajia@corp.netease.com>
+Date: Mon, 25 Apr 2022 10:16:42 +0800
+Subject: [PATCH] fix: #902 Do not set -moutline-atomics flag under iOS arm64
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: 邓佳佳 <dengjiajia@corp.netease.com>
+---
+ cmake/AwsCFlags.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/AwsCFlags.cmake b/cmake/AwsCFlags.cmake
+index a0a4708..d6ef775 100644
+--- a/cmake/AwsCFlags.cmake
++++ b/cmake/AwsCFlags.cmake
+@@ -123,7 +123,7 @@ function(aws_set_common_properties target)
+        # -moutline-atomics generates code for both older load/store exclusive atomics and also
+        # Arm's Large System Extensions (LSE) which scale substantially better on large core count systems
+         check_c_compiler_flag("-moutline-atomics -Werror" HAS_MOUTLINE_ATOMICS)
+-        if (HAS_MOUTLINE_ATOMICS AND AWS_ARCH_ARM64)
++        if (HAS_MOUTLINE_ATOMICS AND AWS_ARCH_ARM64 AND NOT IOS)
+             list(APPEND AWS_C_FLAGS -moutline-atomics)
+         endif()
+ 
+-- 
+2.32.0 (Apple Git-132)
+


### PR DESCRIPTION
Signed-off-by: 邓佳佳 <dengjiajia@corp.netease.com>

Specify library name and version:  **aws-c-common/0.6.9**

Under iOS arm64, link aws-c-common got error like:

```
Undefined symbols for architecture arm64:
  "___aarch64_ldadd8_relax", referenced from:
      _aws_atomic_fetch_add_explicit in libaws-c-common.a(ref_count.c.o)
      _aws_atomic_fetch_sub_explicit in libaws-c-common.a(ref_count.c.o)
  "___aarch64_ldadd8_acq", referenced from:
      _aws_atomic_fetch_add_explicit in libaws-c-common.a(ref_count.c.o)
      _aws_atomic_fetch_sub_explicit in libaws-c-common.a(ref_count.c.o)
  "___aarch64_ldadd8_rel", referenced from:
      _aws_atomic_fetch_add_explicit in libaws-c-common.a(ref_count.c.o)
      _aws_atomic_fetch_sub_explicit in libaws-c-common.a(ref_count.c.o)
  "___aarch64_ldadd8_acq_rel", referenced from:
      _aws_atomic_fetch_add_explicit in libaws-c-common.a(ref_count.c.o)
      _aws_atomic_fetch_sub_explicit in libaws-c-common.a(ref_count.c.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This RP unset `-moutline-atomics` flag under iOS arm64.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
