### PR TITLE
added cci.20210422 flann release

### DIFF
--- a/recipes/flann/all/conandata.yml
+++ b/recipes/flann/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "1.9.1":
     sha256: b23b5f4e71139faa3bcb39e6bbcc76967fbaf308c4ee9d4f5bfbeceaa76cc5d3
     url: https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz
+  "cci.20210422":
+    sha256: 97ace141fedf7878fa746f3097b21f3ef79b07c8501eced857a1dd74ac6c8804
+    url: https://github.com/flann-lib/flann/archive/1d04523268c388dabf1c0865d69e1b638c8c7d9d.zip
 patches:
   "1.9.1":
     - patch_file: "patches/external-lz4-and-export-symbols.patch"

--- a/recipes/flann/all/conanfile.py
+++ b/recipes/flann/all/conanfile.py
@@ -24,7 +24,7 @@ class FlannConan(ConanFile):
         "with_hdf5": "deprecated",
     }
 
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package", "pkg_config"
     _cmake = None
 
     @property
@@ -113,6 +113,7 @@ class FlannConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         # Remove vc runtimes
         if self.settings.os == "Windows":
             if self.options.shared:

--- a/recipes/flann/config.yml
+++ b/recipes/flann/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.9.1":
     folder: all
+  "cci.20210422":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **flann/cci.20210422**

Flann development has staled in recent years and there seems to be no clear organisation around it. Although there seem to be [attempts at maintenance/releases on forks](https://github.com/tkircher/flann/releases/tag/1.9.2), there is [no indication](https://github.com/flann-lib/flann/issues/476#issuecomment-819205380) there will be any new releases/tags on official repo, [latest state of master branch contains several improvements](https://github.com/flann-lib/flann/compare/1.9.1...master) that are valuable to have in new conan package, most notably C++17 compatibility and built in LZ4 dependency improvements (currently handled through patch). 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
