### PR TITLE
aws-c-common(0.6.19): unset -moutline-atomics-flag under iOS arm64

### DIFF
--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -30,3 +30,6 @@ patches:
   "0.4.25":
     - patch_file: "patches/0001-disable-fPIC.patch"
       base_path: "source_subfolder"
+  "0.6.19":
+    - patch_file: "patches/0002-fix-902-unset-moutline-atomics-flag-under-iOS-arm64.patch"
+      base_path: "source_subfolder"

--- a/recipes/aws-c-common/all/patches/0002-fix-902-unset-moutline-atomics-flag-under-iOS-arm64.patch
+++ b/recipes/aws-c-common/all/patches/0002-fix-902-unset-moutline-atomics-flag-under-iOS-arm64.patch
@@ -1,0 +1,26 @@
+From f96fdbcbaf5cefbcb7623a63705a10166ff8aefa Mon Sep 17 00:00:00 2001
+From: Dylan <2894220@gmail.com>
+Date: Mon, 25 Apr 2022 17:03:23 +0800
+Subject: [PATCH] fix: #902 unset -moutline-atomics flag under iOS arm64
+
+Signed-off-by: Dylan <2894220@gmail.com>
+---
+ cmake/AwsCFlags.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/AwsCFlags.cmake b/cmake/AwsCFlags.cmake
+index a0a4708..d6ef775 100644
+--- a/cmake/AwsCFlags.cmake
++++ b/cmake/AwsCFlags.cmake
+@@ -123,7 +123,7 @@ function(aws_set_common_properties target)
+        # -moutline-atomics generates code for both older load/store exclusive atomics and also
+        # Arm's Large System Extensions (LSE) which scale substantially better on large core count systems
+         check_c_compiler_flag("-moutline-atomics -Werror" HAS_MOUTLINE_ATOMICS)
+-        if (HAS_MOUTLINE_ATOMICS AND AWS_ARCH_ARM64)
++        if (HAS_MOUTLINE_ATOMICS AND AWS_ARCH_ARM64 AND NOT IOS)
+             list(APPEND AWS_C_FLAGS -moutline-atomics)
+         endif()
+ 
+-- 
+2.35.1
+


### PR DESCRIPTION
 - add patch file to patches folder to unset `outline-atomics` flag under iOS arm64

Signed-off-by: Dylan <2894220@gmail.com>

Specify library name and version:  **aws-c-common/0.6.19**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
