### PR TITLE
opentelemetry-cpp: retrieve proto files from opentelemetry-proto (with updating dependencies)

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -104,10 +104,11 @@ class OpenTelemetryCppConan(ConanFile):
             self._source_subfolder,
             "cmake",
             "opentelemetry-proto.cmake")
-        tools.replace_in_file(
-            protos_cmake_path,
-            "if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto/.git)",
-            "if(1)")
+        if tools.Version(self.version) >= "1.1.0":
+            tools.replace_in_file(
+                protos_cmake_path,
+                "if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto/.git)",
+                "if(1)")
         tools.replace_in_file(
             protos_cmake_path,
             "set(PROTO_PATH \"${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto\")",


### PR DESCRIPTION
Specify library name and version:  **opentelemetry-cpp/***

The recipe for opentelemetry-cpp could not be compiled in an environment without the git command.
By patching cmake module, it is now referenced from the opentelemetry-proto recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
