### PR TITLE
Add recipe for libsigc++-2.0

### DIFF
--- a/recipes/libsigcpp/2.x.x/conandata.yml
+++ b/recipes/libsigcpp/2.x.x/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.10.8":
+    url: "https://ftp2.nluug.nl/windowing/gnome/sources/libsigc++/2.10/libsigc++-2.10.8.tar.xz"
+    sha256: "235a40bec7346c7b82b6a8caae0456353dc06e71f14bc414bcc858af1838719a"

--- a/recipes/libsigcpp/2.x.x/conanfile.py
+++ b/recipes/libsigcpp/2.x.x/conanfile.py
@@ -89,10 +89,12 @@ class LibSigCppConanV2(ConanFile):
         self.copy("COPYING", dst="licenses", src=self._source_subfolder)
         meson = self._configure_meson()
         meson.install()
-        if self.settings.compiler == "Visual Studio" and not self.options.shared:
-            rename(self,
-                   os.path.join(self.package_folder, "lib", "libsigc-2.0.a"),
-                   os.path.join(self.package_folder, "lib", "sigc-2.0.lib"))
+        if self.settings.compiler == "Visual Studio":
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.pdb")
+            if not self.options.shared:
+                rename(self,
+                       os.path.join(self.package_folder, "lib", "libsigc-2.0.a"),
+                       os.path.join(self.package_folder, "lib", "sigc-2.0.lib"))
 
         for header_file in glob.glob(os.path.join(self.package_folder, "lib", "sigc++-2.0", "include", "*.h")):
             shutil.move(

--- a/recipes/libsigcpp/2.x.x/conanfile.py
+++ b/recipes/libsigcpp/2.x.x/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, Meson, tools
 from conan.tools.files import rename
+from conans.errors import ConanInvalidConfiguration
 import glob
 import os
 import shutil
@@ -29,6 +30,8 @@ class LibSigCppConanV2(ConanFile):
     short_paths = True
 
     def validate(self):
+        if hasattr(self, "settings_build") and tools.cross_building(self):
+            raise ConanInvalidConfiguration("Cross-building not implemented")
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, 11)
 

--- a/recipes/libsigcpp/2.x.x/conanfile.py
+++ b/recipes/libsigcpp/2.x.x/conanfile.py
@@ -1,0 +1,108 @@
+from conans import ConanFile, Meson, tools
+from conan.tools.files import rename
+import glob
+import os
+import shutil
+
+required_conan_version = ">=1.43.0"
+
+
+class LibSigCppConanV2(ConanFile):
+    name = "libsigcpp"
+    homepage = "https://github.com/libsigcplusplus/libsigcplusplus"
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "LGPL-3.0"
+    description = "libsigc++ implements a typesafe callback system for standard C++."
+    topics = ("libsigcpp", "callback")
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    generators = "pkg_config"
+    short_paths = True
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def build_requirements(self):
+        self.build_requires("meson/0.59.1")
+        self.build_requires("pkgconf/1.7.4")
+
+    def source(self):
+        tools.get(
+            **self.conan_data["sources"][self.version],
+            strip_root=True,
+            destination=self._source_subfolder
+        )
+
+    def build(self):
+        if not self.options.shared:
+            tools.replace_in_file(
+                os.path.join(self._source_subfolder, "sigc++config.h.meson"),
+                "define SIGC_DLL 1", "undef SIGC_DLL")
+        with tools.environment_append(tools.RunEnvironment(self).vars):
+            meson = self._configure_meson()
+            meson.build()
+
+    def _configure_meson(self):
+        meson = Meson(self)
+        defs = {}
+        defs["build-examples"] = "false"
+        defs["build-documentation"] = "false"
+        defs["default_library"] = "shared" if self.options.shared else "static"
+        meson.configure(
+            defs=defs,
+            build_folder=self._build_subfolder,
+            source_folder=self._source_subfolder,
+            pkg_config_paths=[self.install_folder],
+        )
+        return meson
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        meson = self._configure_meson()
+        meson.install()
+        if self.settings.compiler == "Visual Studio" and not self.options.shared:
+            rename(self,
+                   os.path.join(self.package_folder, "lib", "libsigc-2.0.a"),
+                   os.path.join(self.package_folder, "lib", "sigc-2.0.lib"))
+
+        for header_file in glob.glob(os.path.join(self.package_folder, "lib", "sigc++-2.0", "include", "*.h")):
+            shutil.move(
+                header_file,
+                os.path.join(self.package_folder, "include",
+                             "sigc++-2.0", os.path.basename(header_file))
+            )
+
+        for dir_to_remove in ["pkgconfig", "sigc++-2.0"]:
+            tools.rmdir(os.path.join(
+                self.package_folder, "lib", dir_to_remove))
+
+    def package_info(self):
+        self.cpp_info.components["sigc++-2.0"].names["pkg_config"] = "sigc++-2.0"
+        self.cpp_info.components["sigc++-2.0"].includedirs.append(os.path.join("include", "sigc++-2.0"))
+        self.cpp_info.components["sigc++-2.0"].libs = tools.collect_libs(self)

--- a/recipes/libsigcpp/2.x.x/conanfile.py
+++ b/recipes/libsigcpp/2.x.x/conanfile.py
@@ -110,4 +110,4 @@ class LibSigCppConanV2(ConanFile):
     def package_info(self):
         self.cpp_info.components["sigc++-2.0"].names["pkg_config"] = "sigc++-2.0"
         self.cpp_info.components["sigc++-2.0"].includedirs.append(os.path.join("include", "sigc++-2.0"))
-        self.cpp_info.components["sigc++-2.0"].libs = tools.collect_libs(self)
+        self.cpp_info.components["sigc++-2.0"].libs = ["sigc-2.0"]

--- a/recipes/libsigcpp/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/libsigcpp/2.x.x/test_package/CMakeLists.txt
@@ -1,11 +1,12 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.6)
 project(test_package)
 
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGET)
+
+find_package(PkgConfig REQUIRED)
+pkg_search_module(SIGCPP IMPORTED_TARGET REQUIRED sigc++-2.0)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-target_include_directories(${PROJECT_NAME} PRIVATE ${CONAN_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PkgConfig::SIGCPP)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/libsigcpp/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/libsigcpp/2.x.x/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_include_directories(${PROJECT_NAME} PRIVATE ${CONAN_INCLUDE_DIRS})
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/libsigcpp/2.x.x/test_package/conanfile.py
+++ b/recipes/libsigcpp/2.x.x/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libsigcpp/2.x.x/test_package/conanfile.py
+++ b/recipes/libsigcpp/2.x.x/test_package/conanfile.py
@@ -4,7 +4,10 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "cmake", "pkg_config"
+
+    def build_requirements(self):
+        self.build_requires("pkgconf/1.7.4")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/libsigcpp/2.x.x/test_package/test_package.cpp
+++ b/recipes/libsigcpp/2.x.x/test_package/test_package.cpp
@@ -1,0 +1,24 @@
+/* Copyright 2003 - 2016, The libsigc++ Development Team
+ *
+ *  Assigned to the public domain.  Use as you wish without
+ *  restriction.
+ */
+
+#include <iostream>
+#include <string>
+
+#include <sigc++/sigc++.h>
+// make sure that sigc++config.h can be included
+#include <sigc++config.h>
+
+void on_print(const std::string &str) { std::cout << str; }
+
+int main() {
+  sigc::signal<void(const std::string &)> signal_print;
+
+  signal_print.connect(sigc::ptr_fun(&on_print));
+
+  signal_print.emit("hello world\n");
+
+  return 0;
+}

--- a/recipes/libsigcpp/config.yml
+++ b/recipes/libsigcpp/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: "3.x.x"
   "3.0.0":
     folder: "3.x.x"
+  "2.10.8":
+    folder: "2.x.x"


### PR DESCRIPTION
Specify library name and version:  **libsigcpp/2.0**

I'm trying to use conan to fetch [Synfig](https://www.synfig.org/)'s dependencies. One of these dependencies is gtkmm 3, which depends on libsigc++ 2, so this is a step on the direction of writing a recipe for gtkmm 3.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
