### PR TITLE
[innoextract] Use sha256 in conandata.yml

### DIFF
--- a/recipes/innoextract/all/CMakeLists.txt
+++ b/recipes/innoextract/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 2.8.11)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATH)
 
 add_subdirectory("source_subfolder")

--- a/recipes/innoextract/all/conandata.yml
+++ b/recipes/innoextract/all/conandata.yml
@@ -3,7 +3,7 @@ sources:
     url:
       - "https://constexpr.org/innoextract/files/innoextract-1.9.tar.gz"
       - "https://github.com/dscharrer/innoextract/releases/download/1.9/innoextract-1.9.tar.gz"
-    md5: "964f39bb3f8fd2313629e69ffd3dab9f"
+    sha256: "6344a69fc1ed847d4ed3e272e0da5998948c6b828cb7af39c6321aba6cf88126"
 patches:
   "1.9.0":
     - patch_file: "patches/0001-cmake-fix-module.patch"

--- a/recipes/innoextract/all/test_package/conanfile.py
+++ b/recipes/innoextract/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, tools
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "arch"
+    settings = "os", "arch", "build_type", "compiler"
 
     def test(self):
         if not tools.cross_building(self):


### PR DESCRIPTION
Specify library name and version:  **innoextract/1.9.0**

- Replace md5 by sha256 in conandata.yml
- Modernize conanfile.py

Related to https://github.com/conan-io/hooks/pull/407

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
