### PR TITLE
quill: add version 1.7.2

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -32,3 +32,6 @@ sources:
   "1.7.0":
     url: "https://github.com/odygrd/quill/archive/v1.7.0.tar.gz"
     sha256: "f6eb9711b949effbd8caf06ee464f66f619b94d3b39f820fa288d0745c620ed1"
+  "1.7.2":
+    url: "https://github.com/odygrd/quill/archive/v1.7.2.tar.gz"
+    sha256: "e2153c6e25f3a6cee47c2a9edbabdace418f6d64f62cd701dfdae38d5892bb1b"

--- a/recipes/quill/all/conanfile.py
+++ b/recipes/quill/all/conanfile.py
@@ -65,7 +65,7 @@ class QuillConan(ConanFile):
         if tools.Version(self.version) >= "1.6.3":
             self.requires("fmt/8.1.1")
         elif tools.Version(self.version) >= "1.3.3":
-            self.requires("fmt/7.1.2")
+            self.requires("fmt/7.1.3")
         else:
             self.requires("fmt/6.2.1")
 

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -21,3 +21,5 @@ versions:
     folder: "all"
   "1.7.0":
     folder: "all"
+  "1.7.2":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **quill/1.7.2**

I also updated fmt version from 7.1.2 to 7.1.3 on quill/[>= 1.5.2, <= 1.6.2] to fix some bugs.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
