### PR TITLE
[changelog] Deploy new version

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 28-April-2022 - 9:56 CEST
+
+- [config] Update Conan client to 1.46.2
+- [fix] Do not create GitHub pull-request statuses in advance.
+- [fix] Move some Conan command calls to the wrapper.
+- [feature] Added compatibility for Conan v2 export command.
+- [config] Changed the required number of reviewers: 1 team and 1 community is enough
+
 ### 21-April-2022 - 13:46 CEST
 
 - [feature] Updated Python version to > 3.7 in all build agents.

--- a/docs/review_process.md
+++ b/docs/review_process.md
@@ -108,10 +108,10 @@ The list includes conan-center-index contributors who are very active and proven
 The list is not constant and will change periodically based on contribution.
 That also means you can be included in this list as well - submit PRs and provide reviews, and in time you may be added as a trusted contributor.
 
-### Rule of 3 reviews
+### Rule of 2 reviews
 
-At least 3 approving reviews are required, and at least one of them has to be from the official reviewers.
-So, it might be 1 official + 2 community, or 3 official, but it couldn't be just 3 community reviews.
+At least 2 approving reviews are required, and at least one of them has to be from the official reviewers.
+So, it might be 1 official + 1 community, or 2 official, but it couldn't be just 2 community reviews.
 Approvals are only counted if they are associated with the latest commit in the PR, while "Change requested" ones (from the Conan team) will persist even if there are new commits. Don't hesitate to dismiss old reviews if the issues have already been addressed.
 
 > **Note.-** Pull requests labelled as [`Bump version`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+version%22)


### PR DESCRIPTION
### 28-April-2022 - 9:56 CEST

- [config] Update Conan client to 1.46.2
- [fix] Do not create GitHub pull-request statuses in advance.

   We have been experiencing issues in GitHub with status checks that were not reported after the build finishes successfully. This situation is very inconvenient for reviewers, as pull-requests appear to be running forever and reviewers usually don't look at them until the green check appears. With this change, these status checks won't be sent when the job begins (with value _running_), but only when they are finished with either status success or failure.
   
   We have added an issue to our backlog to investigate it and recover this feature in the future, but there are other developments with more priority now (Conan v2 is in the horizon)

- [fix] Move some Conan command calls to the wrapper.
- [feature] Added compatibility for Conan v2 export command.
- [config] Changed the required number of reviewers: 1 team and 1 community is enough


