### PR TITLE
miniaudio: add version 0.11.9

### DIFF
--- a/recipes/miniaudio/all/conandata.yml
+++ b/recipes/miniaudio/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.9":
+    url: "https://github.com/mackron/miniaudio/archive/4dfe7c4c31df46e78d9a1cc0d2d6f1aef5a5d58c.tar.gz"
+    sha256: "76c154a60e320ae2054ac0e93480f2dffc12a5129bdb2ed4a62e0cce8d345c36"
   "0.11.8":
     url: "https://github.com/mackron/miniaudio/archive/82e70f4cbe6e613c8edc0ac7b97ff3dd00f2ca27.tar.gz"
     sha256: "a18540062e46f6308c962068125c9560a1a51abeb4fa8dc26a91ea55fc043c6b"

--- a/recipes/miniaudio/config.yml
+++ b/recipes/miniaudio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.9":
+    folder: all
   "0.11.8":
     folder: all
   "0.11.7":


### PR DESCRIPTION
Specify library name and version:  **miniaudio/0.11.9**

mniaudio doesn't use release features in github.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
