### PR TITLE
Qt6: fix multi profile windows build

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -648,7 +648,7 @@ class QtConan(ConanFile):
             cmake.definitions["BUILD_WITH_PCH"]= "OFF" # disabling PCH to save disk space
 
         if self.settings.os == "Windows":
-            cmake.definitions["HOST_PERL"] = self.deps_user_info["strawberryperl"].perl
+            cmake.definitions["HOST_PERL"] = getattr(self, "user_info_build", self.deps_user_info)["strawberryperl"].perl
 
         try:
             cmake.configure(source_folder="qt6")


### PR DESCRIPTION
Specify library name and version:  **qt/6.***

Fixes conan-io/conan-center-index#10538

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
