### PR TITLE
Relax minimun required GCC version

### DIFF
--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -41,7 +41,7 @@ class SentryCrashpadConan(ConanFile):
     def _minimum_compilers_version(self):
         return {
             "Visual Studio": "15" if tools.Version(self.version) < "0.4.16" else "16",
-            "gcc": "9",
+            "gcc": "5",
             "clang": "3.4",
             "apple-clang": "5.1",
         }

--- a/recipes/sentry-crashpad/all/conanfile.py
+++ b/recipes/sentry-crashpad/all/conanfile.py
@@ -41,7 +41,7 @@ class SentryCrashpadConan(ConanFile):
     def _minimum_compilers_version(self):
         return {
             "Visual Studio": "15" if tools.Version(self.version) < "0.4.16" else "16",
-            "gcc": "5",
+            "gcc": "6",
             "clang": "3.4",
             "apple-clang": "5.1",
         }


### PR DESCRIPTION
sentry-crashpad requires C++ 14 to compile which is fully implemented in GCC 5
https://gcc.gnu.org/projects/cxx-status.html#cxx14

For some reason the minimum GCC version has been bumped here https://github.com/conan-io/conan-center-index/pull/10429

This broke our GCC 8 builds.

**UPDATE**: For some reason the GCC5 builds fail with a cryptic error. This used to work, it must be related to the newer sentry versions. It looks like a bug  in the compiler rather than GCC5 not supporting C++ 14.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
