### PR TITLE
Add recipe for glibmm

### DIFF
--- a/recipes/glibmm/all/conandata.yml
+++ b/recipes/glibmm/all/conandata.yml
@@ -1,0 +1,19 @@
+sources:
+  "2.72.1":
+    url: "https://download.gnome.org/sources/glibmm/2.72/glibmm-2.72.1.tar.xz"
+    sha256: "2a7649a28ab5dc53ac4dabb76c9f61599fbc628923ab6a7dd74bf675d9155cd8"
+  "2.66.4":
+    url: "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.4.tar.xz"
+    sha256: "199ace5682d81b15a1d565480b4a950682f2db6402c8aa5dd7217d71edff81d5"
+
+patches:
+  "2.72.1":
+    - patch_file: "patches/enable_static_libs_2_72_1.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix_initialization_order_fiasco_2_72_1.patch"
+      base_path: "source_subfolder"
+  "2.66.4":
+    - patch_file: "patches/enable_static_libs_2_66_4.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/fix_initialization_order_fiasco_2_66_4.patch"
+      base_path: "source_subfolder"

--- a/recipes/glibmm/all/conanfile.py
+++ b/recipes/glibmm/all/conanfile.py
@@ -1,0 +1,229 @@
+from conans import ConanFile, Meson, tools
+from conan.tools.files import rename
+from conan.tools.microsoft import is_msvc
+from conans.errors import ConanInvalidConfiguration
+import os
+import glob
+import shutil
+
+
+class GlibmmConan(ConanFile):
+    name = "glibmm"
+    homepage = "https://gitlab.gnome.org/GNOME/glibmm"
+    license = "LGPL-2.1"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "glibmm is a C++ API for parts of glib that are useful for C++."
+    topics = ["glibmm", "giomm"]
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    generators = "pkg_config"
+    exports_sources = "patches/**"
+    short_paths = True
+
+    def _abi_version(self):
+        return "2.68" if tools.Version(self.version) >= "2.68.0" else "2.4"
+
+    def _glibmm_lib(self):
+        return f"glibmm-{self._abi_version()}"
+
+    def _giomm_lib(self):
+        return f"giomm-{self._abi_version()}"
+
+    def validate(self):
+        if hasattr(self, "settings_build") and tools.cross_building(self):
+            raise ConanInvalidConfiguration("Cross-building not implemented")
+
+        if self.settings.compiler.get_safe("cppstd"):
+            if self._abi_version() == "2.68":
+                tools.check_min_cppstd(self, 17)
+            else:
+                tools.check_min_cppstd(self, 11)
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def build_requirements(self):
+        self.build_requires("meson/0.59.1")
+        self.build_requires("pkgconf/1.7.4")
+
+    def requirements(self):
+        self.requires("glib/2.72.1")
+
+        if self._abi_version() == "2.68":
+            self.requires("libsigcpp/3.0.7")
+        else:
+            self.requires("libsigcpp/2.10.8")
+
+    def source(self):
+        tools.get(
+            **self.conan_data["sources"][self.version],
+            strip_root=True,
+            destination=self._source_subfolder,
+        )
+
+    def _patch_sources(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        if self.options.shared and is_msvc(self):
+            # Two shared libraries are created: glibmm and giomm
+            # On Windows: if glib is a static library, then each one of them
+            # will get its own version of glib, with its own version of static
+            # global variables
+            # A possible solution would be to make glibmm link against glib
+            # and giomm link against glibmm only, so that they share the same glib
+            # But this won't work since msvc does not export any symbols linked
+            # from static libraries so giomm wouldn't know about glib's symbols
+            self.options["glib"].shared = True
+
+    def build(self):
+        self._patch_sources()
+
+        if not self.options.shared:
+            if is_msvc(self):
+                tools.replace_in_file(
+                    os.path.join(self._source_subfolder, "tools",
+                                 "extra_defs_gen", "generate_extra_defs.h"),
+                    "#if defined (_MSC_VER) && !defined (GLIBMM_GEN_EXTRA_DEFS_STATIC)",
+                    "#if 0",
+                )
+
+        with tools.environment_append(tools.RunEnvironment(self).vars):
+            meson = self._configure_meson()
+            meson.build()
+
+    def _configure_meson(self):
+        meson = Meson(self)
+        defs = {
+            "build-examples": "false",
+            "build-documentation": "false",
+            "msvc14x-parallel-installable": "false",
+            "default_library": "shared" if self.options.shared else "static",
+        }
+
+        meson.configure(
+            defs=defs,
+            build_folder=self._build_subfolder,
+            source_folder=self._source_subfolder,
+            pkg_config_paths=[self.install_folder],
+        )
+
+        return meson
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        meson = self._configure_meson()
+        meson.install()
+
+        if is_msvc(self):
+            tools.remove_files_by_mask(
+                os.path.join(self.package_folder, "bin"), "*.pdb")
+            if not self.options.shared:
+                rename(
+                    self,
+                    os.path.join(self.package_folder, "lib",
+                                 f"libglibmm-{self._abi_version()}.a"),
+                    os.path.join(self.package_folder, "lib",
+                                 f"{self._glibmm_lib()}.lib"),
+                )
+                rename(
+                    self,
+                    os.path.join(self.package_folder, "lib",
+                                 f"libgiomm-{self._abi_version()}.a"),
+                    os.path.join(self.package_folder, "lib",
+                                 f"{self._giomm_lib()}.lib"),
+                )
+                rename(
+                    self,
+                    os.path.join(
+                        self.package_folder,
+                        "lib",
+                        f"libglibmm_generate_extra_defs-{self._abi_version()}.a",
+                    ),
+                    os.path.join(
+                        self.package_folder,
+                        "lib",
+                        f"glibmm_generate_extra_defs-{self._abi_version()}.lib",
+                    ),
+                )
+
+        for directory in [self._glibmm_lib(), self._giomm_lib()]:
+            directory_path = os.path.join(self.package_folder, "lib",
+                                          directory, "include", "*.h")
+            for header_file in glob.glob(directory_path):
+                shutil.move(
+                    header_file,
+                    os.path.join(
+                        self.package_folder,
+                        "include",
+                        directory,
+                        os.path.basename(header_file),
+                    ),
+                )
+
+        for dir_to_remove in [
+                "pkgconfig",
+                self._glibmm_lib(),
+                self._giomm_lib()
+        ]:
+            tools.rmdir(os.path.join(self.package_folder, "lib",
+                                     dir_to_remove))
+
+    def package_info(self):
+        if self._abi_version() == "2.68":
+            self.cpp_info.components["glibmm-2.68"].names[
+                "pkg_config"] = "glibmm-2.68"
+            self.cpp_info.components["glibmm-2.68"].libs = ["glibmm-2.68"]
+            self.cpp_info.components["glibmm-2.68"].libs = ["glibmm-2.68"]
+            self.cpp_info.components["glibmm-2.68"].includedirs = [
+                os.path.join("include", "glibmm-2.68")
+            ]
+            self.cpp_info.components["glibmm-2.68"].requires = [
+                "glib::gobject-2.0", "libsigcpp::sigc++"
+            ]
+
+            self.cpp_info.components["giomm-2.68"].names[
+                "pkg_config"] = "giomm-2.68"
+            self.cpp_info.components["giomm-2.68"].libs = ["giomm-2.68"]
+            self.cpp_info.components["giomm-2.68"].includedirs = [
+                os.path.join("include", "giomm-2.68")
+            ]
+            self.cpp_info.components["giomm-2.68"].requires = [
+                "glibmm-2.68", "glib::gio-2.0"
+            ]
+
+        else:
+            self.cpp_info.components["glibmm-2.4"].names[
+                "pkg_config"] = "glibmm-2.4"
+            self.cpp_info.components["glibmm-2.4"].libs = ["glibmm-2.4"]
+            self.cpp_info.components["glibmm-2.4"].libs = ["glibmm-2.4"]
+            self.cpp_info.components["glibmm-2.4"].includedirs = [
+                os.path.join("include", "glibmm-2.4")
+            ]
+            self.cpp_info.components["glibmm-2.4"].requires = [
+                "glib::gobject-2.0", "libsigcpp::sigc++-2.0"
+            ]
+
+            self.cpp_info.components["giomm-2.4"].names[
+                "pkg_config"] = "giomm-2.4"
+            self.cpp_info.components["giomm-2.4"].libs = ["giomm-2.4"]
+            self.cpp_info.components["giomm-2.4"].includedirs = [
+                os.path.join("include", "giomm-2.4")
+            ]
+            self.cpp_info.components["giomm-2.4"].requires = [
+                "glibmm-2.4", "glib::gio-2.0"
+            ]

--- a/recipes/glibmm/all/patches/enable_static_libs_2_66_4.patch
+++ b/recipes/glibmm/all/patches/enable_static_libs_2_66_4.patch
@@ -1,0 +1,32 @@
+diff --git a/glib/glibmmconfig.h.meson b/glib/glibmmconfig.h.meson
+index e50dcccf..19e64a46 100644
+--- a/glib/glibmmconfig.h.meson
++++ b/glib/glibmmconfig.h.meson
+@@ -47,7 +47,9 @@
+ # if defined(_MSC_VER)
+ #  define GLIBMM_MSC 1
+ #  define GLIBMM_WIN32 1
+-#  define GLIBMM_DLL 1
++#  ifndef GLIBMM_STATIC_LIB
++#    define GLIBMM_DLL 1
++#  endif
+ # elif defined(__CYGWIN__)
+ #  define GLIBMM_CONFIGURE 1
+ # elif defined(__MINGW32__)
+diff --git a/glib/meson.build b/glib/meson.build
+index 4feee0fd..9382645a 100644
+--- a/glib/meson.build
++++ b/glib/meson.build
+@@ -36,12 +36,6 @@ pkg_conf_data.set('MSVC_TOOLSET_VER', msvc14x_toolset_ver)
+ 
+ library_build_type = get_option('default_library')
+ 
+-if cpp_compiler.get_argument_syntax() == 'msvc'
+-  if library_build_type == 'static' or library_build_type == 'both'
+-    error('Static builds are not supported by MSVC-style builds')
+-  endif
+-endif
+-
+ if library_build_type == 'static'
+   pkg_conf_data.set('GLIBMM_STATIC_LIB', 1)
+   pkg_conf_data.set('GIOMM_STATIC_LIB', 1)

--- a/recipes/glibmm/all/patches/enable_static_libs_2_72_1.patch
+++ b/recipes/glibmm/all/patches/enable_static_libs_2_72_1.patch
@@ -1,0 +1,32 @@
+diff --git a/glib/glibmmconfig.h.meson b/glib/glibmmconfig.h.meson
+index ef4753d..58b343c 100644
+--- a/glib/glibmmconfig.h.meson
++++ b/glib/glibmmconfig.h.meson
+@@ -27,7 +27,9 @@
+ # if defined(_MSC_VER)
+ #  define GLIBMM_MSC 1
+ #  define GLIBMM_WIN32 1
+-#  define GLIBMM_DLL 1
++#  ifndef GLIBMM_STATIC_LIB
++#    define GLIBMM_DLL 1
++#  endif
+ # elif defined(__CYGWIN__)
+ #  define GLIBMM_CONFIGURE 1
+ # elif defined(__MINGW32__)
+diff --git a/glib/meson.build b/glib/meson.build
+index 0c20a91..6b8baa0 100644
+--- a/glib/meson.build
++++ b/glib/meson.build
+@@ -36,12 +36,6 @@ pkg_conf_data.set('MSVC_TOOLSET_VER', msvc14x_toolset_ver)
+ 
+ library_build_type = get_option('default_library')
+ 
+-if cpp_compiler.get_argument_syntax() == 'msvc'
+-  if library_build_type == 'static' or library_build_type == 'both'
+-    error('Static builds are not supported by MSVC-style builds')
+-  endif
+-endif
+-
+ if library_build_type == 'static'
+   pkg_conf_data.set('GLIBMM_STATIC_LIB', 1)
+   pkg_conf_data.set('GIOMM_STATIC_LIB', 1)

--- a/recipes/glibmm/all/patches/fix_initialization_order_fiasco_2_66_4.patch
+++ b/recipes/glibmm/all/patches/fix_initialization_order_fiasco_2_66_4.patch
@@ -1,0 +1,163 @@
+Author: Hesham <hesham.essam.mail@gmail.com>
+Date:   Fri May 6 20:02:25 2022 +0000
+
+    Fix initialization order fiasco
+
+    By default global static initialization with shared libraries begins down
+    the linking chain upwards, so that the deepest dependency initializes first
+    This is not guaranteed with static libraries, which might cause glibmm to
+    initialize before glib. This fix uses lazy initialization for static vars
+    in glibmm that depend on glib.
+
+diff --git a/glib/glibmm/class.cc b/glib/glibmm/class.cc
+index 057abed..e51d01b 100644
+--- a/glib/glibmm/class.cc
++++ b/glib/glibmm/class.cc
+@@ -170,7 +170,11 @@ Class::clone_custom_type(
+ }
+ 
+ // Initialize the static quark to store/get custom type properties.
++#if GLIB_STATIC_COMPILATION
++GQuark Class::iface_properties_quark = 0;
++#else
+ GQuark Class::iface_properties_quark = g_quark_from_string("gtkmm_CustomObject_iface_properties");
++#endif
+ 
+ // static
+ void
+diff --git a/glib/glibmm/init.cc b/glib/glibmm/init.cc
+index ab96892..267a6c0 100644
+--- a/glib/glibmm/init.cc
++++ b/glib/glibmm/init.cc
+@@ -14,15 +14,25 @@
+  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
++#include <glib.h>
+ #include <glibmm/init.h>
+ #include <glibmm/error.h>
+ 
++#if GLIB_STATIC_COMPILATION
++#include <glibmm/class.h>
++#endif
++
+ namespace Glib
+ {
+ 
+ void
+ init()
+ {
++#if GLIB_STATIC_COMPILATION
++  Glib::Class::iface_properties_quark =
++      g_quark_from_string("gtkmm_CustomObject_iface_properties");
++#endif
++
+   // Also calls Glib::wrap_register_init() and Glib::wrap_init().
+   Glib::Error::register_init();
+ }
+diff --git a/glib/glibmm/property.cc b/glib/glibmm/property.cc
+index a2624e5..d9f1095 100644
+--- a/glib/glibmm/property.cc
++++ b/glib/glibmm/property.cc
+@@ -89,8 +89,10 @@ struct custom_properties_type
+ };
+ 
+ // The quark used for storing/getting the custom properties of custom types.
+-static const GQuark custom_properties_quark =
+-  g_quark_from_string("gtkmm_CustomObject_custom_properties");
++static const GQuark& custom_properties_quark() {
++  static const GQuark custom_properties_quark_ = g_quark_from_string("gtkmm_CustomObject_custom_properties");
++  return custom_properties_quark_;
++}
+ 
+ // Delete the custom properties data when an object of a custom type is finalized.
+ void destroy_notify_obj_custom_props(void* data)
+@@ -111,12 +113,12 @@ custom_properties_type*
+ get_obj_custom_props(GObject* obj)
+ {
+   auto obj_custom_props =
+-    static_cast<custom_properties_type*>(g_object_get_qdata(obj, custom_properties_quark));
++    static_cast<custom_properties_type*>(g_object_get_qdata(obj, custom_properties_quark()));
+   if (!obj_custom_props)
+   {
+     obj_custom_props = new custom_properties_type();
+     g_object_set_qdata_full(
+-      obj, custom_properties_quark, obj_custom_props, destroy_notify_obj_custom_props);
++      obj, custom_properties_quark(), obj_custom_props, destroy_notify_obj_custom_props);
+   }
+   return obj_custom_props;
+ }
+diff --git a/untracked/gio/giomm/application.cc b/untracked/gio/giomm/application.cc
+index 43ae9df..0d12c9d 100644
+--- a/untracked/gio/giomm/application.cc
++++ b/untracked/gio/giomm/application.cc
+@@ -51,8 +51,13 @@ struct ExtraApplicationData
+   }
+ };
+ 
+-GQuark quark_extra_application_data =
+-  g_quark_from_string("glibmm__Gio::Application::quark_extra_application_data");
++static GQuark&
++quark_extra_application_data()
++{
++  static GQuark quark_extra_application_data_ =
++    g_quark_from_string("glibmm__Gio::Application::quark_extra_application_data");
++  return quark_extra_application_data_;
++}
+ 
+ void
+ Application_delete_extra_application_data(gpointer data)
+@@ -465,11 +470,11 @@ Application::add_main_option_entry_private(GOptionArg arg, const Glib::ustring&
+   gchar* arg_desc = arg_description.empty() ? nullptr : g_strdup(arg_description.c_str());
+ 
+   ExtraApplicationData* extra_application_data =
+-    static_cast<ExtraApplicationData*>(g_object_get_qdata(gobject_, quark_extra_application_data));
++    static_cast<ExtraApplicationData*>(g_object_get_qdata(gobject_, quark_extra_application_data()));
+   if (!extra_application_data)
+   {
+     extra_application_data = new ExtraApplicationData();
+-    g_object_set_qdata_full(gobject_, quark_extra_application_data, extra_application_data,
++    g_object_set_qdata_full(gobject_, quark_extra_application_data(), extra_application_data,
+       Application_delete_extra_application_data);
+   }
+ 
+@@ -1546,5 +1551,3 @@ void Gio::Application::run_mainloop_vfunc()
+ 
+ 
+ } // namespace Gio
+-
+-
+diff --git a/untracked/glib/glibmm/binding.cc b/untracked/glib/glibmm/binding.cc
+index d0d4f47..0528893 100644
+--- a/untracked/glib/glibmm/binding.cc
++++ b/untracked/glib/glibmm/binding.cc
+@@ -29,7 +29,10 @@
+ namespace
+ {
+ // TODO: When we can break ABI, replace this GQuark by a new data member in Glib::Binding.
+-GQuark quark_manage = g_quark_from_string("glibmm__Glib::Binding::manage");
++GQuark& quark_manage() {
++	static GQuark quark_manage_ = g_quark_from_string("glibmm__Glib::Binding::manage");
++	return quark_manage_;
++}
+ 
+ struct BindingTransformSlots
+ {
+@@ -150,7 +153,7 @@ Binding::unbind()
+ void
+ Binding::unreference() const
+ {
+-  if (!g_object_get_qdata(gobject_, quark_manage))
++  if (!g_object_get_qdata(gobject_, quark_manage()))
+   {
+     GBinding* const binding = const_cast<GBinding*>(gobj());
+ 
+@@ -168,7 +171,7 @@ void
+ Binding::set_manage()
+ {
+   // Any pointer can be set, just not nullptr.
+-  g_object_set_qdata(gobject_, quark_manage, this);
++  g_object_set_qdata(gobject_, quark_manage(), this);
+ }
+ 
+ const Glib::RefPtr<Glib::Binding>&

--- a/recipes/glibmm/all/patches/fix_initialization_order_fiasco_2_72_1.patch
+++ b/recipes/glibmm/all/patches/fix_initialization_order_fiasco_2_72_1.patch
@@ -1,0 +1,95 @@
+Author: Hesham <hesham.essam.mail@gmail.com>
+Date:   Fri May 6 19:37:32 2022 +0000
+
+    Fix initialization order fiasco
+
+    By default global static initialization with shared libraries begins down
+    the linking chain upwards, so that the deepest dependency initializes first
+    This is not guaranteed with static libraries, which might cause glibmm to
+    initialize before glib. This fix uses lazy initialization for static vars
+    in glibmm that depend on glib.
+
+diff --git a/glib/glibmm/class.cc b/glib/glibmm/class.cc
+index 36c3c4b..f735129 100644
+--- a/glib/glibmm/class.cc
++++ b/glib/glibmm/class.cc
+@@ -157,7 +157,11 @@ Class::clone_custom_type(
+ }
+ 
+ // Initialize the static quark to store/get custom type properties.
++#if GLIB_STATIC_COMPILATION
++GQuark Class::iface_properties_quark = 0;
++#else
+ GQuark Class::iface_properties_quark = g_quark_from_string("gtkmm_CustomObject_iface_properties");
++#endif
+ 
+ // static
+ void
+diff --git a/glib/glibmm/init.cc b/glib/glibmm/init.cc
+index 0b34447..6b70a4c 100644
+--- a/glib/glibmm/init.cc
++++ b/glib/glibmm/init.cc
+@@ -14,12 +14,17 @@
+  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
++#include <glib.h>
+ #include <glibmm/init.h>
+ #include <glibmm/error.h>
+ #include <locale>
+ #include <clocale>
+ #include <stdexcept>
+ 
++#if GLIB_STATIC_COMPILATION
++#include <glibmm/class.h>
++#endif
++
+ namespace
+ {
+   bool init_to_users_preferred_locale = true;
+@@ -45,6 +50,11 @@ void init()
+   if (is_initialized)
+     return;
+ 
++#if GLIB_STATIC_COMPILATION
++  Glib::Class::iface_properties_quark =
++      g_quark_from_string("gtkmm_CustomObject_iface_properties");
++#endif
++
+   if (init_to_users_preferred_locale)
+   {
+     try
+diff --git a/glib/glibmm/property.cc b/glib/glibmm/property.cc
+index 56dad84..630b35b 100644
+--- a/glib/glibmm/property.cc
++++ b/glib/glibmm/property.cc
+@@ -89,8 +89,12 @@ struct custom_properties_type
+ };
+ 
+ // The quark used for storing/getting the custom properties of custom types.
+-static const GQuark custom_properties_quark =
+-  g_quark_from_string("gtkmm_CustomObject_custom_properties");
++static const GQuark&
++custom_properties_quark()
++{
++  static GQuark custom_properties_quark_ = g_quark_from_string("gtkmm_CustomObject_custom_properties");
++  return custom_properties_quark_;
++}
+ 
+ // Delete the custom properties data when an object of a custom type is finalized.
+ void destroy_notify_obj_custom_props(void* data)
+@@ -111,12 +115,12 @@ custom_properties_type*
+ get_obj_custom_props(GObject* obj)
+ {
+   auto obj_custom_props =
+-    static_cast<custom_properties_type*>(g_object_get_qdata(obj, custom_properties_quark));
++    static_cast<custom_properties_type*>(g_object_get_qdata(obj, custom_properties_quark()));
+   if (!obj_custom_props)
+   {
+     obj_custom_props = new custom_properties_type();
+     g_object_set_qdata_full(
+-      obj, custom_properties_quark, obj_custom_props, destroy_notify_obj_custom_props);
++      obj, custom_properties_quark(), obj_custom_props, destroy_notify_obj_custom_props);
+   }
+   return obj_custom_props;
+ }

--- a/recipes/glibmm/all/test_package/CMakeLists.txt
+++ b/recipes/glibmm/all/test_package/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.6)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGET)
+
+find_package(glibmm REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+
+if (TARGET glibmm::glibmm-2.68)
+  set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+  target_link_libraries(${PROJECT_NAME} glibmm::glibmm-2.68 glibmm::giomm-2.68)
+else()
+  set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+  target_link_libraries(${PROJECT_NAME} glibmm::glibmm-2.4 glibmm::giomm-2.4)
+endif()
+

--- a/recipes/glibmm/all/test_package/conanfile.py
+++ b/recipes/glibmm/all/test_package/conanfile.py
@@ -1,0 +1,20 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build_requirements(self):
+        self.build_requires("pkgconf/1.7.4")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/glibmm/all/test_package/conanfile.py
+++ b/recipes/glibmm/all/test_package/conanfile.py
@@ -6,9 +6,6 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
-    def build_requirements(self):
-        self.build_requires("pkgconf/1.7.4")
-
     def build(self):
         cmake = CMake(self)
         cmake.configure()

--- a/recipes/glibmm/all/test_package/test_package.cpp
+++ b/recipes/glibmm/all/test_package/test_package.cpp
@@ -1,0 +1,63 @@
+/* Copyright (C) 2004 The glibmm Development Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <glibmm.h>
+#include <giomm.h>
+#include <iomanip>
+#include <iostream>
+
+int
+main(int, char**)
+{
+  Glib::init();
+  /* Reusing one regex pattern: */
+  const auto regex = Glib::Regex::create("(a)?(b)");
+  std::cout << "Pattern=" << regex->get_pattern() << ", with string=abcd, result=" << std::boolalpha
+            << regex->match("abcd") << std::endl;
+  std::cout << "Pattern=" << regex->get_pattern() << ", with string=1234, result=" << std::boolalpha
+            << regex->match("1234") << std::endl;
+  std::cout << std::endl;
+
+  /* Using the static function without a regex instance: */
+  std::cout << "Pattern=b* with string=abcd, result=" << std::boolalpha
+            << Glib::Regex::match_simple("b*", "abcd") << std::endl;
+
+  Gio::init();
+  try
+  {
+    auto directory = Gio::File::create_for_path(".");
+    if(!directory)
+      std::cerr << "Gio::File::create_for_path() returned an empty RefPtr." << std::endl;
+
+    auto enumerator = directory->enumerate_children();
+    if(!enumerator)
+      std::cerr << "Gio::File::enumerate_children() returned an empty RefPtr." << std::endl;
+
+    auto file_info = enumerator->next_file();
+    while(file_info)
+    {
+      std::cout << "file: " << file_info->get_name() << std::endl;
+      file_info = enumerator->next_file();
+    }
+
+  }
+  catch(const Glib::Error& ex)
+  {
+    std::cerr << "Exception caught: " << ex.what() << std::endl;
+  }
+
+  return 0;
+}

--- a/recipes/glibmm/config.yml
+++ b/recipes/glibmm/config.yml
@@ -1,0 +1,5 @@
+versions:
+  "2.72.1":
+    folder: "all"
+  "2.66.4":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  glibmm

This adds glibmm 2.72.0 for gtkmm 4, and 2.66.2 for gtkmm 3. However, glibmm 2.66.2 is commented out until [libsigcpp 2](https://github.com/conan-io/conan-center-index/pull/10517) is merged.


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
