### PR TITLE
minizip-ng: bump dependencies + modernize

### DIFF
--- a/recipes/minizip-ng/all/CMakeLists.txt
+++ b/recipes/minizip-ng/all/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.4)
-project(cmake_wrapper)
+project(cmake_wrapper C)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/recipes/minizip-ng/all/conanfile.py
+++ b/recipes/minizip-ng/all/conanfile.py
@@ -58,7 +58,7 @@ class MinizipNgConan(ConanFile):
             del self.options.with_libcomp
 
     def build_requirements(self):
-        self.build_requires('pkgconf/1.7.3')
+        self.build_requires("pkgconf/1.7.4")
 
     def configure(self):
         if self.options.shared:
@@ -72,15 +72,15 @@ class MinizipNgConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("with_zlib"):
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.12")
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.with_lzma:
             self.requires("xz_utils/5.2.5")
         if self.options.with_zstd:
-            self.requires("zstd/1.5.0")
+            self.requires("zstd/1.5.2")
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1l")
+            self.requires("openssl/1.1.1n")
         if self.settings.os != "Windows":
             if self.options.get_safe("with_iconv"):
                 self.requires("libiconv/1.16")

--- a/recipes/minizip-ng/all/test_package/CMakeLists.txt
+++ b/recipes/minizip-ng/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)

--- a/recipes/minizip-ng/all/test_package/conanfile.py
+++ b/recipes/minizip-ng/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- bump dependencies
- `CMakeDeps` & `PkgConfigDeps` support
- cache CMake configuration with `functools.lru_cache`
- explicit `cpp_info.libs` in `package_info()`

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
