### PR TITLE
tomlplusplus: add version 3.1.0

### DIFF
--- a/recipes/tomlplusplus/all/conandata.yml
+++ b/recipes/tomlplusplus/all/conandata.yml
@@ -29,3 +29,6 @@ sources:
   "3.0.1":
     url: "https://github.com/marzer/tomlplusplus/archive/v3.0.1.tar.gz"
     sha256: "e05b2814b891e223d7546aa2408d6cba0628164a84ac453205c7743cb667b9cf"
+  "3.1.0":
+    url: "https://github.com/marzer/tomlplusplus/archive/v3.1.0.tar.gz"
+    sha256: "dae72714fc356ca1b019298d9e6275cc41ba95546ae722ccdb6795e92f47762e"

--- a/recipes/tomlplusplus/config.yml
+++ b/recipes/tomlplusplus/config.yml
@@ -19,3 +19,5 @@ versions:
     folder: all
   "3.0.1":
     folder: all
+  "3.1.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **tomlplusplus/3.1.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
