### PR TITLE
opencolorio: bump dependencies + modernize

### DIFF
--- a/recipes/opencolorio/all/CMakeLists.txt
+++ b/recipes/opencolorio/all/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -52,15 +52,16 @@ class OpenColorIOConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        # TODO: add GLUT (needed for ociodisplay tool)
-        self.requires("lcms/2.13.1")
-        self.requires("yaml-cpp/0.7.0")
-        if tools.Version(self.version) < "2.1.0":
-            self.requires("tinyxml/2.6.2")
-        if tools.Version(self.version) >= "2.1.0":
-            self.requires("pystring/1.1.3")
         self.requires("expat/2.4.8")
         self.requires("openexr/2.5.7")
+        self.requires("yaml-cpp/0.7.0")
+        if tools.Version(self.version) < "2.0.0":
+            self.requires("tinyxml/2.6.2")
+        else:
+            self.requires("pystring/1.1.3")
+        # for tools only
+        self.requires("lcms/2.13.1")
+        # TODO: add GLUT (needed for ociodisplay tool)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -144,7 +144,7 @@ class OpenColorIOConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "OpenColorIO::OpenColorIO")
         self.cpp_info.set_property("pkg_config_name", "OpenColorIO")
 
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = ["OpenColorIO"]
 
         if tools.Version(self.version) < "2.1.0":
             if not self.options.shared:

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -53,13 +53,13 @@ class OpenColorIOConan(ConanFile):
 
     def requirements(self):
         # TODO: add GLUT (needed for ociodisplay tool)
-        self.requires("lcms/2.12")
+        self.requires("lcms/2.13.1")
         self.requires("yaml-cpp/0.7.0")
         if tools.Version(self.version) < "2.1.0":
             self.requires("tinyxml/2.6.2")
         if tools.Version(self.version) >= "2.1.0":
             self.requires("pystring/1.1.3")
-        self.requires("expat/2.4.1")
+        self.requires("expat/2.4.8")
         self.requires("openexr/2.5.7")
 
     def validate(self):

--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -1,7 +1,9 @@
+from conan.tools.microsoft import is_msvc
 from conans import ConanFile, CMake, tools
+import functools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.45.0"
 
 
 class OpenColorIOConan(ConanFile):
@@ -10,22 +12,21 @@ class OpenColorIOConan(ConanFile):
     license = "BSD-3-Clause"
     homepage = "https://opencolorio.org/"
     url = "https://github.com/conan-io/conan-center-index"
-    settings = "os", "compiler", "build_type", "arch"
+    topics = ("colors", "visual", "effects", "animation")
+
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "use_sse": [True, False]
+        "use_sse": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "use_sse": True
+        "use_sse": True,
     }
-    generators = "cmake", "cmake_find_package"
-    exports_sources = ["CMakeLists.txt", "patches/*"]
-    topics = ("colors", "visual", "effects", "animation")
 
-    _cmake = None
+    generators = "cmake", "cmake_find_package"
 
     @property
     def _source_subfolder(self):
@@ -34,6 +35,11 @@ class OpenColorIOConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -44,10 +50,6 @@ class OpenColorIOConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-
-    def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 11)
 
     def requirements(self):
         # TODO: add GLUT (needed for ociodisplay tool)
@@ -60,47 +62,49 @@ class OpenColorIOConan(ConanFile):
         self.requires("expat/2.4.1")
         self.requires("openexr/2.5.7")
 
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-
-        self._cmake = CMake(self)
+        cmake = CMake(self)
 
         if tools.Version(self.version) >= "2.1.0":
-            self._cmake.definitions["OCIO_BUILD_PYTHON"] = False
+            cmake.definitions["OCIO_BUILD_PYTHON"] = False
         else:
-            self._cmake.definitions["OCIO_BUILD_SHARED"] = self.options.shared
-            self._cmake.definitions["OCIO_BUILD_STATIC"] = not self.options.shared
-            self._cmake.definitions["OCIO_BUILD_PYGLUE"] = False
+            cmake.definitions["OCIO_BUILD_SHARED"] = self.options.shared
+            cmake.definitions["OCIO_BUILD_STATIC"] = not self.options.shared
+            cmake.definitions["OCIO_BUILD_PYGLUE"] = False
 
-            self._cmake.definitions["USE_EXTERNAL_YAML"] = True
-            self._cmake.definitions["USE_EXTERNAL_TINYXML"] = True
-            self._cmake.definitions["USE_EXTERNAL_LCMS"] = True
+            cmake.definitions["USE_EXTERNAL_YAML"] = True
+            cmake.definitions["USE_EXTERNAL_TINYXML"] = True
+            cmake.definitions["USE_EXTERNAL_LCMS"] = True
 
-        self._cmake.definitions["OCIO_USE_SSE"] = self.options.get_safe("use_sse", False)
+        cmake.definitions["OCIO_USE_SSE"] = self.options.get_safe("use_sse", False)
 
         # openexr 2.x provides Half library
-        self._cmake.definitions["OCIO_USE_OPENEXR_HALF"] = True
+        cmake.definitions["OCIO_USE_OPENEXR_HALF"] = True
 
-        self._cmake.definitions["OCIO_BUILD_APPS"] = True
-        self._cmake.definitions["OCIO_BUILD_DOCS"] = False
-        self._cmake.definitions["OCIO_BUILD_TESTS"] = False
-        self._cmake.definitions["OCIO_BUILD_GPU_TESTS"] = False
-        self._cmake.definitions["OCIO_USE_BOOST_PTR"] = False
+        cmake.definitions["OCIO_BUILD_APPS"] = True
+        cmake.definitions["OCIO_BUILD_DOCS"] = False
+        cmake.definitions["OCIO_BUILD_TESTS"] = False
+        cmake.definitions["OCIO_BUILD_GPU_TESTS"] = False
+        cmake.definitions["OCIO_USE_BOOST_PTR"] = False
 
         # avoid downloading dependencies
-        self._cmake.definitions["OCIO_INSTALL_EXT_PACKAGE"] = "NONE"
+        cmake.definitions["OCIO_INSTALL_EXT_PACKAGE"] = "NONE"
 
-        if self.settings.compiler == "Visual Studio" and not self.options.shared:
+        if is_msvc(self) and not self.options.shared:
             # define any value because ifndef is used
-            self._cmake.definitions["OpenColorIO_SKIP_IMPORTS"] = True
+            cmake.definitions["OpenColorIO_SKIP_IMPORTS"] = True
 
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -136,9 +140,9 @@ class OpenColorIOConan(ConanFile):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "OpenColorIO"
-        self.cpp_info.names["cmake_find_package_multi"] = "OpenColorIO"
-        self.cpp_info.names["pkg_config"] = "OpenColorIO"
+        self.cpp_info.set_property("cmake_file_name", "OpenColorIO")
+        self.cpp_info.set_property("cmake_target_name", "OpenColorIO::OpenColorIO")
+        self.cpp_info.set_property("pkg_config_name", "OpenColorIO")
 
         self.cpp_info.libs = tools.collect_libs(self)
 
@@ -149,9 +153,14 @@ class OpenColorIOConan(ConanFile):
         if self.settings.os == "Macos":
             self.cpp_info.frameworks.extend(["Foundation", "IOKit", "ColorSync", "CoreGraphics"])
 
-        if self.settings.compiler == "Visual Studio" and not self.options.shared:
+        if is_msvc(self) and not self.options.shared:
             self.cpp_info.defines.append("OpenColorIO_SKIP_IMPORTS")
 
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH env var with: {}".format(bin_path))
         self.env_info.PATH.append(bin_path)
+
+        # TODO: to remove in conan v2 once cmake_find_package_* & pkg_config generators removed
+        self.cpp_info.names["cmake_find_package"] = "OpenColorIO"
+        self.cpp_info.names["cmake_find_package_multi"] = "OpenColorIO"
+        self.cpp_info.names["pkg_config"] = "OpenColorIO"

--- a/recipes/opencolorio/all/test_package/conanfile.py
+++ b/recipes/opencolorio/all/test_package/conanfile.py
@@ -1,8 +1,9 @@
 from conans import ConanFile, CMake, tools
 import os
 
-class DefaultNameConan(ConanFile):
-    settings = "os", "compiler", "arch", "build_type"
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- `CMakeDeps` & `PkgConfigDeps` support
- cache CMake configuration with `functools.lru_cache`
- explicit cpp_info.libs
- bump dependencies

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
