### PR TITLE
openimageio: bump dependencies + modernize

### DIFF
--- a/recipes/openimageio/all/CMakeLists.txt
+++ b/recipes/openimageio/all/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include("conanbuildinfo.cmake")
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 include_directories(
     BEFORE

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -109,7 +109,10 @@ class OpenImageIOConan(ConanFile):
         if self.options.with_hdf5:
             self.requires("hdf5/1.12.1")
         if self.options.with_opencolorio:
-            self.requires("opencolorio/2.1.0")
+            if tools.Version(self.version) < "2.3.7.2":
+                self.requires("opencolorio/1.1.1")
+            else:
+                self.requires("opencolorio/2.1.0")
         if self.options.with_opencv:
             self.requires("opencv/4.5.5")
         if self.options.with_tbb:

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -252,7 +252,7 @@ class OpenImageIOConan(ConanFile):
         if self.options.with_opencv:
             self.cpp_info.components["main"].requires.append("opencv::opencv")
         if self.options.with_tbb:
-            self.cpp_info.components["main"].requires.append("tbb::tbb")
+            self.cpp_info.components["main"].requires.append("onetbb::onetbb")
         if self.options.with_dicom:
             self.cpp_info.components["main"].requires.append("dcmtk::dcmtk")
         if self.options.with_ffmpeg:

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -88,19 +88,18 @@ class OpenImageIOConan(ConanFile):
 
     def requirements(self):
         # Required libraries
-        self.requires("zlib/1.2.11")
-        self.requires("boost/1.76.0")
+        self.requires("zlib/1.2.12")
+        self.requires("boost/1.78.0")
         self.requires("libtiff/4.3.0")
         self.requires("openexr/2.5.7")
         if self.options.with_libjpeg == "libjpeg":
             self.requires("libjpeg/9d")
         elif self.options.with_libjpeg == "libjpeg-turbo":
-            self.requires("libjpeg-turbo/2.1.1")
-        self.requires("pugixml/1.11")
+            self.requires("libjpeg-turbo/2.1.2")
+        self.requires("pugixml/1.12.1")
         self.requires("libsquish/1.15")
-        self.requires("tsl-robin-map/0.6.3")
-        self.requires("libsquish/1.15")
-        self.requires("fmt/8.0.1")
+        self.requires("tsl-robin-map/1.0.1")
+        self.requires("fmt/8.1.1")
 
         # Optional libraries
         if self.options.with_libpng:
@@ -108,13 +107,13 @@ class OpenImageIOConan(ConanFile):
         if self.options.with_freetype:
             self.requires("freetype/2.11.1")
         if self.options.with_hdf5:
-            self.requires("hdf5/1.12.0")
+            self.requires("hdf5/1.12.1")
         if self.options.with_opencolorio:
-            self.requires("opencolorio/1.1.1")
+            self.requires("opencolorio/2.1.0")
         if self.options.with_opencv:
-            self.requires("opencv/4.5.3")
+            self.requires("opencv/4.5.5")
         if self.options.with_tbb:
-            self.requires("tbb/2020.3")
+            self.requires("onetbb/2020.3")
         if self.options.with_dicom:
             self.requires("dcmtk/3.6.6")
         if self.options.with_ffmpeg:


### PR DESCRIPTION
- relocatable shared lib on macOS: see https://github.com/conan-io/hooks/issues/376
- `CMakeDeps` & `PkgConfigDeps` support
- cache CMake configuration with `functools.lru_cache`
- bump dependencies

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
