### PR TITLE
onetbb 2021.x: modernize

### DIFF
--- a/recipes/onetbb/all/conandata.yml
+++ b/recipes/onetbb/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  2021.3.0:
-    url: https://github.com/oneapi-src/oneTBB/archive/v2021.3.0.tar.gz
-    sha256: 8f616561603695bbb83871875d2c6051ea28f8187dbe59299961369904d1d49e
+  "2021.3.0":
+    url: "https://github.com/oneapi-src/oneTBB/archive/v2021.3.0.tar.gz"
+    sha256: "8f616561603695bbb83871875d2c6051ea28f8187dbe59299961369904d1d49e"

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -4,10 +4,10 @@ from conans.errors import ConanInvalidConfiguration
 import os
 import re
 
-required_conan_version = ">=1.37.0"
+required_conan_version = ">=1.43.0"
 
 
-class ConanFile(ConanFile):
+class OneTBBConan(ConanFile):
     name = "onetbb"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
@@ -17,8 +17,8 @@ class ConanFile(ConanFile):
         " programs that take full advantage of multicore performance, that are portable, composable"
         " and have future-proof scalability.")
     topics = ("tbb", "threading", "parallelism", "tbbmalloc")
-    provides = "tbb",
-    settings = "os", "compiler", "build_type", "arch"
+
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -93,19 +93,13 @@ class ConanFile(ConanFile):
     def package(self):
         CMake(self).install()
         self.copy(os.path.join("src", "LICENSE.txt"), dst="licenses")
-
-        # Remove cmake targets
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-
-        # Remove pkgconfig files
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-
-        # Remove documentation
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "TBB"
-        self.cpp_info.names["cmake_find_package_multi"] = "TBB"
+        self.cpp_info.set_property("cmake_file_name", "TBB")
+        self.cpp_info.set_property("pkg_config_name", "tbb")
 
         def lib_name(name):
             if self.settings.build_type == "Debug":
@@ -114,9 +108,8 @@ class ConanFile(ConanFile):
 
         # tbb
         tbb = self.cpp_info.components["libtbb"]
-        tbb.names["cmake_find_package"] = "tbb"
-        tbb.names["cmake_find_package_multi"] = "tbb"
 
+        tbb.set_property("cmake_target_name", "TBB::tbb")
         tbb.libs = [lib_name("tbb")]
         if self.settings.os == "Windows":
             version_info = tools.load(
@@ -130,24 +123,29 @@ class ConanFile(ConanFile):
                 flags=re.MULTILINE | re.DOTALL,
             )
             tbb.libs.append(lib_name("tbb{}".format(binary_version)))
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             tbb.system_libs = ["dl", "rt", "pthread"]
 
         # tbbmalloc
         if self.options.tbbmalloc:
             tbbmalloc = self.cpp_info.components["tbbmalloc"]
 
-            tbbmalloc.names["cmake_find_package"] = "tbbmalloc"
-            tbbmalloc.names["cmake_find_package_multi"] = "tbbmalloc"
+            tbbmalloc.set_property("cmake_target_name", "TBB::tbbmalloc")
             tbbmalloc.libs = [lib_name("tbbmalloc")]
-            if self.settings.os == "Linux":
+            if self.settings.os in ["Linux", "FreeBSD"]:
                 tbbmalloc.system_libs = ["dl", "pthread"]
 
             # tbbmalloc_proxy
             if self.options.tbbproxy:
                 tbbproxy = self.cpp_info.components["tbbmalloc_proxy"]
 
-                tbbproxy.names["cmake_find_package"] = "tbbmalloc_proxy"
-                tbbproxy.names["cmake_find_package_multi"] = "tbbmalloc_proxy"
+                tbbproxy.set_property("cmake_target_name", "TBB::tbbmalloc_proxy")
                 tbbproxy.libs = [lib_name("tbbmalloc_proxy")]
                 tbbproxy.requires = ["tbbmalloc"]
+
+        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
+        self.cpp_info.names["cmake_find_package"] = "TBB"
+        self.cpp_info.names["cmake_find_package_multi"] = "TBB"
+        self.cpp_info.names["pkg_config"] = "tbb"
+        tbb.names["cmake_find_package"] = "tbb"
+        tbb.names["cmake_find_package_multi"] = "tbb"

--- a/recipes/onetbb/all/test_package/conanfile.py
+++ b/recipes/onetbb/all/test_package/conanfile.py
@@ -3,14 +3,9 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
-    def build_requirements(self):
-        if self.settings.os == "Macos" and self.settings.arch == "armv8":
-            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
-            # set. This could be because you are using a Mac OS X version less than 10.5
-            # or because CMake's platform configuration is corrupt.
-            self.build_requires("cmake/3.20.1")
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
- remove `provides = "tbb"`, since tbb recipe is deprecated
- CMakeDeps & PkgConfigDeps support
- fix pkgconfig name

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
