### PR TITLE
(#10577) Add libipt recipe

### DIFF
--- a/recipes/libipt/all/CMakeLists.txt
+++ b/recipes/libipt/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(KEEP_RPATHS)
+
+add_subdirectory(source_subfolder)

--- a/recipes/libipt/all/conandata.yml
+++ b/recipes/libipt/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.0.5":
+    url: https://github.com/intel/libipt/archive/refs/tags/v2.0.5.tar.gz
+    sha256: 95acf499fdf0a0f5ebd07587bb443c702b1fd79f7d869749824234388b9bff80

--- a/recipes/libipt/all/conanfile.py
+++ b/recipes/libipt/all/conanfile.py
@@ -19,7 +19,6 @@ class LibIptConan(ConanFile):
             "fPIC": True,
     }
 
-    short_paths = True
     generators = "cmake"
     _cmake = None
 
@@ -67,7 +66,4 @@ class LibIptConan(ConanFile):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
         cmake = self._configure_cmake()
         cmake.install()
-
-    def package_info(self):
-        self.cpp_info.libs = ["ipt"]
 

--- a/recipes/libipt/all/conanfile.py
+++ b/recipes/libipt/all/conanfile.py
@@ -1,0 +1,76 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+
+import os
+
+required_conan_version = ">=1.33.0"
+
+class LibIptConan(ConanFile):
+    name = "libipt"
+    license = "BSD-3-Clause"
+    homepage = "https://github.com/intel/libipt"
+    url = "https://github.com/intel/libipt"
+    description = "Intel(R) Processor Trace Decoder Library"
+    topics = ("profiling", "tracing")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+            "shared": [True, False],
+            "fPIC": [True, False],
+    }
+    default_options = {
+            "shared": False,
+            "fPIC": True,
+    }
+
+    short_paths = True
+    generators = "cmake"
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def validate(self):
+        pass
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+               strip_root=True, destination=self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure()
+        return self._cmake
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
+    def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+    def build(self):
+        self._patch_sources()
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["ipt"]
+

--- a/recipes/libipt/all/conanfile.py
+++ b/recipes/libipt/all/conanfile.py
@@ -70,5 +70,5 @@ class LibIptConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["libipt"] if self.settings.os == "Windows" else ["ipt"]
         self.cpp_info.set_property("cmake_file_name", "libipt")
-        self.cpp_info.set_property("cmake_target_name", "libipt")
+        self.cpp_info.set_property("cmake_target_name", "libipt::libipt")
 

--- a/recipes/libipt/all/conanfile.py
+++ b/recipes/libipt/all/conanfile.py
@@ -67,3 +67,6 @@ class LibIptConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
 
+    def package_info(self):
+        self.cpp_info.libs = ["ipt"]
+

--- a/recipes/libipt/all/conanfile.py
+++ b/recipes/libipt/all/conanfile.py
@@ -1,7 +1,4 @@
 from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
-
-import os
 
 required_conan_version = ">=1.33.0"
 

--- a/recipes/libipt/all/conanfile.py
+++ b/recipes/libipt/all/conanfile.py
@@ -6,7 +6,7 @@ class LibIptConan(ConanFile):
     name = "libipt"
     license = "BSD-3-Clause"
     homepage = "https://github.com/intel/libipt"
-    url = "https://github.com/intel/libipt"
+    url = "https://github.com/conan-io/conan-center-index"
     description = "Intel(R) Processor Trace Decoder Library"
     topics = ("profiling", "tracing")
     settings = "os", "compiler", "build_type", "arch"

--- a/recipes/libipt/all/conanfile.py
+++ b/recipes/libipt/all/conanfile.py
@@ -68,5 +68,7 @@ class LibIptConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = ["ipt"]
+        self.cpp_info.libs = ["libipt"] if self.settings.os == "Windows" else ["ipt"]
+        self.cpp_info.set_property("cmake_file_name", "libipt")
+        self.cpp_info.set_property("cmake_target_name", "libipt")
 

--- a/recipes/libipt/all/test_package/CMakeLists.txt
+++ b/recipes/libipt/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(libipt REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_compile_features(test_package PRIVATE cxx_std_11 cxx_constexpr)
+target_link_libraries(${PROJECT_NAME} libipt::libipt)

--- a/recipes/libipt/all/test_package/conanfile.py
+++ b/recipes/libipt/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libipt/all/test_package/test_package.cpp
+++ b/recipes/libipt/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include <intel-pt.h>
+
+int main(int argc, char **argv)
+{
+    auto version = pt_library_version();
+
+	return 0;
+}

--- a/recipes/libipt/all/test_package/test_package.cpp
+++ b/recipes/libipt/all/test_package/test_package.cpp
@@ -2,7 +2,8 @@
 
 int main(int argc, char **argv)
 {
-    auto version = pt_library_version();
+    pt_config cfg;
+    pt_config_init(&cfg);
 
-	return 0;
+    return 0;
 }

--- a/recipes/libipt/config.yml
+++ b/recipes/libipt/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.0.5":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libipt/v.1.0.5**

Intel(R) Processor Trace Decoder Library
========================================

The Intel Processor Trace (Intel PT) Decoder Library is Intel's reference
implementation for decoding Intel PT.  It can be used as a standalone library or
it can be partially or fully integrated into your tool.

The library comes with a set of sample tools built on top of it and a test
system built on top of the sample tools.  The samples demonstrate how to use the
library and may serve as a starting point for integrating the library into your
tool.

Closes #10577 
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
