### PR TITLE
add libcurl version 7.83.0

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.83.0":
+    sha256: c0e64302a33d2fb79e0fc4e674260a22941e92ee2f11b894bf94d32b8f5531af
+    url: https://curl.se/download/curl-7.83.0.tar.gz
   "7.82.0":
     sha256: 910cc5fe279dc36e2cca534172c94364cf3fcf7d6494ba56e6c61a390881ddce
     url: https://curl.se/download/curl-7.82.0.tar.gz

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.83.0":
+    folder: all
   "7.82.0":
     folder: all
   "7.80.0":


### PR DESCRIPTION
Specify library name and version:  **libcurl/7.83.0**

Bumping to the latest upstream. I depend on this package, and this version corrects several security vulnerabilities.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
