### PR TITLE
hipony-enumerate: bump pfr + modernize

### DIFF
--- a/recipes/hipony-enumerate/all/conanfile.py
+++ b/recipes/hipony-enumerate/all/conanfile.py
@@ -1,14 +1,14 @@
-import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import functools
+import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class HiponyEnumerateConan(ConanFile):
     name = "hipony-enumerate"
     license = "BSL-1.0"
-
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/hipony/enumerate"
     description = "C++11 compatible version of enumerate"
@@ -20,17 +20,16 @@ class HiponyEnumerateConan(ConanFile):
         "aggregates": [True, False],
     }
     default_options = {
-        "aggregates": False
+        "aggregates": False,
     }
 
     generators = "cmake", "cmake_find_package_multi"
     no_copy_source = True
     exports_sources = ["CMakeLists.txt"]
-    _cmake = None
 
-    def requirements(self):
-        if self.options.aggregates:
-            self.requires("pfr/2.0.2")
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
     @property
     def _compilers_minimum_version(self):
@@ -44,6 +43,13 @@ class HiponyEnumerateConan(ConanFile):
     @property
     def _minimum_standard(self):
         return "17" if self.options.aggregates else "11"
+
+    def requirements(self):
+        if self.options.aggregates:
+            self.requires("pfr/2.0.2")
+
+    def package_id(self):
+        self.info.header_only()
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -67,23 +73,17 @@ class HiponyEnumerateConan(ConanFile):
                 "{} {} requires C++{}, which your compiler does not support."
                 .format(self.name, self.version, self._minimum_standard))
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
         cmake = CMake(self)
         cmake.definitions["BUILD_TESTING"] = "OFF"
         cmake.definitions["HIPONY_ENUMERATE_AGGREGATES_ENABLED"] = self.options.aggregates
         cmake.configure()
-        self._cmake = cmake
-        return self._cmake
+        return cmake
 
     def build(self):
         cmake = self._configure_cmake()
@@ -95,19 +95,22 @@ class HiponyEnumerateConan(ConanFile):
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
-    def package_id(self):
-        self.info.header_only()
-
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "hipony-enumerate")
+        self.cpp_info.set_property("cmake_target_name", "hipony::enumerate")
+
+        # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
+        if self.options.aggregates:
+            self.cpp_info.components["enumerate"].defines.append(
+                "HIPONY_ENUMERATE_AGGREGATES_ENABLED")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "hipony-enumerate"
         self.cpp_info.filenames["cmake_find_package_multi"] = "hipony-enumerate"
         self.cpp_info.names["cmake_find_package"] = "hipony"
         self.cpp_info.names["cmake_find_package_multi"] = "hipony"
         self.cpp_info.components["enumerate"].names["cmake_find_package"] = "enumerate"
         self.cpp_info.components["enumerate"].names["cmake_find_package_multi"] = "enumerate"
-
+        self.cpp_info.components["enumerate"].set_property("cmake_target_name", "hipony::enumerate")
         if self.options.aggregates:
-            self.cpp_info.components["enumerate"].requires.append(
-                "pfr::pfr")
-            self.cpp_info.components["enumerate"].defines.append(
-                "HIPONY_ENUMERATE_AGGREGATES_ENABLED")
+            self.cpp_info.components["enumerate"].requires.append("pfr::pfr")

--- a/recipes/hipony-enumerate/all/conanfile.py
+++ b/recipes/hipony-enumerate/all/conanfile.py
@@ -46,7 +46,7 @@ class HiponyEnumerateConan(ConanFile):
 
     def requirements(self):
         if self.options.aggregates:
-            self.requires("pfr/2.0.2")
+            self.requires("pfr/2.0.3")
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/hipony-enumerate/all/test_package/CMakeLists.txt
+++ b/recipes/hipony-enumerate/all/test_package/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-find_package(hipony-enumerate REQUIRED)
+find_package(hipony-enumerate REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE hipony::enumerate)

--- a/recipes/hipony-enumerate/all/test_package/conanfile.py
+++ b/recipes/hipony-enumerate/all/test_package/conanfile.py
@@ -3,8 +3,7 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
@@ -13,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
- `CMakeDeps` support
- cache CMake configuration with `functools.lru_cache`
- bump pfr to 2.0.3

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
