### PR TITLE
libarchive/3.6.x: Fix compile for Android

### DIFF
--- a/recipes/libarchive/all/conandata.yml
+++ b/recipes/libarchive/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.6.1":
+    url: "https://github.com/libarchive/libarchive/releases/download/v3.6.1/libarchive-3.6.1.tar.xz"
+    sha256: "5a411aceb978f43e626f0c2d1812ddd8807b645ed892453acabd532376c148e6"
   "3.6.0":
     url: "https://github.com/libarchive/libarchive/releases/download/v3.6.0/libarchive-3.6.0.tar.xz"
     sha256: "df283917799cb88659a5b33c0a598f04352d61936abcd8a48fe7b64e74950de7"
@@ -15,6 +18,12 @@ sources:
     url: "https://github.com/libarchive/libarchive/releases/download/v3.4.0/libarchive-3.4.0.tar.gz"
     sha256: "8643d50ed40c759f5412a3af4e353cffbce4fdf3b5cf321cb72cacf06b2d825e"
 patches:
+  "3.6.1":
+    - patch_file: "patches/android_compile.patch"
+      base_path: "source_subfolder"
+  "3.6.0":
+    - patch_file: "patches/android_compile.patch"
+      base_path: "source_subfolder"
   "3.4.0":
     - patch_file: "patches/msvc-no-we4061.patch"
       base_path: "source_subfolder"

--- a/recipes/libarchive/all/patches/android_compile.patch
+++ b/recipes/libarchive/all/patches/android_compile.patch
@@ -1,0 +1,15 @@
+diff --git a/libarchive/CMakeLists.txt b/libarchive/CMakeLists.txt
+index e1d76a5..e4a83e7 100644
+--- a/libarchive/CMakeLists.txt
++++ b/libarchive/CMakeLists.txt
+@@ -5,6 +5,10 @@
+ #
+ ############################################
+ 
++if (ANDROID)
++    include_directories(${PROJECT_SOURCE_DIR}/contrib/android/include)
++endif()
++
+ # Public headers
+ SET(include_HEADERS
+   archive.h

--- a/recipes/libarchive/config.yml
+++ b/recipes/libarchive/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.1":
+    folder: all
   "3.6.0":
     folder: all
   "3.5.2":


### PR DESCRIPTION
Bump version in the process

Specify library name and version:  **libarchive/3.6.x**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
