### PR TITLE
gdal: Allow the headers to be installed in include/gdal

### DIFF
--- a/recipes/gdal/all/conanfile.py
+++ b/recipes/gdal/all/conanfile.py
@@ -542,6 +542,7 @@ class GdalConan(ConanFile):
 
         args = []
         args.append("GDAL_HOME=\"{}\"".format(self.package_folder))
+        args.append("INCDIR=\"{}\"".format(os.path.join(self.package_folder, "include", "gdal")))
         args.append("DATADIR=\"{}\"".format(os.path.join(self.package_folder, "res", "gdal")))
         if self.settings.arch == "x86_64":
             args.append("WIN64=1")
@@ -697,6 +698,8 @@ class GdalConan(ConanFile):
             "--enable-static={}".format(yes_no(not self.options.shared)),
             "--enable-shared={}".format(yes_no(self.options.shared)),
         ])
+        args.append("--includedir={}".format(tools.unix_path(os.path.join(self.package_folder, "include", "gdal"))))
+
         # Enable C++14 if requested in conan profile or if with_charls enabled
         if (self.settings.compiler.cppstd and tools.valid_min_cppstd(self, 14)) or self.options.with_charls:
             args.append("--with-cpp14")
@@ -925,6 +928,7 @@ class GdalConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "GDAL"
         self.cpp_info.filenames["cmake_find_package"] = "GDAL"
         self.cpp_info.filenames["cmake_find_package_multi"] = "GDAL"
+        self.cpp_info.includedirs.append(os.path.join("include", "gdal"))
 
         lib_suffix = ""
         if self._is_msvc:


### PR DESCRIPTION
In some (most?) linux distros gdal headers files are installed in /usr/include/gdal
instead of /usr/include, the problem is that most of the apps that are using it they
will #include <gdal/gdal.h> not #include <gdal.h> and they can not work with the
current package layout.

List of distros that are using prefixed install:
 - debian https://packages.debian.org/bullseye/amd64/libgdal-dev/filelist
 - ubuntu (no surprise here) https://packages.ubuntu.com/jammy/amd64/libgdal-dev/filelist 
 - fedora https://packages.fedoraproject.org/pkgs/gdal/gdal-devel/fedora-rawhide.html#files


Specify library name and version:  **gdal/1.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
