### PR TITLE
[icu] Add an option to turn on the enable-rpath configure flag.

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -25,6 +25,7 @@ class ICUBase(ConanFile):
         "with_unit_tests": [True, False],
         "silent": [True, False],
         "with_dyload": [True, False],
+        "with_rpath": [True, False],
         "dat_package_file": "ANY",
         "with_icuio": [True, False],
         "with_extras": [True, False],
@@ -36,6 +37,7 @@ class ICUBase(ConanFile):
         "with_unit_tests": False,
         "silent": True,
         "with_dyload": True,
+        "with_rpath": False,
         "dat_package_file": None,
         "with_icuio": True,
         "with_extras": False,
@@ -208,6 +210,9 @@ class ICUBase(ConanFile):
 
         if not self.options.with_dyload:
             args += ["--disable-dyload"]
+
+        if self.options.with_rpath:
+            args.append("--enable-rpath")
 
         if not self._enable_icu_tools:
             args.append("--disable-tools")


### PR DESCRIPTION
Specify library name and version:  **icu/any**

Expose a configure flag `--enable-rpath` that is useful for shared builds with an option.

https://github.com/conan-io/conan-center-index/issues/10604

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
