### PR TITLE
taocpp-taopq: bump libpq + modernize

### DIFF
--- a/recipes/taocpp-taopq/all/CMakeLists.txt
+++ b/recipes/taocpp-taopq/all/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.4)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_subdirectory(source_subfolder)

--- a/recipes/taocpp-taopq/all/conanfile.py
+++ b/recipes/taocpp-taopq/all/conanfile.py
@@ -53,7 +53,7 @@ class TaoCPPTaopqConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("libpq/13.3")
+        self.requires("libpq/14.2")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/taocpp-taopq/all/conanfile.py
+++ b/recipes/taocpp-taopq/all/conanfile.py
@@ -1,9 +1,9 @@
-import os
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import functools
+import os
 
-
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class TaoCPPTaopqConan(ConanFile):
@@ -13,13 +13,19 @@ class TaoCPPTaopqConan(ConanFile):
     homepage = "https://github.com/taocpp/taopq"
     description = "C++ client library for PostgreSQL"
     topics = ("cpp17", "postgresql", "libpq", "data-base", "sql")
+
     settings = "os", "build_type", "compiler", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
     exports_sources = "CMakeLists.txt"
     generators = "cmake", "cmake_find_package"
-
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -46,8 +52,11 @@ class TaoCPPTaopqConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    def requirements(self):
+        self.requires("libpq/13.3")
+
     def validate(self):
-        if self.settings.compiler.cppstd:
+        if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "17")
         min_compiler_version = self._min_compilers_version.get(str(self.settings.compiler), False)
         if min_compiler_version:
@@ -56,21 +65,16 @@ class TaoCPPTaopqConan(ConanFile):
         else:
             self.output.warn("taocpp-taopq requires C++17. Your compiler is unknown. Assuming it supports C++17.")
 
-    def requirements(self):
-        self.requires("libpq/13.3")
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if not self._cmake:
-            self._cmake = CMake(self)
-            self._cmake.definitions["TAOPQ_BUILD_TESTS"] = False
-            self._cmake.definitions["TAOPQ_INSTALL_DOC_DIR"] = "licenses"
-            if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
-                self._cmake.definitions["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = self.options.shared
-            self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["TAOPQ_BUILD_TESTS"] = False
+        cmake.definitions["TAOPQ_INSTALL_DOC_DIR"] = "licenses"
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
 
     def build(self):
         cmake = self._configure_cmake()
@@ -82,13 +86,19 @@ class TaoCPPTaopqConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "taopq")
+        self.cpp_info.set_property("cmake_target_name", "taocpp::taopq")
+        # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.components["_taocpp-taopq"].libs = ["taopq"]
+        if self.settings.os == "Windows":
+            self.cpp_info.components["_taocpp-taopq"].system_libs = ["Ws2_32"]
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "taopq"
         self.cpp_info.filenames["cmake_find_package_multi"] = "taopq"
         self.cpp_info.names["cmake_find_package"] = "taocpp"
         self.cpp_info.names["cmake_find_package_multi"] = "taocpp"
         self.cpp_info.components["_taocpp-taopq"].names["cmake_find_package"] = "taopq"
         self.cpp_info.components["_taocpp-taopq"].names["cmake_find_package_multi"] = "taopq"
-        self.cpp_info.components["_taocpp-taopq"].libs = ["taopq"]
-        if self.settings.os == "Windows":
-            self.cpp_info.components["_taocpp-taopq"].system_libs = ["Ws2_32"]
+        self.cpp_info.components["_taocpp-taopq"].set_property("cmake_target_name", "taocpp::taopq")
         self.cpp_info.components["_taocpp-taopq"].requires = ["libpq::libpq"]

--- a/recipes/taocpp-taopq/all/test_package/CMakeLists.txt
+++ b/recipes/taocpp-taopq/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/taocpp-taopq/all/test_package/conanfile.py
+++ b/recipes/taocpp-taopq/all/test_package/conanfile.py
@@ -1,10 +1,9 @@
-import os.path
-
 from conans import ConanFile, CMake, tools
+import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
@@ -13,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- cache CMake configuration with `functools.lru_cache`
- `CMakeDeps` support
- bump libpq to 14.2
- move `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` to CMakeList wrapper

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
