### PR TITLE
sdl: add 2.0.22 + also provide SDL2::SDL2 in CMakeDeps if static

### DIFF
--- a/recipes/sdl/all/conandata.yml
+++ b/recipes/sdl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.22":
+    url: "https://www.libsdl.org/release/SDL2-2.0.22.tar.gz"
+    sha256: fe7cbf3127882e3fc7259a75a0cb585620272c51745d3852ab9dd87960697f2e
   "2.0.20":
     url: "https://www.libsdl.org/release/SDL2-2.0.20.tar.gz"
     sha256: c56aba1d7b5b0e7e999e4a7698c70b63a3394ff9704b5f6e1c57e0c16f04dd06

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan.tools.microsoft import is_msvc
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import functools
 import os
 
 required_conan_version = ">=1.45.0"
@@ -75,7 +76,6 @@ class SDLConan(ConanFile):
     }
 
     generators = ["cmake", "pkg_config"]
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -191,161 +191,160 @@ class SDLConan(ConanFile):
                 "find_program(WAYLAND_SCANNER NAMES wayland-scanner REQUIRED PATHS {} NO_DEFAULT_PATH)".format(wayland_bin_path),
             )
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
+        cmake = CMake(self)
         cmake_required_includes = []  # List of directories used by CheckIncludeFile (https://cmake.org/cmake/help/latest/module/CheckIncludeFile.html)
         cmake_extra_ldflags = []
         # FIXME: self.install_folder not defined? Neccessary?
-        self._cmake.definitions["CONAN_INSTALL_FOLDER"] = self.install_folder
+        cmake.definitions["CONAN_INSTALL_FOLDER"] = self.install_folder
         if self.settings.os != "Windows" and not self.options.shared:
-            self._cmake.definitions["SDL_STATIC_PIC"] = self.options.fPIC
+            cmake.definitions["SDL_STATIC_PIC"] = self.options.fPIC
         if is_msvc(self) and not self.options.shared:
-            self._cmake.definitions["HAVE_LIBC"] = True
-        self._cmake.definitions["SDL_SHARED"] = self.options.shared
-        self._cmake.definitions["SDL_STATIC"] = not self.options.shared
+            cmake.definitions["HAVE_LIBC"] = True
+        cmake.definitions["SDL_SHARED"] = self.options.shared
+        cmake.definitions["SDL_STATIC"] = not self.options.shared
 
         if tools.Version(self.version) < "2.0.18":
-            self._cmake.definitions["VIDEO_OPENGL"] = self.options.opengl
-            self._cmake.definitions["VIDEO_OPENGLES"] = self.options.opengles
-            self._cmake.definitions["VIDEO_VULKAN"] = self.options.vulkan
+            cmake.definitions["VIDEO_OPENGL"] = self.options.opengl
+            cmake.definitions["VIDEO_OPENGLES"] = self.options.opengles
+            cmake.definitions["VIDEO_VULKAN"] = self.options.vulkan
             if self.settings.os == "Linux":
                 # See https://github.com/bincrafters/community/issues/696
-                self._cmake.definitions["SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS"] = 1
+                cmake.definitions["SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS"] = 1
 
-                self._cmake.definitions["ALSA"] = self.options.alsa
+                cmake.definitions["ALSA"] = self.options.alsa
                 if self.options.alsa:
-                    self._cmake.definitions["ALSA_SHARED"] = self.deps_cpp_info["libalsa"].shared
-                    self._cmake.definitions["HAVE_ASOUNDLIB_H"] = True
-                    self._cmake.definitions["HAVE_LIBASOUND"] = True
-                self._cmake.definitions["JACK"] = self.options.jack
+                    cmake.definitions["ALSA_SHARED"] = self.deps_cpp_info["libalsa"].shared
+                    cmake.definitions["HAVE_ASOUNDLIB_H"] = True
+                    cmake.definitions["HAVE_LIBASOUND"] = True
+                cmake.definitions["JACK"] = self.options.jack
                 if self.options.jack:
-                    self._cmake.definitions["JACK_SHARED"] = self.deps_cpp_info["jack"].shared
-                self._cmake.definitions["ESD"] = self.options.esd
+                    cmake.definitions["JACK_SHARED"] = self.deps_cpp_info["jack"].shared
+                cmake.definitions["ESD"] = self.options.esd
                 if self.options.esd:
-                    self._cmake.definitions["ESD_SHARED"] = self.deps_cpp_info["esd"].shared
-                self._cmake.definitions["PULSEAUDIO"] = self.options.pulse
+                    cmake.definitions["ESD_SHARED"] = self.deps_cpp_info["esd"].shared
+                cmake.definitions["PULSEAUDIO"] = self.options.pulse
                 if self.options.pulse:
-                    self._cmake.definitions["PULSEAUDIO_SHARED"] = self.deps_cpp_info["pulseaudio"].shared
-                self._cmake.definitions["SNDIO"] = self.options.sndio
+                    cmake.definitions["PULSEAUDIO_SHARED"] = self.deps_cpp_info["pulseaudio"].shared
+                cmake.definitions["SNDIO"] = self.options.sndio
                 if self.options.sndio:
-                    self._cmake.definitions["SNDIO_SHARED"] = self.deps_cpp_info["sndio"].shared
-                self._cmake.definitions["NAS"] = self.options.nas
+                    cmake.definitions["SNDIO_SHARED"] = self.deps_cpp_info["sndio"].shared
+                cmake.definitions["NAS"] = self.options.nas
                 if self.options.nas:
                     cmake_extra_ldflags += ["-lXau"]  # FIXME: SDL sources doesn't take into account transitive dependencies
                     cmake_required_includes += [os.path.join(self.deps_cpp_info["nas"].rootpath, str(it)) for it in self.deps_cpp_info["nas"].includedirs]
-                    self._cmake.definitions["NAS_SHARED"] = self.options["nas"].shared
-                self._cmake.definitions["VIDEO_X11"] = self.options.x11
+                    cmake.definitions["NAS_SHARED"] = self.options["nas"].shared
+                cmake.definitions["VIDEO_X11"] = self.options.x11
                 if self.options.x11:
-                    self._cmake.definitions["HAVE_XEXT_H"] = True
-                self._cmake.definitions["VIDEO_X11_XCURSOR"] = self.options.xcursor
+                    cmake.definitions["HAVE_XEXT_H"] = True
+                cmake.definitions["VIDEO_X11_XCURSOR"] = self.options.xcursor
                 if self.options.xcursor:
-                    self._cmake.definitions["HAVE_XCURSOR_H"] = True
-                self._cmake.definitions["VIDEO_X11_XINERAMA"] = self.options.xinerama
+                    cmake.definitions["HAVE_XCURSOR_H"] = True
+                cmake.definitions["VIDEO_X11_XINERAMA"] = self.options.xinerama
                 if self.options.xinerama:
-                    self._cmake.definitions["HAVE_XINERAMA_H"] = True
-                self._cmake.definitions["VIDEO_X11_XINPUT"] = self.options.xinput
+                    cmake.definitions["HAVE_XINERAMA_H"] = True
+                cmake.definitions["VIDEO_X11_XINPUT"] = self.options.xinput
                 if self.options.xinput:
-                    self._cmake.definitions["HAVE_XINPUT_H"] = True
-                self._cmake.definitions["VIDEO_X11_XRANDR"] = self.options.xrandr
+                    cmake.definitions["HAVE_XINPUT_H"] = True
+                cmake.definitions["VIDEO_X11_XRANDR"] = self.options.xrandr
                 if self.options.xrandr:
-                    self._cmake.definitions["HAVE_XRANDR_H"] = True
-                self._cmake.definitions["VIDEO_X11_XSCRNSAVER"] = self.options.xscrnsaver
+                    cmake.definitions["HAVE_XRANDR_H"] = True
+                cmake.definitions["VIDEO_X11_XSCRNSAVER"] = self.options.xscrnsaver
                 if self.options.xscrnsaver:
-                    self._cmake.definitions["HAVE_XSS_H"] = True
-                self._cmake.definitions["VIDEO_X11_XSHAPE"] = self.options.xshape
+                    cmake.definitions["HAVE_XSS_H"] = True
+                cmake.definitions["VIDEO_X11_XSHAPE"] = self.options.xshape
                 if self.options.xshape:
-                    self._cmake.definitions["HAVE_XSHAPE_H"] = True
-                self._cmake.definitions["VIDEO_X11_XVM"] = self.options.xvm
+                    cmake.definitions["HAVE_XSHAPE_H"] = True
+                cmake.definitions["VIDEO_X11_XVM"] = self.options.xvm
                 if self.options.xvm:
-                    self._cmake.definitions["HAVE_XF86VM_H"] = True
-                self._cmake.definitions["VIDEO_WAYLAND"] = self.options.wayland
+                    cmake.definitions["HAVE_XF86VM_H"] = True
+                cmake.definitions["VIDEO_WAYLAND"] = self.options.wayland
                 if self.options.wayland:
                     # FIXME: Otherwise 2.0.16 links with system wayland (from egl/system requirement)
                     cmake_extra_ldflags += ["-L{}".format(os.path.join(self.deps_cpp_info["wayland"].rootpath, it)) for it in self.deps_cpp_info["wayland"].libdirs]
-                    self._cmake.definitions["WAYLAND_SHARED"] = self.options["wayland"].shared
-                    self._cmake.definitions["WAYLAND_SCANNER_1_15_FOUND"] = 1  # FIXME: Check actual build-requires version
+                    cmake.definitions["WAYLAND_SHARED"] = self.options["wayland"].shared
+                    cmake.definitions["WAYLAND_SCANNER_1_15_FOUND"] = 1  # FIXME: Check actual build-requires version
 
-                self._cmake.definitions["VIDEO_DIRECTFB"] = self.options.directfb
-                self._cmake.definitions["VIDEO_RPI"] = self.options.video_rpi
-                self._cmake.definitions["HAVE_LIBUNWIND_H"] = self.options.libunwind
+                cmake.definitions["VIDEO_DIRECTFB"] = self.options.directfb
+                cmake.definitions["VIDEO_RPI"] = self.options.video_rpi
+                cmake.definitions["HAVE_LIBUNWIND_H"] = self.options.libunwind
             elif self.settings.os == "Windows":
-                self._cmake.definitions["DIRECTX"] = self.options.directx
+                cmake.definitions["DIRECTX"] = self.options.directx
         else:
-            self._cmake.definitions["SDL_OPENGL"] = self.options.opengl
-            self._cmake.definitions["SDL_OPENGLES"] = self.options.opengles
-            self._cmake.definitions["SDL_VULKAN"] = self.options.vulkan
+            cmake.definitions["SDL_OPENGL"] = self.options.opengl
+            cmake.definitions["SDL_OPENGLES"] = self.options.opengles
+            cmake.definitions["SDL_VULKAN"] = self.options.vulkan
             if self.settings.os == "Linux":
                 # See https://github.com/bincrafters/community/issues/696
-                self._cmake.definitions["SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS"] = 1
+                cmake.definitions["SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS"] = 1
 
-                self._cmake.definitions["SDL_ALSA"] = self.options.alsa
+                cmake.definitions["SDL_ALSA"] = self.options.alsa
                 if self.options.alsa:
-                    self._cmake.definitions["SDL_ALSA_SHARED"] = self.deps_cpp_info["libalsa"].shared
-                    self._cmake.definitions["HAVE_ASOUNDLIB_H"] = True
-                    self._cmake.definitions["HAVE_LIBASOUND"] = True
-                self._cmake.definitions["SDL_JACK"] = self.options.jack
+                    cmake.definitions["SDL_ALSA_SHARED"] = self.deps_cpp_info["libalsa"].shared
+                    cmake.definitions["HAVE_ASOUNDLIB_H"] = True
+                    cmake.definitions["HAVE_LIBASOUND"] = True
+                cmake.definitions["SDL_JACK"] = self.options.jack
                 if self.options.jack:
-                    self._cmake.definitions["SDL_JACK_SHARED"] = self.deps_cpp_info["jack"].shared
-                self._cmake.definitions["SDL_ESD"] = self.options.esd
+                    cmake.definitions["SDL_JACK_SHARED"] = self.deps_cpp_info["jack"].shared
+                cmake.definitions["SDL_ESD"] = self.options.esd
                 if self.options.esd:
-                    self._cmake.definitions["SDL_ESD_SHARED"] = self.deps_cpp_info["esd"].shared
-                self._cmake.definitions["SDL_PULSEAUDIO"] = self.options.pulse
+                    cmake.definitions["SDL_ESD_SHARED"] = self.deps_cpp_info["esd"].shared
+                cmake.definitions["SDL_PULSEAUDIO"] = self.options.pulse
                 if self.options.pulse:
-                    self._cmake.definitions["SDL_PULSEAUDIO_SHARED"] = self.deps_cpp_info["pulseaudio"].shared
-                self._cmake.definitions["SDL_SNDIO"] = self.options.sndio
+                    cmake.definitions["SDL_PULSEAUDIO_SHARED"] = self.deps_cpp_info["pulseaudio"].shared
+                cmake.definitions["SDL_SNDIO"] = self.options.sndio
                 if self.options.sndio:
-                    self._cmake.definitions["SDL_SNDIO_SHARED"] = self.deps_cpp_info["sndio"].shared
-                self._cmake.definitions["SDL_NAS"] = self.options.nas
+                    cmake.definitions["SDL_SNDIO_SHARED"] = self.deps_cpp_info["sndio"].shared
+                cmake.definitions["SDL_NAS"] = self.options.nas
                 if self.options.nas:
                     cmake_extra_ldflags += ["-lXau"]  # FIXME: SDL sources doesn't take into account transitive dependencies
                     cmake_required_includes += [os.path.join(self.deps_cpp_info["nas"].rootpath, str(it)) for it in self.deps_cpp_info["nas"].includedirs]
-                    self._cmake.definitions["SDL_NAS_SHARED"] = self.options["nas"].shared
-                self._cmake.definitions["SDL_X11"] = self.options.x11
+                    cmake.definitions["SDL_NAS_SHARED"] = self.options["nas"].shared
+                cmake.definitions["SDL_X11"] = self.options.x11
                 if self.options.x11:
-                    self._cmake.definitions["HAVE_XEXT_H"] = True
-                self._cmake.definitions["SDL_X11_XCURSOR"] = self.options.xcursor
+                    cmake.definitions["HAVE_XEXT_H"] = True
+                cmake.definitions["SDL_X11_XCURSOR"] = self.options.xcursor
                 if self.options.xcursor:
-                    self._cmake.definitions["HAVE_XCURSOR_H"] = True
-                self._cmake.definitions["SDL_X11_XINERAMA"] = self.options.xinerama
+                    cmake.definitions["HAVE_XCURSOR_H"] = True
+                cmake.definitions["SDL_X11_XINERAMA"] = self.options.xinerama
                 if self.options.xinerama:
-                    self._cmake.definitions["HAVE_XINERAMA_H"] = True
-                self._cmake.definitions["SDL_X11_XINPUT"] = self.options.xinput
+                    cmake.definitions["HAVE_XINERAMA_H"] = True
+                cmake.definitions["SDL_X11_XINPUT"] = self.options.xinput
                 if self.options.xinput:
-                    self._cmake.definitions["HAVE_XINPUT_H"] = True
-                self._cmake.definitions["SDL_X11_XRANDR"] = self.options.xrandr
+                    cmake.definitions["HAVE_XINPUT_H"] = True
+                cmake.definitions["SDL_X11_XRANDR"] = self.options.xrandr
                 if self.options.xrandr:
-                    self._cmake.definitions["HAVE_XRANDR_H"] = True
-                self._cmake.definitions["SDL_X11_XSCRNSAVER"] = self.options.xscrnsaver
+                    cmake.definitions["HAVE_XRANDR_H"] = True
+                cmake.definitions["SDL_X11_XSCRNSAVER"] = self.options.xscrnsaver
                 if self.options.xscrnsaver:
-                    self._cmake.definitions["HAVE_XSS_H"] = True
-                self._cmake.definitions["SDL_X11_XSHAPE"] = self.options.xshape
+                    cmake.definitions["HAVE_XSS_H"] = True
+                cmake.definitions["SDL_X11_XSHAPE"] = self.options.xshape
                 if self.options.xshape:
-                    self._cmake.definitions["HAVE_XSHAPE_H"] = True
-                self._cmake.definitions["SDL_X11_XVM"] = self.options.xvm
+                    cmake.definitions["HAVE_XSHAPE_H"] = True
+                cmake.definitions["SDL_X11_XVM"] = self.options.xvm
                 if self.options.xvm:
-                    self._cmake.definitions["HAVE_XF86VM_H"] = True
-                self._cmake.definitions["SDL_WAYLAND"] = self.options.wayland
+                    cmake.definitions["HAVE_XF86VM_H"] = True
+                cmake.definitions["SDL_WAYLAND"] = self.options.wayland
                 if self.options.wayland:
                     # FIXME: Otherwise 2.0.16 links with system wayland (from egl/system requirement)
                     cmake_extra_ldflags += ["-L{}".format(os.path.join(self.deps_cpp_info["wayland"].rootpath, it)) for it in self.deps_cpp_info["wayland"].libdirs]
-                    self._cmake.definitions["SDL_WAYLAND_SHARED"] = self.options["wayland"].shared
+                    cmake.definitions["SDL_WAYLAND_SHARED"] = self.options["wayland"].shared
 
-                self._cmake.definitions["SDL_DIRECTFB"] = self.options.directfb
-                self._cmake.definitions["SDL_RPI"] = self.options.video_rpi
-                self._cmake.definitions["HAVE_LIBUNWIND_H"] = self.options.libunwind
+                cmake.definitions["SDL_DIRECTFB"] = self.options.directfb
+                cmake.definitions["SDL_RPI"] = self.options.video_rpi
+                cmake.definitions["HAVE_LIBUNWIND_H"] = self.options.libunwind
             elif self.settings.os == "Windows":
-                self._cmake.definitions["SDL_DIRECTX"] = self.options.directx
+                cmake.definitions["SDL_DIRECTX"] = self.options.directx
 
         if tools.Version(self.version) >= "2.0.22":
-            self._cmake.definitions["SDL2_DISABLE_SDL2MAIN"] = not self.options.sdl2main
+            cmake.definitions["SDL2_DISABLE_SDL2MAIN"] = not self.options.sdl2main
 
         # Add extra information collected from the deps
-        self._cmake.definitions["EXTRA_LDFLAGS"] = " ".join(cmake_extra_ldflags)
-        self._cmake.definitions["CMAKE_REQUIRED_INCLUDES"] = ";".join(cmake_required_includes)
-        self._cmake.configure(build_dir=self._build_subfolder)
-        return self._cmake
+        cmake.definitions["EXTRA_LDFLAGS"] = " ".join(cmake_extra_ldflags)
+        cmake.definitions["CMAKE_REQUIRED_INCLUDES"] = ";".join(cmake_required_includes)
+        cmake.configure(build_dir=self._build_subfolder)
+        return cmake
 
     def build(self):
         self._patch_sources()

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -372,10 +372,12 @@ class SDLConan(ConanFile):
         postfix = "d" if self.settings.os != "Android" and self.settings.build_type == "Debug" else ""
 
         # SDL2
-        sdl2_cmake_target = "SDL2" if self.options.shared else "SDL2-static"
-        self.cpp_info.components["libsdl2"].set_property("cmake_target_name", "SDL2::{}".format(sdl2_cmake_target))
+        self.cpp_info.components["libsdl2"].set_property("cmake_target_name", "SDL2::SDL2")
+        if not self.options.shared:
+            self.cpp_info.components["libsdl2"].set_property("cmake_target_aliases", ["SDL2::SDL2-static"])
         self.cpp_info.components["libsdl2"].set_property("pkg_config_name", "sdl2")
 
+        sdl2_cmake_target = "SDL2" if self.options.shared else "SDL2-static"
         self.cpp_info.components["libsdl2"].names["cmake_find_package"] = sdl2_cmake_target
         self.cpp_info.components["libsdl2"].names["cmake_find_package_multi"] = sdl2_cmake_target
 
@@ -453,5 +455,5 @@ class SDLConan(ConanFile):
         # Workaround to avoid unwanted sdl::sdl target in CMakeDeps generator
         self.cpp_info.set_property(
             "cmake_target_name",
-            "SDL2::{}".format("SDL2main" if self.options.sdl2main else sdl2_cmake_target),
+            "SDL2::{}".format("SDL2main" if self.options.sdl2main else "SDL2"),
         )

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -162,7 +162,8 @@ class SDLConan(ConanFile):
                 raise ConanInvalidConfiguration("Package for 'directfb' is not available (yet)")
 
     def package_id(self):
-        del self.info.options.sdl2main
+        if tools.Version(self.version) < "2.0.22":
+            del self.info.options.sdl2main
 
     def build_requirements(self):
         if self.settings.os == "Linux":
@@ -336,6 +337,9 @@ class SDLConan(ConanFile):
                 self._cmake.definitions["HAVE_LIBUNWIND_H"] = self.options.libunwind
             elif self.settings.os == "Windows":
                 self._cmake.definitions["SDL_DIRECTX"] = self.options.directx
+
+        if tools.Version(self.version) >= "2.0.22":
+            self._cmake.definitions["SDL2_DISABLE_SDL2MAIN"] = not self.options.sdl2main
 
         # Add extra information collected from the deps
         self._cmake.definitions["EXTRA_LDFLAGS"] = " ".join(cmake_extra_ldflags)

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -1,8 +1,9 @@
+from conan.tools.microsoft import is_msvc
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.45.0"
 
 
 class SDLConan(ConanFile):
@@ -92,7 +93,7 @@ class SDLConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-            if self.settings.compiler in ["Visual Studio", "msvc"]:
+            if is_msvc(self):
                 del self.options.iconv
         if self.settings.os != "Linux":
             del self.options.alsa
@@ -199,7 +200,7 @@ class SDLConan(ConanFile):
         self._cmake.definitions["CONAN_INSTALL_FOLDER"] = self.install_folder
         if self.settings.os != "Windows" and not self.options.shared:
             self._cmake.definitions["SDL_STATIC_PIC"] = self.options.fPIC
-        if self.settings.compiler in ["Visual Studio", "msvc"] and not self.options.shared:
+        if is_msvc(self) and not self.options.shared:
             self._cmake.definitions["HAVE_LIBC"] = True
         self._cmake.definitions["SDL_SHARED"] = self.options.shared
         self._cmake.definitions["SDL_STATIC"] = not self.options.shared

--- a/recipes/sdl/config.yml
+++ b/recipes/sdl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.22":
+    folder: all
   "2.0.20":
     folder: all
   "2.0.18":


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/10614

Since https://github.com/libsdl-org/SDL/pull/4502, upstream provides `SDL2::SDL2` target in static only build as an alias of `SDL2::SDL2-static`.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
