### PR TITLE
libsodium: add cci.20220501

### DIFF
--- a/recipes/libsodium/all/conandata.yml
+++ b/recipes/libsodium/all/conandata.yml
@@ -2,7 +2,13 @@ sources:
   "1.0.18":
     url: "https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18.tar.gz"
     sha256: "6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1"
+  "cci.20220501":
+    url: "https://github.com/jedisct1/libsodium/archive/78b6f57493a02a70fca44e5ef3f9d7d1cae9029f.tar.gz"
+    sha256: "5274b09894c0a7d6676325277cb2e278f45e1e5e077bae4bd8778aba4d6d40da"
 patches:
   "1.0.18":
+    - patch_file: "patches/0001-1.0.18-msvc_props.patch"
+      base_path: "source_subfolder"
+  "cci.20220501":
     - patch_file: "patches/0001-1.0.18-msvc_props.patch"
       base_path: "source_subfolder"

--- a/recipes/libsodium/all/conandata.yml
+++ b/recipes/libsodium/all/conandata.yml
@@ -1,14 +1,16 @@
+# To update the version on CCI, add a new cci.date entry from the stable branch:
+# https://github.com/jedisct1/libsodium/commits/stable
 sources:
   "1.0.18":
     url: "https://github.com/jedisct1/libsodium/releases/download/1.0.18-RELEASE/libsodium-1.0.18.tar.gz"
     sha256: "6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1"
-  "cci.20220501":
+  "cci.20220430":
     url: "https://github.com/jedisct1/libsodium/archive/78b6f57493a02a70fca44e5ef3f9d7d1cae9029f.tar.gz"
     sha256: "5274b09894c0a7d6676325277cb2e278f45e1e5e077bae4bd8778aba4d6d40da"
 patches:
   "1.0.18":
     - patch_file: "patches/0001-1.0.18-msvc_props.patch"
       base_path: "source_subfolder"
-  "cci.20220501":
+  "cci.20220430":
     - patch_file: "patches/0001-1.0.18-msvc_props.patch"
       base_path: "source_subfolder"

--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -87,17 +87,19 @@ class LibsodiumConan(ConanFile):
                 "14": "vs2015",
                 "15": "vs2017",
                 "16": "vs2019",
+                "17": "vs2022",
             }
         else:
             folder = {
                 "190": "vs2015",
                 "191": "vs2017",
                 "192": "vs2019",
+                "193": "vs2022",
             }
         return folder.get(str(self.settings.compiler.version))
 
     def _build_msvc(self):
-        msvc_sln_folder = self._msvc_sln_folder or "vs2019"
+        msvc_sln_folder = self._msvc_sln_folder or "vs2022"
         upgrade_project = self._msvc_sln_folder is None
         sln_path = os.path.join(self.build_folder, self._source_subfolder, "builds", "msvc", msvc_sln_folder, "libsodium.sln")
         build_type = "{}{}".format(

--- a/recipes/libsodium/all/readme-update-cci.txt
+++ b/recipes/libsodium/all/readme-update-cci.txt
@@ -1,0 +1,9 @@
+2022-05-01
+
+Note that the libsodium project does not create new release version numbers since 1.0.18
+
+Instead, they maintain a fork branch (stable) into which they cherry-pick commits.
+Consumers of the library are expected to simply use the current head of the stable branch.
+
+To update the version on CCI, add a new entry from this branch:
+https://github.com/jedisct1/libsodium/commits/stable

--- a/recipes/libsodium/all/readme-update-cci.txt
+++ b/recipes/libsodium/all/readme-update-cci.txt
@@ -1,9 +1,0 @@
-2022-05-01
-
-Note that the libsodium project does not create new release version numbers since 1.0.18
-
-Instead, they maintain a fork branch (stable) into which they cherry-pick commits.
-Consumers of the library are expected to simply use the current head of the stable branch.
-
-To update the version on CCI, add a new entry from this branch:
-https://github.com/jedisct1/libsodium/commits/stable

--- a/recipes/libsodium/config.yml
+++ b/recipes/libsodium/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.0.18":
     folder: all
+  "cci.20220501":
+    folder: all

--- a/recipes/libsodium/config.yml
+++ b/recipes/libsodium/config.yml
@@ -1,5 +1,5 @@
 versions:
   "1.0.18":
     folder: all
-  "cci.20220501":
+  "cci.20220430":
     folder: all


### PR DESCRIPTION
Upstream does not tag new releases anymore,
instead they continue to push to the stable branch, and expect consumers
to use the latest commit on the stable branch.

libsodium/cci.20220501

I also added support for MSVC 2022 in the recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
