### PR TITLE
gfortran: fix hooks

### DIFF
--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -9,3 +9,6 @@ sources:
     "Macos":
       url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz
       sha256: 2de46f571eefc2b544db4ed6c958c78a5e3e78c4b4b5daab38aabc1b08dd5666
+    "Linux-infrastructure":
+      url: https://gfortran.meteodat.ch/download/x86_64/gcc-infrastructure.tar.xz
+      sha256: bc4bb9931d0d94de70de3488183a76178e2d3a3447cd1f4fbbd5539223034693

--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -2,7 +2,6 @@ sources:
   "10.2":
     "Windows":
       url: https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
-      filename: GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
       sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
     "Linux":
       url: https://gfortran.meteodat.ch/download/x86_64/snapshots/gcc-10-20210109.tar.xz

--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  "10.2":
+  "10.2.0":
     "Windows":
       url: https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
       sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44

--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -5,7 +5,7 @@ sources:
       sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
     "Linux":
       url: https://gfortran.meteodat.ch/download/x86_64/releases/gcc-10.3.0.tar.xz
-      sha256: 494e9d881d6d9bb4a5707bfa149f77001599f093090c6c78fdb19cefbacda7b8
+      sha256: df89539786951fee8a97ade67b5a24bdf24734f1057fedd50d8335e9309c432b
     "Macos":
       url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz
       sha256: 2de46f571eefc2b544db4ed6c958c78a5e3e78c4b4b5daab38aabc1b08dd5666

--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -4,7 +4,7 @@ sources:
       url: https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
       sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
     "Linux":
-      url: https://gfortran.meteodat.ch/download/x86_64/releases/gcc-10.3.0.tar.xz
+      url: https://gfortran.meteodat.ch/download/x86_64/releases/gcc-10.2.0.tar.xz
       sha256: df89539786951fee8a97ade67b5a24bdf24734f1057fedd50d8335e9309c432b
     "Macos":
       url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz

--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -5,7 +5,7 @@ sources:
       sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
     "Linux":
       url: https://gfortran.meteodat.ch/download/x86_64/releases/gcc-10.2.0.tar.xz
-      sha256: df89539786951fee8a97ade67b5a24bdf24734f1057fedd50d8335e9309c432b
+      sha256: 5cfaf152db442bb967963ca62d4590980cb2664c5902c1a9578fc8a9c6efe40f
     "Macos":
       url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz
       sha256: 2de46f571eefc2b544db4ed6c958c78a5e3e78c4b4b5daab38aabc1b08dd5666

--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -1,13 +1,12 @@
 sources:
   "10.2":
-    "url":
-      "Windows":
-        url: https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
-        filename: GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
-        sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
-      "Linux":
-        url: https://gfortran.meteodat.ch/download/x86_64/snapshots/gcc-10-20210109.tar.xz
-        sha256: 494e9d881d6d9bb4a5707bfa149f77001599f093090c6c78fdb19cefbacda7b8
-      "Macos":
-        url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz
-        sha256: 2de46f571eefc2b544db4ed6c958c78a5e3e78c4b4b5daab38aabc1b08dd5666
+    "Windows":
+      url: https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
+      filename: GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
+      sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
+    "Linux":
+      url: https://gfortran.meteodat.ch/download/x86_64/snapshots/gcc-10-20210109.tar.xz
+      sha256: 494e9d881d6d9bb4a5707bfa149f77001599f093090c6c78fdb19cefbacda7b8
+    "Macos":
+      url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz
+      sha256: 2de46f571eefc2b544db4ed6c958c78a5e3e78c4b4b5daab38aabc1b08dd5666

--- a/recipes/gfortran/all/conandata.yml
+++ b/recipes/gfortran/all/conandata.yml
@@ -4,7 +4,7 @@ sources:
       url: https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/ray_linn/GCC-10.X-with-ada/GCC-10.2.0-crt-8.0.0-with-ada-20201019.7z
       sha256: 5c3fc254494bc24eb201870f4b781d401cf7279bd03ea1aba6f2ffae771ded44
     "Linux":
-      url: https://gfortran.meteodat.ch/download/x86_64/snapshots/gcc-10-20210109.tar.xz
+      url: https://gfortran.meteodat.ch/download/x86_64/releases/gcc-10.3.0.tar.xz
       sha256: 494e9d881d6d9bb4a5707bfa149f77001599f093090c6c78fdb19cefbacda7b8
     "Macos":
       url: https://downloads.sourceforge.net/project/hpc/hpc/g95/gfortran-10.2-bin.tar.gz

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -64,11 +64,7 @@ class GFortranConan(ConanFile):
             "Macos": "x86_64-apple-darwin19"
         }[str(self.settings.os)]
 
-        self.copy("libgfortran.spec", dst="lib", src=os.path.join(self._source_subfolder, "lib"))
-        self.copy("*", dst="lib", src=os.path.join(self._source_subfolder, "lib", "gcc", tripplet, self.version))
-
-        self.copy("libgfortran.a", dst="lib", src=os.path.join(self._source_subfolder, "lib64"))
-        self.copy("libgfortran.a", dst="lib", src=os.path.join(self._source_subfolder, "lib"))
+        self.copy("*", dst="lib", src=os.path.join(self._source_subfolder, "lib"))
 
         self.copy("liblto_plugin-0.dll", dst=os.path.join("libexec", "gcc", tripplet, self.version), src=os.path.join(self._source_subfolder, "libexec", "gcc", tripplet, self.version))
 
@@ -79,6 +75,19 @@ class GFortranConan(ConanFile):
         self.copy("*", dst=".", src=os.path.join(self._source_subfolder, tripplet))
 
         tools.remove_files_by_mask(self.package_folder, "*.la*")
+        tools.rmdir(os.path.join(self.package_folder, "include"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "include"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "include-fixed"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "finclude"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "32", "finclude"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "plugin", "include"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "install-tools"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "gcc", tripplet, self.version, "include"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "gcc", tripplet, self.version, "include-fixed"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "gcc", tripplet, self.version, "finclude"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "gcc", tripplet, self.version, "32", "finclude"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "gcc", tripplet, self.version, "plugin", "include"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "gcc", tripplet, self.version, "install-tools"))
 
     def package_info(self):
         bin_path = os.path.join(self.package_folder, "bin")

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -49,8 +49,7 @@ class GFortranConan(ConanFile):
         tools.rename(root_folder[str(self.settings.os)], self._source_subfolder)
 
     def _extract_license(self):
-        base_folder = "local" if self.settings.os == "Macos" else ""
-        info = tools.load(os.path.join(self.source_folder, self._source_subfolder, base_folder, "share", "info", "gfortran.info"))
+        info = tools.load(os.path.join(self.source_folder, self._source_subfolder, "share", "info", "gfortran.info"))
         license_contents = info[info.find("Version 3"):info.find("END OF TERMS", 1)]
         tools.save("LICENSE", license_contents)
 

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -66,7 +66,7 @@ class GFortranConan(ConanFile):
 
         self.copy("*", dst="lib", src=os.path.join(self._source_subfolder, "lib"))
 
-        self.copy("liblto_plugin-0.dll", dst=os.path.join("libexec", "gcc", tripplet, self.version), src=os.path.join(self._source_subfolder, "libexec", "gcc", tripplet, self.version))
+        self.copy("liblto_plugin*", dst=os.path.join("libexec", "gcc", tripplet, self.version), src=os.path.join(self._source_subfolder, "libexec", "gcc", tripplet, self.version))
 
         self.copy("f951*", dst=os.path.join("libexec", "gcc", tripplet, self.version), src=os.path.join(self._source_subfolder, "libexec", "gcc", tripplet, self.version))
         self.copy("as.exe", dst="bin", src=os.path.join(self._source_subfolder, "bin"))

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -32,7 +32,7 @@ class GFortranConan(ConanFile):
             self.build_requires("7zip/19.00")
 
     def source(self):
-        sources = self.conan_data["sources"][self.version][self.settings.os]
+        sources = self.conan_data["sources"][self.version][str(self.settings.os)]
         if sources["url"].endswith(".7z"):
             tools.download(**sources)
             url = sources["url"]

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -37,9 +37,16 @@ class GFortranConan(ConanFile):
             tools.download(**sources, filename=filename)
             self.run("7z x {0}".format(filename))
             os.unlink(filename)
-            tools.rename("mingw64", self._source_subfolder)
         else:
-            tools.get(**sources, strip_root=True, destination =self._source_subfolder)
+            # can't use strip_root here because if fails with:
+            # KeyError: "linkname 'gcc-10.2.0/bin/g++' not found"
+            tools.get(**sources)
+        root_folder = {
+            "Linux": "gcc-%s" % self.version,
+            "Macos": "usr",
+            "Windows": "mingw64"
+        }
+        os.rename(root_folder[str(self.settings.os)], self._source_subfolder)
 
     def _extract_license(self):
         base_folder = "local" if self.settings.os == "Macos" else ""

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -34,9 +34,8 @@ class GFortranConan(ConanFile):
     def source(self):
         sources = self.conan_data["sources"][self.version][str(self.settings.os)]
         if sources["url"].endswith(".7z"):
-            tools.download(**sources)
-            url = sources["url"]
-            filename = url[url.rfind("/")+1:]
+            filename = "archive.7z"
+            tools.download(**sources, filename=filename)
             self.run("7z x {0}".format(filename))
             os.unlink(filename)
             tools.rename("mingw64", self._source_subfolder)

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -32,7 +32,7 @@ class GFortranConan(ConanFile):
             self.build_requires("7zip/19.00")
 
     def source(self):
-        url = self.conan_data["sources"][self.version]["url"]
+        url = self.conan_data["sources"][self.version]
         for it in url.keys():
             if self.settings.os == "Windows" and it == "Windows":
                 filename = url[it]["filename"]

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -65,6 +65,7 @@ class GFortranConan(ConanFile):
         }[str(self.settings.os)]
 
         self.copy("*", dst="lib", src=os.path.join(self._source_subfolder, "lib"))
+        self.copy("*", dst="lib", src=os.path.join(self._source_subfolder, "lib64"))
 
         self.copy("liblto_plugin*", dst=os.path.join("libexec", "gcc", tripplet, self.version), src=os.path.join(self._source_subfolder, "libexec", "gcc", tripplet, self.version))
 

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -48,6 +48,9 @@ class GFortranConan(ConanFile):
         }
         tools.rename(root_folder[str(self.settings.os)], self._source_subfolder)
 
+        if self.settings.os == "Linux":
+            tools.get(**self.conan_data["sources"][self.version]["Linux-infrastructure"], destination=self._source_subfolder)
+
     def _extract_license(self):
         info = tools.load(os.path.join(self.source_folder, self._source_subfolder, "share", "info", "gfortran.info"))
         license_contents = info[info.find("Version 3"):info.find("END OF TERMS", 1)]

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -1,7 +1,6 @@
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os
-import glob
 
 
 required_conan_version = ">=1.32.0"

--- a/recipes/gfortran/all/conanfile.py
+++ b/recipes/gfortran/all/conanfile.py
@@ -43,7 +43,8 @@ class GFortranConan(ConanFile):
             tools.get(**sources, strip_root=True, destination =self._source_subfolder)
 
     def _extract_license(self):
-        info = tools.load(os.path.join(self.source_folder, self._source_subfolder, "share", "info", "gfortran.info"))
+        base_folder = "local" if self.settings.os == "Macos" else ""
+        info = tools.load(os.path.join(self.source_folder, self._source_subfolder, base_folder, "share", "info", "gfortran.info"))
         license_contents = info[info.find("Version 3"):info.find("END OF TERMS", 1)]
         tools.save("LICENSE", license_contents)
 

--- a/recipes/gfortran/all/test_package/conanfile.py
+++ b/recipes/gfortran/all/test_package/conanfile.py
@@ -10,11 +10,12 @@ class TestPackageConan(ConanFile):
 
     @property
     def _exe(self):
-        return "hello%s" % (".exe" if self.settings.os == "Windows" else "")
+        return os.path.join("bin", "hello")
 
     def build(self):
         if not tools.cross_building(self):
             self.run("gfortran --version", run_environment=True)
+            tools.mkdir("bin")
             self.run("gfortran %s -o %s" % (self._source, self._exe), run_environment=True)
 
     def test(self):

--- a/recipes/gfortran/all/test_package/conanfile.py
+++ b/recipes/gfortran/all/test_package/conanfile.py
@@ -16,7 +16,7 @@ class TestPackageConan(ConanFile):
         if not tools.cross_building(self):
             self.run("gfortran --version", run_environment=True)
             tools.mkdir("bin")
-            self.run("gfortran %s -o %s" % (self._source, self._exe), run_environment=True)
+            self.run("gfortran -m64 %s -o %s" % (self._source, self._exe), run_environment=True)
 
     def test(self):
         if not tools.cross_building(self):

--- a/recipes/gfortran/all/test_package/conanfile.py
+++ b/recipes/gfortran/all/test_package/conanfile.py
@@ -1,13 +1,22 @@
 from conans import ConanFile, tools
+import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
 
+    @property
+    def _source(self):
+        return os.path.join(self.source_folder, "hello.f90")
+
+    @property
+    def _exe(self):
+        return "hello%s" % (".exe" if self.settings.os == "Windows" else "")
+
     def build(self):
         if not tools.cross_building(self):
             self.run("gfortran --version", run_environment=True)
-            self.run("gfortran hello.f90 -o hello%s" % (".exe" if self.settings.os == "Windows" else ""), run_environment=True)
+            self.run("gfortran %s -o %s" % (self._source, self._exe), run_environment=True)
 
     def test(self):
         if not tools.cross_building(self):
-            self.run("hello%s" % (".exe" if self.settings.os == "Windows" else ""), run_environment=True)
+            self.run(self._exe, run_environment=True)

--- a/recipes/gfortran/all/test_package/conanfile.py
+++ b/recipes/gfortran/all/test_package/conanfile.py
@@ -3,6 +3,11 @@ from conans import ConanFile, tools
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
 
-    def test(self):
+    def build(self):
         if not tools.cross_building(self):
             self.run("gfortran --version", run_environment=True)
+            self.run("gfortran hello.f90 -o hello%s" % (".exe" if self.settings.os == "Windows" else ""), run_environment=True)
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run("hello%s" % (".exe" if self.settings.os == "Windows" else ""), run_environment=True)

--- a/recipes/gfortran/all/test_package/hello.f90
+++ b/recipes/gfortran/all/test_package/hello.f90
@@ -1,0 +1,4 @@
+program hello
+  ! This is a comment line; it is ignored by the compiler
+  print *, 'Hello, World!'
+end program hello

--- a/recipes/gfortran/config.yml
+++ b/recipes/gfortran/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "10.2":
+  "10.2.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **gfortran/***

things fixed in this PR:

- download only the binary matching the os
- download linux binary from stable URL

things that still need to be fixed:
- actually test gfortran by compiling and running a program

fixes conan-io/conan-center-index#4696

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
