### PR TITLE
libressl: add 3.5.2

### DIFF
--- a/recipes/libressl/all/conandata.yml
+++ b/recipes/libressl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.5.2":
+    url: "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.5.2.tar.gz"
+    sha256: "56feab8e21c3fa6549f8b7d7511658b8e98518162838a795314732654adf3e5f"
   "3.4.3":
     url: "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.4.3.tar.gz"
     sha256: "ff88bffe354818b3ccf545e3cafe454c5031c7a77217074f533271d63c37f08d"

--- a/recipes/libressl/config.yml
+++ b/recipes/libressl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.5.2":
+    folder: all
   "3.4.3":
     folder: all
   "3.2.1":


### PR DESCRIPTION
Specify library name and version:  **libressl/3.5.2**

LibreSSL 3.5.2 Release
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.5.2-relnotes.txt

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
