### PR TITLE
imgui: remove older versions

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -1,37 +1,4 @@
 sources:
-  "1.74":
-    url: "https://github.com/ocornut/imgui/archive/v1.74.tar.gz"
-    sha256: "2f5f2b789edb00260aa71f03189da5f21cf4b5617c4fbba709e9fbcfc76a2f1e"
-  "1.75":
-    url: "https://github.com/ocornut/imgui/archive/v1.75.tar.gz"
-    sha256: "1023227fae4cf9c8032f56afcaea8902e9bfaad6d9094d6e48fb8f3903c7b866"
-  "1.76":
-    url: "https://github.com/ocornut/imgui/archive/v1.76.tar.gz"
-    sha256: "e482dda81330d38c87bd81597cacaa89f05e20ed2c4c4a93a64322e97565f6dc"
-  "1.77":
-    url: "https://github.com/ocornut/imgui/archive/v1.77.tar.gz"
-    sha256: "c0dae830025d4a1a169df97409709f40d9dfa19f8fc96b550052224cbb238fa8"
-  "1.78":
-    url: "https://github.com/ocornut/imgui/archive/v1.78.tar.gz"
-    sha256: "f70bbb17581ee2bd42fda526d9c3dc1a5165f3847ff047483d4d7980e166f9a3"
-  "1.79":
-    url: "https://github.com/ocornut/imgui/archive/v1.79.tar.gz"
-    sha256: "f1908501f6dc6db8a4d572c29259847f6f882684b10488d3a8d2da31744cd0a4"
-  "1.80":
-    url: "https://github.com/ocornut/imgui/archive/v1.80.tar.gz"
-    sha256: "d7e4e1c7233409018437a646680316040e6977b9a635c02da93d172baad94ce9"
-  "1.81":
-    url: "https://github.com/ocornut/imgui/archive/v1.81.tar.gz"
-    sha256: "f7c619e03a06c0f25e8f47262dbc32d61fd033d2c91796812bf0f8c94fca78fb"
-  "1.82":
-    url: "https://github.com/ocornut/imgui/archive/v1.82.tar.gz"
-    sha256: "fefa2804bd55f3d25b134af08c0e1f86d4d059ac94cef3ee7bd21e2f194e5ce5"
-  "1.83":
-    url: "https://github.com/ocornut/imgui/archive/v1.83.tar.gz"
-    sha256: "ccf3e54b8d1fa30dd35682fc4f50f5d2fe340b8e29e08de71287d0452d8cc3ff"
-  "1.84.2":
-    url: "https://github.com/ocornut/imgui/archive/v1.84.2.tar.gz"
-    sha256: "35cb5ca0fb42cb77604d4f908553f6ef3346ceec4fcd0189675bdfb764f62b9b"
   "1.85":
     url: "https://github.com/ocornut/imgui/archive/v1.85.tar.gz"
     sha256: "7ed49d1f4573004fa725a70642aaddd3e06bb57fcfe1c1a49ac6574a3e895a77"

--- a/recipes/imgui/all/conanfile.py
+++ b/recipes/imgui/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, CMake, tools
 import os
 import re
+import functools
 
 required_conan_version = ">=1.33.0"
 
@@ -25,7 +26,6 @@ class IMGUIConan(ConanFile):
 
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -43,12 +43,11 @@ class IMGUIConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.configure()
-        return self._cmake
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
 
     def _patch_sources(self):
         # Ensure we take into account export_headers

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -1,26 +1,4 @@
 versions:
-  "1.74":
-    folder: all
-  "1.75":
-    folder: all
-  "1.76":
-    folder: all
-  "1.77":
-    folder: all
-  "1.78":
-    folder: all
-  "1.79":
-    folder: all
-  "1.80":
-    folder: all
-  "1.81":
-    folder: all
-  "1.82":
-    folder: all
-  "1.83":
-    folder: all
-  "1.84.2":
-    folder: all
   "1.85":
     folder: all
   "1.86":


### PR DESCRIPTION
Specify library name and version:  **imgui**

After #10636 and #10637 these versions are no longer used