### PR TITLE
libxml2: use up-to-date URL for old sources tarballs

### DIFF
--- a/recipes/libxml2/all/conandata.yml
+++ b/recipes/libxml2/all/conandata.yml
@@ -3,11 +3,11 @@ sources:
     url: "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.13.tar.xz"
     sha256: "276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e"
   "2.9.12":
-    url: "http://xmlsoft.org/sources/libxml2-2.9.12.tar.gz"
-    sha256: "c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92"
+    url: "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.12.tar.xz"
+    sha256: "28a92f6ab1f311acf5e478564c49088ef0ac77090d9c719bbc5d518f1fe62eb9"
   "2.9.10":
-    url: "http://xmlsoft.org/sources/libxml2-2.9.10.tar.gz"
-    sha256: "aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f"
+    url: "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.10.tar.xz"
+    sha256: "593b7b751dd18c2d6abcd0c4bcb29efc203d0b4373a6df98e3a455ea74ae2813"
   "2.9.9":
-    url: "http://xmlsoft.org/sources/libxml2-2.9.9.tar.gz"
-    sha256: "94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871"
+    url: "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.9.tar.xz"
+    sha256: "58a5c05a2951f8b47656b676ce1017921a29f6b1419c45e3baed0d6435ba03f5"


### PR DESCRIPTION
xmlsoft.org is nowadays a redirect to Gnome GitLab, and using old URLs causes error 403 (same as #10750)

Specify library name and version:  **libxml2/2.9.***

I've been trying to build older versions of the package, and encountered an error during `source()` step.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] ~I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.~
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
