### PR TITLE
oniguruma: add 6.9.8 + modernize

### DIFF
--- a/recipes/oniguruma/all/CMakeLists.txt
+++ b/recipes/oniguruma/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.11)
-project(cmake_wrapper)
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper C)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)

--- a/recipes/oniguruma/all/conandata.yml
+++ b/recipes/oniguruma/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.9.8":
+    url: "https://github.com/kkos/oniguruma/releases/download/v6.9.8/onig-6.9.8.tar.gz"
+    sha256: "28cd62c1464623c7910565fb1ccaaa0104b2fe8b12bcd646e81f73b47535213e"
   "6.9.7.1":
     url: "https://github.com/kkos/oniguruma/releases/download/v6.9.7.1/onig-6.9.7.1.tar.gz"
     sha256: "6444204b9c34e6eb6c0b23021ce89a0370dad2b2f5c00cd44c342753e0b204d9"

--- a/recipes/oniguruma/all/conanfile.py
+++ b/recipes/oniguruma/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+import functools
 import os
 
 required_conan_version = ">=1.43.0"
@@ -8,7 +9,7 @@ class OnigurumaConan(ConanFile):
     name = "oniguruma"
     description = "Oniguruma is a modern and flexible regular expressions library."
     license = "BSD-2-Clause"
-    topics = ("conan", "oniguruma", "regex")
+    topics = ("oniguruma", "regex")
     homepage = "https://github.com/kkos/oniguruma"
     url = "https://github.com/conan-io/conan-center-index"
 
@@ -26,7 +27,6 @@ class OnigurumaConan(ConanFile):
 
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -46,17 +46,16 @@ class OnigurumaConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["ENABLE_POSIX_API"] = self.options.posix_api
-        self._cmake.definitions["ENABLE_BINARY_COMPATIBLE_POSIX_API"] = self.options.posix_api
+        cmake = CMake(self)
+        cmake.definitions["ENABLE_POSIX_API"] = self.options.posix_api
+        cmake.definitions["ENABLE_BINARY_COMPATIBLE_POSIX_API"] = self.options.posix_api
         if tools.Version(self.version) >= "6.9.8":
-            self._cmake.definitions["INSTALL_DOCUMENTATION"] = False
-            self._cmake.definitions["INSTALL_EXAMPLES"] = False
-        self._cmake.configure()
-        return self._cmake
+            cmake.definitions["INSTALL_DOCUMENTATION"] = False
+            cmake.definitions["INSTALL_EXAMPLES"] = False
+        cmake.configure()
+        return cmake
 
     def build(self):
         cmake = self._configure_cmake()

--- a/recipes/oniguruma/all/conanfile.py
+++ b/recipes/oniguruma/all/conanfile.py
@@ -52,6 +52,9 @@ class OnigurumaConan(ConanFile):
         self._cmake = CMake(self)
         self._cmake.definitions["ENABLE_POSIX_API"] = self.options.posix_api
         self._cmake.definitions["ENABLE_BINARY_COMPATIBLE_POSIX_API"] = self.options.posix_api
+        if tools.Version(self.version) >= "6.9.8":
+            self._cmake.definitions["INSTALL_DOCUMENTATION"] = False
+            self._cmake.definitions["INSTALL_EXAMPLES"] = False
         self._cmake.configure()
         return self._cmake
 
@@ -65,7 +68,13 @@ class OnigurumaConan(ConanFile):
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        if tools.Version(self.version) < "6.9.8":
+            tools.rmdir(os.path.join(self.package_folder, "share"))
+        else:
+            if self.settings.os == "Windows" and self.options.shared:
+                tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "onig-config")
+            else:
+                tools.rmdir(os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "oniguruma")

--- a/recipes/oniguruma/config.yml
+++ b/recipes/oniguruma/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "6.9.8":
+    folder: all
   "6.9.7.1":
     folder: all


### PR DESCRIPTION
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- cache CMake configuration with `functools.lru_cache`
- add oniguruma/6.9.8

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
