### PR TITLE
zlib/1.2.* Fix zlib urls

### DIFF
--- a/recipes/zlib/all/conandata.yml
+++ b/recipes/zlib/all/conandata.yml
@@ -1,15 +1,9 @@
 sources:
   "1.2.12":
-    url: [
-      "https://zlib.net/zlib-1.2.12.tar.gz",
-      # libpng does not provide zlib 1.2.12 yet.
-    ]
-    sha256: ""
+    url: "https://zlib.net/fossils/zlib-1.2.12.tar.gz"
+    sha256: "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
   "1.2.11":
-    url: [
-      # zlib.net provides latest version only.
-      "https://downloads.sourceforge.net/project/libpng/zlib/1.2.11/zlib-1.2.11.tar.gz",
-    ]
+    url: "https://zlib.net/fossils/zlib-1.2.11.tar.gz"
     sha256: "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
 patches:
   "1.2.12":


### PR DESCRIPTION
zlib/1.2.12
zlib/1.2.11

`zlib` puts old releases in [zlib/fossils](https://zlib.net/fossils/), not the root path. This means that the root path breaks sometimes. This fixes the remotes to always use the fossils directory.

This also uses zlib.net for all sources, instead of using sourceforge for older releases.


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
