### PR TITLE
[qt] add USTC mirror address for download qt source

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -5,6 +5,7 @@ sources:
       - "https://qt-mirror.dannhauer.de/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
       - "https://www.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
       - "https://ftp.fau.de/qtproject/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
+      - "https://mirrors.ustc.edu.cn/qtproject/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
     sha256: "3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240"
   "5.15.3":
     url:
@@ -12,6 +13,7 @@ sources:
       - "https://qt-mirror.dannhauer.de/archive/qt/5.15/5.15.3/single/qt-everywhere-opensource-src-5.15.3.tar.xz"
       - "https://www.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/5.15/5.15.3/single/qt-everywhere-opensource-src-5.15.3.tar.xz"
       - "https://ftp.fau.de/qtproject/archive/qt/5.15/5.15.3/single/qt-everywhere-opensource-src-5.15.3.tar.xz"
+      - "https://mirrors.ustc.edu.cn/qtproject/archive/qt/5.15/5.15.3/single/qt-everywhere-opensource-src-5.15.3.tar.xz"
     sha256: "b7412734698a87f4a0ae20751bab32b1b07fdc351476ad8e35328dbe10efdedb"
 patches:
   "5.15.2":

--- a/recipes/qt/6.x.x/conandata.yml
+++ b/recipes/qt/6.x.x/conandata.yml
@@ -5,6 +5,7 @@ sources:
       - "https://qt-mirror.dannhauer.de/archive/qt/6.0/6.0.4/single/qt-everywhere-src-6.0.4.tar.xz"
       - "https://www.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/6.0/6.0.4/single/qt-everywhere-src-6.0.4.tar.xz"
       - "https://ftp.fau.de/qtproject/archive/qt/6.0/6.0.4/single/qt-everywhere-src-6.0.4.tar.xz"
+      - "https://mirrors.ustc.edu.cn/qtproject/archive/qt/6.0/6.0.4/single/qt-everywhere-src-6.0.4.tar.xz"
     sha256: "677db6472420f9046b16f7c0d0aa15c4f11f344462a6374feb860625c12fc72b"
   "6.1.3":
     url:
@@ -12,6 +13,7 @@ sources:
       - "https://qt-mirror.dannhauer.de/archive/qt/6.1/6.1.3/single/qt-everywhere-src-6.1.3.tar.xz"
       - "https://www.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/6.1/6.1.3/single/qt-everywhere-src-6.1.3.tar.xz"
       - "https://ftp.fau.de/qtproject/archive/qt/6.1/6.1.3/single/qt-everywhere-src-6.1.3.tar.xz"
+      - "https://mirrors.ustc.edu.cn/qtproject/archive/qt/6.1/6.1.3/single/qt-everywhere-src-6.1.3.tar.xz"
     sha256: "552342a81fa76967656b0301233b4b586d36967fad5cd110765347aebe07413c"
   "6.2.4":
     url:
@@ -19,6 +21,7 @@ sources:
       - "https://qt-mirror.dannhauer.de/archive/qt/6.2/6.2.4/single/qt-everywhere-src-6.2.4.tar.xz"
       - "https://www.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/6.2/6.2.4/single/qt-everywhere-src-6.2.4.tar.xz"
       - "https://ftp.fau.de/qtproject/archive/qt/6.2/6.2.4/single/qt-everywhere-src-6.2.4.tar.xz"
+      - "https://mirrors.ustc.edu.cn/qtproject/archive/qt/6.2/6.2.4/single/qt-everywhere-src-6.2.4.tar.xz"
     sha256: "cfe41905b6bde3712c65b102ea3d46fc80a44c9d1487669f14e4a6ee82ebb8fd"
   "6.3.0":
     url:
@@ -26,6 +29,7 @@ sources:
       - "https://qt-mirror.dannhauer.de/archive/qt/6.3/6.3.0/single/qt-everywhere-src-6.3.0.tar.xz"
       - "https://www.funet.fi/pub/mirrors/download.qt-project.org/archive/qt/6.3/6.3.0/single/qt-everywhere-src-6.3.0.tar.xz"
       - "https://ftp.fau.de/qtproject/archive/qt/6.3/6.3.0/single/qt-everywhere-src-6.3.0.tar.xz"
+      - "https://mirrors.ustc.edu.cn/qtproject/archive/qt/6.3/6.3.0/single/qt-everywhere-src-6.3.0.tar.xz"
     sha256: "cd2789cade3e865690f3c18df58ffbff8af74cc5f01faae50634c12eb52dd85b"
 patches:
   "6.0.4":


### PR DESCRIPTION
Signed-off-by: Dylan <2894220@gmail.com>

Specify library name and version:  **qt/5.x**
Specify library name and version:  **qt/6.x**

Added mirror(USTC) for download qt source code.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
