### PR TITLE
[Sentry-native] Move option deletion to the configure method

### DIFF
--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -86,6 +86,10 @@ class SentryNativeConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        if self.options.backend != "crashpad":
+            del self.options.with_crashpad
+        if self.options.backend != "breakpad":
+            del self.options.with_breakpad
 
     def requirements(self):
         if self.options.transport == "curl":
@@ -116,13 +120,8 @@ class SentryNativeConan(ConanFile):
         elif tools.Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("Build requires support for C++14. Minimum version for {} is {}"
                 .format(str(self.settings.compiler), minimum_version))
-
         if self.options.backend == "inproc" and self.settings.os == "Windows" and tools.Version(self.version) < "0.4":
             raise ConanInvalidConfiguration("The in-process backend is not supported on Windows")
-        if self.options.backend != "crashpad":
-            del self.options.with_crashpad
-        if self.options.backend != "breakpad":
-            del self.options.with_breakpad
         if self.options.transport == "winhttp" and self.settings.os != "Windows":
             raise ConanInvalidConfiguration("The winhttp transport is only supported on Windows")
         if tools.Version(self.version) >= "0.4.7" and self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) < "10.0":


### PR DESCRIPTION
If we delete options on the `validate()` method their value gets captured in the lockfiles which renders them unusable. See associated issue for a complete explanation. 

Closes https://github.com/conan-io/conan/issues/11137

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
