### PR TITLE
thelink2012-any: add recipe

### DIFF
--- a/recipes/thelink2012-any/all/conandata.yml
+++ b/recipes/thelink2012-any/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20200719":
+    url: "https://github.com/thelink2012/any/archive/f67bd5f8bbf7eb628bf38206d4ac5cb22438e6bb.tar.gz"
+    sha256: "1cd121a2fb27936213397ff4ff94fe4d6d4e28cabc13894cc4512eb046d71be8"

--- a/recipes/thelink2012-any/all/conanfile.py
+++ b/recipes/thelink2012-any/all/conanfile.py
@@ -1,0 +1,37 @@
+from conans import ConanFile, tools
+
+required_conan_version = ">=1.33.0"
+
+class Thelink2012AnyConan(ConanFile):
+    name = "thelink2012-any"
+    license = "BSL-1.0"
+    description = "Implementation of std::experimental::any, including small object optimization, for C++11 compilers"
+    topics = ("any", "c++11", "data-structures")
+    homepage = "https://github.com/thelink2012/any"
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, "11")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy("LICENSE*", "licenses", self._source_subfolder)
+        self.copy("any.hpp", "include", self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "any"
+        self.cpp_info.names["cmake_find_package_multi"] = "any"
+        self.cpp_info.set_property("cmake_target_name", "any::any")

--- a/recipes/thelink2012-any/all/test_package/CMakeLists.txt
+++ b/recipes/thelink2012-any/all/test_package/CMakeLists.txt
@@ -8,4 +8,4 @@ find_package(any CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} any::any)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/thelink2012-any/all/test_package/CMakeLists.txt
+++ b/recipes/thelink2012-any/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(any CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} any::any)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/thelink2012-any/all/test_package/conanfile.py
+++ b/recipes/thelink2012-any/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class TestConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/thelink2012-any/all/test_package/test_package.cpp
+++ b/recipes/thelink2012-any/all/test_package/test_package.cpp
@@ -1,0 +1,28 @@
+#include <string>
+
+#include "any.hpp"
+
+struct big_type {
+    char i_wanna_be_big[256];
+    std::string value;
+
+    big_type() :
+        value(std::string(300, 'b'))
+    {
+        i_wanna_be_big[0] = i_wanna_be_big[50] = 'k';
+    }
+};
+
+int main() {
+    linb::any x = 4;
+    linb::any y = big_type{};
+    linb::any z = 6.5;
+
+    y.clear();
+
+    x = y;
+
+    z = linb::any();
+
+    return 0;
+}

--- a/recipes/thelink2012-any/config.yml
+++ b/recipes/thelink2012-any/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20200719":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **thelink2012-any/cci.20200719**

This is renamed version of linb-any. https://github.com/conan-io/conan-center-index/pull/10616
thelink-any is required by libcluon which I am going to add recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
