### PR TITLE
wayland - run the build in a run_environment

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -86,7 +86,8 @@ class WaylandConan(ConanFile):
     def build(self):
         self._patch_sources()
         meson = self._configure_meson()
-        meson.build()
+        with tools.run_environment(self):
+            meson.build()
 
     def package(self):
         self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)


### PR DESCRIPTION
During the compile, "wayland-scanner" exe is built and used for further
steps in the build.
The execution can fail as libxml2 does not include the rpath for
libiconv.
So, use the handy tools.run_environment(self) so "wayland-scanner" can
find its libraries.

I'm not sure why the execution doesn't fail for everyone else.  I am forcing all libs to be built shared, with -o "*:shared=True", and I added a dummy flag in the compiler settings in settings.yml + profile, to ensure the packages don't match anything prebuilt on CCI (ie to avoid linking static libs into shared libs, due to known v1 package_id issues).

Specify library name and version:  **wayland/1.20.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
