### PR TITLE
(#10727) Add recipe for cuda-api-wrappers/0.5.1

### DIFF
--- a/recipes/cuda-api-wrappers/all/conandata.yml
+++ b/recipes/cuda-api-wrappers/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.5.1":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.5.1.tar.gz"
+    sha256: "3a6d49f3da411c3da825b3781115c09e3420b49d53e83a3982cf4e222e223e4e"

--- a/recipes/cuda-api-wrappers/all/conanfile.py
+++ b/recipes/cuda-api-wrappers/all/conanfile.py
@@ -1,0 +1,34 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+class CudaKatConan(ConanFile):
+    name = "cuda-api-wrappers"
+    homepage = "https://github.com/eyalroz/cuda-api-wrappers"
+    description = "Thin C++-flavored wrappers for the CUDA APIs"
+    topics = ("gpgpu", "cuda", "cuda-api", "header-only")
+    url = "https://github.com/conan-io/conan-center-index"
+    no_copy_source = True
+    license = "BSD-3-Clause"
+
+    settings = "os", "arch", "compiler", "build_type"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def package_id(self):
+        self.info.header_only()
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy(pattern="LICENSE*", src=self._source_subfolder, dst="licenses")
+        self.copy("*", src=os.path.join(self._source_subfolder, "src"), dst="include")
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "cuda-api-wrappers"
+        self.cpp_info.names["cmake_find_package_multi"] = "cuda-api-wrappers"

--- a/recipes/cuda-api-wrappers/all/test_package/CMakeLists.txt
+++ b/recipes/cuda-api-wrappers/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(cuda-api-wrappers REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} cuda-api-wrappers::cuda-api-wrappers)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)

--- a/recipes/cuda-api-wrappers/all/test_package/conanfile.py
+++ b/recipes/cuda-api-wrappers/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/cuda-api-wrappers/all/test_package/test_package.cpp
+++ b/recipes/cuda-api-wrappers/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+#include <cuda/undefine_specifiers.hpp>
+
+
+int main() {
+
+    return 0;
+}
+

--- a/recipes/cuda-api-wrappers/config.yml
+++ b/recipes/cuda-api-wrappers/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.5.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **cuda-api-wrappers/0.5.1**

Thin C++-flavored header-only wrappers for the CUDA APIs.

This library is header-only, but it requires **cuda**. So test-package just checks presence of some header that do not include cuda related headers.

closes #10727 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
