### PR TITLE
(#10737) Add libtcf package

### DIFF
--- a/recipes/libtcf/all/CMakeLists.txt
+++ b/recipes/libtcf/all/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.0)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(KEEP_RPATHS)
+
+add_subdirectory(source_subfolder)
+
+install(
+  TARGETS tcf
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/recipes/libtcf/all/conandata.yml
+++ b/recipes/libtcf/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "1.7.0":
+    url: https://git.eclipse.org/c/tcf/org.eclipse.tcf.agent.git/snapshot/org.eclipse.tcf.agent-1.7.0.zip
+    sha256: 5123b4cf745c53e00509cd9dd8813d29b775ecfa75a111daf0670ee6555d1229
+
+patches:
+  "1.7.0":
+    - patch_file: "patches/0001-Add-synthetic-CMakeLists.txt.patch"
+      base_path: "source_subfolder"

--- a/recipes/libtcf/all/conanfile.py
+++ b/recipes/libtcf/all/conanfile.py
@@ -1,0 +1,85 @@
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.33.0"
+
+class TcfAgentConan(ConanFile):
+    name = "libtcf"
+    license = "BSD-3-Clause"
+    homepage = "https://git.eclipse.org/c/tcf/org.eclipse.tcf.agent.git/"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "Eclipse target communication framework agent"
+    topics = ("debugging", "tracing")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+            "shared": [True, False],
+            "fPIC": [True, False],
+    }
+    default_options = {
+            "shared": False,
+            "fPIC": True,
+    }
+
+    generators = "cmake"
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def validate(self):
+        pass
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+               strip_root=True, destination=self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+            self._cmake.definitions["TCF_OPSYS"]="Windows"
+        if self.settings.os == "Linux":
+            self._cmake.definitions["TCF_OPSYS"]="GNU/Linux"
+        if self.settings.os == "FreeBSD":
+            self._cmake.definitions["TCF_OPSYS"]="FreeBSD"
+        if self.settings.os == "Macos":
+            self._cmake.definitions["TCF_OPSYS"]="Darwin"
+
+        self._cmake.definitions["TCF_MACHINE"]=self.settings.arch
+        self._cmake.configure()
+        return self._cmake
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
+    def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+    def build(self):
+        self._patch_sources()
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["libtcf"]
+        self.cpp_info.set_property("cmake_file_name", "libtcf")
+        self.cpp_info.set_property("cmake_target_name", "libtcf::libtcf")
+

--- a/recipes/libtcf/all/patches/0001-Add-synthetic-CMakeLists.txt.patch
+++ b/recipes/libtcf/all/patches/0001-Add-synthetic-CMakeLists.txt.patch
@@ -1,0 +1,7 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..d2393db
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1 @@
++include(cmake-tcf-lib.txt)

--- a/recipes/libtcf/config.yml
+++ b/recipes/libtcf/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.7.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libtcf/1.7.0**

TCF defines the protocol, independent of application programming interfaces (APIs). [ECF](http://www.eclipse.org/ecf) defines the APIs, independent of protocol. It's as simple as that. Or, to be more elaborate:

TCF is a "vertical" technology stack: it includes all components needed to communicate with embedded remote systems end-to-end. This includes the plain C lightweight target agent, the TCF protocol specification at its core, the Java protocol API as well as 3 example clients.

Closes #10737 
---

- [ x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ x ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ x ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
