### PR TITLE
libxslt: use up-to-date URL for sources tarball

### DIFF
--- a/recipes/libxslt/all/conandata.yml
+++ b/recipes/libxslt/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.1.34":
-    sha256: "98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f"
-    url: "http://xmlsoft.org/sources/libxslt-1.1.34.tar.gz"
+    sha256: "28c47db33ab4daefa6232f31ccb3c65260c825151ec86ec461355247f3f56824"
+    url: "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.34.tar.xz"
 patches:
   "1.1.34":
     - patch_file: "patches/0001-Add-configuration-for-profiler.diff"


### PR DESCRIPTION
xmlsoft.org is nowadays a redirect to Gnome GitLab, and using old URLs causes error 403 (same as #10643)

Specify library name and version:  **libxslt/1.1.34**

I've been trying to build older versions of the package, and encountered an error during source() step.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] ~I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.~
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
