### PR TITLE
Add 'maxTaskqThreads' option

### DIFF
--- a/recipes/nng/all/conanfile.py
+++ b/recipes/nng/all/conanfile.py
@@ -28,7 +28,7 @@ class NngConan(ConanFile):
         "nngcat": False,
         "http": True,
         "tls": False,
-        "maxTaskqThreads": None
+        "max_taskq_threads": None
     }
 
     generators = "cmake"

--- a/recipes/nng/all/conanfile.py
+++ b/recipes/nng/all/conanfile.py
@@ -78,8 +78,8 @@ class NngConan(ConanFile):
         self._cmake.definitions["NNG_ENABLE_TLS"] = self.options.tls
         self._cmake.definitions["NNG_ENABLE_NNGCAT"] = self.options.nngcat
         self._cmake.definitions["NNG_ENABLE_HTTP"] = self.options.http
-        if self.options.maxTaskqThreads:
-            self._cmake.definitions["NNG_MAX_TASKQ_THREADS"] = self.options.maxTaskqThreads
+        if self.options.max_taskq_threads:
+            self._cmake.definitions["NNG_MAX_TASKQ_THREADS"] = self.options.max_taskq_threads
         self._cmake.configure()
 
         return self._cmake

--- a/recipes/nng/all/conanfile.py
+++ b/recipes/nng/all/conanfile.py
@@ -28,7 +28,7 @@ class NngConan(ConanFile):
         "nngcat": False,
         "http": True,
         "tls": False,
-        "max_taskq_threads": None
+        "max_taskq_threads": "16"
     }
 
     generators = "cmake"
@@ -64,6 +64,8 @@ class NngConan(ConanFile):
         if self.settings.compiler == "Visual Studio" and \
                 tools.Version(self.settings.compiler.version) < 14:
             raise ConanInvalidConfiguration("MSVC < 14 is not supported")
+        if not self.options.max_taskq_threads.value.isdigit():
+            raise ConanInvalidConfiguration("max_taskq_threads must be an integral number")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -78,8 +80,8 @@ class NngConan(ConanFile):
         self._cmake.definitions["NNG_ENABLE_TLS"] = self.options.tls
         self._cmake.definitions["NNG_ENABLE_NNGCAT"] = self.options.nngcat
         self._cmake.definitions["NNG_ENABLE_HTTP"] = self.options.http
-        if self.options.max_taskq_threads:
-            self._cmake.definitions["NNG_MAX_TASKQ_THREADS"] = self.options.max_taskq_threads
+        self._cmake.definitions["NNG_MAX_TASKQ_THREADS"] = self.options.max_taskq_threads
+
         self._cmake.configure()
 
         return self._cmake

--- a/recipes/nng/all/conanfile.py
+++ b/recipes/nng/all/conanfile.py
@@ -20,7 +20,7 @@ class NngConan(ConanFile):
         "nngcat": [True, False],
         "http": [True, False],
         "tls": [True, False],
-        "maxTaskqThreads": "ANY"
+        "max_taskq_threads": "ANY"
     }
     default_options = {
         "shared": False,

--- a/recipes/nng/all/conanfile.py
+++ b/recipes/nng/all/conanfile.py
@@ -20,6 +20,7 @@ class NngConan(ConanFile):
         "nngcat": [True, False],
         "http": [True, False],
         "tls": [True, False],
+        "maxTaskqThreads": "ANY"
     }
     default_options = {
         "shared": False,
@@ -27,6 +28,7 @@ class NngConan(ConanFile):
         "nngcat": False,
         "http": True,
         "tls": False,
+        "maxTaskqThreads": None
     }
 
     generators = "cmake"
@@ -76,6 +78,8 @@ class NngConan(ConanFile):
         self._cmake.definitions["NNG_ENABLE_TLS"] = self.options.tls
         self._cmake.definitions["NNG_ENABLE_NNGCAT"] = self.options.nngcat
         self._cmake.definitions["NNG_ENABLE_HTTP"] = self.options.http
+        if self.options.maxTaskqThreads:
+            self._cmake.definitions["NNG_MAX_TASKQ_THREADS"] = self.options.maxTaskqThreads
         self._cmake.configure()
 
         return self._cmake


### PR DESCRIPTION
Specify library name and version:  **nng/1.5.2**

nng supports a cmake option NNG_MAX_TASKQ_THREADS that allows setting of the maximum number of worker threads. Being able to control the number of worker threads is esp. important when working with constrained devices (the name of the library is "nanomsg", after all)
Hence, add conanfile support for this configuration value

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
