### PR TITLE
xsimd: add version 8.1.0

### DIFF
--- a/recipes/xsimd/all/conandata.yml
+++ b/recipes/xsimd/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.1.0":
+    url: "https://github.com/xtensor-stack/xsimd/archive/8.1.0.tar.gz"
+    sha256: "d52551360d37709675237d2a0418e28f70995b5b7cdad7c674626bcfbbf48328"
   "8.0.5":
     url: "https://github.com/xtensor-stack/xsimd/archive/8.0.5.tar.gz"
     sha256: "0e1b5d973b63009f06a3885931a37452580dbc8d7ca8ad40d4b8c80d2a0f84d7"

--- a/recipes/xsimd/config.yml
+++ b/recipes/xsimd/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.1.0":
+    folder: all
   "8.0.5":
     folder: all
   "8.0.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **ximd/8.1.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
