### PR TITLE
gettext: fix hooks

### DIFF
--- a/recipes/gettext/all/conanfile.py
+++ b/recipes/gettext/all/conanfile.py
@@ -154,4 +154,8 @@ class GetTextConan(ConanFile):
         self.output.info("Setting AUTOPOINT environment variable: {}".format(autopoint))
         self.env_info.AUTOPOINT = autopoint
 
+        gettext_datadir = tools.unix_path(os.path.join(self.package_folder, "res", "gettext"))
+        self.output.info("Setting gettext_datadir environment variable: {}".format(gettext_datadir))
+        self.env_info.gettext_datadir = gettext_datadir
+
         self.env_info.GETTEXT_ROOT_UNIX = tools.unix_path(self.package_folder)

--- a/recipes/gettext/all/conanfile.py
+++ b/recipes/gettext/all/conanfile.py
@@ -124,6 +124,7 @@ class GetTextConan(ConanFile):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         tools.replace_in_file(os.path.join(self._source_subfolder, "gettext-tools", "misc", "autopoint.in"), "@prefix@", "$GETTEXT_ROOT_UNIX")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "gettext-tools", "misc", "autopoint.in"), "@datarootdir@", "$prefix/res")
         with self._build_context():
             autotools = self._configure_autotools()
             autotools.make()
@@ -153,9 +154,5 @@ class GetTextConan(ConanFile):
         autopoint = tools.unix_path(os.path.join(self.package_folder, "bin", "autopoint"))
         self.output.info("Setting AUTOPOINT environment variable: {}".format(autopoint))
         self.env_info.AUTOPOINT = autopoint
-
-        gettext_datadir = tools.unix_path(os.path.join(self.package_folder, "res", "gettext"))
-        self.output.info("Setting gettext_datadir environment variable: {}".format(gettext_datadir))
-        self.env_info.gettext_datadir = gettext_datadir
 
         self.env_info.GETTEXT_ROOT_UNIX = tools.unix_path(self.package_folder)

--- a/recipes/gettext/all/test_package/conanfile.py
+++ b/recipes/gettext/all/test_package/conanfile.py
@@ -13,7 +13,11 @@ class TestPackageConan(ConanFile):
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
+    def requirements(self):
+         self.requires(self.tested_reference_str)
+
     def build_requirements(self):
+        self.build_requires(self.tested_reference_str)
         self.build_requires("automake/1.16.4")
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")

--- a/recipes/gettext/all/test_package/conanfile.py
+++ b/recipes/gettext/all/test_package/conanfile.py
@@ -7,7 +7,7 @@ import shutil
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler"
     exports_sources = "configure.ac",
-    test_type = "build_requires", "requires"
+    test_type = "explicit"
 
     @property
     def _settings_build(self):


### PR DESCRIPTION
Specify library name and version:  **gettext/***

closes conan-io/conan-center-index#9592

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
