### PR TITLE
dlib: add 19.24 + add options + improve reproducibility of builds

### DIFF
--- a/recipes/dlib/all/CMakeLists.txt
+++ b/recipes/dlib/all/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 # Include the dlib subdirectory to skip a check
 add_subdirectory(source_subfolder/dlib)

--- a/recipes/dlib/all/conandata.yml
+++ b/recipes/dlib/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
-  "19.19":
-    sha256: 7af455bb422d3ae5ef369c51ee64e98fa68c39435b0fa23be2e5d593a3d45b87
-    url: https://github.com/davisking/dlib/archive/v19.19.tar.gz
-  "19.21":
-    sha256: 116f52e58be04b47dab52057eaad4b5c4d5c3032d927fe23d55b0741fc4107a0
-    url: https://github.com/davisking/dlib/archive/v19.21.tar.gz
   "19.23":
-    sha256: 0fc74a39d2046ad15819bab25a695333a63e740c91ed3c620c8594381c132e88
-    url: https://github.com/davisking/dlib/archive/v19.23.tar.gz
+    url: "https://github.com/davisking/dlib/archive/v19.23.tar.gz"
+    sha256: "0fc74a39d2046ad15819bab25a695333a63e740c91ed3c620c8594381c132e88"
+  "19.21":
+    url: "https://github.com/davisking/dlib/archive/v19.21.tar.gz"
+    sha256: "116f52e58be04b47dab52057eaad4b5c4d5c3032d927fe23d55b0741fc4107a0"
+  "19.19":
+    url: "https://github.com/davisking/dlib/archive/v19.19.tar.gz"
+    sha256: "7af455bb422d3ae5ef369c51ee64e98fa68c39435b0fa23be2e5d593a3d45b87"

--- a/recipes/dlib/all/conandata.yml
+++ b/recipes/dlib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "19.24":
+    url: "https://github.com/davisking/dlib/archive/refs/tags/v19.24.tar.gz"
+    sha256: "3cc42e84c7b1bb926c6451a21ad1595f56c5b10be3a1d7aa2f3c716a25b7ae39"
   "19.23":
     url: "https://github.com/davisking/dlib/archive/v19.23.tar.gz"
     sha256: "0fc74a39d2046ad15819bab25a695333a63e740c91ed3c620c8594381c132e88"

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -1,7 +1,10 @@
-import os
-
+from conan.tools.microsoft import is_msvc
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+import functools
+import os
+
+required_conan_version = ">=1.45.0"
 
 
 class DlibConan(ConanFile):
@@ -11,8 +14,6 @@ class DlibConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://dlib.net"
     license = "BSL-1.0"
-    exports_sources = "CMakeLists.txt"
-    generators = "cmake"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -36,10 +37,10 @@ class DlibConan(ConanFile):
         "with_sse4": "auto",
         "with_avx": "auto",
         "with_openblas": True,
-
     }
 
-    _cmake = None
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake"
 
     @property
     def _source_subfolder(self):
@@ -60,12 +61,6 @@ class DlibConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        if self.settings.compiler == "Visual Studio" and self.options.shared:
-            raise ConanInvalidConfiguration("dlib can not be built as a shared library with Visual Studio")
-
-    def validate(self):
-        if self.settings.os == "Macos" and self.settings.arch == "armv8":
-            raise ConanInvalidConfiguration("dlib doesn't support macOS M1")
 
     def requirements(self):
         if self.options.with_gif:
@@ -77,36 +72,40 @@ class DlibConan(ConanFile):
         if self.options.with_openblas:
             self.requires("openblas/0.3.17")
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+    def validate(self):
+        if is_msvc(self) and self.options.shared:
+            raise ConanInvalidConfiguration("dlib can not be built as a shared library with Visual Studio")
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            raise ConanInvalidConfiguration("dlib doesn't support macOS M1")
 
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
+        cmake = CMake(self)
 
         # With in-project builds dlib is always built as a static library,
         # we want to be able to build it as a shared library too
-        self._cmake.definitions["DLIB_IN_PROJECT_BUILD"] = "OFF"
+        cmake.definitions["DLIB_IN_PROJECT_BUILD"] = False
 
         # Configure external dependencies
-        self._cmake.definitions["DLIB_GIF_SUPPORT"] = self.options.with_gif
-        self._cmake.definitions["DLIB_JPEG_SUPPORT"] = self.options.with_jpeg
-        self._cmake.definitions["DLIB_PNG_SUPPORT"] = self.options.with_png
+        cmake.definitions["DLIB_GIF_SUPPORT"] = self.options.with_gif
+        cmake.definitions["DLIB_JPEG_SUPPORT"] = self.options.with_jpeg
+        cmake.definitions["DLIB_PNG_SUPPORT"] = self.options.with_png
 
         # Configure SIMD options if possible
         if self.settings.arch in ["x86", "x86_64"]:
             if self.options.with_sse2 != "auto":
-                self._cmake.definitions["USE_SSE2_INSTRUCTIONS"] = self.options.with_sse2
+                cmake.definitions["USE_SSE2_INSTRUCTIONS"] = self.options.with_sse2
             if self.options.with_sse4 != "auto":
-                self._cmake.definitions["USE_SSE4_INSTRUCTIONS"] = self.options.with_sse4
+                cmake.definitions["USE_SSE4_INSTRUCTIONS"] = self.options.with_sse4
             if self.options.with_avx != "auto":
-                self._cmake.definitions["USE_AVX_INSTRUCTIONS"] = self.options.with_avx
+                cmake.definitions["USE_AVX_INSTRUCTIONS"] = self.options.with_avx
 
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
 
     def build(self):
         cmake = self._configure_cmake()
@@ -128,9 +127,13 @@ class DlibConan(ConanFile):
             tools.rmdir(os.path.join(self.package_folder, dir_to_remove))
 
     def package_info(self):
-        self.cpp_info.names["pkg_config"] = "dlib-1"
+        self.cpp_info.set_property("cmake_file_name", "dlib")
+        self.cpp_info.set_property("cmake_target_name", "dlib::dlib")
+        self.cpp_info.set_property("pkg_config_name", "dlib-1")
         self.cpp_info.libs = tools.collect_libs(self)
-        if self.settings.os == "Linux":
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread"]
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs = ["ws2_32", "winmm", "comctl32", "gdi32", "imm32"]
+
+        self.cpp_info.names["pkg_config"] = "dlib-1"

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -32,7 +32,7 @@ class DlibConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_gif": False,  # Doesn't work out-of-the-box with MSVC
+        "with_gif": True,
         "with_jpeg": True,
         "with_png": True,
         "with_webp": True,

--- a/recipes/dlib/all/conanfile.py
+++ b/recipes/dlib/all/conanfile.py
@@ -118,11 +118,18 @@ class DlibConan(ConanFile):
         # we want to be able to build it as a shared library too
         cmake.definitions["DLIB_IN_PROJECT_BUILD"] = False
 
+        cmake.definitions["DLIB_ISO_CPP_ONLY"] = False
+        cmake.definitions["DLIB_NO_GUI_SUPPORT"] = True
+
         # Configure external dependencies
         cmake.definitions["DLIB_JPEG_SUPPORT"] = self.options.with_jpeg
         cmake.definitions["DLIB_LINK_WITH_SQLITE3"] = self.options.with_sqlite3
+        cmake.definitions["DLIB_USE_BLAS"] = True    # FIXME: all the logic behind is not sufficiently under control
+        cmake.definitions["DLIB_USE_LAPACK"] = True  # FIXME: all the logic behind is not sufficiently under control
+        cmake.definitions["DLIB_USE_CUDA"] = False   # TODO: add with_cuda option?
         cmake.definitions["DLIB_PNG_SUPPORT"] = self.options.with_png
         cmake.definitions["DLIB_GIF_SUPPORT"] = self.options.with_gif
+        cmake.definitions["DLIB_USE_MKL_FFT"] = False
 
         # Configure SIMD options if possible
         if self.settings.arch in ["x86", "x86_64"]:

--- a/recipes/dlib/all/test_package/CMakeLists.txt
+++ b/recipes/dlib/all/test_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(dlib REQUIRED CONFIG)
 

--- a/recipes/dlib/all/test_package/conanfile.py
+++ b/recipes/dlib/all/test_package/conanfile.py
@@ -1,10 +1,9 @@
-import os.path
-
 from conans import ConanFile, CMake, tools
+import os
 
 
-class DlibTestConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):

--- a/recipes/dlib/all/test_package/test_package.cpp
+++ b/recipes/dlib/all/test_package/test_package.cpp
@@ -8,8 +8,8 @@ dlib::logger dlog("conan-test");
 int main()
 {
     // Every logger has a logging level (given by dlog.level()).  Each log message is tagged with a
-    // level and only levels equal to or higher than dlog.level() will be printed.  By default all 
-    // loggers start with level() == LERROR.  In this case I'm going to set the lowest level LALL 
+    // level and only levels equal to or higher than dlog.level() will be printed.  By default all
+    // loggers start with level() == LERROR.  In this case I'm going to set the lowest level LALL
     // which means that dlog will print all logging messages it gets.
     dlog.set_level(dlib::LALL);
 
@@ -22,7 +22,7 @@ int main()
 
     // the logger can be used pretty much like any ostream object.  But you have to give a logging
     // level first.  But after that you can chain << operators like normal.
-    
+
     if (variable > 4)
         dlog << dlib::LWARN << "The variable is bigger than 4!  Its value is " << variable;
 
@@ -32,4 +32,5 @@ int main()
     dlog << dlib::LINFO << "we just woke up";
 
     dlog << dlib::LINFO << "program ending";
+    return 0;
 }

--- a/recipes/dlib/config.yml
+++ b/recipes/dlib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "19.24":
+    folder: all
   "19.23":
     folder: all
   "19.21":

--- a/recipes/dlib/config.yml
+++ b/recipes/dlib/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "19.19":
+  "19.23":
     folder: all
   "19.21":
     folder: all
-  "19.23":
+  "19.19":
     folder: all


### PR DESCRIPTION
- use `cmake_find_package` for discovery/injections of external dependencies (I guess it was the reason of failures when `with_gif` was True for msvc)
- enable `with_gif` option by default
- add `with_sqlite3` option (enabled by default upstream, so it also avoids to discover system sqilte)
- disable `DLIB_USE_CUDA` & `DLIB_USE_MKL_FFT` for the moment
- enable `DLIB_NO_GUI_SUPPORT`, otherwise it requires X11 (also on macOS)
- I've explicitly enabled `DLIB_USE_BLAS` & `DLIB_USE_LAPACK` (default value upstream), but mainly to add a FIXME. Indeed what happen behind these options is quite obscure and does not guarantee that `OpenBlas` is used for example.
- add dlib/19.24: a new option `with_webp` is introduced

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
