### PR TITLE
Update aws sdk cpp version to 1.9.258

### DIFF
--- a/recipes/aws-sdk-cpp/all/conandata.yml
+++ b/recipes/aws-sdk-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.9.258":
+    url: "https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.9.258.tar.gz"
+    sha256: "28fa67a424c1913c3a5a2b9efaf747f045b41e0087200684193dce9552bfd24c"
   "1.9.234":
     url: "https://github.com/aws/aws-sdk-cpp/archive/1.9.234.tar.gz"
     sha256: "52e36cf568fe0b2a0fc82a9333c0b31ba843db16670f4ccbb7b9fd142f1b00a5"
@@ -9,6 +12,13 @@ sources:
     url: "https://github.com/aws/aws-sdk-cpp/archive/1.8.130.tar.gz"
     sha256: "5dd09baa28d3f6f4fb03fbba1a4269724d79bcca3d47752cd3e15caf97276bda"
 patches:
+  "1.9.258":
+    - base_path: source_subfolder
+      patch_file: patches/1.9.255-0001-issue-1816.patch
+    - base_path: source_subfolder
+      patch_file: patches/1.9.234-0002-disable-sort-links.patch
+    - base_path: source_subfolder
+      patch_file: patches/1.9.100-0002-aws-plugin-conf.patch
   "1.9.234":
     - base_path: source_subfolder
       patch_file: patches/1.9.234-0001-issue-1816.patch

--- a/recipes/aws-sdk-cpp/all/patches/1.9.255-0001-issue-1816.patch
+++ b/recipes/aws-sdk-cpp/all/patches/1.9.255-0001-issue-1816.patch
@@ -1,0 +1,20 @@
+diff --git a/aws-cpp-sdk-text-to-speech/source/text-to-speech/TextToSpeechManager.cpp b/aws-cpp-sdk-text-to-speech/source/text-to-speech/TextToSpeechManager.cpp
+index 82a298f5a4..f995fcfd4a 100644
+--- a/aws-cpp-sdk-text-to-speech/source/text-to-speech/TextToSpeechManager.cpp
++++ b/aws-cpp-sdk-text-to-speech/source/text-to-speech/TextToSpeechManager.cpp
+@@ -152,7 +152,6 @@ namespace Aws
+                 AWS_LOGSTREAM_TRACE(CLASS_TAG, "Audio retrieved from Polly. " << result.GetContentType() << " with " 
+                     << result.GetRequestCharacters() << " characters syntesized");
+ 
+-                std::streamsize amountRead(0);
+                 unsigned char buffer[BUFF_SIZE];
+ 
+                 std::lock_guard<std::mutex> m(m_driverLock);
+@@ -165,7 +164,6 @@ namespace Aws
+                     AWS_LOGSTREAM_TRACE(CLASS_TAG, "Writing " << read << " bytes to device.");
+ 
+                     successfullyPlayed = m_activeDriver->WriteBufferToDevice(buffer, (std::size_t)read);
+-                    amountRead += read;
+                     played = successfullyPlayed;
+                 }
+ 

--- a/recipes/aws-sdk-cpp/config.yml
+++ b/recipes/aws-sdk-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.258":
+    folder: "all"
   "1.9.234":
     folder: "all"
   "1.9.100":


### PR DESCRIPTION
Specify library name and version:  **awssdkcpp/1.9.258**

This is an update of the available versions to the latest release of AWS-SDK-CPP. The patch files are taken almost verbatim from the previous version 1.9.100, except the sort links patch I adjusted the line number of the commented out line.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
