### PR TITLE
jemalloc: add version 5.3.0

### DIFF
--- a/recipes/jemalloc/all/conandata.yml
+++ b/recipes/jemalloc/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "5.2.1":
     url: "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2"
     sha256: "34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6"
+  "5.3.0":
+    url: "https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
+    sha256: "2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa"
 
 patches:
   "5.2.1":

--- a/recipes/jemalloc/config.yml
+++ b/recipes/jemalloc/config.yml
@@ -1,3 +1,6 @@
 versions:
   "5.2.1":
     folder: all
+  "5.3.0":
+    folder: all
+"

--- a/recipes/jemalloc/config.yml
+++ b/recipes/jemalloc/config.yml
@@ -3,4 +3,3 @@ versions:
     folder: all
   "5.3.0":
     folder: all
-"


### PR DESCRIPTION
Specify library name and version:  **jemalloc/5.3.0**

**jemalloc** recently released a new version, 5.3.0. I would like to add support of this version to the Conan.

---

- [*] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [*] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [*] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [*] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
