### PR TITLE
zlib: fix lib name in CMakeLists directly instead of fragile renaming

### DIFF
--- a/recipes/zlib/all/conanfile.py
+++ b/recipes/zlib/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools, CMake
+import functools
 import os
 
 required_conan_version = ">=1.43.0"
@@ -24,7 +25,6 @@ class ZlibConan(ConanFile):
     }
 
     generators = "cmake"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -70,16 +70,15 @@ class ZlibConan(ConanFile):
                                           '/* may be set to #if 1 by ./configure */',
                                           '#if defined(HAVE_STDARG_H) && (1-HAVE_STDARG_H-1 != 0)')
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["SKIP_INSTALL_ALL"] = False
-        self._cmake.definitions["SKIP_INSTALL_LIBRARIES"] = False
-        self._cmake.definitions["SKIP_INSTALL_HEADERS"] = False
-        self._cmake.definitions["SKIP_INSTALL_FILES"] = True
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["SKIP_INSTALL_ALL"] = False
+        cmake.definitions["SKIP_INSTALL_LIBRARIES"] = False
+        cmake.definitions["SKIP_INSTALL_HEADERS"] = False
+        cmake.definitions["SKIP_INSTALL_FILES"] = True
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
 
     def build(self):
         self._patch_sources()

--- a/recipes/zlib/all/conanfile.py
+++ b/recipes/zlib/all/conanfile.py
@@ -1,8 +1,9 @@
+from conan.tools.microsoft import is_msvc
 from conans import ConanFile, tools, CMake
 import functools
 import os
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.45.0"
 
 
 class ZlibConan(ConanFile):
@@ -33,6 +34,10 @@ class ZlibConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    @property
+    def _is_clang_cl(self):
+        return self.settings.os == "Windows" and self.settings.compiler == "clang"
 
     def export_sources(self):
         self.copy("CMakeLists.txt")
@@ -101,7 +106,7 @@ class ZlibConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "ZLIB")
         self.cpp_info.set_property("cmake_target_name", "ZLIB::ZLIB")
         self.cpp_info.set_property("cmake_find_mode", "both")
-        self.cpp_info.libs = ["zlib" if self.settings.os == "Windows" and not self.settings.os.subsystem else "z"]
+        self.cpp_info.libs = ["zlib" if is_msvc(self) or self._is_clang_cl else "z"]
 
         self.cpp_info.names["cmake_find_package"] = "ZLIB"
         self.cpp_info.names["cmake_find_package_multi"] = "ZLIB"

--- a/recipes/zlib/all/conanfile.py
+++ b/recipes/zlib/all/conanfile.py
@@ -34,10 +34,6 @@ class ZlibConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
-    @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
-
     def export_sources(self):
         self.copy("CMakeLists.txt")
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -90,24 +86,6 @@ class ZlibConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.build()
 
-    def _rename_libraries(self):
-        if self.settings.os == "Windows":
-            lib_path = os.path.join(self.package_folder, "lib")
-            suffix = "d" if self.settings.build_type == "Debug" else ""
-
-            if self.options.shared:
-                if (self._is_msvc or self.settings.compiler == "clang") and suffix:
-                    current_lib = os.path.join(lib_path, "zlib%s.lib" % suffix)
-                    tools.rename(current_lib, os.path.join(lib_path, "zlib.lib"))
-            else:
-                if self._is_msvc or self.settings.compiler == "clang":
-                    current_lib = os.path.join(lib_path, "zlibstatic%s.lib" % suffix)
-                    tools.rename(current_lib, os.path.join(lib_path, "zlib.lib"))
-                elif self.settings.compiler == "gcc":
-                    if not self.settings.os.subsystem:
-                        current_lib = os.path.join(lib_path, "libzlibstatic.a")
-                        tools.rename(current_lib, os.path.join(lib_path, "libzlib.a"))
-
     def _extract_license(self):
         with tools.chdir(os.path.join(self.source_folder, self._source_subfolder)):
             tmp = tools.load("zlib.h")
@@ -119,7 +97,6 @@ class ZlibConan(ConanFile):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
         cmake = self._configure_cmake()
         cmake.install()
-        self._rename_libraries()
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "ZLIB")

--- a/recipes/zlib/all/conanfile.py
+++ b/recipes/zlib/all/conanfile.py
@@ -107,7 +107,11 @@ class ZlibConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "ZLIB")
         self.cpp_info.set_property("cmake_target_name", "ZLIB::ZLIB")
         self.cpp_info.set_property("pkg_config_name", "zlib")
-        self.cpp_info.libs = ["zlib" if is_msvc(self) or self._is_clang_cl else "z"]
+        if is_msvc(self) or self._is_clang_cl:
+            libname = "zdll" if self.options.shared else "zlib"
+        else:
+            libname = "z"
+        self.cpp_info.libs = [libname]
 
         self.cpp_info.names["cmake_find_package"] = "ZLIB"
         self.cpp_info.names["cmake_find_package_multi"] = "ZLIB"

--- a/recipes/zlib/all/conanfile.py
+++ b/recipes/zlib/all/conanfile.py
@@ -103,9 +103,10 @@ class ZlibConan(ConanFile):
         cmake.install()
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_file_name", "ZLIB")
         self.cpp_info.set_property("cmake_target_name", "ZLIB::ZLIB")
-        self.cpp_info.set_property("cmake_find_mode", "both")
+        self.cpp_info.set_property("pkg_config_name", "zlib")
         self.cpp_info.libs = ["zlib" if is_msvc(self) or self._is_clang_cl else "z"]
 
         self.cpp_info.names["cmake_find_package"] = "ZLIB"

--- a/recipes/zlib/all/patches/0001-fix-cmake.patch
+++ b/recipes/zlib/all/patches/0001-fix-cmake.patch
@@ -76,7 +76,7 @@
 +if(BUILD_SHARED_LIBS AND WIN32)
      # Creates zlib1.dll when building shared library version
 -    set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
-+    set_target_properties(zlib PROPERTIES PREFIX "" SUFFIX "1.dll")
++    set_target_properties(zlib PROPERTIES PREFIX "" RUNTIME_OUTPUT_NAME "zlib" SUFFIX "1.dll")
  endif()
  
  if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )

--- a/recipes/zlib/all/patches/0001-fix-cmake.patch
+++ b/recipes/zlib/all/patches/0001-fix-cmake.patch
@@ -59,12 +59,16 @@
  
  if(NOT CYGWIN)
      # This property causes shared libraries on Linux to have the full version
-@@ -199,19 +201,20 @@ if(NOT CYGWIN)
+@@ -199,19 +201,24 @@ if(NOT CYGWIN)
      set_target_properties(zlib PROPERTIES VERSION ${ZLIB_FULL_VERSION})
  endif()
  
 -if(UNIX)
-+if(NOT MSVC)
++if(MSVC)
++    if(BUILD_SHARED_LIBS)
++        set_target_properties(zlib PROPERTIES ARCHIVE_OUTPUT_NAME zdll)
++    endif()
++else()
      # On unix-like platforms the library is almost always called libz
 -   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
 +   set_target_properties(zlib PROPERTIES OUTPUT_NAME z)
@@ -76,7 +80,7 @@
 +if(BUILD_SHARED_LIBS AND WIN32)
      # Creates zlib1.dll when building shared library version
 -    set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
-+    set_target_properties(zlib PROPERTIES PREFIX "" RUNTIME_OUTPUT_NAME "zlib" SUFFIX "1.dll")
++    set_target_properties(zlib PROPERTIES PREFIX "" RUNTIME_OUTPUT_NAME "zlib1")
  endif()
  
  if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
@@ -85,7 +89,7 @@
          RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
          ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
          LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
-@@ -230,6 +233,7 @@ endif()
+@@ -230,6 +237,7 @@ endif()
  # Example binaries
  #============================================================================
  
@@ -93,7 +97,7 @@
  add_executable(example test/example.c)
  target_link_libraries(example zlib)
  add_test(example example)
-@@ -247,3 +251,4 @@ if(HAVE_OFF64_T)
+@@ -247,3 +255,4 @@ if(HAVE_OFF64_T)
      target_link_libraries(minigzip64 zlib)
      set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
  endif()

--- a/recipes/zlib/all/patches/0001-fix-cmake.patch
+++ b/recipes/zlib/all/patches/0001-fix-cmake.patch
@@ -64,7 +64,7 @@
  endif()
  
 -if(UNIX)
-+if(NOT WIN32)
++if(UNIX OR NOT WIN32)
      # On unix-like platforms the library is almost always called libz
 -   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
 +   set_target_properties(zlib PROPERTIES OUTPUT_NAME z)

--- a/recipes/zlib/all/patches/0001-fix-cmake.patch
+++ b/recipes/zlib/all/patches/0001-fix-cmake.patch
@@ -6,7 +6,15 @@
  set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
  
  project(zlib C)
-@@ -83,7 +83,7 @@ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/zlib.pc.cmakein
+@@ -60,7 +60,6 @@ endif()
+ check_include_file(unistd.h Z_HAVE_UNISTD_H)
+ 
+ if(MSVC)
+-    set(CMAKE_DEBUG_POSTFIX "d")
+     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+     add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+@@ -83,7 +82,7 @@ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/zlib.pc.cmakein
  		${ZLIB_PC} @ONLY)
  configure_file(	${CMAKE_CURRENT_SOURCE_DIR}/zconf.h.cmakein
  		${CMAKE_CURRENT_BINARY_DIR}/zconf.h @ONLY)
@@ -15,7 +23,7 @@
  
  
  #============================================================================
-@@ -123,7 +123,7 @@ set(ZLIB_SRCS
+@@ -123,7 +122,7 @@ set(ZLIB_SRCS
      zutil.c
  )
  
@@ -24,7 +32,7 @@
      set(ZLIB_DLL_SRCS
          win32/zlib1.rc # If present will override custom build rule below.
      )
-@@ -167,7 +167,7 @@ file(READ ${CMAKE_CURRENT_SOURCE_DIR}/zlib.h _zlib_h_contents)
+@@ -167,7 +166,7 @@ file(READ ${CMAKE_CURRENT_SOURCE_DIR}/zlib.h _zlib_h_contents)
  string(REGEX REPLACE ".*#define[ \t]+ZLIB_VERSION[ \t]+\"([-0-9A-Za-z.]+)\".*"
      "\\1" ZLIB_FULL_VERSION ${_zlib_h_contents})
  
@@ -33,7 +41,7 @@
      # This gets us DLL resource information when compiling on MinGW.
      if(NOT CMAKE_RC_COMPILER)
          set(CMAKE_RC_COMPILER windres.exe)
-@@ -181,14 +181,19 @@ if(MINGW)
+@@ -181,12 +180,15 @@ if(MINGW)
                              -o ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
                              -i ${CMAKE_CURRENT_SOURCE_DIR}/win32/zlib1.rc)
      set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
@@ -45,38 +53,34 @@
 -add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
  set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
  set_target_properties(zlib PROPERTIES SOVERSION 1)
-+set(ZLIB_TARGET zlib)
 +else()
-+add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
-+set(ZLIB_TARGET zlibstatic)
++add_library(zlib STATIC ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
 +endif()
  
--if(NOT CYGWIN)
-+if(BUILD_SHARED_LIBS AND NOT CYGWIN)
+ if(NOT CYGWIN)
      # This property causes shared libraries on Linux to have the full version
-     # encoded into their final filename.  We disable this on Cygwin because
-     # it causes cygz-${ZLIB_FULL_VERSION}.dll to be created when cygz.dll
-@@ -201,8 +206,8 @@ endif()
+@@ -199,9 +201,9 @@ if(NOT CYGWIN)
+     set_target_properties(zlib PROPERTIES VERSION ${ZLIB_FULL_VERSION})
+ endif()
  
- if(UNIX)
+-if(UNIX)
++if(NOT WIN32)
      # On unix-like platforms the library is almost always called libz
 -   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
--   if(NOT APPLE)
-+   set_target_properties(${ZLIB_TARGET} PROPERTIES OUTPUT_NAME z)
-+   if(BUILD_SHARED_LIBS AND NOT APPLE)
++   set_target_properties(zlib PROPERTIES OUTPUT_NAME z)
+    if(NOT APPLE)
       set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
     endif()
- elseif(BUILD_SHARED_LIBS AND WIN32)
-@@ -211,7 +216,7 @@ elseif(BUILD_SHARED_LIBS AND WIN32)
+@@ -211,7 +213,7 @@ elseif(BUILD_SHARED_LIBS AND WIN32)
  endif()
  
  if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
 -    install(TARGETS zlib zlibstatic
-+    install(TARGETS ${ZLIB_TARGET}
++    install(TARGETS zlib
          RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
          ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
          LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
-@@ -230,6 +235,7 @@ endif()
+@@ -230,6 +232,7 @@ endif()
  # Example binaries
  #============================================================================
  
@@ -84,7 +88,7 @@
  add_executable(example test/example.c)
  target_link_libraries(example zlib)
  add_test(example example)
-@@ -247,3 +253,4 @@ if(HAVE_OFF64_T)
+@@ -247,3 +250,4 @@ if(HAVE_OFF64_T)
      target_link_libraries(minigzip64 zlib)
      set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
  endif()

--- a/recipes/zlib/all/patches/0001-fix-cmake.patch
+++ b/recipes/zlib/all/patches/0001-fix-cmake.patch
@@ -59,19 +59,24 @@
  
  if(NOT CYGWIN)
      # This property causes shared libraries on Linux to have the full version
-@@ -199,9 +201,9 @@ if(NOT CYGWIN)
+@@ -199,19 +201,20 @@ if(NOT CYGWIN)
      set_target_properties(zlib PROPERTIES VERSION ${ZLIB_FULL_VERSION})
  endif()
  
 -if(UNIX)
-+if(UNIX OR NOT WIN32)
++if(NOT MSVC)
      # On unix-like platforms the library is almost always called libz
 -   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
 +   set_target_properties(zlib PROPERTIES OUTPUT_NAME z)
     if(NOT APPLE)
       set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
     endif()
-@@ -211,7 +213,7 @@ elseif(BUILD_SHARED_LIBS AND WIN32)
+-elseif(BUILD_SHARED_LIBS AND WIN32)
++endif()
++if(BUILD_SHARED_LIBS AND WIN32)
+     # Creates zlib1.dll when building shared library version
+-    set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
++    set_target_properties(zlib PROPERTIES PREFIX "" SUFFIX "1.dll")
  endif()
  
  if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
@@ -80,7 +85,7 @@
          RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
          ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
          LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
-@@ -230,6 +232,7 @@ endif()
+@@ -230,6 +233,7 @@ endif()
  # Example binaries
  #============================================================================
  
@@ -88,7 +93,7 @@
  add_executable(example test/example.c)
  target_link_libraries(example zlib)
  add_test(example example)
-@@ -247,3 +250,4 @@ if(HAVE_OFF64_T)
+@@ -247,3 +251,4 @@ if(HAVE_OFF64_T)
      target_link_libraries(minigzip64 zlib)
      set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
  endif()


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/10770

I don't know whether it was a good idea in the first place to rename zlibstatic on Windows, and remove d postfix for debug build type, but now it's done directly in CMakeLists with simple criteria (`zlib` for Windows, `z` for other platforms).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
