### PR TITLE
opentelemetry-proto: add version 0.17.0

### DIFF
--- a/recipes/opentelemetry-proto/all/conandata.yml
+++ b/recipes/opentelemetry-proto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.17.0":
+    url: "https://github.com/open-telemetry/opentelemetry-proto/archive/v0.17.0.tar.gz"
+    sha256: "f269fbcb30e17b03caa1decd231ce826e59d7651c0f71c3b28eb5140b4bb5412"
   "0.16.0":
     url: "https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v0.16.0.tar.gz"
     sha256: "22763df2020d4e16a411b249f86dda8fa1bea69a9592915bf0b1dab6d7005190"

--- a/recipes/opentelemetry-proto/config.yml
+++ b/recipes/opentelemetry-proto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.17.0":
+    folder: all
   "0.16.0":
     folder: all
   "0.11.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **opentelemetry-proto/0.17.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
