### PR TITLE
st_tree: add version 1.2.2

### DIFF
--- a/recipes/st_tree/all/conandata.yml
+++ b/recipes/st_tree/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.2":
+    url: "https://github.com/erikerlandson/st_tree/archive/version_1.2.2.tar.gz"
+    sha256: "7accf5e257407512c2025e074c9d990ebb1bf4beff22b4204b432e9b6c2b5e49"
   "1.2.1":
     url: "https://github.com/erikerlandson/st_tree/archive/refs/tags/version_1.2.1.tar.gz"
     sha256: "02161784c9092a3f78b3964fdf98bc58a3699b5e966f00554562428d804bb205"

--- a/recipes/st_tree/config.yml
+++ b/recipes/st_tree/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.2.2":
+    folder: all
   "1.2.1":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **st_tree/1.2.2**



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
