### PR TITLE
shield: add version 0.2

### DIFF
--- a/recipes/shield/all/conandata.yml
+++ b/recipes/shield/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2":
+    url: "https://github.com/holoplot/shield/archive/0.2.tar.gz"
+    sha256: "bbc22d122a73467715074a92cbcd31c51adacf03256e5d24e304613f8f72197e"
   "0.1":
     url: "https://github.com/holoplot/shield/archive/refs/tags/0.1.tar.gz"
     sha256: "83d10f4e2946a32762bd5718b98f1fbfbb5c7f6d3841d44030b17aeacfbd92f4"

--- a/recipes/shield/config.yml
+++ b/recipes/shield/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.2":
+    folder: all
   "0.1":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **shield/0.2**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
