### PR TITLE
[aws-c-common] add new versions

### DIFF
--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -1,4 +1,22 @@
 sources:
+  "0.7.4":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.7.4.tar.gz"
+    sha256: "e9462a141b5db30006704f537d19b92357a59be38d590272e6118976b0356ccd"
+  "0.7.3":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.7.3.tar.gz"
+    sha256: "e4b80d368668814d9b76989fd2e3cd0fcf0be160bbb8bfeedf1f652e27f9c08c"
+  "0.7.2":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.7.2.tar.gz"
+    sha256: "455aed7447ed58eb7d5d3e8c952ed59f77c71dfed4115883e900f36d95f06dab"
+  "0.7.1":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.7.1.tar.gz"
+    sha256: "75c444a337e446e82d4f71c127118981656234b25cbdfd5913b8de713354fb43"
+  "0.7.0":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.7.0.tar.gz"
+    sha256: "a4e94d2c1d045a27467c9dfae51382f851a5223c3a0ecc15a96d1dba94f85ad6"
+  "0.6.20":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.6.20.tar.gz"
+    sha256: "6eb0b806c78b36a32eec9bcba8d2833e3973491a29d46fe3d11edc3f8d3e7f73"
   "0.6.19":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.6.19.tar.gz"
     sha256: "91cb2b809687be19fce8d6ca03ddc00c78723854ead30dcb58bdc4172cb1796c"

--- a/recipes/aws-c-common/config.yml
+++ b/recipes/aws-c-common/config.yml
@@ -1,4 +1,16 @@
 versions:
+  "0.7.4":
+    folder: all
+  "0.7.3":
+    folder: all
+  "0.7.2":
+    folder: all
+  "0.7.1":
+    folder: all
+  "0.7.0":
+    folder: all
+  "0.6.20":
+    folder: all
   "0.6.19":
     folder: all
   "0.6.17":


### PR DESCRIPTION
Signed-off-by: Dylan <2894220@gmail.com>

**aws-c-common/0.6.20 ~ 0.7.4**

added new version for aws-c-common: 0.6.20, 0.7.0, 0.7.1, 0.7.2, 0.7.3, 0.7.4

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
