### PR TITLE
Add protobuf v3.15.8

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -18,7 +18,7 @@ sources:
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.16.0.tar.gz"
     sha256: "7892a35d979304a404400a101c46ce90e85ec9e2a766a86041bb361f626247f5"
   "3.15.8":
-    url: "https://github.com/protocolbuffers/protobuf/archive/v3.15.8.tar.gz",
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.15.8.tar.gz"
     sha256: "0cbdc9adda01f6d2facc65a22a2be5cecefbefe5a09e5382ee8879b522c04441"
   "3.15.5":
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.15.5.tar.gz"

--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -17,6 +17,12 @@ sources:
   "3.16.0":
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.16.0.tar.gz"
     sha256: "7892a35d979304a404400a101c46ce90e85ec9e2a766a86041bb361f626247f5"
+  "3.15.8":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.15.8.tar.gz",
+    sha256: "0cbdc9adda01f6d2facc65a22a2be5cecefbefe5a09e5382ee8879b522c04441"
+  "3.15.5":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.15.8.tar.gz"
+    sha256: "bc3dbf1f09dba1b2eb3f2f70352ee97b9049066c9040ce0c9b67fb3294e91e4b"
   "3.15.5":
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.15.5.tar.gz"
     sha256: "bc3dbf1f09dba1b2eb3f2f70352ee97b9049066c9040ce0c9b67fb3294e91e4b"

--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -21,9 +21,6 @@ sources:
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.15.8.tar.gz",
     sha256: "0cbdc9adda01f6d2facc65a22a2be5cecefbefe5a09e5382ee8879b522c04441"
   "3.15.5":
-    url: "https://github.com/protocolbuffers/protobuf/archive/v3.15.8.tar.gz"
-    sha256: "bc3dbf1f09dba1b2eb3f2f70352ee97b9049066c9040ce0c9b67fb3294e91e4b"
-  "3.15.5":
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.15.5.tar.gz"
     sha256: "bc3dbf1f09dba1b2eb3f2f70352ee97b9049066c9040ce0c9b67fb3294e91e4b"
   "3.13.0":

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -11,6 +11,8 @@ versions:
     folder: all
   "3.16.0":
     folder: all
+  "3.15.8":
+    folder: all
   "3.15.5":
     folder: all
   "3.13.0":


### PR DESCRIPTION
Specify library name and version:  **protobuf/3.15.8**

There are some applications that require this version.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
