### PR TITLE
libtiff: fix patch to work on older cmake releases

### DIFF
--- a/recipes/libtiff/all/patches/4.3.0-0001-cmake-add-libjpeg-turbo.patch
+++ b/recipes/libtiff/all/patches/4.3.0-0001-cmake-add-libjpeg-turbo.patch
@@ -5,9 +5,9 @@
 +if(NOT TARGET ZSTD::ZSTD)
 +  add_library(ZSTD::ZSTD INTERFACE IMPORTED)
 +  if(TARGET zstd::libzstd_shared)
-+    target_link_libraries(ZSTD::ZSTD INTERFACE zstd::libzstd_shared)
++    set_target_properties(ZSTD::ZSTD PROPERTIES INTERFACE_LINK_LIBRARIES zstd::libzstd_shared)
 +  else()
-+    target_link_libraries(ZSTD::ZSTD INTERFACE zstd::libzstd_static)
++    set_target_properties(ZSTD::ZSTD PROPERTIES INTERFACE_LINK_LIBRARIES zstd::libzstd_static)
 +  endif()
 +endif()
 --- cmake/FindJBIG.cmake
@@ -16,7 +16,7 @@
 +include("${cmake_wrapper_SOURCE_DIR}/ConanFindjbig.cmake")
 +if(NOT TARGET JBIG::JBIG)
 +  add_library(JBIG::JBIG INTERFACE IMPORTED)
-+  target_link_libraries(JBIG::JBIG INTERFACE jbig::jbig)
++  set_target_properties(JBIG::JBIG PROPERTIES INTERFACE_LINK_LIBRARIES jbig::jbig)
 +endif()
 --- cmake/JPEGCodec.cmake
 +++ cmake/JPEGCodec.cmake


### PR DESCRIPTION
Specify library name and version:  **libtiff/4.3.0**

Older CMake does not allow `target_link_libraries` on imported targets.
Use `set_target_properties` instead.

Fixes #10811

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
