### PR TITLE
quill: add version 1.7.3 and remove old versions 

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -1,37 +1,25 @@
 sources:
-  "1.2.3":
-    sha256: f318fa87a39aea76c66cfe09c686f5ce2cacaf2980678ada310acac8cf42ffd0
-    url: https://github.com/odygrd/quill/archive/v1.2.3.tar.gz
-  "1.3.1":
-    sha256: 00e491212139462d87897af02794d19b8a213ff190be59a6799aed515463ca78
-    url: https://github.com/odygrd/quill/archive/v1.3.1.tar.gz
-  "1.3.2":
-    sha256: bf7090c4770cf548d0093499ffb15c0d80c87d74c9bd4cb648f6b6c1e8de35b5
-    url: https://github.com/odygrd/quill/archive/v1.3.2.tar.gz
-  "1.3.3":
-    sha256: 5e185ebe7318fe8ce6e3fd849ec8f7fcb1298ab0302b2268382c7aef1c9542ce
-    url: https://github.com/odygrd/quill/archive/v1.3.3.tar.gz
-  "1.4.0":
-    sha256: e6e9b603caa32c6693cccda8c547b298f3f73867a45e49b33c006cb17b24fa33
-    url: https://github.com/odygrd/quill/archive/v1.4.0.tar.gz
-  "1.5.2":
-    sha256: e409fda0bd949e997f63de4d422a8f17ccc9cb0d58f11403bd309c7a93aa0d6b
-    url: https://github.com/odygrd/quill/archive/v1.5.2.tar.gz
-  "1.6.0":
-    sha256: ab83b418f720effb4a626af7b851fa6421aa8cdb43f4f492ba81aa3ad148ad89
-    url: https://github.com/odygrd/quill/archive/v1.6.0.tar.gz
-  "1.6.1":
-    sha256: 282f54a67fecaa7f094cf986a9e2f7fab342f39e9167c76d7619ad531d0bbaa5
-    url: https://github.com/odygrd/quill/archive/v1.6.1.tar.gz
-  "1.6.2":
-    url: "https://github.com/odygrd/quill/archive/v1.6.2.tar.gz"
-    sha256: "9c27cd7fdf4459c75d1722dd9f2226b5e82ad96b5dbf58559bc8ba3df6af8839"
-  "1.6.3":
-    url: "https://github.com/odygrd/quill/archive/v1.6.3.tar.gz"
-    sha256: "886120b084db952aafe651c64f459e69fec481b4e189c14daa8c4108afebcba3"
-  "1.7.0":
-    url: "https://github.com/odygrd/quill/archive/v1.7.0.tar.gz"
-    sha256: "f6eb9711b949effbd8caf06ee464f66f619b94d3b39f820fa288d0745c620ed1"
+  "1.7.3":
+    url: "https://github.com/odygrd/quill/archive/v1.7.3.tar.gz"
+    sha256: "3fff0c5ffb19bbde5429369079741f84a6acce3a781b504cec5e677b05461208"
   "1.7.2":
     url: "https://github.com/odygrd/quill/archive/v1.7.2.tar.gz"
     sha256: "e2153c6e25f3a6cee47c2a9edbabdace418f6d64f62cd701dfdae38d5892bb1b"
+  "1.7.0":
+    url: "https://github.com/odygrd/quill/archive/v1.7.0.tar.gz"
+    sha256: "f6eb9711b949effbd8caf06ee464f66f619b94d3b39f820fa288d0745c620ed1"
+  "1.6.3":
+    url: "https://github.com/odygrd/quill/archive/v1.6.3.tar.gz"
+    sha256: "886120b084db952aafe651c64f459e69fec481b4e189c14daa8c4108afebcba3"
+  "1.5.2":
+    url: "https://github.com/odygrd/quill/archive/v1.5.2.tar.gz"
+    sha256: "e409fda0bd949e997f63de4d422a8f17ccc9cb0d58f11403bd309c7a93aa0d6b"
+  "1.4.0":
+    url: "https://github.com/odygrd/quill/archive/v1.4.0.tar.gz"
+    sha256: "e6e9b603caa32c6693cccda8c547b298f3f73867a45e49b33c006cb17b24fa33"
+  "1.3.3":
+    url: "https://github.com/odygrd/quill/archive/v1.3.3.tar.gz"
+    sha256: "5e185ebe7318fe8ce6e3fd849ec8f7fcb1298ab0302b2268382c7aef1c9542ce"
+  "1.2.3":
+    url: "https://github.com/odygrd/quill/archive/v1.2.3.tar.gz"
+    sha256: "f318fa87a39aea76c66cfe09c686f5ce2cacaf2980678ada310acac8cf42ffd0"

--- a/recipes/quill/all/conanfile.py
+++ b/recipes/quill/all/conanfile.py
@@ -8,21 +8,23 @@ required_conan_version = ">=1.33.0"
 class QuillConan(ConanFile):
     name = "quill"
     description = "C++14 Asynchronous Low Latency Logging Library"
-    homepage = "https://github.com/odygrd/quill/"
     topics = ("quill", "logging", "log")
-    url = "https://github.com/conan-io/conan-center-index"
     license = "MIT"
+    homepage = "https://github.com/odygrd/quill/"
+    url = "https://github.com/conan-io/conan-center-index"
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake", "cmake_find_package"
-    settings = "os", "compiler", "build_type", "arch"
-
-    options = {"fPIC": [True, False],
-               "with_bounded_queue": [True, False],
-               "with_no_exceptions": [True, False]}
-
-    default_options = {"fPIC": True,
-                       "with_bounded_queue": False,
-                       "with_no_exceptions": False}
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+        "with_bounded_queue": [True, False],
+        "with_no_exceptions": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "with_bounded_queue": False,
+        "with_no_exceptions": False,
+    }
 
     @property
     def _source_subfolder(self):
@@ -70,9 +72,7 @@ class QuillConan(ConanFile):
             self.requires("fmt/6.2.1")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     @functools.lru_cache(1)
     def _configure_cmake(self):

--- a/recipes/quill/all/test_package/CMakeLists.txt
+++ b/recipes/quill/all/test_package/CMakeLists.txt
@@ -8,4 +8,4 @@ find_package(quill CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} quill::quill)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 14)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/quill/all/test_package/conanfile.py
+++ b/recipes/quill/all/test_package/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -1,25 +1,17 @@
 versions:
-  "1.2.3":
+  "1.7.3":
     folder: "all"
-  "1.3.1":
-    folder: "all"
-  "1.3.2":
-    folder: "all"
-  "1.3.3":
-    folder: "all"
-  "1.4.0":
-    folder: "all"
-  "1.5.2":
-    folder: "all"
-  "1.6.0":
-    folder: "all"
-  "1.6.1":
-    folder: "all"
-  "1.6.2":
-    folder: "all"
-  "1.6.3":
+  "1.7.2":
     folder: "all"
   "1.7.0":
     folder: "all"
-  "1.7.2":
+  "1.6.3":
+    folder: "all"
+  "1.5.2":
+    folder: "all"
+  "1.4.0":
+    folder: "all"
+  "1.3.3":
+    folder: "all"
+  "1.2.3":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **quill/***

I deleted several old versions because there are lots of versions in this recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
