### PR TITLE
Test for conan bug: module-config problems

### DIFF
--- a/recipes/test_module_config/all/CMakeLists.txt
+++ b/recipes/test_module_config/all/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_module_config CXX)
+
+find_package(Fontconfig)
+
+add_executable(test_module_config src/test_module_config.cpp src/main.cpp)
+target_include_directories(test_module_config PUBLIC include)
+
+target_link_libraries(test_module_config PUBLIC Fontconfig::Fontconfig)
+
+install(TARGETS test_module_config)

--- a/recipes/test_module_config/all/conanfile.py
+++ b/recipes/test_module_config/all/conanfile.py
@@ -1,0 +1,38 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+
+class TestModuleConfigConan(ConanFile):
+    name = "test_module_config"
+    version = "1.0.0"
+
+    # Optional metadata
+    license = "<Put the package license here>"
+    author = "<Put your name here> <And your email here>"
+    url = "<Package recipe repository url here, for issues about the package>"
+    description = "<Description of TestModuleConfig here>"
+    topics = ("<Put some tag here>", "<here>", "<and here>")
+
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+
+    generators = "CMakeDeps"
+    requires = "fontconfig/2.13.93"
+
+    # Sources are located in the same place as this recipe, copy them to the recipe
+    exports_sources = "CMakeLists.txt", "src/*", "include/*"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()

--- a/recipes/test_module_config/all/include/test_module_config.h
+++ b/recipes/test_module_config/all/include/test_module_config.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef _WIN32
+  #define test_module_config_EXPORT __declspec(dllexport)
+#else
+  #define test_module_config_EXPORT
+#endif
+
+test_module_config_EXPORT void test_module_config();

--- a/recipes/test_module_config/all/src/main.cpp
+++ b/recipes/test_module_config/all/src/main.cpp
@@ -1,0 +1,5 @@
+#include "test_module_config.h"
+
+int main() {
+    test_module_config();
+}

--- a/recipes/test_module_config/all/src/test_module_config.cpp
+++ b/recipes/test_module_config/all/src/test_module_config.cpp
@@ -1,0 +1,87 @@
+#include <iostream>
+#include "test_module_config.h"
+
+void test_module_config(){
+    #ifdef NDEBUG
+    std::cout << "test_module_config/1.0.0: Hello World Release!\n";
+    #else
+    std::cout << "test_module_config/1.0.0: Hello World Debug!\n";
+    #endif
+
+    // ARCHITECTURES
+    #ifdef _M_X64
+    std::cout << "  test_module_config/1.0.0: _M_X64 defined\n";
+    #endif
+
+    #ifdef _M_IX86
+    std::cout << "  test_module_config/1.0.0: _M_IX86 defined\n";
+    #endif
+
+    #if __i386__
+    std::cout << "  test_module_config/1.0.0: __i386__ defined\n";
+    #endif
+
+    #if __x86_64__
+    std::cout << "  test_module_config/1.0.0: __x86_64__ defined\n";
+    #endif
+
+    // Libstdc++
+    #if defined _GLIBCXX_USE_CXX11_ABI
+    std::cout << "  test_module_config/1.0.0: _GLIBCXX_USE_CXX11_ABI "<< _GLIBCXX_USE_CXX11_ABI << "\n";
+    #endif
+
+    // COMPILER VERSIONS
+    #if _MSC_VER
+    std::cout << "  test_module_config/1.0.0: _MSC_VER" << _MSC_VER<< "\n";
+    #endif
+
+    #if _MSVC_LANG
+    std::cout << "  test_module_config/1.0.0: _MSVC_LANG" << _MSVC_LANG<< "\n";
+    #endif
+
+    #if __cplusplus
+    std::cout << "  test_module_config/1.0.0: __cplusplus" << __cplusplus<< "\n";
+    #endif
+
+    #if __INTEL_COMPILER
+    std::cout << "  test_module_config/1.0.0: __INTEL_COMPILER" << __INTEL_COMPILER<< "\n";
+    #endif
+
+    #if __GNUC__
+    std::cout << "  test_module_config/1.0.0: __GNUC__" << __GNUC__<< "\n";
+    #endif
+
+    #if __GNUC_MINOR__
+    std::cout << "  test_module_config/1.0.0: __GNUC_MINOR__" << __GNUC_MINOR__<< "\n";
+    #endif
+
+    #if __clang_major__
+    std::cout << "  test_module_config/1.0.0: __clang_major__" << __clang_major__<< "\n";
+    #endif
+
+    #if __clang_minor__
+    std::cout << "  test_module_config/1.0.0: __clang_minor__" << __clang_minor__<< "\n";
+    #endif
+
+    #if __apple_build_version__
+    std::cout << "  test_module_config/1.0.0: __apple_build_version__" << __apple_build_version__<< "\n";
+    #endif
+
+    // SUBSYSTEMS
+
+    #if __MSYS__
+    std::cout << "  test_module_config/1.0.0: __MSYS__" << __MSYS__<< "\n";
+    #endif
+
+    #if __MINGW32__
+    std::cout << "  test_module_config/1.0.0: __MINGW32__" << __MINGW32__<< "\n";
+    #endif
+
+    #if __MINGW64__
+    std::cout << "  test_module_config/1.0.0: __MINGW64__" << __MINGW64__<< "\n";
+    #endif
+
+    #if __CYGWIN__
+    std::cout << "  test_module_config/1.0.0: __CYGWIN__" << __CYGWIN__<< "\n";
+    #endif
+}

--- a/recipes/test_module_config/all/test_package/conanfile.py
+++ b/recipes/test_module_config/all/test_package/conanfile.py
@@ -1,0 +1,23 @@
+import os
+from conan import ConanFile
+from conan.tools.build import cross_building
+from conan.tools.layout import basic_layout
+
+
+class TestModuleConfigTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    # VirtualRunEnv can be avoided if "tools.env.virtualenv:auto_use" is defined
+    # (it will be defined in Conan 2.0)
+    generators = "VirtualRunEnv"
+    apply_env = False
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        basic_layout(self)
+
+    def test(self):
+        if not cross_building(self):
+            self.run("test_module_config", env="conanrun")

--- a/recipes/test_module_config/config.yml
+++ b/recipes/test_module_config/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0":
+    folder: all


### PR DESCRIPTION
This PR is for testing bug conan-io/conan#11201
I have a fix to consider in conan-io/conan#11217

Note that this should be tested with the latest release-1.48.0 branch
AND with this added to the profile:
```
[conf]
tools.cmake.cmaketoolchain:find_package_prefer_config=False
```

Error message is:
```
-- Detecting CXX compile features - done
-- Found Fontconfig: 2.13.93 (found version "2.13.93") 
-- Conan: Target declared 'Fontconfig::Fontconfig'
CMake Error at /build/msrap2/devenv/share/cmake-3.23/Modules/CMakeFindDependencyMacro.cmake:47 (find_package):
  No "Findfreetype.cmake" found in CMAKE_MODULE_PATH.
Call Stack (most recent call first):
  build/generators/FindFontconfig.cmake:25 (find_dependency)
  CMakeLists.txt:4 (find_package)
```

The problem is conan wants to import "freetype" as a MODULE, but the python code to compute the filename is assuming the caller wants the CONFIG version of the filename.

My solution is to ensure the filename-calculation is told whether the caller wants to force the MODULE or CONFIG variant.
