### PR TITLE
fix SyntaxWarning: "is not" with a literal

### DIFF
--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -75,9 +75,9 @@ class DbusConan(ConanFile):
             args.append("--with-systemdsystemunitdir=%s" % os.path.join(self.package_folder, "lib", "systemd", "system"))
             args.append("--with-systemduserunitdir=%s" % os.path.join(self.package_folder, "lib", "systemd", "user"))
 
-            if str(self.options.system_socket) is not "":
+            if str(self.options.system_socket) != "":
                 args.append("--with-system-socket=%s" % self.options.system_socket)
-            if str(self.options.system_pid_file) is not "":
+            if str(self.options.system_pid_file) != "":
                 args.append("--with-system-pid-file=%s" % self.options.system_pid_file)
 
             args.append("--disable-launchd")

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -160,7 +160,7 @@ class DiligentCoreConan(ConanFile):
             self.copy(pattern="*.so", dst="lib", keep_path=False)
             self.copy(pattern="*.dll", dst="bin", keep_path=False)
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.a")
-            if self.settings.os is not "Windows":
+            if self.settings.os != "Windows":
                 tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.lib")
         else:
             self.copy(pattern="*.a", dst="lib", keep_path=False)

--- a/recipes/libigl/2.x.x/conanfile.py
+++ b/recipes/libigl/2.x.x/conanfile.py
@@ -52,7 +52,7 @@ class LibiglConan(ConanFile):
                     self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
         if self.settings.compiler == "Visual Studio" and "MT" in self.settings.compiler.runtime and not self.options.header_only:
             raise ConanInvalidConfiguration("Visual Studio build with MT runtime is not supported")
-        if "arm" in self.settings.arch or "x86" is self.settings.arch:
+        if "arm" in self.settings.arch or "x86" == self.settings.arch:
             raise ConanInvalidConfiguration("Not available for arm. Requested arch: {}".format(self.settings.arch))
 
     def config_options(self):


### PR DESCRIPTION
Specify library name and version:  **diligent-core/all**

fix python syntax warning in conanfile.py

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

