### PR TITLE
fix SyntaxWarning: "is not" with a literal in `diligent-core/all`

### DIFF
--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -160,7 +160,7 @@ class DiligentCoreConan(ConanFile):
             self.copy(pattern="*.so", dst="lib", keep_path=False)
             self.copy(pattern="*.dll", dst="bin", keep_path=False)
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.a")
-            if self.settings.os is not "Windows":
+            if self.settings.os != "Windows":
                 tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.lib")
         else:
             self.copy(pattern="*.a", dst="lib", keep_path=False)


### PR DESCRIPTION
Specify library name and version:  **diligent-core/all**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): Fix syntax warning in conan file.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
