### PR TITLE
fix SyntaxWarning: "is" with a literal in `libigl/2.x.x`

### DIFF
--- a/recipes/libigl/2.x.x/conanfile.py
+++ b/recipes/libigl/2.x.x/conanfile.py
@@ -52,7 +52,7 @@ class LibiglConan(ConanFile):
                     self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
         if self.settings.compiler == "Visual Studio" and "MT" in self.settings.compiler.runtime and not self.options.header_only:
             raise ConanInvalidConfiguration("Visual Studio build with MT runtime is not supported")
-        if "arm" in self.settings.arch or "x86" is self.settings.arch:
+        if "arm" in self.settings.arch or "x86" == self.settings.arch:
             raise ConanInvalidConfiguration("Not available for arm. Requested arch: {}".format(self.settings.arch))
 
     def config_options(self):


### PR DESCRIPTION
Specify library name and version:  **libigl/2.x.x**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): Fix syntax warning in conan file.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
