### PR TITLE
fix SyntaxWarning: "is not" with a literal in `dbus/1.x.x`

### DIFF
--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -75,9 +75,9 @@ class DbusConan(ConanFile):
             args.append("--with-systemdsystemunitdir=%s" % os.path.join(self.package_folder, "lib", "systemd", "system"))
             args.append("--with-systemduserunitdir=%s" % os.path.join(self.package_folder, "lib", "systemd", "user"))
 
-            if str(self.options.system_socket) is not "":
+            if str(self.options.system_socket) != "":
                 args.append("--with-system-socket=%s" % self.options.system_socket)
-            if str(self.options.system_pid_file) is not "":
+            if str(self.options.system_pid_file) != "":
                 args.append("--with-system-pid-file=%s" % self.options.system_pid_file)
 
             args.append("--disable-launchd")


### PR DESCRIPTION
Specify library name and version:  **dbus/1.x.x**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): Fix syntax warning in conan file

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
