### PR TITLE
lockfiles: link issues in v1, add note around recommendation

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -324,7 +324,7 @@ The minimum solution involves small changes to your Conan client configuration b
 
 * **Pin the version of every reference you consume in your project** using either:
   * [recipe revision (RREV)](https://docs.conan.io/en/latest/versioning/revisions.html): `foo/1.0@#RREV` instead of `foo/1.0` in your conanfile.
-  * [lockfiles](https://docs.conan.io/en/latest/versioning/lockfiles/introduction.html).
+  * [lockfiles](https://docs.conan.io/en/latest/versioning/lockfiles/introduction.html) (please, be aware there are some [knowns bugs](https://github.com/conan-io/conan/issues?q=is%3Aissue+lockfile) related to lockfiles that are not being fixed in Conan v1.x).
    
 For larger projects and teams it is recommended to add some infrastructure to ensure stability by
 


### PR DESCRIPTION
We cannot simply recommend them, there are some known bugs that won't be fixed in v1