### PR TITLE
[Qt/6.3.0] Allow to use the envirenment variable HOST_PERL when is set

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -646,8 +646,7 @@ class QtConan(ConanFile):
         cmake.definitions["FEATURE_pkg_config"] = "ON"
         if self.settings.compiler == "gcc" and self.settings.build_type == "Debug" and not self.options.shared:
             cmake.definitions["BUILD_WITH_PCH"]= "OFF" # disabling PCH to save disk space
-
-        if self.settings.os == "Windows":
+        if self.settings.os == "Windows" and os.environ.get('HOST_PERL') is None:
             cmake.definitions["HOST_PERL"] = getattr(self, "user_info_build", self.deps_user_info)["strawberryperl"].perl
 
         try:


### PR DESCRIPTION
**Qt/6.3.0**

With the current Qt/6.3.0 recipe I keep having the issue that `strawberryperl.perl` is not part of the `self.deps_user_info`, like so:

```
ERROR: qt/6.3.0@dashandslash/testing: Error in build() method, line 704
        cmake = self._configure_cmake()
while calling '_configure_cmake', line 651
        cmake.definitions["HOST_PERL"] = getattr(self, "user_info_build", self.deps_user_info)["strawberryperl"].perl
        AttributeError:
```

The only way to fix it on my side was to define the environment variable `HOST_PERL` holding the path to the perl executable, and then modify the condition in the `conanfile.py`

After this little workaround, I am finally able to create the package using conan create and passing the -e option:
`conan create . qt/6.3.0@dashandslash/testing -e HOST_PERL=/abs/path/to/perl.exe`

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
