### PR TITLE
New: seqan3/3.1.0

### DIFF
--- a/recipes/seqan3/all/conandata.yml
+++ b/recipes/seqan3/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.1.0":
+    url: https://github.com/seqan/seqan3/releases/download/3.1.0/seqan3-3.1.0-Source.tar.xz
+    sha256: 0b37b1c3450e19c0ebe42c052c3f87babb8074bd772f10a553949c312c285726

--- a/recipes/seqan3/all/conanfile.py
+++ b/recipes/seqan3/all/conanfile.py
@@ -1,0 +1,60 @@
+import os
+import conan.tools.files
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+
+class SeqanConan(ConanFile):
+    name = "seqan3"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/seqan/seqan3"
+    description = "SeqAn3 is the new version of the popular SeqAn template library for the analysis of biological sequences."
+    topics = ("cpp20", "algorithms", "data structures", "biological sequences")
+    license = "BSD-3-Clause"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "10"
+        }
+
+    def configure(self):
+        if self.settings.compiler != "gcc":
+            raise ConanInvalidConfiguration("SeqAn3 only supports GCC.")
+
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 20)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version:
+            if tools.Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration("SeqAn3 requires C++20, which your compiler does not fully support.")
+        else:
+            self.output.warn("SeqAn3 requires C++20. Your compiler is unknown. Assuming it supports C++20.")
+
+        if self.settings.compiler == "gcc" and self.settings.compiler.libcxx != "libstdc++11":
+            self.output.warn("SeqAn3 does not actively support libstdc++, consider using libstdc++11 instead.")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "seqan3-" + self.version + "-Source"
+        conan.tools.files.rename(self, extracted_dir, self._source_subfolder)
+
+    def package(self):
+        self.copy("*", dst="include",
+                  src=os.path.join(self._source_subfolder, "include"), keep_path=True)
+        for submodule in ["range-v3", "cereal", "sdsl-lite"]:
+            self.copy("*.hpp", dst="include",
+                  src=os.path.join(self._source_subfolder, "submodules", submodule, "include"), keep_path=True)
+        self.copy("LICENSE.md", dst="licenses", src=self._source_subfolder)
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "seqan3"
+        self.cpp_info.names["cmake_find_package_multi"] = "seqan3"

--- a/recipes/seqan3/all/test_package/CMakeLists.txt
+++ b/recipes/seqan3/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} CONAN_PKG::seqan3)

--- a/recipes/seqan3/all/test_package/conanfile.py
+++ b/recipes/seqan3/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/seqan3/all/test_package/test_package.cpp
+++ b/recipes/seqan3/all/test_package/test_package.cpp
@@ -1,0 +1,15 @@
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/views/complement.hpp>
+#include <seqan3/core/debug_stream.hpp>
+
+int main()
+{
+    using namespace seqan3::literals;
+
+    std::vector<seqan3::dna4> seq = "AGTGTACGTAC"_dna4;
+
+    seqan3::debug_stream << "Sequence: " << seq << '\n';
+    seqan3::debug_stream << "Reverse complement: " << (seq | std::views::reverse | seqan3::views::complement) << '\n';
+
+    return 0;
+}

--- a/recipes/seqan3/config.yml
+++ b/recipes/seqan3/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.1.0":
+    folder: "all"


### PR DESCRIPTION
Library name and version:  **seqan3/3.1.0**

[seqan3](https://github.com/seqan/seqan3) is a header-only C++ library for sequence analysis

I am adding this recipe since a user requested it to be added: https://github.com/seqan/seqan3/issues/2974

It is very likely that we will add applications in the future that rely on seqan3 as a dependency, we have by now done so for other package repositories.

There is already a `seqan` recipe, it is for the old 2.x.x versions. _SeqAn3 is a complete rewrite_.

I am uncertain whether it should be added as a new version for the `seqan` recipe, or if it may exist as a separate package. 
**I am happy to handle this in whatever way you deem appropriate.**

Currently, we have some standalone packages (alongside the "old" `seqan` package):

* Conda: https://anaconda.org/bioconda/seqan3
* Debian: https://packages.debian.org/sid/libseqan3-dev
* MacPorts: https://ports.macports.org/port/seqan3/

And only one where both seqan 2.x.x and 3.x.x are one package (with `seqan@2` and `seqan@3`):
* Brew: https://github.com/brewsci/homebrew-bio/blob/develop/Formula/seqan%403.rb
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
