### PR TITLE
capnproto: Patch for fixing compilation with NOGDI flag

### DIFF
--- a/recipes/capnproto/all/conandata.yml
+++ b/recipes/capnproto/all/conandata.yml
@@ -14,6 +14,8 @@ patches:
       base_path: source_subfolder
     - patch_file: patches/0011-msvc-cpp17-hassubstring-fix-0.9.1.patch
       base_path: source_subfolder
+    - patch_file: patches/0012-msvc-nogdi-fix-0.9.1.patch
+      base_path: source_subfolder
   "0.8.0":
     - patch_file: patches/0001-disable-tests.patch
       base_path: source_subfolder

--- a/recipes/capnproto/all/patches/0012-msvc-nogdi-fix-0.9.1.patch
+++ b/recipes/capnproto/all/patches/0012-msvc-nogdi-fix-0.9.1.patch
@@ -1,0 +1,29 @@
+--- c++/src/kj/windows-sanity.h
++++ c++/src/kj/windows-sanity.h
+@@ -48,10 +48,13 @@
+ // now, we use `#pragma once` to tell the compiler never to include this file again.
+ #pragma once
+ 
+-namespace win32 {
+-  const auto ERROR_ = ERROR;
++namespace kj_win32_workarounds {
++  // Namespace containing constant definitions intended to replace constants that are defined as
++  // macros in the Windows headers. Do not refer to this namespace directly, we'll import it into
++  // the global scope below.
+ 
+ #ifdef ERROR  // This could be absent if e.g. NOGDI was used.
++  const auto ERROR_ = ERROR;
+ #undef ERROR
+   const auto ERROR = ERROR_;
+ #endif
+@@ -61,7 +64,8 @@
+   typedef VOID_ VOID;
+ }
+ 
+-using win32::ERROR;
+-using win32::VOID;
++// Pull our constant definitions into the global namespace -- but only if they don't already exist
++// in the global namespace.
++using namespace kj_win32_workarounds;
+ 
+ #endif


### PR DESCRIPTION
capnproto/0.9.1

There is a bug in the 0.9.1 release that prevents it from compiling using MSVC with NOGDI flag. To fix this I backported patches from master.

Issue: https://github.com/capnproto/capnproto/issues/1421


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
