### PR TITLE
ffmpeg: extra configuration options

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -71,6 +71,9 @@ class FFMpegConan(ConanFile):
         "disable_all_hardware_accelerators": [True, False],
         "disable_hardware_accelerators": "ANY",
         "enable_hardware_accelerators": "ANY",
+        "disable_all_muxers": [True, False],
+        "disable_muxers": "ANY",
+        "enable_muxers": "ANY",
     }
     default_options = {
         "shared": False,
@@ -122,6 +125,9 @@ class FFMpegConan(ConanFile):
         "disable_all_hardware_accelerators": False,
         "disable_hardware_accelerators": "",
         "enable_hardware_accelerators": "",
+        "disable_all_muxers": False,
+        "disable_muxers": "",
+        "enable_muxers": "",
     }
 
     generators = "pkg_config"
@@ -354,6 +360,8 @@ class FFMpegConan(ConanFile):
                 "decoders", self.options.disable_all_decoders),
             opt_disable_if_set(
                 "hwaccels", self.options.disable_all_hardware_accelerators),
+            opt_disable_if_set(
+                "muxers", self.options.disable_all_muxers),
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
             opt_enable_disable("zlib", self.options.with_zlib),
@@ -417,6 +425,10 @@ class FFMpegConan(ConanFile):
             "enable-hwaccel", self.options.enable_hardware_accelerators))
         args.extend(self._split_and_format_options_string(
             "disable-hwaccel", self.options.disable_hardware_accelerators))
+        args.extend(self._split_and_format_options_string(
+            "enable-muxer", self.options.enable_muxers))
+        args.extend(self._split_and_format_options_string(
+            "disable-muxer", self.options.disable_muxers))
 
         if self._version_supports_vulkan():
             args.append(opt_enable_disable(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -882,8 +882,10 @@ class FFMpegConan(ConanFile):
         if self.options.get_safe("with_vaapi"):
             self.cpp_info.components["avutil"].requires.extend(
                 ["vaapi::vaapi", "xorg::x11"])
+
         if self.options.get_safe("with_vdpau"):
             self.cpp_info.components["avutil"].requires.append("vdpau::vdpau")
+
         if self._version_supports_vulkan() and self.options.get_safe("with_vulkan"):
             self.cpp_info.components["avutil"].requires.append(
                 "vulkan-loader::vulkan-loader")

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -89,6 +89,9 @@ class FFMpegConan(ConanFile):
         "disable_all_input_devices": [True, False],
         "disable_input_devices": "ANY",
         "enable_input_devices": "ANY",
+        "disable_all_output_devices": [True, False],
+        "disable_output_devices": "ANY",
+        "enable_output_devices": "ANY",
     }
     default_options = {
         "shared": False,
@@ -158,6 +161,9 @@ class FFMpegConan(ConanFile):
         "disable_all_input_devices": False,
         "disable_input_devices": "",
         "enable_input_devices": "",
+        "disable_all_output_devices": False,
+        "disable_output_devices": "",
+        "enable_output_devices": "",
     }
 
     generators = "pkg_config"
@@ -402,6 +408,8 @@ class FFMpegConan(ConanFile):
                 "protocols", self.options.disable_all_protocols),
             opt_disable_if_set(
                 "indevs", self.options.disable_all_input_devices),
+            opt_disable_if_set(
+                "outdevs", self.options.disable_all_output_devices),
 
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
@@ -490,6 +498,10 @@ class FFMpegConan(ConanFile):
             "enable-indev", self.options.enable_input_devices))
         args.extend(self._split_and_format_options_string(
             "disable-indev", self.options.disable_input_devices))
+        args.extend(self._split_and_format_options_string(
+            "enable-outdev", self.options.enable_output_devices))
+        args.extend(self._split_and_format_options_string(
+            "disable-outdev", self.options.disable_output_devices))
 
         if self._version_supports_vulkan():
             args.append(opt_enable_disable(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -65,7 +65,9 @@ class FFMpegConan(ConanFile):
         "disable_all_encoders": [True, False],
         "disable_encoders": "ANY",
         "enable_encoders": "ANY",
-
+        "disable_all_decoders": [True, False],
+        "disable_decoders": "ANY",
+        "enable_decoders": "ANY",
     }
     default_options = {
         "shared": False,
@@ -111,6 +113,9 @@ class FFMpegConan(ConanFile):
         "disable_all_encoders": False,
         "disable_encoders": "",
         "enable_encoders": "",
+        "disable_all_decoders": False,
+        "disable_decoders": "",
+        "enable_decoders": "",
     }
 
     generators = "pkg_config"
@@ -339,6 +344,8 @@ class FFMpegConan(ConanFile):
                 "everything", self.options.disable_everything),
             opt_disable_if_set(
                 "encoders", self.options.disable_all_encoders),
+            opt_disable_if_set(
+                "decoders", self.options.disable_all_decoders),
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
             opt_enable_disable("zlib", self.options.with_zlib),
@@ -394,6 +401,10 @@ class FFMpegConan(ConanFile):
             "enable-encoder", self.options.enable_encoders))
         args.extend(self._split_and_format_options_string(
             "disable-encoder", self.options.disable_encoders))
+        args.extend(self._split_and_format_options_string(
+            "enable-decoder", self.options.enable_decoders))
+        args.extend(self._split_and_format_options_string(
+            "disable-decoder", self.options.disable_decoders))
 
         if self._version_supports_vulkan():
             args.append(opt_enable_disable(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -93,6 +93,9 @@ class FFMpegConan(ConanFile):
         "disable_all_output_devices": [True, False],
         "disable_output_devices": "ANY",
         "enable_output_devices": "ANY",
+        "disable_all_filters": [True, False],
+        "disable_filters": "ANY",
+        "enable_filters": "ANY",
     }
     default_options = {
         "shared": False,
@@ -166,6 +169,9 @@ class FFMpegConan(ConanFile):
         "disable_all_output_devices": False,
         "disable_output_devices": "",
         "enable_output_devices": "",
+        "disable_all_filters": False,
+        "disable_filters": "",
+        "enable_filters": "",
     }
 
     generators = "pkg_config"
@@ -414,6 +420,8 @@ class FFMpegConan(ConanFile):
                 "indevs", self.options.disable_all_input_devices),
             opt_disable_if_set(
                 "outdevs", self.options.disable_all_output_devices),
+            opt_disable_if_set(
+                "filters", self.options.disable_all_filters),
 
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
@@ -506,6 +514,10 @@ class FFMpegConan(ConanFile):
             "enable-outdev", self.options.enable_output_devices))
         args.extend(self._split_and_format_options_string(
             "disable-outdev", self.options.disable_output_devices))
+        args.extend(self._split_and_format_options_string(
+            "enable-filter", self.options.enable_filters))
+        args.extend(self._split_and_format_options_string(
+            "disable-filter", self.options.disable_filters))
 
         if self._version_supports_vulkan():
             args.append(opt_enable_disable(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -83,6 +83,9 @@ class FFMpegConan(ConanFile):
         "disable_all_bitstream_filters": [True, False],
         "disable_bitstream_filters": "ANY",
         "enable_bitstream_filters": "ANY",
+        "disable_all_protocols": [True, False],
+        "disable_protocols": "ANY",
+        "enable_protocols": "ANY",
     }
     default_options = {
         "shared": False,
@@ -146,6 +149,9 @@ class FFMpegConan(ConanFile):
         "disable_all_bitstream_filters": False,
         "disable_bitstream_filters": "",
         "enable_bitstream_filters": "",
+        "disable_all_protocols": False,
+        "disable_protocols": "",
+        "enable_protocols": "",
     }
 
     generators = "pkg_config"
@@ -386,6 +392,9 @@ class FFMpegConan(ConanFile):
                 "parsers", self.options.disable_all_parsers),
             opt_disable_if_set(
                 "bsfs", self.options.disable_all_bitstream_filters),
+            opt_disable_if_set(
+                "protocols", self.options.disable_all_protocols),
+
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
             opt_enable_disable("zlib", self.options.with_zlib),
@@ -465,6 +474,10 @@ class FFMpegConan(ConanFile):
             "enable-bsf", self.options.enable_bitstream_filters))
         args.extend(self._split_and_format_options_string(
             "disable-bsf", self.options.disable_bitstream_filters))
+        args.extend(self._split_and_format_options_string(
+            "enable-protocol", self.options.enable_protocols))
+        args.extend(self._split_and_format_options_string(
+            "disable-protocol", self.options.disable_protocols))
 
         if self._version_supports_vulkan():
             args.append(opt_enable_disable(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -139,39 +139,39 @@ class FFMpegConan(ConanFile):
         "with_programs": True,
         "disable_everything": False,
         "disable_all_encoders": False,
-        "disable_encoders": "",
-        "enable_encoders": "",
+        "disable_encoders": None,
+        "enable_encoders": None,
         "disable_all_decoders": False,
-        "disable_decoders": "",
-        "enable_decoders": "",
+        "disable_decoders": None,
+        "enable_decoders": None,
         "disable_all_hardware_accelerators": False,
-        "disable_hardware_accelerators": "",
-        "enable_hardware_accelerators": "",
+        "disable_hardware_accelerators": None,
+        "enable_hardware_accelerators": None,
         "disable_all_muxers": False,
-        "disable_muxers": "",
-        "enable_muxers": "",
+        "disable_muxers": None,
+        "enable_muxers": None,
         "disable_all_demuxers": False,
-        "disable_demuxers": "",
-        "enable_demuxers": "",
+        "disable_demuxers": None,
+        "enable_demuxers": None,
         "disable_all_parsers": False,
-        "disable_parsers": "",
-        "enable_parsers": "",
+        "disable_parsers": None,
+        "enable_parsers": None,
         "disable_all_bitstream_filters": False,
-        "disable_bitstream_filters": "",
-        "enable_bitstream_filters": "",
+        "disable_bitstream_filters": None,
+        "enable_bitstream_filters": None,
         "disable_all_protocols": False,
-        "disable_protocols": "",
-        "enable_protocols": "",
+        "disable_protocols": None,
+        "enable_protocols": None,
         "disable_all_devices": False,
         "disable_all_input_devices": False,
-        "disable_input_devices": "",
-        "enable_input_devices": "",
+        "disable_input_devices": None,
+        "enable_input_devices": None,
         "disable_all_output_devices": False,
-        "disable_output_devices": "",
-        "enable_output_devices": "",
+        "disable_output_devices": None,
+        "enable_output_devices": None,
         "disable_all_filters": False,
-        "disable_filters": "",
-        "enable_filters": "",
+        "disable_filters": None,
+        "enable_filters": None,
     }
 
     generators = "pkg_config"
@@ -566,6 +566,9 @@ class FFMpegConan(ConanFile):
         return self._autotools
 
     def _split_and_format_options_string(self, flag_name, options_list):
+        if not options_list:
+            return []
+
         def _format_options_list_item(flag_name, options_item):
             return "--{}={}".format(flag_name, options_item)
 

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -281,7 +281,7 @@ class FFMpegConan(ConanFile):
         if self.options.with_libwebp:
             self.requires("libwebp/1.2.2")
         if self.options.with_ssl == "openssl":
-            self.requires("openssl/1.1.1n")
+            self.requires("openssl/1.1.1o")
         if self.options.get_safe("with_libalsa"):
             self.requires("libalsa/1.2.5.1")
         if self.options.get_safe("with_xcb") or self.options.get_safe("with_vaapi"):

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -80,6 +80,9 @@ class FFMpegConan(ConanFile):
         "disable_all_parsers": [True, False],
         "disable_parsers": "ANY",
         "enable_parsers": "ANY",
+        "disable_all_bitstream_filters": [True, False],
+        "disable_bitstream_filters": "ANY",
+        "enable_bitstream_filters": "ANY",
     }
     default_options = {
         "shared": False,
@@ -140,6 +143,9 @@ class FFMpegConan(ConanFile):
         "disable_all_parsers": False,
         "disable_parsers": "",
         "enable_parsers": "",
+        "disable_all_bitstream_filters": False,
+        "disable_bitstream_filters": "",
+        "enable_bitstream_filters": "",
     }
 
     generators = "pkg_config"
@@ -378,6 +384,8 @@ class FFMpegConan(ConanFile):
                 "demuxers", self.options.disable_all_demuxers),
             opt_disable_if_set(
                 "parsers", self.options.disable_all_parsers),
+            opt_disable_if_set(
+                "bsfs", self.options.disable_all_bitstream_filters),
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
             opt_enable_disable("zlib", self.options.with_zlib),
@@ -453,6 +461,10 @@ class FFMpegConan(ConanFile):
             "enable-parser", self.options.enable_parsers))
         args.extend(self._split_and_format_options_string(
             "disable-parser", self.options.disable_parsers))
+        args.extend(self._split_and_format_options_string(
+            "enable-bsf", self.options.enable_bitstream_filters))
+        args.extend(self._split_and_format_options_string(
+            "disable-bsf", self.options.disable_bitstream_filters))
 
         if self._version_supports_vulkan():
             args.append(opt_enable_disable(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -62,7 +62,10 @@ class FFMpegConan(ConanFile):
         "with_videotoolbox": [True, False],
         "with_programs": [True, False],
         "disable_everything": [True, False],
+        "disable_all_encoders": [True, False],
+        "disable_encoders": "ANY",
         "enable_encoders": "ANY",
+
     }
     default_options = {
         "shared": False,
@@ -105,6 +108,8 @@ class FFMpegConan(ConanFile):
         "with_videotoolbox": True,
         "with_programs": True,
         "disable_everything": False,
+        "disable_all_encoders": False,
+        "disable_encoders": "",
         "enable_encoders": "",
     }
 
@@ -332,6 +337,8 @@ class FFMpegConan(ConanFile):
             # Individual Component Options
             opt_disable_if_set(
                 "everything", self.options.disable_everything),
+            opt_disable_if_set(
+                "encoders", self.options.disable_all_encoders),
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
             opt_enable_disable("zlib", self.options.with_zlib),
@@ -383,8 +390,10 @@ class FFMpegConan(ConanFile):
         ]
 
         # Individual Component Options
-        args.extend(self._split_and_format_options_string("enable-encoder",
-                                                          self.options.enable_encoders))
+        args.extend(self._split_and_format_options_string(
+            "enable-encoder", self.options.enable_encoders))
+        args.extend(self._split_and_format_options_string(
+            "disable-encoder", self.options.disable_encoders))
 
         if self._version_supports_vulkan():
             args.append(opt_enable_disable(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -376,8 +376,10 @@ class FFMpegConan(ConanFile):
 
         def opt_enable_disable(
             what, v): return "--{}-{}".format("enable" if v else "disable", what)
-        def opt_disable_if_set(
-            what, v): return "--disable-{}".format(what) if v else ""
+
+        def opt_append_disable_if_set(args, what, v):
+            if v:
+                args.append("--disable-{}".format(what))
 
         args = [
             "--pkg-config-flags=--static",
@@ -395,33 +397,6 @@ class FFMpegConan(ConanFile):
             opt_enable_disable("swscale", self.options.swscale),
             opt_enable_disable("postproc", self.options.postproc),
             opt_enable_disable("avfilter", self.options.avfilter),
-            # Individual Component Options
-            opt_disable_if_set(
-                "everything", self.options.disable_everything),
-            opt_disable_if_set(
-                "encoders", self.options.disable_all_encoders),
-            opt_disable_if_set(
-                "decoders", self.options.disable_all_decoders),
-            opt_disable_if_set(
-                "hwaccels", self.options.disable_all_hardware_accelerators),
-            opt_disable_if_set(
-                "muxers", self.options.disable_all_muxers),
-            opt_disable_if_set(
-                "demuxers", self.options.disable_all_demuxers),
-            opt_disable_if_set(
-                "parsers", self.options.disable_all_parsers),
-            opt_disable_if_set(
-                "bsfs", self.options.disable_all_bitstream_filters),
-            opt_disable_if_set(
-                "protocols", self.options.disable_all_protocols),
-            opt_disable_if_set(
-                "devices", self.options.disable_all_devices),
-            opt_disable_if_set(
-                "indevs", self.options.disable_all_input_devices),
-            opt_disable_if_set(
-                "outdevs", self.options.disable_all_output_devices),
-            opt_disable_if_set(
-                "filters", self.options.disable_all_filters),
 
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
@@ -474,6 +449,20 @@ class FFMpegConan(ConanFile):
         ]
 
         # Individual Component Options
+        opt_append_disable_if_set(args, "everything", self.options.disable_everything)
+        opt_append_disable_if_set(args, "encoders", self.options.disable_all_encoders)
+        opt_append_disable_if_set(args, "decoders", self.options.disable_all_decoders)
+        opt_append_disable_if_set(args, "hwaccels", self.options.disable_all_hardware_accelerators)
+        opt_append_disable_if_set(args, "muxers", self.options.disable_all_muxers)
+        opt_append_disable_if_set(args, "demuxers", self.options.disable_all_demuxers)
+        opt_append_disable_if_set(args, "parsers", self.options.disable_all_parsers)
+        opt_append_disable_if_set(args, "bsfs", self.options.disable_all_bitstream_filters)
+        opt_append_disable_if_set(args, "protocols", self.options.disable_all_protocols)
+        opt_append_disable_if_set(args, "devices", self.options.disable_all_devices)
+        opt_append_disable_if_set(args, "indevs", self.options.disable_all_input_devices)
+        opt_append_disable_if_set(args, "outdevs", self.options.disable_all_output_devices)
+        opt_append_disable_if_set(args, "filters", self.options.disable_all_filters)
+
         args.extend(self._split_and_format_options_string(
             "enable-encoder", self.options.enable_encoders))
         args.extend(self._split_and_format_options_string(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -86,6 +86,7 @@ class FFMpegConan(ConanFile):
         "disable_all_protocols": [True, False],
         "disable_protocols": "ANY",
         "enable_protocols": "ANY",
+        "disable_all_devices": [True, False],
         "disable_all_input_devices": [True, False],
         "disable_input_devices": "ANY",
         "enable_input_devices": "ANY",
@@ -158,6 +159,7 @@ class FFMpegConan(ConanFile):
         "disable_all_protocols": False,
         "disable_protocols": "",
         "enable_protocols": "",
+        "disable_all_devices": False,
         "disable_all_input_devices": False,
         "disable_input_devices": "",
         "enable_input_devices": "",
@@ -406,6 +408,8 @@ class FFMpegConan(ConanFile):
                 "bsfs", self.options.disable_all_bitstream_filters),
             opt_disable_if_set(
                 "protocols", self.options.disable_all_protocols),
+            opt_disable_if_set(
+                "devices", self.options.disable_all_devices),
             opt_disable_if_set(
                 "indevs", self.options.disable_all_input_devices),
             opt_disable_if_set(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -74,6 +74,9 @@ class FFMpegConan(ConanFile):
         "disable_all_muxers": [True, False],
         "disable_muxers": "ANY",
         "enable_muxers": "ANY",
+        "disable_all_demuxers": [True, False],
+        "disable_demuxers": "ANY",
+        "enable_demuxers": "ANY",
     }
     default_options = {
         "shared": False,
@@ -128,6 +131,9 @@ class FFMpegConan(ConanFile):
         "disable_all_muxers": False,
         "disable_muxers": "",
         "enable_muxers": "",
+        "disable_all_demuxers": False,
+        "disable_demuxers": "",
+        "enable_demuxers": "",
     }
 
     generators = "pkg_config"
@@ -362,6 +368,8 @@ class FFMpegConan(ConanFile):
                 "hwaccels", self.options.disable_all_hardware_accelerators),
             opt_disable_if_set(
                 "muxers", self.options.disable_all_muxers),
+            opt_disable_if_set(
+                "demuxers", self.options.disable_all_demuxers),
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
             opt_enable_disable("zlib", self.options.with_zlib),
@@ -429,6 +437,10 @@ class FFMpegConan(ConanFile):
             "enable-muxer", self.options.enable_muxers))
         args.extend(self._split_and_format_options_string(
             "disable-muxer", self.options.disable_muxers))
+        args.extend(self._split_and_format_options_string(
+            "enable-demuxer", self.options.enable_demuxers))
+        args.extend(self._split_and_format_options_string(
+            "disable-demuxer", self.options.disable_demuxers))
 
         if self._version_supports_vulkan():
             args.append(opt_enable_disable(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -77,6 +77,9 @@ class FFMpegConan(ConanFile):
         "disable_all_demuxers": [True, False],
         "disable_demuxers": "ANY",
         "enable_demuxers": "ANY",
+        "disable_all_parsers": [True, False],
+        "disable_parsers": "ANY",
+        "enable_parsers": "ANY",
     }
     default_options = {
         "shared": False,
@@ -134,6 +137,9 @@ class FFMpegConan(ConanFile):
         "disable_all_demuxers": False,
         "disable_demuxers": "",
         "enable_demuxers": "",
+        "disable_all_parsers": False,
+        "disable_parsers": "",
+        "enable_parsers": "",
     }
 
     generators = "pkg_config"
@@ -370,6 +376,8 @@ class FFMpegConan(ConanFile):
                 "muxers", self.options.disable_all_muxers),
             opt_disable_if_set(
                 "demuxers", self.options.disable_all_demuxers),
+            opt_disable_if_set(
+                "parsers", self.options.disable_all_parsers),
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
             opt_enable_disable("zlib", self.options.with_zlib),
@@ -441,6 +449,10 @@ class FFMpegConan(ConanFile):
             "enable-demuxer", self.options.enable_demuxers))
         args.extend(self._split_and_format_options_string(
             "disable-demuxer", self.options.disable_demuxers))
+        args.extend(self._split_and_format_options_string(
+            "enable-parser", self.options.enable_parsers))
+        args.extend(self._split_and_format_options_string(
+            "disable-parser", self.options.disable_parsers))
 
         if self._version_supports_vulkan():
             args.append(opt_enable_disable(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -68,6 +68,9 @@ class FFMpegConan(ConanFile):
         "disable_all_decoders": [True, False],
         "disable_decoders": "ANY",
         "enable_decoders": "ANY",
+        "disable_all_hardware_accelerators": [True, False],
+        "disable_hardware_accelerators": "ANY",
+        "enable_hardware_accelerators": "ANY",
     }
     default_options = {
         "shared": False,
@@ -116,6 +119,9 @@ class FFMpegConan(ConanFile):
         "disable_all_decoders": False,
         "disable_decoders": "",
         "enable_decoders": "",
+        "disable_all_hardware_accelerators": False,
+        "disable_hardware_accelerators": "",
+        "enable_hardware_accelerators": "",
     }
 
     generators = "pkg_config"
@@ -346,6 +352,8 @@ class FFMpegConan(ConanFile):
                 "encoders", self.options.disable_all_encoders),
             opt_disable_if_set(
                 "decoders", self.options.disable_all_decoders),
+            opt_disable_if_set(
+                "hwaccels", self.options.disable_all_hardware_accelerators),
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
             opt_enable_disable("zlib", self.options.with_zlib),
@@ -405,6 +413,10 @@ class FFMpegConan(ConanFile):
             "enable-decoder", self.options.enable_decoders))
         args.extend(self._split_and_format_options_string(
             "disable-decoder", self.options.disable_decoders))
+        args.extend(self._split_and_format_options_string(
+            "enable-hwaccel", self.options.enable_hardware_accelerators))
+        args.extend(self._split_and_format_options_string(
+            "disable-hwaccel", self.options.disable_hardware_accelerators))
 
         if self._version_supports_vulkan():
             args.append(opt_enable_disable(

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -86,6 +86,9 @@ class FFMpegConan(ConanFile):
         "disable_all_protocols": [True, False],
         "disable_protocols": "ANY",
         "enable_protocols": "ANY",
+        "disable_all_input_devices": [True, False],
+        "disable_input_devices": "ANY",
+        "enable_input_devices": "ANY",
     }
     default_options = {
         "shared": False,
@@ -152,6 +155,9 @@ class FFMpegConan(ConanFile):
         "disable_all_protocols": False,
         "disable_protocols": "",
         "enable_protocols": "",
+        "disable_all_input_devices": False,
+        "disable_input_devices": "",
+        "enable_input_devices": "",
     }
 
     generators = "pkg_config"
@@ -394,6 +400,8 @@ class FFMpegConan(ConanFile):
                 "bsfs", self.options.disable_all_bitstream_filters),
             opt_disable_if_set(
                 "protocols", self.options.disable_all_protocols),
+            opt_disable_if_set(
+                "indevs", self.options.disable_all_input_devices),
 
             # Dependencies
             opt_enable_disable("bzlib", self.options.with_bzip2),
@@ -478,6 +486,10 @@ class FFMpegConan(ConanFile):
             "enable-protocol", self.options.enable_protocols))
         args.extend(self._split_and_format_options_string(
             "disable-protocol", self.options.disable_protocols))
+        args.extend(self._split_and_format_options_string(
+            "enable-indev", self.options.enable_input_devices))
+        args.extend(self._split_and_format_options_string(
+            "disable-indev", self.options.disable_input_devices))
 
         if self._version_supports_vulkan():
             args.append(opt_enable_disable(

--- a/recipes/ffmpeg/all/test_package/test_package.c
+++ b/recipes/ffmpeg/all/test_package/test_package.c
@@ -26,10 +26,6 @@ int main()
     #ifdef HAVE_FFMPEG_AVCODEC
         printf("configuration: %s\n", avcodec_configuration());
         printf("avcodec version: %d.%d.%d\n", AV_VERSION_MAJOR(avcodec_version()), AV_VERSION_MINOR(avcodec_version()), AV_VERSION_MICRO(avcodec_version()));
-        if (avcodec_find_encoder_by_name("rawvideo") == NULL) {
-            printf("Unable to find rawvideo encoder\n");
-            return EXIT_FAILURE;
-        }
     #else
         printf("avcodec is disabled!\n");
     #endif


### PR DESCRIPTION
Specify library name and version:  **ffmpeg/5.0**

This PR fixes #10700 by adding options to allow enabling / disabling various ffmpeg features such as encoder, decoders, muxers etc. See the original issue for the discussion around how to surface these options.

The formatter in VS Code seems to have reformatted some of the existing code, but looking a the pep8 guidelines the lines were previously too long anyway, so I guess I've left it. If this is wrong I'm happy to revert those changes,  or split them into a precursor PR for easier review.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
