### PR TITLE
botan: fix pkgconfig name + bump dependencies + modernize

### DIFF
--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -117,6 +117,18 @@ class BotanConan(ConanFile):
         if self.options.get_safe('single_amalgamation'):
             self.options.amalgamation = True
 
+    def requirements(self):
+        if self.options.with_bzip2:
+            self.requires("bzip2/1.0.8")
+        if self.options.with_openssl:
+            self.requires("openssl/1.1.1o")
+        if self.options.with_zlib:
+            self.requires("zlib/1.2.12")
+        if self.options.with_sqlite3:
+            self.requires("sqlite3/3.38.5")
+        if self.options.with_boost:
+            self.requires("boost/1.79.0")
+
     @property
     def _required_boost_components(self):
         return ['coroutine', 'system']
@@ -150,18 +162,6 @@ class BotanConan(ConanFile):
                (compiler == 'clang' and version < '7'):
                 raise ConanInvalidConfiguration(
                     'botan amalgamation is not supported for {}/{}'.format(compiler, version))
-
-    def requirements(self):
-        if self.options.with_bzip2:
-            self.requires('bzip2/1.0.8')
-        if self.options.with_openssl:
-            self.requires('openssl/1.1.1k')
-        if self.options.with_zlib:
-            self.requires('zlib/1.2.11')
-        if self.options.with_sqlite3:
-            self.requires('sqlite3/3.35.5')
-        if self.options.with_boost:
-            self.requires('boost/1.76.0')
 
     def source(self):
         tools.get(**self.conan_data['sources'][self.version], strip_root=True, destination=self._source_subfolder)

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -7,68 +7,70 @@ required_conan_version = ">=1.45.0"
 
 
 class BotanConan(ConanFile):
-    name = 'botan'
+    name = "botan"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/randombit/botan"
     license = "BSD-2-Clause"
-    exports = ["patches/*"]
     description = "Botan is a cryptography library written in C++11."
     topics = ("cryptography", "crypto", "C++11", "tls")
-    settings = 'os', 'arch', 'compiler', 'build_type'
+
+    settings = "os", "arch", "compiler", "build_type"
     options = {
-        'amalgamation': [True, False],
-        'with_bzip2': [True, False],
-        'with_openssl': [True, False],
-        'shared': [True, False],
-        'fPIC': [True, False],
-        'single_amalgamation': [True, False],
-        'with_sqlite3': [True, False],
-        'with_zlib': [True, False],
-        'with_boost': [True, False],
-        'with_sse2': [True, False],
-        'with_ssse3': [True, False],
-        'with_sse4_1': [True, False],
-        'with_sse4_2': [True, False],
-        'with_avx2': [True, False],
-        'with_bmi2': [True, False],
-        'with_rdrand': [True, False],
-        'with_rdseed': [True, False],
-        'with_aes_ni': [True, False],
-        'with_sha_ni': [True, False],
-        'with_altivec': [True, False],
-        'with_neon': [True, False],
-        'with_armv8crypto': [True, False],
-        'with_powercrypto': [True, False],
-        'enable_modules': 'ANY',
-        'system_cert_bundle': 'ANY',
-        'module_policy': [None, 'bsi', 'modern', 'nist']
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "amalgamation": [True, False],
+        "with_bzip2": [True, False],
+        "with_openssl": [True, False],
+        "single_amalgamation": [True, False],
+        "with_sqlite3": [True, False],
+        "with_zlib": [True, False],
+        "with_boost": [True, False],
+        "with_sse2": [True, False],
+        "with_ssse3": [True, False],
+        "with_sse4_1": [True, False],
+        "with_sse4_2": [True, False],
+        "with_avx2": [True, False],
+        "with_bmi2": [True, False],
+        "with_rdrand": [True, False],
+        "with_rdseed": [True, False],
+        "with_aes_ni": [True, False],
+        "with_sha_ni": [True, False],
+        "with_altivec": [True, False],
+        "with_neon": [True, False],
+        "with_armv8crypto": [True, False],
+        "with_powercrypto": [True, False],
+        "enable_modules": "ANY",
+        "system_cert_bundle": "ANY",
+        "module_policy": [None, "bsi", "modern", "nist"],
     }
-    default_options = {'amalgamation': True,
-                       'with_bzip2': False,
-                       'with_openssl': False,
-                       'shared': False,
-                       'fPIC': True,
-                       'single_amalgamation': False,
-                       'with_sqlite3': False,
-                       'with_zlib': False,
-                       'with_boost': False,
-                       'with_sse2': True,
-                       'with_ssse3': True,
-                       'with_sse4_1': True,
-                       'with_sse4_2': True,
-                       'with_avx2': True,
-                       'with_bmi2': True,
-                       'with_rdrand': True,
-                       'with_rdseed': True,
-                       'with_aes_ni': True,
-                       'with_sha_ni': True,
-                       'with_altivec': True,
-                       'with_neon': True,
-                       'with_armv8crypto': True,
-                       'with_powercrypto': True,
-                       'enable_modules': None,
-                       'system_cert_bundle': None,
-                       'module_policy': None}
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "amalgamation": True,
+        "with_bzip2": False,
+        "with_openssl": False,
+        "single_amalgamation": False,
+        "with_sqlite3": False,
+        "with_zlib": False,
+        "with_boost": False,
+        "with_sse2": True,
+        "with_ssse3": True,
+        "with_sse4_1": True,
+        "with_sse4_2": True,
+        "with_avx2": True,
+        "with_bmi2": True,
+        "with_rdrand": True,
+        "with_rdseed": True,
+        "with_aes_ni": True,
+        "with_sha_ni": True,
+        "with_altivec": True,
+        "with_neon": True,
+        "with_armv8crypto": True,
+        "with_powercrypto": True,
+        "enable_modules": None,
+        "system_cert_bundle": None,
+        "module_policy": None,
+    }
 
     @property
     def _is_x86(self):
@@ -82,7 +84,14 @@ class BotanConan(ConanFile):
     def _is_arm(self):
         return 'arm' in str(self.settings.arch)
 
-    _source_subfolder = 'sources' # Required to build at least 2.12.1
+    @property
+    def _source_subfolder(self):
+        # Required to build at least 2.12.1
+        return "sources"
+
+    def export_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == 'Windows':

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -2,6 +2,8 @@ import os
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.36.0"
+
 
 class BotanConan(ConanFile):
     name = 'botan'
@@ -177,7 +179,10 @@ class BotanConan(ConanFile):
             self.run(self._make_install_cmd)
 
     def package_info(self):
-        self.cpp_info.libs = ['botan' if self.settings.compiler == 'Visual Studio' else 'botan-2']
+        major_version = tools.Version(self.version).major
+        self.cpp_info.set_property("pkg_config_name", f"botan-{major_version}")
+        self.cpp_info.names["pkg_config"] = f"botan-{major_version}"
+        self.cpp_info.libs = ["botan" if self.settings.compiler == "Visual Studio" else f"botan-{major_version}"]
         if self.settings.os == 'Linux':
             self.cpp_info.system_libs.extend(['dl', 'rt', 'pthread'])
         if self.settings.os == 'Macos':
@@ -185,7 +190,7 @@ class BotanConan(ConanFile):
         if self.settings.os == 'Windows':
             self.cpp_info.system_libs.extend(['ws2_32', 'crypt32'])
 
-        self.cpp_info.includedirs = [os.path.join('include', 'botan-2')]
+        self.cpp_info.includedirs = [os.path.join("include", f"botan-{major_version}")]
 
     @property
     def _is_mingw_windows(self):

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -124,9 +124,6 @@ class BotanConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
-        if self.options.get_safe('single_amalgamation'):
-            self.options.amalgamation = True
-
     def requirements(self):
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
@@ -172,6 +169,9 @@ class BotanConan(ConanFile):
                (compiler == 'clang' and version < '7'):
                 raise ConanInvalidConfiguration(
                     'botan amalgamation is not supported for {}/{}'.format(compiler, version))
+
+        if self.options.get_safe("single_amalgamation", False) and not self.options.amalgamation:
+            raise ConanInvalidConfiguration("botan:single_amalgamation=True requires botan:amalgamation=True")
 
     def source(self):
         tools.get(**self.conan_data['sources'][self.version], strip_root=True, destination=self._source_subfolder)

--- a/recipes/botan/all/test_package/CMakeLists.txt
+++ b/recipes/botan/all/test_package/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
-file(GLOB SOURCE_FILES *.cpp)
+find_package(botan REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} botan::botan)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/recipes/botan/all/test_package/conanfile.py
+++ b/recipes/botan/all/test_package/conanfile.py
@@ -1,10 +1,10 @@
-import os
 from conans import ConanFile, CMake, tools
+import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/botan/all/test_package/test_package.cpp
+++ b/recipes/botan/all/test_package/test_package.cpp
@@ -2,5 +2,6 @@
 
 int main()
 {
-	std::vector<uint8_t> key = Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
+    std::vector<uint8_t> key = Botan::hex_decode("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F");
+    return 0;
 }


### PR DESCRIPTION
- pkgconfig file is `botan-2.pc`: see https://github.com/randombit/botan/blob/2.19.1/configure.py#L2215-L2216
- support of `compiler=msvc` in profile
- use `cmake_find_package_multi` in test package
- bump dependencies
- don't force value of `amalgamation` option when `single_amalgamation` option is enabled, but raise instead if value is not the expected one.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
