### PR TITLE
opengl: Fix package and target name for CMakeDeps generator

### DIFF
--- a/recipes/opengl/all/conanfile.py
+++ b/recipes/opengl/all/conanfile.py
@@ -6,7 +6,7 @@ class SysConfigOpenGLConan(ConanFile):
     name = "opengl"
     version = "system"
     description = "cross-platform virtual conan package for the OpenGL support"
-    topics = ("conan", "opengl", "gl")
+    topics = ("opengl", "gl")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.opengl.org/"
     license = "MIT"

--- a/recipes/opengl/all/conanfile.py
+++ b/recipes/opengl/all/conanfile.py
@@ -70,7 +70,6 @@ class SysConfigOpenGLConan(ConanFile):
         self.cpp_info.filenames["cmake_find_package_multi"] = "opengl_system"
 
         self.cpp_info.set_property("cmake_file_name", "opengl_system")
-        self.cpp_info.set_property("cmake_target_name", "opengl_system::opengl_system")
 
         self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []

--- a/recipes/opengl/all/conanfile.py
+++ b/recipes/opengl/all/conanfile.py
@@ -69,6 +69,9 @@ class SysConfigOpenGLConan(ConanFile):
         self.cpp_info.filenames["cmake_find_package"] = "opengl_system"
         self.cpp_info.filenames["cmake_find_package_multi"] = "opengl_system"
 
+        self.cpp_info.set_property("cmake_file_name", "opengl_system")
+        self.cpp_info.set_property("cmake_target_name", "opengl_system::opengl_system")
+
         self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []
         if self.settings.os == "Macos":

--- a/recipes/opengl/all/test_package/conanfile.py
+++ b/recipes/opengl/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/opengl/all/test_package/test_package.cpp
+++ b/recipes/opengl/all/test_package/test_package.cpp
@@ -26,8 +26,14 @@ int main()
 {
     if (!init_context())
     {
-        std::cerr << "failed to initialize OpenGL context!" << std::endl;
-        return -1;
+       // std::cerr << "failed to initialize OpenGL context!" << std::endl;
+       // return -1;
+
+       // Don't fail if we can't init the context - won't work on a headless CI
+       // Instead, if we made it this far, then we were able to #include and link,
+       // count that as a success!
+       std::cout << "Linked test, but failed to initialize OpenGL context (headless platform?)" << std::endl;
+       return 0;
     }
     const char * gl_vendor = (const char *) glGetString(GL_VENDOR);
     const char * gl_renderer = (const char *) glGetString(GL_RENDERER);


### PR DESCRIPTION
Specify library name and version:  **opengl/system**

#2311 requires the package (finders) and target name to be "opengl_system", and not "opengl", so conan's cmake files do not shadow the system's FindOpenGL.cmake files.

This worked with the old cmake_find_package, but needed an upgrade to work with CMakeDeps

Thanks go to VTK's cmake checkers, which pointed out that its opengl targets didn't declare any include_dirs or libs.


QUESTION: there is one more warning from the hooks that could be resolved.
```
[HOOK - conan-center.py] pre_export(): WARN: [MANDATORY SETTINGS (KB-H070)] The values 'arch', 'compiler', 'build_type' are missing on 'settings' attribute. Update settings with the missing values and use 'package_id(self)' method to manage the package ID.
```
How can that be fixed?



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
