### PR TITLE
prometheus-cpp: Bump to 1.0.1

### DIFF
--- a/recipes/prometheus-cpp/all/conandata.yml
+++ b/recipes/prometheus-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.1":
+    url: "https://github.com/jupp0r/prometheus-cpp/archive/v1.0.1.tar.gz"
+    sha256: "593e028d401d3298eada804d252bc38d8cab3ea1c9e88bcd72095281f85e6d16"
   "1.0.0":
     url: "https://github.com/jupp0r/prometheus-cpp/archive/v1.0.0.tar.gz"
     sha256: "07018db604ea3e61f5078583e87c80932ea10c300d979061490ee1b7dc8e3a41"

--- a/recipes/prometheus-cpp/config.yml
+++ b/recipes/prometheus-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.1":
+    folder: all
   "1.0.0":
     folder: all
   "0.12.3":


### PR DESCRIPTION
Specify library name and version:  **prometheus-cpp/1.0.1**

Update prometheus-cpp to latest patch release.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
