### PR TITLE
fltk: fix windows build error on shared=True

### DIFF
--- a/recipes/fltk/all/conandata.yml
+++ b/recipes/fltk/all/conandata.yml
@@ -9,3 +9,5 @@ patches:
       patch_file: "patches/1.3.8-0001-remove-fluid.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/1.3.8-0002-fix-resources.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/1.3.8-0003-build-static-only-on-static.patch"

--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -86,6 +86,7 @@ class FltkConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
         tools.rmdir(os.path.join(self.package_folder, "FLTK.framework"))
         tools.rmdir(os.path.join(self.package_folder, "CMake"))
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "fltk-config*")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "fltk")

--- a/recipes/fltk/all/patches/1.3.8-0003-build-static-only-on-static.patch
+++ b/recipes/fltk/all/patches/1.3.8-0003-build-static-only-on-static.patch
@@ -1,0 +1,20 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index d153b1c..ef5a492 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -303,6 +303,7 @@ if (USE_XFT)
+   endif (LIB_fontconfig)
+ endif (USE_XFT)
+ 
++if (NOT OPTION_BUILD_SHARED_LIBS)
+ #######################################################################
+ 
+ FL_ADD_LIBRARY (fltk STATIC "${STATIC_FILES}")
+@@ -342,6 +343,7 @@ if (OPENGL_FOUND)
+   FL_ADD_LIBRARY (fltk_gl STATIC "${GLCPPFILES}")
+   target_link_libraries (fltk_gl fltk ${OPENGL_LIBRARIES})
+ endif (OPENGL_FOUND)
++endif (NOT OPTION_BUILD_SHARED_LIBS)
+ 
+ #######################################################################
+ # Build shared libraries (optional)


### PR DESCRIPTION
Specify library name and version:  **fltk/1.3.8**

try to fix https://github.com/conan-io/conan-center-index/issues/10852.

The original CMakeLists.txt always build static library.
It causes a lot of linked errors.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
