### PR TITLE
Bump reqs for everything for libxml2 and xkbcommon

### DIFF
--- a/recipes/aravis/all/conanfile.py
+++ b/recipes/aravis/all/conanfile.py
@@ -77,7 +77,7 @@ class AravisConan(ConanFile):
 
     def requirements(self):
         self.requires("glib/2.70.1")
-        self.requires("libxml2/2.9.12")
+        self.requires("libxml2/2.9.14")
         self.requires("zlib/1.2.11")
         if self.options.usb:
             self.requires("libusb/1.0.24")

--- a/recipes/at-spi2-atk/all/conanfile.py
+++ b/recipes/at-spi2-atk/all/conanfile.py
@@ -50,7 +50,7 @@ class AtSPI2AtkConan(ConanFile):
         self.requires('at-spi2-core/2.42.0')
         self.requires('atk/2.36.0')
         self.requires('glib/2.70.1')
-        self.requires('libxml2/2.9.12')
+        self.requires('libxml2/2.9.14')
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/azure-storage-cpp/all/conanfile.py
+++ b/recipes/azure-storage-cpp/all/conanfile.py
@@ -50,7 +50,7 @@ class AzureStorageCppConan(ConanFile):
         self.requires("cpprestsdk/2.10.18")
         if self.settings.os != "Windows":
             self.requires("boost/1.76.0")
-            self.requires("libxml2/2.9.10")
+            self.requires("libxml2/2.9.14")
             self.requires("libuuid/1.0.3")
         if self.settings.os == "Macos":
             self.requires("libgettext/0.20.1")

--- a/recipes/cern-root/all/conanfile.py
+++ b/recipes/cern-root/all/conanfile.py
@@ -85,7 +85,7 @@ class CernRootConan(ConanFile):
         self.requires("libcurl/7.78.0")
         self.requires("libjpeg/9d")
         self.requires("libpng/1.6.37")
-        self.requires("libxml2/2.9.12")
+        self.requires("libxml2/2.9.14")
         self.requires("lz4/1.9.3")
         self.requires("opengl/system")
         self.requires("openssl/1.1.1l")

--- a/recipes/dcmtk/all/conanfile.py
+++ b/recipes/dcmtk/all/conanfile.py
@@ -86,7 +86,7 @@ class DCMTKConan(ConanFile):
         elif self.options.charset_conversion == "icu":
             self.requires("icu/71.1")
         if self.options.with_libxml2:
-            self.requires("libxml2/2.9.13")
+            self.requires("libxml2/2.9.14")
         if self.options.with_zlib:
             self.requires("zlib/1.2.12")
         if self.options.with_openssl:

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -102,7 +102,7 @@ class DiligentCoreConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("xorg/system")
             if not tools.cross_building(self, skip_x64_x86=True):
-                self.requires("xkbcommon/1.3.1")
+                self.requires("xkbcommon/1.4.1")
 
     def _diligent_platform(self):
         if self.settings.os == "Windows":

--- a/recipes/gtk/all/conanfile.py
+++ b/recipes/gtk/all/conanfile.py
@@ -102,7 +102,7 @@ class GtkConan(ConanFile):
     def build_requirements(self):
         self.build_requires("meson/0.61.2")
         if self._gtk4:
-            self.build_requires("libxml2/2.9.13") # for xmllint
+            self.build_requires("libxml2/2.9.14") # for xmllint
         self.build_requires("pkgconf/1.7.4")
         if self._gtk4:
             self.build_requires("sassc/3.6.2")
@@ -120,12 +120,12 @@ class GtkConan(ConanFile):
             self.requires("libjpeg/9d")
         if self.settings.os == "Linux":
             if self._gtk4:
-                self.requires("xkbcommon/1.4.0")
+                self.requires("xkbcommon/1.4.1")
             if self._gtk3:
                 self.requires("at-spi2-atk/2.38.0")
             if self.options.with_wayland:
                 if self._gtk3:
-                    self.requires("xkbcommon/1.4.0")
+                    self.requires("xkbcommon/1.4.1")
                 self.requires("wayland/1.20.0")
             if self.options.with_x11:
                 self.requires("xorg/system")

--- a/recipes/imagemagick/all/conanfile.py
+++ b/recipes/imagemagick/all/conanfile.py
@@ -130,7 +130,7 @@ class ImageMagicConan(ConanFile):
         if self.options.with_webp:
             self.requires("libwebp/1.2.0")
         if self.options.with_xml2:
-            self.requires("libxml2/2.9.10")
+            self.requires("libxml2/2.9.14")
         if self.options.with_freetype:
             self.requires("freetype/2.10.4")
         if self.options.with_djvu:

--- a/recipes/libarchive/all/conanfile.py
+++ b/recipes/libarchive/all/conanfile.py
@@ -91,7 +91,7 @@ class LibarchiveConan(ConanFile):
         if self.options.with_bzip2:
             self.requires("bzip2/1.0.8")
         if self.options.with_libxml2:
-            self.requires("libxml2/2.9.13")
+            self.requires("libxml2/2.9.14")
         if self.options.with_expat:
             self.requires("expat/2.4.8")
         if self.options.with_iconv:

--- a/recipes/libgphoto2/all/conanfile.py
+++ b/recipes/libgphoto2/all/conanfile.py
@@ -77,7 +77,7 @@ class LibGphoto2(ConanFile):
         if self.options.with_libcurl:
             self.requires("libcurl/7.74.0")
         if self.options.with_libxml2:
-            self.requires("libxml2/2.9.10")
+            self.requires("libxml2/2.9.14")
         if self.options.with_libexif:
             self.requires("libexif/0.6.23")
         if self.options.with_libjpeg:

--- a/recipes/libmetalink/all/conanfile.py
+++ b/recipes/libmetalink/all/conanfile.py
@@ -62,7 +62,7 @@ class LibmetalinkConan(ConanFile):
         if self.options.xml_backend == "expat":
             self.requires("expat/2.4.6")
         if self.options.xml_backend == "libxml2":
-            self.requires("libxml2/2.9.12")
+            self.requires("libxml2/2.9.14")
 
     def validate(self):
         if self._is_msvc:

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -67,7 +67,7 @@ class Nghttp2Conan(ConanFile):
             self.requires("c-ares/1.18.1")
             self.requires("libev/4.33")
             self.requires("libevent/2.1.12")
-            self.requires("libxml2/2.9.13")
+            self.requires("libxml2/2.9.14")
             self.requires("zlib/1.2.12")
             if self.options.with_jemalloc:
                 self.requires("jemalloc/5.2.1")

--- a/recipes/librasterlite2/all/conanfile.py
+++ b/recipes/librasterlite2/all/conanfile.py
@@ -75,7 +75,7 @@ class Librasterlite2Conan(ConanFile):
         self.requires("libpng/1.6.37")
         self.requires("libspatialite/5.0.1")
         self.requires("libtiff/4.3.0")
-        self.requires("libxml2/2.9.13")
+        self.requires("libxml2/2.9.14")
         self.requires("sqlite3/3.38.1")
         self.requires("zlib/1.2.12")
         if self.options.with_openjpeg:

--- a/recipes/libspatialite/all/conanfile.py
+++ b/recipes/libspatialite/all/conanfile.py
@@ -97,7 +97,7 @@ class LibspatialiteConan(ConanFile):
         if self.options.get_safe("with_rttopo"):
             self.requires("librttopo/1.1.0")
         if self.options.with_libxml2:
-            self.requires("libxml2/2.9.13")
+            self.requires("libxml2/2.9.14")
         if self.options.with_minizip:
             self.requires("minizip/1.2.12")
 

--- a/recipes/libxslt/all/conanfile.py
+++ b/recipes/libxslt/all/conanfile.py
@@ -60,7 +60,7 @@ class LibxsltConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def requirements(self):
-        self.requires("libxml2/2.9.13")
+        self.requires("libxml2/2.9.14")
 
     def validate(self):
         if self.options.plugins and not self.options.shared:

--- a/recipes/llvm-core/all/conanfile.py
+++ b/recipes/llvm-core/all/conanfile.py
@@ -201,7 +201,7 @@ class LLVMCoreConan(ConanFile):
         if self.options.get_safe('with_zlib', False):
             self.requires('zlib/1.2.11')
         if self.options.get_safe('with_xml2', False):
-            self.requires('libxml2/2.9.10')
+            self.requires('libxml2/2.9.14')
 
     def package_id(self):
         del self.info.options.use_llvm_cmake_files

--- a/recipes/ncbi-cxx-toolkit-public/26/conanfile.py
+++ b/recipes/ncbi-cxx-toolkit-public/26/conanfile.py
@@ -41,7 +41,7 @@ class NcbiCxxToolkit(ConanFile):
         "PNG":          "libpng/1.6.37",
         "SQLITE3":      "sqlite3/3.37.2",
         "TIFF":         "libtiff/4.3.0",
-        "XML":          "libxml2/2.9.12",
+        "XML":          "libxml2/2.9.14",
         "XSLT":         "libxslt/1.1.34",
         "UV":           "libuv/1.42.0",
         "Z":            "zlib/1.2.11",

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -58,7 +58,7 @@ class OpenTDFConan(ConanFile):
         self.requires("boost/1.76.0@")
         self.requires("zlib/1.2.11@")
         self.requires("ms-gsl/2.1.0@")
-        self.requires("libxml2/2.9.10@")
+        self.requires("libxml2/2.9.14@")
         self.requires("libarchive/3.5.1@")
         self.requires("nlohmann_json/3.10.4@")
         self.requires("jwt-cpp/0.4.0@")

--- a/recipes/pdal/all/conanfile.py
+++ b/recipes/pdal/all/conanfile.py
@@ -76,7 +76,7 @@ class PdalConan(ConanFile):
         self.requires("libgeotiff/1.7.1")
         self.requires("nanoflann/1.4.2")
         if self.options.with_xml:
-            self.requires("libxml2/2.9.13")
+            self.requires("libxml2/2.9.14")
         if self.options.with_zstd:
             self.requires("zstd/1.5.2")
         if self.options.with_laszip:

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -372,7 +372,7 @@ class QtConan(ConanFile):
             self.requires("libalsa/1.2.5.1")
         if self.options.gui and self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("xorg/system")
-            self.requires("xkbcommon/1.4.0")
+            self.requires("xkbcommon/1.4.1")
         if self.options.get_safe("opengl", "no") != "no":
             self.requires("opengl/system")
         if self.options.with_zstd:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -361,7 +361,7 @@ class QtConan(ConanFile):
             self.requires("libalsa/1.2.5.1")
         if self.options.gui and self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("xorg/system")
-            self.requires("xkbcommon/1.4.0")
+            self.requires("xkbcommon/1.4.1")
         if self.settings.os != "Windows" and self.options.get_safe("opengl", "no") != "no":
             self.requires("opengl/system")
         if self.options.with_zstd:

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -138,7 +138,7 @@ class SDLConan(ConanFile):
                 self.requires("nas/1.9.4")
             if self.options.wayland:
                 self.requires("wayland/1.20.0")
-                self.requires("xkbcommon/1.4.0")
+                self.requires("xkbcommon/1.4.1")
                 self.requires("egl/system")
             if self.options.libunwind:
                 self.requires("libunwind/1.6.2")

--- a/recipes/tmx/all/conanfile.py
+++ b/recipes/tmx/all/conanfile.py
@@ -46,7 +46,7 @@ class TmxConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def requirements(self):
-        self.requires("libxml2/2.9.13")
+        self.requires("libxml2/2.9.14")
         if self.options.with_zlib:
             self.requires("zlib/1.2.12")
         if self.options.with_zstd:

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -51,7 +51,7 @@ class WaylandConan(ConanFile):
         if self.options.enable_libraries:
             self.requires("libffi/3.4.2")
         if self.options.enable_dtd_validation:
-            self.requires("libxml2/2.9.13")
+            self.requires("libxml2/2.9.14")
         self.requires("expat/2.4.8")
 
     def build_requirements(self):

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -59,7 +59,7 @@ class XkbcommonConan(ConanFile):
     def requirements(self):
         self.requires("xorg/system")
         if self.options.get_safe("xkbregistry"):
-            self.requires("libxml2/2.9.13")
+            self.requires("libxml2/2.9.14")
         if self.options.get_safe("with_wayland"):
             self.requires("wayland/1.20.0")
             self.requires("wayland-protocols/1.24")  # FIXME: This should be a build-requires

--- a/recipes/xmlsec/all/conanfile.py
+++ b/recipes/xmlsec/all/conanfile.py
@@ -61,7 +61,7 @@ class XmlSecConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def requirements(self):
-        self.requires("libxml2/2.9.12")
+        self.requires("libxml2/2.9.14")
         if self.options.with_openssl:
             self.requires("openssl/1.1.1m")
         if self.options.with_xslt:


### PR DESCRIPTION
Is this too audacious a PR?

Bulk-update requirements for libxml2 and xkbcommon.

```
  1  aravis
  2  at-spi2-atk
  3  azure-storage-cpp
  4  cern-root
  5  dcmtk
  6  diligent-core
  7  gtk
  8  imagemagick
  9  libarchive
 10  libgphoto2
 11  libmetalink
 12  libnghttp2
 13  librasterlite2
 14  libspatialite
 15  libxslt
 16  llvm-core
 17  ncbi-cxx-toolkit-public
 18  opentdf-client
 19  pdal
 20  qt
 21  qt
 22  sdl
 23  tmx
 24  wayland
 25  xkbcommon
 26  xmlsec
```
I had to bump requirements in a couple of recipes directly,
because `conan info --require-override` doesn't work.

Waiting for conan-io/conan#10023

So then I thought, why not update them all at the same time?

Please discuss...
