### PR TITLE
protobuf: fix compilation error in protobuf/3.20.0 in gcc12

### DIFF
--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -201,6 +201,12 @@ class ProtobufConan(ConanFile):
             "endif()",
         )
 
+        # https://github.com/protocolbuffers/protobuf/issues/9916
+        if tools.Version(self.version) == "3.20.0":
+            tools.replace_in_file(os.path.join(self._source_subfolder, "src", "google", "protobuf", "port_def.inc"),
+                "#elif PROTOBUF_GNUC_MIN(12, 0)",
+                "#elif PROTOBUF_GNUC_MIN(12, 2)")
+
     def build(self):
         self._patch_sources()
         cmake = self._configure_cmake()

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -202,6 +202,7 @@ class ProtobufConan(ConanFile):
         )
 
         # https://github.com/protocolbuffers/protobuf/issues/9916
+        # it will be solved in protobuf 3.21.0
         if tools.Version(self.version) == "3.20.0":
             tools.replace_in_file(os.path.join(self._source_subfolder, "src", "google", "protobuf", "port_def.inc"),
                 "#elif PROTOBUF_GNUC_MIN(12, 0)",


### PR DESCRIPTION
Specify library name and version:  **protobuf/3.20.0**

There is a bug in gcc 12.1 regarding constinit.
This causes protobuf/3.20.0 to compile error with gcc 12.
https://github.com/protocolbuffers/protobuf/issues/9916

The patch is very simple and has already been applied to the main branch of protobuf.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
