### PR TITLE
libsodium/1.0.18 - Don't use vs2022 for old v1.0.18

### DIFF
--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -87,19 +87,24 @@ class LibsodiumConan(ConanFile):
                 "14": "vs2015",
                 "15": "vs2017",
                 "16": "vs2019",
-                "17": "vs2022",
             }
         else:
             folder = {
                 "190": "vs2015",
                 "191": "vs2017",
                 "192": "vs2019",
-                "193": "vs2022",
             }
+
+        if self.version != "1.0.18":
+            if self.settings.compiler == "Visual Studio":
+                folder["17"] = "vs2022"
+            else:
+                folder["193"] = "vs2022"
+
         return folder.get(str(self.settings.compiler.version))
 
     def _build_msvc(self):
-        msvc_sln_folder = self._msvc_sln_folder or "vs2022"
+        msvc_sln_folder = self._msvc_sln_folder or ("vs2022" if self.version != "1.0.18" else "vs2019")
         upgrade_project = self._msvc_sln_folder is None
         sln_path = os.path.join(self.build_folder, self._source_subfolder, "builds", "msvc", msvc_sln_folder, "libsodium.sln")
         build_type = "{}{}".format(


### PR DESCRIPTION
Continuing #10628 

Not sure if this is the right way of handling this issue.
Doesn't feel very streamlined to me.