### PR TITLE
icu - Use the env's CC compiler for Linux/GCC platform

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -92,7 +92,7 @@ class ICUBase(ConanFile):
             ("AIX", "xlc"): "AIX",
             ("Android", "clang"): "Linux",
             ("SunOS", "gcc"): "Solaris/GCC",
-            ("Linux", "gcc"): "Linux/gcc",
+            ("Linux", "gcc"): "Linux",
             ("Linux", "clang"): "Linux",
             ("Macos", "gcc"): "MacOSX",
             ("Macos", "clang"): "MacOSX",


### PR DESCRIPTION
Trust in the compiler given to it by conan.

Before, it would use "gcc" no matter if you asked it to use gcc-11 or otherwise.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
