### PR TITLE
libxml2 - bump ICU dep, use run_environment

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -94,7 +94,7 @@ class Libxml2Conan(ConanFile):
         if self.options.iconv:
             self.requires("libiconv/1.16")
         if self.options.icu:
-            self.requires("icu/70.1")
+            self.requires("icu/71.1")
 
     def build_requirements(self):
         if not (self._is_msvc or self._is_mingw_windows):
@@ -270,11 +270,12 @@ class Libxml2Conan(ConanFile):
         elif self._is_mingw_windows:
             self._build_mingw()
         else:
-            autotools = self._configure_autotools()
-            autotools.make(["libxml2.la"])
+            with tools.run_environment(self):   # required for ICU build
+                autotools = self._configure_autotools()
+                autotools.make(["libxml2.la"])
 
-            if self.options.include_utils:
-                autotools.make(["xmllint", "xmlcatalog", "xml2-config"])
+                if self.options.include_utils:
+                    autotools.make(["xmllint", "xmlcatalog", "xml2-config"])
 
     def package(self):
         # copy package license


### PR DESCRIPTION
run_environment is needed for icu=True build to work,
as there is no rpath for the required icu libs.

Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
