### PR TITLE
structopt: make dependencies libraries required

### DIFF
--- a/recipes/structopt/all/conandata.yml
+++ b/recipes/structopt/all/conandata.yml
@@ -11,3 +11,16 @@ sources:
   "0.1.0":
     url: "https://github.com/p-ranav/structopt/archive/v0.1.0.tar.gz"
     sha256: "a0552e81312cfafcc5319a25c0571ca2470f43461e9f3f72e5f9d89ea4139505"
+patches:
+  "0.1.3":
+    - base_path: "source_subfolder"
+      patch_file: "patches/0.1.0-0001-use-recipes.patch"
+  "0.1.2":
+    - base_path: "source_subfolder"
+      patch_file: "patches/0.1.0-0001-use-recipes.patch"
+  "0.1.1":
+    - base_path: "source_subfolder"
+      patch_file: "patches/0.1.0-0001-use-recipes.patch"
+  "0.1.0":
+    - base_path: "source_subfolder"
+      patch_file: "patches/0.1.0-0001-use-recipes.patch"

--- a/recipes/structopt/all/conanfile.py
+++ b/recipes/structopt/all/conanfile.py
@@ -1,5 +1,5 @@
 import os
-from conans import ConanFile, tools
+from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.33.0"
@@ -11,16 +11,26 @@ class StructoptConan(ConanFile):
         "single-header-lib", "header-library", "command-line", "arguments",
         "mit-license", "modern-cpp", "structopt", "lightweight", "reflection",
         "cross-platform", "library", "type-safety", "type-safe", "argparse",
-        "clap", "visit-struct-library", "magic-enum")
-    homepage = "https://github.com/p-ranav/structopt"
+        "clap",)
     license = "MIT"
+    homepage = "https://github.com/p-ranav/structopt"
     url = "https://github.com/conan-io/conan-center-index"
-    settings = "compiler", "os"
-    no_copy_source = True
+    settings = "os", "arch", "compiler", "build_type"
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def export_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
+    def requirements(self):
+        self.requires("magic_enum/0.8.0")
+        self.requires("visit_struct/1.0")
+
+    def package_id(self):
+        self.info.header_only()
 
     @property
     def _supported_compiler(self):
@@ -38,21 +48,46 @@ class StructoptConan(ConanFile):
             self.output.warn("{} recipe lacks information about the {} compiler standard version support".format(self.name, compiler))
         return False    
 
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "9",
+            "Visual Studio": "15.0",
+            "clang": "5",
+            "apple-clang": "10",
+        }
+
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, "17")
-        if not self._supported_compiler:
-            raise ConanInvalidConfiguration("structopt: Unsupported compiler: {}-{} "
-                                            "(https://github.com/p-ranav/structopt#compiler-compatibility)."
-                                            .format(self.settings.compiler, self.settings.compiler.version))
 
-    def package_id(self):
-        self.info.header_only()
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version:
+            if tools.Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration("structopt: Unsupported compiler: {}-{} "
+                                                "(https://github.com/p-ranav/structopt#compiler-compatibility)."
+                                                .format(self.settings.compiler, self.settings.compiler.version))
+        else:
+            self.output.warn("{} requires C++14. Your compiler is unknown. Assuming it supports C++14.".format(self.name))
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure(source_folder=self._source_subfolder)
+        return cmake
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        tools.rmdir(os.path.join(self._source_subfolder, "include", "structopt", "third_party"))
+
+
     def package(self):
         self.copy(pattern="LICENSE", src=self._source_subfolder, dst="licenses")
-        self.copy(pattern="*.h", src=os.path.join(self._source_subfolder, "include"), dst="include")
-        self.copy(pattern="*.hpp", src=os.path.join(self._source_subfolder, "include"), dst="include")
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "share"))

--- a/recipes/structopt/all/patches/0.1.0-0001-use-recipes.patch
+++ b/recipes/structopt/all/patches/0.1.0-0001-use-recipes.patch
@@ -1,0 +1,41 @@
+diff --git a/include/structopt/app.hpp b/include/structopt/app.hpp
+index b60cc29..c89aa5d 100644
+--- a/include/structopt/app.hpp
++++ b/include/structopt/app.hpp
+@@ -6,7 +6,7 @@
+ #include <string>
+ #include <structopt/is_stl_container.hpp>
+ #include <structopt/parser.hpp>
+-#include <structopt/third_party/visit_struct/visit_struct.hpp>
++#include <visit_struct/visit_struct.hpp>
+ #include <type_traits>
+ #include <vector>
+ 
+diff --git a/include/structopt/parser.hpp b/include/structopt/parser.hpp
+index 5ef391c..a8f51e6 100644
+--- a/include/structopt/parser.hpp
++++ b/include/structopt/parser.hpp
+@@ -13,8 +13,8 @@
+ #include <structopt/is_number.hpp>
+ #include <structopt/is_specialization.hpp>
+ #include <structopt/sub_command.hpp>
+-#include <structopt/third_party/magic_enum/magic_enum.hpp>
+-#include <structopt/third_party/visit_struct/visit_struct.hpp>
++#include <magic_enum.hpp>
++#include <visit_struct/visit_struct.hpp>
+ #include <tuple>
+ #include <type_traits>
+ #include <utility>
+diff --git a/include/structopt/visitor.hpp b/include/structopt/visitor.hpp
+index f36c155..dbaa619 100644
+--- a/include/structopt/visitor.hpp
++++ b/include/structopt/visitor.hpp
+@@ -7,7 +7,7 @@
+ #include <string>
+ #include <structopt/is_specialization.hpp>
+ #include <structopt/string.hpp>
+-#include <structopt/third_party/visit_struct/visit_struct.hpp>
++#include <visit_struct/visit_struct.hpp>
+ #include <type_traits>
+ #include <vector>
+ 

--- a/recipes/structopt/all/test_package/CMakeLists.txt
+++ b/recipes/structopt/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
@@ -8,4 +8,4 @@ find_package(structopt REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} structopt::structopt)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)


### PR DESCRIPTION
Specify library name and version:  **structopt/***

The upstream structopt uses the internal magic_enum and visit_struct.
Since the headers of these libraries use the original Include Guard, 
problems may occur when used with other recipes at the same time.

I want to avoid this.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
