### PR TITLE
libpciaccess: fix unexpected keyword argument

### DIFF
--- a/recipes/libpciaccess/all/conanfile.py
+++ b/recipes/libpciaccess/all/conanfile.py
@@ -71,7 +71,10 @@ class LibPciAccessConan(ConanFile):
         self.copy(pattern="COPYING", dst="licenses",
                   src=self._source_subfolder)
 
-        autotools = Autotools(self)
+        if conan_version < tools.Version("1.48.0"):
+            autotools = Autotools(self)
+        else:
+            autotools = Autotools(self, build_script_folder=self._source_subfolder)
         autotools.install()
 
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))

--- a/recipes/libpciaccess/all/conanfile.py
+++ b/recipes/libpciaccess/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.48.0"
 
 
 class LibPciAccessConan(ConanFile):

--- a/recipes/libpciaccess/all/conanfile.py
+++ b/recipes/libpciaccess/all/conanfile.py
@@ -1,10 +1,10 @@
 import os
 
 from conan.tools.gnu import Autotools, AutotoolsToolchain
-from conans import ConanFile, tools
+from conans import ConanFile, tools, __version__ as conan_version
 from conans.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.48.0"
+required_conan_version = ">=1.33.0"
 
 
 class LibPciAccessConan(ConanFile):
@@ -59,8 +59,12 @@ class LibPciAccessConan(ConanFile):
         self.run("{} -fiv".format(tools.get_env("AUTORECONF") or "autoreconf"),
                  win_bash=tools.os_info.is_windows, run_environment=True, cwd=self._source_subfolder)
 
-        autotools = Autotools(self, build_script_folder=self._source_subfolder)
-        autotools.configure()
+        if conan_version < tools.Version("1.48.0"):
+            autotools = Autotools(self)
+            autotools.configure(, build_script_folder=self._source_subfolder)
+        else:
+            autotools = Autotools(self, build_script_folder=self._source_subfolder)
+            autotools.configure()
         autotools.make()
 
     def package(self):

--- a/recipes/libpciaccess/all/conanfile.py
+++ b/recipes/libpciaccess/all/conanfile.py
@@ -61,7 +61,7 @@ class LibPciAccessConan(ConanFile):
 
         if conan_version < tools.Version("1.48.0"):
             autotools = Autotools(self)
-            autotools.configure(, build_script_folder=self._source_subfolder)
+            autotools.configure(build_script_folder=self._source_subfolder)
         else:
             autotools = Autotools(self, build_script_folder=self._source_subfolder)
             autotools.configure()

--- a/recipes/libpciaccess/all/conanfile.py
+++ b/recipes/libpciaccess/all/conanfile.py
@@ -59,8 +59,8 @@ class LibPciAccessConan(ConanFile):
         self.run("{} -fiv".format(tools.get_env("AUTORECONF") or "autoreconf"),
                  win_bash=tools.os_info.is_windows, run_environment=True, cwd=self._source_subfolder)
 
-        autotools = Autotools(self)
-        autotools.configure(build_script_folder=self._source_subfolder)
+        autotools = Autotools(self, build_script_folder=self._source_subfolder)
+        autotools.configure()
         autotools.make()
 
     def package(self):


### PR DESCRIPTION
fixes conan-io/conan-center-index#10909

Specify library name and version:  **libpciaccess/***

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
