### PR TITLE
(#10919) libcurl: Expose control to --with_ca_bundle and --with_ca_pa…

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -56,6 +56,8 @@ class LibcurlConan(ConanFile):
         "with_verbose_debug": [True, False],
         "with_symbol_hiding": [True, False],
         "with_unix_sockets": [True, False],
+        "with_ca_bundle": "ANY",
+        "with_ca_path": "ANY",
     }
     default_options = {
         "shared": False,
@@ -96,6 +98,8 @@ class LibcurlConan(ConanFile):
         "with_verbose_debug": True,
         "with_symbol_hiding": False,
         "with_unix_sockets": True,
+        "with_ca_bundle": None,
+        "with_ca_path": None,
     }
 
     generators = "cmake", "cmake_find_package_multi", "pkg_config", "cmake_find_package"
@@ -420,6 +424,16 @@ class LibcurlConan(ConanFile):
         if not self.options.with_ntlm_wb:
             params.append("--disable-ntlm-wb")
 
+        if self.options.with_ca_bundle == False:
+            params.append("--without-ca-bundle")
+        elif self.options.with_ca_bundle:
+            params.append("--with-ca-bundle=" + str(self.options.with_ca_bundle))
+
+        if self.options.with_ca_path == False:
+            params.append('--without-ca-path')
+        elif self.options.with_ca_path:
+            params.append("--with-ca-path=" + str(self.options.with_ca_path))
+
         # Cross building flags
         if tools.cross_building(self.settings):
             if self.settings.os == "Linux" and "arm" in self.settings.arch:
@@ -560,6 +574,16 @@ class LibcurlConan(ConanFile):
             else:
                 self._cmake.definitions["CURL_DISABLE_NTLM"] = True
         self._cmake.definitions["NTLM_WB_ENABLED"] = self.options.with_ntlm_wb
+
+        if self.options.with_ca_bundle == False:
+            cmake.definitions['CURL_CA_BUNDLE'] = 'none'
+        elif self.options.with_ca_bundle:
+            cmake.definitions['CURL_CA_BUNDLE'] = self.options.with_ca_bundle
+
+        if self.options.with_ca_path == False:
+            cmake.definitions['CURL_CA_PATH'] = 'none'
+        elif self.options.with_ca_path:
+            cmake.definitions['CURL_CA_PATH'] = self.options.with_ca_path
 
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake


### PR DESCRIPTION

We needed a way to expose control of the --with_ca_bundle and --with_ca_path libcurl option to the users of this recipe.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
