### PR TITLE
[libpng] Add other operating systems to the list of those who need the math library

### DIFF
--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -175,5 +175,5 @@ class LibpngConan(ConanFile):
         prefix = "lib" if self._is_msvc else ""
         suffix = "d" if self.settings.build_type == "Debug" else ""
         self.cpp_info.libs = ["{}png16{}".format(prefix, suffix)]
-        if self.settings.os in ["Linux", "Android", "FreeBSD"]:
+        if self.settings.os in ["Linux", "Android", "FreeBSD", "SunOS", "AIX"]:
             self.cpp_info.system_libs.append("m")


### PR DESCRIPTION
Add other operating systems to the list of those who need the math library added for the package check build.

Specify library name and version: **libpng/1.6.37**

https://github.com/conan-io/conan-center-index/issues/10937

Static library packages fail the package check on these operating systems as well, so add them to the list of OS' that wil add -lm to the package check link line.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
