### PR TITLE
llvm-openmp: change default fPIC option to True and modernize

### DIFF
--- a/recipes/llvm-openmp/all/CMakeLists.txt
+++ b/recipes/llvm-openmp/all/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory("source_subfolder")

--- a/recipes/llvm-openmp/all/test_package/CMakeLists.txt
+++ b/recipes/llvm-openmp/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(OpenMP CONFIG REQUIRED)
 
 add_executable(test_package test_package.cpp)
-target_link_libraries(test_package ${CONAN_LIBS})
+target_link_libraries(test_package OpenMP::OpenMP)

--- a/recipes/llvm-openmp/all/test_package/conanfile.py
+++ b/recipes/llvm-openmp/all/test_package/conanfile.py
@@ -1,10 +1,10 @@
-import os
 from conans import ConanFile, CMake, tools
+import os
 
 
 class LLVMOpenMpTestConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **llvm-openmp/12.0.1**

The default fPIC option should be True to account for the case where it is linked to a dynamic library.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
