### PR TITLE
WIP: nasm: fix build in msys shell

### DIFF
--- a/recipes/nasm/all/conanfile.py
+++ b/recipes/nasm/all/conanfile.py
@@ -52,7 +52,7 @@ class NASMConan(ConanFile):
     def _configure_autotools(self):
         if self._autotools:
             return self._autotools
-        self._autotools = AutoToolsBuildEnvironment(self)
+        self._autotools = AutoToolsBuildEnvironment(self, win_bash=(self._settings_build.os == "Windows"))
         if self.settings.arch == "x86":
             self._autotools.flags.append("-m32")
         elif self.settings.arch == "x86_64":


### PR DESCRIPTION
Specify library name and version:  **nasm/all**

Building nasm from msys shell fails with:

```
nasm/2.14: Calling:
 > source_subfolder/configure --prefix=C:/Users/user/.conan/data/nasm/2.14/_/_/package0a420ff5c47119e668867cdb51baff0eca1fdb68
'source_subfolder' is not recognized as an internal or external command,
  operable program or batch file.
```

Configure should be invoked in bash explicitly, as mentioned in https://docs.conan.io/en/latest/reference/build_helpers/autotools.html in the section that mentions MSYS2. So we use win_bash parameter in the AutoToolsBuildEnvironment constructor.

But instead of using tools.os_info.is_windows as in example, we use self._settings_build.os, as was done in https://github.com/conan-io/conan-center-index/pull/6978.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
