### PR TITLE
libgd: Add other operating systems to the list of those who need the math lib

### DIFF
--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -121,7 +121,7 @@ class LibgdConan(ConanFile):
         if self.settings.os == "Windows" and not self.options.shared:
             self.cpp_info.defines.append("BGD_NONDLL")
             self.cpp_info.defines.append("BGDWIN32")
-        if self.settings.os in ("FreeBSD", "Linux"):
+        if self.settings.os in ("FreeBSD", "Linux", "Android", "SunOS", "AIX"):
             self.cpp_info.system_libs.append("m")
 
         bin_path = os.path.join(self.package_folder, "bin")


### PR DESCRIPTION
Add other operating systems to the list of those who need the math library added for the package check build.

Specify library name and version: libgd/2.3.2

fixes https://github.com/conan-io/conan-center-index/issues/10937

Static library packages fail the package check on these operating systems as well, so add them to the list of OS' that wil add -lm to the package check link line.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
