### PR TITLE
libtiff: Add other operating systems to the list of those who need the math lib

### DIFF
--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -199,7 +199,7 @@ class LibtiffConan(ConanFile):
             self.cpp_info.libs = [lib + "d" for lib in self.cpp_info.libs]
         if self.options.shared and self.settings.os == "Windows" and not self._is_msvc:
             self.cpp_info.libs = [lib + ".dll" for lib in self.cpp_info.libs]
-        if self.settings.os in ["Linux", "FreeBSD"]:
+        if self.settings.os in ["Linux", "Android", "FreeBSD", "SunOS", "AIX"]:
             self.cpp_info.system_libs.append("m")
 
         # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed


### PR DESCRIPTION
Add other operating systems to the list of those who need the math library added for the package check build.

Specify library name and version: **libtiff/4.3.0**

https://github.com/conan-io/conan-center-index/issues/10937

Static library packages fail the package check on these operating systems as well, so add them to the list of operating systems that will add -lm to the package check link line.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
