### PR TITLE
Add recipe for libxml++

### DIFF
--- a/recipes/libxml++/2.x.x/conandata.yml
+++ b/recipes/libxml++/2.x.x/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "2.42.1":
+    url: "https://github.com/libxmlplusplus/libxmlplusplus/releases/download/2.42.1/libxml++-2.42.1.tar.xz"
+    sha256: "9b59059abe5545d28ceb388a55e341095f197bd219c73e6623aeb6d801e00be8"
+
+patches:
+  "2.42.1":
+    - patch_file: "patches/enable_static_builds_on_msvc.patch"
+      base_path: "source_subfolder"

--- a/recipes/libxml++/2.x.x/conanfile.py
+++ b/recipes/libxml++/2.x.x/conanfile.py
@@ -1,0 +1,131 @@
+from conans import ConanFile, Meson, tools
+from conan.tools.files import rename
+from conans.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc
+import shutil
+import os
+
+
+class LibXMLPlusPlus(ConanFile):
+    name = "libxml++"
+    homepage = "https://github.com/libxmlplusplus/libxmlplusplus"
+    license = "LGPL-2.1"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "libxml++ (a.k.a. libxmlplusplus) provides a C++ interface to XML files"
+    topics = ["xml", "parser", "wrapper"]
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    generators = "pkg_config"
+    exports_sources = "patches/**"
+    short_paths = True
+
+    def validate(self):
+        if hasattr(self, "settings_build") and tools.cross_building(self):
+            raise ConanInvalidConfiguration("Cross-building not implemented")
+
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 11)
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def build_requirements(self):
+        self.build_requires("meson/0.59.1")
+        self.build_requires("pkgconf/1.7.4")
+
+    def requirements(self):
+        self.requires("libxml2/2.9.14")
+        self.requires("glibmm/2.66.4")
+
+    def source(self):
+        tools.get(
+            **self.conan_data["sources"][self.version],
+            strip_root=True,
+            destination=self._source_subfolder,
+        )
+
+    def _patch_sources(self):
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+
+        if is_msvc(self):
+            # when using cpp_std=c++NM the /permissive- flag is added which
+            # attempts enforcing standard conformant c++ code. the problem is
+            # that older versions of the Windows SDK isn't standard conformant!
+            # see:
+            # https://developercommunity.visualstudio.com/t/error-c2760-in-combaseapih-with-windows-sdk-81-and/185399
+            tools.replace_in_file(
+                os.path.join(self._source_subfolder, "meson.build"),
+                "cpp_std=c++", "cpp_std=vc++")
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def _configure_meson(self):
+        meson = Meson(self)
+        defs = {
+            "build-examples": "false",
+            "build-tests": "false",
+            "build-documentation": "false",
+            "msvc14x-parallel-installable": "false",
+            "default_library": "shared" if self.options.shared else "static",
+        }
+        meson.configure(
+            defs=defs,
+            build_folder=self._build_subfolder,
+            source_folder=self._source_subfolder,
+            pkg_config_paths=[self.install_folder],
+        )
+        return meson
+
+    def build(self):
+        self._patch_sources()
+        with tools.environment_append(tools.RunEnvironment(self).vars):
+            meson = self._configure_meson()
+            meson.build()
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        meson = self._configure_meson()
+        meson.install()
+
+        shutil.move(
+            os.path.join(self.package_folder, "lib", "libxml++-2.6",
+                         "include", "libxml++config.h"),
+            os.path.join(self.package_folder, "include", "libxml++-2.6",
+                         "libxml++config.h"))
+
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "libxml++-2.6"))
+
+        if is_msvc(self):
+            tools.remove_files_by_mask(
+                os.path.join(self.package_folder, "bin"), "*.pdb")
+            if not self.options.shared:
+                rename(
+                    self,
+                    os.path.join(self.package_folder, "lib", "libxml++-2.6.a"),
+                    os.path.join(self.package_folder, "lib", "xml++-2.6.lib"))
+
+    def package_info(self):
+        self.cpp_info.components["libxml++-2.6"].names[
+            "pkg_config"] = "libxml++-2.6"
+        self.cpp_info.components["libxml++-2.6"].libs = ["xml++-2.6"]
+        self.cpp_info.components["libxml++-2.6"].includedirs = [
+            os.path.join("include", "libxml++-2.6")
+        ]
+        self.cpp_info.components["libxml++-2.6"].requires = [
+                "glibmm::glibmm-2.4", "libxml2::libxml2"
+        ]

--- a/recipes/libxml++/2.x.x/patches/enable_static_builds_on_msvc.patch
+++ b/recipes/libxml++/2.x.x/patches/enable_static_builds_on_msvc.patch
@@ -1,0 +1,40 @@
+diff --git a/libxml++config.h.meson b/libxml++config.h.meson
+index fdae143..99a6ad4 100755
+--- a/libxml++config.h.meson
++++ b/libxml++config.h.meson
+@@ -21,7 +21,10 @@
+ /* Micro version number of libxml++. */
+ #mesondefine LIBXMLXX_MICRO_VERSION
+ 
+-#if defined (GLIBMM_DLL) && !defined (LIBXMLXX_STATIC)
++/* Defined if libxml++ is built as a static library. */
++#mesondefine LIBXMLXX_STATIC
++
++#if !defined (LIBXMLXX_STATIC)
+   #ifdef LIBXMLPP_BUILD
+     #define LIBXMLPP_API __declspec(dllexport)
+   #elif !defined (__GNUC__)
+diff --git a/meson.build b/meson.build
+index e89f2c6..20d66ed 100644
+--- a/meson.build
++++ b/meson.build
+@@ -292,15 +292,13 @@ endif
+ # Always set for backwards compatibility.
+ pkg_conf_data.set('LIBXMLCPP_EXCEPTIONS_ENABLED', 1)
+ 
++if get_option('default_library') == 'static'
++  pkg_conf_data.set('LIBXMLXX_STATIC', 1)
++endif
++
+ # Static library?
+ library_build_type = get_option('default_library')
+ 
+-if cpp_compiler.get_argument_syntax() == 'msvc'
+-  if library_build_type == 'static' or library_build_type == 'both'
+-    error('Static builds are not supported by MSVC-style builds')
+-  endif
+-endif
+-
+ configure_file(
+   input: 'libxml++-2.6.pc.in',
+   output: '@BASENAME@',

--- a/recipes/libxml++/2.x.x/patches/enable_static_builds_on_msvc.patch
+++ b/recipes/libxml++/2.x.x/patches/enable_static_builds_on_msvc.patch
@@ -1,8 +1,8 @@
 diff --git a/libxml++config.h.meson b/libxml++config.h.meson
-index fdae143..99a6ad4 100755
+index fdae143..5d853c2 100755
 --- a/libxml++config.h.meson
 +++ b/libxml++config.h.meson
-@@ -21,7 +21,10 @@
+@@ -21,9 +21,16 @@
  /* Micro version number of libxml++. */
  #mesondefine LIBXMLXX_MICRO_VERSION
  
@@ -12,8 +12,15 @@ index fdae143..99a6ad4 100755
 +
 +#if !defined (LIBXMLXX_STATIC)
    #ifdef LIBXMLPP_BUILD
-     #define LIBXMLPP_API __declspec(dllexport)
+-    #define LIBXMLPP_API __declspec(dllexport)
++    #ifdef __GNUC__
++      #define LIBXMLPP_API __attribute__((visibility("default")))
++    #else
++      #define LIBXMLPP_API __declspec(dllexport)
++    #endif
    #elif !defined (__GNUC__)
+     #define LIBXMLPP_API __declspec(dllimport)
+   #else /* don't dllimport classes/methods on GCC/MinGW */
 diff --git a/meson.build b/meson.build
 index e89f2c6..20d66ed 100644
 --- a/meson.build

--- a/recipes/libxml++/2.x.x/test_package/CMakeLists.txt
+++ b/recipes/libxml++/2.x.x/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.6)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGET)
+
+find_package(libxml++ REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} libxml++::libxml++-2.6)

--- a/recipes/libxml++/2.x.x/test_package/conanfile.py
+++ b/recipes/libxml++/2.x.x/test_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = f'{os.path.join("bin", "test_package")} \
+                    {os.path.join(self.source_folder, "example.xml")}'
+            self.run(bin_path, run_environment=True)

--- a/recipes/libxml++/2.x.x/test_package/example.xml
+++ b/recipes/libxml++/2.x.x/test_package/example.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!DOCTYPE example PUBLIC "" "example.dtd">
+
+<example toto="1">
+  <examplechild id="1">
+    <child_of_child/>
+  </examplechild>
+  <examplechild id="2" toto="3">
+    <child_of_child>Some content :-)</child_of_child>
+  </examplechild>
+</example>

--- a/recipes/libxml++/2.x.x/test_package/test_package.cpp
+++ b/recipes/libxml++/2.x.x/test_package/test_package.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2002 The libxml++ development team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <libxml++/libxml++.h>
+#include <libxml++/parsers/textreader.h>
+
+#include <iostream>
+#include <stdlib.h>
+
+struct indent {
+  int depth_;
+  explicit indent(int depth): depth_(depth) {};
+};
+
+std::ostream & operator<<(std::ostream & o, indent const & in)
+{
+  for(int i = 0; i != in.depth_; ++i)
+  {
+    o << "  ";
+  }
+  return o;
+}
+
+int main(int argc, char** argv)
+{
+  if (argc == 1) {
+    std::cerr << "Expected an xml file as a command line argument!\n";
+    return EXIT_FAILURE;
+  }
+
+  try
+  {
+    xmlpp::TextReader reader(argv[1]);
+
+    while(reader.read())
+    {
+      int depth = reader.get_depth();
+      std::cout << indent(depth) << "--- node ---" << std::endl;
+      std::cout << indent(depth) << "name: " << reader.get_name() << std::endl;
+      std::cout << indent(depth) << "depth: " << reader.get_depth() << std::endl;
+
+      if(reader.has_attributes())
+      {
+        std::cout << indent(depth) << "attributes: " << std::endl;
+        reader.move_to_first_attribute();
+        do
+        {
+          std::cout << indent(depth) << "  " << reader.get_name() << ": " << reader.get_value() << std::endl;
+        } while(reader.move_to_next_attribute());
+        reader.move_to_element();
+      }
+      else
+      {
+        std::cout << indent(depth) << "no attributes" << std::endl;
+      }
+
+      if(reader.has_value())
+        std::cout << indent(depth) << "value: '" << reader.get_value() << "'" << std::endl;
+      else
+        std::cout << indent(depth) << "novalue" << std::endl;
+
+    }
+  }
+  catch(const std::exception& e)
+  {
+    std::cerr << "Exception caught: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+

--- a/recipes/libxml++/config.yml
+++ b/recipes/libxml++/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.42.1":
+    folder: "2.x.x"


### PR DESCRIPTION
Specify library name and version:  **libxml++/2.42.1**

I'm working on porting all of [synfig](https://www.synfig.org/)'s dependencies, and this is one of them.


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
