### PR TITLE
Fix argparse compilation on gcc12

### DIFF
--- a/recipes/argparse/all/conandata.yml
+++ b/recipes/argparse/all/conandata.yml
@@ -11,3 +11,17 @@ sources:
   "2.1":
     url: "https://github.com/p-ranav/argparse/archive/v2.1.tar.gz"
     sha256: "0a82f464b568b8ee6650fc837f371eb9c81417e2ef9fb3b51f65ad50fa3b8662"
+patches:
+  "2.4":
+    - patch_file: "patches/0001-v2.3-add-missing-include.patch"
+      base_path: "source_subfolder"
+  "2.3":
+    - patch_file: "patches/0001-v2.3-add-missing-include.patch"
+      base_path: "source_subfolder"
+  "2.2":
+    - patch_file: "patches/0001-v2.2-add-missing-include.patch"
+      base_path: "source_subfolder"
+  "2.1":
+    - patch_file: "patches/0001-v2.1-add-missing-include.patch"
+      base_path: "source_subfolder"
+

--- a/recipes/argparse/all/conanfile.py
+++ b/recipes/argparse/all/conanfile.py
@@ -13,7 +13,6 @@ class ArgparseConan(ConanFile):
     license = "MIT"
     description = "Argument Parser for Modern C++"
     settings = "os", "arch", "compiler", "build_type"
-    no_copy_source = True
 
     @property
     def _compiler_required_cpp17(self):
@@ -27,6 +26,17 @@ class ArgparseConan(ConanFile):
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    def export_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
+    def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+    def build(self):
+        self._patch_sources()
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/argparse/all/patches/0001-v2.1-add-missing-include.patch
+++ b/recipes/argparse/all/patches/0001-v2.1-add-missing-include.patch
@@ -1,0 +1,12 @@
+diff --git a/include/argparse.hpp b/include/argparse.hpp
+index 30c42da..7bf16a3 100644
+--- a/include/argparse.hpp
++++ b/include/argparse.hpp
+@@ -44,6 +44,7 @@ SOFTWARE.
+ #include <string_view>
+ #include <tuple>
+ #include <type_traits>
++#include <utility>
+ #include <variant>
+ #include <vector>
+ 

--- a/recipes/argparse/all/patches/0001-v2.2-add-missing-include.patch
+++ b/recipes/argparse/all/patches/0001-v2.2-add-missing-include.patch
@@ -1,0 +1,12 @@
+diff --git a/include/argparse/argparse.hpp b/include/argparse/argparse.hpp
+index 7da3462..efd78b2 100644
+--- a/include/argparse/argparse.hpp
++++ b/include/argparse/argparse.hpp
+@@ -47,6 +47,7 @@ SOFTWARE.
+ #include <string_view>
+ #include <tuple>
+ #include <type_traits>
++#include <utility>
+ #include <variant>
+ #include <vector>
+ 

--- a/recipes/argparse/all/patches/0001-v2.3-add-missing-include.patch
+++ b/recipes/argparse/all/patches/0001-v2.3-add-missing-include.patch
@@ -1,0 +1,12 @@
+diff --git a/include/argparse/argparse.hpp b/include/argparse/argparse.hpp
+index 55828ed..112534b 100644
+--- a/include/argparse/argparse.hpp
++++ b/include/argparse/argparse.hpp
+@@ -48,6 +48,7 @@ SOFTWARE.
+ #include <string_view>
+ #include <tuple>
+ #include <type_traits>
++#include <utility>
+ #include <variant>
+ #include <vector>
+ 


### PR DESCRIPTION
This has been fixed in upstream already, so starting from v2.5 this shouldn't be needed anymore.