### PR TITLE
etl: add version 20.28.0

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.28.0":
+    url: "https://github.com/ETLCPP/etl/archive/20.28.0.tar.gz"
+    sha256: "2298d1872a8a387e0cdfb17cc0826107b2509286267ce5ff87956d740e80290d"
   "20.27.1":
     url: "https://github.com/ETLCPP/etl/archive/20.27.1.tar.gz"
     sha256: "0f24130ede2d07a5584ea264e340bdb4d67025edd2ddd000953f35a81b1c944b"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.28.0":
+    folder: all
   "20.27.1":
     folder: all
   "20.25.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **etl/20.28.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
