### PR TITLE
cwalk: add version 1.2.7

### DIFF
--- a/recipes/cwalk/all/conandata.yml
+++ b/recipes/cwalk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.7":
+    url: "https://github.com/likle/cwalk/archive/v1.2.7.tar.gz"
+    sha256: "ae424ec30830c970412e34d9092eaa6131d91af289cdad0ad66a7b1c58e768e7"
   "1.2.6":
     url: "https://github.com/likle/cwalk/archive/v1.2.6.tar.gz"
     sha256: "4e7c0e9e30e93343ebc9d5dc3ffc1703b3abb05baf8d8a3ab05a75b69a65a3ef"
@@ -15,6 +18,9 @@ sources:
     url: "https://github.com/likle/cwalk/archive/v1.0.0.zip"
     sha256: "9ff6d85f88e7fe4877698afb40745d301491c1d3fca96f08d1622f5fe3494182"
 patches:
+  "1.2.7":
+    - patch_file: "patches/0001-fix-cmake-1.2.5.patch"
+      base_path: "source_subfolder"
   "1.2.6":
     - patch_file: "patches/0001-fix-cmake-1.2.5.patch"
       base_path: "source_subfolder"

--- a/recipes/cwalk/config.yml
+++ b/recipes/cwalk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.7":
+    folder: all
   "1.2.6":
     folder: all
   "1.2.5":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cwalk/1.2.7**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
