### PR TITLE
[CI bug] hdf5 - unchanged recipe from CCI now won't build

### DIFF
--- a/recipes/hdf5/all/conanfile.py
+++ b/recipes/hdf5/all/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.43.0"
 
 class Hdf5Conan(ConanFile):
     name = "hdf5"
-    description = "HDF5 is a data model, library, and file format for storing and managing data."
+    description = "HDF5 is a data model, library, and file format for storing and managing data.  Test it again."
     license = "BSD-3-Clause"
     topics = ("hdf5", "hdf", "data")
     homepage = "https://portal.hdfgroup.org/display/HDF5/HDF5"


### PR DESCRIPTION
I've been hitting my head against the wall, wondering why my only-slightly-modified HDF5 recipe won't pass the CI tests.

Now I see that the *existing* CCI recipe won't pass the CI.

It was able to pass only 26 days ago, in #10552 

Even more confusing, I don't even know why it has ever been able to pass.
It should NOT be able to build.

Even now with my modified recipe, it passes on SOME of the Linux platforms, but not all of them.

The problem with the recipe is HDF5 wasn't linking to zlib.   So why would it work on some CI images and not the others?

I'll do a parallel bug report elsewhere.