### PR TITLE
glib: add version 2.73.0

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -89,3 +89,6 @@ sources:
   "2.72.1":
     url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.72.1/glib-2.72.1.tar.gz"
     sha256: "4a345987a9ee7709417f5a5c6f4eeec2497bc2a913f14c1b9bdc403409d5ffb7"
+  "2.73.0":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.73.0/glib-2.73.0.tar.gz"
+    sha256: "3f573319adbdf572d79255e8bae85c7e2902d1aa6177d2646605a00c0a607eca"

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -59,3 +59,5 @@ versions:
     folder: all
   "2.72.1":
     folder: all
+  "2.73.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **glib/2.73.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
