### PR TITLE
jasper: add version 3.0.3

### DIFF
--- a/recipes/jasper/all/conandata.yml
+++ b/recipes/jasper/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.3":
+    url: "https://github.com/jasper-software/jasper/archive/refs/tags/version-3.0.3.tar.gz"
+    sha256: "1b324f7746681f6d24d06fcf163cf3b8ae7ac320adc776c3d611b2b62c31b65f"
   "2.0.33":
     url: "https://github.com/jasper-software/jasper/archive/refs/tags/version-2.0.33.tar.gz"
     sha256: "38b8f74565ee9e7fec44657e69adb5c9b2a966ca5947ced5717cde18a7d2eca6"

--- a/recipes/jasper/config.yml
+++ b/recipes/jasper/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.3":
+    folder: all
   "2.0.33":
     folder: all
   "2.0.32":


### PR DESCRIPTION
Specify library name and version:  **jasper/3.0.3**

Update to latest jasper.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
