### PR TITLE
[rotor] export thread unsafety

### DIFF
--- a/recipes/rotor/all/conanfile.py
+++ b/recipes/rotor/all/conanfile.py
@@ -113,6 +113,9 @@ class RotorConan(ConanFile):
         self.cpp_info.components["core"].requires = ["boost::date_time", "boost::system", "boost::regex"]
 
 
+        if not self.options.multithreading:
+            self.cpp_info.components["core"].defines.append("BUILD_THREAD_UNSAFE")
+
         if self.options.enable_asio:
             self.cpp_info.components["asio"].libs = ["rotor_asio"]
             self.cpp_info.components["asio"].requires = ["core"]


### PR DESCRIPTION
Specify library name and version:  **rotor/0.xx**

The `BUILD_THREAD_UNSAFE` should be used every time during compilation of user's code, when multithreading option is disabled.

I'm the author of the library

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
