### PR TITLE
fix drogon boost requirement

### DIFF
--- a/recipes/drogon/all/conanfile.py
+++ b/recipes/drogon/all/conanfile.py
@@ -17,6 +17,7 @@ class DrogonConan(ConanFile):
     options = {
         "shared": [False, True],
         "fPIC": [True, False],
+        "with_boost": [True, False],
         "with_ctl": [True, False],
         "with_orm": [True, False],
         "with_profile": [True, False],
@@ -30,6 +31,7 @@ class DrogonConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_boost": False,
         "with_ctl": False,
         "with_orm": True,
         "with_profile": False,
@@ -89,7 +91,6 @@ class DrogonConan(ConanFile):
 
     def requirements(self):
         self.requires("trantor/1.5.5")
-        self.requires("boost/1.79.0")
         self.requires("jsoncpp/1.9.5")
         self.requires("openssl/1.1.1o")
         self.requires("zlib/1.2.12")
@@ -97,6 +98,8 @@ class DrogonConan(ConanFile):
             self.requires("libuuid/1.0.3")
         if self.options.with_profile:
             self.requires("coz/cci.20210322")
+        if self.options.with_boost:
+            self.requires("boost/1.79.0")
         if self.options.with_brotli:
             self.requires("brotli/1.0.9")
         if self.options.get_safe("with_postgres"):


### PR DESCRIPTION
Specify library name and version:  **drogon/1.7.5**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

---

This put on drogon recipe, the requirement of `boost` as optional, because it is officially required in only few cases:
https://github.com/drogonframework/drogon/blob/v1.7.5/CMakeLists.txt#L142-L201

