### PR TITLE
croncpp: add recipe

### DIFF
--- a/recipes/croncpp/all/CMakeLists.txt
+++ b/recipes/croncpp/all/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(conan_wrapper CXX)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_subdirectory(source_subfolder)

--- a/recipes/croncpp/all/conandata.yml
+++ b/recipes/croncpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+    "cci.20220503":
+        url: "https://github.com/mariusbancila/croncpp/archive/5c28f410db1af9507ef8469c9796a7070e5e8e2e.tar.gz"
+        sha256: "cabc480c78ebf12b11bd9fcd705a7ecb1c85ac88a8c9debe8de67f30abd808a8"

--- a/recipes/croncpp/all/conanfile.py
+++ b/recipes/croncpp/all/conanfile.py
@@ -1,0 +1,49 @@
+import os
+import functools
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.33.0"
+
+class CroncppConan(ConanFile):
+    name = "croncpp"
+    description = "A C++11/14/17 header-only cross-platform library for handling CRON expressions"
+    topics = ("cron", "header-only")
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/mariusbancila/croncpp/"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake",
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+
+    def package_id(self):
+        self.info.header_only()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, "11")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE*", "licenses", self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))

--- a/recipes/croncpp/all/conanfile.py
+++ b/recipes/croncpp/all/conanfile.py
@@ -38,10 +38,6 @@ class CroncppConan(ConanFile):
         cmake.configure()
         return cmake
 
-    def build(self):
-        cmake = self._configure_cmake()
-        cmake.build()
-
     def package(self):
         self.copy("LICENSE*", "licenses", self._source_subfolder)
         cmake = self._configure_cmake()

--- a/recipes/croncpp/all/test_package/CMakeLists.txt
+++ b/recipes/croncpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(croncpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} croncpp::croncpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/croncpp/all/test_package/conanfile.py
+++ b/recipes/croncpp/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class CroncppConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/croncpp/all/test_package/test_package.cpp
+++ b/recipes/croncpp/all/test_package/test_package.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+#include <ctime>
+
+#include "croncpp.h"
+
+int main(int argc, const char** argv) {
+    try {
+        auto cron = cron::make_cron("* 0/5 * * * ?");
+
+        auto now = std::time(0);
+        auto next = cron::cron_next(cron, now);
+        std::cout << (next - now) << "[sec]" << std::endl;
+        return 0;
+    } catch (cron::bad_cronexpr const& ex) {
+        std::cerr << ex.what() << std::endl;
+    }
+    return -1;
+}

--- a/recipes/croncpp/config.yml
+++ b/recipes/croncpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20220503":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **croncpp/cci.20220503**

croncpp is unix cron expression parser library.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
