### PR TITLE
argparse: add version 2.5

### DIFF
--- a/recipes/argparse/all/conandata.yml
+++ b/recipes/argparse/all/conandata.yml
@@ -27,4 +27,3 @@ patches:
   "2.1":
     - patch_file: "patches/0001-v2.1-add-missing-include.patch"
       base_path: "source_subfolder"
-

--- a/recipes/argparse/all/conandata.yml
+++ b/recipes/argparse/all/conandata.yml
@@ -15,9 +15,6 @@ sources:
     url: "https://github.com/p-ranav/argparse/archive/v2.1.tar.gz"
     sha256: "0a82f464b568b8ee6650fc837f371eb9c81417e2ef9fb3b51f65ad50fa3b8662"
 patches:
-  "2.5":
-    - patch_file: "patches/0001-v2.3-add-missing-include.patch"
-      base_path: "source_subfolder"
   "2.4":
     - patch_file: "patches/0001-v2.3-add-missing-include.patch"
       base_path: "source_subfolder"

--- a/recipes/argparse/all/conandata.yml
+++ b/recipes/argparse/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5":
+    url: "https://github.com/p-ranav/argparse/archive/refs/tags/v2.5.tar.gz"
+    sha256: "aad087125bed01ae73e650ce33f9a5edbcbceb6c30f6a43824b1afa8df5a6fac"
   "2.4":
     url: "https://github.com/p-ranav/argparse/archive/refs/tags/v2.4.tar.gz"
     sha256: "3589559f115bfedfef2edffb3e7b61d88657ba7b70a0b1f47352ff3043abc825"
@@ -12,6 +15,9 @@ sources:
     url: "https://github.com/p-ranav/argparse/archive/v2.1.tar.gz"
     sha256: "0a82f464b568b8ee6650fc837f371eb9c81417e2ef9fb3b51f65ad50fa3b8662"
 patches:
+  "2.5":
+    - patch_file: "patches/0001-v2.3-add-missing-include.patch"
+      base_path: "source_subfolder"
   "2.4":
     - patch_file: "patches/0001-v2.3-add-missing-include.patch"
       base_path: "source_subfolder"

--- a/recipes/argparse/all/conanfile.py
+++ b/recipes/argparse/all/conanfile.py
@@ -19,7 +19,10 @@ class ArgparseConan(ConanFile):
         return {
             "gcc": "7" if tools.Version(self.version) <= "2.1" else "8",
             "clang": "5" if tools.Version(self.version) <= "2.1" else "7",
-            "Visual Studio": "15",
+            # trantor/2.5 uses [[maybe_unused]] in range-based for loop
+            # Visual Studio 15 doesn't support it:
+            # https://developercommunity.visualstudio.com/t/compiler-bug-on-parsing-maybe-unused-in-range-base/209488
+            "Visual Studio": "15" if tools.Version(self.version) < "2.5" else "16",
             "apple-clang": "10",
         }
 

--- a/recipes/argparse/config.yml
+++ b/recipes/argparse/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5":
+    folder: all
   "2.4":
     folder: all
   "2.3":


### PR DESCRIPTION
Specify library name and version:  **argparse/2.5**

Try to solve https://github.com/conan-io/conan-center-index/issues/10979.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
