### PR TITLE
drogon: fix drogon_ctl compilation error

### DIFF
--- a/recipes/drogon/all/conandata.yml
+++ b/recipes/drogon/all/conandata.yml
@@ -8,3 +8,5 @@ patches:
       patch_file: "patches/1.7.5-0001-disable_trantor.patch"
     - base_path: "source_subfolder"
       patch_file: "patches/1.7.5-0002-remove-boost-components.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/1.7.5-0003-find-package-trantor.patch"

--- a/recipes/drogon/all/patches/1.7.5-0003-find-package-trantor.patch
+++ b/recipes/drogon/all/patches/1.7.5-0003-find-package-trantor.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 46a23fd..d2e2f69 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -118,7 +118,8 @@ if (WIN32)
+         PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/mman-win32>)
+ endif (WIN32)
+ 
+-target_link_libraries(${PROJECT_NAME} PUBLIC trantor)
++find_package(Trantor REQUIRED)
++target_link_libraries(${PROJECT_NAME} PUBLIC Trantor::Trantor)
+ 
+ if(${CMAKE_SYSTEM_NAME} STREQUAL "Haiku")
+     target_link_libraries(${PROJECT_NAME} PRIVATE network)


### PR DESCRIPTION
Specify library name and version:  **drogon/1.7.5**

A compile error occurs with drogon:with_ctl=True.
This is due to a missing link library in the drogon library.
I want to add Trantor in cci recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
