### PR TITLE
simdjson: add version 2.0.3

### DIFF
--- a/recipes/simdjson/all/conandata.yml
+++ b/recipes/simdjson/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.0.2":
-    url: "https://github.com/simdjson/simdjson/archive/v2.0.2.tar.gz"
-    sha256: "e302a74a62ad4c9bb2275e0e8eaf63131f212ad76ebdefdd450c435a558a6645"
+  "2.0.3":
+    url: "https://github.com/simdjson/simdjson/archive/v2.0.3.tar.gz"
+    sha256: "c1bcf65b3bd830bf8f747b8dd7126edd4bb7562bebb92698c1750acf4c979df6"
   "2.0.1":
     url: "https://github.com/simdjson/simdjson/archive/v2.0.1.tar.gz"
     sha256: "581e508210614a5024edf79e0b65db943ab5711cc42163826bcbf3df6a5e34d1"

--- a/recipes/simdjson/all/conandata.yml
+++ b/recipes/simdjson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.2":
+    url: "https://github.com/simdjson/simdjson/archive/v2.0.2.tar.gz"
+    sha256: "e302a74a62ad4c9bb2275e0e8eaf63131f212ad76ebdefdd450c435a558a6645"
   "2.0.1":
     url: "https://github.com/simdjson/simdjson/archive/v2.0.1.tar.gz"
     sha256: "581e508210614a5024edf79e0b65db943ab5711cc42163826bcbf3df6a5e34d1"

--- a/recipes/simdjson/all/conanfile.py
+++ b/recipes/simdjson/all/conanfile.py
@@ -39,8 +39,8 @@ class SimdjsonConan(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            # several AVX-512 instructions are not support by GCC < 9.0
-            "gcc": "8" if tools.Version(self.version) < "2.0.0" else "9",
+            # In simdjson/2.0.1, several AVX-512 instructions are not support by GCC < 9.0
+            "gcc": "8" if tools.Version(self.version) != "2.0.1" else "9",
             "Visual Studio": "16",
             "clang": "6",
             "apple-clang": "9.4",

--- a/recipes/simdjson/config.yml
+++ b/recipes/simdjson/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.0.2":
+  "2.0.3":
     folder: all
   "2.0.1":
     folder: all

--- a/recipes/simdjson/config.yml
+++ b/recipes/simdjson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.2":
+    folder: all
   "2.0.1":
     folder: all
   "1.1.0":


### PR DESCRIPTION
Specify library name and version:  **simdjson/2.0.3**

simdjson/2.0.2 fix compilation error in gcc 8.
simdjson/2.0.3 fix compilation error in Visual Sutdio 2019.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
