### PR TITLE
opencolorio: fixed missing strlen

### DIFF
--- a/recipes/opencolorio/all/conandata.yml
+++ b/recipes/opencolorio/all/conandata.yml
@@ -11,6 +11,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/pstring.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/strlen.patch"
+      base_path: "source_subfolder"
   "1.1.1":
     - patch_file: "patches/1.1.1.patch"
       base_path: "source_subfolder"

--- a/recipes/opencolorio/all/patches/strlen.patch
+++ b/recipes/opencolorio/all/patches/strlen.patch
@@ -6,7 +6,7 @@ index 794dfdbe..94729459 100644
  #include <map>
  #include <regex>
  #include <sstream>
-+#include <cstring>
++#include <string.h>
  
  #include <OpenColorIO/OpenColorIO.h>
  

--- a/recipes/opencolorio/all/patches/strlen.patch
+++ b/recipes/opencolorio/all/patches/strlen.patch
@@ -1,0 +1,12 @@
+diff --git a/src/OpenColorIO/FileRules.cpp b/src/OpenColorIO/FileRules.cpp
+index 794dfdbe..94729459 100644
+--- a/src/OpenColorIO/FileRules.cpp
++++ b/src/OpenColorIO/FileRules.cpp
+@@ -6,6 +6,7 @@
+ #include <map>
+ #include <regex>
+ #include <sstream>
++#include <cstring>
+ 
+ #include <OpenColorIO/OpenColorIO.h>
+ 


### PR DESCRIPTION
Specify library name and version:  **opencolorio/2.1.0**

fix #11031

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
