### PR TITLE
[gdk-pixbuf]: bump requirements and fix linking against static gdk-pixbuf

### DIFF
--- a/recipes/gdk-pixbuf/all/conandata.yml
+++ b/recipes/gdk-pixbuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.42.8":
+    url: "https://download.gnome.org/sources/gdk-pixbuf/2.42/gdk-pixbuf-2.42.8.tar.xz"
+    sha256: "84acea3acb2411b29134b32015a5b1aaa62844b19c4b1ef8b8971c6b0759f4c6"
   "2.42.6":
     url: "https://download.gnome.org/sources/gdk-pixbuf/2.42/gdk-pixbuf-2.42.6.tar.xz"
     sha256: "c4a6b75b7ed8f58ca48da830b9fa00ed96d668d3ab4b1f723dcf902f78bde77f"
@@ -11,3 +14,8 @@ sources:
   "2.42.0":
     url: "https://download.gnome.org/sources/gdk-pixbuf/2.42/gdk-pixbuf-2.42.0.tar.xz"
     sha256: "73441338d1a901dc7a3940113cb0aac22776b2832f7eab8f8ec7ec5755adaec7"
+
+patches:
+  "2.42.8":
+    - patch_file: "patches/define_dllmain_only_when_shared.patch"
+      base_path: "source_subfolder"

--- a/recipes/gdk-pixbuf/all/conanfile.py
+++ b/recipes/gdk-pixbuf/all/conanfile.py
@@ -22,7 +22,6 @@ class GdkPixbufConan(ConanFile):
         "with_libpng": [True, False],
         "with_libtiff": [True, False],
         "with_libjpeg": ["libjpeg", "libjpeg-turbo", False],
-        "with_jasper": [True, False],
         "with_introspection": [True, False],
     }
     default_options = {
@@ -31,11 +30,11 @@ class GdkPixbufConan(ConanFile):
         "with_libpng": True,
         "with_libtiff": True,
         "with_libjpeg": "libjpeg",
-        "with_jasper": False,
         "with_introspection": False,
     }
 
     generators = "pkg_config"
+    exports_sources = "patches/**"
 
     @property
     def _source_subfolder(self):
@@ -48,8 +47,6 @@ class GdkPixbufConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if tools.Version(self.version) >= "2.42.0":
-            del self.options.with_jasper
 
     def configure(self):
         if self.options.shared:
@@ -63,7 +60,7 @@ class GdkPixbufConan(ConanFile):
             # see https://github.com/conan-io/conan-center-index/pull/10154#issuecomment-1094224794
             self.requires("glib/2.70.4")
         else:
-            self.requires("glib/2.72.0")
+            self.requires("glib/2.73.0")
         if self.options.with_libpng:
             self.requires("libpng/1.6.37")
         if self.options.with_libtiff:
@@ -72,8 +69,6 @@ class GdkPixbufConan(ConanFile):
             self.requires("libjpeg-turbo/2.1.2")
         elif self.options.with_libjpeg == "libjpeg":
             self.requires("libjpeg/9d")
-        if self.options.get_safe("with_jasper"):
-            self.requires("jasper/2.0.33")
 
     def validate(self):
         if self.settings.os == "Macos":
@@ -92,6 +87,9 @@ class GdkPixbufConan(ConanFile):
                   strip_root=True, destination=self._source_subfolder)
 
     def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
         meson_build = os.path.join(self._source_subfolder, "meson.build")
         tools.replace_in_file(meson_build, "subdir('tests')", "#subdir('tests')")
         tools.replace_in_file(meson_build, "subdir('thumbnailer')", "#subdir('thumbnailer')")
@@ -114,13 +112,15 @@ class GdkPixbufConan(ConanFile):
         defs["docs"] = "false"
         defs["man"] = "false"
         defs["installed_tests"] = "false"
-        defs["png"] = "true" if self.options.with_libpng else "false"
-        defs["tiff"] = "true" if self.options.with_libtiff else "false"
-        defs["jpeg"] = "true" if self.options.with_libjpeg else "false"
-        if "with_jasper" in self.options:
-            defs["jasper"] = "true" if self.options.with_jasper else "false"
-        if tools.Version(self.version) < "2.42.0":
-            defs["x11"] = "false"
+        if tools.Version(self.version) >= "2.42.8":
+            defs["png"] = "enabled" if self.options.with_libpng else "disabled"
+            defs["tiff"] = "enabled" if self.options.with_libtiff else "disabled"
+            defs["jpeg"] = "enabled" if self.options.with_libjpeg else "disabled"
+        else:
+            defs["png"] = "true" if self.options.with_libpng else "false"
+            defs["tiff"] = "true" if self.options.with_libtiff else "false"
+            defs["jpeg"] = "true" if self.options.with_libjpeg else "false"
+
         defs["builtin_loaders"] = "all"
         defs["gio_sniffing"] = "false"
         defs["introspection"] = "enabled" if self.options.with_introspection else "disabled"
@@ -132,7 +132,7 @@ class GdkPixbufConan(ConanFile):
     def build(self):
         self._patch_sources()
         if self.options.with_libpng:
-            shutil.move("libpng.pc", "libpng16.pc")
+            shutil.copy("libpng.pc", "libpng16.pc")
         meson = self._configure_meson()
         meson.build()
 

--- a/recipes/gdk-pixbuf/all/patches/define_dllmain_only_when_shared.patch
+++ b/recipes/gdk-pixbuf/all/patches/define_dllmain_only_when_shared.patch
@@ -1,0 +1,63 @@
+commit 9521539021d6c8e57fd40d1bf0ff34abf2edbd6b
+Author: Hesham Essam <hesham.essam.mail@gmail.com>
+Date:   Fri Jun 3 13:29:28 2022 +0200
+
+    Enable static builds on Windows
+
+diff --git a/gdk-pixbuf/gdk-pixbuf-io.c b/gdk-pixbuf/gdk-pixbuf-io.c
+index 182781178..e207d8143 100644
+--- a/gdk-pixbuf/gdk-pixbuf-io.c
++++ b/gdk-pixbuf/gdk-pixbuf-io.c
+@@ -182,6 +182,8 @@ get_file_formats (void)
+         return file_formats;
+ }
+ 
++#ifdef GDK_PIXBUF_RELOCATABLE // implies that gdk-pixbuf is built as a dll on windows
++
+ #ifdef G_OS_WIN32
+ 
+ /* DllMain function needed to tuck away the gdk-pixbuf DLL handle */
+@@ -203,9 +205,6 @@ DllMain (HINSTANCE hinstDLL,
+ }
+ #endif
+ 
+-
+-#ifdef GDK_PIXBUF_RELOCATABLE
+-
+ gchar *
+ gdk_pixbuf_get_toplevel (void)
+ {
+diff --git a/gdk-pixbuf/queryloaders.c b/gdk-pixbuf/queryloaders.c
+index ddcae7b6f..1d39b442e 100644
+--- a/gdk-pixbuf/queryloaders.c
++++ b/gdk-pixbuf/queryloaders.c
+@@ -280,7 +280,7 @@ query_module (GString *contents, const char *dir, const char *file)
+         g_free (path);
+ }
+ 
+-#ifdef G_OS_WIN32
++#if defined(G_OS_WIN32) && defined(GDK_PIXBUF_RELOCATABLE)
+ 
+ static char *
+ get_libdir (void)
+diff --git a/meson.build b/meson.build
+index ed82464e4..6b123847f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -382,7 +382,7 @@ endif
+ # Determine whether we enable application bundle relocation support, and we use
+ # this always on Windows
+ if host_system == 'windows'
+-  relocatable = true
++  relocatable = (get_option('default_library') != 'static')
+ else
+   relocatable = get_option('relocatable')
+ endif
+@@ -445,6 +445,6 @@ summary('MediaLib', use_medialib, section: 'Build')
+ summary('Introspection', build_gir, section: 'Build')
+ summary('Documentation', build_docs, section: 'Build')
+ summary('Manual pages', get_option('man'), section: 'Build')
+-summary('Relocatable', get_option('relocatable'), section: 'Build')
++summary('Relocatable', relocatable, section: 'Build')
+ summary('Installed tests', get_option('installed_tests'), section: 'Build')
+ 

--- a/recipes/gdk-pixbuf/config.yml
+++ b/recipes/gdk-pixbuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.42.8":
+    folder: all
   "2.42.6":
     folder: all
   "2.42.4":


### PR DESCRIPTION
Specify library name and version:  **gdk-pixbuf**

gdk-pixbuf defines DllMain which makes it impossible for a shared library that also defines DllMain to link against it.
DllMain is defined to enable "reloaction" functionality. I added a patch that disables this functionality when built as a static library, since it's not possible to get the location of the dll (which doesn't exist).

This is a step towards completely static gtk 3 on windows.

It's worth noting that even with a static gdk-pixbuf it is not possible to copy a resulting application on a different pc and expect it to work correctly, since directories will be hard coded inside the library (a.k.a. not relocatable). Same case on Linux.

I suggest either we do this patch, or we disable building static gdk-pixbuf on Windows, since it's not supported upstream. I created a patch upstream https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/136, but I found out that there was a similar patch 5 months ago with little interest https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/127

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
