### PR TITLE
[atk]: enable linking against static atk and bump requirements

### DIFF
--- a/recipes/atk/all/conandata.yml
+++ b/recipes/atk/all/conandata.yml
@@ -5,3 +5,8 @@ sources:
   "2.36.0":
     url: "https://download.gnome.org/sources/atk/2.36/atk-2.36.0.tar.xz"
     sha256: "fb76247e369402be23f1f5c65d38a9639c1164d934e40f6a9cf3c9e96b652788"
+
+patches:
+  "2.38.0":
+    - patch_file: "patches/define_dllmain_only_when_shared.patch"
+      base_path: "source_subfolder"

--- a/recipes/atk/all/conanfile.py
+++ b/recipes/atk/all/conanfile.py
@@ -27,6 +27,8 @@ class AtkConan(ConanFile):
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
 
+    exports_sources = "patches/**"
+
     def config_options(self):
         if self.settings.os == 'Windows':
             del self.options.fPIC
@@ -36,7 +38,7 @@ class AtkConan(ConanFile):
         self.build_requires('pkgconf/1.7.4')
 
     def requirements(self):
-        self.requires('glib/2.70.1')
+        self.requires('glib/2.73.0')
 
     def configure(self):
         if self.options.shared:
@@ -60,7 +62,12 @@ class AtkConan(ConanFile):
         meson.configure(defs=defs, build_folder=self._build_subfolder, source_folder=self._source_subfolder, pkg_config_paths='.', args=args)
         return meson
 
+    def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
     def build(self):
+        self._patch_sources()
         tools.replace_in_file(os.path.join(self._source_subfolder, 'meson.build'),
             "subdir('tests')",
             "#subdir('tests')")

--- a/recipes/atk/all/patches/define_dllmain_only_when_shared.patch
+++ b/recipes/atk/all/patches/define_dllmain_only_when_shared.patch
@@ -1,0 +1,19 @@
+commit 2c8b80761a9ef6b381c909cf05dda711e7e9b85c
+Author: Hesham Essam <hesham.essam.mail@gmail.com>
+Date:   Fri Jun 3 15:58:03 2022 +0200
+
+    Define DllMain only when building a dll
+
+diff --git a/atk/atkprivate.c b/atk/atkprivate.c
+index e414bf2..988acc8 100644
+--- a/atk/atkprivate.c
++++ b/atk/atkprivate.c
+@@ -30,7 +30,7 @@
+ 
+ #include "atkprivate.h"
+ 
+-#ifdef G_OS_WIN32
++#if defined(G_OS_WIN32) && defined(DLL_EXPORT)
+ 
+ #define STRICT
+ #include <windows.h>


### PR DESCRIPTION
Specify library name and version:  **atk**

atk defines DllMain which makes it impossible for a shared library that also defines DllMain to link against it.
DllMain is defined to enable reloaction (get locale folder based on location of the dll). I added a patch that disables this functionality when built as a static library, since it's not possible to get the location of the dll (which doesn't exist).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
