### PR TITLE
ogg: Add option to disable testing

### DIFF
--- a/recipes/ogg/all/conanfile.py
+++ b/recipes/ogg/all/conanfile.py
@@ -21,7 +21,7 @@ class OggConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "testing": True,
+        "build_testing": False,
     }
 
     generators = "cmake"

--- a/recipes/ogg/all/conanfile.py
+++ b/recipes/ogg/all/conanfile.py
@@ -16,7 +16,7 @@ class OggConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "testing": [True, False],
+        "build_testing": [True, False],
     }
     default_options = {
         "shared": False,

--- a/recipes/ogg/all/conanfile.py
+++ b/recipes/ogg/all/conanfile.py
@@ -60,8 +60,7 @@ class OggConan(ConanFile):
         self._cmake = CMake(self)
         # Generate a relocatable shared lib on Macos
         self._cmake.definitions["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
-        if not self.options.testing:
-            self._cmake.definitions["BUILD_TESTING"] = False
+        self._cmake.definitions["BUILD_TESTING"] = self.options.build_testing
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 

--- a/recipes/ogg/all/conanfile.py
+++ b/recipes/ogg/all/conanfile.py
@@ -16,10 +16,12 @@ class OggConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "testing": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "testing": True,
     }
 
     generators = "cmake"
@@ -58,6 +60,8 @@ class OggConan(ConanFile):
         self._cmake = CMake(self)
         # Generate a relocatable shared lib on Macos
         self._cmake.definitions["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        if not self.options.testing:
+            self._cmake.definitions["BUILD_TESTING"] = False
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 


### PR DESCRIPTION
Specify library name and version:  **ogg**

Sometimes you don't want to run the BUILD_TESTING steps from the CMakeLists.
This adds an option for it

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
