### PR TITLE
opentdf-client: add version 1.0.0

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/opentdf/client-cpp/archive/1.0.0.tar.gz"
+    sha256: "a0c38aa06bb592b8749f8d02cbe67cbe7e35f83fde24b47c516ff28801414ac3"
   "0.9.0":
     url: "https://github.com/opentdf/client-cpp/archive/opentdf-0.9.0.tar.gz"
     sha256: "152e79c136b472e13a37c108118c8d4d7b5a85a8e34f4f284452ac59bdb7afdb"

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "0.9.0":
     folder: all
   "0.6.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **opentdf-client/1.0.0**

Upgrades to official 1.0.0 release of opentdf c++ client.  See opentdf.io for more information.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
