### PR TITLE
zlib-ng: fix mingw compilation error in shared=False

### DIFF
--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -1,20 +1,21 @@
-from conans import ConanFile, CMake, tools
+from conans import CMake, tools
+from conan import ConanFile
 from conans.errors import ConanInvalidConfiguration
-
+from conan.tools.microsoft import is_msvc
 import os
+import functools
 
 equired_conan_version = ">=1.33.0"
 
 class ZlibNgConan(ConanFile):
     name = "zlib-ng"
     description = "zlib data compression library for the next generation systems"
+    topics = ("zlib", "compression")
+    license ="Zlib"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/zlib-ng/zlib-ng/"
-    license ="Zlib"
-    topics = ("zlib", "compression")
-    exports_sources = ["CMakeLists.txt"]
-    generators = "cmake",
     settings = "os", "arch", "compiler", "build_type"
+    exports_sources = ["CMakeLists.txt"]
     options = {"shared": [True, False],
                "zlib_compat": [True, False],
                "with_gzfileop": [True, False],
@@ -29,7 +30,7 @@ class ZlibNgConan(ConanFile):
                        "with_new_strategies": True,
                        "with_native_instructions": False,
                        "fPIC": True}
-    _cmake = None
+    generators = "cmake",
 
     @property
     def _source_subfolder(self):
@@ -57,18 +58,18 @@ class ZlibNgConan(ConanFile):
         if self.options.zlib_compat and not self.options.with_gzfileop:
             raise ConanInvalidConfiguration("The option 'with_gzfileop' must be True when 'zlib_compat' is True.")
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if not self._cmake:
-            self._cmake = CMake(self)
-        self._cmake.definitions["ZLIB_ENABLE_TESTS"] = False
-        self._cmake.definitions["ZLIB_COMPAT"] = self.options.zlib_compat
-        self._cmake.definitions["WITH_GZFILEOP"] = self.options.with_gzfileop
-        self._cmake.definitions["WITH_OPTIM"] = self.options.with_optim
-        self._cmake.definitions["WITH_NEW_STRATEGIES"] = self.options.with_new_strategies
-        self._cmake.definitions["WITH_NATIVE_INSTRUCTIONS"] = self.options.with_native_instructions
+        cmake = CMake(self)
+        cmake.definitions["ZLIB_ENABLE_TESTS"] = False
+        cmake.definitions["ZLIB_COMPAT"] = self.options.zlib_compat
+        cmake.definitions["WITH_GZFILEOP"] = self.options.with_gzfileop
+        cmake.definitions["WITH_OPTIM"] = self.options.with_optim
+        cmake.definitions["WITH_NEW_STRATEGIES"] = self.options.with_new_strategies
+        cmake.definitions["WITH_NATIVE_INSTRUCTIONS"] = self.options.with_native_instructions
 
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake.configure()
+        return cmake
 
     def build(self):
         cmake = self._configure_cmake()
@@ -85,9 +86,12 @@ class ZlibNgConan(ConanFile):
         suffix = "" if self.options.zlib_compat else "-ng"
         self.cpp_info.names["pkg_config"] = "zlib" + suffix
         if self.settings.os == "Windows":
-            static_flag = "static" if not self.options.shared and tools.Version(self.version) >= "2.0.5" else ""
+            # The library name of zlib-ng is complicated in zlib-ng>=2.0.4:
+            # https://github.com/zlib-ng/zlib-ng/blob/2.0.4/CMakeLists.txt#L994-L1016
+            base = "zlib" if is_msvc(self) or tools.Version(self.version) < "2.0.4" or self.options.shared else "z"
+            static_flag = "static" if is_msvc(self) and not self.options.shared and tools.Version(self.version) >= "2.0.4" else ""
             build_type = "d" if self.settings.build_type == "Debug" else ""
-            self.cpp_info.libs = ["zlib{}{}{}".format(static_flag, suffix, build_type)]
+            self.cpp_info.libs = ["{}{}{}{}".format(base, static_flag, suffix, build_type)]
         else:
             self.cpp_info.libs = ["z{}".format(suffix)]
         if self.options.zlib_compat:


### PR DESCRIPTION
Specify library name and version:  **zlib-ng/***

After zlib-ng/2.0.4, the library naming rule is modified.
But current recipe supports MSVC only.

I want to fix it.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
