### PR TITLE
libsixel: add recipe

### DIFF
--- a/recipes/libsixel/all/conandata.yml
+++ b/recipes/libsixel/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.10.3":
+    url: "https://github.com/libsixel/libsixel/archive/refs/tags/v1.10.3.tar.gz"
+    sha256: "028552eb8f2a37c6effda88ee5e8f6d87b5d9601182ddec784a9728865f821e0"

--- a/recipes/libsixel/all/conanfile.py
+++ b/recipes/libsixel/all/conanfile.py
@@ -49,6 +49,8 @@ class LibSixelConan(ConanFile):
         del self.settings.compiler.libcxx
 
     def validate(self):
+        if hasattr(self, "settings_build") and tools.cross_building(self):
+            raise ConanInvalidConfiguration("Cross-building not implemented")
         if is_msvc(self):
             raise ConanInvalidConfiguration("{}/{} does not support Visual Studio".format(self.name, self.version))
 

--- a/recipes/libsixel/all/conanfile.py
+++ b/recipes/libsixel/all/conanfile.py
@@ -1,0 +1,104 @@
+import os
+import functools
+from conans import ConanFile, Meson, tools
+from conans.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc
+
+required_conan_version = ">=1.33.0"
+
+class LibSixelConan(ConanFile):
+    name = "libsixel"
+    description = "A SIXEL encoder/decoder implementation derived from kmiya's sixel (https://github.com/saitoha/sixel)."
+    topics = ("sixel")
+    license = "MIT"
+    homepage = "https://github.com/libsixel/libsixel"
+    url = "https://github.com/conan-io/conan-center-index"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_curl": [True, False],
+        "with_gdk_pixbuf2": [True, False],
+        "with_gd": [True, False],
+        "with_jpeg": [True, False],
+        "with_png": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_curl": True,
+        "with_gd": False,
+        "with_gdk_pixbuf2": False,
+        "with_jpeg": True,
+        "with_png": True,
+    }
+    generators = "cmake", "pkg_config"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == 'Windows':
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.cppstd
+        del self.settings.compiler.libcxx
+
+    def validate(self):
+        if is_msvc(self):
+            raise ConanInvalidConfiguration("{}/{} does not support Visual Studio".format(self.name, self.version))
+
+    def build_requirements(self):
+        self.build_requires("meson/0.62.2")
+        self.build_requires("pkgconf/1.7.4")
+
+    def requirements(self):
+        if self.options.with_curl:
+            self.requires("libcurl/7.83.1")
+        if self.options.with_gd:
+            self.requires("libgd/2.3.2")
+        if self.options.with_gdk_pixbuf2:
+            self.requires("gdk-pixbuf/2.42.6")
+        if self.options.with_jpeg:
+            self.requires("libjpeg/9d")
+        if self.options.with_png:
+            self.requires("libpng/1.6.37")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    @functools.lru_cache(1)
+    def _configure_meson(self):
+        meson = Meson(self)
+        defs = {
+            "libcurl": "enabled" if self.options.with_curl else "disabled",
+            "gd": "enabled" if self.options.with_gd else "disabled",
+            "gdk-pixbuf2": "enabled" if self.options.with_gdk_pixbuf2 else "disabled",
+            "img2sixel": "disabled",
+            "sixel2png": "disabled",
+            "python2": "disabled",
+        }
+        meson.configure(
+            defs=defs,
+            source_folder=self._source_subfolder,
+        )
+        return meson
+
+    def build(self):
+        meson = self._configure_meson()
+        meson.build()
+
+    def package(self):
+        self.copy("LICENSE*", dst="licenses", src=self._source_subfolder)
+        meson = self._configure_meson()
+        meson.install()
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["sixel"]

--- a/recipes/libsixel/all/test_package/CMakeLists.txt
+++ b/recipes/libsixel/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(libsixel REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.c)
+target_link_libraries(${PROJECT_NAME} libsixel::libsixel)

--- a/recipes/libsixel/all/test_package/conanfile.py
+++ b/recipes/libsixel/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libsixel/all/test_package/test_package.c
+++ b/recipes/libsixel/all/test_package/test_package.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <sixel.h>
+
+static int sixel_write(char *data, int size, void *priv)
+{
+    return fwrite(data, 1, size, (FILE *)priv);
+}
+
+int main() {
+  SIXELSTATUS status = SIXEL_FALSE;
+  sixel_output_t *output = NULL;
+
+  status = sixel_output_new(&output, sixel_write, stdout, NULL);
+  if (SIXEL_FAILED(status))
+      return 1;
+
+  return 0;
+}
+

--- a/recipes/libsixel/config.yml
+++ b/recipes/libsixel/config.yml
@@ -1,0 +1,4 @@
+---
+versions:
+  "1.10.3":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libsixel/1.10.3**

libsixel provide sixel support which is a bitmap graphics format supported by terminal and printers.

Original repository is https://github.com/saitoha/libsixel, but it seems not to be maintained since 2020.
This recipe uses forked repository (https://github.com/libsixel/libsixel)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
