### PR TITLE
add tizen sdk recipe

### DIFF
--- a/recipes/tizen-sdk/all/conandata.yml
+++ b/recipes/tizen-sdk/all/conandata.yml
@@ -1,0 +1,14 @@
+sources:
+  "6.2_0.1.4":
+    "Windows":
+      "x86_64":
+        url: "https://download.tizen.org/sdk/tizenstudio/official/binary/cross-aarch64-gcc-6.2_0.1.4_windows-64.zip"
+        sha256: "bf54dc03bac42ed1be7ce72a65123d15466b9dcdc271422d67d10d142cc96cff"
+    "Linux":
+      "x86_64":
+        url: "https://download.tizen.org/sdk/tizenstudio/official/binary/cross-aarch64-gcc-6.2_0.1.4_ubuntu-64.zip"
+        sha256: "b53318b0a5b1715e1c27058d4c687da5588c83a080e51f7686c54860868b11b0"
+    "Macos":
+      "x86_64":
+        url: "https://download.tizen.org/sdk/tizenstudio/official/binary/cross-aarch64-gcc-6.2_0.1.4_macos-64.zip"
+        sha256: "bd16e8db9eb427c33cf4314b2112f71116507cff7cff2588742283f639a55995"

--- a/recipes/tizen-sdk/all/conanfile.py
+++ b/recipes/tizen-sdk/all/conanfile.py
@@ -1,0 +1,170 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class TizenSDKConan(ConanFile):
+    name = "tizen-sdk"
+    description = "The Tizen SDK is a toolset that lets you compile code for Tizen platform, using languages such as C and C++"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://docs.tizen.org/application/"
+    topics = ("tizen", "sdk", "toolchain", "compiler")
+    license = "Apache-2.0"
+
+    settings = "os", "arch", "build_type", "compiler"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _arch(self):
+        return self.settings.arch
+
+    @property
+    def _triplet(self):
+        arch = {
+            "armv8": "aarch64",
+        }.get(str(self.settings_target.arch))
+
+        return f"{arch}-linux-gnu"
+
+    @property
+    def _sdk_version_major(self):
+        version_data = self.version.split("_")
+        return version_data[0]
+
+    @property
+    def _sdk_version_minor(self):
+        version_data = self.version.split("_")
+        return version_data[1]
+
+    @property
+    def _sdk_root(self):
+        return os.path.join(self.package_folder)
+
+    @property
+    def _tizen_abi(self):
+        return {
+            "armv7": "arm",
+            "armv8": "aarch64",
+            "x86": "i586",
+            "x86_64": "x86_64",
+        }.get(str(self.settings_target.arch))
+
+    def _wrap_executable(self, tool):
+        suffix = ".exe" if self.settings.os == "Windows" else ""
+        return f"{tool}{suffix}"
+
+    def _tool_name(self, tool):
+        prefix = f"{self._triplet}"
+        executable = f"{prefix}-{tool}"
+        return self._wrap_executable(executable)
+
+    def _define_tool_var(self, name, value):
+        sdk_bin = os.path.join(self._sdk_root, "bin")
+        path = os.path.join(sdk_bin, self._tool_name(value))
+
+        if not os.path.isfile(path):
+            self.output.error(f"'Environment variable {name} could not be created: '{path}'")
+            return "UNKNOWN"
+
+        self._chmod_plus_x(path)
+        self.output.info(f"Creating {name} environment variable: {path}")
+        return path
+
+    def build(self):
+        tools.get(**self.conan_data["sources"][self.version][str(self.settings.os)][str(self._arch)], destination=self._source_subfolder)
+
+    def package(self):
+        version = self._sdk_version_major
+        abi = self._tizen_abi
+        self.copy("*", src=os.path.join(self._source_subfolder, "data", "tools", f"{abi}-linux-gnu-gcc-{version}"), dst=".", keep_path=True, symlinks=True)
+        #self._fix_permissions()
+
+    def validate(self):
+        if not self._settings_os_supported():
+            raise ConanInvalidConfiguration(f"os={self.settings.os} is not supported by {self.name} (no binaries are available)")
+        if not self._settings_arch_supported():
+            raise ConanInvalidConfiguration(f"os,arch={self.settings.os},{self.settings.arch} is not supported by {self.name} (no binaries are available)")
+
+    def package_info(self):
+        self.output.info(f"Creating TIZEN_SDK_ROOT environment variable: {self._sdk_root}")
+        self.env_info.TIZEN_SDK_ROOT = self._sdk_root
+
+        # we need this?
+        self.output.info(f"Creating CHOST environment variable: {self._triplet}")
+        self.env_info.CHOST = self._triplet
+
+        sdk_sysroot = os.path.join(self._sdk_root)
+        self.output.info(f"Creating CONAN_CMAKE_FIND_ROOT_PATH environment variable: {sdk_sysroot}")
+        self.env_info.CONAN_CMAKE_FIND_ROOT_PATH = sdk_sysroot
+
+        self.output.info(f"Creating SYSROOT environment variable: {sdk_sysroot}")
+        self.env_info.SYSROOT = sdk_sysroot
+
+        self.output.info(f"Creating self.cpp_info.sysroot: {sdk_sysroot}")
+        self.cpp_info.sysroot = sdk_sysroot
+
+        self.env_info.CC = self._define_tool_var("CC", "gcc")
+        self.env_info.CXX = self._define_tool_var("CXX", "g++")
+        self.env_info.AR = self._define_tool_var("AR", "ar")
+        self.env_info.AS = self._define_tool_var("AS", "as")
+        self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib")
+        self.env_info.STRIP = self._define_tool_var("STRIP", "strip")
+        self.env_info.ADDR2LINE = self._define_tool_var("ADDR2LINE", "addr2line")
+        self.env_info.NM = self._define_tool_var("NM", "nm")
+        self.env_info.OBJCOPY = self._define_tool_var("OBJCOPY", "objcopy")
+        self.env_info.OBJDUMP = self._define_tool_var("OBJDUMP", "objdump")
+        self.env_info.READELF = self._define_tool_var("READELF", "readelf")
+        self.env_info.LD = self._define_tool_var("LD", "ld")
+
+        self.env_info.CMAKE_SYSTEM_NAME = "Linux"
+        self.env_info.CMAKE_C_COMPILER_TARGET = self._triplet
+        self.env_info.CMAKE_CXX_COMPILER_TARGET = self._triplet
+        self.env_info.CMAKE_CROSSCOMPILING = 1
+
+        self.env_info.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "NEVER"
+        self.env_info.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = "ONLY"
+        self.env_info.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "ONLY"
+        self.env_info.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE = "ONLY"
+
+    def _settings_os_supported(self):
+        return self.conan_data["sources"][self.version].get(str(self.settings.os)) is not None
+
+    def _settings_arch_supported(self):
+        return self.conan_data["sources"][self.version].get(str(self.settings.os), {}).get(str(self._arch)) is not None
+
+    def _fix_permissions(self):
+        if os.name != "posix":
+            return
+        for root, _, files in os.walk(self.package_folder):
+            for filename in files:
+                filename = os.path.join(root, filename)
+                with open(filename, "rb") as f:
+                    sig = f.read(4)
+                    if type(sig) is str:
+                        sig = [ord(s) for s in sig]
+                    else:
+                        sig = [s for s in sig]
+                    if len(sig) > 2 and sig[0] == 0x23 and sig[1] == 0x21:
+                        self.output.info(f"chmod on script file: '{filename}'")
+                        self._chmod_plus_x(filename)
+                    elif sig == [0x7F, 0x45, 0x4C, 0x46]:
+                        self.output.info(f"chmod on ELF file: '{filename}'")
+                        self._chmod_plus_x(filename)
+                    elif sig == [0xCA, 0xFE, 0xBA, 0xBE] or \
+                         sig == [0xBE, 0xBA, 0xFE, 0xCA] or \
+                         sig == [0xFE, 0xED, 0xFA, 0xCF] or \
+                         sig == [0xCF, 0xFA, 0xED, 0xFE] or \
+                         sig == [0xFE, 0xEF, 0xFA, 0xCE] or \
+                         sig == [0xCE, 0xFA, 0xED, 0xFE]:
+                        self.output.info(f"chmod on Mach-O file: '{filename}'")
+                        self._chmod_plus_x(filename)
+
+    @staticmethod
+    def _chmod_plus_x(filename):
+        if os.name == "posix":
+            os.chmod(filename, os.stat(filename).st_mode | 0o111)

--- a/recipes/tizen-sdk/all/test_package/CMakeLists.txt
+++ b/recipes/tizen-sdk/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.0)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME})

--- a/recipes/tizen-sdk/all/test_package/conanfile.py
+++ b/recipes/tizen-sdk/all/test_package/conanfile.py
@@ -1,0 +1,24 @@
+import os
+from conans import ConanFile, CMake
+
+
+class TestPackgeConan(ConanFile):
+    settings = "os", "arch"
+    test_type = "explicit"
+    generators = "cmake"
+
+    def build_requirements(self):
+        self.build_requires(self.tested_reference_str)
+
+    def build(self):
+        # It only makes sense to build a library, if the target os is Linux
+        if self.settings.os == "Linux":
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
+
+    def test(self):
+        # Run the project that was built using the SDK
+        if self.settings.os == "Linux":
+            test_file = os.path.join("bin", "test_package")
+            assert os.path.exists(test_file)

--- a/recipes/tizen-sdk/all/test_package/test_package.cpp
+++ b/recipes/tizen-sdk/all/test_package/test_package.cpp
@@ -1,0 +1,26 @@
+#include <cstdlib>
+#include <iostream>
+
+#include <tizen.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// This method is exported from library
+EXPORT_API bool tizen_test(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+bool tizen_test(void)
+{
+	return true;
+}
+
+int main()
+{
+    std::cout << "conan-center-index\n";
+    return EXIT_SUCCESS;
+}

--- a/recipes/tizen-sdk/config.yml
+++ b/recipes/tizen-sdk/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "6.2_0.1.4":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **tizen-sdk/6.2_0.1.4**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

---

Im trying add Tizen SDK recipe.

Some CMake old examples:
- https://github.com/tangrams/tangram-es/blob/main/cmake/tizen.toolchain.cmake
- https://github.com/FWGS/xash3d-tizen-project/blob/master/tizen.toolchain.cmake 

All Tizen Packages:
- https://download.tizen.org/sdk/tizenstudio/official/binary/

Current Problems:
1. My conanfile.py is correct?
2. I need sysroot or it is embedded with the downloaded zip?
3. Im executing this command to test locally, it is correct?
```
conan create . 6.2_0.1.4@tizen-sdk/stable -s:h arch=armv8 -s:h os=Linux -s:b arch=x86_64 -s:b os=Macos
```
4. Current error when i try call conan create:
```
tizen-sdk/6.2_0.1.4@tizen-sdk/stable (test package): Calling build()
Re-run cmake no build system arguments
-- The C compiler identification is unknown
-- The CXX compiler identification is unknown
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
-- Check for working C compiler: /Users/paulo/.conan/data/tizen-sdk/6.2_0.1.4/tizen-sdk/stable/package/4b92821f1af51ada4198018b78c8b197b32c6c18/bin/aarch64-linux-gnu-gcc
-- Check for working C compiler: /Users/paulo/.conan/data/tizen-sdk/6.2_0.1.4/tizen-sdk/stable/package/4b92821f1af51ada4198018b78c8b197b32c6c18/bin/aarch64-linux-gnu-gcc - broken
CMake Error at /usr/local/Cellar/cmake/3.22.2/share/cmake/Modules/CMakeTestCCompiler.cmake:69 (message):
  The C compiler

    "/Users/paulo/.conan/data/tizen-sdk/6.2_0.1.4/tizen-sdk/stable/package/4b92821f1af51ada4198018b78c8b197b32c6c18/bin/aarch64-linux-gnu-gcc"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /Users/paulo/Developer/workspaces/cpp/conan-center-index/recipes/tizen-sdk/all/test_package/build/344c2fa5e20d5768ec612fa97a72da12e0ceebd7/CMakeFiles/CMakeTmp
    
    Run Build Command(s):/usr/bin/make -f Makefile cmTC_4bfe0/fast && /Applications/Xcode.app/Contents/Developer/usr/bin/make  -f CMakeFiles/cmTC_4bfe0.dir/build.make CMakeFiles/cmTC_4bfe0.dir/build
    Building C object CMakeFiles/cmTC_4bfe0.dir/testCCompiler.c.o
    /Users/paulo/.conan/data/tizen-sdk/6.2_0.1.4/tizen-sdk/stable/package/4b92821f1af51ada4198018b78c8b197b32c6c18/bin/aarch64-linux-gnu-gcc    -o CMakeFiles/cmTC_4bfe0.dir/testCCompiler.c.o -c /Users/paulo/Developer/workspaces/cpp/conan-center-index/recipes/tizen-sdk/all/test_package/build/344c2fa5e20d5768ec612fa97a72da12e0ceebd7/CMakeFiles/CMakeTmp/testCCompiler.c
    aarch64-linux-gnu-gcc: error trying to exec 'cc1': execvp: No such file or directory
    make[1]: *** [CMakeFiles/cmTC_4bfe0.dir/testCCompiler.c.o] Error 1
    make: *** [cmTC_4bfe0/fast] Error 2
    
    

  

  CMake will not be able to correctly generate this project.
Call Stack (most recent call first):
  CMakeLists.txt:2 (project)


-- Configuring incomplete, errors occurred!
See also "/Users/paulo/Developer/workspaces/cpp/conan-center-index/recipes/tizen-sdk/all/test_package/build/344c2fa5e20d5768ec612fa97a72da12e0ceebd7/CMakeFiles/CMakeOutput.log".
See also "/Users/paulo/Developer/workspaces/cpp/conan-center-index/recipes/tizen-sdk/all/test_package/build/344c2fa5e20d5768ec612fa97a72da12e0ceebd7/CMakeFiles/CMakeError.log".
ERROR: tizen-sdk/6.2_0.1.4@tizen-sdk/stable (test package): Error in build() method, line 17
	cmake.configure()
	ConanException: Error 1 while executing cd '/Users/paulo/Developer/workspaces/cpp/conan-center-index/recipes/tizen-sdk/all/test_package/build/344c2fa5e20d5768ec612fa97a72da12e0ceebd7' && cmake -G "Unix Makefiles" -DCMAKE_SYSTEM_NAME="Linux" -DCONAN_CMAKE_FIND_ROOT_PATH="/Users/paulo/.conan/data/tizen-sdk/6.2_0.1.4/tizen-sdk/stable/package/4b92821f1af51ada4198018b78c8b197b32c6c18" -DCONAN_IN_LOCAL_CACHE="OFF" -DCMAKE_INSTALL_PREFIX="/Users/paulo/Developer/workspaces/cpp/conan-center-index/recipes/tizen-sdk/all/test_package/build/344c2fa5e20d5768ec612fa97a72da12e0ceebd7/package" -DCMAKE_INSTALL_BINDIR="bin" -DCMAKE_INSTALL_SBINDIR="bin" -DCMAKE_INSTALL_LIBEXECDIR="bin" -DCMAKE_INSTALL_LIBDIR="lib" -DCMAKE_INSTALL_INCLUDEDIR="include" -DCMAKE_INSTALL_OLDINCLUDEDIR="include" -DCMAKE_INSTALL_DATAROOTDIR="share" -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -DCONAN_EXPORTED="1" -Wno-dev '/Users/paulo/Developer/workspaces/cpp/conan-center-index/recipes/tizen-sdk/all/test_package'
```