### PR TITLE
[libjpeg] Use SPDX license identifer

### DIFF
--- a/recipes/libjpeg/all/conanfile.py
+++ b/recipes/libjpeg/all/conanfile.py
@@ -11,7 +11,7 @@ class LibjpegConan(ConanFile):
     description = "Libjpeg is a widely used C library for reading and writing JPEG image files."
     url = "https://github.com/conan-io/conan-center-index"
     topics = ("image", "format", "jpg", "jpeg", "picture", "multimedia", "graphics")
-    license = "http://ijg.org/files/README"
+    license = "IJG"
     homepage = "http://ijg.org"
 
     settings = "os", "arch", "compiler", "build_type"

--- a/recipes/libjpeg/all/conanfile.py
+++ b/recipes/libjpeg/all/conanfile.py
@@ -71,12 +71,12 @@ class LibjpegConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "Win32.Mak"),
                               "\nccommon = -c ",
                               "\nccommon = -c -DLIBJPEG_BUILDING {}".format("" if self.options.shared else "-DLIBJPEG_STATIC "))
-        with tools.chdir(self._source_subfolder):
+        # clean environment variables that might affect on the build (e.g. if set by Jenkins)
+        with tools.chdir(self._source_subfolder), tools.environment_append({"PROFILE": None, "TUNE": None, "NODEBUG": None}):
             shutil.copy("jconfig.vc", "jconfig.h")
             make_args = [
                 "nodebug=1" if self.settings.build_type != 'Debug' else "",
             ]
-            self.output.info(os.environ)
             if self._is_clang_cl:
                 cl = os.environ.get('CC', 'clang-cl')
                 link = os.environ.get('LD', 'lld-link')

--- a/recipes/libjpeg/all/conanfile.py
+++ b/recipes/libjpeg/all/conanfile.py
@@ -76,6 +76,7 @@ class LibjpegConan(ConanFile):
             make_args = [
                 "nodebug=1" if self.settings.build_type != 'Debug' else "",
             ]
+            self.output.info(os.environ)
             if self._is_clang_cl:
                 cl = os.environ.get('CC', 'clang-cl')
                 link = os.environ.get('LD', 'lld-link')


### PR DESCRIPTION
Specify library name and version:  libjpeg/all

I've altered the license info in the libjpeg recipe to use the appropriate SPDX identifier. The existing recipe refers to http://ijg.org/files/README which doesn't cover actual license information. The SPDX ID `IJG` is the "Independent JPEG Group License" listed here: https://spdx.org/licenses/IJG.html

This follows the SPDX recommendation mentioned here: https://github.com/conan-io/docs/blob/master/reference/conanfile/attributes.rst#license

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.