### PR TITLE
[pybind11] Do not support Mac for now

### DIFF
--- a/recipes/pybind11/all/conandata.yml
+++ b/recipes/pybind11/all/conandata.yml
@@ -1,22 +1,4 @@
 sources:
-  2.4.3:
-    url: "https://github.com/pybind/pybind11/archive/v2.4.3.tar.gz"
-    sha256: "1eed57bc6863190e35637290f97a20c81cfe4d9090ac0a24f3bbf08f265eb71d"
-  2.5.0:
-    url: "https://github.com/pybind/pybind11/archive/v2.5.0.tar.gz"
-    sha256: "97504db65640570f32d3fdf701c25a340c8643037c3b69aec469c10c93dc8504"
-  2.6.0:
-    url: "https://github.com/pybind/pybind11/archive/v2.6.0.tar.gz"
-    sha256: "90b705137b69ee3b5fc655eaca66d0dc9862ea1759226f7ccd3098425ae69571"
-  2.6.1:
-    url: "https://github.com/pybind/pybind11/archive/v2.6.1.tar.gz"
-    sha256: "cdbe326d357f18b83d10322ba202d69f11b2f49e2d87ade0dc2be0c5c34f8e2a"
-  2.6.2:
-    url: "https://github.com/pybind/pybind11/archive/v2.6.2.tar.gz"
-    sha256: "8ff2fff22df038f5cd02cea8af56622bc67f5b64534f1b83b9f133b8366acff2"
-  2.7.0:
-    url: "https://github.com/pybind/pybind11/archive/v2.7.0.tar.gz"
-    sha256: "6cd73b3d0bf3daf415b5f9b87ca8817cc2e2b64c275d65f9500250f9fee1677e"
   2.7.1:
     url: "https://github.com/pybind/pybind11/archive/v2.7.1.tar.gz"
     sha256: "616d1c42e4cf14fa27b2a4ff759d7d7b33006fdc5ad8fd603bb2c22622f27020"

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools, CMake
+from conans.errors import ConanInvalidConfiguration
 import os
 import functools
 
@@ -25,6 +26,10 @@ class PyBind11Conan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def validate(self):
+        if tools.is_apple_os(self):
+            raise ConanInvalidConfiguration("OSX support is bugged. Check https://github.com/pybind/pybind11/issues/3081")
 
     @functools.lru_cache(1)
     def _configure_cmake(self):

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -1,5 +1,7 @@
 from conans import ConanFile, tools, CMake
 import os
+import functools
+
 
 required_conan_version = ">=1.33.0"
 
@@ -16,24 +18,22 @@ class PyBind11Conan(ConanFile):
     generators = "cmake"
     no_copy_source = True
 
-    _source_subfolder = "source_subfolder"
 
-    _cmake = None
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("{}-{}".format(self.name, self.version),
-                  self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["PYBIND11_INSTALL"] = True
-        self._cmake.definitions["PYBIND11_TEST"] = False
-        self._cmake.definitions["PYBIND11_CMAKECONFIG_INSTALL_DIR"] = "lib/cmake/pybind11"
-        self._cmake.configure()
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["PYBIND11_INSTALL"] = True
+        cmake.definitions["PYBIND11_TEST"] = False
+        cmake.definitions["PYBIND11_CMAKECONFIG_INSTALL_DIR"] = "lib/cmake/pybind11"
+        cmake.configure()
+        return cmake
 
     def build(self):
         cmake = self._configure_cmake()

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -28,7 +28,7 @@ class PyBind11Conan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def validate(self):
-        if tools.is_apple_os(self):
+        if self.settings.os == "Macos":
             raise ConanInvalidConfiguration("OSX support is bugged. Check https://github.com/pybind/pybind11/issues/3081")
 
     @functools.lru_cache(1)

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -28,7 +28,7 @@ class PyBind11Conan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def validate(self):
-        if self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) in ["11.0", "12.0"]:
+        if self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) >= "11.0":
             raise ConanInvalidConfiguration("OSX support is bugged. Check https://github.com/pybind/pybind11/issues/3081")
 
     @functools.lru_cache(1)

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -28,7 +28,7 @@ class PyBind11Conan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def validate(self):
-        if self.settings.compiler == "apple-clang" and self.settings.compiler.version == "11":
+        if self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) == "11.0":
             raise ConanInvalidConfiguration("OSX support is bugged. Check https://github.com/pybind/pybind11/issues/3081")
 
     @functools.lru_cache(1)

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -28,7 +28,7 @@ class PyBind11Conan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def validate(self):
-        if self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) == "11.0":
+        if self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) in ["11.0", "12.0"]:
             raise ConanInvalidConfiguration("OSX support is bugged. Check https://github.com/pybind/pybind11/issues/3081")
 
     @functools.lru_cache(1)

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -28,7 +28,7 @@ class PyBind11Conan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def validate(self):
-        if self.settings.os == "Macos":
+        if self.settings.compiler == "apple-clang" and self.settings.compiler.version == "11":
             raise ConanInvalidConfiguration("OSX support is bugged. Check https://github.com/pybind/pybind11/issues/3081")
 
     @functools.lru_cache(1)

--- a/recipes/pybind11/all/test_package/CMakeLists.txt
+++ b/recipes/pybind11/all/test_package/CMakeLists.txt
@@ -10,12 +10,7 @@ conan_check_compiler()
 conan_set_libcxx()
 conan_set_vs_runtime()
 
-find_package(pybind11 REQUIRED)
+find_package(pybind11 REQUIRED CONFIG)
 
 pybind11_add_module(test_package MODULE test_package.cpp)
 set_property(TARGET test_package PROPERTY CXX_STANDARD 11)
-
-enable_testing()
-
-add_test(run_example
-  ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test.py ${CMAKE_CURRENT_BINARY_DIR}/lib)

--- a/recipes/pybind11/all/test_package/conanfile.py
+++ b/recipes/pybind11/all/test_package/conanfile.py
@@ -6,7 +6,7 @@ from platform import python_version
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -21,7 +21,7 @@ class TestPackageConan(ConanFile):
         return sys.executable
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             with tools.environment_append({"PYTHONPATH": "lib"}):
                 self.run("{} {}".format(self._python_interpreter, os.path.join(
                     self.source_folder, "test.py")), run_environment=True)

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -1,16 +1,4 @@
 versions:
-  "2.4.3":
-    folder: all
-  "2.5.0":
-    folder: all
-  "2.6.0":
-    folder: all
-  "2.6.1":
-    folder: all
-  "2.6.2":
-    folder: all
-  "2.7.0":
-    folder: all
   "2.7.1":
     folder: all
   "2.8.1":


### PR DESCRIPTION
Specify library name and version:  **pybind11/2.9.1**

- Mac OS is no longer supported (temporary until https://github.com/pybind/pybind11/issues/3081 become fixed)
- Removed old releases
- Cache CMake instance with lru_cache
- Remove cmake test support. We use test_package.py only

Related to https://github.com/conan-io/conan-center-index/pull/10817

/cc @ericLemanissier 
/cc @vectorsli

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
