### PR TITLE
cereal: add version 1.3.2

### DIFF
--- a/recipes/cereal/all/conandata.yml
+++ b/recipes/cereal/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.2":
+    url: "https://github.com/USCiLab/cereal/archive/v1.3.2.tar.gz"
+    sha256: "16a7ad9b31ba5880dac55d62b5d6f243c3ebc8d46a3514149e56b5e7ea81f85f"
   "1.3.1":
     url: "https://github.com/USCiLab/cereal/archive/v1.3.1.tar.gz"
     sha256: "65ea6ddda98f4274f5c10fb3e07b2269ccdd1e5cbb227be6a2fd78b8f382c976"

--- a/recipes/cereal/config.yml
+++ b/recipes/cereal/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.2":
+    folder: all
   "1.3.1":
     folder: all
   "1.3.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cereal/1.3.2**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
