### PR TITLE
aws-c-event-stream: add version 0.2.11

### DIFF
--- a/recipes/aws-c-event-stream/all/conandata.yml
+++ b/recipes/aws-c-event-stream/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.11":
+    url: "https://github.com/awslabs/aws-c-event-stream/archive/v0.2.11.tar.gz"
+    sha256: "4818b8d3fe02016fcfdd033c1e9d8f6be07ccaeb38664fe8c31c0fd153ea56e6"
   "0.2.7":
     url: "https://github.com/awslabs/aws-c-event-stream/archive/v0.2.7.tar.gz"
     sha256: "bb5c94cdff70c1985fb0b5f30d81756cedb5a3c3075d37f7e1e2b34e2a33c8c0"

--- a/recipes/aws-c-event-stream/config.yml
+++ b/recipes/aws-c-event-stream/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.11":
+    folder: all
   0.2.7:
     folder: all
   0.1.5:


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **aws-c-event-stream/0.2.11**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
