### PR TITLE
fast-cpp-csv-parser: add version cci.20211104 and modernize

### DIFF
--- a/recipes/fast-cpp-csv-parser/all/conandata.yml
+++ b/recipes/fast-cpp-csv-parser/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20211104":
+    url: "https://github.com/ben-strasser/fast-cpp-csv-parser/archive/5a417973b4cea674a5e4a3b88a23098a2ab75479.zip"
+    sha256: "33a22bda2603a87b8f36c79673339490f58656d92a4882e788de3f4ef7ec57b2"
   "cci.20200830":
     url: "https://github.com/ben-strasser/fast-cpp-csv-parser/archive/1165be530d19ed730228dd122f2df0896be8f64e.zip"
     sha256: "28ae9e3b95dcb7a78086ff1425f3bd1258407ebedc34d8517c5bcb8084b5833e"

--- a/recipes/fast-cpp-csv-parser/all/conanfile.py
+++ b/recipes/fast-cpp-csv-parser/all/conanfile.py
@@ -2,14 +2,16 @@ import os
 
 from conans import ConanFile, tools
 
+required_conan_version = ">=1.33.0"
+
 class FastcppcsvparserConan(ConanFile):
     name = "fast-cpp-csv-parser"
     description = "C++11 header-only library for reading comma separated value (CSV) files."
     license = "BSD-3-Clause"
-    topics = ("conan", "fast-cpp-csv-parser", "csv", "parser", "header-only")
-    homepage = "https://github.com/ben-strasser/fast-cpp-csv-parser"
     url = "https://github.com/conan-io/conan-center-index"
-    settings = "os", "compiler"
+    homepage = "https://github.com/ben-strasser/fast-cpp-csv-parser"
+    topics = ("csv", "parser", "header-only")
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
     options = {"with_thread": [True, False]}
     default_options = {"with_thread": True}
@@ -18,15 +20,13 @@ class FastcppcsvparserConan(ConanFile):
     def _source_subfolder(self):
         return "source_subfolder"
 
-    def configure(self):
-        if self.settings.compiler.cppstd:
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, 11)
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        url = self.conan_data["sources"][self.version]["url"]
-        extracted_dir = self.name + "-" + os.path.splitext(os.path.basename(url))[0]
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
@@ -36,8 +36,12 @@ class FastcppcsvparserConan(ConanFile):
         self.info.header_only()
 
     def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []
         self.cpp_info.includedirs = ["include", os.path.join("include", "fast-cpp-csv-parser")]
         if not self.options.with_thread:
             self.cpp_info.defines.append("CSV_IO_NO_THREAD")
-        if self.settings.os == "Linux" and self.options.with_thread:
+        if self.settings.os in ["Linux", "FreeBSD"] and self.options.with_thread:
             self.cpp_info.system_libs.append("pthread")

--- a/recipes/fast-cpp-csv-parser/all/test_package/CMakeLists.txt
+++ b/recipes/fast-cpp-csv-parser/all/test_package/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(fast-cpp-csv-parser REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} fast-cpp-csv-parser::fast-cpp-csv-parser)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/fast-cpp-csv-parser/all/test_package/conanfile.py
+++ b/recipes/fast-cpp-csv-parser/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake, tools
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/fast-cpp-csv-parser/config.yml
+++ b/recipes/fast-cpp-csv-parser/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20211104":
+    folder: all
   "cci.20200830":
     folder: all
   "20191004":


### PR DESCRIPTION
Specify library name and version:  **fast-cpp-csv-parser/cci.20211104**

The several PRs are merged since cci.20200830.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
