### PR TITLE
b2: Fix problems building with toolset=cxx

### DIFF
--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -92,6 +92,7 @@ class B2Conan(ConanFile):
         self.copy(pattern="*.jam", dst="bin", src="output")
 
     def package_info(self):
+        self.cpp_info.includedirs = []
         self.cpp_info.bindirs = ["bin"]
         self.env_info.path = [os.path.join(
             self.package_folder, "bin")]

--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -76,7 +76,9 @@ class B2Conan(ConanFile):
         os.chdir(build_dir)
         command = os.path.join(
             engine_dir, "b2.exe" if use_windows_commands else "b2")
-        if self.options.toolset != 'auto':
+        # auto, cxx, and cross-cxx aren't toolsets in b2; they're only used to affect
+        # the way build.sh builds b2. Don't pass them to b2 itself.
+        if self.options.toolset not in ['auto', 'cxx', 'cross-cxx']:
             command += " toolset=" + str(self.options.toolset)
         full_command = \
             "{0} --ignore-site-config --prefix=../output --abbreviate-paths install b2-install-layout=portable".format(


### PR DESCRIPTION
Specify library name and version:  **b2/4.8.0**

Fixes a problem using the `cxx` and `cross-cxx` toolsets. Those toolsets only have meaning when passed to `build.sh`, so don't pass them to `b2` in the second step of building.

Also remove the include dirs, because the hooks got an error.

Amends #10292 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
