### PR TITLE
[cairo]: use shared glib for shared cairo

### DIFF
--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -79,6 +79,8 @@ class CairoConan(ConanFile):
             del self.options.with_symbol_lookup
         if self.settings.os in ["Macos", "Windows"]:
             del self.options.with_opengl
+        if self.options.with_glib and self.options.shared:
+            self.options["glib"].shared = True
 
     def configure(self):
         if self.options.shared:
@@ -121,6 +123,10 @@ class CairoConan(ConanFile):
     def validate(self):
         if self.options.get_safe("with_xlib_xrender") and not self.options.get_safe("with_xlib"):
             raise ConanInvalidConfiguration("'with_xlib_xrender' option requires 'with_xlib' option to be enabled as well!")
+        if self.options.with_glib and not self.options["glib"].shared and self.options.shared:
+            raise ConanInvalidConfiguration(
+                "Linking a shared library against static glib can cause unexpected behaviour."
+            )
 
     @property
     def _is_msvc(self):
@@ -378,3 +384,6 @@ class CairoConan(ConanFile):
         # binary tools
         if self.options.with_zlib and self.options.with_png:
             self.cpp_info.components["cairo_util_"].requires.append("expat::expat") # trace-to-xml.c, xml-to-trace.c
+
+    def package_id(self):
+        self.info.requires["glib"].full_package_mode()

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -79,14 +79,14 @@ class CairoConan(ConanFile):
             del self.options.with_symbol_lookup
         if self.settings.os in ["Macos", "Windows"]:
             del self.options.with_opengl
-        if self.options.with_glib and self.options.shared:
-            self.options["glib"].shared = True
 
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
+        if self.options.with_glib and self.options.shared:
+            self.options["glib"].shared = True
 
     def requirements(self):
         self.requires("pixman/0.40.0")


### PR DESCRIPTION
Specify library name and version:  **cairo**

Building shared libraries that depend on static glib causes problems since this shared library will get its unique instance of glib. This is particularly a problem for gtk for example, which is a main user of cairo. See https://github.com/conan-io/conan-center-index/issues/11022.

Same problem when mixing different versions of static glib. For example if gtk is built with static cairo with glib 2.73, and with static pango with static glib 2.72. Or when mixing shared and static glibs. This is why I changed package_id to use full_package_mode with glib.

I would like to apply this patch to all dependencies of gtk.


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
