### PR TITLE
thrift: add version 0.16.0 and update dependencies

### DIFF
--- a/recipes/thrift/all/conandata.yml
+++ b/recipes/thrift/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.16.0":
+    url: "https://github.com/apache/thrift/archive/refs/tags/v0.16.0.tar.gz"
+    sha256: "df2931de646a366c2e5962af679018bca2395d586e00ba82d09c0379f14f8e7b"
   "0.15.0":
     url: "https://github.com/apache/thrift/archive/refs/tags/v0.15.0.tar.gz"
     sha256: "32d2f18aa9be114619ee54e1abc3bb497febb2a8aa917894c20bae21185fac15"
@@ -12,6 +15,9 @@ sources:
     url: "https://github.com/apache/thrift/archive/0.13.0.tar.gz"
     sha256: "8469c8d72c684c6de72ddf55fc65d1c10868a576e7dc4d1f4a21a59814b97110"
 patches:
+  "0.16.0":
+    - patch_file: "patches/cmake-0.16.0.patch"
+      base_path: "source_subfolder"
   "0.15.0":
     - patch_file: "patches/cmake-0.15.0.patch"
       base_path: "source_subfolder"

--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -185,6 +185,8 @@ class ThriftConan(ConanFile):
         self.cpp_info.components["libthrift"].libs = ["thrift" + libsuffix]
         if self.settings.os == "Windows":
             self.cpp_info.components["libthrift"].defines.append("NOMINMAX")
+            if tools.Version(self.version) >= "0.15.0":
+                self.cpp_info.components["libthrift"].system_libs.append("shlwapi")
         elif self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libthrift"].system_libs.extend(["m", "pthread"])
         self.cpp_info.components["libthrift"].requires.append("boost::headers")

--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -192,6 +192,7 @@ class ThriftConan(ConanFile):
         self.cpp_info.components["libthrift"].requires.append("boost::headers")
         if self.options.with_openssl:
             self.cpp_info.components["libthrift"].requires.append("openssl::openssl")
+        self.cpp_info.components["libthrift"].builddirs = [os.path.join("lib", "cmake")]
 
         if self.options.with_zlib:
             self.cpp_info.components["libthrift_z"].set_property("cmake_target_name", "thriftz::thriftz")

--- a/recipes/thrift/all/conanfile.py
+++ b/recipes/thrift/all/conanfile.py
@@ -1,7 +1,9 @@
 from conans import tools, CMake, ConanFile
 from conans.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 import os
 import textwrap
+import functools
 
 required_conan_version = ">1.43.0"
 
@@ -9,11 +11,10 @@ required_conan_version = ">1.43.0"
 class ThriftConan(ConanFile):
     name = "thrift"
     description = "Thrift is an associated code generation mechanism for RPC"
-    topics = ("thrift", "serialization", "rpc")
+    license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/apache/thrift"
-    license = "Apache-2.0"
-
+    topics = ("thrift", "serialization", "rpc")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -25,7 +26,7 @@ class ThriftConan(ConanFile):
         "with_cpp": [True, False],
         "with_java": [True, False],
         "with_python": [True, False],
-        "with_qt": [True, False],
+        "with_qt5": [True, False],
         "with_haskell": [True, False],
     }
     default_options = {
@@ -38,13 +39,12 @@ class ThriftConan(ConanFile):
         "with_cpp": True,
         "with_java": False,
         "with_python": False,
-        "with_qt": False,
+        "with_qt5": False,
         "with_haskell": False,
     }
 
     short_paths = True
     generators = "cmake", "cmake_find_package"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -53,15 +53,6 @@ class ThriftConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
-
-    @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
-
-    @property
-    def _is_vc_static_runtime(self):
-        return (self.settings.compiler == "Visual Studio" and "MT" in self.settings.compiler.runtime) or \
-               (str(self.settings.compiler) == "msvc" and self.settings.compiler.runtime == "static")
 
     @property
     def _settings_build(self):
@@ -81,18 +72,15 @@ class ThriftConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("boost/1.78.0")
+        self.requires("boost/1.79.0")
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1n")
+            self.requires("openssl/1.1.1o")
         if self.options.with_zlib:
             self.requires("zlib/1.2.12")
         if self.options.with_libevent:
             self.requires("libevent/2.1.12")
-
-    def validate(self):
-        if self.options.with_qt:
-            # FIXME: missing qt recipe
-            raise ConanInvalidConfiguration("qt is not (yet) available on cci")
+        if self.options.with_qt5:
+            self.requires("qt/5.15.4")
 
     def build_requirements(self):
         if self._settings_build.os == "Windows":
@@ -105,36 +93,33 @@ class ThriftConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
+        cmake = CMake(self)
         for option, value in self.options.items():
             if option.startswith("with_"):
-                self._cmake.definitions[option.upper()] = value
+                cmake.definitions[option.upper()] = value
 
-        self._cmake.definitions["WITH_SHARED_LIB"] = self.options.shared
-        self._cmake.definitions["WITH_STATIC_LIB"] = not self.options.shared
-        self._cmake.definitions["BOOST_ROOT"] = self.deps_cpp_info["boost"].rootpath
-        self._cmake.definitions["BUILD_TESTING"] = False
-        self._cmake.definitions["BUILD_COMPILER"] = True
-        self._cmake.definitions["BUILD_LIBRARIES"] = True
-        self._cmake.definitions["BUILD_TUTORIALS"] = False
+        cmake.definitions["BOOST_ROOT"] = self.deps_cpp_info["boost"].rootpath
+        cmake.definitions["BUILD_TESTING"] = False
+        cmake.definitions["BUILD_COMPILER"] = True
+        cmake.definitions["BUILD_LIBRARIES"] = True
+        cmake.definitions["BUILD_TUTORIALS"] = False
 
-        if self._is_msvc:
-            self._cmake.definitions["WITH_MT"] = self._is_vc_static_runtime
+        if is_msvc(self):
+            cmake.definitions["WITH_MT"] = is_msvc_static_runtime(self)
 
         # Make optional libs "findable"
         if self.options.with_openssl:
-            self._cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath
+            cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath
         if self.options.with_zlib:
-            self._cmake.definitions["ZLIB_ROOT"] = self.deps_cpp_info["zlib"].rootpath
-        self._cmake.definitions["WITH_LIBEVENT"] = self.options.with_libevent
+            cmake.definitions["ZLIB_ROOT"] = self.deps_cpp_info["zlib"].rootpath
+        cmake.definitions["WITH_LIBEVENT"] = self.options.with_libevent
         if self.options.with_libevent:
-            self._cmake.definitions["LIBEVENT_ROOT"] = self.deps_cpp_info["libevent"].rootpath
+            cmake.definitions["LIBEVENT_ROOT"] = self.deps_cpp_info["libevent"].rootpath
 
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -161,7 +146,7 @@ class ThriftConan(ConanFile):
             targets.update({"thriftz::thriftz": "thrift::thriftz"})
         if self.options.with_libevent:
             targets.update({"thriftnb::thriftnb": "thrift::thriftnb"})
-        if self.options.with_qt:
+        if self.options.with_qt5:
             targets.update({"thriftqt5::thriftqt5": "thrift::thriftqt5"})
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),
@@ -191,7 +176,7 @@ class ThriftConan(ConanFile):
         self.cpp_info.set_property("pkg_config_name", "thrift_conan_do_not_use")
 
         libsuffix = "{}{}".format(
-            ("mt" if self._is_vc_static_runtime else "md") if self._is_msvc else "",
+            ("mt" if is_msvc_static_runtime(self) else "md") if is_msvc(self) else "",
             "d" if self.settings.build_type == "Debug" else "",
         )
 
@@ -219,11 +204,11 @@ class ThriftConan(ConanFile):
             self.cpp_info.components["libthrift_nb"].libs = ["thriftnb" + libsuffix]
             self.cpp_info.components["libthrift_nb"].requires = ["libthrift", "libevent::libevent"]
 
-        if self.options.with_qt:
+        if self.options.with_qt5:
             self.cpp_info.components["libthrift_qt5"].set_property("cmake_target_name", "thriftqt5::thriftqt5")
             self.cpp_info.components["libthrift_qt5"].set_property("pkg_config_name", "thrift-qt5")
             self.cpp_info.components["libthrift_qt5"].libs = ["thriftqt5" + libsuffix]
-            self.cpp_info.components["libthrift_qt5"].requires = ["libthrift", "qt::core"]
+            self.cpp_info.components["libthrift_qt5"].requires = ["libthrift", "qt::qtCore"]
 
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH env var with : {}".format(bin_path))
@@ -247,7 +232,7 @@ class ThriftConan(ConanFile):
             self.cpp_info.components["libthrift_nb"].names["cmake_find_package_multi"] = "thriftnb"
             self.cpp_info.components["libthrift_nb"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
             self.cpp_info.components["libthrift_nb"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
-        if self.options.with_qt:
+        if self.options.with_qt5:
             self.cpp_info.components["libthrift_qt5"].names["cmake_find_package"] = "thriftqt5"
             self.cpp_info.components["libthrift_qt5"].names["cmake_find_package_multi"] = "thriftqt5"
             self.cpp_info.components["libthrift_qt5"].build_modules["cmake_find_package"] = [self._module_file_rel_path]

--- a/recipes/thrift/all/patches/cmake-0.16.0.patch
+++ b/recipes/thrift/all/patches/cmake-0.16.0.patch
@@ -1,0 +1,125 @@
+diff --git a/build/cmake/DefineInstallationPaths.cmake b/build/cmake/DefineInstallationPaths.cmake
+index 23962b4..0c824cc 100644
+--- a/build/cmake/DefineInstallationPaths.cmake
++++ b/build/cmake/DefineInstallationPaths.cmake
+@@ -20,11 +20,7 @@
+ 
+ # Define the default install paths
+ set(BIN_INSTALL_DIR "bin" CACHE PATH "The binary install dir (default: bin)")
+-if(MSVC)
+-    set(LIB_INSTALL_DIR "bin${LIB_SUFFIX}" CACHE PATH "The library install dir (default: bin${LIB_SUFFIX})")
+-else()
+-    set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE PATH "The library install dir (default: lib${LIB_SUFFIX})")
+-endif()
++set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE PATH "The library install dir (default: lib${LIB_SUFFIX})")
+ set(INCLUDE_INSTALL_DIR "include" CACHE PATH "The library install dir (default: include)")
+ set(CMAKE_INSTALL_DIR "lib/cmake" CACHE PATH "The subdirectory to install cmake config files (default: cmake)")
+ set(PKGCONFIG_INSTALL_DIR "lib/pkgconfig" CACHE PATH "The subdirectory to install pkgconfig config files (default: lib/pkgconfig)")
+diff --git a/build/cmake/DefineOptions.cmake b/build/cmake/DefineOptions.cmake
+index 3cca31e..ffc2811 100644
+--- a/build/cmake/DefineOptions.cmake
++++ b/build/cmake/DefineOptions.cmake
+@@ -39,11 +39,6 @@ option(BUILD_LIBRARIES "Build Thrift libraries" ON)
+ # and enables the library if all are found. This means the default is to build as
+ # much as possible but leaving out libraries if their dependencies are not met.
+ 
+-if (NOT Boost_USE_STATIC_LIBS)
+-    add_definitions(-DBOOST_ALL_DYN_LINK)
+-    add_definitions(-DBOOST_TEST_DYN_LINK)
+-endif()
+-
+ # as3
+ option(WITH_AS3 "Build ActionScript 3 Thrift Library" ON)
+ if (WITH_AS3)
+@@ -90,6 +85,7 @@ if(WITH_CPP OR WITH_C_GLIB)
+     find_package(OpenSSL QUIET)
+     CMAKE_DEPENDENT_OPTION(WITH_OPENSSL "Build with OpenSSL support" ON
+                         "OPENSSL_FOUND" OFF)
++    OPTION(WITH_OPENSSL "Build with OpenSSL support" ON)
+ endif()
+ 
+ # Java
+@@ -106,14 +102,10 @@ else()
+ endif()
+ 
+ # Javascript
+-option(WITH_JAVASCRIPT "Build Javascript Thrift library" ON)
+-CMAKE_DEPENDENT_OPTION(BUILD_JAVASCRIPT "Build Javascript library" ON
+-                       "BUILD_LIBRARIES;WITH_JAVASCRIPT;NOT WIN32; NOT CYGWIN" OFF)
++option(WITH_JAVASCRIPT "Build Javascript Thrift library" OFF)
+ 
+ # NodeJS
+-option(WITH_NODEJS "Build NodeJS Thrift library" ON)
+-CMAKE_DEPENDENT_OPTION(BUILD_NODEJS "Build NodeJS library" ON
+-                       "BUILD_LIBRARIES;WITH_NODEJS" OFF)
++option(WITH_NODEJS "Build NodeJS Thrift library" OFF)
+ 
+ # Python
+ option(WITH_PYTHON "Build Python Thrift library" ON)
+diff --git a/lib/c_glib/CMakeLists.txt b/lib/c_glib/CMakeLists.txt
+index 218f7dd..b879830 100644
+--- a/lib/c_glib/CMakeLists.txt
++++ b/lib/c_glib/CMakeLists.txt
+@@ -71,7 +71,8 @@ set(thrift_c_glib_zlib_SOURCES
+ )
+ 
+ # If OpenSSL is not found just ignore the OpenSSL stuff
+-if(OPENSSL_FOUND AND WITH_OPENSSL)
++if(WITH_OPENSSL)
++    find_package(OpenSSL REQUIRED)
+     list(APPEND thrift_c_glib_SOURCES
+ 	    src/thrift/c_glib/transport/thrift_ssl_socket.c
+     )
+@@ -83,8 +84,7 @@ if(OPENSSL_FOUND AND WITH_OPENSSL)
+             list(APPEND SYSLIBS OpenSSL::Crypto)
+         endif()
+     else()
+-        include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
+-        list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
++        list(APPEND SYSLIBS OpenSSL::OpenSSL)
+     endif()
+ endif()
+ 
+diff --git a/lib/cpp/CMakeLists.txt b/lib/cpp/CMakeLists.txt
+index 13b41c5..4b2b116 100755
+--- a/lib/cpp/CMakeLists.txt
++++ b/lib/cpp/CMakeLists.txt
+@@ -96,7 +96,8 @@ else()
+ endif()
+ 
+ # If OpenSSL is not found or disabled just ignore the OpenSSL stuff
+-if(OPENSSL_FOUND AND WITH_OPENSSL)
++if(WITH_OPENSSL)
++    find_package(OpenSSL REQUIRED)
+     list(APPEND thriftcpp_SOURCES
+        src/thrift/transport/TSSLSocket.cpp
+        src/thrift/transport/TSSLServerSocket.cpp
+@@ -111,8 +112,7 @@ if(OPENSSL_FOUND AND WITH_OPENSSL)
+             list(APPEND SYSLIBS OpenSSL::Crypto)
+         endif()
+     else()
+-        include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
+-        list(APPEND SYSLIBS "${OPENSSL_LIBRARIES}")
++        list(APPEND SYSLIBS OpenSSL::OpenSSL)
+     endif()
+ endif()
+ 
+@@ -167,16 +167,11 @@ ADD_PKGCONFIG_THRIFT(thrift)
+ 
+ if(WITH_LIBEVENT)
+     find_package(Libevent REQUIRED)  # Libevent comes with CMake support from upstream
+-    include_directories(SYSTEM ${LIBEVENT_INCLUDE_DIRS})
+ 
+     ADD_LIBRARY_THRIFT(thriftnb ${thriftcppnb_SOURCES})
+     target_link_libraries(thriftnb PUBLIC thrift)
+-    if(TARGET libevent::core AND TARGET libevent::extra)
+-        # libevent was found via its cmake config, use modern style targets
+-        target_link_libraries(thriftnb PUBLIC libevent::core libevent::extra)
+-    else()
+-        target_link_libraries(thriftnb PUBLIC ${LIBEVENT_LIBRARIES})
+-    endif()
++    # libevent was found via its cmake config, use modern style targets
++    target_link_libraries(thriftnb PUBLIC libevent::core libevent::extra)
+     ADD_PKGCONFIG_THRIFT(thrift-nb)
+ endif()
+ 

--- a/recipes/thrift/config.yml
+++ b/recipes/thrift/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.16.0":
+    folder: all
   "0.15.0":
     folder: all
   "0.14.2":


### PR DESCRIPTION
Specify library name and version:  **thrift/0.16.0**

- update boost/1.79.0
- enable with_qt (renamed as with_qt5 because cmake option is `WITH_QT5`
- some cmake options(WITH_STATIC_LIB, WITH_SHARED_LIB) are deprecated since 0.12.0. So they are removed.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
