### PR TITLE
[icu] Eliminate the runConfigureICU script from the ICU build.

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -108,8 +108,11 @@ class ICUBase(ConanFile):
         env_build = self._configure_autotools()
         build_dir = os.path.join(self.build_folder, self._source_subfolder, "build")
         os.mkdir(build_dir)
+        build_env = env_build.vars
+        if self._is_msvc:
+            build_env.update({'CC': 'cl', 'CXX': 'cl'})
         with tools.vcvars(self.settings) if self._is_msvc else tools.no_op():
-            with tools.environment_append(env_build.vars):
+            with tools.environment_append(build_env):
                 with tools.chdir(build_dir):
                     # workaround for https://unicode-org.atlassian.net/browse/ICU-20531
                     os.makedirs(os.path.join("data", "out", "tmp"))

--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -154,6 +154,8 @@ class ICUBase(ConanFile):
         if self._env_build:
             return self._env_build
         self._env_build = AutoToolsBuildEnvironment(self)
+        if self._is_msvc:
+            self._env_build.flags.append("-FS")
         if not self.options.shared:
             self._env_build.defines.append("U_STATIC_IMPLEMENTATION")
         if tools.is_apple_os(self.settings.os):


### PR DESCRIPTION
runConfigureICU sets up a few fixed configuraitons, providing flags to configure, but also
prevents configure from using other environment variables it is designed to use.
We could, if there is a need, add these to flags set in conanfile.py, but because
Conan supports Autoconf directly, there probably isn't a need for this.
The reciple only supports a few configuraitons, so adding support for a new compiler
or operating system would require modificaitons to runConfgiureICU - none of which is actually useful.

Specify library name and version:  **icu/71.1**

As discussed in [PR#10906](https://github.com/conan-io/conan-center-index/pull/10906) (previous PR for the ICU recipe), runConfigureICU really just limits what Autoconf can do.
For the Msys/Cygwin flags that it does set, these probably don't need to be handled any differently than any other Autoconf based project. 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
