### PR TITLE
cpp-httplib: add version 0.10.8

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10.8":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.10.8.tar.gz"
+    sha256: "2959ae3669e34ca8934dfe066cd72fc2bfff44ba53bfc26f3b2cb81ed664ca0d"
   "0.10.7":
     url: "https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.10.7.tar.gz"
     sha256: "f89e2e74f64821f3cd925750dcee5dde7160600b1122e692253a4ebed8e1b1b1"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.10.8":
+    folder: all
   "0.10.7":
     folder: all
   "0.10.6":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cpp-httplib/0.10.8**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
