### PR TITLE
cpp-peglib: add version 1.4.2

### DIFF
--- a/recipes/cpp-peglib/1.x.x/conandata.yml
+++ b/recipes/cpp-peglib/1.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.2":
+    url: "https://github.com/yhirose/cpp-peglib/archive/v1.4.2.tar.gz"
+    sha256: "28a09c1bee50608733a989cd5b62368a767a66f9e1a39654c0342e9698c479ca"
   "1.4.1":
     url: "https://github.com/yhirose/cpp-peglib/archive/v1.4.1.tar.gz"
     sha256: "3784039727f8317cd5e202c5a2d142584bf48a311910643298dc4ba9083424e7"

--- a/recipes/cpp-peglib/config.yml
+++ b/recipes/cpp-peglib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.2":
+    folder: "1.x.x"
   "1.4.1":
     folder: "1.x.x"
   "1.3.10":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cpp-peglib/1.4.2**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
