### PR TITLE
libmysqlclient: add version 8.0.29

### DIFF
--- a/recipes/libmysqlclient/all/conandata.yml
+++ b/recipes/libmysqlclient/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.0.29":
+    url: "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.29.tar.gz"
+    sha256: "512170fa6f78a694d6f18d197e999d2716ee68dc541d7644dd922a3663407266"
   "8.0.25":
     url: "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.25.tar.gz"
     sha256: "c16aa9cf621bc028efba2bb11f3c36a323b125fa0d108ff92fab60e46309206e"
@@ -6,6 +9,9 @@ sources:
     url: "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.17.tar.gz"
     sha256: "c6e3f38199a77bfd8a4925ca00b252d3b6159b90e4980c7232f1c58d6ca759d6"
 patches:
+  "8.0.29":
+    - patch_file: "patches/0006-fix-cpp20-build-8.0.29.patch"
+      base_path: "source_subfolder"
   "8.0.25":
     - patch_file: "patches/0004-fix-805-cpp17-build.patch"
       base_path: "source_subfolder"

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -189,6 +189,7 @@ class LibMysqlClientCConan(ConanFile):
         cmake.definitions["WITHOUT_SERVER"] = True
         cmake.definitions["WITH_UNIT_TESTS"] = False
         cmake.definitions["ENABLED_PROFILING"] = False
+        cmake.definitions["MYSQL_MAINTAINER_MODE"] = False
         cmake.definitions["WIX_DIR"] = False
         if self._with_lz4:
             cmake.definitions["WITH_LZ4"] = "system"

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -102,6 +102,12 @@ class LibMysqlClientCConan(ConanFile):
            tools.Version(self.settings.compiler.version) >= "12.0":
             raise ConanInvalidConfiguration("libmysqlclient 8.0.17 doesn't support apple-clang >= 12.0")
 
+        # mysql>=8.0.17 doesn't support shared library on MacOS.
+        # https://github.com/mysql/mysql-server/blob/mysql-8.0.17/cmake/libutils.cmake#L333-L335
+        if tools.Version(self.version) >= "8.0.17" and self.settings.compiler == "apple-clang" and \
+           self.options.shared:
+            raise ConanInvalidConfiguration("{}/{} doesn't support shared library".format( self.name, self.version))
+
         # mysql < 8.0.29 uses `requires` in source code. It is the reserved keyword in C++20.
         # https://github.com/mysql/mysql-server/blob/mysql-8.0.0/include/mysql/components/services/dynamic_loader.h#L270
         if self.settings.compiler.get_safe("cppstd") == "20" and tools.Version(self.version) < "8.0.29":

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -49,7 +49,7 @@ class LibMysqlClientCConan(ConanFile):
     def _compilers_minimum_version(self):
         return {
             "Visual Studio": "16" if tools.Version(self.version) > "8.0.17" else "15",
-            "gcc": "5.3",
+            "gcc": "7" if tools.Version(self.version) >= "8.0.27" else "5.3",
             "clang": "6",
         }
 

--- a/recipes/libmysqlclient/all/patches/0006-fix-cpp20-build-8.0.29.patch
+++ b/recipes/libmysqlclient/all/patches/0006-fix-cpp20-build-8.0.29.patch
@@ -1,0 +1,17 @@
+diff --git a/sql/sql_bitmap.h b/sql/sql_bitmap.h
+index a03d754..381216d 100644
+--- a/sql/sql_bitmap.h
++++ b/sql/sql_bitmap.h
+@@ -138,10 +138,10 @@ class Bitmap<64> {
+   ulonglong map;
+ 
+  public:
+-  Bitmap<64>() { init(); }
++  Bitmap() { init(); }
+   enum { ALL_BITS = 64 };
+ 
+-  explicit Bitmap<64>(uint prefix_to_set) { set_prefix(prefix_to_set); }
++  explicit Bitmap(uint prefix_to_set) { set_prefix(prefix_to_set); }
+   void init() { clear_all(); }
+   void init(uint prefix_to_set) { set_prefix(prefix_to_set); }
+   uint length() const { return 64; }

--- a/recipes/libmysqlclient/config.yml
+++ b/recipes/libmysqlclient/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.0.29":
+    folder: all
   "8.0.25":
     folder: all
   "8.0.17":


### PR DESCRIPTION
Specify library name and version:  **libmysqlclient/8.0.29**

libmysqlclient uses `requires` C++20 keyword since 8.0.0.
I have to update libmysqlclient to 8.0.29 to compile it with C++20.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
