### PR TITLE
add dice-template-library conan package

### DIFF
--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -1,0 +1,6 @@
+sources:
+  "0.1":
+    # this is a workaround, because the template library isn't publicly released currently!
+    # just start a simple http server via `python3 -m http.server 8000' in a folder with the tar.gz file.
+    url: "http://localhost:8000/DiceTemplateLibrary-0.1.tar.gz"
+    sha256: "192ea3d2c14952e7ac49128fed0fb908db60f9b88d24bfa61a7782e6b06feb03"

--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -2,5 +2,5 @@ sources:
   "0.1.0":
     # this is a workaround, because the template library isn't publicly released currently!
     # just start a simple http server via `python3 -m http.server 8000' in a folder with the tar.gz file.
-    url: "http://localhost:8000/DiceTemplateLibrary-0.1.0.tar.gz"
-    sha256: "527d77c10412797444d57fd16cc67f64e8128d11eeecdb54c67ff0de7023c07b"
+    url: "http://localhost:8000/dice-template-library-0.1.0.tar.gz"
+    sha256: "3f40705a9e3cb048d7ea3d1081ee7d2a99728f07444adcd5ccda26dea7f82617"

--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -3,4 +3,4 @@ sources:
     # this is a workaround, because the template library isn't publicly released currently!
     # just start a simple http server via `python3 -m http.server 8000' in a folder with the tar.gz file.
     url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v0.1.0.tar.gz"
-    sha256: "a832e9984bae4fd50575f07fb0e39a9fc401eb54c1847b20c3f5266c4af24f45"
+    sha256: "780239cabab23f72982fb1891e031a3b280f27b27ac0b5adb7a30d648c5474d0"

--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
-  "0.1":
+  "0.1.0":
     # this is a workaround, because the template library isn't publicly released currently!
     # just start a simple http server via `python3 -m http.server 8000' in a folder with the tar.gz file.
-    url: "http://localhost:8000/DiceTemplateLibrary-0.1.tar.gz"
-    sha256: "192ea3d2c14952e7ac49128fed0fb908db60f9b88d24bfa61a7782e6b06feb03"
+    url: "http://localhost:8000/DiceTemplateLibrary-0.1.0.tar.gz"
+    sha256: "527d77c10412797444d57fd16cc67f64e8128d11eeecdb54c67ff0de7023c07b"

--- a/recipes/dice-template-library/all/conandata.yml
+++ b/recipes/dice-template-library/all/conandata.yml
@@ -2,5 +2,5 @@ sources:
   "0.1.0":
     # this is a workaround, because the template library isn't publicly released currently!
     # just start a simple http server via `python3 -m http.server 8000' in a folder with the tar.gz file.
-    url: "http://localhost:8000/dice-template-library-0.1.0.tar.gz"
-    sha256: "3f40705a9e3cb048d7ea3d1081ee7d2a99728f07444adcd5ccda26dea7f82617"
+    url: "https://github.com/dice-group/dice-template-library/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "a832e9984bae4fd50575f07fb0e39a9fc401eb54c1847b20c3f5266c4af24f45"

--- a/recipes/dice-template-library/all/conanfile.py
+++ b/recipes/dice-template-library/all/conanfile.py
@@ -1,0 +1,34 @@
+import os
+from conans import ConanFile, CMake, tools
+
+required_conan_version = ">=1.33.0"
+
+class DiceTemplateLibrary(ConanFile):
+    description = "some description"
+    name = "dice-template-library"
+    homepage = "https://dice-research.org/"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("some", "topics")
+    license = "mit"
+    settings = "build_type", "compiler", "os", "arch"
+    generators = "cmake", "cmake_find_package", "cmake_paths"
+    exports_sources = "include/*", "CMakeLists.txt", "cmake/*"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+       tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def package(self):
+        self.copy(pattern="license", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "DiceTemplateLibrary"
+        self.cpp_info.names["cmake_find_package_multi"] = "DiceTemplateLibrary"

--- a/recipes/dice-template-library/all/conanfile.py
+++ b/recipes/dice-template-library/all/conanfile.py
@@ -6,10 +6,9 @@ required_conan_version = ">=1.33.0"
 
 class DiceTemplateLibrary(ConanFile):
     name = "dice-template-library"
-    author = "DICE Group <info@dice-research.org>"
     description = "This template library is a collection of handy template-oriented code that we, the Data Science Group at UPB, found pretty handy."
     homepage = "https://dice-research.org/"
-    url = "https://github.com/dice-group/DiceTemplateLibrary.git"
+    url = "https://github.com/conan-io/conan-center-index"
     license = "MIT"
     topics = ("template", "template library", "compile-time", "switch", "integral tuple")
     settings = "build_type", "compiler", "os", "arch"

--- a/recipes/dice-template-library/all/conanfile.py
+++ b/recipes/dice-template-library/all/conanfile.py
@@ -3,13 +3,15 @@ from conans import ConanFile, CMake, tools
 
 required_conan_version = ">=1.33.0"
 
+
 class DiceTemplateLibrary(ConanFile):
-    description = "some description"
-    name = "dice-template-library"
+    name = "DiceTemplateLibrary"
+    author = "DICE Group <info@dice-research.org>"
+    description = "This template library is a collection of handy template-oriented code that we, the Data Science Group at UPB, found pretty handy."
     homepage = "https://dice-research.org/"
-    url = "https://github.com/conan-io/conan-center-index"
-    topics = ("some", "topics")
-    license = "mit"
+    url = "https://github.com/dice-group/DiceTemplateLibrary.git"
+    license = "MIT"
+    topics = ("template", "template library", "compile-time", "switch", "integral tuple")
     settings = "build_type", "compiler", "os", "arch"
     generators = "cmake", "cmake_find_package", "cmake_paths"
     exports_sources = "include/*", "CMakeLists.txt", "cmake/*"
@@ -20,7 +22,7 @@ class DiceTemplateLibrary(ConanFile):
         return "source_subfolder"
 
     def source(self):
-       tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def package(self):
         self.copy(pattern="license", dst="licenses", src=self._source_subfolder)

--- a/recipes/dice-template-library/all/conanfile.py
+++ b/recipes/dice-template-library/all/conanfile.py
@@ -5,7 +5,7 @@ required_conan_version = ">=1.33.0"
 
 
 class DiceTemplateLibrary(ConanFile):
-    name = "DiceTemplateLibrary"
+    name = "dice-template-library"
     author = "DICE Group <info@dice-research.org>"
     description = "This template library is a collection of handy template-oriented code that we, the Data Science Group at UPB, found pretty handy."
     homepage = "https://dice-research.org/"

--- a/recipes/dice-template-library/all/test_package/CMakeLists.txt
+++ b/recipes/dice-template-library/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/dice-template-library/all/test_package/conanfile.py
+++ b/recipes/dice-template-library/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)
+

--- a/recipes/dice-template-library/all/test_package/test_package.cpp
+++ b/recipes/dice-template-library/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+#include <concepts>
+#include <Dice/IntegralTemplatedTuple.hpp>
+#include <ios>
+#include <iostream>
+
+template <int N> struct Wrapper { static constexpr int i = N; };
+
+int main() {
+  Dice::templateLibrary::IntegralTemplatedTuple<Wrapper, 0, 5> tup;
+  std::cout << std::boolalpha << "tup.get<3>().i == 3: " << (tup.get<3>().i == 3) << std::endl;
+}

--- a/recipes/dice-template-library/all/test_package/test_package.cpp
+++ b/recipes/dice-template-library/all/test_package/test_package.cpp
@@ -1,5 +1,5 @@
 #include <concepts>
-#include <Dice/template_library/IntegralTemplatedTuple.hpp>
+#include <Dice/template-library/integral_templated_tuple.hpp>
 #include <ios>
 #include <iostream>
 

--- a/recipes/dice-template-library/all/test_package/test_package.cpp
+++ b/recipes/dice-template-library/all/test_package/test_package.cpp
@@ -1,11 +1,11 @@
 #include <concepts>
-#include <Dice/IntegralTemplatedTuple.hpp>
+#include <Dice/template_library/IntegralTemplatedTuple.hpp>
 #include <ios>
 #include <iostream>
 
 template <int N> struct Wrapper { static constexpr int i = N; };
 
 int main() {
-  Dice::templateLibrary::IntegralTemplatedTuple<Wrapper, 0, 5> tup;
+  Dice::template_library::IntegralTemplatedTuple<Wrapper, 0, 5> tup;
   std::cout << std::boolalpha << "tup.get<3>().i == 3: " << (tup.get<3>().i == 3) << std::endl;
 }

--- a/recipes/dice-template-library/all/test_package/test_package.cpp
+++ b/recipes/dice-template-library/all/test_package/test_package.cpp
@@ -1,11 +1,11 @@
 #include <concepts>
-#include <Dice/template-library/integral_templated_tuple.hpp>
+#include <Dice/template-library/integral_template_tuple.hpp>
 #include <ios>
 #include <iostream>
 
 template <int N> struct Wrapper { static constexpr int i = N; };
 
 int main() {
-  Dice::template_library::IntegralTemplatedTuple<Wrapper, 0, 5> tup;
+  Dice::template_library::integral_template_tuple<Wrapper, 0, 5> tup;
   std::cout << std::boolalpha << "tup.get<3>().i == 3: " << (tup.get<3>().i == 3) << std::endl;
 }

--- a/recipes/dice-template-library/config.yml
+++ b/recipes/dice-template-library/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1":
+    folder: all

--- a/recipes/dice-template-library/config.yml
+++ b/recipes/dice-template-library/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1":
+  "0.1.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **[dice-template-library/0.1.0](https://github.com/dice-group/dice-template-library)**

This template library is a collection of template-oriented code that we, the Data Science Group at UPB, found pretty handy. This is a new addition to conan center.  

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
