### PR TITLE
tinycthread: add recipe

### DIFF
--- a/recipes/tinycthread/all/CMakeLists.txt
+++ b/recipes/tinycthread/all/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper C)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(TARGETS KEEP_RPATHS)
+
+set(CMAKE_C_STANDARD 11)
+
+add_subdirectory(source_subfolder)

--- a/recipes/tinycthread/all/conandata.yml
+++ b/recipes/tinycthread/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "cci.20161001":
+    url: "https://github.com/tinycthread/tinycthread/archive/6957fc8383d6c7db25b60b8c849b29caab1caaee.tar.gz"
+    sha256: "7068d21ddffaab68eea6d41a39ea8b6597984ef2436eee3d4bcf664ec67528f9"

--- a/recipes/tinycthread/all/conanfile.py
+++ b/recipes/tinycthread/all/conanfile.py
@@ -64,3 +64,5 @@ class TinycthreadConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["tinycthread"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["pthread"]

--- a/recipes/tinycthread/all/conanfile.py
+++ b/recipes/tinycthread/all/conanfile.py
@@ -1,0 +1,66 @@
+from conans import CMake, ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import msvc_runtime_flag, is_msvc
+import functools
+import os
+
+required_conan_version = ">=1.33.0"
+
+class TinycthreadConan(ConanFile):
+    name = "tinycthread"
+    description = "Small, portable implementation of the C11 threads API"
+    license = "zlib"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/tinycthread/tinycthread"
+    topics = ("thread", "c11", "portable")
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+
+    def configure(self):
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["TINYCTHREAD_DISABLE_TESTS"] = True
+        cmake.definitions["TINYCTHREAD_INSTALL"] = True
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def _extract_license(self):
+        file = os.path.join(self.source_folder, self._source_subfolder, "source", "tinycthread.h")
+        file_content = tools.load(file)
+
+        license_start = file_content.find("Copyright")
+        license_end = file_content.find("*/")
+        license_contents = file_content[license_start:license_end]
+        tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), license_contents)
+
+    def package(self):
+        self._extract_license()
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["tinycthread"]

--- a/recipes/tinycthread/all/test_package/CMakeLists.txt
+++ b/recipes/tinycthread/all/test_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+
+conan_basic_setup(TARGETS)
+
+find_package(tinycthread REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} tinycthread::tinycthread)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_11)

--- a/recipes/tinycthread/all/test_package/conanfile.py
+++ b/recipes/tinycthread/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/tinycthread/all/test_package/test_package.c
+++ b/recipes/tinycthread/all/test_package/test_package.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <tinycthread.h>
+
+/* This is the child thread function */
+int HelloThread(void * aArg)
+{
+  (void)aArg;
+
+  printf("Hello world!\n");
+  return 0;
+}
+
+/* This is the main program (i.e. the main thread) */
+int main()
+{
+  /* Start the child thread */
+  thrd_t t;
+  if (thrd_create(&t, HelloThread, (void*)0) == thrd_success)
+  {
+    /* Wait for the thread to finish */
+    thrd_join(t, NULL);
+  }
+
+  return 0;
+}

--- a/recipes/tinycthread/config.yml
+++ b/recipes/tinycthread/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "cci.20161001":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **tinycthread/cci.20161001**

tinycthread has 1.1 release but it doesn't use CMakeLists.txt.
Because HEAD already uses CMakeLists.txt, I decide to use it.

Try to solve https://github.com/conan-io/conan-center-index/issues/11070.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
