### PR TITLE
capnproto: add version 0.10.1

### DIFF
--- a/recipes/capnproto/all/conandata.yml
+++ b/recipes/capnproto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10.1":
+    url: "https://github.com/capnproto/capnproto/archive/v0.10.1.tar.gz"
+    sha256: "2e9c918f02c198557c75ca7c635fe281337c9755b752a6ab3a841bcc1cf5176b"
   "0.10.0":
     url: "https://github.com/capnproto/capnproto/archive/v0.10.0.tar.gz"
     sha256: "0e46a72d086830762c001116c0a146098fbdce3cd40665a0ffd4742962d42bfd"
@@ -12,6 +15,9 @@ sources:
     url: "https://github.com/capnproto/capnproto/archive/v0.7.0.tar.gz"
     sha256: 76c7114a3d142ad08b7208b3964a26e72a6320ee81331d3f0b87569fc9c47a28
 patches:
+  "0.10.1":
+    - patch_file: patches/0014-disable-tests-for-0.10.1.patch
+      base_path: source_subfolder
   "0.10.0":
     - patch_file: patches/0013-disable-tests-for-0.10.0.patch
       base_path: source_subfolder

--- a/recipes/capnproto/all/patches/0014-disable-tests-for-0.10.1.patch
+++ b/recipes/capnproto/all/patches/0014-disable-tests-for-0.10.1.patch
@@ -1,0 +1,176 @@
+diff --git a/c++/Makefile.am b/c++/Makefile.am
+index 40a1d95..08f6eda 100644
+--- a/c++/Makefile.am
++++ b/c++/Makefile.am
+@@ -446,171 +446,3 @@ endif LITE_MODE
+ #  src/capnp/benchmark/...
+ #  src/capnp/compiler/...
+ 
+-# Tests ==============================================================
+-
+-test_capnpc_inputs =                                           \
+-  src/capnp/test.capnp                                         \
+-  src/capnp/test-import.capnp                                  \
+-  src/capnp/test-import2.capnp                                 \
+-  src/capnp/compat/json-test.capnp
+-
+-test_capnpc_outputs =                                          \
+-  src/capnp/test.capnp.c++                                     \
+-  src/capnp/test.capnp.h                                       \
+-  src/capnp/test-import.capnp.c++                              \
+-  src/capnp/test-import.capnp.h                                \
+-  src/capnp/test-import2.capnp.c++                             \
+-  src/capnp/test-import2.capnp.h                               \
+-  src/capnp/compat/json-test.capnp.c++                         \
+-  src/capnp/compat/json-test.capnp.h
+-
+-if USE_EXTERNAL_CAPNP
+-
+-test_capnpc_middleman: $(test_capnpc_inputs)
+-	@$(MKDIR_P) src
+-	$(CAPNP) compile --src-prefix=$(srcdir)/src -o$(CAPNPC_CXX):src -I$(srcdir)/src $$(for FILE in $(test_capnpc_inputs); do echo $(srcdir)/$$FILE; done)
+-	touch test_capnpc_middleman
+-
+-else
+-
+-test_capnpc_middleman: capnp$(EXEEXT) capnpc-c++$(EXEEXT) $(test_capnpc_inputs)
+-	@$(MKDIR_P) src
+-	./capnp$(EXEEXT) compile --src-prefix=$(srcdir)/src -o./capnpc-c++$(EXEEXT):src -I$(srcdir)/src $$(for FILE in $(test_capnpc_inputs); do echo $(srcdir)/$$FILE; done)
+-	touch test_capnpc_middleman
+-
+-endif
+-
+-$(test_capnpc_outputs): test_capnpc_middleman
+-
+-BUILT_SOURCES = $(test_capnpc_outputs)
+-
+-check_LIBRARIES = libcapnp-test.a
+-libcapnp_test_a_SOURCES =                                      \
+-  src/capnp/test-util.c++                                      \
+-  src/capnp/test-util.h
+-nodist_libcapnp_test_a_SOURCES = $(test_capnpc_outputs)
+-
+-if LITE_MODE
+-
+-check_PROGRAMS = capnp-test
+-compiler_tests =
+-capnp_test_LDADD = libcapnp-test.a libcapnp.la libkj-test.la libkj.la
+-
+-else !LITE_MODE
+-
+-check_PROGRAMS = capnp-test capnp-evolution-test capnp-afl-testcase
+-if HAS_FUZZING_ENGINE
+-    check_PROGRAMS += capnp-llvm-fuzzer-testcase
+-endif
+-heavy_tests =                                                  \
+-  src/kj/async-test.c++                                        \
+-  src/kj/async-xthread-test.c++                                \
+-  src/kj/async-coroutine-test.c++                              \
+-  src/kj/async-unix-test.c++                                   \
+-  src/kj/async-unix-xthread-test.c++                           \
+-  src/kj/async-win32-test.c++                                  \
+-  src/kj/async-win32-xthread-test.c++                          \
+-  src/kj/async-io-test.c++                                     \
+-  src/kj/async-queue-test.c++                                  \
+-  src/kj/parse/common-test.c++                                 \
+-  src/kj/parse/char-test.c++                                   \
+-  src/kj/std/iostream-test.c++                                 \
+-  src/kj/compat/url-test.c++                                   \
+-  src/kj/compat/http-test.c++                                  \
+-  $(MAYBE_KJ_GZIP_TESTS)                                       \
+-  $(MAYBE_KJ_TLS_TESTS)                                        \
+-  src/capnp/canonicalize-test.c++                              \
+-  src/capnp/capability-test.c++                                \
+-  src/capnp/membrane-test.c++                                  \
+-  src/capnp/schema-test.c++                                    \
+-  src/capnp/schema-loader-test.c++                             \
+-  src/capnp/schema-parser-test.c++                             \
+-  src/capnp/dynamic-test.c++                                   \
+-  src/capnp/stringify-test.c++                                 \
+-  src/capnp/serialize-async-test.c++                           \
+-  src/capnp/serialize-text-test.c++                            \
+-  src/capnp/rpc-test.c++                                       \
+-  src/capnp/rpc-twoparty-test.c++                              \
+-  src/capnp/ez-rpc-test.c++                                    \
+-  src/capnp/compat/json-test.c++                               \
+-  src/capnp/compat/websocket-rpc-test.c++                      \
+-  src/capnp/compiler/lexer-test.c++                            \
+-  src/capnp/compiler/type-id-test.c++
+-capnp_test_LDADD =                                             \
+-  libcapnp-test.a                                              \
+-  libcapnpc.la                                                 \
+-  libcapnp-rpc.la                                              \
+-  libcapnp-websocket.la                                        \
+-  libcapnp-json.la                                             \
+-  libcapnp.la                                                  \
+-  libkj-http.la                                                \
+-  $(MAYBE_KJ_GZIP_LA)                                          \
+-  $(MAYBE_KJ_TLS_LA)                                           \
+-  libkj-async.la                                               \
+-  libkj-test.la                                                \
+-  libkj.la                                                     \
+-  $(ASYNC_LIBS)                                                \
+-  $(PTHREAD_LIBS)
+-
+-endif !LITE_MODE
+-
+-capnp_test_CPPFLAGS = -Wno-deprecated-declarations
+-capnp_test_SOURCES =                                           \
+-  src/kj/common-test.c++                                       \
+-  src/kj/memory-test.c++                                       \
+-  src/kj/refcount-test.c++                                     \
+-  src/kj/array-test.c++                                        \
+-  src/kj/list-test.c++                                         \
+-  src/kj/string-test.c++                                       \
+-  src/kj/string-tree-test.c++                                  \
+-  src/kj/table-test.c++                                        \
+-  src/kj/map-test.c++                                          \
+-  src/kj/encoding-test.c++                                     \
+-  src/kj/exception-test.c++                                    \
+-  src/kj/debug-test.c++                                        \
+-  src/kj/arena-test.c++                                        \
+-  src/kj/units-test.c++                                        \
+-  src/kj/tuple-test.c++                                        \
+-  src/kj/one-of-test.c++                                       \
+-  src/kj/function-test.c++                                     \
+-  src/kj/io-test.c++                                           \
+-  src/kj/mutex-test.c++                                        \
+-  src/kj/time-test.c++                                         \
+-  src/kj/threadlocal-test.c++                                  \
+-  src/kj/filesystem-test.c++                                   \
+-  src/kj/filesystem-disk-test.c++                              \
+-  src/kj/test-test.c++                                         \
+-  src/capnp/common-test.c++                                    \
+-  src/capnp/blob-test.c++                                      \
+-  src/capnp/endian-test.c++                                    \
+-  src/capnp/endian-fallback-test.c++                           \
+-  src/capnp/endian-reverse-test.c++                            \
+-  src/capnp/layout-test.c++                                    \
+-  src/capnp/any-test.c++                                       \
+-  src/capnp/message-test.c++                                   \
+-  src/capnp/encoding-test.c++                                  \
+-  src/capnp/orphan-test.c++                                    \
+-  src/capnp/serialize-test.c++                                 \
+-  src/capnp/serialize-packed-test.c++                          \
+-  src/capnp/fuzz-test.c++                                      \
+-  $(heavy_tests)
+-
+-if !LITE_MODE
+-capnp_evolution_test_LDADD = libcapnpc.la libcapnp.la libkj.la
+-capnp_evolution_test_SOURCES = src/capnp/compiler/evolution-test.c++
+-
+-capnp_afl_testcase_LDADD = libcapnp-test.a libcapnp-rpc.la libcapnp.la libkj.la libkj-async.la
+-capnp_afl_testcase_SOURCES = src/capnp/afl-testcase.c++
+-
+-if HAS_FUZZING_ENGINE
+-    capnp_llvm_fuzzer_testcase_LDADD = libcapnp-test.a libcapnp-rpc.la libcapnp.la libkj.la libkj-async.la
+-    capnp_llvm_fuzzer_testcase_SOURCES = src/capnp/llvm-fuzzer-testcase.c++
+-    capnp_llvm_fuzzer_testcase_LDFLAGS = $(LIB_FUZZING_ENGINE)
+-endif
+-endif !LITE_MODE
+-
+-if LITE_MODE
+-TESTS = capnp-test
+-else !LITE_MODE
+-TESTS = capnp-test capnp-evolution-test src/capnp/compiler/capnp-test.sh
+-endif !LITE_MODE

--- a/recipes/capnproto/config.yml
+++ b/recipes/capnproto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.10.1":
+    folder: all
   "0.10.0":
     folder: all
   "0.9.1":


### PR DESCRIPTION
Specify library name and version:  **capnproto/0.10.1**

0.10.1 has made some performance improvements.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
