### PR TITLE
catch2: add extras cmake script in 3.0.1

### DIFF
--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -97,6 +97,12 @@ class ConanRecipe(ConanFile):
         cmake.install()
         tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
         tools.rmdir(os.path.join(self.package_folder, "share"))
+        for cmake_file in ["ParseAndAddCatchTests.cmake", "Catch.cmake", "CatchAddTests.cmake"]:
+            self.copy(
+                cmake_file,
+                src=os.path.join(self._source_subfolder, "extras"),
+                dst=os.path.join("lib", "cmake", "Catch2"),
+            )
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "Catch2")


### PR DESCRIPTION
Specify library name and version:  **catch2/3.0.1**

In 2.x.x, cmake scripts are placed in `contrib`.
In 3.x.x, cmake scripts are placed in `extras`.

fix https://github.com/conan-io/conan-center-index/issues/11112.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
