### PR TITLE
icu/71.1 - Don't undef __STRICT_ANSI__

### DIFF
--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -41,3 +41,5 @@ patches:
   "71.1":
     - patch_file: "patches/0001-69.1-fix-mingw.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0001-71.1-fix-undef-strict-ansi.patch"
+      base_path: "source_subfolder"

--- a/recipes/icu/all/patches/0001-71.1-fix-undef-strict-ansi.patch
+++ b/recipes/icu/all/patches/0001-71.1-fix-undef-strict-ansi.patch
@@ -1,0 +1,18 @@
+Waiting on a fix for: https://unicode-org.atlassian.net/browse/ICU-22002
+
+--- source/io/ufile.cpp	2022-04-08 06:41:55.000000000 +0800
++++ source/io/ufile.cpp	2022-06-10 13:00:05.354655951 +0800
+@@ -21,13 +21,6 @@
+ */
+ 
+ #include "unicode/platform.h"
+-#if defined(__GNUC__) && !defined(__clang__) && defined(__STRICT_ANSI__)
+-// g++, fileno isn't defined                  if     __STRICT_ANSI__ is defined.
+-// clang fails to compile the <string> header unless __STRICT_ANSI__ is defined.
+-// __GNUC__ is set by both gcc and clang.
+-#undef __STRICT_ANSI__
+-#endif
+-
+ #include "locmap.h"
+ #include "unicode/ustdio.h"
+ 


### PR DESCRIPTION
This prevents compiling with GCC11 with C++20,
and has probably not been needed for some time now.

There is a pending bug report upstream:
https://unicode-org.atlassian.net/browse/ICU-22002

Specify library name and version:  **icu/71.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
