### PR TITLE
linter: downgrade pylint

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.8"
 
-      - run: "pip3 install conan==1.45.0 yamllint packaging pylint=2.13.9 astroid"
+      - run: "pip3 install conan==1.45.0 yamllint packaging pylint==2.13.9 astroid"
 
       - name: install hook
         run: |

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.8"
 
-      - run: "pip3 install conan==1.45.0 yamllint packaging pylint astroid"
+      - run: "pip3 install conan==1.45.0 yamllint packaging pylint=2.13.9 astroid"
 
       - name: install hook
         run: |


### PR DESCRIPTION
it looks like pylint 2.14.0 chokes on conan recipes:
The symptom is `[HOOK - recipe_linter.py] pre_export(): ERROR: Error parsing JSON output: Expecting value: line 1 column 1 (char 0)`

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
