### PR TITLE
dcmtk: Correctly enable DCMTK_ENABLE_STL

### DIFF
--- a/recipes/dcmtk/all/conanfile.py
+++ b/recipes/dcmtk/all/conanfile.py
@@ -146,7 +146,7 @@ class DCMTKConan(ConanFile):
         if self.options.with_zlib:
             cmake.definitions["WITH_ZLIBINC"] = self.deps_cpp_info["zlib"].rootpath
 
-        cmake.definitions["DCMTK_ENABLE_STL"] = True
+        cmake.definitions["DCMTK_ENABLE_STL"] = "ON"
         cmake.definitions["DCMTK_ENABLE_CXX11"] = True
 
         cmake.definitions["DCMTK_ENABLE_MANPAGE"] = False


### PR DESCRIPTION
Dcmtk explicitly compares the value of DCMTK_ENABLE_STL with the
string "ON". This will hopefully be fixed with
https://github.com/DCMTK/dcmtk/pull/60 but this makes the recipe work
correctly with already released versions of Dcmtk.

fixes #11124 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
