### PR TITLE
xbyak: add version 6.60

### DIFF
--- a/recipes/xbyak/all/conandata.yml
+++ b/recipes/xbyak/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.60":
+    url: "https://github.com/herumi/xbyak/archive/v6.60.tar.gz"
+    sha256: "fb478da9d66fabe155d54436645ffbbdc44b513027391c4662983d44ea483d59"
   "6.01":
     url: "https://github.com/herumi/xbyak/archive/v6.01.tar.gz"
     sha256: "d28a03c0db1fe16e49572e5f6e1d825decc373022acd0f331646152aef60b550"

--- a/recipes/xbyak/config.yml
+++ b/recipes/xbyak/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.60":
+    folder: all
   "6.01":
     folder: all
   "6.00":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **xbyak/6.60**


---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
