### PR TITLE
ctml: add recipe

### DIFF
--- a/recipes/ctml/all/conandata.yml
+++ b/recipes/ctml/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.0.0":
+    url: "https://github.com/tinfoilboy/CTML/archive/refs/tags/2.0.0.tar.gz"
+    sha256: "e13b3bb04903f47b90b286f8a4695232179e28474a0a33f1a3f333552338d132"

--- a/recipes/ctml/all/conanfile.py
+++ b/recipes/ctml/all/conanfile.py
@@ -1,0 +1,42 @@
+import os
+from conans import ConanFile, tools
+
+required_conan_version = ">=1.43.0"
+
+class CtmlLibrariesConan(ConanFile):
+    name = "ctml"
+    description = "A C++ HTML document constructor only depending on the standard library."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/tinfoilboy/CTML"
+    topics = ("generator", "html", )
+    settings = "os", "arch", "compiler", "build_type",
+    generators = "cmake",
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def package_id(self):
+        self.info.header_only()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, "11")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy("LICENSE*", "licenses", self._source_subfolder)
+        self.copy("ctml.hpp", "include", os.path.join(self._source_subfolder, "include"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "CTML")
+        self.cpp_info.set_property("cmake_target_name", "CTML::CTML")
+
+        self.cpp_info.filenames["cmake_find_package"] = "CTML"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "CTML"
+        self.cpp_info.names["cmake_find_package"] = "CTML"
+        self.cpp_info.names["cmake_find_package_multi"] = "CTML"

--- a/recipes/ctml/all/test_package/CMakeLists.txt
+++ b/recipes/ctml/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(CTML CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} CTML::CTML)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/ctml/all/test_package/conanfile.py
+++ b/recipes/ctml/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class TestWrapperConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/ctml/all/test_package/test_package.cpp
+++ b/recipes/ctml/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+
+#include "ctml.hpp"
+
+int main() {
+    CTML::Node node("div#first section#second article#third");
+
+    std::cout << node.ToString() << std::endl;
+
+    return 0;
+}

--- a/recipes/ctml/config.yml
+++ b/recipes/ctml/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.0.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **ctml/2.0.0**

ctml is header only HTML generater.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
