### PR TITLE
Add appending of `PATH` with zlib's bin directory

### DIFF
--- a/recipes/zlib/all/conanfile.py
+++ b/recipes/zlib/all/conanfile.py
@@ -113,5 +113,9 @@ class ZlibConan(ConanFile):
             libname = "z"
         self.cpp_info.libs = [libname]
 
+        bindir = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bindir))
+        self.env_info.PATH.append(bindir)
+
         self.cpp_info.names["cmake_find_package"] = "ZLIB"
         self.cpp_info.names["cmake_find_package_multi"] = "ZLIB"


### PR DESCRIPTION
Specify library name and version:  **zlib/all**

Add zlib's bin directory to PATH in order for dependent recipes with executables that are linked to zlib to find its shared library.

This is a result of my findings in #11118 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
