### PR TITLE
override sentry default backend and not the backend itself

### DIFF
--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -186,7 +186,7 @@ class SentryNativeConan(ConanFile):
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs = ["shlwapi", "dbghelp"]
             if tools.Version(self.version) >= "0.4.7":
-                self.cpp_info.system_libs.append("Version")
+                self.cpp_info.system_libs.append("version")
             if self.options.transport == "winhttp":
                 self.cpp_info.system_libs.append("winhttp")
 

--- a/recipes/sentry-native/all/conanfile.py
+++ b/recipes/sentry-native/all/conanfile.py
@@ -72,16 +72,19 @@ class SentryNativeConan(ConanFile):
         else:
             self.options.transport = "none"
 
+        default_backend = "none"
         # Configure default backend
         if self.settings.os == "Windows" or self.settings.os == "Macos":  # Don't use tools.is_apple_os(os) here
             # FIXME: for self.version < 0.4: default backend is "breakpad" when building with MSVC for Windows xp; else: backend=none
-            self.options.backend = "crashpad"
+            default_backend = "crashpad"
         elif self.settings.os in ("FreeBSD", "Linux"):
-            self.options.backend = "breakpad"
+            default_backend = "breakpad"
         elif self.settings.os == "Android":
-            self.options.backend = "inproc"
+            default_backend = "inproc"
         else:
-            self.options.backend = "inproc"
+            default_backend = "inproc"
+
+        self.default_options['backend'] = default_backend
 
     def configure(self):
         if self.options.shared:


### PR DESCRIPTION
Specify library name and version:  **sentry-native/0.4.17**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
