### PR TITLE
always set CMAKE_CXX_STANDARD

### DIFF
--- a/recipes/mongo-cxx-driver/all/conanfile.py
+++ b/recipes/mongo-cxx-driver/all/conanfile.py
@@ -143,8 +143,7 @@ class MongoCxxConan(ConanFile):
         self._cmake.definitions["BSONCXX_LINK_WITH_STATIC_MONGOC"] = not self.options["mongo-c-driver"].shared
         self._cmake.definitions["MONGOCXX_LINK_WITH_STATIC_MONGOC"] = not self.options["mongo-c-driver"].shared
         self._cmake.definitions["MONGOCXX_ENABLE_SSL"] = self.options.with_ssl
-        if not tools.valid_min_cppstd(self, self._minimal_std_version):
-            self._cmake.definitions["CMAKE_CXX_STANDARD"] = self._minimal_std_version
+        self._cmake.definitions["CMAKE_CXX_STANDARD"] = self._minimal_std_version
         # FIXME: two CMake module/config files should be generated (mongoc-1.0-config.cmake and bson-1.0-config.cmake),
         # but it can't be modeled right now.
         # Fix should happen in mongo-c-driver recipe


### PR DESCRIPTION
no matter what cpp std is used, we should set the CMAKE_CXX_STANDARD to required one.
when i am using std polyfill, and my compiler supports c++20, but build failed because CMAKE_CXX_STANDARD is not set.
after setting this, it all works out

Specify library name and version:  **mongo-cxx-drver/3.6.6**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
