### PR TITLE
linter - errors should appear in PR

### DIFF
--- a/linter/recipe_linter.json
+++ b/linter/recipe_linter.json
@@ -5,7 +5,7 @@
             "severity": "error",
             "pattern": [
                 {
-                    "regexp": "(\\S+):(\\d+): \\[(E\\d+\\(\\S+\\)),\\s(.+?)\\](.+)",
+                    "regexp": "Error: (\\S+):(\\d+): \\[(E\\d+\\(\\S+\\)),\\s(.+?)\\](.+)",
                     "file": 1,
                     "line": 2,
                     "message": 5,

--- a/recipes/7zip/19.00/conanfile.py
+++ b/recipes/7zip/19.00/conanfile.py
@@ -6,7 +6,7 @@ required_conan_version = ">=1.33.0"
 
 
 class SevenZipConan(ConanFile):
-    name = "7zip"
+    name = "7Zip"
     url = "https://github.com/conan-io/conan-center-index"
     description = "7-Zip is a file archiver with a high compression ratio"
     license = ("LGPL-2.1", "BSD-3-Clause", "Unrar")


### PR DESCRIPTION
Following https://github.com/conan-io/conan-center-index/pull/11160, it looks like the error doesn't show inline