### PR TITLE
[pango]: use shared glib for shared pango

### DIFF
--- a/recipes/pango/all/conanfile.py
+++ b/recipes/pango/all/conanfile.py
@@ -198,3 +198,6 @@ class PangoConan(ConanFile):
 
     def package_id(self):
         self.info.requires["glib"].full_package_mode()
+        self.info.requires["harfbuzz"].full_package_mode()
+        if self.options.with_cairo:
+            self.info.requires["cairo"].full_package_mode()


### PR DESCRIPTION
Specify library name and version:  **pango**

Building shared libraries that depend on static glib causes problems. See https://github.com/conan-io/conan-center-index/issues/11022.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
