### PR TITLE
[fontconfig]: bump dependencies

### DIFF
--- a/recipes/fontconfig/all/conanfile.py
+++ b/recipes/fontconfig/all/conanfile.py
@@ -57,7 +57,7 @@ class FontconfigConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def requirements(self):
-        self.requires("freetype/2.11.1")
+        self.requires("freetype/2.12.1")
         self.requires("expat/2.4.8")
         if self.settings.os == "Linux":
             self.requires("libuuid/1.0.3")


### PR DESCRIPTION
Specify library name and version:  **fontconfig**

bump freetype dependency

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
