### PR TITLE
fix: package/ignition-math 

### DIFF
--- a/recipes/ignition-math/all/conandata.yml
+++ b/recipes/ignition-math/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
   "6.7.0":
-    url: "https://github.com/ignitionrobotics/ign-math/archive/ignition-math6_6.7.0.tar.gz"
-    sha256: "8456af51cbb128d7468d65b55124af7a235f052214ac2a239c3f23197416f2d2"
+    url: "https://github.com/gazebosim/gz-math/archive/ignition-math6_6.7.0.tar.gz"
+    sha256: "e5dac5aca6a117af8bd07ebca6e4ec8255682453487bf8d706bdb0315d17d6af"
   "6.10.0":
-    url: "https://github.com/ignitionrobotics/ign-math/archive/refs/tags/ignition-math6_6.10.0.tar.gz"
-    sha256: "9e00284cd6d51afe190165b2b44258e19bd4a28781cbacf21fd6b0bae43c16aa"
+    url: "https://github.com/gazebosim/gz-math/archive/ignition-math6_6.10.0.tar.gz"
+    sha256: "94e853e1dfba97ebec4b6152691a89af1e94660b02f4ecdf04356b763c2848bd"
 patches:
   "6.7.0":
     - base_path: "source_subfolder"

--- a/recipes/ignition-math/all/conanfile.py
+++ b/recipes/ignition-math/all/conanfile.py
@@ -128,7 +128,6 @@ class IgnitionMathConan(ConanFile):
     def package_info(self):
         version_major = tools.Version(self.version).major
         lib_name = f"ignition-math{version_major}"
-        build_dirs = os.path.join("lib", "cmake")
 
         self.cpp_info.names["cmake_find_package"] = lib_name
         self.cpp_info.names["cmake_find_package_multi"] = lib_name
@@ -141,9 +140,7 @@ class IgnitionMathConan(ConanFile):
         self.cpp_info.components[lib_name].includedirs.append(os.path.join("include", "ignition", "math"+version_major))
         self.cpp_info.components[lib_name].requires = ["swig::swig", "eigen::eigen", "doxygen::doxygen"]
 
-        self.cpp_info.components[lib_name].builddirs = [build_dirs]
-        self.cpp_info.components[lib_name].builddirs = [build_dirs]
-        self.cpp_info.components[lib_name].builddirs = [build_dirs]
+        self.cpp_info.components[lib_name].builddirs = [self._module_file_rel_dir]
         self.cpp_info.components[lib_name].build_modules["cmake_find_package"] = [self._module_file_rel_path]
         self.cpp_info.components[lib_name].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
         self.cpp_info.components[lib_name].build_modules["cmake_paths"] = [self._module_file_rel_path]
@@ -153,6 +150,8 @@ class IgnitionMathConan(ConanFile):
         self.cpp_info.components["eigen3"].names["cmake_paths"] = "eigen3"
         self.cpp_info.components["eigen3"].includedirs.append(os.path.join("include", "ignition", "math"+version_major))
         self.cpp_info.components["eigen3"].requires = ["eigen::eigen"]
+
+        self.cpp_info.components["eigen3"].builddirs = [self._module_file_rel_dir]
         self.cpp_info.components["eigen3"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
         self.cpp_info.components["eigen3"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
         self.cpp_info.components["eigen3"].build_modules["cmake_paths"] = [self._module_file_rel_path]
@@ -162,6 +161,10 @@ class IgnitionMathConan(ConanFile):
             raise ConanInvalidConfiguration("sorry, M1 builds are not currently supported, give up!")
     
     @property
+    def _module_file_rel_dir(self):
+        return os.path.join("lib", "cmake")
+    
+    @property
     def _module_file_rel_path(self):
-        return os.path.join("lib", "cmake", f"conan-official-{self.name}-variables.cmake")
+        return os.path.join(self._module_file_rel_dir, f"conan-official-{self.name}-variables.cmake")
 

--- a/recipes/ignition-math/all/conanfile.py
+++ b/recipes/ignition-math/all/conanfile.py
@@ -78,11 +78,6 @@ class IgnitionMathConan(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
-        version_major = tools.Version(self.version).major
-        conan.tools.files.rename(
-             self, f"gz-math-ignition-math{version_major}_{self.version}",
-             self._source_subfolder
-            )
 
     def _configure_cmake(self):
         if self._cmake:

--- a/recipes/ignition-math/all/conanfile.py
+++ b/recipes/ignition-math/all/conanfile.py
@@ -128,6 +128,8 @@ class IgnitionMathConan(ConanFile):
     def package_info(self):
         version_major = tools.Version(self.version).major
         lib_name = f"ignition-math{version_major}"
+        build_dirs = os.path.join("lib", "cmake")
+
         self.cpp_info.names["cmake_find_package"] = lib_name
         self.cpp_info.names["cmake_find_package_multi"] = lib_name
         self.cpp_info.names["cmake_paths"] = lib_name
@@ -138,6 +140,10 @@ class IgnitionMathConan(ConanFile):
         self.cpp_info.components[lib_name].libs = [lib_name]
         self.cpp_info.components[lib_name].includedirs.append(os.path.join("include", "ignition", "math"+version_major))
         self.cpp_info.components[lib_name].requires = ["swig::swig", "eigen::eigen", "doxygen::doxygen"]
+
+        self.cpp_info.components[lib_name].builddirs = [build_dirs]
+        self.cpp_info.components[lib_name].builddirs = [build_dirs]
+        self.cpp_info.components[lib_name].builddirs = [build_dirs]
         self.cpp_info.components[lib_name].build_modules["cmake_find_package"] = [self._module_file_rel_path]
         self.cpp_info.components[lib_name].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
         self.cpp_info.components[lib_name].build_modules["cmake_paths"] = [self._module_file_rel_path]
@@ -158,3 +164,4 @@ class IgnitionMathConan(ConanFile):
     @property
     def _module_file_rel_path(self):
         return os.path.join("lib", "cmake", f"conan-official-{self.name}-variables.cmake")
+

--- a/recipes/ignition-math/all/conanfile.py
+++ b/recipes/ignition-math/all/conanfile.py
@@ -77,7 +77,7 @@ class IgnitionMathConan(ConanFile):
             self.build_requires("ignition-cmake/2.10.0")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
         version_major = tools.Version(self.version).major
         conan.tools.files.rename(
              self, f"gz-math-ignition-math{version_major}_{self.version}",


### PR DESCRIPTION
## Description
* The current recipe of ignition-math has bugs
   - it doesn't provide `Eigen` compoent
   - It doesn't set the ignition-math cmake VERSION info which is used in downstream dependencies
   - It uses the outdated ignition-math urls
       - Look at this post from gazebo on more updates: https://discourse.ros.org/t/a-new-era-for-gazebo-cross-post/25012

## Fix summary
* This MR fixes the issues described above
* Both the versions 6.7.0 and 6.10.0 are fixed in this MR

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
