### PR TITLE
fix: ignition-utils

### DIFF
--- a/recipes/ignition-utils/all/conandata.yml
+++ b/recipes/ignition-utils/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
   "1.3.0":
-    url: "https://github.com/ignitionrobotics/ign-utils/archive/refs/tags/ignition-utils1_1.3.0.tar.gz"
+    url: "https://github.com/gazebosim/gz-utils/archive/refs/tags/ignition-utils1_1.3.0.tar.gz"
     sha256: "4ca4f553c2a1cf77c02bd37e0cba35837fd4f46145eac2b0334e33f74fd98163"
 
 patches:

--- a/recipes/ignition-utils/all/conandata.yml
+++ b/recipes/ignition-utils/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "1.3.0":
     url: "https://github.com/gazebosim/gz-utils/archive/refs/tags/ignition-utils1_1.3.0.tar.gz"
-    sha256: "4ca4f553c2a1cf77c02bd37e0cba35837fd4f46145eac2b0334e33f74fd98163"
+    sha256: "062bfbbdc185e1dacc4ffd9e70572fc01e32d11782e991ae027541ee02858e92"
 
 patches:
   "1.3.0":

--- a/recipes/ignition-utils/all/conanfile.py
+++ b/recipes/ignition-utils/all/conanfile.py
@@ -153,10 +153,7 @@ class IgnitionUitlsConan(ConanFile):
         if self.options.ign_utils_vendor_cli11:
             self.cpp_info.components[lib_name].requires.append("cli11::cli11")
 
-        self.cpp_info.components[lib_name].builddirs["cmake_find_package"] = [build_dirs]
-        self.cpp_info.components[lib_name].builddirs["cmake_find_package_multi"] = [build_dirs]
-        self.cpp_info.components[lib_name].builddirs["cmake_paths"] = [build_dirs]
-
+        self.cpp_info.components[lib_name].builddirs.append(build_dirs)
         self.cpp_info.components[lib_name].build_modules["cmake_find_package"] = [self._module_file_rel_path]
         self.cpp_info.components[lib_name].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
         self.cpp_info.components[lib_name].build_modules["cmake_paths"] = [self._module_file_rel_path]
@@ -168,10 +165,7 @@ class IgnitionUitlsConan(ConanFile):
         if self.options.ign_utils_vendor_cli11:
             self.cpp_info.components["cli"].requires = ["cli11::cli11"]
 
-        self.cpp_info.components["cli"].builddirs["cmake_find_package"] = [build_dirs]
-        self.cpp_info.components["cli"].builddirs["cmake_find_package_multi"] = [build_dirs]
-        self.cpp_info.components["cli"].builddirs["cmake_paths"] = [build_dirs]
-
+        self.cpp_info.components["cli"].builddirs.append(build_dirs)
         self.cpp_info.components["cli"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
         self.cpp_info.components["cli"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
         self.cpp_info.components["cli"].build_modules["cmake_paths"] = [self._module_file_rel_path]

--- a/recipes/ignition-utils/all/conanfile.py
+++ b/recipes/ignition-utils/all/conanfile.py
@@ -9,13 +9,19 @@ required_conan_version = ">=1.29.1"
 class IgnitionUitlsConan(ConanFile):
     name = "ignition-utils"
     license = "Apache-2.0"
-    homepage = "https://ignitionrobotics.org/libs/utils"
+    homepage = "https://gazebosim.org/libs/utils"
     url = "https://github.com/conan-io/conan-center-index"
     description = "Provides general purpose classes and functions designed for robotic applications.."
     topics = ("ignition", "robotics", "utils")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], 
+                "fPIC": [True, False],
+                "ign_utils_vendor_cli11": [True, False]
+              }
+    default_options = {"shared": False, 
+                       "fPIC": True,
+                       "ign_utils_vendor_cli11": True
+                       }
     generators = "cmake", "cmake_find_package_multi"
     exports_sources = "CMakeLists.txt", "patches/**"
     _cmake = None
@@ -68,8 +74,9 @@ class IgnitionUitlsConan(ConanFile):
                 )
     
     def requirements(self):
-        self.requires("cli11/2.1.2")
         self.requires("doxygen/1.9.2")
+        if self.options.ign_utils_vendor_cli11:
+            self.requires("cli11/2.1.2")
 
     def build_requirements(self):
         self.build_requires("ignition-cmake/2.10.0")
@@ -82,7 +89,7 @@ class IgnitionUitlsConan(ConanFile):
             return self._cmake
         self._cmake = CMake(self)
         self._cmake.definitions["BUILD_TESTING"] = False
-        #self._cmake.definitions["IGN_UTILS_VENDOR_CLI11"] = True
+        self._cmake.definitions["IGN_UTILS_VENDOR_CLI11"] = self.options.ign_utils_vendor_cli11
         self._cmake.definitions["CMAKE_FIND_DEBUG_MODE"] = "1"
         self._cmake.configure()
         return self._cmake
@@ -111,17 +118,63 @@ class IgnitionUitlsConan(ConanFile):
         # Remove MS runtime files
         for dll_pattern_to_remove in ["concrt*.dll", "msvcp*.dll", "vcruntime*.dll"]:
             tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), dll_pattern_to_remove)
+        
+        self._create_cmake_module_variables(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            tools.Version(self.version)
+        )
+
+    @staticmethod
+    def _create_cmake_module_variables(module_file, version):
+        content = textwrap.dedent("""\
+            set(ignition-utils{major}_VERSION_MAJOR {major})
+            set(ignition-utils{major}_VERSION_MINOR {minor})
+            set(ignition-utils{major}_VERSION_PATCH {patch})
+            set(ignition-utils{major}_VERSION_STRING "{major}.{minor}.{patch}")
+        """.format(major=version.major, minor=version.minor, patch=version.patch))
+        tools.save(module_file, content)
 
     def package_info(self):
         version_major = tools.Version(self.version).major
-        self.cpp_info.names["cmake_find_package"] = "ignition-utils{}".format(version_major)
-        self.cpp_info.names["cmake_find_package_multi"] = "ignition-utils{}".format(version_major)
+        lib_name = f"ignition-utils{version_major}"
+        build_dirs = os.path.join(self.package_folder, "lib", "cmake")
+        include_dir = os.path.join("include", "ignition", "utils"+version_major)
+        self.cpp_info.names["cmake_find_package"] = lib_name
+        self.cpp_info.names["cmake_find_package_multi"] = lib_name
+        self.cpp_info.names["cmake_paths"] = lib_name
 
-        # cmake_find_package filename: ignition-utils-config.cmake
-        self.cpp_info.components["libignition-utils"].libs = ["ignition-utils{}".format(version_major)]
-        self.cpp_info.components["libignition-utils"].includedirs.append("include/ignition/utils{}".format(version_major))
-        self.cpp_info.components["libignition-utils"].names["cmake_find_package"] = "ignition-utils{}".format(version_major)
-        self.cpp_info.components["libignition-utils"].names["cmake_find_package_multi"] = "ignition-utils{}".format(version_major)
-        self.cpp_info.components["libignition-utils"].names["pkg_config"] = "ignition-utils{}".format(version_major)
-        self.cpp_info.components["libignition-utils"].requires = ["cli11::cli11"]
-        self.cpp_info.components["libignition-msgs"].requires.append("doxygen::doxygen")
+        self.cpp_info.components[lib_name].names["cmake_find_package"] = lib_name
+        self.cpp_info.components[lib_name].names["cmake_find_package_multi"] = lib_name
+        self.cpp_info.components[lib_name].names["cmake_paths"] = lib_name
+        self.cpp_info.components[lib_name].libs = [lib_name]
+        self.cpp_info.components[lib_name].includedirs.append(include_dir)
+        self.cpp_info.components[lib_name].requires = ["doxygen::doxygen"]
+        if self.options.ign_utils_vendor_cli11:
+            self.cpp_info.components[lib_name].requires.append("cli11::cli11")
+
+        self.cpp_info.components[lib_name].builddirs["cmake_find_package"] = [build_dirs]
+        self.cpp_info.components[lib_name].builddirs["cmake_find_package_multi"] = [build_dirs]
+        self.cpp_info.components[lib_name].builddirs["cmake_paths"] = [build_dirs]
+
+        self.cpp_info.components[lib_name].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.components[lib_name].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+        self.cpp_info.components[lib_name].build_modules["cmake_paths"] = [self._module_file_rel_path]
+
+        self.cpp_info.components["cli"].names["cmake_find_package"] = "cli"
+        self.cpp_info.components["cli"].names["cmake_find_package_multi"] = "cli"
+        self.cpp_info.components["cli"].names["cmake_paths"] = "cli"
+        self.cpp_info.components["cli"].includedirs.append(os.path.join(include_dir, "ignition", "utils"))
+        if self.options.ign_utils_vendor_cli11:
+            self.cpp_info.components["cli"].requires = ["cli11::cli11"]
+
+        self.cpp_info.components["cli"].builddirs["cmake_find_package"] = [build_dirs]
+        self.cpp_info.components["cli"].builddirs["cmake_find_package_multi"] = [build_dirs]
+        self.cpp_info.components["cli"].builddirs["cmake_paths"] = [build_dirs]
+
+        self.cpp_info.components["cli"].build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.components["cli"].build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]
+        self.cpp_info.components["cli"].build_modules["cmake_paths"] = [self._module_file_rel_path]
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-variables.cmake")

--- a/recipes/ignition-utils/all/conanfile.py
+++ b/recipes/ignition-utils/all/conanfile.py
@@ -2,6 +2,7 @@ import os
 from conans import CMake, ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import conan.tools.files
+import textwrap
 
 required_conan_version = ">=1.29.1"
 


### PR DESCRIPTION
## Library Details
* Name: ignition-utils/1.3.0
* URL: https://gazebosim.org/libs/utils
*
## Description
* The current recipe of ignition-math has bugs
   - it doesn't provide `CLI11` component
   - It doesn't set the ignition-math cmake VERSION info which is used in downstream dependencies
   - It uses the outdated ignition-utls urls
       - Look at this post from gazebo on more updates: https://discourse.ros.org/t/a-new-era-for-gazebo-cross-post/25012

## Fix summary
* This MR fixes the issues described above
* Similar to fixes in #11172
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
