### PR TITLE
kuba-zip: add version 0.2.3

### DIFF
--- a/recipes/kuba-zip/all/conandata.yml
+++ b/recipes/kuba-zip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.3":
+    url: "https://github.com/kuba--/zip/archive/v0.2.3.tar.gz"
+    sha256: "800e9dc2d2834d92ad333dac29b438dfb495c765bc4e97c7b10101f4f22d53d4"
   "0.2.2":
     url: "https://github.com/kuba--/zip/archive/refs/tags/v0.2.2.tar.gz"
     sha256: "f278b1da5e5382c7a1a1db1502cfa1f6df6b1e05e36253d661344d30277f9895"

--- a/recipes/kuba-zip/config.yml
+++ b/recipes/kuba-zip/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.3":
+    folder: "all"
   "0.2.2":
     folder: "all"
   "0.2.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **kuba-zip/0.2.3**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
