### PR TITLE
(#11195) perfetto: bump version to v26.1

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "25.0":
     url: https://github.com/google/perfetto/archive/refs/tags/v25.0.tar.gz
     sha256: 73a4b895df9222ddb231b8d903099d6da08cd079f27983f540e89156fa88ba67
+  "26.1":
+    url: https://github.com/google/perfetto/archive/refs/tags/v26.1.tar.gz
+    sha256: cce387e82e2a137fce2eba927f80f20407764b77637a1a92b9b24065a500ce6d
 
 patches:
   "20.1":

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "25.0":
     folder: all
+  "26.1":
+    folder: all


### PR DESCRIPTION
Package Name/Version: perfetto/v26.1
Changelog: https://github.com/google/perfetto/releases/tag/v26.1
The above mentioned version is newly released by the upstream project and not yet available as a recipe.

Closes #11195 

```
v26.1 - 2022-06-13:
  Trace Processor:
    * Fixed build failures on Windows.


v26.0 - 2022-06-13:
  Tracing service and probes:
    * Added wildcard (*) support when targeting processes by their command line
      in the Android perf profiler ("linux.perf" data source) and Java heap
      snapshots ("android.java_hprof").
    * Added support for kernel thread sampling, and kernel-only callstacks in
      the Android perf profiler.
    * Fixed rare crash when parsing zero-length ftrace __data_loc strings.
    * Fixed rare crash on 4.19 kernel when encountering unexpected zero-padded
      ftrace pages.
    * Removed capturing of thread_time_in_state (per-UID, per-OOM-adj time).
      The data was unused and subsumed by correlating sched data with power
      rail monitors.
  Trace Processor:
    * Added CREATE_VIEW_FUNCTION operator to define a SQL function that can
      return a temporary table and yield multiple rows and columns.
    * Changed kernel threads to be represented as single-thread processes in
      Linux system traces. The (incorrect) legacy behaviour was to treat them
      as threads of the kthreadd process.
    * Added ABS_TIME_STR function which converts a trace timestamp to
      an ISO8601 string.
    * Added ingestion for phase='R' events, used by performance.{now,mark}().
    * Changed 'trace_to_text' to be named 'traceconv'. The source
      location also moved from 'tools/trace_to_text' to 'src/traceconv'.
    * Changed compiler flags, added -mavx2. The previous patch in v22.0 was
      supposed to add AVX2 support but added only AVX.
    * Changed the handling of the last per-cpu sched slices: rather than
      extending the last event to the end of the trace, the last scheduling
      event has a -1 duration. UIs are supposed to deal with visual extension.
    * Removed android_thread_time_in_state metric. It was an experiment and was
      unused.
    * Removed `instant` table. All instant events are now 0-duration events in
      the `slice` table.
    * Removed the /raw_query REST endpoint from --httpd. This will break very
      old clients that have not switched over the new streaming-based /query
      endoint or even newer /websocket.
  UI:
    * Changed detail panel to separate slice args from generic slice properties.
    * Automatically enabled sched_compact when generating trace configs for 
      Android S+ targets.
  SDK:
    * Added option for recording thread CPU times at the beginning and end of
      each slice.
    * Added perfetto::DynamicString() to use non-literal strings as event names
      in the TRACE_EVENT API.
    * Remove the pre-SDK consumer_api_deprecated interface. It was introduced
      for iorapd, now deleted from the Android tree.
```
---

- [ x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ x ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ x ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
