### PR TITLE
scons: add version 4.3.0

### DIFF
--- a/recipes/scons/all/conandata.yml
+++ b/recipes/scons/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.3.0":
+    url: "http://prdownloads.sourceforge.net/scons/SCons-4.3.0.tar.gz"
+    sha256: "2efc81754a4491299c0c64a6230715dfe33f7a3a42a0834a4ce1756af117bdec"
   "4.2.0":
     url: "http://prdownloads.sourceforge.net/scons/scons-4.2.0.tar.gz"
     sha256: "691893b63f38ad14295f5104661d55cb738ec6514421c6261323351c25432b0a"

--- a/recipes/scons/config.yml
+++ b/recipes/scons/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.3.0":
+    folder: all
   "4.2.0":
     folder: all
   "3.1.2":


### PR DESCRIPTION
Specify library name and version:  scons/4.3.0

This will be a dependency for adding a visual studio 2022 build of serf: https://scons.org/scons-430-is-available.html

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
