### PR TITLE
[atk]: use shared glib for shared atk

### DIFF
--- a/recipes/atk/all/conanfile.py
+++ b/recipes/atk/all/conanfile.py
@@ -45,6 +45,14 @@ class AtkConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+        if self.options.shared:
+            self.options["glib"].shared = True
+
+    def validate(self):
+        if self.options.shared and not self.options["glib"].shared:
+            raise ConanInvalidConfiguration(
+                "Linking a shared library against static glib can cause unexpected behaviour."
+            )
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -89,3 +97,6 @@ class AtkConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
         self.cpp_info.includedirs = ['include/atk-1.0']
+
+    def package_id(self):
+        self.info.requires["glib"].full_package_mode()


### PR DESCRIPTION
Specify library name and version:  **atk**

Building shared libraries that depend on static glib causes problems. See https://github.com/conan-io/conan-center-index/issues/11022.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
