### PR TITLE
[at-spi2-core]: use shared glib for shared at-spi2-core

### DIFF
--- a/recipes/at-spi2-core/all/conanfile.py
+++ b/recipes/at-spi2-core/all/conanfile.py
@@ -27,11 +27,11 @@ class AtSpi2CoreConan(ConanFile):
     @property
     def _source_subfolder(self):
         return "source_subfolder"
-        
+
     @property
     def _build_subfolder(self):
         return "build_subfolder"
-    
+
     _meson = None
 
     def export_sources(self):
@@ -43,13 +43,21 @@ class AtSpi2CoreConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+        if self.options.shared:
+            self.options["glib"].shared = True
+
+    def validate(self):
+        if self.options.shared and not self.options["glib"].shared:
+            raise ConanInvalidConfiguration(
+                "Linking a shared library against static glib can cause unexpected behaviour."
+            )
 
     def build_requirements(self):
-        self.build_requires("meson/0.59.1")
+        self.build_requires("meson/0.62.2")
         self.build_requires("pkgconf/1.7.4")
-    
+
     def requirements(self):
-        self.requires("glib/2.70.0")
+        self.requires("glib/2.73.0")
         if self.options.with_x11:
             self.requires("xorg/system")
         self.requires("dbus/1.12.20")
@@ -77,7 +85,7 @@ class AtSpi2CoreConan(ConanFile):
         self._meson.configure(defs=defs, build_folder=self._build_subfolder, source_folder=self._source_subfolder, pkg_config_paths=".", args=args)
         return self._meson
 
-    def build(self):        
+    def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
         if tools.Version(self.version) >= "2.42.0":
@@ -100,3 +108,5 @@ class AtSpi2CoreConan(ConanFile):
         self.cpp_info.includedirs = ["include/at-spi-2.0"]
         self.cpp_info.names["pkg_config"] = "atspi-2"
 
+    def package_id(self):
+        self.info.requires["glib"].full_package_mode()


### PR DESCRIPTION
Specify library name and version:  **at-spi2-core**

Building shared libraries that depend on static glib causes problems. See https://github.com/conan-io/conan-center-index/issues/11022.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
