### PR TITLE
[gdk-pixbuf]: use shared glib for shared gdk-pixbuf

### DIFF
--- a/recipes/gdk-pixbuf/all/conanfile.py
+++ b/recipes/gdk-pixbuf/all/conanfile.py
@@ -53,6 +53,14 @@ class GdkPixbufConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+        if self.options.shared:
+            self.options["glib"].shared = True
+
+    def validate(self):
+        if self.options.shared and not self.options["glib"].shared:
+            raise ConanInvalidConfiguration(
+                "Linking a shared library against static glib can cause unexpected behaviour."
+            )
 
     def requirements(self):
         if self.settings.compiler == "clang":
@@ -162,3 +170,6 @@ class GdkPixbufConan(ConanFile):
 
         # TODO: to remove in conan v2 once pkg_config generator removed
         self.cpp_info.names["pkg_config"] = "gdk-pixbuf-2.0"
+
+    def package_id(self):
+        self.info.requires["glib"].full_package_mode()


### PR DESCRIPTION
Specify library name and version:  **gdk-pixbuf**

Building shared libraries that depend on static glib causes problems. See https://github.com/conan-io/conan-center-index/issues/11022.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
