### PR TITLE
scons: Preserve word boundaries in wrapper script

### DIFF
--- a/recipes/scons/all/conanfile.py
+++ b/recipes/scons/all/conanfile.py
@@ -67,7 +67,7 @@ class SConsConan(ConanFile):
             currentdir="$(dirname "$(realpath "$0")")"
 
             export PYTHONPATH="$currentdir/../res:$PYTHONPATH"
-            exec ${PYTHON:-python3} "$currentdir/../res/SCons/__main__.py" $*
+            exec ${PYTHON:-python3} "$currentdir/../res/SCons/__main__.py" "$@"
         """))
         self._chmod_x(self._scons_sh)
         tools.save(self._scons_cmd, textwrap.dedent(r"""


### PR DESCRIPTION
scons/* (all versions)

`$*` is a single shell word contatenating all the arguments
`$@` is multiple words and expanding it inside "" keeps the word boundaries

No change is required to the .bat version, as cmd's `%*` expands to the
entire verbatim command-line, preserving the original caller's quoting.

Fixes #9308 and #9311, should unblock #9301 and #11215

Fixes #9308
Fixes #9311

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
