### PR TITLE
opencv4.x: bump eigen version to 3.4.0

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -192,7 +192,7 @@ class OpenCVConan(ConanFile):
         if self.options.get_safe("with_tiff"):
             self.requires("libtiff/4.3.0")
         if self.options.with_eigen:
-            self.requires("eigen/3.3.9")
+            self.requires("eigen/3.4.0")
         if self.options.get_safe("with_ffmpeg"):
             self.requires("ffmpeg/4.4")
         if self.options.parallel == "tbb":


### PR DESCRIPTION
Specify library name and version:  **opencv/4.x**

opencv 2.x is already eigen/3.4.0
opencv 3.x is still eigen/3.3.9(but has build error with eigen/3.4.0)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
