### PR TITLE
Bump vulkan-loader in glfw for static build

### DIFF
--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -57,7 +57,7 @@ class GlfwConan(ConanFile):
     def requirements(self):
         self.requires("opengl/system")
         if self.options.vulkan_static:
-            self.requires("vulkan-loader/1.3.204.1")
+            self.requires("vulkan-loader/1.3.211.0")
         if self.settings.os == "Linux":
             self.requires("xorg/system")
 


### PR DESCRIPTION
Specify library name and version:  **glfw/3.3.7**

When using both moltenvk/1.1.9 & glfw/3.3.7 as dependencies, the required version of vulkan-headers will be different when `vulkan_static ` is set. This PR fixes and aligns them.

Related to #11237

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
