### PR TITLE
[graphene]: use shared glib for shared graphene

### DIFF
--- a/recipes/graphene/all/conanfile.py
+++ b/recipes/graphene/all/conanfile.py
@@ -41,13 +41,21 @@ class LibnameConan(ConanFile):
     
     def requirements(self):
         if self.options.with_glib:
-            self.requires("glib/2.72.0")
+            self.requires("glib/2.73.0")
 
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+        if self.options.shared and self.options.with_glib:
+            self.options["glib"].shared = True
+
+    def validate(self):
+        if self.options.shared and self.options.with_glib and not self.options["glib"].shared:
+            raise ConanInvalidConfiguration(
+                "Linking a shared library against static glib can cause unexpected behaviour."
+            )
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -101,3 +109,7 @@ class LibnameConan(ConanFile):
             self.cpp_info.components["graphene-gobject-1.0"].includedirs = [os.path.join("include", "graphene-1.0")]
             self.cpp_info.components["graphene-gobject-1.0"].names["pkg_config"] = "graphene-gobject-1.0"
             self.cpp_info.components["graphene-gobject-1.0"].requires = ["graphene-1.0", "glib::gobject-2.0"]
+
+    def package_id(self):
+        if self.options.with_glib:
+            self.info.requires["glib"].full_package_mode()


### PR DESCRIPTION
Specify library name and version:  **graphene**

Building shared libraries that depend on static glib causes problems. See https://github.com/conan-io/conan-center-index/issues/11022.
Last dependency at last!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
