### PR TITLE
msgpack-cxx: add version 4.1.1

### DIFF
--- a/recipes/msgpack-cxx/all/conandata.yml
+++ b/recipes/msgpack-cxx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.1.1":
+    url: "https://github.com/msgpack/msgpack-c/archive/cpp-4.1.1.tar.gz"
+    sha256: "221cc539e77f5ca02f4f0bbb1edafa9ca8c08de7ba8072d7baf2139930d99182"
   "4.1.0":
     url: "https://github.com/msgpack/msgpack-c/archive/cpp-4.1.0.tar.gz"
     sha256: "634762502a192026bd5db773f9e18d900ad04cfc312b52faee350a5c76e5ccfb"

--- a/recipes/msgpack-cxx/config.yml
+++ b/recipes/msgpack-cxx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.1.1":
+    folder: all
   "4.1.0":
     folder: all
   "4.0.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **msgpack-cxx**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
