### PR TITLE
hidapi: add version 0.12.0

### DIFF
--- a/recipes/hidapi/all/conandata.yml
+++ b/recipes/hidapi/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.12.0":
+    url: "https://github.com/libusb/hidapi/archive/hidapi-0.12.0.tar.gz"
+    sha256: "28ec1451f0527ad40c1a4c92547966ffef96813528c8b184a665f03ecbb508bc"
   "0.11.2":
     url: "https://github.com/libusb/hidapi/archive/hidapi-0.11.2.tar.gz"
     sha256: "bc4ac0f32a6b21ef96258a7554c116152e2272dacdec1e4620fc44abeea50c27"

--- a/recipes/hidapi/config.yml
+++ b/recipes/hidapi/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.12.0":
+    folder: all
   "0.11.2":
     folder: all
   "0.11.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **lhidapi/0.12.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
