### PR TITLE
huffman: add version 1.2.7

### DIFF
--- a/recipes/huffman/all/conandata.yml
+++ b/recipes/huffman/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.7":
+    url: "https://github.com/drichardson/huffman/archive/v1.2.7.tar.gz"
+    sha256: "b7fa4c52fbebe2e6d573350d6b64faaec4216beeb78d1fc25ce74e6a9a756a6c"
   "1.2.2":
     url: "https://github.com/drichardson/huffman/archive/refs/tags/v1.2.2.zip"
     sha256: "7968728c4a0e2705575e9f03e0252cb5195919756d3a64343255f518548cb533"

--- a/recipes/huffman/config.yml
+++ b/recipes/huffman/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.2.7":
+    folder: all
   "1.2.2":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **huffman/1.2.7**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
