### PR TITLE
nsync: add version 1.25.0

### DIFF
--- a/recipes/nsync/all/conandata.yml
+++ b/recipes/nsync/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.25.0":
+    url: "https://github.com/google/nsync/archive/1.25.0.tar.gz"
+    sha256: "2be9dbfcce417c7abcc2aa6fee351cd4d292518d692577e74a2c6c05b049e442"
   "1.24.0":
     url: "https://github.com/google/nsync/archive/1.24.0.tar.gz"
     sha256: "47a6eb2a295be5121a1904a6a775722338a20dc02ee3eec4169ed2c3f203617a"
@@ -6,6 +9,9 @@ sources:
     sha256: "b7e75b17957c62bd02dd73890bde22da3a564903fcaad651b395453d41d3325b"
     url: "https://github.com/google/nsync/archive/refs/tags/1.23.0.tar.gz"
 patches:
+  "1.25.0":
+    - patch_file: "patches/0001-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch"
+      base_path: "source_subfolder"
   "1.24.0":
     - patch_file: "patches/0001-darwin-exclude_semaphore_mutex_c_from_nsync_cpp_lib.patch"
       base_path: "source_subfolder"

--- a/recipes/nsync/config.yml
+++ b/recipes/nsync/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.25.0":
+    folder: "all"
   "1.24.0":
     folder: "all"
   "1.23.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **nsync/1.25.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
