### PR TITLE
rmlui 4.x: Upgrade CMake to support VS2022

### DIFF
--- a/recipes/rmlui/4.x/conanfile.py
+++ b/recipes/rmlui/4.x/conanfile.py
@@ -29,7 +29,7 @@ class RmluiConan(ConanFile):
         "with_lua_bindings": False,
         "with_thirdparty_containers": True
     }
-    build_requires = ["cmake/3.20.0"]
+    build_requires = ["cmake/3.23.2"]
     exports_sources = ["CMakeLists.txt"]
     generators = ["cmake", "cmake_find_package"]
 


### PR DESCRIPTION
Specify library name and version:  **rmlui/4.x**

This should fix #9284.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
