### PR TITLE
taskflow: add version 3.4.0

### DIFF
--- a/recipes/taskflow/all/conandata.yml
+++ b/recipes/taskflow/all/conandata.yml
@@ -1,31 +1,28 @@
 sources:
-  "2.2.0":
-    url: "https://github.com/taskflow/taskflow/archive/v2.2.0.tar.gz"
-    sha256: "A8AD8C94CEEAC0BC18D8429F877E10A2AF2CD44CD9DC420D9751E69F48FF85D1"
-  "2.4.0":
-    url: "https://github.com/taskflow/taskflow/archive/v2.4.0.tar.gz"
-    sha256: "1F6CC854DD579396CA22AE86014CBF13DD90205E7C9438E2B6B2FDDACA99668C"
-  "2.5.0":
-    url: "https://github.com/taskflow/taskflow/archive/v2.5.0.tar.gz"
-    sha256: "B7016EE3486458AE401D521EA6BC0403DDE975828038B9734621A6A325ACAC1A"
-  "2.6.0":
-    url: "https://github.com/taskflow/taskflow/archive/v2.6.0.tar.gz"
-    sha256: "2F511F4291653D759AF12A7854BABCEBF57CFBB8B49BF6CD3EB0DD98A1A4039C"
-  "2.7.0":
-    url: "https://github.com/taskflow/taskflow/archive/v2.7.0.tar.gz"
-    sha256: "BC2227DCABEC86ABEBA1FEE56BB357D9D3C0EF0184F7C2275D7008E8758DFC3E"
-  "3.0.0":
-    url: "https://github.com/taskflow/taskflow/archive/v3.0.0.tar.gz"
-    sha256: "553C88A6E56E115D29AC1520B8A0FEA4557A5FCDA1AF1427BD3BA454926D03A2"
-  "3.1.0":
-    url: "https://github.com/taskflow/taskflow/archive/v3.1.0.tar.gz"
-    sha256: "B83E9A78C254D831B8401D0F8A766E3C5B60D8D20BE5AF6E2D2FAD4AA4A8B980"
-  "3.2.0":
-    url: "https://github.com/taskflow/taskflow/archive/v3.2.0.tar.gz"
-    sha256: "26c37a494789fedc5de8d1f8452dc8a7774a220d02c14d5b19efe0dfe0359c0c"
+  "3.4.0":
+    url: "https://github.com/taskflow/taskflow/archive/v3.4.0.tar.gz"
+    sha256: "8f449137d3f642b43e905aeacdf1d7c5365037d5e1586103ed4f459f87cecf89"
   "3.3.0":
     url: "https://github.com/taskflow/taskflow/archive/v3.3.0.tar.gz"
     sha256: "66b891f706ba99a5ca5ed239d520ad6943ebe94728d1c89e07a939615a6488ef"
+  "3.2.0":
+    url: "https://github.com/taskflow/taskflow/archive/v3.2.0.tar.gz"
+    sha256: "26c37a494789fedc5de8d1f8452dc8a7774a220d02c14d5b19efe0dfe0359c0c"
+  "3.1.0":
+    url: "https://github.com/taskflow/taskflow/archive/v3.1.0.tar.gz"
+    sha256: "B83E9A78C254D831B8401D0F8A766E3C5B60D8D20BE5AF6E2D2FAD4AA4A8B980"
+  "3.0.0":
+    url: "https://github.com/taskflow/taskflow/archive/v3.0.0.tar.gz"
+    sha256: "553C88A6E56E115D29AC1520B8A0FEA4557A5FCDA1AF1427BD3BA454926D03A2"
+  "2.7.0":
+    url: "https://github.com/taskflow/taskflow/archive/v2.7.0.tar.gz"
+    sha256: "BC2227DCABEC86ABEBA1FEE56BB357D9D3C0EF0184F7C2275D7008E8758DFC3E"
+  "2.6.0":
+    url: "https://github.com/taskflow/taskflow/archive/v2.6.0.tar.gz"
+    sha256: "2F511F4291653D759AF12A7854BABCEBF57CFBB8B49BF6CD3EB0DD98A1A4039C"
+  "2.5.0":
+    url: "https://github.com/taskflow/taskflow/archive/v2.5.0.tar.gz"
+    sha256: "B7016EE3486458AE401D521EA6BC0403DDE975828038B9734621A6A325ACAC1A"
 patches:
   "3.3.0":
     - base_path: "source_subfolder"

--- a/recipes/taskflow/all/conanfile.py
+++ b/recipes/taskflow/all/conanfile.py
@@ -1,9 +1,9 @@
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc
 import os
 
 required_conan_version = ">=1.43.0"
-
 
 class TaskflowConan(ConanFile):
     name = "taskflow"
@@ -11,11 +11,10 @@ class TaskflowConan(ConanFile):
         "A fast C++ header-only library to help you quickly write parallel "
         "programs with complex task dependencies."
     )
-    topics = ("taskflow", "tasking", "parallelism")
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/taskflow/taskflow"
-    license = "MIT"
-
+    topics = ("taskflow", "tasking", "parallelism")
     settings = "os", "arch", "compiler", "build_type"
 
     @property
@@ -23,12 +22,8 @@ class TaskflowConan(ConanFile):
         return "source_subfolder"
 
     @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
-
-    @property
     def _min_cppstd(self):
-        if tools.Version(self.version) <= "2.2.0" or tools.Version(self.version) >= "3.0.0":
+        if tools.Version(self.version) >= "3.0.0":
             return "17"
         return "14"
 
@@ -87,7 +82,7 @@ class TaskflowConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "Taskflow::Taskflow")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("pthread")
-        if self._is_msvc:
+        if is_msvc(self):
             self.cpp_info.defines.append("_ENABLE_EXTENDED_ALIGNED_STORAGE")
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed

--- a/recipes/taskflow/all/conanfile.py
+++ b/recipes/taskflow/all/conanfile.py
@@ -16,6 +16,7 @@ class TaskflowConan(ConanFile):
     homepage = "https://github.com/taskflow/taskflow"
     topics = ("taskflow", "tasking", "parallelism")
     settings = "os", "arch", "compiler", "build_type"
+    short_paths = True
 
     @property
     def _source_subfolder(self):

--- a/recipes/taskflow/all/test_package/CMakeLists.txt
+++ b/recipes/taskflow/all/test_package/CMakeLists.txt
@@ -1,16 +1,16 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(Taskflow REQUIRED)
+find_package(Taskflow REQUIRED CONFIG)
 
-set(_CXX_STANDARD 14)
-if (Taskflow_VERSION LESS_EQUAL "2.2.0" OR Taskflow_VERSION GREATER_EQUAL "3.0.0")
-    set(_CXX_STANDARD 17)
+set(_CXX_STANDARD cxx_std_14)
+if (Taskflow_VERSION GREATER_EQUAL "3.0.0")
+    set(_CXX_STANDARD cxx_std_17)
 endif()
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD ${_CXX_STANDARD})
+target_compile_features(${PROJECT_NAME} PRIVATE ${_CXX_STANDARD})
 target_link_libraries(${PROJECT_NAME} Taskflow::Taskflow)

--- a/recipes/taskflow/all/test_package/conanfile.py
+++ b/recipes/taskflow/all/test_package/conanfile.py
@@ -4,8 +4,8 @@ from conans import ConanFile, tools, CMake
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/taskflow/config.yml
+++ b/recipes/taskflow/config.yml
@@ -1,19 +1,17 @@
 versions:
-  "2.2.0":
+  "3.4.0":
     folder: all
-  "2.4.0":
-    folder: all
-  "2.5.0":
-    folder: all
-  "2.6.0":
-    folder: all
-  "2.7.0":
-    folder: all
-  "3.0.0":
-    folder: all
-  "3.1.0":
+  "3.3.0":
     folder: all
   "3.2.0":
     folder: all
-  "3.3.0":
+  "3.1.0":
+    folder: all
+  "3.0.0":
+    folder: all
+  "2.7.0":
+    folder: all
+  "2.6.0":
+    folder: all
+  "2.5.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **taskflow/***

- add version 3.4.0
- remove versions 2.2.0, 2.4.0
- taskflow/3.4.0 doesn't require patch for taskflow/3.3.0. (already fixed)
- sort versions 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
