### PR TITLE
sentry-breakpad/0.4.18

### DIFF
--- a/recipes/sentry-breakpad/all/conandata.yml
+++ b/recipes/sentry-breakpad/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.4.18":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.4.18/sentry-native.zip"
+    sha256: "41fdf6499cd8576142beb03104badcc9e0b80b8ef27080ca71cd4408cc1d7ece"
   "0.4.17":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.4.17/sentry-native.zip"
     sha256: "38c9e180c29b6561c5f91ada154e191eabe9d7c270734cff81e55532878ec273"

--- a/recipes/sentry-breakpad/config.yml
+++ b/recipes/sentry-breakpad/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.4.18":
+    folder: all
   "0.4.17":
     folder: all
   "0.4.15":


### PR DESCRIPTION
Specify library name and version:  **sentry-breakpad/0.4.18**

Version bump

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
