### PR TITLE
quazip/1.3.0: Add qt6 support

### DIFF
--- a/recipes/quazip/all/conanfile.py
+++ b/recipes/quazip/all/conanfile.py
@@ -37,6 +37,10 @@ class QuaZIPConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    @property
+    def _qt_major(self):
+        return tools.Version(self.deps_cpp_info["qt"].version).major
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -56,6 +60,7 @@ class QuaZIPConan(ConanFile):
     @functools.lru_cache(1)
     def _configure_cmake(self):
         cmake = CMake(self)
+        cmake.definitions["QUAZIP_QT_MAJOR_VERSION"] = self._qt_major
         cmake.configure()
         return cmake
 
@@ -72,19 +77,19 @@ class QuaZIPConan(ConanFile):
 
     def package_info(self):
         quazip_major = tools.Version(self.version).major
-        qt_major = tools.Version(self.deps_cpp_info["qt"].version).major
-        self.cpp_info.set_property("cmake_file_name", f"QuaZip-Qt{qt_major}")
+        _qt_major = tools.Version(self.deps_cpp_info["qt"].version).major
+        self.cpp_info.set_property("cmake_file_name", f"QuaZip-Qt{_qt_major}")
         self.cpp_info.set_property("cmake_target_name", "QuaZip::QuaZip")
-        self.cpp_info.set_property("pkg_config_name", f"quazip{quazip_major}-qt{qt_major}")
+        self.cpp_info.set_property("pkg_config_name", f"quazip{quazip_major}-qt{_qt_major}")
         suffix = "d" if self.settings.build_type == "Debug" else ""
-        self.cpp_info.libs = [f"quazip{quazip_major}-qt{qt_major}{suffix}"]
-        self.cpp_info.includedirs = [os.path.join("include", f"QuaZip-Qt{qt_major}-{self.version}")]
+        self.cpp_info.libs = [f"quazip{quazip_major}-qt{_qt_major}{suffix}"]
+        self.cpp_info.includedirs = [os.path.join("include", f"QuaZip-Qt{_qt_major}-{self.version}")]
         if not self.options.shared:
             self.cpp_info.defines.append("QUAZIP_STATIC")
 
         # TODO: to remove in conan v2 once cmake_find_package_* & pkg_config generators removed
-        self.cpp_info.filenames["cmake_find_package"] = f"QuaZip-Qt{qt_major}"
-        self.cpp_info.filenames["cmake_find_package_multi"] = f"QuaZip-Qt{qt_major}"
+        self.cpp_info.filenames["cmake_find_package"] = f"QuaZip-Qt{_qt_major}"
+        self.cpp_info.filenames["cmake_find_package_multi"] = f"QuaZip-Qt{_qt_major}"
         self.cpp_info.names["cmake_find_package"] = "QuaZip"
         self.cpp_info.names["cmake_find_package_multi"] = "QuaZip"
-        self.cpp_info.names["pkg_config"] = f"quazip{quazip_major}-qt{qt_major}"
+        self.cpp_info.names["pkg_config"] = f"quazip{quazip_major}-qt{_qt_major}"


### PR DESCRIPTION
Specify library name and version:  **quazip/1.3.0**

This replace https://github.com/conan-io/conan-center-index/pull/10049 
fixes https://github.com/conan-io/conan-center-index/issues/10640
, after getting help from https://github.com/stachenov/quazip/issues/145#issuecomment-1158950307

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
