### PR TITLE
qt: Link dbus-1 not dbus-1d in Debug builds on Windows

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -420,6 +420,10 @@ class QtConan(ConanFile):
                                   "  if (enable_precompiled_headers) {\n    if (is_win) {",
                                   "  if (enable_precompiled_headers) {\n    if (false) {"
                                   )
+        tools.replace_in_file(os.path.join(self.source_folder, "qt5", "qtbase", "configure.json"),
+                                  "-ldbus-1d",
+                                  "-ldbus-1"
+                                  )
 
     def _make_program(self):
         if self._is_msvc:


### PR DESCRIPTION
Neither the Conan or the vanilla CMake-build version of the dbus
package use a d-suffix for the debug version of the library on
Windows.

Fixes #11286

Specify library name and version:  **qt/5.15.4**
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
