### PR TITLE
qr-code-generator: add version 1.8.0

### DIFF
--- a/recipes/qr-code-generator/all/conandata.yml
+++ b/recipes/qr-code-generator/all/conandata.yml
@@ -11,6 +11,9 @@ sources:
   "1.7.0":
     url: "https://github.com/nayuki/QR-Code-generator/archive/v1.7.0.tar.gz"
     sha256: "a8138d84a2adbc9168bfadfb9db5272c89b69fb87f72a88ecd08ce7f402ee710"
+  "1.8.0":
+    url: "https://github.com/nayuki/QR-Code-generator/archive/v1.8.0.tar.gz"
+    sha256: "2ec0a4d33d6f521c942eeaf473d42d5fe139abcfa57d2beffe10c5cf7d34ae60"
 patches:
   "1.4.0":
     - base_path: "source_subfolder"
@@ -24,5 +27,8 @@ patches:
     - base_path: "."
       patch_file: "patches/003-cmake-1.6.patch"
   "1.7.0":
+    - base_path: "."
+      patch_file: "patches/004-cmake-1.7.patch"
+  "1.8.0":
     - base_path: "."
       patch_file: "patches/004-cmake-1.7.patch"

--- a/recipes/qr-code-generator/config.yml
+++ b/recipes/qr-code-generator/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "1.7.0":
     folder: all
+  "1.8.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **qr-code-generator/1.8.0**



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
