### PR TITLE
qr-code-generator: add math lib and modernize

### DIFF
--- a/recipes/qr-code-generator/all/conandata.yml
+++ b/recipes/qr-code-generator/all/conandata.yml
@@ -1,34 +1,34 @@
 sources:
-  "1.4.0":
-    url: "https://github.com/nayuki/QR-Code-generator/archive/v1.4.0.tar.gz"
-    sha256: "fcdf9fd69fde07ae4dca2351d84271a9de8093002f733b77c70f52f1630f6e4a"
-  "1.5.0":
-    url: "https://github.com/nayuki/QR-Code-generator/archive/v1.5.0.tar.gz"
-    sha256: "6cf993c10fbf96b5e8f8e4eaad8ea1ca3bbc58fb4d00a4728b4f818c27fb4d5e"
-  "1.6.0":
-    url: "https://github.com/nayuki/QR-Code-generator/archive/v1.6.0.tar.gz"
-    sha256: "8acee5a77325e075b910747ad4b1fdb1491b7e22d0b8f1b5a6ea15ea08ba33a8"
-  "1.7.0":
-    url: "https://github.com/nayuki/QR-Code-generator/archive/v1.7.0.tar.gz"
-    sha256: "a8138d84a2adbc9168bfadfb9db5272c89b69fb87f72a88ecd08ce7f402ee710"
   "1.8.0":
     url: "https://github.com/nayuki/QR-Code-generator/archive/v1.8.0.tar.gz"
     sha256: "2ec0a4d33d6f521c942eeaf473d42d5fe139abcfa57d2beffe10c5cf7d34ae60"
+  "1.7.0":
+    url: "https://github.com/nayuki/QR-Code-generator/archive/v1.7.0.tar.gz"
+    sha256: "a8138d84a2adbc9168bfadfb9db5272c89b69fb87f72a88ecd08ce7f402ee710"
+  "1.6.0":
+    url: "https://github.com/nayuki/QR-Code-generator/archive/v1.6.0.tar.gz"
+    sha256: "8acee5a77325e075b910747ad4b1fdb1491b7e22d0b8f1b5a6ea15ea08ba33a8"
+  "1.5.0":
+    url: "https://github.com/nayuki/QR-Code-generator/archive/v1.5.0.tar.gz"
+    sha256: "6cf993c10fbf96b5e8f8e4eaad8ea1ca3bbc58fb4d00a4728b4f818c27fb4d5e"
+  "1.4.0":
+    url: "https://github.com/nayuki/QR-Code-generator/archive/v1.4.0.tar.gz"
+    sha256: "fcdf9fd69fde07ae4dca2351d84271a9de8093002f733b77c70f52f1630f6e4a"
 patches:
+  "1.8.0":
+    - base_path: "."
+      patch_file: "patches/004-cmake-1.7.patch"
+  "1.7.0":
+    - base_path: "."
+      patch_file: "patches/004-cmake-1.7.patch"
+  "1.6.0":
+    - base_path: "."
+      patch_file: "patches/003-cmake-1.6.patch"
+  "1.5.0":
+    - base_path: "."
+      patch_file: "patches/002-cmake-pre-1.6.patch"
   "1.4.0":
     - base_path: "source_subfolder"
       patch_file: "patches/001-qrcode-1_4.patch"
     - base_path: "."
       patch_file: "patches/002-cmake-pre-1.6.patch"
-  "1.5.0":
-    - base_path: "."
-      patch_file: "patches/002-cmake-pre-1.6.patch"
-  "1.6.0":
-    - base_path: "."
-      patch_file: "patches/003-cmake-1.6.patch"
-  "1.7.0":
-    - base_path: "."
-      patch_file: "patches/004-cmake-1.7.patch"
-  "1.8.0":
-    - base_path: "."
-      patch_file: "patches/004-cmake-1.7.patch"

--- a/recipes/qr-code-generator/all/test_package/CMakeLists.txt
+++ b/recipes/qr-code-generator/all/test_package/CMakeLists.txt
@@ -1,13 +1,14 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(qr-code-generator REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-if (QRCODEGEN_VERSION VERSION_LESS "1.7.0")
+target_link_libraries(${PROJECT_NAME} qr-code-generator::qr-code-generator)
+if (qr-code-generator_VERSION VERSION_LESS "1.7.0")
     target_compile_definitions(${PROJECT_NAME} PRIVATE QR_USE_OLD_INCLUDE)
 endif()
-
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/qr-code-generator/all/test_package/conanfile.py
+++ b/recipes/qr-code-generator/all/test_package/conanfile.py
@@ -3,16 +3,15 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["QRCODEGEN_VERSION"] = tools.Version(self.requires["qr-code-generator"].ref.version)
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/qr-code-generator/config.yml
+++ b/recipes/qr-code-generator/config.yml
@@ -1,11 +1,11 @@
 versions:
-  "1.4.0":
-    folder: all
-  "1.5.0":
-    folder: all
-  "1.6.0":
+  "1.8.0":
     folder: all
   "1.7.0":
     folder: all
-  "1.8.0":
+  "1.6.0":
+    folder: all
+  "1.5.0":
+    folder: all
+  "1.4.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **qr-code-generator/***

- add math lib in Linux, FreeBSD
- sort versions
- use lru_cache for configure_cmake
- use `find_package` in test_package

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
