### PR TITLE
Add nmos-cpp/cci.20220620

### DIFF
--- a/recipes/nmos-cpp/all/conandata.yml
+++ b/recipes/nmos-cpp/all/conandata.yml
@@ -15,3 +15,6 @@ sources:
   "cci.20220428":
     url: "https://github.com/sony/nmos-cpp/archive/07b8742d5e3413c903a0b0e74d0c87a76e9ecdfa.tar.gz"
     sha256: "be305ea343822f0aa76376955b7adcbf61807b2fe54084c067daa837ef37b0cd"
+  "cci.20220620":
+    url: "https://github.com/sony/nmos-cpp/archive/3a904a3fcc39057a8db74656a697f0d97d8a3651.tar.gz"
+    sha256: "49a16ad5c8b1cf45cd519b96c880340b369a737c6814f8c533fff1cf49439fda"

--- a/recipes/nmos-cpp/all/conanfile.py
+++ b/recipes/nmos-cpp/all/conanfile.py
@@ -56,10 +56,10 @@ class NmosCppConan(ConanFile):
 
     def requirements(self):
         # for now, consistent with project's conanfile.txt
-        self.requires("boost/1.78.0")
+        self.requires("boost/1.79.0")
         self.requires("cpprestsdk/2.10.18")
         self.requires("websocketpp/0.8.2")
-        self.requires("openssl/1.1.1n")
+        self.requires("openssl/1.1.1o")
         self.requires("json-schema-validator/2.1.0")
 
         if self.options.get_safe("with_dnssd") == "mdnsresponder":
@@ -73,7 +73,7 @@ class NmosCppConan(ConanFile):
 
     def build_requirements(self):
         # nmos-cpp needs CMake 3.17 or higher but CCI doesn't allow version ranges
-        self.build_requires("cmake/3.22.0")
+        self.build_requires("cmake/3.23.2")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/nmos-cpp/config.yml
+++ b/recipes/nmos-cpp/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "cci.20220428":
     folder: all
+  "cci.20220620":
+    folder: all


### PR DESCRIPTION
Latest upstream, bumps dependencies to boost/1.79.0 and openssl/1.1.1o
