### PR TITLE
cpprestsdk: bump to boost/1.79.0 and openssl/1.1.1o

### DIFF
--- a/recipes/cpprestsdk/all/conanfile.py
+++ b/recipes/cpprestsdk/all/conanfile.py
@@ -62,8 +62,8 @@ class CppRestSDKConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("boost/1.78.0")
-        self.requires("openssl/1.1.1n")
+        self.requires("boost/1.79.0")
+        self.requires("openssl/1.1.1o")
         if self.options.with_compression:
             self.requires("zlib/1.2.12")
         if self.options.with_websockets:


### PR DESCRIPTION
cpprestsdk: bump to boost/1.79.0 and openssl/1.1.1o