### PR TITLE
cubicinterpolation: temporatily downgrade boost dependency

### DIFF
--- a/recipes/cubicinterpolation/all/conanfile.py
+++ b/recipes/cubicinterpolation/all/conanfile.py
@@ -43,7 +43,8 @@ class CubicInterpolationConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("boost/1.78.0")
+        # TODO: update boost dependency as soon as issue #11207 is fixed
+        self.requires("boost/1.75.0")
         self.requires("eigen/3.3.9")
 
     @property


### PR DESCRIPTION
Specify library name and version:  **cubicinterpolation/x.x.x**

Temporary solution to make packages compiling again (see issue #11207).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
