### PR TITLE
[gtk]: Enable gtk3 on windows and use shared glib when shared

### DIFF
--- a/recipes/gtk/all/conandata.yml
+++ b/recipes/gtk/all/conandata.yml
@@ -2,24 +2,12 @@ sources:
   "4.7.0":
     sha256: "913fcd9d065efb348723e18c3b9113e23b92072e927ebd2f61d32745c8228b94"
     url: "https://download.gnome.org/sources/gtk/4.7/gtk-4.7.0.tar.xz"
-  "4.6.2":
-    url: "https://download.gnome.org/sources/gtk/4.6/gtk-4.6.2.tar.xz"
-    sha256: "ff263af609a50eb76056653592d929459aef4819a444c436f6d52c6f63c1faec"
   "4.4.0":
     url: "https://download.gnome.org/sources/gtk/4.4/gtk-4.4.0.tar.xz"
     sha256: "e0a1508f441686c3a20dfec48af533b19a4b2e017c18eaee31dccdb7d292505b"
-  "4.3.2":
-    url: "https://download.gnome.org/sources/gtk/4.3/gtk-4.3.2.tar.xz"
-    sha256: "20639bb2be8b9f58304f14480e3d957abd2c9fa3f671bb7e05193f9a8389d93f"
-  "4.2.1":
-    url: "https://download.gnome.org/sources/gtk/4.2/gtk-4.2.1.tar.xz"
-    sha256: "023169775de43f0a1fde066fbc19d78545ea6a7562c1915abde9b8ae4a7309e6"
   "4.1.2":
     url: "https://download.gnome.org/sources/gtk/4.1/gtk-4.1.2.tar.xz"
     sha256: "33407da437c5e5ac09e7a463ba3bd025da3d80ba1953b8bbe2bce97dd2609677"
-  "4.0.2":
-    url: "https://download.gnome.org/sources/gtk/4.0/gtk-4.0.2.tar.xz"
-    sha256: "626707ac6751426ed76fed49c5b2d052dfee45757ce3827088ba87ca7f1dbc84"
   "3.24.34":
     url: "https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.34.tar.xz"
     sha256: "dbc69f90ddc821b8d1441f00374dc1da4323a2eafa9078e61edbe5eeefa852ec"
@@ -28,16 +16,6 @@ sources:
     sha256: "cc9d4367c55b724832f6b09ab85481738ea456871f0381768a6a99335a98378a"
 patches:
   "4.4.0":
-    - patch_file: "patches/0001-fix-UAC-manifest-rc.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0002-fix-version-resource-for-Windows-11-sdk.patch"
-      base_path: "source_subfolder"
-  "4.3.2":
-    - patch_file: "patches/0001-fix-UAC-manifest-rc.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0002-fix-version-resource-for-Windows-11-sdk.patch"
-      base_path: "source_subfolder"
-  "4.2.1":
     - patch_file: "patches/0001-fix-UAC-manifest-rc.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0002-fix-version-resource-for-Windows-11-sdk.patch"

--- a/recipes/gtk/all/conandata.yml
+++ b/recipes/gtk/all/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "4.0.2":
     url: "https://download.gnome.org/sources/gtk/4.0/gtk-4.0.2.tar.xz"
     sha256: "626707ac6751426ed76fed49c5b2d052dfee45757ce3827088ba87ca7f1dbc84"
+  "3.24.34":
+    url: "https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.34.tar.xz"
+    sha256: "dbc69f90ddc821b8d1441f00374dc1da4323a2eafa9078e61edbe5eeefa852ec"
   "3.24.24":
     url: "https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.24.tar.xz"
     sha256: "cc9d4367c55b724832f6b09ab85481738ea456871f0381768a6a99335a98378a"

--- a/recipes/gtk/all/conanfile.py
+++ b/recipes/gtk/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, Meson, tools
+from conan.tools.files import rename
 from conans.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import is_msvc
 import os
@@ -238,6 +239,24 @@ class GtkConan(ConanFile):
         tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.pdb")
         tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.pdb")
 
+        if self._gtk3 and is_msvc(self) and not self.options.shared:
+            rename(
+                self,
+                os.path.join(self.package_folder, "lib", f"libgtk-3.a"),
+                os.path.join(self.package_folder, "lib", f"gtk-3.lib"),
+            )
+            rename(
+                self,
+                os.path.join(self.package_folder, "lib", f"libgdk-3.a"),
+                os.path.join(self.package_folder, "lib", f"gdk-3.lib"),
+            )
+            rename(
+                self,
+                os.path.join(self.package_folder, "lib", f"libgailutil-3.a"),
+                os.path.join(self.package_folder, "lib", f"gailutil-3.lib"),
+            )
+
+
     def package_info(self):
         if self._gtk3:
             self.cpp_info.components["gdk-3.0"].libs = ["gdk-3"]
@@ -253,6 +272,12 @@ class GtkConan(ConanFile):
                     self.cpp_info.components["gdk-3.0"].requires.append("xorg::xorg")
             self.cpp_info.components["gdk-3.0"].requires.append("libepoxy::libepoxy")
             self.cpp_info.components["gdk-3.0"].names["pkg_config"] = "gdk-3.0"
+            if self.settings.os == "Windows":
+                self.cpp_info.components["gdk-3.0"].system_libs = [
+                    "imm32", "gdi32", "shell32", "ole32", "winmm", "dwmapi",
+                    "setupapi", "cfgmgr32", "hid", "winspool", "comctl32",
+                    "comdlg32"
+                ]
 
             self.cpp_info.components["gtk+-3.0"].libs = ["gtk-3"]
             self.cpp_info.components["gtk+-3.0"].requires = ["gdk-3.0", "atk::atk"]

--- a/recipes/gtk/all/conanfile.py
+++ b/recipes/gtk/all/conanfile.py
@@ -242,18 +242,18 @@ class GtkConan(ConanFile):
         if self._gtk3 and is_msvc(self) and not self.options.shared:
             rename(
                 self,
-                os.path.join(self.package_folder, "lib", f"libgtk-3.a"),
-                os.path.join(self.package_folder, "lib", f"gtk-3.lib"),
+                os.path.join(self.package_folder, "lib", "libgtk-3.a"),
+                os.path.join(self.package_folder, "lib", "gtk-3.lib"),
             )
             rename(
                 self,
-                os.path.join(self.package_folder, "lib", f"libgdk-3.a"),
-                os.path.join(self.package_folder, "lib", f"gdk-3.lib"),
+                os.path.join(self.package_folder, "lib", "libgdk-3.a"),
+                os.path.join(self.package_folder, "lib", "gdk-3.lib"),
             )
             rename(
                 self,
-                os.path.join(self.package_folder, "lib", f"libgailutil-3.a"),
-                os.path.join(self.package_folder, "lib", f"gailutil-3.lib"),
+                os.path.join(self.package_folder, "lib", "libgailutil-3.a"),
+                os.path.join(self.package_folder, "lib", "gailutil-3.lib"),
             )
 
 
@@ -311,6 +311,12 @@ class GtkConan(ConanFile):
                 "libepoxy::libepoxy", "graphene::graphene-gobject-1.0",
                 "fribidi::fribidi"
             ])
+            if self.settings.os == "Windows":
+                self.cpp_info.system_libs = [
+                    "advapi32", "comctl32", "crypt32", "dwmapi", "imm32",
+                    "setupapi", "winmm"
+                ]
+
             if self.settings.os == "Linux":
                 if self.options.with_x11:
                     self.cpp_info.requires.append("xorg::xorg")

--- a/recipes/gtk/all/conanfile.py
+++ b/recipes/gtk/all/conanfile.py
@@ -124,8 +124,7 @@ class GtkConan(ConanFile):
     def requirements(self):
         self.requires("gdk-pixbuf/2.42.8")
         self.requires("glib/2.73.0")
-        if self._gtk4 or self.settings.compiler != "Visual Studio":
-            self.requires("cairo/1.17.4")
+        self.requires("cairo/1.17.4")
         if self._gtk4:
             self.requires("graphene/1.10.8")
             self.requires("fribidi/1.0.12")

--- a/recipes/gtk/all/conanfile.py
+++ b/recipes/gtk/all/conanfile.py
@@ -280,8 +280,7 @@ class GtkConan(ConanFile):
 
             self.cpp_info.components["gtk+-3.0"].libs = ["gtk-3"]
             self.cpp_info.components["gtk+-3.0"].requires = ["gdk-3.0", "atk::atk"]
-            if self.settings.compiler != "Visual Studio":
-                self.cpp_info.components["gtk+-3.0"].requires.extend(["cairo::cairo", "cairo::cairo-gobject"])
+            self.cpp_info.components["gtk+-3.0"].requires.extend(["cairo::cairo", "cairo::cairo-gobject"])
             self.cpp_info.components["gtk+-3.0"].requires.extend(["gdk-pixbuf::gdk-pixbuf", "glib::gio-2.0"])
             if self.settings.os == "Linux":
                 self.cpp_info.components["gtk+-3.0"].requires.append("at-spi2-atk::at-spi2-atk")

--- a/recipes/gtk/all/conanfile.py
+++ b/recipes/gtk/all/conanfile.py
@@ -89,12 +89,6 @@ class GtkConan(ConanFile):
         if self.settings.os == "Linux" and (self.options.with_wayland or self.options.with_x11) and not self.options["pango"].with_freetype:
             raise ConanInvalidConfiguration(
                 "gtk requires pango with freetype when built with wayland/x11 support")
-        if self.settings.compiler == "clang":
-            # FIXME: gdk-pixbuf cannot be built using clang with the latest glib
-            # which all other dependencies of gtk depend on
-            # see https://github.com/conan-io/conan-center-index/pull/10154#issuecomment-1094224794
-            raise ConanInvalidConfiguration(
-                "this recipe does not support building with clang")
 
     def configure(self):
         if self.options.shared:

--- a/recipes/gtk/all/conanfile.py
+++ b/recipes/gtk/all/conanfile.py
@@ -77,7 +77,7 @@ class GtkConan(ConanFile):
         if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "5":
             raise ConanInvalidConfiguration("this recipes does not support GCC before version 5. contributions are welcome")
         if is_msvc(self):
-            # TODO: Remove once gtk 4.1.2 and 4.0.2 are removed
+            # TODO: Remove once gtk 4.1.2 is removed
             if self._gtk4 and tools.Version(self.version) < "4.2":
                 raise ConanInvalidConfiguration("MSVC support of this recipe requires at least gtk/4.2")
             # TODO: Remove once gtk 3.24.24 is removed

--- a/recipes/gtk/config.yml
+++ b/recipes/gtk/config.yml
@@ -15,5 +15,7 @@ versions:
         folder: all
     "4.0.2":
         folder: all
+    "3.24.34":
+        folder: all
     "3.24.24":
         folder: all

--- a/recipes/gtk/config.yml
+++ b/recipes/gtk/config.yml
@@ -3,17 +3,9 @@ versions:
         folder: "system"
     "4.7.0":
         folder: all
-    "4.6.2":
-        folder: all
     "4.4.0":
         folder: all
-    "4.3.2":
-        folder: all
-    "4.2.1":
-        folder: all
     "4.1.2":
-        folder: all
-    "4.0.2":
         folder: all
     "3.24.34":
         folder: all


### PR DESCRIPTION
Specify library name and version:  **gtk**

The major blocker for building gtk 3 on windows was [LNK1170 error ](https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-error-lnk1170?view=msvc-170); that is the linking command for gtk 3 was so big the msvc linker can't handle it even with short_paths on.

This patch fixes this by editing the `ninja.build` file and removing duplicates in the link arguments.

It's worth noting that for static gtk to work, it has to be built from scratch on the host device, since the location of the resources will be hard coded, and as such I propose to make gtk shared by default.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
