### PR TITLE
ffmpeg - link avformat with Secur32.lib on windows for static builds

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -767,6 +767,7 @@ class FFMpegConan(ConanFile):
                     "ole32", "psapi", "strmiids", "uuid", "oleaut32", "shlwapi", "gdi32", "vfw32"]
             self.cpp_info.components["avutil"].system_libs = [
                 "user32", "bcrypt"]
+            self.cpp_info.components["avformat"].system_libs = ["secur32"]
         elif tools.is_apple_os(self.settings.os):
             if self.options.avdevice:
                 self.cpp_info.components["avdevice"].frameworks = [


### PR DESCRIPTION
When linking to avformat statically,
we also need to link with the system library Secur32.lib

Specify library name and version:  **ffmpeg/5.0**

Without this patch, we get "unresolved external symbol AcquireCredentialsHandleA referenced in function tls_open" and other errors.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
