### PR TITLE
qt: Fix qtwebengine not finding fontconfig correctly

### DIFF
--- a/recipes/qt/5.x.x/conandata.yml
+++ b/recipes/qt/5.x.x/conandata.yml
@@ -107,6 +107,8 @@ patches:
       base_path: "qt5/qtwebengine/src/3rdparty"
     - patch_file: "patches/skia-cd397f3.diff"
       base_path: "qt5/qtwebengine/src/3rdparty/chromium/third_party/skia"
+    - patch_file: "patches/0001-Find-fontconfig-using-pkg-config.patch"
+      base_path: "qt5/qtwebengine/src/3rdparty"
   "5.15.5":
     - patch_file: "patches/aa2a39dea5.diff"
       base_path: "qt5/qtbase"
@@ -128,3 +130,5 @@ patches:
       base_path: "qt5/qtwebengine/src/3rdparty"
     - patch_file: "patches/skia-cd397f3.diff"
       base_path: "qt5/qtwebengine/src/3rdparty/chromium/third_party/skia"
+    - patch_file: "patches/0001-Find-fontconfig-using-pkg-config.patch"
+      base_path: "qt5/qtwebengine/src/3rdparty"

--- a/recipes/qt/5.x.x/patches/0001-Find-fontconfig-using-pkg-config.patch
+++ b/recipes/qt/5.x.x/patches/0001-Find-fontconfig-using-pkg-config.patch
@@ -1,0 +1,56 @@
+From fb103459151fcf02706dd5abda95c716a934d610 Mon Sep 17 00:00:00 2001
+From: Allan Sandfeld Jensen <allan.jensen@qt.io>
+Date: Mon, 9 May 2022 10:32:24 +0200
+Subject: [PATCH] Find fontconfig using pkg-config
+
+We already verify that it can be found like that during configure
+
+Task-number: QTBUG-61158
+Change-Id: I569590e96a490c4ed6e6dc560fbd110d86d77956
+Reviewed-by: Michal Klocek <michal.klocek@qt.io>
+(cherry picked from commit 357dcbf7d9510b5282a18e8211e2494f353b4e5e)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+(cherry picked from commit 43329f9d7f38a5092a9c054c5d450072b236c6f8)
+---
+ chromium/components/services/font/BUILD.gn | 1 +
+ chromium/third_party/fontconfig/BUILD.gn   | 5 +++--
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git chromium/components/services/font/BUILD.gn chromium/components/services/font/BUILD.gn
+index b065131e035..f3e544ed29f 100644
+--- chromium/components/services/font/BUILD.gn
++++ chromium/components/services/font/BUILD.gn
+@@ -42,6 +42,7 @@ if ((is_linux || is_chromeos) && enable_plugins) {
+       "//base:base",
+       "//ppapi/buildflags:buildflags",
+       "//ppapi/c",
++      "//third_party/fontconfig",
+     ]
+   }
+ }
+diff --git chromium/third_party/fontconfig/BUILD.gn chromium/third_party/fontconfig/BUILD.gn
+index 1bee7acb6b9..4cc32d62774 100644
+--- chromium/third_party/fontconfig/BUILD.gn
++++ chromium/third_party/fontconfig/BUILD.gn
+@@ -3,6 +3,7 @@
+ # found in the LICENSE file.
+ 
+ import("//build/config/sanitizers/sanitizers.gni")
++import("//build/config/linux/pkg_config.gni")
+ import("//third_party/fontconfig/fontconfig.gni")
+ 
+ assert(is_linux || is_chromeos)
+@@ -110,8 +111,8 @@ if (use_bundled_fontconfig) {
+     }
+   }
+ } else {
+-  config("fontconfig_config") {
+-    libs = [ "fontconfig" ]
++  pkg_config("fontconfig_config") {
++    packages = [ "fontconfig" ]
+   }
+ 
+   group("fontconfig") {
+-- 
+2.36.1
+


### PR DESCRIPTION
The included patch is the fix for QTBUG-61158 committed to
qtwebengine-chromium.git branch 90-based rebased on the branch
87-based to match the chromium version shipped with Qt 5.15.4.

Fixes #11300

Specify library name and version:  **qt/5.15.4** and **qt/5.15.5**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
