### PR TITLE
openssl: add 3.0.4,3.0.5,1.1.1p,1.1.1q

### DIFF
--- a/recipes/openssl/1.x.x/conandata.yml
+++ b/recipes/openssl/1.x.x/conandata.yml
@@ -107,6 +107,12 @@ sources:
       "https://www.openssl.org/source/openssl-1.1.1o.tar.gz",
       "https://www.openssl.org/source/old/openssl-1.1.1o.tar.gz"
     ]
+  1.1.1p:
+    sha256: bf61b62aaa66c7c7639942a94de4c9ae8280c08f17d4eac2e44644d9fc8ace6f
+    url: [
+      "https://www.openssl.org/source/openssl-1.1.1p.tar.gz",
+      "https://www.openssl.org/source/old/openssl-1.1.1p.tar.gz"
+    ]
 patches:
   1.0.2s:
     - patch_file: patches/1.0.2u-darwin-arm64.patch
@@ -142,5 +148,8 @@ patches:
     - patch_file: patches/1.1.1-tvos-watchos.patch
       base_path: source_subfolder
   1.1.1o:
+    - patch_file: patches/1.1.1-tvos-watchos.patch
+      base_path: source_subfolder
+  1.1.1p:
     - patch_file: patches/1.1.1-tvos-watchos.patch
       base_path: source_subfolder

--- a/recipes/openssl/1.x.x/conandata.yml
+++ b/recipes/openssl/1.x.x/conandata.yml
@@ -113,6 +113,12 @@ sources:
       "https://www.openssl.org/source/openssl-1.1.1p.tar.gz",
       "https://www.openssl.org/source/old/openssl-1.1.1p.tar.gz"
     ]
+  1.1.1q:
+    sha256: d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca
+    url: [
+      "https://www.openssl.org/source/openssl-1.1.1q.tar.gz",
+      "https://www.openssl.org/source/old/openssl-1.1.1q.tar.gz"
+    ]
 patches:
   1.0.2s:
     - patch_file: patches/1.0.2u-darwin-arm64.patch
@@ -151,5 +157,8 @@ patches:
     - patch_file: patches/1.1.1-tvos-watchos.patch
       base_path: source_subfolder
   1.1.1p:
+    - patch_file: patches/1.1.1-tvos-watchos.patch
+      base_path: source_subfolder
+  1.1.1q:
     - patch_file: patches/1.1.1-tvos-watchos.patch
       base_path: source_subfolder

--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  3.0.5:
+    url: https://www.openssl.org/source/openssl-3.0.5.tar.gz
+    sha256: aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a
   3.0.4:
     url: https://www.openssl.org/source/openssl-3.0.4.tar.gz
     sha256: 2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f

--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  3.0.4:
+    url: https://www.openssl.org/source/openssl-3.0.4.tar.gz
+    sha256: 2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f
   3.0.3:
     url: https://www.openssl.org/source/openssl-3.0.3.tar.gz
     sha256: ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -1,5 +1,7 @@
 versions:
   # 3.0.x releases
+  3.0.4:
+    folder: "3.x.x"
   3.0.3:
     folder: "3.x.x"
   3.0.2:
@@ -9,6 +11,8 @@ versions:
   3.0.0:
     folder: "3.x.x"
   # 1.1.1x releases
+  1.1.1p:
+    folder: "1.x.x"
   1.1.1o:
     folder: "1.x.x"
   1.1.1n:

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -1,5 +1,7 @@
 versions:
   # 3.0.x releases
+  3.0.5:
+    folder: "3.x.x"
   3.0.4:
     folder: "3.x.x"
   3.0.3:
@@ -11,6 +13,8 @@ versions:
   3.0.0:
     folder: "3.x.x"
   # 1.1.1x releases
+  1.1.1q:
+    folder: "1.x.x"
   1.1.1p:
     folder: "1.x.x"
   1.1.1o:


### PR DESCRIPTION
Specify library name and version:  **openssl/3.0.4** **openssl/1.1.1p**

Security fix: https://www.openssl.org/news/secadv/20220621.txt

Fixes #11319

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
