### PR TITLE
flatcc: add version 0.6.1

### DIFF
--- a/recipes/flatcc/all/conandata.yml
+++ b/recipes/flatcc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.1":
+    url: "https://github.com/dvidelabs/flatcc/archive/v0.6.1.tar.gz"
+    sha256: "2533c2f1061498499f15acc7e0937dcf35bc68e685d237325124ae0d6c600c2b"
   "0.6.0":
-    sha256: a92da3566d11e19bb807a83554b1a2c644a5bd91c9d9b088514456bb56e1c666
-    url: https://github.com/dvidelabs/flatcc/archive/v0.6.0.tar.gz
+    url: "https://github.com/dvidelabs/flatcc/archive/v0.6.0.tar.gz"
+    sha256: "a92da3566d11e19bb807a83554b1a2c644a5bd91c9d9b088514456bb56e1c666"

--- a/recipes/flatcc/all/conanfile.py
+++ b/recipes/flatcc/all/conanfile.py
@@ -83,6 +83,7 @@ class FlatccConan(ConanFile):
         cmake.definitions["FLATCC_FAST_DOUBLE"] = self.options.fast_double
         cmake.definitions["FLATCC_IGNORE_CONST_COND"] = self.options.ignore_const_condition
         cmake.definitions["FLATCC_TEST"] = False
+        cmake.definitions["FLATCC_ALLOW_WERROR"] = False
         cmake.configure(build_folder=self._build_subfolder)
         return cmake
 

--- a/recipes/flatcc/all/conanfile.py
+++ b/recipes/flatcc/all/conanfile.py
@@ -1,14 +1,18 @@
-import os
 from conans import CMake, ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
+import os
+import functools
+
+required_conan_version = ">=1.33.0"
 
 class FlatccConan(ConanFile):
     name = "flatcc"
     description = "C language binding for Flatbuffers, an efficient cross platform serialization library"
-    topics = ("conan", "flatbuffers", "serialization")
+    license = "Apache-2.0"
+    topics = ("flatbuffers", "serialization")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/dvidelabs/flatcc"
-    license = "Apache-2.0"
+    settings = "os", "arch", "compiler", "build_type"
     options = { "shared": [True, False],
                 "fPIC": [True, False],
                 "portable": [True, False],
@@ -33,12 +37,8 @@ class FlatccConan(ConanFile):
                         "fast_double": False,
                         "ignore_const_condition": False
     }
-    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
     exports_sources = ["CMakeLists.txt"]
-
-    _cmake = None
-
 
     @property
     def _source_subfolder(self):
@@ -53,42 +53,42 @@ class FlatccConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def validate(self):
         if self.settings.os == "Windows":
             if self.settings.compiler == "Visual Studio" and self.options.shared:
                 #Building flatcc shared libs with Visual Studio is broken
                 raise ConanInvalidConfiguration("Building flatcc libraries shared is not supported")
-            if self.settings.compiler == "gcc":
+            if tools.Version(self.version) == "0.6.0" and self.settings.compiler == "gcc":
                 raise ConanInvalidConfiguration("Building flatcc with MinGW is not supported")
-        if self.options.shared:
-            del self.options.fPIC
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if not self._cmake:
-            self._cmake = CMake(self)
-            self._cmake.definitions["FLATCC_PORTABLE"] = self.options.portable
-            self._cmake.definitions["FLATCC_GNU_POSIX_MEMALIGN"] = self.options.gnu_posix_memalign
-            self._cmake.definitions["FLATCC_RTONLY"] = self.options.runtime_lib_only
-            self._cmake.definitions["FLATCC_INSTALL"] = True
-            self._cmake.definitions["FLATCC_COVERAGE"] = False
-            self._cmake.definitions["FLATCC_DEBUG_VERIFY"] = self.options.verify_assert
-            self._cmake.definitions["FLATCC_TRACE_VERIFY"] = self.options.verify_trace
-            self._cmake.definitions["FLATCC_REFLECTION"] = self.options.reflection
-            self._cmake.definitions["FLATCC_NATIVE_OPTIM"] = self.options.native_optim
-            self._cmake.definitions["FLATCC_FAST_DOUBLE"] = self.options.fast_double
-            self._cmake.definitions["FLATCC_IGNORE_CONST_COND"] = self.options.ignore_const_condition
-            self._cmake.definitions["FLATCC_TEST"] = False
-            self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["FLATCC_PORTABLE"] = self.options.portable
+        cmake.definitions["FLATCC_GNU_POSIX_MEMALIGN"] = self.options.gnu_posix_memalign
+        cmake.definitions["FLATCC_RTONLY"] = self.options.runtime_lib_only
+        cmake.definitions["FLATCC_INSTALL"] = True
+        cmake.definitions["FLATCC_COVERAGE"] = False
+        cmake.definitions["FLATCC_DEBUG_VERIFY"] = self.options.verify_assert
+        cmake.definitions["FLATCC_TRACE_VERIFY"] = self.options.verify_trace
+        cmake.definitions["FLATCC_REFLECTION"] = self.options.reflection
+        cmake.definitions["FLATCC_NATIVE_OPTIM"] = self.options.native_optim
+        cmake.definitions["FLATCC_FAST_DOUBLE"] = self.options.fast_double
+        cmake.definitions["FLATCC_IGNORE_CONST_COND"] = self.options.ignore_const_condition
+        cmake.definitions["FLATCC_TEST"] = False
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
 
     def build(self):
         cmake = self._configure_cmake()
         cmake.build()
-
 
     def package(self):
         cmake = self._configure_cmake()

--- a/recipes/flatcc/all/test_package/CMakeLists.txt
+++ b/recipes/flatcc/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(flatcc_example)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(flatcc REQUIRED CONFIG)
 
 set(INC_DIR "${PROJECT_SOURCE_DIR}/include")
 set(GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
@@ -28,5 +30,4 @@ if (NOT MACOS_SIP_WORKAROUND)
     add_dependencies(monster gen_monster_fbs)
 endif()
 
-
-target_link_libraries(monster ${CONAN_LIBS})
+target_link_libraries(monster flatcc::flatcc)

--- a/recipes/flatcc/all/test_package/conanfile.py
+++ b/recipes/flatcc/all/test_package/conanfile.py
@@ -27,7 +27,7 @@ class FlatccTestConan(ConanFile):
 
     def test(self):
         if tools.cross_building(self):
-            bin_path = os.path.join(self.deps_cpp_info["objectbox-generator"].rootpath, "bin", "flatcc")
+            bin_path = os.path.join(self.deps_cpp_info["flatcc"].rootpath, "bin", "flatcc")
             if not os.path.isfile(bin_path) or not os.access(bin_path, os.X_OK):
                 raise ConanException("flatcc doesn't exist.")
         else:

--- a/recipes/flatcc/all/test_package/conanfile.py
+++ b/recipes/flatcc/all/test_package/conanfile.py
@@ -1,6 +1,7 @@
 import os.path
 
 from conans import ConanFile, CMake, tools, RunEnvironment
+from conans.errors import ConanException
 
 
 class FlatccTestConan(ConanFile):
@@ -8,6 +9,9 @@ class FlatccTestConan(ConanFile):
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
+        if tools.cross_building(self):
+            return
+
         env_build = RunEnvironment(self)
         with tools.environment_append(env_build.vars):
             cmake = CMake(self)
@@ -22,6 +26,10 @@ class FlatccTestConan(ConanFile):
             cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if tools.cross_building(self):
+            bin_path = os.path.join(self.deps_cpp_info["objectbox-generator"].rootpath, "bin", "flatcc")
+            if not os.path.isfile(bin_path) or not os.access(bin_path, os.X_OK):
+                raise ConanException("flatcc doesn't exist.")
+        else:
             bin_path = os.path.join(self.build_folder, "bin", "monster")
             self.run(bin_path, cwd=self.source_folder, run_environment=True)

--- a/recipes/flatcc/all/test_package/conanfile.py
+++ b/recipes/flatcc/all/test_package/conanfile.py
@@ -4,8 +4,8 @@ from conans import ConanFile, CMake, tools, RunEnvironment
 
 
 class FlatccTestConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         env_build = RunEnvironment(self)

--- a/recipes/flatcc/config.yml
+++ b/recipes/flatcc/config.yml
@@ -1,3 +1,5 @@
 versions:
+  0.6.1:
+    folder: all
   0.6.0:
     folder: all


### PR DESCRIPTION
Specify library name and version:  **flatcc/0.6.1**

- add version 0.6.1
- support gcc on Windows in 0.6.1
- use lru_cache in _configure_cmake
- use find_package in test_package

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
