### PR TITLE
boost/1.79.0: Patch Boost.SmartPtr to support a specific variant of PowerPC

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -276,3 +276,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/1.79.0-0001-json-array-erase-relocate.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/1.79.0-smart_ptr_cw_ppc_msync.patch"
+      base_path: "source_subfolder"

--- a/recipes/boost/all/patches/1.79.0-smart_ptr_cw_ppc_msync.patch
+++ b/recipes/boost/all/patches/1.79.0-smart_ptr_cw_ppc_msync.patch
@@ -1,0 +1,25 @@
+diff --git a/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp b/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
+index 81387ce..58a69e6 100644
+--- a/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
++++ b/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
+@@ -35,8 +35,6 @@ BOOST_PRAGMA_MESSAGE("Using CodeWarrior/PowerPC sp_counted_base")
+ 
+ #endif
+ 
+-BOOST_SP_OBSOLETE()
+-
+ namespace boost
+ {
+ 
+@@ -64,7 +62,11 @@ inline long atomic_decrement( register long * pw )
+ 
+     asm
+     {
++#if defined(__PPCZen__) || defined(__PPCe500__) || defined(__PPCe500v2__)
++    msync
++#else
+     sync
++#endif
+ 
+ loop:
+ 


### PR DESCRIPTION
This patch adds support for CodeWarrior / PowerPC platforms which support the `msync` instead of the `sync` assembly instruction.
This change has been fixed upstream in Boost.SmartPtr by boostorg/smart_ptr#95.
THe change should be included in an upcoming upstream release.

Specify library name and version:  **boost/1.79.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
