### PR TITLE
geotrans/3.8: patch to compile with MSVC2022 and c++20

### DIFF
--- a/recipes/geotrans/all/conandata.yml
+++ b/recipes/geotrans/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "3.8":
     url: "https://c3i.jfrog.io/artifactory/cci-sources-backup/sources/geotrans/geotrans-3.8.tgz"
     sha256: "BAA72D3B1AE12F237A8AD30F2DEB3FED2B80FEB759528EA0A72B4B42CB77C565"
+patches:
+  "3.8":
+    - patch_file: "patches/3.8-fix-for-cxx20.patch"
+      base_path: "source_subfolder"

--- a/recipes/geotrans/all/conanfile.py
+++ b/recipes/geotrans/all/conanfile.py
@@ -34,7 +34,6 @@ class GeotransConan(ConanFile):
     }
 
     generators = "cmake"
-    exports_sources = "CMakeLists.txt"
     _cmake = None
 
     @property
@@ -44,6 +43,11 @@ class GeotransConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -69,6 +73,8 @@ class GeotransConan(ConanFile):
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/geotrans/all/conanfile.py
+++ b/recipes/geotrans/all/conanfile.py
@@ -93,6 +93,7 @@ class GeotransConan(ConanFile):
         ]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["dtcc"].system_libs.append("pthread")
+            self.cpp_info.components["dtcc"].system_libs.append("m")
 
         self.cpp_info.components["ccs"].libs = ["MSPCoordinateConversionService"]
         self.cpp_info.components["ccs"].requires = ["dtcc"]

--- a/recipes/geotrans/all/conanfile.py
+++ b/recipes/geotrans/all/conanfile.py
@@ -3,7 +3,6 @@ import os
 
 required_conan_version = ">=1.35.0"
 
-
 class GeotransConan(ConanFile):
     name = "geotrans"
     license = (

--- a/recipes/geotrans/all/patches/3.8-fix-for-cxx20.patch
+++ b/recipes/geotrans/all/patches/3.8-fix-for-cxx20.patch
@@ -1,0 +1,15 @@
+Only in b/CCS/src/dtcc/CoordinateSystems/gars: .GARS.cpp.swp
+diff -ru a/CCS/src/dtcc/CoordinateSystems/gars/GARS.cpp b/CCS/src/dtcc/CoordinateSystems/gars/GARS.cpp
+--- a/CCS/src/dtcc/CoordinateSystems/gars/GARS.cpp	2019-05-09 08:43:20.000000000 +0800
++++ b/CCS/src/dtcc/CoordinateSystems/gars/GARS.cpp	2022-06-23 08:04:37.949610100 +0800
+@@ -199,8 +199,8 @@
+   char _15_minute_value_str[2] = "";
+   char _5_minute_value_str[2] = "";
+   double round_error = 5.0e-11;
+-  char* _15_minute_array[2][2] = {{"3", "1"}, {"4", "2"}};
+-  char* _5_minute_array[3][3] = {{"7", "4", "1"}, {"8", "5", "2"}, {"9", "6", "3"}};
++  const char* _15_minute_array[2][2] = {{"3", "1"}, {"4", "2"}};
++  const char* _5_minute_array[3][3] = {{"7", "4", "1"}, {"8", "5", "2"}, {"9", "6", "3"}};
+   double long_minutes, lat_minutes; 
+   double long_remainder, lat_remainder; 
+   long horiz_index_30, vert_index_30; 


### PR DESCRIPTION
Specify library name and version:  **geotrans/3.8**

Small simple patch to add const where required on 2 lines.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
