### PR TITLE
websocketpp: bump to boost/1.79.0 and openssl/1.1.1o

### DIFF
--- a/recipes/websocketpp/all/conanfile.py
+++ b/recipes/websocketpp/all/conanfile.py
@@ -34,7 +34,7 @@ class WebsocketPPConan(ConanFile):
 
     def requirements(self):
         if self.options.with_openssl:
-            self.requires("openssl/1.1.1n")
+            self.requires("openssl/1.1.1o")
 
         if self.options.with_zlib:
             self.requires("zlib/1.2.12")
@@ -42,7 +42,7 @@ class WebsocketPPConan(ConanFile):
         if self.options.asio == "standalone":
             self.requires("asio/1.22.1")
         elif self.options.asio == "boost":
-            self.requires("boost/1.78.0")
+            self.requires("boost/1.79.0")
 
     def package_id(self):
         self.info.header_only()


### PR DESCRIPTION
Specify library name and version:  **websocketpp/0.8.2**

websocketpp: bump to boost/1.79.0 and openssl/1.1.1o

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
