### PR TITLE
fontconfig: fixed build on non-English versions of Windows

### DIFF
--- a/recipes/fontconfig/all/patches/0001-meson-win32.patch
+++ b/recipes/fontconfig/all/patches/0001-meson-win32.patch
@@ -1,11 +1,19 @@
 --- conf.d/link_confs.py
 +++ conf.d/link_confs.py
-@@ -26,7 +26,7 @@
+@@ -3,6 +3,7 @@
+ import os
+ import sys
+ import argparse
++import platform
+ 
+ if __name__=='__main__':
+     parser = argparse.ArgumentParser()
+@@ -26,7 +27,7 @@ if __name__=='__main__':
              break
          except OSError as e:
              # Symlink privileges are not available
 -            if len(e.args) == 1 and 'privilege' in e.args[0]:
-+            if (len(e.args) == 1 and 'privilege' in e.args[0]) or (len(e.args) == 2 and 'privilege' in e.args[1]):
++            if platform.system().lower() == 'windows' and e.winerror == 1314:
                  break
              raise
          except FileExistsError:


### PR DESCRIPTION
Specify library name and version:  **fontconfig/2.13.93**

On non-English versions of Windows, the error message is localized so the condition does not work as expected and build fails.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
