### PR TITLE
dbus: Add option to enable and disable the dependency on libselinux

### DIFF
--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -20,12 +20,14 @@ class DbusConan(ConanFile):
         "system_pid_file": "ANY",
         "with_x11": [True, False],
         "with_glib": [True, False],
+        "with_selinux": [True, False],
     }
     default_options = {
         "system_socket": "",
         "system_pid_file": "",
         "with_x11": False,
         "with_glib": False,
+        "with_selinux": False,
     }
 
     generators = "pkg_config", "cmake", "cmake_find_package"
@@ -52,6 +54,8 @@ class DbusConan(ConanFile):
         self.requires("expat/2.4.8")
         if self.options.with_glib:
             self.requires("glib/2.72.0")
+        if self.options.with_selinux:
+            self.requires("selinux/3.3")
         if self.options.get_safe("with_x11"):
             self.requires("xorg/system")
 
@@ -74,6 +78,9 @@ class DbusConan(ConanFile):
 
             args.append("--with-systemdsystemunitdir=%s" % os.path.join(self.package_folder, "lib", "systemd", "system"))
             args.append("--with-systemduserunitdir=%s" % os.path.join(self.package_folder, "lib", "systemd", "user"))
+
+            if not self.options.with_selinux:
+                args.append("--disable-selinux")
 
             if str(self.options.system_socket) != "":
                 args.append("--with-system-socket=%s" % self.options.system_socket)


### PR DESCRIPTION
Fixes #8626.

Note: There is no CMake configuration option to toggle SELinux support.

Specify library name and version:  **dbus/1.12.20**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
