### PR TITLE
[cocoyaxi] Macos: Remove cmake as build_requirement

### DIFF
--- a/recipes/cocoyaxi/all/test_package/conanfile.py
+++ b/recipes/cocoyaxi/all/test_package/conanfile.py
@@ -5,15 +5,6 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake", "cmake_find_package_multi"
 
-    def build_requirements(self):
-        if self.settings.os == "Macos" and self.settings.arch == "armv8":
-            # Workaround for CMake bug with error message:
-            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
-            # set. This could be because you are using a Mac OS X version less than 10.5
-            # or because CMake's platform configuration is corrupt.
-            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
-            self.build_requires("cmake/3.22.0")
-
     def build(self):
         cmake = CMake(self)
         cmake.configure()


### PR DESCRIPTION
All Macos nodes are running CMake +3.22. It is longer required a specific CMake version for test package.