### PR TITLE
bison: Fix Conan Hook warning for empty include directory

### DIFF
--- a/recipes/bison/all/conanfile.py
+++ b/recipes/bison/all/conanfile.py
@@ -150,6 +150,7 @@ class BisonConan(ConanFile):
                       os.path.join(self.package_folder, "lib", "y.lib"))
 
     def package_info(self):
+        self.cpp_info.includedirs = []
         self.cpp_info.libs = ["y"]
 
         self.output.info("Setting BISON_ROOT environment variable: {}".format(self.package_folder))


### PR DESCRIPTION
When running with CONAN_HOOK_ERROR_LEVEL=40, the bison package fails to build:

```sh
[HOOK - conan-center.py] post_package_info(): ERROR: [INCLUDE PATH DOES NOT EXIST (KB-H071)] Component bison::bison include dir 'include' is listed in the recipe, but not found in package folder. The include dir should probably be fixed or removed. (https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#KB-H071) 
```

This is because the default include directory is empty.
This PR just sets the include directory to be empty explicitly.

Specify library name and version:  **bison/3.7.6**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
