### PR TITLE
xorg: remove obsolete workaround

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -83,9 +83,6 @@ class ConanXOrg(ConanFile):
         if packages:
             package_tool = tools.SystemPackageTool(conanfile=self, default_mode="verify")
             package_tool.install_packages(update=True, packages=packages)
-    
-    def package(self):
-        tools.mkdir(os.path.join(self.package_folder, "include")) # to satisfy KB-H071
 
     def package_info(self):
         for name in ["x11", "x11-xcb", "fontenc", "ice", "sm", "xau", "xaw7",


### PR DESCRIPTION
fixed by conan-io/hooks#425

Specify library name and version:  **xorg/system**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
