### PR TITLE
libcuckoo: new recipe

### DIFF
--- a/recipes/libcuckoo/all/conandata.yml
+++ b/recipes/libcuckoo/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.3.0":
+    sha256: "b91b77c49577059cd47b258e783f60d5b07dccc5e47258fea00cdedffd84afbe"
+    url: "https://github.com/efficient/libcuckoo/archive/refs/tags/v0.3.tar.gz"

--- a/recipes/libcuckoo/all/conanfile.py
+++ b/recipes/libcuckoo/all/conanfile.py
@@ -1,0 +1,56 @@
+import os
+from conans import CMake, ConanFile, tools
+
+required_conan_version = ">=1.33.0"
+
+
+class LibCuckooConan(ConanFile):
+    name = "libcuckoo"
+    description = "A high-performance, concurrent hash table"
+    license = "Apache-2.0"
+    homepage = "https://github.com/efficient/libcuckoo"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("concurrency", "hashmap", "header-only", "library", "cuckoo")
+    settings = "arch", "build_type", "compiler", "os"
+    generators = "cmake", "cmake_find_package_multi"
+    no_copy_source = True
+
+    @property
+    def _minimum_cpp_standard(self):
+        return 11
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def validate(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            tools.check_min_cppstd(self, self._minimum_cpp_standard)
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        # Install with CMake
+        cmake = CMake(self)
+        cmake.definitions["BUILD_EXAMPLES"] = "OFF"
+        cmake.definitions["BUILD_STRESS_TESTS"] = "OFF"
+        cmake.definitions["BUILD_TESTS"] = "OFF"
+        cmake.definitions["BUILD_UNIT_TESTS"] = "OFF"
+        cmake.definitions["BUILD_UNIVERSAL_BENCHMARK"] = "OFF"
+        cmake.configure(source_folder=self._source_subfolder)
+        cmake.install()
+        # Copy license files
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        # Remove CMake config files (only files in share)
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs = ["pthread"]
+        self.cpp_info.names["cmake_find_package"] = "libcuckoo"
+        self.cpp_info.names["cmake_find_package_multi"] = "libcuckoo"

--- a/recipes/libcuckoo/all/test_package/CMakeLists.txt
+++ b/recipes/libcuckoo/all/test_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package)
+
+set(CMAKE_CXX_STANDARD 11)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(libcuckoo REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE libcuckoo::libcuckoo)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_${CMAKE_CXX_STANDARD})

--- a/recipes/libcuckoo/all/test_package/conanfile.py
+++ b/recipes/libcuckoo/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run("{0}".format(bin_path), run_environment=True)

--- a/recipes/libcuckoo/all/test_package/test_package.cpp
+++ b/recipes/libcuckoo/all/test_package/test_package.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <string>
+
+#include <libcuckoo/cuckoohash_map.hh>
+
+int main() {
+  libcuckoo::cuckoohash_map<int, std::string> Table;
+
+  for (int i = 0; i < 10; i++) {
+    Table.insert(i, "found");
+  }
+
+  std::string out;
+  for (int i = 0; i < 11; i++) {
+
+    if (Table.find(i, out)) {
+      std::cout << i << "  " << out << '\n';
+    } else {
+      std::cout << i << "  NOT FOUND\n";
+    }
+  }
+}

--- a/recipes/libcuckoo/config.yml
+++ b/recipes/libcuckoo/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.3.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libcuckoo/0.3.0**

Contribute recipe for [efficient/libcuckoo](https://github.com/efficient/libcuckoo), a high-performance concurrent hash table.

I am not the author of this library, but some of my projects depend on it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
