### PR TITLE
itlib: add version 1.5.1

### DIFF
--- a/recipes/itlib/all/conandata.yml
+++ b/recipes/itlib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.1":
+    url: "https://github.com/iboB/itlib/archive/v1.5.1.tar.gz"
+    sha256: "70f3c3cd5b3d4baf440bf19848936882e50c06924ca319d0bf91763ae3a65570"
   "1.5.0":
     url: "https://github.com/iboB/itlib/archive/refs/tags/v1.5.0.tar.gz"
     sha256: "940589080fb486e19d7cf8e79665bac017a55f1c8b8fa4fb889a77f80645f289"

--- a/recipes/itlib/config.yml
+++ b/recipes/itlib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.1":
+    folder: all
   "1.5.0":
     folder: all
   "1.4.5":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **itlib/1.5.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
