### PR TITLE
opentelemetry-cpp: add version 1.4.1

### DIFF
--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.1":
+    url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.4.1.tar.gz"
+    sha256: "301b1ab74a664723560f46c29f228360aff1e2d63e930b963755ea077ae67524"
   "1.4.0":
     url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.4.0.tar.gz"
     sha256: "110f4fb2e38dcc72a421647631cfbb9429afd3c77c6c98829cc1d11bd0c72563"
@@ -13,6 +16,9 @@ sources:
     sha256: "32f12ff15ec257e3462883f84bc291c2d5dc30055604c12ec4b46a36dfa3f189"
 
 patches:
+  "1.4.1":
+    - patch_file: "patches/1.4.0-0001-fix-cmake.patch"
+      base_path: "source_subfolder"
   "1.4.0":
     - patch_file: "patches/1.4.0-0001-fix-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/opentelemetry-cpp/config.yml
+++ b/recipes/opentelemetry-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.1":
+    folder: all
   "1.4.0":
     folder: all
   "1.3.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **opentelemetry-cpp/1.4.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
