### PR TITLE
kissfft/131.1.0: add more public defines

### DIFF
--- a/recipes/kissfft/all/conanfile.py
+++ b/recipes/kissfft/all/conanfile.py
@@ -90,7 +90,7 @@ class KissfftConan(ConanFile):
         self.cpp_info.components["libkissfft"].libs = [lib_name]
 
         # got to duplicate the logic from kissfft/CMakeLists.txt
-        if self.options.datatype == "float" or self.options.datatype == "double":
+        if self.options.datatype in ["float", "double"]:
             self.cpp_info.components["libkissfft"].defines.append("kiss_fft_scalar={}".format(self.options.datatype))
         elif self.options.datatype == "int16_t":
             self.cpp_info.components["libkissfft"].defines.append("FIXED_POINT=16")

--- a/recipes/kissfft/all/conanfile.py
+++ b/recipes/kissfft/all/conanfile.py
@@ -88,8 +88,23 @@ class KissfftConan(ConanFile):
         # TODO: back to global scope in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.components["libkissfft"].includedirs.append(os.path.join("include", "kissfft"))
         self.cpp_info.components["libkissfft"].libs = [lib_name]
+
+        # got to duplicate the logic from kissfft/CMakeLists.txt
+        if self.options.datatype == "float" or self.options.datatype == "double":
+            self.cpp_info.components["libkissfft"].defines.append("kiss_fft_scalar={}".format(self.options.datatype))
+        elif self.options.datatype == "int16_t":
+            self.cpp_info.components["libkissfft"].defines.append("FIXED_POINT=16")
+        elif self.options.datatype == "int32_t":
+            self.cpp_info.components["libkissfft"].defines.append("FIXED_POINT=32")
+        elif self.options.datatype == "simd":
+            self.cpp_info.components["libkissfft"].defines.append("USE_SIMD")
+
+        if self.options.use_alloca:
+            self.cpp_info.components["libkissfft"].defines.append("KISS_FFT_USE_ALLOCA")
+
         if self.options.shared:
             self.cpp_info.components["libkissfft"].defines.append("KISS_FFT_SHARED")
+
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libkissfft"].system_libs = ["m"]
 


### PR DESCRIPTION
These were defined in kissfft's CMakeLists.txt, but they did not exist
in the recipe.

kissfft/131.1.0

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
