### PR TITLE
veque: add version 1.3.6

### DIFF
--- a/recipes/veque/all/conandata.yml
+++ b/recipes/veque/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.6":
+    url: "https://github.com/Shmoopty/veque/archive/v1.3.6.tar.gz"
+    sha256: "9d149b415d948529ac166c962501c59605ef24b3a8ab8561956a6d05f14870ea"
   "1.3.5":
     url: https://github.com/Shmoopty/veque/archive/refs/tags/v1.3.5.tar.gz
     sha256: cdab543718aacee1a55f4b6203b5b6074c34db1f6b9775d8bece84fb0d4a8f5c

--- a/recipes/veque/config.yml
+++ b/recipes/veque/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.3.6":
+    folder: all
   "1.3.5":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
