### PR TITLE
sol2: add version 3.3.0

### DIFF
--- a/recipes/sol2/3.x.x/conandata.yml
+++ b/recipes/sol2/3.x.x/conandata.yml
@@ -14,3 +14,6 @@ sources:
   "3.2.3":
     url: "https://github.com/ThePhD/sol2/archive/v3.2.3.tar.gz"
     sha256: "f74158f92996f476786be9c9e83f8275129bb1da2a8d517d050421ac160a4b9e"
+  "3.3.0":
+    url: "https://github.com/ThePhD/sol2/archive/v3.3.0.tar.gz"
+    sha256: "b82c5de030e18cb2bcbcefcd5f45afd526920c517a96413f0b59b4332d752a1e"

--- a/recipes/sol2/config.yml
+++ b/recipes/sol2/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: "3.x.x"
   "3.2.3":
     folder: "3.x.x"
+  "3.3.0":
+    folder: "3.x.x"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **sol2/3.3.0**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
