### PR TITLE
antlr4-cppruntime: Fix an issue that dylibs are not removed when users request the static library on macOS

### DIFF
--- a/recipes/antlr4-cppruntime/all/conanfile.py
+++ b/recipes/antlr4-cppruntime/all/conanfile.py
@@ -134,6 +134,7 @@ class Antlr4CppRuntimeConan(ConanFile):
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "antlr4-runtime.lib")
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*antlr4-runtime.so*")
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*antlr4-runtime.dll*")
+            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*antlr4-runtime*.dylib")
             tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*antlr4-runtime.dylib*")
         tools.rmdir(os.path.join(self.package_folder, "share"))
 

--- a/recipes/antlr4-cppruntime/all/conanfile.py
+++ b/recipes/antlr4-cppruntime/all/conanfile.py
@@ -135,7 +135,6 @@ class Antlr4CppRuntimeConan(ConanFile):
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*antlr4-runtime.so*")
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*antlr4-runtime.dll*")
             tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*antlr4-runtime*.dylib")
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*antlr4-runtime.dylib*")
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
         # FIXME: this also removes lib/cmake/antlr4-generator


### PR DESCRIPTION
Specify library name and version:  **antlr4-cppruntime/4.10.1, 4.10, 4.9.3**

The current recipe is supposed to remove the dynamic library if `shared` is set to `False`, but it fails to do so on macOS. This pull request fixes the recipe by removing antlr4's dynamic libraries from the `lib` folder.

Thank you.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
