### PR TITLE
ninja: Fix empty include directories Conan Hook warning

### DIFF
--- a/recipes/ninja/1.10.x/conanfile.py
+++ b/recipes/ninja/1.10.x/conanfile.py
@@ -45,5 +45,6 @@ class NinjaConan(ConanFile):
         cmake.install()
 
     def package_info(self):
+        self.cpp_info.includedirs = []
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
         self.env_info.CONAN_CMAKE_GENERATOR = "Ninja"

--- a/recipes/ninja/1.9.x/conanfile.py
+++ b/recipes/ninja/1.9.x/conanfile.py
@@ -60,6 +60,7 @@ class NinjaConan(ConanFile):
             os.unlink(pdb)
 
     def package_info(self):
+        self.cpp_info.includedirs = []
         # ensure ninja is executable
         if self.settings.os in ["Linux", "Macos"]:
             name = os.path.join(self.package_folder, "bin", "ninja")


### PR DESCRIPTION
Specify library name and version:  **ninja/1.x.x**

Fixes the following Conan Hook warning:

```sh
[HOOK - conan-center.py] post_package_info(): ERROR: [INCLUDE PATH DOES NOT EXIST (KB-H071)] Component ninja::ninja include dir 'include' is listed in the recipe, but not found in package folder. The include dir should probably be fixed or removed. (https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#KB-H071) 
ERROR: 
        ConanException: [HOOK - conan-center.py] post_package_info(): Some checks failed running the hook, check the output
```

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
