### PR TITLE
fix poppler's cairo consumption

### DIFF
--- a/recipes/poppler/all/conanfile.py
+++ b/recipes/poppler/all/conanfile.py
@@ -233,6 +233,9 @@ class PopplerConan(ConanFile):
     def _patch_sources(self):
         for patchdata in self.conan_data["patches"][self.version]:
             tools.patch(**patchdata)
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+            r"find_package(Cairo",
+            r"find_package(cairo")
         if tools.Version(self.version) < "21.07.0" and not self.options.shared:
             poppler_global = os.path.join(self._source_subfolder, "cpp", "poppler-global.h")
             tools.replace_in_file(poppler_global, "__declspec(dllimport)", "")


### PR DESCRIPTION
Specify library name and version:  **poppler/***

popper CMake requires `Cairo` in uppercase but conan will provide `cairo` lower case which will effectively disable cairo as dependency https://github.com/freedesktop/poppler/blob/poppler-0.89.0/CMakeLists.txt#L163