### PR TITLE
daw_header_libraries: add version 2.64.2

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.64.2":
+    url: "https://github.com/beached/header_libraries/archive/v2.64.2.tar.gz"
+    sha256: "886cabc542714e3959d8d00799c0becbf00437278844b3ef399c99acab2e23fa"
   "2.53.3":
     url: "https://github.com/beached/header_libraries/archive/v2.53.3.tar.gz"
     sha256: "04c83338d21e40f1973fa7ba42cbc9a71c314fdebfabc8d612e330b7c7043d77"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.64.2":
+    folder: all
   "2.53.3":
     folder: all
   "2.50.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **daw_header_libraries/2.64.2**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
