### PR TITLE
libjpeg: add version 9e

### DIFF
--- a/recipes/libjpeg/all/conandata.yml
+++ b/recipes/libjpeg/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "9e":
+    url: "http://ijg.org/files/jpegsrc.v9e.tar.gz"
+    sha256: "4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d"
   "9d":
     url: "http://ijg.org/files/jpegsrc.v9d.tar.gz"
     sha256: "2303a6acfb6cc533e0e86e8a9d29f7e6079e118b9de3f96e07a71a11c082fa6a"
@@ -6,6 +9,9 @@ sources:
     url: "http://ijg.org/files/jpegsrc.v9c.tar.gz"
     sha256: "682aee469c3ca857c4c38c37a6edadbfca4b04d42e56613b11590ec6aa4a278d"
 patches:
+  "9e":
+    - patch_file: "patches/0001-libjpeg-add-msvc-dll-support.patch"
+      base_path: "source_subfolder"
   "9d":
     - patch_file: "patches/0001-libjpeg-add-msvc-dll-support.patch"
       base_path: "source_subfolder"

--- a/recipes/libjpeg/config.yml
+++ b/recipes/libjpeg/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "9e":
+    folder: all
   "9d":
     folder: all
   "9c":


### PR DESCRIPTION
Specify library name and version:  **libjpeg/9e**

It's the latest version of libjpeg and isn't automatically detected by conan-center-bot.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
