### PR TITLE
Verilator: add version 4.200

### DIFF
--- a/recipes/verilator/all/conandata.yml
+++ b/recipes/verilator/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.200":
+    url: "https://www.veripool.org/ftp/verilator-4.200.tgz"
+    sha256: "773913f4410512a7a51de3d04964766438dc11fc22b213eab5c6c29730df3e36"
   "4.038":
     url: "https://www.veripool.org/ftp/verilator-4.038.tgz"
     sha256: "fa004493216034ac3e26b21b814441bd5801592f4f269c5a4672e3351d73b515"
@@ -6,6 +9,11 @@ sources:
     url: "https://www.veripool.org/ftp/verilator-4.034.tgz"
     sha256: "54ed7b06ee28b5d21f9d0ee98406d29a508e6124b0d10e54bb32081613ddb80b"
 patches:
+  "4.200":
+    - patch_file: "patches/0003-add-msvc_link-sh.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0005-msvc-patches.patch"
+      base_path: "source_subfolder"
   "4.038":
     - patch_file: "patches/0001-split-opt-and-debug-build-install.patch"
       base_path: "source_subfolder"

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -35,6 +35,10 @@ class VerilatorConan(ConanFile):
     def _needs_old_bison(self):
         return tools.Version(self.version) < "4.100"
 
+    def validate(self):
+        if tools.Version(self.version) >= "4.200" and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "7":
+            raise ConanInvalidConfiguration("GCC < version 7 is not supported")
+
     def build_requirements(self):
         if self._settings_build.os == "Windows" and "CONAN_BASH_PATH" not in os.environ:
             if self.settings.compiler == "Visual Studio":

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -35,10 +35,6 @@ class VerilatorConan(ConanFile):
     def _needs_old_bison(self):
         return tools.Version(self.version) < "4.100"
 
-    def validate(self):
-        if tools.Version(self.version) >= "4.200" and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "7":
-            raise ConanInvalidConfiguration("GCC < version 7 is not supported")
-
     def build_requirements(self):
         if self._settings_build.os == "Windows" and "CONAN_BASH_PATH" not in os.environ:
             if self.settings.compiler == "Visual Studio":
@@ -73,6 +69,9 @@ class VerilatorConan(ConanFile):
     def validate(self):
         if hasattr(self, "settings_build") and tools.cross_building(self):
             raise ConanInvalidConfiguration("Cross building is not yet supported. Contributions are welcome")
+
+        if tools.Version(self.version) >= "4.200" and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "7":
+            raise ConanInvalidConfiguration("GCC < version 7 is not supported")
 
     @contextmanager
     def _build_context(self):

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -149,18 +149,16 @@ class VerilatorConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "verilator", "examples"))
 
         os.unlink(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config-version.cmake"))
-        tools.rename(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config.cmake"),
-                     os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"))
+        shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config.cmake"), os.path.join(self.package_folder, "verilator-tools.cmake"))
 
         if self.settings.build_type == "Debug":
             tools.replace_in_file(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"),
                                   "verilator_bin", "verilator_bin_dbg")
 
-        shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "include"),
-                    os.path.join(self.package_folder))
+        shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "include"), os.path.join(self.package_folder))
 
         tools.remove_files_by_mask(os.path.join(self.package_folder, "bin", "share", "verilator", "bin"), "*")
-        tools.rmdir(os.path.join(self.package_folder, "bin", "share", "verilator", "bin"))
+        tools.rmdir(os.path.join(self.package_folder, "bin", "share"))
 
     def package_id(self):
         # Verilator is a executable-only package, so the compiler version does not matter
@@ -179,5 +177,4 @@ class VerilatorConan(ConanFile):
         self.output.info("Setting VERILATOR_ROOT environment variable to {}".format(verilator_root))
         self.env_info.VERILATOR_ROOT = verilator_root
 
-        self.cpp_info.builddirs = [os.path.join("bin", "share", "verilator")]
-        self.cpp_info.build_modules = [os.path.join("bin", "share", "verilator", "verilator-tools.cmake")]
+        self.cpp_info.build_modules = [os.path.join("verilator-tools.cmake")]

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -153,7 +153,7 @@ class VerilatorConan(ConanFile):
         tools.rename(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config.cmake"),
                      os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"))
         tools.replace_in_file(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"), 
-                            "${CMAKE_CURRENT_LIST_DIR}", os.path.join(self.package_folder))
+                            "${CMAKE_CURRENT_LIST_DIR}", "${CMAKE_CURRENT_LIST_DIR}/../../..")
         if self.settings.build_type == "Debug":
             tools.replace_in_file(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"), 
                                 "verilator_bin", "verilator_bin_dbg")

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -181,5 +181,5 @@ class VerilatorConan(ConanFile):
         self.output.info("Setting VERILATOR_ROOT environment variable to {}".format(verilator_root))
         self.env_info.VERILATOR_ROOT = verilator_root
 
-        self.cpp_info.builddirs = [os.path.join("bin", "share", "verilator")]
-        self.cpp_info.build_modules = [os.path.join("bin", "share", "verilator", "verilator-tools.cmake")]
+        self.cpp_info.builddirs.append(os.path.join("bin", "share", "verilator"))
+        self.cpp_info.build_modules.append(os.path.join("bin", "share", "verilator", "verilator-tools.cmake"))

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -13,7 +13,7 @@ class VerilatorConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.veripool.org/wiki/verilator"
     description = "Verilator compiles synthesizable Verilog and Synthesis assertions into single- or multithreaded C++ or SystemC code"
-    topics = ("verilog", "HDL", "EDA", "simulator", "hardware", "fpga")
+    topics = ("verilog", "hdl", "eda", "simulator", "hardware", "fpga")
 
     settings = "os", "arch", "compiler", "build_type"
 
@@ -150,10 +150,10 @@ class VerilatorConan(ConanFile):
 
         os.unlink(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config-version.cmake"))
         shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config.cmake"), 
-                    os.path.join(self.package_folder, "verilator-tools.cmake"))
-
+                    os.path.join(self.package_folder, "bin", "verilator-tools.cmake"))
+        tools.replace_in_file(os.path.join(self.package_folder, "bin", "verilator-tools.cmake"), "${CMAKE_CURRENT_LIST_DIR}", "${CMAKE_CURRENT_LIST_DIR}/..")
         if self.settings.build_type == "Debug":
-            tools.replace_in_file(os.path.join(self.package_folder, "verilator-tools.cmake"), "verilator_bin", "verilator_bin_dbg")
+            tools.replace_in_file(os.path.join(self.package_folder, "bin", "verilator-tools.cmake"), "verilator_bin", "verilator_bin_dbg")
 
         shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "include"), os.path.join(self.package_folder))
 
@@ -177,5 +177,6 @@ class VerilatorConan(ConanFile):
         self.output.info("Setting VERILATOR_ROOT environment variable to {}".format(verilator_root))
         self.env_info.VERILATOR_ROOT = verilator_root
 
-        self.cpp_info.build_modules = [os.path.join("verilator-tools.cmake")]
+        self.cpp_info.builddirs = ['bin']  
+        self.cpp_info.build_modules = [os.path.join("bin", "verilator-tools.cmake")]
 

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -1,7 +1,6 @@
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
 from conans.errors import ConanInvalidConfiguration
 from contextlib import contextmanager
-import glob
 import os
 import shutil
 
@@ -70,8 +69,8 @@ class VerilatorConan(ConanFile):
         if hasattr(self, "settings_build") and tools.cross_building(self):
             raise ConanInvalidConfiguration("Cross building is not yet supported. Contributions are welcome")
 
-        if tools.Version(self.version) >= "4.200" and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "9":
-            raise ConanInvalidConfiguration("GCC < version 9 is not supported")
+        if tools.Version(self.version) >= "4.200" and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "7":
+            raise ConanInvalidConfiguration("GCC < version 7 is not supported")
 
     @contextmanager
     def _build_context(self):
@@ -150,13 +149,13 @@ class VerilatorConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "man"))
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "verilator", "examples"))
-
+        tools.mkdir(os.path.join(self.package_folder, "bin", "cmake"))
         os.unlink(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config-version.cmake"))
         shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config.cmake"), 
-                    os.path.join(self.package_folder, "bin", "verilator-tools.cmake"))
-        tools.replace_in_file(os.path.join(self.package_folder, "bin", "verilator-tools.cmake"), "${CMAKE_CURRENT_LIST_DIR}", "${CMAKE_CURRENT_LIST_DIR}/..")
+                    os.path.join(self.package_folder, "bin", "cmake", "verilator-tools.cmake"))
+        tools.replace_in_file(os.path.join(self.package_folder, "bin", "cmake", "verilator-tools.cmake"), "${CMAKE_CURRENT_LIST_DIR}", "${CMAKE_CURRENT_LIST_DIR}/../..")
         if self.settings.build_type == "Debug":
-            tools.replace_in_file(os.path.join(self.package_folder, "bin", "verilator-tools.cmake"), "verilator_bin", "verilator_bin_dbg")
+            tools.replace_in_file(os.path.join(self.package_folder, "bin", "cmake", "verilator-tools.cmake"), "verilator_bin", "verilator_bin_dbg")
 
         shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "include"), os.path.join(self.package_folder))
 
@@ -180,6 +179,6 @@ class VerilatorConan(ConanFile):
         self.output.info("Setting VERILATOR_ROOT environment variable to {}".format(verilator_root))
         self.env_info.VERILATOR_ROOT = verilator_root
 
-        self.cpp_info.builddirs = ['bin']  
-        self.cpp_info.build_modules = [os.path.join("bin", "verilator-tools.cmake")]
+        self.cpp_info.builddirs = [os.path.join("bin", "cmake")]  
+        self.cpp_info.build_modules = [os.path.join("bin", "cmake", "verilator-tools.cmake")]
 

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -149,11 +149,12 @@ class VerilatorConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "verilator", "examples"))
 
         os.unlink(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config-version.cmake"))
-        shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config.cmake"), os.path.join(self.package_folder, "verilator-tools.cmake"))
+        shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config.cmake"), 
+        os.path.join(self.package_folder, "verilator-tools.cmake"))
 
         if self.settings.build_type == "Debug":
-            tools.replace_in_file(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"),
-                                  "verilator_bin", "verilator_bin_dbg")
+            tools.replace_in_file(os.path.join(self.package_folder, "verilator-tools.cmake"),
+             "verilator_bin", "verilator_bin_dbg")
 
         shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "include"), os.path.join(self.package_folder))
 
@@ -178,3 +179,4 @@ class VerilatorConan(ConanFile):
         self.env_info.VERILATOR_ROOT = verilator_root
 
         self.cpp_info.build_modules = [os.path.join("verilator-tools.cmake")]
+

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -72,7 +72,7 @@ class VerilatorConan(ConanFile):
         if tools.Version(self.version) >= "4.200" and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "7":
             raise ConanInvalidConfiguration("GCC < version 7 is not supported")
         
-        if self.settings.os == "Windows" and tools.Version(self.version) >= "4.200":
+        if self.settings.os == "Windows" and tools.Version(self.version) == "4.200":
             raise ConanInvalidConfiguration("Windows build is currently not supported")
 
     @contextmanager
@@ -158,8 +158,8 @@ class VerilatorConan(ConanFile):
         tools.replace_in_file(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"), 
                             "${CMAKE_CURRENT_LIST_DIR}", "${CMAKE_CURRENT_LIST_DIR}/../../..")
         if self.settings.build_type == "Debug":
-            tools.replace_in_file(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"), 
-                                "verilator_bin", "verilator_bin_dbg")
+            tools.replace_in_file(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"),
+                                 "verilator_bin", "verilator_bin_dbg")
 
         shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "include"), 
                     os.path.join(self.package_folder))

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -70,8 +70,8 @@ class VerilatorConan(ConanFile):
         if hasattr(self, "settings_build") and tools.cross_building(self):
             raise ConanInvalidConfiguration("Cross building is not yet supported. Contributions are welcome")
 
-        if tools.Version(self.version) >= "4.200" and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "7":
-            raise ConanInvalidConfiguration("GCC < version 7 is not supported")
+        if tools.Version(self.version) >= "4.200" and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "9":
+            raise ConanInvalidConfiguration("GCC < version 9 is not supported")
 
     @contextmanager
     def _build_context(self):

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -149,18 +149,20 @@ class VerilatorConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "man"))
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "pkgconfig"))
         tools.rmdir(os.path.join(self.package_folder, "bin", "share", "verilator", "examples"))
-        tools.mkdir(os.path.join(self.package_folder, "bin", "cmake"))
         os.unlink(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config-version.cmake"))
-        shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config.cmake"), 
-                    os.path.join(self.package_folder, "bin", "cmake", "verilator-tools.cmake"))
-        tools.replace_in_file(os.path.join(self.package_folder, "bin", "cmake", "verilator-tools.cmake"), "${CMAKE_CURRENT_LIST_DIR}", "${CMAKE_CURRENT_LIST_DIR}/../..")
+        tools.rename(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config.cmake"),
+                     os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"))
+        tools.replace_in_file(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"), 
+                            "${CMAKE_CURRENT_LIST_DIR}", "${CMAKE_CURRENT_LIST_DIR}/../../..")
         if self.settings.build_type == "Debug":
-            tools.replace_in_file(os.path.join(self.package_folder, "bin", "cmake", "verilator-tools.cmake"), "verilator_bin", "verilator_bin_dbg")
+            tools.replace_in_file(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"), 
+                                "verilator_bin", "verilator_bin_dbg")
 
-        shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "include"), os.path.join(self.package_folder))
+        shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "include"), 
+                    os.path.join(self.package_folder))
 
         tools.remove_files_by_mask(os.path.join(self.package_folder, "bin", "share", "verilator", "bin"), "*")
-        tools.rmdir(os.path.join(self.package_folder, "bin", "share"))
+        tools.rmdir(os.path.join(self.package_folder, "bin", "share", "verilator", "bin"))
 
     def package_id(self):
         # Verilator is a executable-only package, so the compiler version does not matter
@@ -179,6 +181,5 @@ class VerilatorConan(ConanFile):
         self.output.info("Setting VERILATOR_ROOT environment variable to {}".format(verilator_root))
         self.env_info.VERILATOR_ROOT = verilator_root
 
-        self.cpp_info.builddirs = [os.path.join("bin", "cmake")]  
-        self.cpp_info.build_modules = [os.path.join("bin", "cmake", "verilator-tools.cmake")]
-
+        self.cpp_info.builddirs = [os.path.join("bin", "share", "verilator")]
+        self.cpp_info.build_modules = [os.path.join("bin", "share", "verilator", "verilator-tools.cmake")]

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -150,11 +150,10 @@ class VerilatorConan(ConanFile):
 
         os.unlink(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config-version.cmake"))
         shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config.cmake"), 
-        os.path.join(self.package_folder, "verilator-tools.cmake"))
+                    os.path.join(self.package_folder, "verilator-tools.cmake"))
 
         if self.settings.build_type == "Debug":
-            tools.replace_in_file(os.path.join(self.package_folder, "verilator-tools.cmake"),
-             "verilator_bin", "verilator_bin_dbg")
+            tools.replace_in_file(os.path.join(self.package_folder, "verilator-tools.cmake"), "verilator_bin", "verilator_bin_dbg")
 
         shutil.move(os.path.join(self.package_folder, "bin", "share", "verilator", "include"), os.path.join(self.package_folder))
 

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -153,7 +153,7 @@ class VerilatorConan(ConanFile):
         tools.rename(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-config.cmake"),
                      os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"))
         tools.replace_in_file(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"), 
-                            "${CMAKE_CURRENT_LIST_DIR}", "${CMAKE_CURRENT_LIST_DIR}/../../..")
+                            "${CMAKE_CURRENT_LIST_DIR}", os.path.join(self.package_folder))
         if self.settings.build_type == "Debug":
             tools.replace_in_file(os.path.join(self.package_folder, "bin", "share", "verilator", "verilator-tools.cmake"), 
                                 "verilator_bin", "verilator_bin_dbg")

--- a/recipes/verilator/all/conanfile.py
+++ b/recipes/verilator/all/conanfile.py
@@ -71,6 +71,9 @@ class VerilatorConan(ConanFile):
 
         if tools.Version(self.version) >= "4.200" and self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "7":
             raise ConanInvalidConfiguration("GCC < version 7 is not supported")
+        
+        if self.settings.os == "Windows" and tools.Version(self.version) >= "4.200":
+            raise ConanInvalidConfiguration("Windows build is currently not supported")
 
     @contextmanager
     def _build_context(self):

--- a/recipes/verilator/all/patches/0005-msvc-patches.patch
+++ b/recipes/verilator/all/patches/0005-msvc-patches.patch
@@ -1,0 +1,86 @@
+--- src/Makefile_obj.in
++++ src/Makefile_obj.in
+@@ -95,6 +95,7 @@ LIBS = $(CFG_LIBS) -lm
+ 
+ CPPFLAGS += -MMD
+ CPPFLAGS += -I. -I$(bldsrc) -I$(srcdir) -I$(incdir) -I../../include
++CPPFLAGS += -DNOMINMAX	# suppress the min and max definitions in Windef.h
+ #CPPFLAGS += -DVL_LEAK_CHECKS 	# If running valgrind or other hunting tool
+ CPPFLAGS += $(COPT)
+ CPPFLAGS += -MP # Only works on recent GCC versions
+@@ -280,7 +281,7 @@ V3__CONCAT.cpp: $(addsuffix .cpp, $(basename $(RAW_OBJS)))
+ 
+ $(TGT): $(PREDEP_H) $(OBJS)
+ 	@echo "      Linking $@..."
+-	${LINK} ${LDFLAGS} -o $@ $(OBJS) $(CCMALLOC) ${LIBS}
++	${LINK} ${LDFLAGS} -o $@$(EXEEXT) $(OBJS) $(CCMALLOC) ${LIBS}
+ 
+ V3Number_test: V3Number_test.o
+ 	${LINK} ${LDFLAGS} -o $@ $^ ${LIBS}
+
+--- src/V3Number.h
++++ melsrc/V3Number.h
+@@ -22,6 +22,7 @@
+ 
+ #include "V3Error.h"
+ 
++#include <algorithm>
+ #include <cmath>
+ #include <limits>
+ #include <vector>
+
+--- src/V3Os.cpp
++++ src/V3Os.cpp
+@@ -73,8 +73,8 @@ string V3Os::getenvStr(const string& envvar, const string& defaultValue) {
+ #if defined(_MSC_VER)
+     // Note: MinGW does not offer _dupenv_s
+     char* envvalue = nullptr;
+-    _dupenv_s(&envvalue, nullptr, envvar.c_str());
+-    if (envvalue != nullptr) {
++    int dupres = _dupenv_s(&envvalue, nullptr, envvar.c_str());
++    if ((dupres == 0) && (envvalue != nullptr)) {
+         const std::string result{envvalue};
+         free(envvalue);
+         return result;
+@@ -346,6 +346,9 @@ void V3Os::u_sleep(int64_t usec) {
+ int V3Os::system(const string& command) {
+     UINFO(1, "Running system: " << command << endl);
+     const int ret = ::system(command.c_str());
++#ifdef _MSC_VER
++    return ret;
++#else
+     if (VL_UNCOVERABLE(ret == -1)) {
+         v3fatal("Failed to execute command:"  // LCOV_EXCL_LINE
+                 << command << " " << strerror(errno));
+@@ -357,4 +360,5 @@ int V3Os::system(const string& command) {
+         UASSERT(exit_code >= 0, "exit code must not be negative");
+         return exit_code;
+     }
++#endif
+ }
+
+--- src/VlcTop.cpp
++++ src/VlcTop.cpp
+@@ -14,6 +14,11 @@
+ //
+ //*************************************************************************
+ 
++#if defined(_WIN32) || defined(__MINGW32__)
++#define NOMINMAX
++#include <windows.h>  
++#endif
++
+ #include "V3Error.h"
+ #include "V3Os.h"
+ #include "VlcOptions.h"
+
+--- include/verilated_imp.h
++++ include/verilated_imp.h
+@@ -30,6 +30,7 @@
+ #include "verilated_heavy.h"
+ #include "verilated_syms.h"
+ 
++#include <algorithm>
+ #include <deque>
+ #include <set>
+ #include <vector>

--- a/recipes/verilator/all/test_package/CMakeLists.txt
+++ b/recipes/verilator/all/test_package/CMakeLists.txt
@@ -18,5 +18,6 @@ if(BUILD_SYSTEMC)
         blinky_sc.cpp
     )
     verilate(blinky_sc SOURCES blinky.v SYSTEMC)
+    target_compile_features(blinky_sc PRIVATE cxx_std_11)
     target_link_libraries(blinky_sc PRIVATE CONAN_PKG::systemc)
 endif()

--- a/recipes/verilator/all/test_package/CMakeLists.txt
+++ b/recipes/verilator/all/test_package/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
 
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup(TARGETS)
 

--- a/recipes/verilator/all/test_package/CMakeLists.txt
+++ b/recipes/verilator/all/test_package/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(PackageTest CXX)
 
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup(TARGETS)
 

--- a/recipes/verilator/all/test_package/CMakeLists.txt
+++ b/recipes/verilator/all/test_package/CMakeLists.txt
@@ -18,6 +18,5 @@ if(BUILD_SYSTEMC)
         blinky_sc.cpp
     )
     verilate(blinky_sc SOURCES blinky.v SYSTEMC)
-    target_compile_features(blinky_sc PRIVATE cxx_std_11)
     target_link_libraries(blinky_sc PRIVATE CONAN_PKG::systemc)
 endif()

--- a/recipes/verilator/config.yml
+++ b/recipes/verilator/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "4.038":
     folder: all
+  "4.200":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **verilator/4.200**

Adding a version 4.200 of the Verilator tool.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
