### PR TITLE
objectbox-generator: add recipe

### DIFF
--- a/recipes/objectbox-generator/all/conandata.yml
+++ b/recipes/objectbox-generator/all/conandata.yml
@@ -1,0 +1,14 @@
+sources:
+  "0.13.0":
+    Windows:
+      url: "https://github.com/objectbox/objectbox-generator/releases/download/v0.13.0/objectbox-generator-Windows.zip"
+      sha256: "ac59297401c73e5f3bc670e59545300fdef5bafb8aa1d5eac8ff5d949576c9dd"
+    Linux:
+      url: "https://github.com/objectbox/objectbox-generator/releases/download/v0.13.0/objectbox-generator-Linux.zip"
+      sha256: "61586f42a658fb46b3b2247bf2bfff898858d91df4fab485d1b0759240fe1964"
+    Macos:
+      url: "https://github.com/objectbox/objectbox-generator/releases/download/v0.13.0/objectbox-generator-macOS.zip"
+      sha256: "09665663f0380c3b112da197186e438cef36bd5f492944fd4b378f1e76b55175"
+    License:
+      url: "https://raw.githubusercontent.com/objectbox/objectbox-generator/v0.13.0/LICENSE.txt"
+      sha256: "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986"

--- a/recipes/objectbox-generator/all/conanfile.py
+++ b/recipes/objectbox-generator/all/conanfile.py
@@ -1,0 +1,48 @@
+from conans import CMake, ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.33.0"
+
+class PackageConan(ConanFile):
+    name = "objectbox-generator"
+    description = "ObjectBox Generator based on FlatBuffers schema files (fbs) for C and C++"
+    license = "GPL-3.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/objectbox/objectbox-generator"
+    topics = ("database", "code-generator", "objectbox")
+    settings = "os", "arch", "compiler", "build_type"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def validate(self):
+        if self.settings.os not in ["Linux", "Windows", "Macos"] or self.settings.arch != "x86_64":
+            raise ConanInvalidConfiguration("{} doesn't support current environment".format(self.name))
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.build_type
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version][str(self.settings.os)],
+                  destination=self.source_folder)
+        tools.download(**self.conan_data["sources"][self.version]["License"], filename="LICENSE.txt")
+
+    def package(self):
+        if self.settings.os != "Windows":
+            bin_path = os.path.join(self.source_folder, "objectbox-generator")
+            os.chmod(bin_path, os.stat(bin_path).st_mode | 0o111)
+        self.copy("objectbox-generator*", src=self.source_folder, dst="bin", keep_path=False)
+        self.copy("LICENSE.txt", dst="licenses", src=self.source_folder)
+
+    def package_info(self):
+        binpath = os.path.join(self.package_folder, "bin")
+        self.output.info("Appending PATH env var: {}".format(binpath))
+        self.env_info.PATH.append(binpath)
+
+        self.cpp_info.includedirs = []
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []

--- a/recipes/objectbox-generator/all/test_package/conanfile.py
+++ b/recipes/objectbox-generator/all/test_package/conanfile.py
@@ -1,0 +1,12 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join(self.deps_cpp_info["objectbox-generator"].rootpath, "bin", "objectbox-generator")
+            print(bin_path)
+            self.run(bin_path + " -help", run_environment=True)

--- a/recipes/objectbox-generator/all/test_package/conanfile.py
+++ b/recipes/objectbox-generator/all/test_package/conanfile.py
@@ -8,5 +8,4 @@ class TestPackageConan(ConanFile):
     def test(self):
         if not tools.cross_building(self):
             bin_path = os.path.join(self.deps_cpp_info["objectbox-generator"].rootpath, "bin", "objectbox-generator")
-            print(bin_path)
             self.run(bin_path + " -help", run_environment=True)

--- a/recipes/objectbox-generator/config.yml
+++ b/recipes/objectbox-generator/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.13.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **objectbox-generator/0.13.0**

objectbox-generator provides precompiled binary to generate codes for objectbox.
It is written in golang, but it is required to use objectbox in C++.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
