### PR TITLE
[bugfix] Fix linter file name

### DIFF
--- a/.github/workflows/linter-conan-v2.yml
+++ b/.github/workflows/linter-conan-v2.yml
@@ -28,7 +28,7 @@ jobs:
         if: steps.changed_files.outputs.any_changed == 'true'
         uses: mikefarah/yq@master
         with:
-          cmd: yq '.conan.version' '.c3i/c3i.yml'
+          cmd: yq '.conan.version' '.c3i/config_v1.yml'
       - uses: actions/setup-python@v3
         if: steps.changed_files.outputs.any_changed == 'true'
         with:
@@ -74,7 +74,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: mikefarah/yq@master
         with:
-          cmd: yq '.conan.version' '.c3i/c3i.yml'
+          cmd: yq '.conan.version' '.c3i/config_v1.yml'
       - uses: actions/setup-python@v3
         if: steps.changed-files.outputs.any_changed == 'true'
         with:


### PR DESCRIPTION
Related to https://github.com/conan-io/conan-center-index/pull/11410

Every PR is failing because it the file name is no longer the same. For instance: https://github.com/conan-io/conan-center-index/runs/7096378631?check_suite_focus=true

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
