### PR TITLE
modern-cpp-kafka: new recipe

### DIFF
--- a/recipes/modern-cpp-kafka/all/conandata.yml
+++ b/recipes/modern-cpp-kafka/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2022.06.15":
+    url: https://github.com/morganstanley/modern-cpp-kafka/archive/refs/tags/v2022.06.15.tar.gz
+    sha256: 478fcf560057b7cf7b4be851838ebf0520806d057b172de23261606fce088d27

--- a/recipes/modern-cpp-kafka/all/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/conanfile.py
@@ -7,7 +7,7 @@ required_conan_version = ">=1.33.0"
 class ModernCppKafkaConan(ConanFile):
     name = "modern-cpp-kafka"
     description = "A C++ API for Kafka clients (i.e. KafkaProducer, KafkaConsumer, AdminClient)"
-    license = "Apache License 2.0"
+    license = "Apache-2.0"
     topics = ("kafka", "librdkafka", "kafkaproducer", "kafkaconsumer")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/morganstanley/modern-cpp-kafka"

--- a/recipes/modern-cpp-kafka/all/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/conanfile.py
@@ -14,12 +14,19 @@ class ModernCppKafkaConan(ConanFile):
     settings = "arch", "build_type", "compiler", "os"
     no_copy_source = True
 
+    def requirements(self):
+        self.requires("librdkafka/1.8.2")
+
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 17)
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)

--- a/recipes/modern-cpp-kafka/all/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/conanfile.py
@@ -23,7 +23,7 @@ class ModernCppKafkaConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))
+        self.copy(pattern="*.h", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
     def package_id(self):
         self.info.header_only()

--- a/recipes/modern-cpp-kafka/all/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/conanfile.py
@@ -1,0 +1,38 @@
+from conans import ConanFile, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class ModernCppKafkaConan(ConanFile):
+    name = "modern-cpp-kafka"
+    description = "A C++ API for Kafka clients (i.e. KafkaProducer, KafkaConsumer, AdminClient)"
+    license = "Apache License 2.0"
+    topics = ("kafka", "librdkafka", "kafkaproducer", "kafkaconsumer")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/morganstanley/modern-cpp-kafka"
+    settings = "arch", "build_type", "compiler", "os"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+       self.cpp_info.set_property("cmake_target_name", "ModernCppKafka::ModernCppKafka")
+
+       self.cpp_info.names["cmake_find_package"] = "ModernCppKafka"
+       self.cpp_info.names["cmake_find_package_multi"] = "ModernCppKafka"
+
+       if self.settings.os in ["Linux", "Macos"]:
+           self.cpp_info.system_libs.append("pthread")

--- a/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
+++ b/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
@@ -6,8 +6,7 @@ conan_basic_setup()
 
 set(CMAKE_CXX_STANDARD 17)
 
-find_package(RdKafka REQUIRED CONFIG)
 find_package(ModernCppKafka REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} RdKafka::rdkafka ModernCppKafka::ModernCppKafka)
+target_link_libraries(${PROJECT_NAME} ModernCppKafka::ModernCppKafka)

--- a/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
+++ b/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(RdKafka REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} RdKafka::rdkafka)

--- a/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
+++ b/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
@@ -4,6 +4,8 @@ project(test_package)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+set(CMAKE_CXX_STANDARD 17)
+
 find_package(RdKafka REQUIRED CONFIG)
 find_package(ModernCppKafka REQUIRED CONFIG)
 

--- a/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
+++ b/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
@@ -5,6 +5,7 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 find_package(RdKafka REQUIRED CONFIG)
+find_package(ModernCppKafka REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} RdKafka::rdkafka)
+target_link_libraries(${PROJECT_NAME} RdKafka::rdkafka ModernCppKafka::ModernCppKafka)

--- a/recipes/modern-cpp-kafka/all/test_package/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/test_package/conanfile.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 from conans import ConanFile, CMake
 from conan.tools.build import cross_building
 import os

--- a/recipes/modern-cpp-kafka/all/test_package/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/test_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def requirements(self):
+        self.requires("librdkafka/1.8.2")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/modern-cpp-kafka/all/test_package/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/test_package/conanfile.py
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/modern-cpp-kafka/all/test_package/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/test_package/conanfile.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 from conans import ConanFile, CMake, tools
 import os
 
@@ -5,15 +6,12 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
-    def requirements(self):
-        self.requires("librdkafka/1.8.2")
-
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not tools.cross_building(self.settings):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/modern-cpp-kafka/all/test_package/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/test_package/conanfile.py
@@ -1,5 +1,6 @@
 # pylint: skip-file
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
 import os
 
 class TestPackageConan(ConanFile):

--- a/recipes/modern-cpp-kafka/all/test_package/test_package.cpp
+++ b/recipes/modern-cpp-kafka/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include "kafka/Utility.h"
+
+#include <iostream>
+
+int main()
+{
+  std::cout << "librdkafka version: " << kafka::utility::getLibRdKafkaVersion() << std::endl;
+}

--- a/recipes/modern-cpp-kafka/config.yml
+++ b/recipes/modern-cpp-kafka/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2022.06.15":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **modern-cpp-kafka/v2022.06.15**

Hi,
I'm the author of `modern-cpp-kafka` (https://github.com/morganstanley/modern-cpp-kafka), a Kafka C++ API, wrapper over `librdkafka`).
Now I'm trying to add this header-only library to the ConanCenter (https://github.com/morganstanley/modern-cpp-kafka/issues/105)
Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.