### PR TITLE
opencv 4.x: fix ffmpeg check in test_package

### DIFF
--- a/recipes/opencv/4.x/test_package/test_package.cpp
+++ b/recipes/opencv/4.x/test_package/test_package.cpp
@@ -12,8 +12,9 @@
 #include <opencv2/gapi/core.hpp>
 #include <opencv2/gapi/imgproc.hpp>
 #endif
-#ifdef BUILD_WITH_FFMPEF
+#ifdef BUILT_WITH_FFMPEG
 #include <opencv2/videoio.hpp>
+#include <opencv2/videoio/registry.hpp>
 #endif
 #ifdef BUILT_CONTRIB_SFM
 #include <opencv2/sfm.hpp>
@@ -218,8 +219,8 @@ void TestGAPI()
 
 void TestVideo()
 {
-#ifdef BUILD_WITH_FFMPEG
-    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+#ifdef BUILT_WITH_FFMPEG
+    if (!cv::videoio_registry::hasBackend(CAP_FFMPEG))
         throw std::runtime_error("FFmpeg backend was not found");
 #endif
 }


### PR DESCRIPTION
Specify library name and version:  **opencv/4.x**

Fix typo and add missing header files to actually run the ffmpeg backend check for opencv

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
