### PR TITLE
qt6: add md4c dependency

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -447,7 +447,7 @@ class QtConan(ConanFile):
             file = os.path.join("qt6", "qtbase", "cmake", f)
             if os.path.isfile(file):
                 os.remove(file)
-        for f in ['double-conversion', 'freetype', 'harfbuzz-ng', 'libjpeg', 'libpng', 'pcre2', 'sqlite', 'xcb', 'zlib']:
+        for f in ['double-conversion', 'freetype', 'harfbuzz-ng', 'libjpeg', 'libpng', 'pcre2', 'sqlite', 'zlib']:
             tools.rmdir(os.path.join(self.source_folder, "qt6", "qtbase", "src", "3rdparty", f))
 
         # workaround QTBUG-94356
@@ -623,7 +623,7 @@ class QtConan(ConanFile):
                               ("with_libpng", "png"),
                               ("with_sqlite3", "sqlite"),
                               ("with_pcre2", "pcre2"),
-                              ("with_md4c", "libmd4c")]:
+                              ("with_md4c", "md4c")]:
             if self.options.get_safe(opt, False):
                 if self.options.multiconfiguration:
                     cmake.definitions["FEATURE_%s" % conf_arg] = "ON"

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -622,8 +622,7 @@ class QtConan(ConanFile):
                               ("with_libjpeg", "jpeg"),
                               ("with_libpng", "png"),
                               ("with_sqlite3", "sqlite"),
-                              ("with_pcre2", "pcre2"),
-                              ("with_md4c", "md4c")]:
+                              ("with_pcre2", "pcre2"),]:
             if self.options.get_safe(opt, False):
                 if self.options.multiconfiguration:
                     cmake.definitions["FEATURE_%s" % conf_arg] = "ON"
@@ -632,6 +631,22 @@ class QtConan(ConanFile):
             else:
                 cmake.definitions["FEATURE_%s" % conf_arg] = "OFF"
                 cmake.definitions["FEATURE_system_%s" % conf_arg] = "OFF"
+                
+        for opt, conf_arg in [
+                              ("with_doubleconversion", "doubleconversion"),
+                              ("with_freetype", "freetype"),
+                              ("with_harfbuzz", "harfbuzz"),
+                              ("with_libjpeg", "libjpeg"),
+                              ("with_libpng", "libpng"),
+                              ("with_md4c", "libmd4c"),
+                              ("with_pcre2", "pcre"),]:
+            if self.options.get_safe(opt, False):
+                if self.options.multiconfiguration:
+                    cmake.definitions["INPUT_%s" % conf_arg] = "qt"
+                else:
+                    cmake.definitions["INPUT_%s" % conf_arg] = "system"
+            else:
+                cmake.definitions["INPUT_%s" % conf_arg] = "no"
 
         for feature in str(self.options.disabled_features).split():
             cmake.definitions["FEATURE_%s" % feature] = "OFF"

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -447,8 +447,6 @@ class QtConan(ConanFile):
             file = os.path.join("qt6", "qtbase", "cmake", f)
             if os.path.isfile(file):
                 os.remove(file)
-        for f in ['double-conversion', 'freetype', 'harfbuzz-ng', 'libjpeg', 'libpng', 'pcre2', 'sqlite', 'zlib']:
-            tools.rmdir(os.path.join(self.source_folder, "qt6", "qtbase", "src", "3rdparty", f))
 
         # workaround QTBUG-94356
         if tools.Version(self.version) >= "6.1.1":


### PR DESCRIPTION
Specify library name and version:  **qt/6.***

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
