### PR TITLE
nodejs: Fix Conan Hook warning for empty include directory

### DIFF
--- a/recipes/nodejs/all/conanfile.py
+++ b/recipes/nodejs/all/conanfile.py
@@ -45,6 +45,7 @@ class NodejsConan(ConanFile):
         self.copy(pattern="npx", src=self._source_subfolder, dst="bin")
 
     def package_info(self):
+        self.cpp_info.includedirs = []
         bin_dir = os.path.join(self.package_folder, "bin")
         self.output.info('Appending PATH environment variable: {}'.format(bin_dir))
         self.env_info.PATH.append(bin_dir)


### PR DESCRIPTION
Specify library name and version:  **nodejs/***

Fixes empty include directory Conan Hook warning:

```
[HOOK - conan-center.py] post_package_info(): ERROR: [INCLUDE PATH DOES NOT EXIST (KB-H071)] Component nodejs::nodejs include dir 'include' is listed in the recipe, but not found in package folder. The include dir should probably be fixed or removed. (https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#KB-H071) 
```

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
