### PR TITLE
(#11354) swig/4.0.2: portable dirname usage in get_exe_path

### DIFF
--- a/recipes/swig/all/patches/0001-swig-linux-library-path.patch
+++ b/recipes/swig/all/patches/0001-swig-linux-library-path.patch
@@ -1,9 +1,9 @@
 --- Source/Modules/main.cxx
 +++ Source/Modules/main.cxx
-@@ -879,6 +881,30 @@ static void getoptions(int argc, char *argv[]) {
+@@ -879,6 +879,32 @@ static void getoptions(int argc, char *a
    }
  }
-
+ 
 +#if defined(HAVE_UNISTD_H) && !defined(_WIN32)
 +#include <libgen.h>
 +#include <unistd.h>
@@ -12,17 +12,19 @@
 +static String *get_exe_path(void) {
 +    Dl_info info;
 +    if (dladdr("main", &info)) {
-+        char buffer[PATH_MAX];
++        char realp_buffer[PATH_MAX];
 +        char* res = NULL;
 +
-+        res = realpath(info.dli_fname, buffer);
++        res = realpath(info.dli_fname, realp_buffer);
 +        if (!res) {
 +         return NewString(SWIG_LIB);
 +        }
 +
-+        dirname(buffer);
-+        strcat(buffer, "/swiglib");
-+        return NewStringWithSize(buffer, strlen(buffer));
++        const char* dir = dirname(realp_buffer);
++        char dest_buf[PATH_MAX];
++        strcpy(dest_buf, dir);
++        strcat(dest_buf, "/swiglib");
++        return NewStringWithSize(dest_buf, strlen(dest_buf));
 +    }
 +    return NewString(SWIG_LIB);
 +}
@@ -31,8 +33,7 @@
  int SWIG_main(int argc, char *argv[], const TargetLanguageModule *tlm) {
    char *c;
  
-@@ -938,13 +953,15 @@
-     char buf[MAX_PATH];
+@@ -939,12 +965,14 @@ int SWIG_main(int argc, char *argv[], co
      char *p;
      if (!(GetModuleFileName(0, buf, MAX_PATH) == 0 || (p = strrchr(buf, '\\')) == 0)) {
        *(p + 1) = '\0';


### PR DESCRIPTION
Use return value from `dirname` since this function is not required to
modify input buffer. This PR fixes issue #11354


fixes #11354

---

- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [no recipe changes] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [+] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
  - Activating hook gives the following error:
   ```
   [HOOK - conan-center.py] post_package_info(): ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)] Exception raised from hook: list indices must be integers or slices, not str (type=TypeError) (https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#KB-H019) 
   ERROR: 
	ConanException: [HOOK - conan-center.py] post_package_info(): list indices must be integers or slices, not str
   ```
   the same error can be reproduced on master. Package can be built and tested successfully with hook disabled
