### PR TITLE
config - execute (and report) v2 export

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -27,7 +27,7 @@ slack:
 
 # Things related to Jenkins jobs
 tasks:
-  conan_v2_run_export: false
+  conan_v2_run_export: true
   write_comments: true
   detailed_status_checks: true
   update_labels: true


### PR DESCRIPTION
On our [roadmap to v2](https://github.com/conan-io/conan-center-index/blob/master/docs/v2_roadmap.md), one of the first things to do is to start exporting recipes using Conan v2. The time is now.

With this change, the bot will start to show the output from Conan v2 export command:

![image](https://user-images.githubusercontent.com/1406456/176614681-852e618d-89ef-41ff-98e1-49a7fc0aaa12.png)

ATM, this is just informative, so people start to gain awareness about Conan v2 changes