### PR TITLE
README.md: Fix broken link to contribution guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 * [Changelog](changelog.md)
 
 * User documentation
-  + [Contributing to Conan Center Index](../contributing.md)
+  + [Contributing to Conan Center Index](../CONTRIBUTING.md)
   + [Adding Packages to ConanCenter](how_to_add_packages.md)
   + [Review Process](review_process.md)
   + [Packaging policy](packaging_policy.md)


### PR DESCRIPTION
Commit fd5f1d05b253 moved the guide from docs/contributing.md ->
CONTRIBUTING.md without updating the reference in
docs/README.md. Commit 2ad9eec8326c (#11227) attempted to fix the link
but did not uppercase the filename as needed.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
