### PR TITLE
New glm version in recipes/glm/all/conandata.yml

### DIFF
--- a/recipes/glm/all/conandata.yml
+++ b/recipes/glm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20220420":
+    url: "https://github.com/g-truc/glm/archive/cc98465e3508535ba8c7f6208df934c156a018dc.zip"
+    sha256: "06d48e336857777d2d1f7da9ccd59e4b9d79720dbd70886d48837d19cda997bb"
   "0.9.9.8":
     url: "https://github.com/g-truc/glm/archive/0.9.9.8.tar.gz"
     sha256: "7d508ab72cb5d43227a3711420f06ff99b0a0cb63ee2f93631b162bfe1fe9592"

--- a/recipes/glm/all/conanfile.py
+++ b/recipes/glm/all/conanfile.py
@@ -26,7 +26,7 @@ class GlmConan(ConanFile):
                   destination=self._source_subfolder, strip_root=True)
 
     def package(self):
-        glm_version = tools.Version(self._get_semver())
+        glm_version = self.version if self.version.startswith("cci") else tools.Version(self._get_semver())
         if glm_version == "0.9.8" or (glm_version == "0.9.9" and self._get_tweak_number() < 6):
             tools.save(os.path.join(self.package_folder, "licenses", "copying.txt"), self._get_license())
         else:

--- a/recipes/glm/config.yml
+++ b/recipes/glm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20220420":
+    folder: all
   "0.9.9.8":
     folder: all
   "0.9.9.7":


### PR DESCRIPTION
Thanks Paul Harris for the hand-holding and bug hunting.

* recipes/glm/all/conandata.yml (sources): Add a source for the latest
commit of 20220420.

* recipes/glm/config.yml: Also mention new version here.

* recipes/glm/all/conanfile.py (GlmConan.package): Tweak for
  "cci.*" versions.

Specify library name and version:  **glm/cci.20220420** built from GitHub's on-demand per-commit zip service.

> This is also a good place to share with all of us **why you are submitting this PR**

Oh, just because the latest tagged verion 0.9.9.8 is from ~2018~2020 but it has a nagging warning (which converts to error with `-Werror` with C++20 that has been fixed 2 years ago.  They should really make a new version tag.

I'm afraid I didn't do any of the below items  :point_down:  :grimacing:   I'm very new to conan and I also don't have much time.
---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
