### PR TITLE
libschrift: add version 0.10.2

### DIFF
--- a/recipes/libschrift/all/conandata.yml
+++ b/recipes/libschrift/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10.2":
+    url: "https://github.com/tomolt/libschrift/archive/v0.10.2.tar.gz"
+    sha256: "23e98611f0dfc6e22dcf531f2de987042ca5a81864911b4e917fb3218795fae0"
   "0.10.1":
     url: "https://github.com/tomolt/libschrift/archive/refs/tags/v0.10.1.tar.gz"
     sha256: "3590c1f9d9cf752edbe51908584aa3dc4d8b466c93bdd3771e830880e143f94c"

--- a/recipes/libschrift/config.yml
+++ b/recipes/libschrift/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.10.2":
+    folder: all
   "0.10.1":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libschrift/0.10.2**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
