### PR TITLE
parallel-hashmap: add version 1.35

### DIFF
--- a/recipes/parallel-hashmap/all/conandata.yml
+++ b/recipes/parallel-hashmap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.35":
+    url: "https://github.com/greg7mdp/parallel-hashmap/archive/1.35.tar.gz"
+    sha256: "308ab6f92e4c6f49304562e352890cf7140de85ce723c097e74fbdec88e0e1ce"
   "1.34":
     url: "https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/1.34.tar.gz"
     sha256: "da4939f5948229abe58acc833b111862411d45669310239b8a163bb73d0197aa"

--- a/recipes/parallel-hashmap/config.yml
+++ b/recipes/parallel-hashmap/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.35":
+    folder: all
   "1.34":
     folder: all
   "1.33":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **parallel-hashmap/1.35**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
