### PR TITLE
arsenalgear: add recipe

### DIFF
--- a/recipes/arsenalgear/all/CMakeLists.txt
+++ b/recipes/arsenalgear/all/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.8)
+project(arsenalgear LANGUAGES CXX)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(KEEP_RPATHS)
+
+include(GNUInstallDirs)
+
+set(arsenalgear_src
+    source_subfolder/src/operators.cpp
+    source_subfolder/src/stream.cpp
+    source_subfolder/src/system.cpp
+    source_subfolder/src/utils.cpp
+)
+
+set(arsenalgear_inc
+    source_subfolder/include/constants.hpp
+    source_subfolder/include/math.hpp
+    source_subfolder/include/operators.hpp
+    source_subfolder/include/stream.hpp
+    source_subfolder/include/system.hpp
+    source_subfolder/include/utils.hpp
+)
+
+add_library(arsenalgear ${arsenalgear_src})
+target_include_directories(arsenalgear PRIVATE "source_subfolder/include")
+set_target_properties(arsenalgear PROPERTIES
+    PUBLIC_HEADER "${arsenalgear_inc}"
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+
+find_library(LIBM m)
+target_link_libraries(arsenalgear PRIVATE $<$<BOOL:${LIBM}>:${LIBM}>)
+
+install(
+    TARGETS arsenalgear
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/recipes/arsenalgear/all/CMakeLists.txt
+++ b/recipes/arsenalgear/all/CMakeLists.txt
@@ -28,6 +28,7 @@ set_target_properties(arsenalgear PROPERTIES
     PUBLIC_HEADER "${arsenalgear_inc}"
     WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
+target_compile_features(arsenalgear PUBLIC cxx_std_17)
 
 find_library(LIBM m)
 target_link_libraries(arsenalgear PRIVATE $<$<BOOL:${LIBM}>:${LIBM}>)

--- a/recipes/arsenalgear/all/conandata.yml
+++ b/recipes/arsenalgear/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.2.2":
+    url: "https://github.com/JustWhit3/arsenalgear-cpp/archive/refs/tags/v1.2.2.tar.gz"
+    sha256: "556155d0be0942bcdd5df02fcda258579915e76b5a70e7220de6ef38c8ca7779"

--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -1,0 +1,85 @@
+from conans import CMake, ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import msvc_runtime_flag, is_msvc
+import functools
+import os
+
+required_conan_version = ">=1.33.0"
+
+class ArsenalgearConan(ConanFile):
+    name = "arsenalgear"
+    description = "A library containing general purpose C++ utils."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/JustWhit3/arsenalgear-cpp"
+    topics = ("constants", "math", "operators", "stream")
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    generators = "cmake"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def requirements(self):
+        self.requires("boost/1.79.0")
+
+    @property
+    def _compiler_required_cpp17(self):
+        return {
+            "Visual Studio": "16",
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "12.0",
+        }
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 17)
+
+        minimum_version = self._compiler_required_cpp17.get(str(self.settings.compiler), False)
+        if minimum_version:
+            if tools.Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration("{} requires C++17, which your compiler does not support.".format(self.name))
+        else:
+            self.output.warn("{0} requires C++17. Your compiler is unknown. Assuming it supports C++17.".format(self.name))
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["arsenalgear"]

--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import is_msvc
 import functools
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.45.0"
 
 class ArsenalgearConan(ConanFile):
     name = "arsenalgear"

--- a/recipes/arsenalgear/all/conanfile.py
+++ b/recipes/arsenalgear/all/conanfile.py
@@ -1,8 +1,7 @@
 from conans import CMake, ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import msvc_runtime_flag, is_msvc
+from conan.tools.microsoft import is_msvc
 import functools
-import os
 
 required_conan_version = ">=1.33.0"
 
@@ -52,6 +51,10 @@ class ArsenalgearConan(ConanFile):
         }
 
     def validate(self):
+        # In 1.2.2, arsenalgear doesn't support Visual Studio.
+        if is_msvc(self):
+            raise ConanInvalidConfiguration("{} doesn't support Visual Studio(yet)".format(self.name))
+
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, 17)
 

--- a/recipes/arsenalgear/all/test_package/CMakeLists.txt
+++ b/recipes/arsenalgear/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(arsenalgear REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} arsenalgear::arsenalgear)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/arsenalgear/all/test_package/conanfile.py
+++ b/recipes/arsenalgear/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/arsenalgear/all/test_package/test_package.cpp
+++ b/recipes/arsenalgear/all/test_package/test_package.cpp
@@ -4,7 +4,6 @@
 #include "constants.hpp"
 #include "operators.hpp"
 
-
 void operators() {
   std::cout << "\n"
             << "======================================================"

--- a/recipes/arsenalgear/all/test_package/test_package.cpp
+++ b/recipes/arsenalgear/all/test_package/test_package.cpp
@@ -1,0 +1,27 @@
+#include <iostream>
+#include <string>
+
+#include "constants.hpp"
+#include "operators.hpp"
+
+
+void operators() {
+  std::cout << "\n"
+            << "======================================================"
+            << "\n"
+            << "     OPERATORS                                        "
+            << "\n"
+            << "======================================================"
+            << "\n"
+            << "\n";
+
+  std::string a = "a";
+  std::cout << "Multiplying \"a\" for 5 times: " << a * 5
+            << agr::empty_space<std::string_view> * 5 << "adding spaces."
+            << "\n\n";
+}
+
+int main() {
+  operators();
+  return 0;
+}

--- a/recipes/arsenalgear/config.yml
+++ b/recipes/arsenalgear/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.2.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **arsenalgear/1.2.2**

The repository name in github is "arsenalgear-cpp".
But the reddit post by author is "arsenalgear: a library containing general purpose utils I developed to summarize helper tools of various projects (constantly in update)".
https://www.reddit.com/r/cpp/comments/vmwnm5/arsenalgear_a_library_containing_general_purpose/

So I use "arsenalgear" in conan recipe.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
