### PR TITLE
gtest: add version 1.12.1

### DIFF
--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.12.1":
+    url: "https://github.com/google/googletest/archive/release-1.12.1.tar.gz"
+    sha256: "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2"
   "1.11.0":
     url: "https://github.com/google/googletest/archive/release-1.11.0.tar.gz"
     sha256: "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5"

--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -15,6 +15,9 @@ sources:
     url: "https://github.com/google/googletest/archive/release-1.8.1.tar.gz"
     sha256: "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c"
 patches:
+  "1.11.0":
+    - patch_file: "patches/gtest-1.11.0.patch"
+      base_path: "source_subfolder"
   "cci.20210126":
     - patch_file: "patches/gtest-1.10.0.patch"
       base_path: "source_subfolder"

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -4,7 +4,7 @@ from conans.errors import ConanInvalidConfiguration
 import os
 import functools
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.45.0"
 
 
 class GTestConan(ConanFile):

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -125,7 +125,7 @@ class GTestConan(ConanFile):
         internal_utils = os.path.join(self._source_subfolder, "googletest",
                                       "cmake", "internal_utils.cmake")
         tools.replace_in_file(internal_utils, "-WX", "")
-        if tools.Version(self.version) < "1.12.0":
+        if self.version == "cci.20210126" or tools.Version(self.version) < "1.12.0":
             tools.replace_in_file(internal_utils, "-Werror", "")
 
     @functools.lru_cache(1)

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan.tools.microsoft import msvc_runtime_flag
+from conan.tools.microsoft import is_msvc, msvc_runtime_flag
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
@@ -10,9 +10,9 @@ required_conan_version = ">=1.43.0"
 class GTestConan(ConanFile):
     name = "gtest"
     description = "Google's C++ test framework"
+    license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/google/googletest"
-    license = "BSD-3-Clause"
     topics = ("testing", "google-testing", "unit-test")
 
     settings = "os", "arch", "compiler", "build_type"
@@ -42,10 +42,6 @@ class GTestConan(ConanFile):
     @property
     def _build_subfolder(self):
         return "build_subfolder"
-
-    @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
 
     @property
     def _minimum_cpp_standard(self):
@@ -90,8 +86,11 @@ class GTestConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    def package_id(self):
+        del self.info.options.no_main
+
     def validate(self):
-        if self.options.shared and self._is_msvc and "MT" in msvc_runtime_flag(self):
+        if self.options.shared and is_msvc(self) and "MT" in msvc_runtime_flag(self):
             raise ConanInvalidConfiguration(
                 "gtest:shared=True with compiler=\"Visual Studio\" is not "
                 "compatible with compiler.runtime=MT/MTd"
@@ -115,9 +114,6 @@ class GTestConan(ConanFile):
                 )
             )
 
-    def package_id(self):
-        del self.info.options.no_main
-
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
@@ -129,14 +125,15 @@ class GTestConan(ConanFile):
         internal_utils = os.path.join(self._source_subfolder, "googletest",
                                       "cmake", "internal_utils.cmake")
         tools.replace_in_file(internal_utils, "-WX", "")
-        tools.replace_in_file(internal_utils, "-Werror", "")
+        if tools.Version(self.version) < "1.12.0":
+            tools.replace_in_file(internal_utils, "-Werror", "")
 
     @functools.lru_cache(1)
     def _configure_cmake(self):
         cmake = CMake(self)
         if self.settings.build_type == "Debug":
             cmake.definitions["CUSTOM_DEBUG_POSTFIX"] = self.options.debug_postfix
-        if self._is_msvc:
+        if is_msvc(self):
             cmake.definitions["gtest_force_shared_crt"] = "MD" in msvc_runtime_flag(self)
         cmake.definitions["BUILD_GMOCK"] = self.options.build_gmock
         if self.settings.os == "Windows" and self.settings.compiler == "gcc":

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -157,6 +157,9 @@ class GTestConan(ConanFile):
 
     @property
     def _postfix(self):
+        # In 1.12.0, gtest remove debug postfix.
+        if self.version != "cci.20210126" and tools.Version(self.version) >= "1.12.0":
+            return ""
         return self.options.debug_postfix if self.settings.build_type == "Debug" else ""
 
     def package_info(self):

--- a/recipes/gtest/all/patches/gtest-1.11.0.patch
+++ b/recipes/gtest/all/patches/gtest-1.11.0.patch
@@ -1,0 +1,13 @@
+diff --git a/googletest/cmake/internal_utils.cmake b/googletest/cmake/internal_utils.cmake
+index 8d8d60a..6ea023a 100644
+--- a/googletest/cmake/internal_utils.cmake
++++ b/googletest/cmake/internal_utils.cmake
+@@ -157,7 +157,7 @@ function(cxx_library_with_type name type cxx_flags)
+   # Generate debug library name with a postfix.
+   set_target_properties(${name}
+     PROPERTIES
+-    DEBUG_POSTFIX "d")
++    DEBUG_POSTFIX "${CUSTOM_DEBUG_POSTFIX}")
+   # Set the output directory for build artifacts
+   set_target_properties(${name}
+     PROPERTIES

--- a/recipes/gtest/config.yml
+++ b/recipes/gtest/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.12.1":
+    folder: all
   "1.11.0":
     folder: all
   "cci.20210126":


### PR DESCRIPTION
Specify library name and version:  **gtest/***

Try to fix https://github.com/conan-io/conan-center-index/issues/11458.

- add version 1.12.1
- use `is_msvc()`
- make disable `replace_in_file` for "-Werror" after 1.12.0

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
