### PR TITLE
libiconv requires at least conan 1.49.0

### DIFF
--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 import os
 import functools
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.49.0"
 
 
 class LibiconvConan(ConanFile):


### PR DESCRIPTION
https://github.com/conan-io/conan-center-index/pull/11422 introduced usage of `is_msvc` in libiconv's recipe. `is_msvc` is [available in conan 1.49.0](https://github.com/conan-io/conan/commit/25081921fcdef2506264cda6bf3e37a76881c127#diff-f1527557f798c1c61c34d36aef944bbbdcbbd23cb03770d071ab9a18e51daef5R6), not in 1.43.0. To make this obvious to users, let's bump libiconv's `required_conan_version`.