### PR TITLE
qt: set QT_PLUGIN_PATH for the run/build environments

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -866,6 +866,10 @@ class QtConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "Qt6"
         self.cpp_info.names["cmake_find_package_multi"] = "Qt6"
 
+        # consumers will need the QT_PLUGIN_PATH defined in runenv
+        self.runenv_info.define("QT_PLUGIN_PATH", os.path.join(self.package_folder, "res", "archdatadir", "plugins"))
+        self.buildenv_info.define("QT_PLUGIN_PATH", os.path.join(self.package_folder, "res", "archdatadir", "plugins"))
+
         build_modules = []
 
         libsuffix = ""


### PR DESCRIPTION
Specify library name and version:  **qt/6.x.x**

QT needs to know where its plugins live.
If QT_PLUGIN_PATH is not set, it'll look in the exe's directory.

qmake.exe and other simple things don't need the plugins,
but any sophisticated consumer of QT will need it set.

I'm not sure I need to set buildenv_info, but runenv_info was needed.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
