### PR TITLE
libdrm/2.4.109: Package man pages in res/man

### DIFF
--- a/recipes/libdrm/all/conanfile.py
+++ b/recipes/libdrm/all/conanfile.py
@@ -101,6 +101,7 @@ class LibdrmConan(ConanFile):
             defs[o] = "true" if getattr(self.options, o) else "false"
 
         defs["datadir"] = os.path.join(self.package_folder, "res")
+        defs["mandir"] = os.path.join(self.package_folder, "res", "man")
 
         meson.configure(
             defs = defs,


### PR DESCRIPTION
Fixes the Conan Hook warning when man pages are installed under share/man.

Specify library name and version:  **libdrm/2.4.109**

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
