### PR TITLE
rapidcsv: add version 8.64

### DIFF
--- a/recipes/rapidcsv/all/conandata.yml
+++ b/recipes/rapidcsv/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.64":
+    url: "https://github.com/d99kris/rapidcsv/archive/v8.64.tar.gz"
+    sha256: "e2ab5231b6e65f1e168dc279bbba2e34afd43c7bc6e2522726b107bcc4e8ebac"
   "8.62":
     url: "https://github.com/d99kris/rapidcsv/archive/refs/tags/v8.62.tar.gz"
     sha256: a7efda6324420f2b69d3448672a9553dc91520632409661f9f83ac0425faa31d

--- a/recipes/rapidcsv/config.yml
+++ b/recipes/rapidcsv/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.64":
+    folder: "all"
   "8.62":
     folder: "all"
   "8.53":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **rapidcsv/8.64**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
