### PR TITLE
[ruy] Upgrade ruy to cci.20220628

### DIFF
--- a/recipes/ruy/all/conandata.yml
+++ b/recipes/ruy/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "cci.20210622":
     url: "https://github.com/google/ruy/archive/9c56af3fce210a8a103eda19bd6f47c08a9e3d90.tar.gz"
     sha256: "8895874cfbf7263b028a6ec55b4b1737af0ea2b7bfedac90fd14d0b0a654f2dc"
+  "cci.20220628":
+    url: "https://github.com/google/ruy/archive/841ea4172ba904fe3536789497f9565f2ef64129.tar.gz"
+    sha256: "fbd20e6c8cd5cf8ef159f69600ea0c7ef0f1401a4c16a9cd04e5a12ffa9c6e14"

--- a/recipes/ruy/all/conanfile.py
+++ b/recipes/ruy/all/conanfile.py
@@ -89,10 +89,17 @@ class RuyConan(ConanFile):
         # This is because ruy only links to 'cpuinfo' but it also needs 'clog' (from the same package)
         cpuinfoLibs = self.deps_cpp_info["cpuinfo"].libs + self.deps_cpp_info["cpuinfo"].system_libs
         libsListAsString = ";".join(cpuinfoLibs)
-        tools.replace_in_file(os.path.join(self._source_subfolder, "ruy", "CMakeLists.txt"),
-                              "set(ruy_6_cpuinfo \"cpuinfo\")",
-                              f"set(ruy_6_cpuinfo \"{libsListAsString}\")"
-                              )
+        if int(self.version.strip('cci.')) < 20220628:
+            tools.replace_in_file(os.path.join(self._source_subfolder, "ruy", "CMakeLists.txt"),
+                                  "set(ruy_6_cpuinfo \"cpuinfo\")",
+                                  f"set(ruy_6_cpuinfo \"{libsListAsString}\")"
+                                  )
+        else:
+            tools.replace_in_file(os.path.join(self._source_subfolder, "ruy", "CMakeLists.txt"),
+                                  "set(ruy_6_cpuinfo_cpuinfo \"cpuinfo::cpuinfo\")",
+                                  f"set(ruy_6_cpuinfo_cpuinfo \"{libsListAsString}\")"
+                                  )
+
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -137,4 +144,4 @@ class RuyConan(ConanFile):
                             "ruy_profiler_profiler"
                             ]
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.system_libs.extend(["m", "pthread"])

--- a/recipes/ruy/config.yml
+++ b/recipes/ruy/config.yml
@@ -1,3 +1,5 @@
 versions:
   "cci.20210622":
     folder: all
+  "cci.20220628":
+    folder: all


### PR DESCRIPTION
Specify library name and version: **ruy/cci.20220628**

This is done as part of https://github.com/conan-io/conan-center-index/pull/11477, but split into a separate PR, since the bot complains. This needs to be merged first!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
