### PR TITLE
Version bump sqlitecpp: sqlite3 3.38.5

### DIFF
--- a/recipes/sqlitecpp/all/conanfile.py
+++ b/recipes/sqlitecpp/all/conanfile.py
@@ -51,7 +51,7 @@ class SQLiteCppConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("sqlite3/3.37.2")
+        self.requires("sqlite3/3.38.5")
 
     def validate(self):
         if tools.Version(self.version) >= "3.0.0" and self.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
Specify library name and version:  **sqlitecpp/3.1.1**

Bump version of sqlite3 requirement to 3.38.5 to match other recipes version in cci.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
