### PR TITLE
libjpeg-turbo: add version 2.1.3

### DIFF
--- a/recipes/libjpeg-turbo/all/conandata.yml
+++ b/recipes/libjpeg-turbo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.3":
+    url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.1.3.tar.gz"
+    sha256: "dbda0c685942aa3ea908496592491e5ec8160d2cf1ec9d5fd5470e50768e7859"
   "2.1.2":
     url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.1.2.tar.gz"
     sha256: "e7fdc8a255c45bc8fbd9aa11c1a49c23092fcd7379296aeaeb14d3343a3d1bed"

--- a/recipes/libjpeg-turbo/config.yml
+++ b/recipes/libjpeg-turbo/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.3":
+    folder: all
   "2.1.2":
     folder: all
   "2.1.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libjpeg-turbo/2.1.3**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
