### PR TITLE
ogg: remove build_testing option

### DIFF
--- a/recipes/ogg/all/conanfile.py
+++ b/recipes/ogg/all/conanfile.py
@@ -16,12 +16,10 @@ class OggConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "build_testing": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "build_testing": False,
     }
 
     generators = "cmake"
@@ -60,7 +58,7 @@ class OggConan(ConanFile):
         self._cmake = CMake(self)
         # Generate a relocatable shared lib on Macos
         self._cmake.definitions["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
-        self._cmake.definitions["BUILD_TESTING"] = self.options.build_testing
+        self._cmake.definitions["BUILD_TESTING"] = False
         self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 


### PR DESCRIPTION
Always disable tests and remove `build_testing` option. See https://github.com/conan-io/conan-center-index/pull/11042#issuecomment-1173930259

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
