### PR TITLE
osmanip: add recipe

### DIFF
--- a/recipes/osmanip/all/CMakeLists.txt
+++ b/recipes/osmanip/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(osmanip LANGUAGES CXX)
 
 include(conanbuildinfo.cmake)

--- a/recipes/osmanip/all/CMakeLists.txt
+++ b/recipes/osmanip/all/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.1)
+project(osmanip LANGUAGES CXX)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(KEEP_RPATHS)
+
+include(GNUInstallDirs)
+
+set(osmanip_src
+    source_subfolder/src/graphics/canvas.cpp
+    source_subfolder/src/graphics/plot_2D.cpp
+    source_subfolder/src/manipulators/csmanip.cpp
+    source_subfolder/src/progressbar/progress_bar.cpp
+    source_subfolder/src/utility/windows.cpp
+)
+
+set(osmanip_inc
+    source_subfolder/include/graphics/canvas.hpp
+    source_subfolder/include/graphics/plot_2D.hpp
+    source_subfolder/include/manipulators/csmanip.hpp
+    source_subfolder/include/progressbar/multi_progress_bar.hpp
+    source_subfolder/include/progressbar/progress_bar.hpp
+    source_subfolder/include/utility/windows.hpp
+)
+
+
+add_library(osmanip ${osmanip_src})
+target_include_directories(osmanip PUBLIC source_subfolder/include/)
+target_compile_features(osmanip PUBLIC cxx_std_17)
+set_target_properties(osmanip PROPERTIES
+    PUBLIC_HEADER "${osmanip_inc}"
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+
+find_library(LIBM m)
+target_link_libraries(osmanip PRIVATE $<$<BOOL:${LIBM}>:${LIBM}>)
+
+install(
+    TARGETS osmanip
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(
+    DIRECTORY source_subfolder/include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/osmanip
+)

--- a/recipes/osmanip/all/conandata.yml
+++ b/recipes/osmanip/all/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+  "4.0.0":
+    url: "https://github.com/JustWhit3/osmanip/archive/refs/tags/v4.0.0.tar.gz"
+    sha256: "c6848e1d9b15eb409af88efeee7cd1ce87374ea7ac87424f5d2cf30104f098a0"
+
+patches:
+  "4.0.0":
+    # This patch is for function renaming on arsenalgear/1.2.2.
+    - patch_file: "patches/0001-replace-runtime_error_func.patch"
+      base_path: "source_subfolder"

--- a/recipes/osmanip/all/conanfile.py
+++ b/recipes/osmanip/all/conanfile.py
@@ -1,0 +1,88 @@
+from conans import CMake, ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import functools
+
+required_conan_version = ">=1.33.0"
+
+class OsmanipConan(ConanFile):
+    name = "osmanip"
+    description = "Library with useful output stream tools like: color and style manipulators, progress bars and terminal graphics."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/JustWhit3/osmanip"
+    topics = ("manipulator", "iostream", "output-stream", "iomanip")
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    generators = "cmake"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def requirements(self):
+        self.requires("boost/1.79.0")
+        self.requires("arsenalgear/1.2.2")
+
+    @property
+    def _compiler_required_cpp17(self):
+        return {
+            "Visual Studio": "16",
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "12.0",
+        }
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 17)
+
+        minimum_version = self._compiler_required_cpp17.get(str(self.settings.compiler), False)
+        if minimum_version:
+            if tools.Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration("{} requires C++17, which your compiler does not support.".format(self.name))
+        else:
+            self.output.warn("{0} requires C++17. Your compiler is unknown. Assuming it supports C++17.".format(self.name))
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["osmanip"]

--- a/recipes/osmanip/all/patches/0001-replace-runtime_error_func.patch
+++ b/recipes/osmanip/all/patches/0001-replace-runtime_error_func.patch
@@ -1,0 +1,102 @@
+diff --git a/src/manipulators/csmanip.cpp b/src/manipulators/csmanip.cpp
+index 064c7ba..6363226 100644
+--- a/src/manipulators/csmanip.cpp
++++ b/src/manipulators/csmanip.cpp
+@@ -208,7 +208,7 @@ namespace osm
+    {
+     if( generic_map.find( feat_string ) == generic_map.end() ) 
+      {
+-      throw agr::runtime_error_func( generic_map.at( "error" ), feat_string, "is not supported!" );
++      throw agr::except_error_func( generic_map.at( "error" ), feat_string, "is not supported!" );
+      }
+     return generic_map.at( feat_string );
+    }
+@@ -228,7 +228,7 @@ namespace osm
+    {
+     if( generic_map.find( feat_string ) == generic_map.end() ) 
+      {
+-      throw agr::runtime_error_func( generic_map.at( "error" ).first, feat_string, "is not supported!" );
++      throw agr::except_error_func( generic_map.at( "error" ).first, feat_string, "is not supported!" );
+      }
+     else
+      {
+@@ -255,7 +255,7 @@ namespace osm
+    {
+     if( rst.find( reset_string ) == rst.end() ) 
+      {
+-      throw agr::runtime_error_func( rst.at( "error" ), reset_string, "is not supported!" );
++      throw agr::except_error_func( rst.at( "error" ), reset_string, "is not supported!" );
+      } 
+     return rst.at( reset_string );
+    }
+@@ -295,4 +295,4 @@ namespace osm
+             std::to_string( g ) + ";"s +
+             std::to_string( b ) + "m"s;
+    }
+- }
+\ No newline at end of file
++ }
+diff --git a/src/progressbar/progress_bar.cpp b/src/progressbar/progress_bar.cpp
+index 485009f..b12aee4 100644
+--- a/src/progressbar/progress_bar.cpp
++++ b/src/progressbar/progress_bar.cpp
+@@ -163,16 +163,16 @@ namespace osm
+        }
+       else if( styles_map_.at( type ).find( style ) == styles_map_.at( type ).end() )
+        {
+-        throw agr::runtime_error_func( "Inserted ProgressBar style", style, "is not supported for this type!" );
++        throw agr::except_error_func( "Inserted ProgressBar style", style, "is not supported for this type!" );
+        }
+       else
+        {
+-        throw agr::runtime_error_func( "Inserted ProgressBar type", type, "is not supported!" );
++        throw agr::except_error_func( "Inserted ProgressBar type", type, "is not supported!" );
+        }
+      }
+     catch ( std::out_of_range const& exception )
+      {
+-      throw agr::runtime_error_func( "Inserted ProgressBar type", type, "is not supported!" );
++      throw agr::except_error_func( "Inserted ProgressBar type", type, "is not supported!" );
+      }
+    }
+ 
+@@ -201,15 +201,15 @@ namespace osm
+      }
+     else if( styles_map_.at( "indicator" ).find( style_p ) == styles_map_.at( "indicator" ).end() )
+      {
+-      throw agr::runtime_error_func( "Inserted indicator style", style_p, "is not supported for this type!" );
++      throw agr::except_error_func( "Inserted indicator style", style_p, "is not supported for this type!" );
+      }
+     else if( styles_map_.at( "loader" ).find( style_l ) == styles_map_.at( "loader" ).end() )
+      {
+-      throw agr::runtime_error_func( "Inserted loader style", style_l, "is not supported for this type!" );
++      throw agr::except_error_func( "Inserted loader style", style_l, "is not supported for this type!" );
+      }
+     else
+      {
+-      throw agr::runtime_error_func( "Inserted ProgressBar type", type, "is not supported!" );
++      throw agr::except_error_func( "Inserted ProgressBar type", type, "is not supported!" );
+      }
+    }
+ 
+@@ -834,11 +834,11 @@ namespace osm
+       }
+      else if( styles_map_.at( type ).find( style ) != styles_map_.at( type ).end() )
+       {
+-       throw agr::runtime_error_func( "Inserted ProgressBar style", style, "is already available!" ); 
++       throw agr::except_error_func( "Inserted ProgressBar style", style, "is already available!" );
+       }
+      else
+       {
+-       throw agr::runtime_error_func( "Inserted ProgressBar type", type, "is already available!" );
++       throw agr::except_error_func( "Inserted ProgressBar type", type, "is already available!" );
+       }
+     }
+   
+@@ -869,4 +869,4 @@ namespace osm
+    * 
+    */
+   BOOST_PP_SEQ_FOR_EACH( PROGRESSBAR, _, ARGS( int, long, long long, double, long double, float ) );
+- }
+\ No newline at end of file
++ }

--- a/recipes/osmanip/all/test_package/CMakeLists.txt
+++ b/recipes/osmanip/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(osmanip REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} osmanip::osmanip)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/osmanip/all/test_package/conanfile.py
+++ b/recipes/osmanip/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/osmanip/all/test_package/test_package.cpp
+++ b/recipes/osmanip/all/test_package/test_package.cpp
@@ -1,0 +1,108 @@
+// This code is a part of upstream example code.
+// https://github.com/JustWhit3/osmanip/blob/v4.0.0/examples/progressbar.cpp
+
+// My headers
+#include "osmanip/progressbar/multi_progress_bar.hpp"
+#include "osmanip/progressbar/progress_bar.hpp"
+#ifdef _WIN32
+#include "osmanip/utility/windows.hpp"
+#endif
+
+// STD headers
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+//====================================================
+//     Percentage bar
+//====================================================
+void
+perc_bars() {
+    std::cout << "\n"
+              << "======================================================"
+              << "\n"
+              << "     PERCENTAGE BARS                                    "
+              << "\n"
+              << "======================================================"
+              << "\n\n";
+
+    // Normal percentage bar.
+    osm::ProgressBar<int> percentage_bar;
+    percentage_bar.setMin(5);
+    percentage_bar.setMax(46);
+    percentage_bar.setStyle("indicator", "%");
+
+    std::cout << "This is a normal percentage bar: "
+              << "\n";
+    for (int i = percentage_bar.getMin(); i < percentage_bar.getMax(); i++) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        percentage_bar.update(i);
+        // Do some operations...
+    }
+    std::cout << "\n\n";
+
+    // Percentage bar with message and different style:
+    osm::ProgressBar<float> percentage_bar_2(1.2f, 4.4f);
+    percentage_bar_2.setMessage("processing...");
+    percentage_bar_2.setStyle("indicator", "/100");
+
+    std::cout << "This is a percentage bar with message and the /100 style: "
+              << "\n";
+    for (float i = percentage_bar_2.getMin(); i < percentage_bar_2.getMax(); i += 0.1f) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        percentage_bar_2.update(i);
+        // Do some operations...
+    }
+    std::cout << "\n\n";
+
+    // Percentage bar with time consuming info:
+    percentage_bar.resetMessage();
+    percentage_bar.setStyle("indicator", "%");
+
+    std::cout << "This is a percentage bar with time consuming info: "
+              << "\n";
+    for (int i = percentage_bar.getMin(); i < percentage_bar.getMax(); i++) {
+        percentage_bar.setBegin();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        percentage_bar.update(i);
+        // Do some operations...
+        percentage_bar.setEnd();
+    }
+    std::cout << "\n"
+              << "Time needed to complete the previous loop: " << percentage_bar.getTime() << " ms."
+              << "\n\n";
+
+    // Percentage bar with estimated time left:
+    percentage_bar.setMin(2);
+    percentage_bar.setMax(121);
+    percentage_bar.setRemainingTimeFlag("on");
+    percentage_bar.resetRemainingTime();
+
+    std::cout << "This is a percentage bar with time-remaining info: "
+              << "\n";
+    for (int i = percentage_bar.getMin(); i < percentage_bar.getMax(); i++) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        percentage_bar.update(i);
+        // Do some operations...
+    }
+    std::cout << "\n\n";
+}
+
+//====================================================
+//     Main
+//====================================================
+int main() {
+#ifdef _WIN32
+    osm::enableANSI();
+#endif
+
+    osm::OPTION(osm::CURSOR::OFF);
+
+    perc_bars();         // Percentage bar.
+
+    osm::OPTION(osm::CURSOR::ON);
+
+#ifdef _WIN32
+    osm::disableANSI();
+#endif
+}

--- a/recipes/osmanip/config.yml
+++ b/recipes/osmanip/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "4.0.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **osmanip/4.0.0**

- osmanip is a terminal library
- it requires boost, arsenalgear
- osmanip doesn't have CMakeLists.txt (only Makefile)
- Because arsenalgear has breaking changes recently and osmanip/4.0.0 doesn't follow yet, I create patch for it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
