### PR TITLE
(#11540) perfetto: Bump version to 27.0

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -23,6 +23,9 @@ sources:
   "26.1":
     url: https://github.com/google/perfetto/archive/refs/tags/v26.1.tar.gz
     sha256: cce387e82e2a137fce2eba927f80f20407764b77637a1a92b9b24065a500ce6d
+  "27.0":
+    url: https://github.com/google/perfetto/archive/refs/tags/v27.0.tar.gz
+    sha256: c22750dd21419cf58132d55d634b88d9947bd0c7244dd98854b0248c7637a98c
 
 patches:
   "20.1":

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -15,3 +15,5 @@ versions:
     folder: all
   "26.1":
     folder: all
+  "27.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **perfetto/27.0**

```
v27.0 - 2022-07-01:
  Tracing service and probes:
    * Fix rare crash due to watchdog timeout being too short.
  Trace Processor:
    * Removed enable_perfetto_x64_cpu_opt by default for x64 MacOS
      since it caused issues for CIs.
    * Improved performance of filtering and sorting on most queries.
  UI:
    * Changed sorting of process groups to take slice count and presence of
      perf profiles into account.
  SDK:
```

Closes #11540 
---

- [ x ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ x ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ x ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
