### PR TITLE
grpc-proto - Add repository

### DIFF
--- a/recipes/grpc-proto/all/conandata.yml
+++ b/recipes/grpc-proto/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "cci.20211106":  # Synced here https://github.com/grpc/grpc/pull/27957
+    url: "https://github.com/grpc/grpc-proto/archive/8e3fec8612bc0708e857950dccadfd5063703e04.zip"
+    sha256: "8675b46d7997f9b6b80b37e8c30c359e0f919632ca3d8d6076944c7893c2d4cf"
+  "cci.20220627":
+    url: "https://github.com/grpc/grpc-proto/archive/d653c6d98105b2af937511aa6e46610c7e677e6e.zip"
+    sha256: "365c0c8d9ae90aa11a8bd7fa870d8962a13600cfc851405acd5327907f9f4c56"

--- a/recipes/grpc-proto/all/conanfile.py
+++ b/recipes/grpc-proto/all/conanfile.py
@@ -1,0 +1,27 @@
+import os
+from conan import ConanFile
+from conan.tools.files import get, copy
+
+
+class GRPCProto(ConanFile):
+    name = "grpc-proto"
+    description = "gRPC-defined protobufs for peripheral services such as health checking, load balancing, etc"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/grpc/grpc-proto"
+    topics = "google", "protos", "api"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def source(self):
+        get(self, **self.conan_data["sources"][str(self.version)], destination=self.source_folder, strip_root=True)
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package(self):
+        copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, pattern="*.proto", src=self.source_folder, dst=os.path.join(self.package_folder, "res"))
+
+    def package_info(self):
+        self.cpp_info.libs = []
+        self.cpp_info.includedirs = []

--- a/recipes/grpc-proto/all/test_package/CMakeLists.txt
+++ b/recipes/grpc-proto/all/test_package/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(protobuf REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE protobuf::protobuf)
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+
+message("GRPC_PROTO_RES_DIR -- ${GRPC_PROTO_RES_DIR}")
+protobuf_generate(
+    LANGUAGE cpp 
+    TARGET ${PROJECT_NAME} 
+    PROTOS ${GRPC_PROTO_RES_DIR}/grpc/health/v1/health.proto
+    IMPORT_DIRS ${GRPC_PROTO_RES_DIR})

--- a/recipes/grpc-proto/all/test_package/conanfile.py
+++ b/recipes/grpc-proto/all/test_package/conanfile.py
@@ -1,0 +1,34 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.build import cross_building as tools_cross_building
+from conan.tools.layout import cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires("protobuf/3.21.1")
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("protobuf/3.21.1")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["GRPC_PROTO_RES_DIR"] = self.dependencies["grpc-proto"].cpp_info.resdirs[0].replace("\\", "/")
+        tc.generate()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools_cross_building(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/grpc-proto/all/test_package/test_package.cpp
+++ b/recipes/grpc-proto/all/test_package/test_package.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+#include "grpc/health/v1/health.pb.h"
+
+int main() {
+    std::cout << "Conan - test package for grpc-proto\n";
+
+    grpc::health::v1::HealthCheckResponse h;
+    h.set_status(::grpc::health::v1::HealthCheckResponse_ServingStatus::HealthCheckResponse_ServingStatus_NOT_SERVING);
+
+    std::cout << h.DebugString();
+
+    return 0;
+}

--- a/recipes/grpc-proto/config.yml
+++ b/recipes/grpc-proto/config.yml
@@ -1,0 +1,5 @@
+versions:
+  "cci.20211106":
+    folder: all
+  "cci.20220627":
+    folder: all


### PR DESCRIPTION
According to the documentation:

> This repository contains the canonical versions of common protocol definitions for peripheral services around gRPC such as health checking and load balancing.

and these repositories (`grpc` and `grpc-proto`) are synced: https://github.com/grpc/grpc/pull/27957, nevertheless, I've found that sometimes information flows from `grpc` to `grpc-proto`... so I have my doubts about how development is being organized around those repositories. 

- [x] Requires https://github.com/conan-io/hooks/pull/433