### PR TITLE
gitignore - with new generators some files appear at root level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# Conan specific
+test_package/build/
+conan.lock
+conanbuildinfo.txt
+conaninfo.txt
+graph_info.json
+build/
+
 # IDEs
 .idea
 .vscode
@@ -9,12 +17,9 @@
 ## emacs
 *~
 
-
 # Byte-compiled / optimized / DLL files / Cache
 __pycache__/
 test_package/__pycache__/
-test_package/build/
-build/
 *.pyc
 *.py[cod]
 *$py.class


### PR DESCRIPTION
When using new layout like `cmake_layout(self)`, these files appear at root level