### PR TITLE
libjpeg-turbo: add version 2.1.3

### DIFF
--- a/recipes/libjpeg-turbo/all/conandata.yml
+++ b/recipes/libjpeg-turbo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.3":
+    url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.1.3.tar.gz"
+    sha256: "dbda0c685942aa3ea908496592491e5ec8160d2cf1ec9d5fd5470e50768e7859"
   "2.1.2":
     url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.1.2.tar.gz"
     sha256: "e7fdc8a255c45bc8fbd9aa11c1a49c23092fcd7379296aeaeb14d3343a3d1bed"
@@ -14,9 +17,8 @@ sources:
   "2.0.5":
     url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.5.tar.gz"
     sha256: "b3090cd37b5a8b3e4dbd30a1311b3989a894e5d3c668f14cbc6739d77c9402b7"
-  "2.0.4":
-    url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.4.tar.gz"
-    sha256: "7777c3c19762940cff42b3ba4d7cd5c52d1671b39a79532050c85efb99079064"
-  "2.0.2":
-    url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.2.tar.gz"
-    sha256: "b45255bd476c19c7c6b198c07c0487e8b8536373b82f2b38346b32b4fa7bb942"
+
+patches:
+  "2.1.3":
+    - patch_file: "patches/2.1.3-0001-fix-cmake.patch"
+      base_path: "source_subfolder"

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.microsoft import is_msvc
 import os
 import functools
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.45.0"
 
 
 class LibjpegTurboConan(ConanFile):

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -1,6 +1,8 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc
 import os
+import functools
 
 required_conan_version = ">=1.43.0"
 
@@ -8,12 +10,11 @@ required_conan_version = ">=1.43.0"
 class LibjpegTurboConan(ConanFile):
     name = "libjpeg-turbo"
     description = "SIMD-accelerated libjpeg-compatible JPEG codec library"
-    topics = ("jpeg", "libjpeg", "image", "multimedia", "format", "graphics")
+    license = "BSD-3-Clause, Zlib"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libjpeg-turbo.org"
-    license = "BSD-3-Clause, Zlib"
+    topics = ("jpeg", "libjpeg", "image", "multimedia", "format", "graphics")
     provides = "libjpeg"
-
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -41,18 +42,16 @@ class LibjpegTurboConan(ConanFile):
         "java": False,
         "enable12bit": False,
     }
-
-    exports_sources = "CMakeLists.txt"
     generators = "cmake"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
-    @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -80,7 +79,7 @@ class LibjpegTurboConan(ConanFile):
             raise ConanInvalidConfiguration("12-bit samples is not allowed with libjpeg v7/v8 API/ABI")
         if self.options.get_safe("java", False) and not self.options.shared:
             raise ConanInvalidConfiguration("java wrapper requires shared libjpeg-turbo")
-        if self._is_msvc and self.options.shared and str(self.settings.compiler.runtime).startswith("MT"):
+        if is_msvc(self) and self.options.shared and str(self.settings.compiler.runtime).startswith("MT"):
             raise ConanInvalidConfiguration("shared libjpeg-turbo can't be built with MT or MTd")
 
     @property
@@ -101,26 +100,25 @@ class LibjpegTurboConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self, set_cmake_flags=True)
-        self._cmake.definitions["ENABLE_STATIC"] = not self.options.shared
-        self._cmake.definitions["ENABLE_SHARED"] = self.options.shared
-        self._cmake.definitions["WITH_SIMD"] = self.options.get_safe("SIMD", False)
-        self._cmake.definitions["WITH_ARITH_ENC"] = self._is_arithmetic_encoding_enabled
-        self._cmake.definitions["WITH_ARITH_DEC"] = self._is_arithmetic_decoding_enabled
-        self._cmake.definitions["WITH_JPEG7"] = self.options.libjpeg7_compatibility
-        self._cmake.definitions["WITH_JPEG8"] = self.options.libjpeg8_compatibility
-        self._cmake.definitions["WITH_MEM_SRCDST"] = self.options.get_safe("mem_src_dst", False)
-        self._cmake.definitions["WITH_TURBOJPEG"] = self.options.get_safe("turbojpeg", False)
-        self._cmake.definitions["WITH_JAVA"] = self.options.get_safe("java", False)
-        self._cmake.definitions["WITH_12BIT"] = self.options.enable12bit
-        if self._is_msvc:
-            self._cmake.definitions["WITH_CRT_DLL"] = True # avoid replacing /MD by /MT in compiler flags
+        cmake = CMake(self, set_cmake_flags=True)
+        cmake.definitions["ENABLE_STATIC"] = not self.options.shared
+        cmake.definitions["ENABLE_SHARED"] = self.options.shared
+        cmake.definitions["WITH_SIMD"] = self.options.get_safe("SIMD", False)
+        cmake.definitions["WITH_ARITH_ENC"] = self._is_arithmetic_encoding_enabled
+        cmake.definitions["WITH_ARITH_DEC"] = self._is_arithmetic_decoding_enabled
+        cmake.definitions["WITH_JPEG7"] = self.options.libjpeg7_compatibility
+        cmake.definitions["WITH_JPEG8"] = self.options.libjpeg8_compatibility
+        cmake.definitions["WITH_MEM_SRCDST"] = self.options.get_safe("mem_src_dst", False)
+        cmake.definitions["WITH_TURBOJPEG"] = self.options.get_safe("turbojpeg", False)
+        cmake.definitions["WITH_JAVA"] = self.options.get_safe("java", False)
+        cmake.definitions["WITH_12BIT"] = self.options.enable12bit
+        if is_msvc(self):
+            cmake.definitions["WITH_CRT_DLL"] = True # avoid replacing /MD by /MT in compiler flags
 
         if tools.Version(self.version) <= "2.1.0":
-            self._cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False # avoid configuration error if building for iOS/tvOS/watchOS
+            cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False # avoid configuration error if building for iOS/tvOS/watchOS
 
         if tools.cross_building(self):
             # TODO: too specific and error prone, should be delegated to a conan helper function
@@ -128,12 +126,15 @@ class LibjpegTurboConan(ConanFile):
                 "armv8": "aarch64",
                 "armv8.3": "aarch64",
             }.get(str(self.settings.arch), str(self.settings.arch))
-            self._cmake.definitions["CONAN_LIBJPEG_SYSTEM_PROCESSOR"] = cmake_system_processor
+            cmake.definitions["CONAN_LIBJPEG_SYSTEM_PROCESSOR"] = cmake_system_processor
 
-        self._cmake.configure()
-        return self._cmake
+        cmake.configure()
+        return cmake
 
     def _patch_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
         # use standard GNUInstallDirs.cmake - custom one is broken
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
                               "include(cmakescripts/GNUInstallDirs.cmake)",
@@ -165,7 +166,7 @@ class LibjpegTurboConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "libjpeg-turbo")
 
         cmake_target_suffix = "-static" if not self.options.shared else ""
-        lib_suffix = "-static" if self._is_msvc and not self.options.shared else ""
+        lib_suffix = "-static" if is_msvc(self) and not self.options.shared else ""
 
         self.cpp_info.components["jpeg"].set_property("cmake_target_name", "libjpeg-turbo::jpeg{}".format(cmake_target_suffix))
         self.cpp_info.components["jpeg"].set_property("pkg_config_name", "libjpeg")

--- a/recipes/libjpeg-turbo/all/patches/2.1.3-0001-fix-cmake.patch
+++ b/recipes/libjpeg-turbo/all/patches/2.1.3-0001-fix-cmake.patch
@@ -1,3 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1198ece..cea737c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -606,7 +606,7 @@ if(WITH_TURBOJPEG)
+       set(TJMAPFILE ${CMAKE_CURRENT_SOURCE_DIR}/turbojpeg-mapfile.jni)
+     endif()
+     if(MSVC)
+-      configure_file(${CMAKE_SOURCE_DIR}/win/turbojpeg.rc.in
++      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/win/turbojpeg.rc.in
+         ${CMAKE_BINARY_DIR}/win/turbojpeg.rc)
+       set(TURBOJPEG_SOURCES ${TURBOJPEG_SOURCES}
+         ${CMAKE_BINARY_DIR}/win/turbojpeg.rc)
 diff --git a/sharedlib/CMakeLists.txt b/sharedlib/CMakeLists.txt
 index aea0b9d..612be16 100644
 --- a/sharedlib/CMakeLists.txt

--- a/recipes/libjpeg-turbo/all/patches/2.1.3-0001-fix-cmake.patch
+++ b/recipes/libjpeg-turbo/all/patches/2.1.3-0001-fix-cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/sharedlib/CMakeLists.txt b/sharedlib/CMakeLists.txt
+index aea0b9d..612be16 100644
+--- a/sharedlib/CMakeLists.txt
++++ b/sharedlib/CMakeLists.txt
+@@ -36,7 +36,7 @@ if(WIN32)
+   endif()
+ endif()
+ if(MSVC)
+-  configure_file(${CMAKE_SOURCE_DIR}/win/jpeg.rc.in
++  configure_file(../win/jpeg.rc.in
+     ${CMAKE_BINARY_DIR}/win/jpeg.rc)
+   set(JPEG_SRCS ${JPEG_SRCS} ${CMAKE_BINARY_DIR}/win/jpeg.rc)
+ endif()

--- a/recipes/libjpeg-turbo/config.yml
+++ b/recipes/libjpeg-turbo/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.3":
+    folder: all
   "2.1.2":
     folder: all
   "2.1.1":
@@ -8,8 +10,4 @@ versions:
   "2.0.6":
     folder: all
   "2.0.5":
-    folder: all
-  "2.0.4":
-    folder: all
-  "2.0.2":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libjpeg-turbo/2.1.3**

Second try to upgrade.
https://github.com/conan-io/conan-center-index/pull/11533

- add version 2.1.3
  - create a patch to fix CMAKE_SOURCE_DIR issue in 2.1.3
- remove versions 2.0.2, 2.0.4
- use is_msvc
- use lru_cache

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
