### PR TITLE
qt/6.x.x: Added missing imageformats plugins

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -988,10 +988,6 @@ class QtConan(ConanFile):
                     gui_reqs.append("moltenvk::moltenvk")
             if self.options.with_harfbuzz:
                 gui_reqs.append("harfbuzz::harfbuzz")
-            if self.options.with_libjpeg == "libjpeg-turbo":
-                gui_reqs.append("libjpeg-turbo::libjpeg-turbo")
-            if self.options.with_libjpeg == "libjpeg":
-                gui_reqs.append("libjpeg::libjpeg")
             if self.options.with_glib:
                 gui_reqs.append("glib::glib")
             if self.options.with_md4c:
@@ -1025,6 +1021,16 @@ class QtConan(ConanFile):
             elif self.settings.os in ["Linux", "FreeBSD"]:
                 _create_module("XcbQpaPrivate", ["xkbcommon::libxkbcommon-x11", "xorg::xorg"], has_include_dir=False)
                 _create_plugin("QXcbIntegrationPlugin", "qxcb", "platforms", ["Core", "Gui", "XcbQpaPrivate"])
+
+            _create_plugin("QGifPlugin", "qgif", "imageformats", ["Gui"])
+            _create_plugin("QIcoPlugin", "qico", "imageformats", ["Gui"])
+            if self.options.get_safe("with_libjpeg"):
+                jpeg_reqs = ["Gui"]
+                if self.options.with_libjpeg == "libjpeg-turbo": 
+                     jpeg_reqs.append("libjpeg-turbo::libjpeg-turbo") 
+                if self.options.with_libjpeg == "libjpeg": 
+                     jpeg_reqs.append("libjpeg::libjpeg") 
+                _create_plugin("QJpegPlugin", "qjpeg", "imageformats", jpeg_reqs)
 
         if self.options.with_sqlite3:
             _create_plugin("QSQLiteDriverPlugin", "qsqlite", "sqldrivers", ["sqlite3::sqlite3"])


### PR DESCRIPTION
Specify library name and version:  **qt/6.x.x**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---


- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
