### PR TITLE
detours: fix static debug runtime

### DIFF
--- a/recipes/detours/all/conanfile.py
+++ b/recipes/detours/all/conanfile.py
@@ -66,7 +66,13 @@ class DetoursConan(ConanFile):
         cmake.configure()
         return cmake
 
+    def _patch_sources(self):
+        if is_msvc(self):
+            tools.replace_in_file(os.path.join(self._source_subfolder, "src", "Makefile"),
+                                  "/MT ", f"/{self.settings.compiler.runtime} ")
+
     def build(self):
+        self._patch_sources()
         if is_msvc(self):
             with tools.vcvars(self):
                 with tools.chdir(os.path.join(self._source_subfolder, "src")):


### PR DESCRIPTION
Specify library name and version:  **detours/all**

Fix runtime compile flag

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
