### PR TITLE
v2 - Do not notify via slack

### DIFF
--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -20,9 +20,9 @@ github:
 #status_checks:
 #  - "continuous-integration/jenkins/pr-merge"
 
-slack:
-  credential_success_url: SLACK_SUCCESS_WEBHOOK_URL
-  ceredential_errors_url: SLACK_FAILURE_WEBHOOK_URL
+#slack:
+#  credential_success_url: SLACK_SUCCESS_WEBHOOK_URL
+#  ceredential_errors_url: SLACK_FAILURE_WEBHOOK_URL
 
 # Things related to Jenkins jobs:
 tasks:


### PR DESCRIPTION
At this moment every v2 build fails, this is especially noisy when the PRs are merged. This change will stop those notifications.
