### PR TITLE
Fix #11553 - ruby/3.1.0: build error on all platforms due to wrong prefix

### DIFF
--- a/recipes/ruby/all/conanfile.py
+++ b/recipes/ruby/all/conanfile.py
@@ -114,6 +114,9 @@ class RubyConan(ConanFile):
             if self.settings.build_type in ["Debug", "RelWithDebInfo"]:
                 tc.ldflags.append("-debug")
             tc.build_type_flags = [f if f != "-O2" else self._msvc_optflag for f in tc.build_type_flags]
+
+        tc.configure_args.append("--prefix=")
+
         tc.generate()
 
     def build(self):

--- a/recipes/ruby/all/conanfile.py
+++ b/recipes/ruby/all/conanfile.py
@@ -97,11 +97,14 @@ class RubyConan(ConanFile):
         td.generate()
 
         tc = AutotoolsToolchain(self)
+        # TODO: removed in conan 1.49
         tc.default_configure_install_args = True
-        tc.configure_args = ["--disable-install-doc"]
+
+        tc.configure_args.append("--disable-install-doc")
         if self.options.shared and not is_msvc(self):
-            tc.configure_args.append("--enable-shared")
+            # Force fPIC
             tc.fpic = True
+
         if cross_building(self) and is_apple_os(self.settings.os):
             apple_arch = to_apple_arch(self.settings.arch)
             if apple_arch:
@@ -114,8 +117,6 @@ class RubyConan(ConanFile):
             if self.settings.build_type in ["Debug", "RelWithDebInfo"]:
                 tc.ldflags.append("-debug")
             tc.build_type_flags = [f if f != "-O2" else self._msvc_optflag for f in tc.build_type_flags]
-
-        tc.configure_args.append("--prefix=")
 
         tc.generate()
 

--- a/recipes/ruby/all/conanfile.py
+++ b/recipes/ruby/all/conanfile.py
@@ -104,6 +104,8 @@ class RubyConan(ConanFile):
         if self.options.shared and not is_msvc(self):
             # Force fPIC
             tc.fpic = True
+            if "--enable-shared" not in tc.configure_args:
+                tc.configure_args.append("--enable-shared")
 
         if cross_building(self) and is_apple_os(self.settings.os):
             apple_arch = to_apple_arch(self.settings.arch)


### PR DESCRIPTION
Specify library name and version:  **ruby/3.1.0**

* Fix #11553 
* Do not override the AutotoolsToolchain default install flags

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
