### PR TITLE
add all *Macros.cmake to cmake build_modules

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1383,9 +1383,9 @@ Examples = bin/datadir/examples""")
         self.cpp_info.components["qtCore"].build_modules["cmake_find_package_multi"].append(self._cmake_qt5_private_file("Core"))
 
         for m in os.listdir(os.path.join("lib", "cmake")):
-            module = os.path.join("lib", "cmake", m, "%sMacros.cmake" % m)
             component_name = m.replace("Qt5", "qt")
-            if os.path.isfile(module):
+            modules = glob.glob(os.path.join("lib", "cmake", m, "*Macros.cmake"))
+            for module in modules:
                 build_modules.append(module)
                 self.cpp_info.components[component_name].build_modules["cmake_find_package"].append(module)
                 self.cpp_info.components[component_name].build_modules["cmake_find_package_multi"].append(module)


### PR DESCRIPTION
**qt/5.x.x**

Add all `*Macros.cmake` to cmake build_modules. 
For example: Qt5Core have two *Macros.cmake scripts

```
lib/cmake/Qt5Core/Qt5CTestMacros.cmake
lib/cmake/Qt5Core/Qt5CoreMacros.cmake
```
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
