### PR TITLE
tracy: add version 0.8.2.1

### DIFF
--- a/recipes/tracy/all/conandata.yml
+++ b/recipes/tracy/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.8.2.1":
+    url: "https://github.com/wolfpld/tracy/archive/v0.8.2.1.tar.gz"
+    sha256: "97f478579efa1f5ce4c8619014a20327010fea122c21248701fe2bbb46ec1c1f"
   "0.8.1":
     url: "https://github.com/wolfpld/tracy/archive/refs/tags/v0.8.1.tar.gz"
     sha256: "004992012b2dc879a9f6d143cbf94d7ea30e88135db3ef08951605d214892891"

--- a/recipes/tracy/config.yml
+++ b/recipes/tracy/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.8.2.1":
+    folder: all
   "0.8.1":
     folder: all
   "cci.20220130":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **tracy/0.8.2.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
