### PR TITLE
wayland: Switch to MesonToolchain generator to allow cross-compiling

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -1,8 +1,15 @@
-from conans import ConanFile, Meson, tools
-from conans.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.36.0"
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import cross_building
+from conan.tools.files import get, mkdir, replace_in_file, rmdir, save
+from conan.tools.gnu.pkgconfigdeps.pc_files_creator import get_pc_files_and_content
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.47.0"
 
 class WaylandConan(ConanFile):
     name = "wayland"
@@ -26,17 +33,8 @@ class WaylandConan(ConanFile):
         "enable_dtd_validation": True,
     }
 
-    generators = "pkg_config"
-    _meson = None
+    generators = "PkgConfigDeps", "VirtualBuildEnv", "VirtualRunEnv"
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-    
     def validate(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration("Wayland can be built on Linux only")
@@ -55,48 +53,61 @@ class WaylandConan(ConanFile):
         self.requires("expat/2.4.8")
 
     def build_requirements(self):
-        self.build_requires("meson/0.60.2")
+        self.tool_requires("meson/0.63.0")
+        self.tool_requires("pkgconf/1.7.4")
+        if cross_building(self):
+            self.tool_requires(f"wayland/{self.version}")
+
+    def layout(self):
+        basic_layout(self)
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  strip_root=True, destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def _patch_sources(self):
-        tools.replace_in_file(os.path.join(self._source_subfolder, "meson.build"),
-                              "subdir('tests')", "#subdir('tests')")
+        replace_in_file(self, os.path.join(self.source_folder, "meson.build"),
+                        "subdir('tests')", "#subdir('tests')")
 
-    def _configure_meson(self):
-        if not self._meson:
-            defs = {
-                "libraries": "true" if self.options.enable_libraries else "false",
-                "dtd_validation": "true" if self.options.enable_dtd_validation else "false",
-                "documentation": "false",
-            }
-            if tools.Version(self.version) >= "1.18.91":
-                defs.update({"scanner": "true"})
-            self._meson = Meson(self)
-            self._meson.configure(
-                source_folder=self._source_subfolder,
-                build_folder=self._build_subfolder,
-                defs=defs,
-                args=["--datadir={}".format(os.path.join(self.package_folder, "res"))]
-            )
-        return self._meson
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.project_options["libdir"] = "lib"
+        tc.project_options["datadir"] = "res"
+        tc.project_options["libraries"] = self.options.enable_libraries
+        tc.project_options["dtd_validation"] = self.options.enable_dtd_validation
+        tc.project_options["documentation"] = False
+        if Version(self.version) >= "1.18.91":
+            tc.project_options["scanner"] = True
+
+            # Generate PC files for the tool_requires wayland package to ensure wayland-scanner is found for build machine.
+            if cross_building(self):
+                native_generators_folder = os.path.join(self.generators_folder, "native")
+                mkdir(self, native_generators_folder)
+                for pc_name, pc_content in get_pc_files_and_content(self, self.dependencies.build["wayland"]).items():
+                    save(self, os.path.join(native_generators_folder, pc_name), pc_content)
+                tc.project_options["build.pkg_config_path"] = native_generators_folder
+        tc.generate()
 
     def build(self):
         self._patch_sources()
-        meson = self._configure_meson()
-        with tools.run_environment(self):
-            meson.build()
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
 
     def package(self):
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        meson = self._configure_meson()
+        self.copy(pattern="COPYING", dst="licenses", src=self.source_folder)
+        meson = Meson(self)
         meson.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        pkg_config_dir = os.path.join(self.package_folder, "lib", "pkgconfig")
+        rmdir(self, pkg_config_dir)
 
     def package_info(self):
+        self.cpp_info.components["wayland-scanner"].set_property("pkg_config_name", "wayland-scanner")
         self.cpp_info.components["wayland-scanner"].names["pkg_config"] = "wayland-scanner"
+        self.cpp_info.components["wayland-scanner"].resdirs = ["res"]
+
+        self.cpp_info.components["wayland-scanner"].includedirs = []
+        self.cpp_info.components["wayland-scanner"].libdirs = []
+
         self.cpp_info.components["wayland-scanner"].requires = ["expat::expat"]
         if self.options.enable_dtd_validation:
             self.cpp_info.components["wayland-scanner"].requires.append("libxml2::libxml2")
@@ -108,44 +119,77 @@ class WaylandConan(ConanFile):
         }
         self.cpp_info.components["wayland-scanner"].set_property(
             "pkg_config_custom_content",
-            "\n".join("%s=%s" % (key, value) for key,value in pkgconfig_variables.items()))
+            "\n".join(f"{key}={value}" for key,value in pkgconfig_variables.items()))
+
+        bindir = os.path.join(self.package_folder, "bin")
+        self.buildenv_info.prepend_path("PATH", bindir)
+        self.runenv_info.prepend_path("PATH", bindir)
 
         if self.options.enable_libraries:
             self.cpp_info.components["wayland-server"].libs = ["wayland-server"]
+            self.cpp_info.components["wayland-server"].set_property("pkg_config_name", "wayland-server")
             self.cpp_info.components["wayland-server"].names["pkg_config"] = "wayland-server"
             self.cpp_info.components["wayland-server"].requires = ["libffi::libffi"]
             self.cpp_info.components["wayland-server"].system_libs = ["pthread", "m"]
+            self.cpp_info.components["wayland-server"].resdirs = ["res"]
+            if self.version >= Version("1.21.0") and self.settings.os == "Linux":
+                self.cpp_info.components["wayland-server"].system_libs += ["rt"]
+
+            # todo Remove in Conan version 1.50.0 where these are set by default for the PkgConfigDeps generator.
+            self.cpp_info.components["wayland-server"].includedirs = ["include"]
+            self.cpp_info.components["wayland-server"].libdirs = ["lib"]
+
             pkgconfig_variables = {
                 'datarootdir': '${prefix}/res',
                 'pkgdatadir': '${datarootdir}/wayland',
             }
             self.cpp_info.components["wayland-server"].set_property(
                 "pkg_config_custom_content",
-                "\n".join("%s=%s" % (key, value) for key,value in pkgconfig_variables.items()))
+                "\n".join(f"{key}={value}" for key, value in pkgconfig_variables.items()))
 
             self.cpp_info.components["wayland-client"].libs = ["wayland-client"]
+            self.cpp_info.components["wayland-client"].set_property("pkg_config_name", "wayland-client")
             self.cpp_info.components["wayland-client"].names["pkg_config"] = "wayland-client"
             self.cpp_info.components["wayland-client"].requires = ["libffi::libffi"]
             self.cpp_info.components["wayland-client"].system_libs = ["pthread", "m"]
+            self.cpp_info.components["wayland-client"].resdirs = ["res"]
+            if self.version >= Version("1.21.0") and self.settings.os == "Linux":
+                self.cpp_info.components["wayland-client"].system_libs += ["rt"]
+
+            # todo Remove in Conan version 1.50.0 where these are set by default for the PkgConfigDeps generator.
+            self.cpp_info.components["wayland-client"].includedirs = ["include"]
+            self.cpp_info.components["wayland-client"].libdirs = ["lib"]
+            
             pkgconfig_variables = {
                 'datarootdir': '${prefix}/res',
                 'pkgdatadir': '${datarootdir}/wayland',
             }
             self.cpp_info.components["wayland-client"].set_property(
                 "pkg_config_custom_content",
-                "\n".join("%s=%s" % (key, value) for key,value in pkgconfig_variables.items()))
+                "\n".join(f"{key}={value}" for key, value in pkgconfig_variables.items()))
 
             self.cpp_info.components["wayland-cursor"].libs = ["wayland-cursor"]
+            self.cpp_info.components["wayland-cursor"].set_property("pkg_config_name", "wayland-cursor")
             self.cpp_info.components["wayland-cursor"].names["pkg_config"] = "wayland-cursor"
             self.cpp_info.components["wayland-cursor"].requires = ["wayland-client"]
 
+            # todo Remove in Conan version 1.50.0 where these are set by default for the PkgConfigDeps generator.
+            self.cpp_info.components["wayland-cursor"].includedirs = ["include"]
+            self.cpp_info.components["wayland-cursor"].libdirs = ["lib"]
+
             self.cpp_info.components["wayland-egl"].libs = ["wayland-egl"]
+            self.cpp_info.components["wayland-egl"].set_property("pkg_config_name", "wayland-egl")
             self.cpp_info.components["wayland-egl"].names["pkg_config"] = "wayland-egl"
             self.cpp_info.components["wayland-egl"].requires = ["wayland-client"]
 
+            # todo Remove in Conan version 1.50.0 where these are set by default for the PkgConfigDeps generator.
+            self.cpp_info.components["wayland-egl"].includedirs = ["include"]
+            self.cpp_info.components["wayland-egl"].libdirs = ["lib"]
+
             self.cpp_info.components["wayland-egl-backend"].names["pkg_config"] = "wayland-egl-backend"
+            self.cpp_info.components["wayland-egl-backend"].set_property("pkg_config_name", "wayland-egl-backend")
             self.cpp_info.components["wayland-egl-backend"].version = "3"
 
-        bindir = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable: {}".format(bindir))
-        self.env_info.PATH.append(bindir)
+            # todo Remove in Conan version 1.50.0 where these are set by default for the PkgConfigDeps generator.
+            self.cpp_info.components["wayland-egl-backend"].includedirs = ["include"]
+            self.cpp_info.components["wayland-egl-backend"].libdirs = ["lib"]

--- a/recipes/wayland/all/test_package/CMakeLists.txt
+++ b/recipes/wayland/all/test_package/CMakeLists.txt
@@ -1,8 +1,7 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(wayland COMPONENTS wayland-client REQUIRED)
 
-add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+add_executable(test_package test_package.c)
+target_link_libraries(test_package PRIVATE wayland::wayland-client)


### PR DESCRIPTION
Specify library name and version:  **wayland**

Fixes issue #11332 and issue #11362. See issue #11579 for an explanation of why the package requires itself as a `tool_requires`.

Let me know if this PR should be a draft until `MesonToolchain` is supported and I will mark it as such.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
