### PR TITLE
[docs] Why not build testing as a recipe option

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -26,6 +26,7 @@ This section gathers the most common questions from the community related to pac
   * [What is the policy for removing older versions of a package?](#what-is-the-policy-for-removing-older-versions-of-a-package)
   * [Can I install packages from the system package manager?](#can-i-install-packages-from-the-system-package-manager)
   * [Why ConanCenter does not build and execute tests in recipes](#why-conancenter-does-not-build-and-execute-tests-in-recipes)
+  * [Why not add an option to build unit tests](#why-not-add-an-option-to-build-unit-tests)
   * [What is the policy for supported python versions?](#what-is-the-policy-for-supported-python-versions)
   * [How to package libraries that depend on proprietary closed-source libraries?](#how-to-package-libraries-that-depend-on-proprietary-closed-source-libraries)
   * [How to protect my project from breaking changes in recipes?](#how-to-protect-my-project-from-breaking-changes-in-recipes)
@@ -226,6 +227,12 @@ in an incompatible Conan package. To deal with those cases, you are allowed to p
 There are different motivations
 - time and resources: adding the build time required by the test suite plus execution time can increase our building times significantly across the 100+ configurations.
 - ConanCenter is a service that builds binaries for the community for existing library versions, this is not an integration system to test the libraries.
+
+# Why not add an option to build unit tests
+
+- Adding a testing option will change the package ID, but will not provide different packaged binaries
+- Use the configuration [skip_test](packaging_policy.md#options) to define the testing behavior.
+
 
 ## What is the policy for supported python versions?
 

--- a/docs/packaging_policy.md
+++ b/docs/packaging_policy.md
@@ -137,7 +137,7 @@ in this direction. However, there are a couple of options that have a special me
    ```python
    def _configure_cmake(self):
       cmake = CMake(self)
-      cmake.definitions['BUILD_TESTING'] = bool(self.conf.get("tools.build:skip_test", check_type=bool))
+      cmake.definitions['BUILD_TESTING'] = bool(self.conf_info.get("tools.build:skip_test", check_type=bool))
    ```
 
    The `skip_test` configuration is supported by [CMake](https://docs.conan.io/en/latest/reference/build_helpers/cmake.html#test) and [Meson](https://docs.conan.io/en/latest/reference/build_helpers/meson.html#test).

--- a/docs/packaging_policy.md
+++ b/docs/packaging_policy.md
@@ -137,7 +137,7 @@ in this direction. However, there are a couple of options that have a special me
    ```python
    def _configure_cmake(self):
       cmake = CMake(self)
-      cmake.definitions['BUILD_TESTING'] = bool(self.conf.get("tools.build:skip_test", check_type=bool))
+      cmake.definitions['BUILD_TESTING'] = self.conf.get("tools.build:skip_test", default=true, check_type=bool)
    ```
 
    The `skip_test` configuration is supported by [CMake](https://docs.conan.io/en/latest/reference/build_helpers/cmake.html#test) and [Meson](https://docs.conan.io/en/latest/reference/build_helpers/meson.html#test).

--- a/docs/packaging_policy.md
+++ b/docs/packaging_policy.md
@@ -137,7 +137,7 @@ in this direction. However, there are a couple of options that have a special me
    ```python
    def _configure_cmake(self):
       cmake = CMake(self)
-      cmake.definitions['BUILD_TESTING'] = bool(self.conf_info.get("tools.build:skip_test", check_type=bool))
+      cmake.definitions['BUILD_TESTING'] = bool(self.conf.get("tools.build:skip_test", check_type=bool))
    ```
 
    The `skip_test` configuration is supported by [CMake](https://docs.conan.io/en/latest/reference/build_helpers/cmake.html#test) and [Meson](https://docs.conan.io/en/latest/reference/build_helpers/meson.html#test).

--- a/docs/packaging_policy.md
+++ b/docs/packaging_policy.md
@@ -130,3 +130,14 @@ in this direction. However, there are a couple of options that have a special me
    ```
 
    ensuring that, when the option is active, the recipe ignores all the settings and only one package ID is generated.
+
+* `build_testing` should not be added, nor any other related unit test option. Options affect the package ID, therefore, testing should not be part of that.
+   Instead, use Conan config [skip_test](https://docs.conan.io/en/latest/reference/config_files/global_conf.html#tools-configurations) feature:
+
+   ```python
+   def _configure_cmake(self):
+      cmake = CMake(self)
+      cmake.definitions['BUILD_TESTING'] = bool(self.conf.get("tools.build:skip_test", check_type=bool))
+   ```
+
+   The `skip_test` configuration is supported by [CMake](https://docs.conan.io/en/latest/reference/build_helpers/cmake.html#test) and [Meson](https://docs.conan.io/en/latest/reference/build_helpers/meson.html#test).

--- a/docs/packaging_policy.md
+++ b/docs/packaging_policy.md
@@ -137,7 +137,7 @@ in this direction. However, there are a couple of options that have a special me
    ```python
    def _configure_cmake(self):
       cmake = CMake(self)
-      cmake.definitions['BUILD_TESTING'] = self.conf.get("tools.build:skip_test", default=true, check_type=bool)
+      cmake.definitions['BUILD_TESTING'] = not self.conf.get("tools.build:skip_test", default=true, check_type=bool)
    ```
 
    The `skip_test` configuration is supported by [CMake](https://docs.conan.io/en/latest/reference/build_helpers/cmake.html#test) and [Meson](https://docs.conan.io/en/latest/reference/build_helpers/meson.html#test).


### PR DESCRIPTION
This PR is motivated by https://github.com/conan-io/conan-center-index/pull/11534

Testing a project does not affect the packaged binaries, but changes the package ID. For those cases which the package ID should not be affect, the [global conf](https://docs.conan.io/en/latest/reference/config_files/global_conf.html) is the answer.

The configuration `skip_test` is supported by CMake and Meson (Meson is bugged), but it only executes or not the tests.

/cc @SpaceIm  

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
