### PR TITLE
Add option to enable opengl support in QCustomPlot

### DIFF
--- a/recipes/qcustomplot/all/CMakeLists.txt
+++ b/recipes/qcustomplot/all/CMakeLists.txt
@@ -32,20 +32,28 @@ option(QCUSTOMPLOT_USE_OPENGL "Use OpenGL" OFF)
 
 if(QCUSTOMPLOT_USE_OPENGL)
     target_compile_definitions(${PROJECT_NAME} PUBLIC QCUSTOMPLOT_USE_OPENGL)
-	target_link_libraries(${PROJECT_NAME} PUBLIC Qt6::OpenGL)
-	if (MSVC)
-	    target_link_libraries(${PROJECT_NAME} PRIVATE OpenGL32)
-	endif()
-	#TODO: Other platforms may need other libraries linked in
+
+    #Set a variable to ensure that OpenGL is found through the find_package statements below.
+    set(OPENGL_COMPONENT "OpenGL")
+
+    #QCustomPlot does not use the QOpenGLFunctions class, and instead needs to link directly
+    #to OpenGL32.lib on Windows, regardless of whether qt:opengl is 'dynamic' or 'desktop'
+    if (MSVC)
+        target_link_libraries(${PROJECT_NAME} PRIVATE OpenGL32)
+    endif()
+
+    #QtX::OpenGL is added as a link library using generator expression below.
 endif()
 
 if(QT_VERSION VERSION_GREATER_EQUAL "6.0.0")
-    find_package(Qt6 COMPONENTS Core Gui Widgets PrintSupport REQUIRED CONFIG)
-    target_link_libraries(${PROJECT_NAME} PUBLIC Qt6::Core Qt6::Gui Qt6::Widgets Qt6::PrintSupport)
+    find_package(Qt6 COMPONENTS Core Gui Widgets PrintSupport ${OPENGL_COMPONENT} REQUIRED CONFIG)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Qt6::Core Qt6::Gui Qt6::Widgets Qt6::PrintSupport 
+                                                 $<$<BOOL:${QCUSTOMPLOT_USE_OPENGL}>:Qt6::OpenGL>)
     target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 elseif(QT_VERSION VERSION_GREATER_EQUAL "5.0.0")
-    find_package(Qt5 COMPONENTS Core Gui Widgets PrintSupport REQUIRED CONFIG)
-    target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Core Qt5::Gui Qt5::Widgets Qt5::PrintSupport)
+    find_package(Qt5 COMPONENTS Core Gui Widgets PrintSupport ${OPENGL_COMPONENT} REQUIRED CONFIG)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Core Qt5::Gui Qt5::Widgets Qt5::PrintSupport
+                                                 $<$<BOOL:${QCUSTOMPLOT_USE_OPENGL}>:Qt5::OpenGL>)
     target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
 else()
     message(FATAL_ERROR "Qt < 5 not yet supported in this recipe")

--- a/recipes/qcustomplot/all/CMakeLists.txt
+++ b/recipes/qcustomplot/all/CMakeLists.txt
@@ -32,6 +32,11 @@ option(QCUSTOMPLOT_USE_OPENGL "Use OpenGL" OFF)
 
 if(QCUSTOMPLOT_USE_OPENGL)
     target_compile_definitions(${PROJECT_NAME} PUBLIC QCUSTOMPLOT_USE_OPENGL)
+	target_link_libraries(${PROJECT_NAME} PUBLIC Qt6::OpenGL)
+	if (MSVC)
+	    target_link_libraries(${PROJECT_NAME} PRIVATE OpenGL32)
+	endif()
+	#TODO: Other platforms may need other libraries linked in
 endif()
 
 if(QT_VERSION VERSION_GREATER_EQUAL "6.0.0")

--- a/recipes/qcustomplot/all/CMakeLists.txt
+++ b/recipes/qcustomplot/all/CMakeLists.txt
@@ -28,6 +28,12 @@ if(BUILD_SHARED_LIBS)
     )
 endif()
 
+option(QCUSTOMPLOT_USE_OPENGL "Use OpenGL" OFF)
+
+if(QCUSTOMPLOT_USE_OPENGL)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC QCUSTOMPLOT_USE_OPENGL)
+endif()
+
 if(QT_VERSION VERSION_GREATER_EQUAL "6.0.0")
     find_package(Qt6 COMPONENTS Core Gui Widgets PrintSupport REQUIRED CONFIG)
     target_link_libraries(${PROJECT_NAME} PUBLIC Qt6::Core Qt6::Gui Qt6::Widgets Qt6::PrintSupport)

--- a/recipes/qcustomplot/all/conanfile.py
+++ b/recipes/qcustomplot/all/conanfile.py
@@ -23,7 +23,7 @@ class QcustomplotConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "opengl": False,
+        "with_opengl": False,
     }
 
     generators = "cmake", "cmake_find_package_multi"

--- a/recipes/qcustomplot/all/conanfile.py
+++ b/recipes/qcustomplot/all/conanfile.py
@@ -18,7 +18,7 @@ class QcustomplotConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "opengl": [True, False],
+        "with_opengl": [True, False],
     }
     default_options = {
         "shared": False,

--- a/recipes/qcustomplot/all/conanfile.py
+++ b/recipes/qcustomplot/all/conanfile.py
@@ -78,8 +78,7 @@ class QcustomplotConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["QT_VERSION"] = self.deps_cpp_info["qt"].version
-        if self.options.opengl:
-            cmake.definitions["QCUSTOMPLOT_USE_OPENGL"] = 1
+        cmake.definitions["QCUSTOMPLOT_USE_OPENGL"] = self.options.with_opengl
         cmake.configure()
         return cmake
 

--- a/recipes/qcustomplot/all/conanfile.py
+++ b/recipes/qcustomplot/all/conanfile.py
@@ -98,6 +98,6 @@ class QcustomplotConan(ConanFile):
         self.cpp_info.libs = ["qcustomplot" + postfix]
         if self.options.shared:
             self.cpp_info.defines.append("QCUSTOMPLOT_USE_LIBRARY")
-        if self.options.opengl:
+        if self.options.with_opengl:
             self.cpp_info.defines.append("QCUSTOMPLOT_USE_OPENGL")
         self.cpp_info.requires = ["qt::qtCore", "qt::qtGui", "qt::qtWidgets", "qt::qtPrintSupport"]

--- a/recipes/qcustomplot/all/conanfile.py
+++ b/recipes/qcustomplot/all/conanfile.py
@@ -18,10 +18,12 @@ class QcustomplotConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "opengl": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "opengl": False,
     }
 
     generators = "cmake", "cmake_find_package_multi"
@@ -76,7 +78,8 @@ class QcustomplotConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["QT_VERSION"] = self.deps_cpp_info["qt"].version
-        # TODO: add an option to enable QCUSTOMPLOT_USE_OPENGL
+        if self.options.opengl:
+            cmake.definitions["QCUSTOMPLOT_USE_OPENGL"] = 1
         cmake.configure()
         return cmake
 
@@ -95,4 +98,6 @@ class QcustomplotConan(ConanFile):
         self.cpp_info.libs = ["qcustomplot" + postfix]
         if self.options.shared:
             self.cpp_info.defines.append("QCUSTOMPLOT_USE_LIBRARY")
+        if self.options.opengl:
+            self.cpp_info.defines.append("QCUSTOMPLOT_USE_OPENGL")
         self.cpp_info.requires = ["qt::qtCore", "qt::qtGui", "qt::qtWidgets", "qt::qtPrintSupport"]

--- a/recipes/qcustomplot/all/conanfile.py
+++ b/recipes/qcustomplot/all/conanfile.py
@@ -60,6 +60,8 @@ class QcustomplotConan(ConanFile):
             tools.check_min_cppstd(self, min_cppstd)
         if not (self.options["qt"].gui and self.options["qt"].widgets):
             raise ConanInvalidConfiguration("qcustomplot requires qt gui and widgets")
+        if self.options.with_opengl and self.options["qt"].opengl == "no":
+            raise ConanInvalidConfiguration("qcustomplot with opengl requires Qt with opengl enabled")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],


### PR DESCRIPTION
Specify library name and version:  **qcustomplot/2.1.0**

This PR adds an option to enable opengl support in the QCustomPlot recipe. In the current recipe there is a TODO that this should be done, and this PR fixes that TODO. The default is to have opengl support disabled, so as to not change the behaviour for current users.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.