### PR TITLE
Add qbs 1.22.1 to recipe

### DIFF
--- a/recipes/qbs/1.x.x/conandata.yml
+++ b/recipes/qbs/1.x.x/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "1.22.1":
+    url: "http://download.qt.io/official_releases/qbs/1.22.1/qbs-src-1.22.1.tar.gz"
+    sha256: b06003f49683971b552bb800bc134bf6c76cff79e1809cce741c40382b297b04
+
+patches:
+  "1.22.1":
+    - patch_file: "patches/0001-Allow-to-get-qbs-settings-dir-from-env-var.patch"
+    - patch_file: "patches/0002-Add-ability-to-bundle-qt-to-build-and-install-folder.patch"

--- a/recipes/qbs/1.x.x/conanfile.py
+++ b/recipes/qbs/1.x.x/conanfile.py
@@ -1,0 +1,148 @@
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+from os import path
+
+required_conan_version = ">=1.33.0"
+
+
+class QbsConan(ConanFile):
+    name = "qbs"
+    description = "The Qbs build system"
+    topics = ("qbs", "build", "tool")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://qbs.io"
+    license = "LGPL-2.1-only", "LGPL-3.0-only", "Nokia-Qt-exception-1.1"
+
+    short_paths = True
+    settings = "os", "arch", "compiler", "build_type"
+    exports = ["patches/*.patch"]
+
+    def validate(self):
+        if self.settings.os not in ["Linux", "Windows", "Macos"]:
+            raise ConanInvalidConfiguration(
+                "qbs supports Linux/Windows/macOS only.")
+
+        if self.settings.build_type not in ["Debug", "Release"]:
+            raise ConanInvalidConfiguration(
+                "qbs can be builed only as debug or release.")
+
+    def build_requirements(self):
+        self.tool_requires("qt/5.15.5")
+        if self.settings.compiler == "Visual Studio":
+            self.tool_requires("jom/1.1.3")
+
+    def configure(self):
+        self.options["qt"].gui = False
+        self.options["qt"].openssl = False
+        self.options["qt"].qtscript = True
+        self.options["qt"].shared = True
+        self.options["qt"].widgets = False
+        self.options["qt"].with_odbc = False
+        self.options["qt"].with_pcre2 = False
+        self.options["qt"].with_pq = False
+        self.options["qt"].with_sqlite3 = False
+        self.options["qt"].with_zstd = False
+
+        if self.settings.compiler not in ["gcc", "clang"] or tools.Version(self.settings.compiler.version) >= "5.3":
+            self.options["qt"].with_mysql = False
+
+        if self.settings.os == "Linux":
+            self.options["qt"].with_icu = False
+
+        minimal_cpp_standard = "11"
+        if self.settings.compiler.cppstd:
+            tools.check_min_cppstd(self, minimal_cpp_standard)
+
+        minimal_version = {
+            "gcc": "5.0",
+            "clang": "6.0",
+            "apple-clang": "11",
+            "Visual Studio": "16",
+        }
+
+        compiler = str(self.settings.compiler)
+        if compiler not in minimal_version:
+            self.output.warn(
+                "%s recipe lacks information about the %s compiler standard version support" % (self.name, compiler))
+            self.output.warn(
+                "%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
+            return
+
+        version = tools.Version(self.settings.compiler.version)
+        if version < minimal_version[compiler]:
+            raise ConanInvalidConfiguration(
+                "%s requires a compiler that supports at least C++%s" % (self.name, minimal_cpp_standard))
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True)
+
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+    @property
+    def _data(self):
+        data = {
+            'Linux': {
+                "build_tool": "make",
+                "frameworks": [],
+                "system_libs": ["m"],
+            },
+            'Macos': {
+                "build_tool": "make",
+                "frameworks": ["SystemConfiguration", "DiskArbitration", "CoreFoundation",
+                               "CFNetwork", "Foundation", "CoreServices", "IOKit", "Security",
+                               "ApplicationServices", "AppKit"],
+                "system_libs": [],
+            },
+            'Windows': {
+                "build_tool": "jom" if self.settings.compiler == "Visual Studio" else "mingw32-make",
+                "frameworks": [],
+                "system_libs": ["mpr", "psapi", "winmm", "winmm", "dnsapi",
+                                "iphlpapi", "netapi32", "userenv", "ws2_32", "ws2_32", "version"],
+            }
+        }
+
+        return data[str(self.settings.os)]
+
+    def build(self):
+        project_filepath = path.join(self.source_folder, "qbs.pro")
+        args = [
+            "-r", project_filepath,
+            "QT-=gui",
+            "CONFIG-=release",
+            "CONFIG-=debug",
+            "CONFIG-=debug_and_release",
+            "CONFIG+=%s" % str(self.settings.build_type).lower(),
+            "CONFIG+=nomake_tests",
+            "CONFIG+=qbs_no_dev_install",
+            "CONFIG+=qbs_no_man_install",
+            "CONFIG+=qbs_enable_bundled_qt",
+            "CONFIG+=no_qt_rpath",
+            "QBS_INSTALL_PREFIX=/"
+        ]
+        ncores = tools.cpu_count()
+
+        with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
+            self.run("qmake  %s" % ' '.join(args), run_environment=True)
+            self.run("%s -j%s" %
+                     (self._data['build_tool'], ncores), run_environment=True)
+
+    def package(self):
+        self.run("%s install INSTALL_ROOT=%s" %
+                 (self._data["build_tool"], self.package_folder))
+        # This recipe builds Qbs statically, the libs are not needed.
+        tools.rmdir(path.join(self.package_folder, "share", "qbs", "examples"))
+        self.copy(dst="licenses", pattern="LICENSE*")
+        self.copy(dst="licenses", pattern="LGPL*")
+
+    def package_id(self):
+        del self.info.settings.compiler
+
+    def package_info(self):
+        binpath = path.join(self.package_folder, 'bin')
+        self.env_info.PATH.append(binpath)
+
+        self.cpp_info.includedirs = []
+
+        self.cpp_info.system_libs = self._data["system_libs"]
+        self.cpp_info.system_libs = self._data["frameworks"]

--- a/recipes/qbs/1.x.x/patches/0001-Allow-to-get-qbs-settings-dir-from-env-var.patch
+++ b/recipes/qbs/1.x.x/patches/0001-Allow-to-get-qbs-settings-dir-from-env-var.patch
@@ -1,0 +1,49 @@
+From 8cc718eaabc2f477759694a03e5a1e6dacbdd281 Mon Sep 17 00:00:00 2001
+From: Petr Mikhalicin <pmikhalicin@rutoken.ru>
+Date: Mon, 4 Jul 2022 12:29:09 +0300
+Subject: [PATCH 1/2] Allow to get qbs settings dir from env var
+
+This feature will be useful for using qbs conan package at virtual
+environment
+
+Change-Id: I0d903d9696edcc9b339226deb2cb38de89e319f5
+---
+ src/lib/corelib/tools/settingscreator.cpp | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib/corelib/tools/settingscreator.cpp b/src/lib/corelib/tools/settingscreator.cpp
+index f94ae6f10..e5b2ae1c3 100644
+--- a/src/lib/corelib/tools/settingscreator.cpp
++++ b/src/lib/corelib/tools/settingscreator.cpp
+@@ -53,14 +53,26 @@
+ namespace qbs {
+ namespace Internal {
+ 
++namespace {
++QString getBaseDir(QString baseDir) {
++    if (!baseDir.isEmpty())
++        return std::move(baseDir);
++
++    const char key[] = "QBS_SETTINGS_DIR";
++    if (qEnvironmentVariableIsSet(key))
++        return QLatin1String(qgetenv(key));
++
++    return QString();
++}
++}
++
+ static QSettings::Format format()
+ {
+     return HostOsInfo::isWindowsHost() ? QSettings::IniFormat : QSettings::NativeFormat;
+ }
+ 
+-
+ SettingsCreator::SettingsCreator(QString baseDir)
+-    : m_settingsBaseDir(std::move(baseDir))
++    : m_settingsBaseDir(getBaseDir(std::move(baseDir)))
+     , m_qbsVersion(Version::fromString(QLatin1String(QBS_VERSION)))
+ {
+ }
+-- 
+2.32.0
+

--- a/recipes/qbs/1.x.x/patches/0002-Add-ability-to-bundle-qt-to-build-and-install-folder.patch
+++ b/recipes/qbs/1.x.x/patches/0002-Add-ability-to-bundle-qt-to-build-and-install-folder.patch
@@ -1,0 +1,109 @@
+From 86d92e01ffdd3689874784e02abfa100f3391b6d Mon Sep 17 00:00:00 2001
+From: Petr Mikhalicin <pmikhalicin@rutoken.ru>
+Date: Tue, 5 Jul 2022 15:04:59 +0300
+Subject: [PATCH 2/2] Add ability to bundle qt to build and install folder via
+ qmake
+
+This feature will be used for creation qbs conan package:
+https://github.com/conan-io/conan-center-index/pull/11592
+
+Change-Id: I8d41544252048300641398446c2f1725156b020e
+---
+ doc/qbs.qdoc                       |  1 +
+ src/app/app.pro                    |  3 ++-
+ src/lib/corelib/corelib.pro        |  5 ++++
+ src/shared/bundledqt/bundledqt.pro | 41 ++++++++++++++++++++++++++++++
+ 4 files changed, 49 insertions(+), 1 deletion(-)
+ create mode 100644 src/shared/bundledqt/bundledqt.pro
+
+diff --git a/doc/qbs.qdoc b/doc/qbs.qdoc
+index 7fcc7e68b..8af637427 100644
+--- a/doc/qbs.qdoc
++++ b/doc/qbs.qdoc
+@@ -557,6 +557,7 @@
+                                         non-developer build.
+     \row    \li qbs_no_man_install  \li Exclude the man page from installation.
+     \row    \li qbs_use_bundled_qtscript        \li Use the bundled QtScript library.
++    \row    \li qbs_enable_bundled_qt        \li Bundle Qt to build and install folder.
+     \endtable
+ 
+     In addition, you can set the \c QBS_SYSTEM_SETTINGS_DIR environment variable
+diff --git a/src/app/app.pro b/src/app/app.pro
+index 935ce1776..5ef24de82 100644
+--- a/src/app/app.pro
++++ b/src/app/app.pro
+@@ -5,6 +5,7 @@ SUBDIRS =\
+     qbs-setup-android \
+     qbs-setup-toolchains \
+     qbs-setup-qt \
+-    config
++    config \
++    ../shared/bundledqt
+ 
+ !isEmpty(QT.widgets.name):SUBDIRS += config-ui
+diff --git a/src/lib/corelib/corelib.pro b/src/lib/corelib/corelib.pro
+index afe07f48f..3b56300b8 100644
+--- a/src/lib/corelib/corelib.pro
++++ b/src/lib/corelib/corelib.pro
+@@ -34,6 +34,11 @@ win32:LIBS += -lpsapi -lshell32
+ HEADERS += \
+     qbs.h
+ 
++qbs_enable_bundled_qt {
++    linux-*: QMAKE_LFLAGS += -Wl,-z,origin \'-Wl,-rpath,\$\$ORIGIN\'
++    macos: QMAKE_LFLAGS += -Wl,-rpath,@loader_path
++}
++
+ !qbs_no_dev_install {
+     qbs_h.files = qbs.h
+     qbs_h.path = $${QBS_INSTALL_PREFIX}/include/qbs
+diff --git a/src/shared/bundledqt/bundledqt.pro b/src/shared/bundledqt/bundledqt.pro
+new file mode 100644
+index 000000000..6d36c01cc
+--- /dev/null
++++ b/src/shared/bundledqt/bundledqt.pro
+@@ -0,0 +1,41 @@
++TEMPLATE = aux
++
++qbs_enable_bundled_qt {
++    !isEmpty(QBS_APPS_DESTDIR): bindir = $${QBS_APPS_DESTDIR}
++    else: bindir = bin
++
++    !isEmpty(QBS_LIBRARY_DIRNAME): libdir = $${QBS_LIBRARY_DIRNAME}
++    else: libdir = lib
++
++    win32: dstdir = $${bindir}
++    else: dstdir = $${libdir}
++    dstdir=$$shell_quote($$shell_path($$absolute_path($$dstdir,  $${OUT_PWD}/../../..)))
++
++    win32: bundled_qt.path = $${QBS_INSTALL_PREFIX}/$${bindir}
++    else: bundled_qt.path = $${QBS_INSTALL_PREFIX}/$${libdir}
++
++    target_qt_libs = Qt5Core Qt5Xml Qt5Network Qt5Script
++    bundled_qt_at_build.target = bundled_qt_libs
++
++    for(lib, target_qt_libs) {
++        win32: srcdir = $$[QT_INSTALL_BINS]
++        else: srcdir = $$[QT_INSTALL_LIBS]
++        srcdir = $$shell_quote($$shell_path($${srcdir}))
++
++        win32: file = "$${lib}.dll"
++        macos: file = "lib$${lib}*.dylib"
++        linux-*: file = "lib$${lib}.so*"
++        file = $$shell_path($$absolute_path($${file}, $${srcdir}))
++
++        win32:bundled_qt.files += $${file}
++        else: bundled_qt.extra += $${QMAKE_COPY} -P $${file} $(INSTALL_ROOT)/$${bundled_qt.path} $$escape_expand(\n\t)
++
++        !win32: copy_flags = -P
++        bundled_qt_at_build.commands += $${QMAKE_COPY} $${copy_flags} $${file} $${dstdir} $$escape_expand(\n\t)
++    }
++
++    QMAKE_EXTRA_TARGETS += bundled_qt_at_build
++    PRE_TARGETDEPS += $${bundled_qt_at_build.target}
++
++    INSTALLS += bundled_qt
++}
+-- 
+2.32.0
+

--- a/recipes/qbs/1.x.x/test_package/conanfile.py
+++ b/recipes/qbs/1.x.x/test_package/conanfile.py
@@ -1,0 +1,15 @@
+from six import StringIO
+from conan import ConanFile, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch"
+
+    def test(self):
+        output = StringIO()
+        self.run("qbs --version", output=output, run_environment=True)
+        output_str = str(output.getvalue()).strip()
+        self.output.info(f"Installed version: {output_str}")
+        require_version = str(self.deps_cpp_info["qbs"].version)
+        self.output.info(f"Expected version: {require_version}")
+        assert require_version == output_str

--- a/recipes/qbs/config.yml
+++ b/recipes/qbs/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.22.1":
+    folder: "1.x.x"


### PR DESCRIPTION
package: qbs/1.22.1
issue: https://github.com/conan-io/conan-center-index/issues/1218

Hi!

Qbs is a build system. My team using it as main build system in our projects. Recently, we decided to pack all our dependencies via conan package manager. Qbs is also our dependency, so, we decided to pack it too.

I wrote conanfile.py and make [PR for that at qbs project](https://github.com/qbs/qbs/pull/8). Maintainer told to me that it would be better to add conanfile to conancenter? So, I do that :)

Also, I found [previous try to pack qbs](https://github.com/conan-io/conan-center-index/pull/1716) and use it as base for my work.

I already manually tested package on Linux, Windows and Macos -- it works

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
