### PR TITLE
zxing-cpp: add version 1.4.0

### DIFF
--- a/recipes/zxing-cpp/all/conandata.yml
+++ b/recipes/zxing-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.0":
+    url: "https://github.com/nu-book/zxing-cpp/archive/v1.4.0.tar.gz"
+    sha256: "126767bb56f8a1f25ae84d233db2e9b9be50d71f5776092d0e170ca0f0ed1862"
   "1.3.0":
     url: "https://github.com/nu-book/zxing-cpp/archive/v1.3.0.tar.gz"
     sha256: "bfd8fc706def30e34f96088b5a7afdbe0917831e57a774d34e3ee864b01c6891"

--- a/recipes/zxing-cpp/config.yml
+++ b/recipes/zxing-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.0":
+    folder: all
   "1.3.0":
     folder: all
   "1.0.8":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **zxing-cpp/1.4.0**

It may be the last release in 1.x.x.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
