### PR TITLE
qt/6.x.x compilation fix on MinGW

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -900,7 +900,7 @@ class QtConan(ConanFile):
 
         libsuffix = ""
         if self.settings.build_type == "Debug":
-            if self.settings.os == "Windows":
+            if self.settings.os == "Windows" and self._is_msvc:
                 libsuffix = "d"
             if tools.is_apple_os(self.settings.os):
                 libsuffix = "_debug"

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -63,6 +63,7 @@ class QtConan(ConanFile):
 
     options = {
         "shared": [True, False],
+        "pch": ["auto", "on", "off"],
         "opengl": ["no", "desktop", "dynamic"],
         "with_vulkan": [True, False],
         "openssl": [True, False],
@@ -105,6 +106,7 @@ class QtConan(ConanFile):
 
     default_options = {
         "shared": False,
+        "pch": "auto",
         "opengl": "desktop",
         "with_vulkan": False,
         "openssl": True,
@@ -675,8 +677,11 @@ class QtConan(ConanFile):
             cmake.definitions["QT_QMAKE_DEVICE_OPTIONS"] = "CROSS_COMPILE=%s" % self.options.cross_compile
 
         cmake.definitions["FEATURE_pkg_config"] = "ON"
-        if self.settings.compiler == "gcc" and self.settings.build_type == "Debug" and not self.options.shared:
+        
+        if self.options.pch == "off" or (self.options.pch == "auto" and self.settings.compiler == "gcc"
+                                         and self.settings.build_type == "Debug" and not self.options.shared):
             cmake.definitions["BUILD_WITH_PCH"]= "OFF" # disabling PCH to save disk space
+        
 
         if self.settings.os == "Windows":
             cmake.definitions["HOST_PERL"] = getattr(self, "user_info_build", self.deps_user_info)["strawberryperl"].perl


### PR DESCRIPTION
Fix two compilation issues on Windows with gcc/MinGW. 

Specify library name and version:  qt/6.x.x

- As reported here, debug library suffix "d" is wrong and only applicable to MSVC builds: https://github.com/conan-io/conan-center-index/issues/11523. Also confirmed by the Qt developers: https://bugreports.qt.io/browse/QTBUG-81021
- When compiling with certain versions of gcc, the PCH files tend to get very large, triggering an old bug in GCC which is still not fixed on Windows. Only solution is to disable PCH or recompile GCC with the fix (which is not reasonable). See these bug reports: https://github.com/conan-io/conan-center-index/issues/10443, https://github.com/brechtsanders/winlibs_mingw/issues/8#issuecomment-1164750704
I added a fix which introduces a new option "pch" which can take the following values:

  - `auto` (default): Current behavior (disable PCH only for GCC in debug mode when shared build is disabled)
  - `off`: Force compilation without PCH
  - `on`: Force compilation with PCH 


---

- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
