### PR TITLE
(#11583) z3: versions 4.10.2 and do not require `mpir`

### DIFF
--- a/recipes/z3/all/conandata.yml
+++ b/recipes/z3/all/conandata.yml
@@ -2,7 +2,17 @@ sources:
   "4.8.8":
     url: "https://github.com/Z3Prover/z3/archive/z3-4.8.8.tar.gz"
     sha256: "6962facdcdea287c5eeb1583debe33ee23043144d0e5308344e6a8ee4503bcff"
+  "4.10.2":
+    url: "https://github.com/Z3Prover/z3/archive/z3-4.10.2.tar.gz"
+    sha256: "889fd035b833775c8cd2eb4723eb011bf916a3e9bf08ce66b31c548acee7a321"
 patches:
   "4.8.8":
-    - patch_file: "patches/0001-cmake-use-conan-mpir.patch"
+    - patch_file: "patches/0001-cmake-use-conan-mpir-4.8.8.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-python-interp-3-4.8.8.patch"
+      base_path: "source_subfolder"
+  "4.10.2":
+    - patch_file: "patches/0001-cmake-use-conan-mpir-4.10.2.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0003-cmake-try-compile-flags-4.10.2.patch"
       base_path: "source_subfolder"

--- a/recipes/z3/all/conandata.yml
+++ b/recipes/z3/all/conandata.yml
@@ -5,14 +5,26 @@ sources:
   "4.10.2":
     url: "https://github.com/Z3Prover/z3/archive/z3-4.10.2.tar.gz"
     sha256: "889fd035b833775c8cd2eb4723eb011bf916a3e9bf08ce66b31c548acee7a321"
+
 patches:
   "4.8.8":
     - patch_file: "patches/0001-cmake-use-conan-mpir-4.8.8.patch"
+      patch_description: "Support building with MPIR"
+      patch_type: "conan"
       base_path: "source_subfolder"
+
     - patch_file: "patches/0002-python-interp-3-4.8.8.patch"
+      patch_description: "Fix finding the Python interpreter"
+      patch_type: "backport"
       base_path: "source_subfolder"
+
   "4.10.2":
     - patch_file: "patches/0001-cmake-use-conan-mpir-4.10.2.patch"
+      patch_description: "Support building with MPIR"
+      patch_type: "conan"
       base_path: "source_subfolder"
+
     - patch_file: "patches/0003-cmake-try-compile-flags-4.10.2.patch"
+      patch_description: "Fix flag transmission to CMake try_compile"
+      patch_type: "portability"
       base_path: "source_subfolder"

--- a/recipes/z3/all/conanfile.py
+++ b/recipes/z3/all/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 class Z3Conan(ConanFile):
     name = "z3"
     description = "The Z3 Theorem Prover"
-    topics = ("z3", "theorem", "SMT", "satisfiability", "prover", "solver")
+    topics = ("z3", "theorem", "smt", "satisfiability", "prover", "solver")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/Z3Prover/z3"
     license = "MIT"

--- a/recipes/z3/all/conanfile.py
+++ b/recipes/z3/all/conanfile.py
@@ -65,7 +65,7 @@ class Z3Conan(ConanFile):
             pass
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
+        get(self, **self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):

--- a/recipes/z3/all/conanfile.py
+++ b/recipes/z3/all/conanfile.py
@@ -1,5 +1,5 @@
 from conans import CMake, ConanFile, tools
-from conan.tools.files import get, patch, rmdir
+from conan.tools.files import apply_conandata_patches, get, rmdir
 from conan.tools.scm import Version
 from conan.errors import ConanException, ConanInvalidConfiguration
 import os
@@ -110,8 +110,7 @@ class Z3Conan(ConanFile):
                     f"{self.name} requires C++17. Your compiler is unknown. Assuming it supports C++17.")
 
     def build(self):
-        for it in self.conan_data.get("patches", {}).get(self.version, []):
-            patch(self, **it)
+        apply_conandata_patches(self)
 
         if self.options.multiprecision == "mpir":
             tools.save(os.path.join(self._build_subfolder, "gmp.h"), textwrap.dedent("""\

--- a/recipes/z3/all/conanfile.py
+++ b/recipes/z3/all/conanfile.py
@@ -97,7 +97,8 @@ class Z3Conan(ConanFile):
             if self.settings.compiler.get_safe("cppstd"):
                 tools.check_min_cppstd(self, "17")
             compiler = self.settings.compiler
-            min_version = self._compilers_minimum_version.get(str(compiler), False)
+            min_version = self._compilers_minimum_version\
+                .get(str(compiler), False)
             if min_version:
                 if tools.Version(compiler.version) < min_version:
                     raise ConanInvalidConfiguration(
@@ -135,8 +136,8 @@ class Z3Conan(ConanFile):
             "libz3" if self.settings.os == "Windows" else "z3"]
         if not self.options.shared:
             if self.settings.os in ["Linux", "FreeBSD"]:
-                self.cpp_info.components["libz3"].system_libs.append("pthread")
-
+                self.cpp_info.components["libz3"]\
+                    .system_libs.extend(["pthread", "m"])
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "Z3"
         self.cpp_info.filenames["cmake_find_package_multi"] = "Z3"

--- a/recipes/z3/all/patches/0001-cmake-use-conan-mpir-4.10.2.patch
+++ b/recipes/z3/all/patches/0001-cmake-use-conan-mpir-4.10.2.patch
@@ -1,16 +1,22 @@
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -246,10 +246,10 @@
+@@ -242,10 +242,16 @@
  if (Z3_USE_LIB_GMP)
    # Because this is off by default we will make the configure fail if libgmp
    # can't be found
 -  find_package(GMP REQUIRED)
-+  #find_package(GMP REQUIRED)
-   message(STATUS "Using libgmp")
--  list(APPEND Z3_DEPENDENT_LIBS ${GMP_C_LIBRARIES})
--  list(APPEND Z3_COMPONENT_EXTRA_INCLUDE_DIRS ${GMP_INCLUDE_DIRS})
-+  list(APPEND Z3_DEPENDENT_LIBS CONAN_PKG::mpir)
+-  message(STATUS "Using libgmp")
+-  list(APPEND Z3_DEPENDENT_LIBS GMP::GMP)
++  if (Z3_USE_LIB_MPIR)
++    message(STATUS "Using libmpir")
++    list(APPEND Z3_DEPENDENT_LIBS CONAN_PKG::mpir)
++  else()
++    message(STATUS "Using libgmp")
++    find_package(GMP REQUIRED)
++    list(APPEND Z3_DEPENDENT_LIBS GMP::GMP)
++  endif()
 +  list(APPEND Z3_COMPONENT_EXTRA_INCLUDE_DIRS "${CMAKE_BINARY_DIR}" ${CONAN_INCLUDE_DIRS})
    list(APPEND Z3_COMPONENT_CXX_DEFINES "-D_MP_GMP")
  else()
    list(APPEND Z3_COMPONENT_CXX_DEFINES "-D_MP_INTERNAL")
+   message(STATUS "Not using libgmp")

--- a/recipes/z3/all/patches/0001-cmake-use-conan-mpir-4.8.8.patch
+++ b/recipes/z3/all/patches/0001-cmake-use-conan-mpir-4.8.8.patch
@@ -1,0 +1,23 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -246,10 +246,16 @@
+ if (Z3_USE_LIB_GMP)
+   # Because this is off by default we will make the configure fail if libgmp
+   # can't be found
+-  find_package(GMP REQUIRED)
+-  message(STATUS "Using libgmp")
+-  list(APPEND Z3_DEPENDENT_LIBS ${GMP_C_LIBRARIES})
+-  list(APPEND Z3_COMPONENT_EXTRA_INCLUDE_DIRS ${GMP_INCLUDE_DIRS})
++  if (Z3_USE_LIB_MPIR)
++    message(STATUS "Using libmpir")
++    list(APPEND Z3_DEPENDENT_LIBS CONAN_PKG::mpir)
++  else()
++    message(STATUS "Using libgmp")
++    find_package(GMP REQUIRED)
++    list(APPEND Z3_DEPENDENT_LIBS ${GMP_C_LIBRARIES})
++    list(APPEND Z3_COMPONENT_EXTRA_INCLUDE_DIRS ${GMP_INCLUDE_DIRS})
++  endif()
++  list(APPEND Z3_COMPONENT_EXTRA_INCLUDE_DIRS "${CMAKE_BINARY_DIR}" ${CONAN_INCLUDE_DIRS})
+   list(APPEND Z3_COMPONENT_CXX_DEFINES "-D_MP_GMP")
+ else()
+   list(APPEND Z3_COMPONENT_CXX_DEFINES "-D_MP_INTERNAL")

--- a/recipes/z3/all/patches/0002-python-interp-3-4.8.8.patch
+++ b/recipes/z3/all/patches/0002-python-interp-3-4.8.8.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -169,7 +169,7 @@
+ ################################################################################
+ # Find Python
+ ################################################################################
+-find_package(PythonInterp REQUIRED)
++find_package(PythonInterp 3 REQUIRED)
+ message(STATUS "PYTHON_EXECUTABLE: ${PYTHON_EXECUTABLE}")
+
+ ################################################################################

--- a/recipes/z3/all/patches/0003-cmake-try-compile-flags-4.10.2.patch
+++ b/recipes/z3/all/patches/0003-cmake-try-compile-flags-4.10.2.patch
@@ -1,0 +1,17 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -1,2 +1,2 @@
+ # Enforce some CMake policies
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.8)
+@@ -179,9 +179,10 @@
+ ################################################################################
+ # C++ language version
+ ################################################################################
+ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
++cmake_policy(SET CMP0067 NEW) # ensures try_compile uses the same standard
+
+ ################################################################################
+ # Platform detection
+ ################################################################################

--- a/recipes/z3/config.yml
+++ b/recipes/z3/config.yml
@@ -1,3 +1,5 @@
 versions:
   "4.8.8":
     folder: "all"
+  "4.10.2":
+    folder: "all"


### PR DESCRIPTION
Library name and version:  **z3/4.10.2**.

Using `mpir` for `z3` is a specific use, and it is incompatible with using `gmp`, the more usual dependency `z3` supports. It results with the impossibility to use `z3` along with other libraries using `gmp`. See #11583.

With this PR, we let `gmp` be used by default, while letting the possibility to build `z3` with `mpir` or an internal implementation.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
