### PR TITLE
osmanip: add version 4.1.0

### DIFF
--- a/recipes/osmanip/all/CMakeLists.txt
+++ b/recipes/osmanip/all/CMakeLists.txt
@@ -6,23 +6,28 @@ conan_basic_setup(KEEP_RPATHS)
 
 find_package(arsenalgear REQUIRED CONFIG)
 
-set(osmanip_src
-    source_subfolder/src/graphics/canvas.cpp
-    source_subfolder/src/graphics/plot_2D.cpp
-    source_subfolder/src/manipulators/csmanip.cpp
-    source_subfolder/src/progressbar/progress_bar.cpp
-    source_subfolder/src/utility/windows.cpp
-)
-
-set(osmanip_inc
-    source_subfolder/include/graphics/canvas.hpp
-    source_subfolder/include/graphics/plot_2D.hpp
-    source_subfolder/include/manipulators/csmanip.hpp
-    source_subfolder/include/progressbar/multi_progress_bar.hpp
-    source_subfolder/include/progressbar/progress_bar.hpp
-    source_subfolder/include/utility/windows.hpp
-)
-
+if(${OSMANIP_VERSION} VERSION_EQUAL 4.0.0)
+    set(osmanip_src
+        source_subfolder/src/graphics/canvas.cpp
+        source_subfolder/src/graphics/plot_2D.cpp
+        source_subfolder/src/manipulators/csmanip.cpp
+        source_subfolder/src/progressbar/progress_bar.cpp
+        source_subfolder/src/utility/windows.cpp
+    )
+elseif(${OSMANIP_VERSION} VERSION_GREATER 4.0.0)
+    set(osmanip_src
+        source_subfolder/src/graphics/canvas.cpp
+        source_subfolder/src/graphics/plot_2D.cpp
+        source_subfolder/src/manipulators/printer.cpp
+        source_subfolder/src/manipulators/cursor.cpp
+        source_subfolder/src/manipulators/common.cpp
+        source_subfolder/src/manipulators/colsty.cpp
+        source_subfolder/src/progressbar/progress_bar.cpp
+        source_subfolder/src/utility/windows.cpp
+    )
+else()
+    message(FATAL_ERROR "unsupported osmanip version : ${OSMANIP_VERSION}")
+endif()
 
 add_library(osmanip ${osmanip_src})
 target_include_directories(osmanip PUBLIC source_subfolder/include/)

--- a/recipes/osmanip/all/CMakeLists.txt
+++ b/recipes/osmanip/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 project(osmanip LANGUAGES CXX)
 
 include(conanbuildinfo.cmake)
@@ -6,30 +6,22 @@ conan_basic_setup(KEEP_RPATHS)
 
 find_package(arsenalgear REQUIRED CONFIG)
 
-if(${OSMANIP_VERSION} VERSION_EQUAL 4.0.0)
-    set(osmanip_src
-        source_subfolder/src/graphics/canvas.cpp
-        source_subfolder/src/graphics/plot_2D.cpp
+add_library(osmanip)
+target_sources(osmanip PRIVATE
+    source_subfolder/src/graphics/canvas.cpp
+    source_subfolder/src/graphics/plot_2D.cpp
+    $<$<VERSION_EQUAL:${OSMANIP_VERSION},4.0.0>:
         source_subfolder/src/manipulators/csmanip.cpp
-        source_subfolder/src/progressbar/progress_bar.cpp
-        source_subfolder/src/utility/windows.cpp
-    )
-elseif(${OSMANIP_VERSION} VERSION_GREATER 4.0.0)
-    set(osmanip_src
-        source_subfolder/src/graphics/canvas.cpp
-        source_subfolder/src/graphics/plot_2D.cpp
+    >
+    $<$<VERSION_GREATER:${OSMANIP_VERSION},4.0.0>:
         source_subfolder/src/manipulators/printer.cpp
         source_subfolder/src/manipulators/cursor.cpp
         source_subfolder/src/manipulators/common.cpp
         source_subfolder/src/manipulators/colsty.cpp
-        source_subfolder/src/progressbar/progress_bar.cpp
-        source_subfolder/src/utility/windows.cpp
-    )
-else()
-    message(FATAL_ERROR "unsupported osmanip version : ${OSMANIP_VERSION}")
-endif()
-
-add_library(osmanip ${osmanip_src})
+    >
+    source_subfolder/src/progressbar/progress_bar.cpp
+    source_subfolder/src/utility/windows.cpp
+)
 target_include_directories(osmanip PUBLIC source_subfolder/include/)
 target_compile_features(osmanip PUBLIC cxx_std_17)
 set_target_properties(osmanip PROPERTIES

--- a/recipes/osmanip/all/conandata.yml
+++ b/recipes/osmanip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.1.0":
+    url: "https://github.com/JustWhit3/osmanip/archive/refs/tags/v4.1.0.tar.gz"
+    sha256: "9830316fea29300aeebadb0cd6cddd6f291a8fa04c397bca9666d045815d1d53"
   "4.0.0":
     url: "https://github.com/JustWhit3/osmanip/archive/refs/tags/v4.0.0.tar.gz"
     sha256: "c6848e1d9b15eb409af88efeee7cd1ce87374ea7ac87424f5d2cf30104f098a0"

--- a/recipes/osmanip/all/conanfile.py
+++ b/recipes/osmanip/all/conanfile.py
@@ -70,6 +70,7 @@ class OsmanipConan(ConanFile):
     @functools.lru_cache(1)
     def _configure_cmake(self):
         cmake = CMake(self)
+        cmake.definitions["OSMANIP_VERSION"] = str(self.version)
         cmake.configure()
         return cmake
 

--- a/recipes/osmanip/all/test_package/test_package.cpp
+++ b/recipes/osmanip/all/test_package/test_package.cpp
@@ -8,6 +8,11 @@
 #include "osmanip/utility/windows.hpp"
 #endif
 
+// Since 4.1.0, options.hpp for `osm::OPTION` is added.
+#if __has_include("osmanip/utility/options.hpp")
+#  include "osmanip/utility/options.hpp"
+#endif
+
 // STD headers
 #include <chrono>
 #include <iostream>

--- a/recipes/osmanip/config.yml
+++ b/recipes/osmanip/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "4.1.0":
+    folder: all
   "4.0.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **osmanip/4.1.0**

- add version 4.1.0
- osmanip/4.1.0 doesn't need patch for arsenalgear
- the list of source files are changed in 4.1.0.
- `utility/option.hpp` is added in 4.1.0 which is used by `test_package.cpp`.
- no need `osmanip_inc`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
