### PR TITLE
mongo-c-driver: fix static build of 1.22.0 on windows

### DIFF
--- a/recipes/mongo-c-driver/all/CMakeLists.txt
+++ b/recipes/mongo-c-driver/all/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(KEEP_RPATHS)
 
 add_subdirectory(source_subfolder)
 

--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -112,6 +112,9 @@ class MongoCDriverConan(ConanFile):
         for old_new in to_replace_old_new:
             tools.replace_in_file(os.path.join(self._source_subfolder, "src", "libmongoc", "CMakeLists.txt"),
                                   old_new["old"], old_new["new"])
+        # cleanup rpath
+        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+                              "set (CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)", "")
 
     @property
     def _ssl_cmake_value(self):

--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -5,6 +5,7 @@ import functools
 
 required_conan_version = ">=1.43.0"
 
+
 class MongoCDriverConan(ConanFile):
     name = "mongo-c-driver"
     description = "A Cross Platform MongoDB Client Library for C"
@@ -12,6 +13,7 @@ class MongoCDriverConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://mongoc.org/"
     topics = ("libbson", "libmongoc", "mongo", "mongodb", "database", "db")
+
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -35,6 +37,7 @@ class MongoCDriverConan(ConanFile):
         "with_icu": True,
         "srv": True,
     }
+
     short_paths = True
     generators = "cmake", "cmake_find_package", "pkg_config"
 
@@ -85,8 +88,6 @@ class MongoCDriverConan(ConanFile):
             raise ConanInvalidConfiguration("with_ssl=windows only allowed on Windows")
         if self.options.with_sasl == "sspi" and self.settings.os != "Windows":
             raise ConanInvalidConfiguration("with_sasl=sspi only allowed on Windows")
-        if tools.Version(self.version) >= "1.21.0" and self.settings.os == "Windows" and not self.options.shared:
-            raise ConanInvalidConfiguration("shared build doesn't allow on Windows after 1.21.0")
 
     def build_requirements(self):
         if self.options.with_ssl == "libressl" or self.options.with_zstd:

--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -165,9 +165,9 @@ class MongoCDriverConan(ConanFile):
         cmake.definitions["ENABLE_PIC"] = self.options.get_safe("fPIC", True)
         if self.options.with_ssl == "openssl":
             cmake.definitions["OPENSSL_ROOT_DIR"] = self.deps_cpp_info["openssl"].rootpath
-
+        if tools.Version(self.version) >= "1.20.0":
+            cmake.definitions["MONGO_USE_CCACHE"] = False
         cmake.configure(build_folder=self._build_subfolder)
-
         return cmake
 
     def build(self):

--- a/recipes/mongo-c-driver/all/patches/1.22.0-0001-disable-shared-when-static.patch
+++ b/recipes/mongo-c-driver/all/patches/1.22.0-0001-disable-shared-when-static.patch
@@ -1,25 +1,22 @@
-diff --git a/src/libbson/CMakeLists.txt b/src/libbson/CMakeLists.txt
-index d6df66f..72fcf47 100644
 --- a/src/libbson/CMakeLists.txt
 +++ b/src/libbson/CMakeLists.txt
-@@ -230,6 +230,8 @@ target_include_directories (
-       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../../src>
-       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/../../src/common>
+@@ -209,6 +209,7 @@ set (HEADERS_FORWARDING
+    ${PROJECT_SOURCE_DIR}/src/bson/forwarding/bson.h
  )
-+
-+if (NOT MONGOC_ENABLE_STATIC_BUILD)
- set_target_properties (bson_shared PROPERTIES VERSION 0.0.0 SOVERSION 0)
- set_target_properties (bson_shared PROPERTIES OUTPUT_NAME "${BSON_OUTPUT_BASENAME}-${BSON_API_VERSION}")
  
-@@ -275,6 +277,7 @@ if (WIN32)
++if (NOT MONGOC_ENABLE_STATIC_BUILD)
+ add_library (bson_shared SHARED ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
+ set (CMAKE_CXX_VISIBILITY_PRESET hidden)
+ target_compile_definitions (bson_shared
+@@ -275,6 +276,7 @@ if (WIN32)
     # must be handled specially since we can't resolve them
     set (BSON_SYSTEM_LIBRARIES ${BSON_SYSTEM_LIBRARIES} ws2_32)
  endif ()
-+endif ()
++endif()
  
  if (MONGOC_ENABLE_STATIC_BUILD)
     add_library (bson_static STATIC ${SOURCES} ${HEADERS} ${HEADERS_FORWARDING})
-@@ -349,7 +352,7 @@ set (BSON_HEADER_INSTALL_DIR
+@@ -349,7 +351,7 @@ set (BSON_HEADER_INSTALL_DIR
  )
  
  if (MONGOC_ENABLE_STATIC_INSTALL)
@@ -28,8 +25,6 @@ index d6df66f..72fcf47 100644
  else ()
     set (TARGETS_TO_INSTALL bson_shared)
  endif ()
-diff --git a/src/libmongoc/CMakeLists.txt b/src/libmongoc/CMakeLists.txt
-index f14ad6b..3a056ce 100644
 --- a/src/libmongoc/CMakeLists.txt
 +++ b/src/libmongoc/CMakeLists.txt
 @@ -758,6 +758,7 @@ if (MONGOC_ENABLE_MONGODB_AWS_AUTH)
@@ -60,7 +55,7 @@ index f14ad6b..3a056ce 100644
        PUBLIC_HEADER "${HEADERS}"
     )
  endif ()
-+endif ()
++endif()
  
  add_executable (mongoc-stat ${PROJECT_SOURCE_DIR}/../../src/tools/mongoc-stat.c)
 +if (NOT MONGOC_ENABLE_STATIC_BUILD)


### PR DESCRIPTION
- static build on windows: see https://github.com/conan-io/conan-center-index/pull/11311#discussion_r915210791
- relocatable shared libs on macOS: see https://github.com/conan-io/hooks/issues/376
- disable internal usage of ccache if found (since 1.20.0)

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
