### PR TITLE
[package] qt/6.x.x - Only expect windeployqt to be built on Windows

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -790,7 +790,9 @@ class QtConan(ConanFile):
         if self.options.widgets:
             targets.append("uic")
         if self.options.qttools:
-            targets.extend(["qhelpgenerator", "qtattributionsscanner", "windeployqt"])
+            targets.extend(["qhelpgenerator", "qtattributionsscanner"])
+            if self.settings.os == "Windows":
+                targets.extend(["windeployqt"])
             targets.extend(["lconvert", "lprodump", "lrelease", "lrelease-pro", "lupdate", "lupdate-pro"])
         if self.options.qtshadertools:
             targets.append("qsb")


### PR DESCRIPTION
Tiny fix so the recipe on linux doesn't complain when it cannot find the "windeployqt" binary.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
