### PR TITLE
glu: fix on ubuntu

### DIFF
--- a/recipes/glu/all/conanfile.py
+++ b/recipes/glu/all/conanfile.py
@@ -19,7 +19,7 @@ class SysConfigGLUConan(ConanFile):
             if tools.os_info.with_yum or tools.os_info.with_dnf:
                 packages = ["mesa-libGLU-devel"]
             elif tools.os_info.with_apt:
-                packages = ["libglu1-mesa-dev"]
+                packages = ["libglu1-mesa-dev", "libopengl-dev"]
             elif tools.os_info.with_pacman:
                 packages = ["glu"]
             elif tools.os_info.with_zypper:


### PR DESCRIPTION
kinetic and jammy don't install this package

fixes:

- https://github.com/bincrafters/system-packages-checks/runs/7269889544?check_suite_focus=true#step:6:546
- https://github.com/bincrafters/system-packages-checks/runs/7269889466?check_suite_focus=true#step:6:546

Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
