### PR TITLE
qt - don't set QT_PLUGIN_PATH for buildenv, as package dir doesn't exist

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -903,7 +903,6 @@ class QtConan(ConanFile):
 
         # consumers will need the QT_PLUGIN_PATH defined in runenv
         self.runenv_info.define("QT_PLUGIN_PATH", os.path.join(self.package_folder, "res", "archdatadir", "plugins"))
-        self.buildenv_info.define("QT_PLUGIN_PATH", os.path.join(self.package_folder, "res", "archdatadir", "plugins"))
 
         build_modules = []
 


### PR DESCRIPTION
Follow up to #11475 
I don't think we should be setting QT_PLUGIN_PATH for the buildenv,
as it points to a packaged folder that doesn't exist during the build.