### PR TITLE
poco: update for version 1.12.0 (handle pcre2)

### DIFF
--- a/recipes/poco/all/conandata.yml
+++ b/recipes/poco/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.12.0":
+    url: "https://github.com/pocoproject/poco/archive/poco-1.12.0-release.tar.gz"
+    sha256: "33b5acd5a09a9466c2710f6f2e3bd2492dd3372b655ea83f62520ac8fc213631"
   "1.11.3":
     url: "https://github.com/pocoproject/poco/archive/poco-1.11.3-release.tar.gz"
     sha256: "fb5e8e70c7dbc8f3b59ec8560140a267b4eaf06ee519dc21f312d0eb195cba37"
@@ -27,6 +30,11 @@ sources:
     url: "https://github.com/pocoproject/poco/archive/poco-1.8.1-release.tar.gz"
     sha256: "43cc469c01d1f799efc51e2bfde6ffdf467b98a8a0901e6b33db86958619b3af"
 patches:
+  "1.12.0":
+    - patch_file: patches/1.12.0.patch
+      base_path: src
+    - patch_file: patches/0002-mysql-include.patch
+      base_path: src
   "1.11.3":
     - patch_file: patches/1.11.3.patch
       base_path: src

--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -119,6 +119,9 @@ class PocoConan(ConanFile):
         if not self.options.enable_json:
             util_dependencies = self._poco_component_tree["Util"].dependencies
             self._poco_component_tree["Util"] = self._poco_component_tree["Util"]._replace(dependencies = [x for x in util_dependencies if x != "JSON"])
+        if tools.Version(self.version) >= "1.12":
+            foundation_external_dependencies = self._poco_component_tree["Foundation"].external_dependencies
+            self._poco_component_tree["Foundation"] = self._poco_component_tree["Foundation"]._replace(external_dependencies = list(map(lambda x: 'pcre2::pcre2' if x == 'pcre::pcre' else x, foundation_external_dependencies)))
 
     def requirements(self):
         if tools.Version(self.version) < "1.12":
@@ -243,9 +246,6 @@ class PocoConan(ConanFile):
             if comp.option is None or self.options.get_safe(comp.option):
                 conan_component = "poco_{}".format(compname.lower())
                 requires = ["poco_{}".format(dependency.lower()) for dependency in comp.dependencies] + comp.external_dependencies
-                # dirty hack to manipulate the external dependencies based on the poco version
-                if tools.Version(self.version) >= "1.12":
-                    requires = list(map(lambda x: 'pcre2::pcre2' if x == 'pcre::pcre' else x, requires))
                 self.cpp_info.components[conan_component].set_property("cmake_target_name", "Poco::{}".format(compname))
                 self.cpp_info.components[conan_component].set_property("cmake_file_name", compname)
                 self.cpp_info.components[conan_component].names["cmake_find_package"] = compname

--- a/recipes/poco/all/conanfile.py
+++ b/recipes/poco/all/conanfile.py
@@ -121,7 +121,10 @@ class PocoConan(ConanFile):
             self._poco_component_tree["Util"] = self._poco_component_tree["Util"]._replace(dependencies = [x for x in util_dependencies if x != "JSON"])
 
     def requirements(self):
-        self.requires("pcre/8.45")
+        if tools.Version(self.version) < "1.12":
+            self.requires("pcre/8.45")
+        else:
+            self.requires("pcre2/10.40")
         self.requires("zlib/1.2.12")
         if self.options.enable_xml:
             self.requires("expat/2.4.8")
@@ -240,6 +243,9 @@ class PocoConan(ConanFile):
             if comp.option is None or self.options.get_safe(comp.option):
                 conan_component = "poco_{}".format(compname.lower())
                 requires = ["poco_{}".format(dependency.lower()) for dependency in comp.dependencies] + comp.external_dependencies
+                # dirty hack to manipulate the external dependencies based on the poco version
+                if tools.Version(self.version) >= "1.12":
+                    requires = list(map(lambda x: 'pcre2::pcre2' if x == 'pcre::pcre' else x, requires))
                 self.cpp_info.components[conan_component].set_property("cmake_target_name", "Poco::{}".format(compname))
                 self.cpp_info.components[conan_component].set_property("cmake_file_name", compname)
                 self.cpp_info.components[conan_component].names["cmake_find_package"] = compname

--- a/recipes/poco/all/patches/1.12.0.patch
+++ b/recipes/poco/all/patches/1.12.0.patch
@@ -1,0 +1,36 @@
+diff -ruN a/cmake/PocoMacros.cmake b/cmake/PocoMacros.cmake
+--- a/cmake/PocoMacros.cmake	2022-07-08 18:28:44.000000000 +0200
++++ b/cmake/PocoMacros.cmake	2022-07-11 17:50:48.547610971 +0200
+@@ -40,7 +40,7 @@
+ 			endforeach()
+ 		endif(X64)
+ 	endif()
+-	find_program(CMAKE_MC_COMPILER mc.exe HINTS "${sdk_bindir}" "${kit_bindir}" "${kit81_bindir}" ${kit10_bindir}
++	find_program(CMAKE_MC_COMPILER NAMES mc.exe windmc.exe HINTS "${sdk_bindir}" "${kit_bindir}" "${kit81_bindir}" ${kit10_bindir}
+ 		DOC "path to message compiler")
+ 	if(NOT CMAKE_MC_COMPILER)
+ 		message(FATAL_ERROR "message compiler not found: required to build")
+diff -ruN a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
+--- a/Foundation/CMakeLists.txt	2022-07-08 18:28:44.000000000 +0200
++++ b/Foundation/CMakeLists.txt	2022-07-11 17:54:24.035097782 +0200
+@@ -107,7 +107,7 @@
+ )
+ 
+ if(POCO_UNBUNDLED)
+-	target_link_libraries(Foundation PUBLIC Pcre2::Pcre2 ZLIB::ZLIB)
++	target_link_libraries(Foundation PUBLIC PCRE2::PCRE2 ZLIB::ZLIB)
+ 	target_compile_definitions(Foundation PUBLIC POCO_UNBUNDLED)
+ endif(POCO_UNBUNDLED)
+ 
+diff -ruN a/NetSSL_Win/CMakeLists.txt b/NetSSL_Win/CMakeLists.txt
+--- a/NetSSL_Win/CMakeLists.txt	2022-07-08 18:28:44.000000000 +0200
++++ b/NetSSL_Win/CMakeLists.txt	2022-07-11 17:50:09.841223897 +0200
+@@ -21,7 +21,7 @@
+ 	DEFINE_SYMBOL NetSSL_Win_EXPORTS
+ )
+ 
+-target_link_libraries(NetSSLWin PUBLIC Poco::Net Poco::Util Crypt32.lib)
++target_link_libraries(NetSSLWin PUBLIC Poco::Net Poco::Util crypt32 ws2_32)
+ target_include_directories(NetSSLWin
+ 	PUBLIC
+ 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/recipes/poco/config.yml
+++ b/recipes/poco/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.12.0":
+    folder: all
   "1.11.3":
     folder: all
   "1.11.2":


### PR DESCRIPTION
Specify library name and version:  **poco/1.12.0**

I want to test the new Poco::Prometheus component and thus I updated the config and recipe for version 1.12.0

important: needs pcre2 (v10.40) instead of pcre (v8.45) - this has to be reflected in the external dependencies
(the other PR https://github.com/conan-io/conan-center-index/pull/11607 does not handle this)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
