### PR TITLE
cpp-peglib: add version 1.6.0

### DIFF
--- a/recipes/cpp-peglib/1.x.x/conandata.yml
+++ b/recipes/cpp-peglib/1.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.0":
+    url: "https://github.com/yhirose/cpp-peglib/archive/v1.6.0.tar.gz"
+    sha256: "2b09d711fd02bad24089bc5a6f51ef4c307d86e0adb6f9938e0549a12c102ac4"
   "1.5.0":
     url: "https://github.com/yhirose/cpp-peglib/archive/refs/tags/v1.5.0.tar.gz"
     sha256: "45a02b749556af6ab0abf78c4c1d1afe02f17705b1c51f5820e957616f453b33"

--- a/recipes/cpp-peglib/config.yml
+++ b/recipes/cpp-peglib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.0":
+    folder: "1.x.x"
   "1.5.0":
     folder: "1.x.x"
   "1.4.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cpp-peglib/1.6.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
