### PR TITLE
imagl: Remove deprecated setting

### DIFF
--- a/recipes/imagl/all/conanfile.py
+++ b/recipes/imagl/all/conanfile.py
@@ -16,15 +16,13 @@ class ImaglConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_png": [True, False],
-        "with_jpeg": [True, False],
-        "allow_clang_11": [None, True, False]
+        "with_jpeg": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_png": True,
-        "with_jpeg": True,
-        "allow_clang_11": None
+        "with_jpeg": True
     }
     generators = "cmake"
     exports_sources = ["CMakeLists.txt", "patches/**"]

--- a/recipes/imagl/all/conanfile.py
+++ b/recipes/imagl/all/conanfile.py
@@ -16,13 +16,13 @@ class ImaglConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_png": [True, False],
-        "with_jpeg": [True, False]
+        "with_jpeg": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_png": True,
-        "with_jpeg": True
+        "with_jpeg": True,
     }
     generators = "cmake"
     exports_sources = ["CMakeLists.txt", "patches/**"]


### PR DESCRIPTION
this was not actually deprecated but it was a temporary workaround for a bug in the infrastructure

If it's preferred, I can leave the setting and added a deprecated warning and circle back later

Specify library name and version:  **imagl/all**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
