### PR TITLE
c-blosc2: add recipe

### DIFF
--- a/recipes/c-blosc2/all/CMakeLists.txt
+++ b/recipes/c-blosc2/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(TARGETS KEEP_RPATHS)
+
+add_subdirectory("source_subfolder")

--- a/recipes/c-blosc2/all/conandata.yml
+++ b/recipes/c-blosc2/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.2.0":
+    url: "https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.2.0.tar.gz"
+    sha256: "66f9977de26d6bc9ea1c0e623d873c3225e4fff709aa09b3335fd09d41d57c0e"

--- a/recipes/c-blosc2/all/conanfile.py
+++ b/recipes/c-blosc2/all/conanfile.py
@@ -1,0 +1,115 @@
+from conans import ConanFile, CMake, tools
+from conan.tools.microsoft import is_msvc
+import os
+import functools
+
+required_conan_version = ">=1.45.0"
+
+class CBlosc2Conan(ConanFile):
+    name = "c-blosc2"
+    description = "A fast, compressed, persistent binary data store library for C."
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/Blosc/c-blosc2"
+    topics = ("c-blosc", "blosc", "compression")
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "simd_intrinsics": [None, "sse2", "avx2"],
+        "with_lz4": [True, False],
+        "with_zlib": [None, "zlib", "zlib-ng"],
+        "with_zstd": [True, False],
+        "with_plugins": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "simd_intrinsics": "avx2",
+        "with_lz4": True,
+        "with_zlib": "zlib",
+        "with_zstd": True,
+        "with_plugins": True,
+    }
+    generators = "cmake", "cmake_find_package"
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+        if self.settings.arch not in ["x86", "x86_64"]:
+            del self.options.simd_intrinsics
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.cppstd
+        del self.settings.compiler.libcxx
+
+    def requirements(self):
+        if self.options.with_lz4:
+            self.requires("lz4/1.9.3")
+        if self.options.with_zlib == "zlib-ng":
+            self.requires("zlib-ng/2.0.6")
+        elif self.options.with_zlib == "zlib":
+            self.requires("zlib/1.2.12")
+        if self.options.with_zstd:
+            self.requires("zstd/1.5.2")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["BLOSC_IS_SUBPROJECT"] = False
+        cmake.definitions["BLOSC_INSTALL"] = True
+        cmake.definitions["BUILD_STATIC"] = not self.options.shared
+        cmake.definitions["BUILD_SHARED"] = self.options.shared
+        cmake.definitions["BUILD_TESTS"] = False
+        cmake.definitions["BUILD_FUZZERS"] = False
+        cmake.definitions["BUILD_BENCHMARKS"] = False
+        cmake.definitions["BUILD_EXAMPLES"] = False
+        simd_intrinsics = self.options.get_safe("simd_intrinsics", False)
+        cmake.definitions["DEACTIVATE_AVX2"] = simd_intrinsics != "avx2"
+        cmake.definitions["DEACTIVATE_LZ4"] = not self.options.with_lz4
+        cmake.definitions["PREFER_EXTERNAL_LZ4"] = self.options.with_lz4
+        cmake.definitions["DEACTIVATE_ZLIB"] = self.options.with_zlib == None
+        cmake.definitions["PREFER_EXTERNAL_ZLIB"] = self.options.with_zlib != None
+        cmake.definitions["DEACTIVATE_ZSTD"] = not self.options.with_zstd
+        cmake.definitions["PREFER_EXTERNAL_ZSTD"] = self.options.with_zstd
+        cmake.definitions["BUILD_PLUGINS"] = self.options.with_plugins
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        licenses = ["BLOSC.txt", "BITSHUFFLE.txt", "FASTLZ.txt", "LZ4.txt", "ZLIB.txt", "STDINT.txt"]
+        for license_file in licenses:
+            self.copy(license_file, dst="licenses", src=os.path.join(self._source_subfolder, "LICENSES"))
+        cmake = self._configure_cmake()
+        cmake.install()
+        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "blosc2")
+        prefix = "lib" if is_msvc(self) and not self.options.shared else ""
+        self.cpp_info.libs = ["{}blosc2".format(prefix)]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m", "pthread"]
+
+        # TODO: to remove in conan v2 once pkg_config generator removed
+        self.cpp_info.names["pkg_config"] = "blosc2"

--- a/recipes/c-blosc2/all/test_package/CMakeLists.txt
+++ b/recipes/c-blosc2/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(c-blosc2 REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} c-blosc2::c-blosc2)

--- a/recipes/c-blosc2/all/test_package/conanfile.py
+++ b/recipes/c-blosc2/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/c-blosc2/all/test_package/test_package.c
+++ b/recipes/c-blosc2/all/test_package/test_package.c
@@ -1,0 +1,79 @@
+/*
+    Copyright (C) 2014  Francesc Alted
+    http://blosc.org
+    License: MIT (see LICENSE.txt)
+    Example program demonstrating use of the Blosc filter from C code.
+    To compile this program:
+    $ gcc simple.c -o simple -lblosc
+    or, if you don't have the blosc library installed:
+    $ gcc -O3 -msse2 simple.c -I../blosc -o simple -L../build/blosc
+    Using MSVC on Windows:
+    $ cl /arch:SSE2 /Ox /Fesimple.exe /Iblosc examples\simple.c blosc\blosc.c blosc\blosclz.c blosc\shuffle.c blosc\shuffle-sse2.c blosc\shuffle-generic.c blosc\bitshuffle-generic.c blosc\bitshuffle-sse2.c
+    To run:
+    $ ./simple
+    Blosc version info: 1.4.2.dev ($Date:: 2014-07-08 #$)
+    Compression: 4000000 -> 158494 (25.2x)
+    Decompression succesful!
+    Succesful roundtrip!
+*/
+
+#include "blosc2.h"
+
+#include <stdio.h>
+
+#define SIZE 100*100*100
+
+int main(){
+  static float data[SIZE];
+  static float data_out[SIZE];
+  static float data_dest[SIZE];
+  int isize = SIZE*sizeof(float), osize = SIZE*sizeof(float);
+  int dsize = SIZE*sizeof(float), csize;
+  int i;
+
+  for(i=0; i<SIZE; i++){
+    data[i] = i;
+  }
+
+  /* Register the filter with the library */
+  printf("Blosc version info: %s (%s)\n",
+	 BLOSC_VERSION_STRING, BLOSC_VERSION_DATE);
+
+  /* Initialize the Blosc compressor */
+  blosc_init();
+
+  /* Compress with clevel=5 and shuffle active  */
+  csize = blosc_compress(5, 1, sizeof(float), isize, data, data_out, osize);
+  if (csize == 0) {
+    printf("Buffer is uncompressible.  Giving up.\n");
+    return 1;
+  }
+  else if (csize < 0) {
+    printf("Compression error.  Error code: %d\n", csize);
+    return csize;
+  }
+
+  printf("Compression: %d -> %d (%.1fx)\n", isize, csize, (1.*isize) / csize);
+
+  /* Decompress  */
+  dsize = blosc_decompress(data_out, data_dest, dsize);
+  if (dsize < 0) {
+    printf("Decompression error.  Error code: %d\n", dsize);
+    return dsize;
+  }
+
+  printf("Decompression succesful!\n");
+
+  /* After using it, destroy the Blosc environment */
+  blosc_destroy();
+
+  for(i=0;i<SIZE;i++){
+    if(data[i] != data_dest[i]) {
+      printf("Decompressed data differs from original!\n");
+      return -1;
+    }
+  }
+
+  printf("Succesful roundtrip!\n");
+  return 0;
+}

--- a/recipes/c-blosc2/config.yml
+++ b/recipes/c-blosc2/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.2.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **c-blosc2/2.2.0**

c-blosc2 is the new major version of c-blosc.
There is already c-blosc recipe in cci.

However these have different repositories, I create another recipe for c-blosc2.
Please review my decision as well.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
