### PR TITLE
Bump draco/1.5.3

### DIFF
--- a/recipes/draco/all/conandata.yml
+++ b/recipes/draco/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.3":
+    url: "https://github.com/google/draco/archive/refs/tags/1.5.3.tar.gz"
+    sha256: "7882a942a1da14a9ae9d557b1a3af7f44bdee7f5d42b745c4e474fb8b28d4e5e"
   "1.5.2":
     url: "https://github.com/google/draco/archive/1.5.2.tar.gz"
     sha256: "a887e311ec04a068ceca0bd6f3865083042334fbff26e65bc809e8978b2ce9cd"

--- a/recipes/draco/config.yml
+++ b/recipes/draco/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.3":
+    folder: all
   "1.5.2":
     folder: all
   "1.4.3":


### PR DESCRIPTION
No need for CMake patch anymore since 1.5.3, dll install location has been fixed in https://github.com/google/draco/pull/838

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
