### PR TITLE
googleapis - dynamically build cmake project

### DIFF
--- a/recipes/googleapis/all/CMakeLists.txt
+++ b/recipes/googleapis/all/CMakeLists.txt
@@ -1,9 +1,10 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
+# CMake >= 3.20 is required. There is a proto with dots in the name 'k8s.min.proto' and CMake fails to generate project files
+
 project(googleapis)
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup(TARGETS)
 
 find_package(Protobuf REQUIRED)
-
 

--- a/recipes/googleapis/all/CMakeLists.txt
+++ b/recipes/googleapis/all/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+project(googleapis)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup(TARGETS)
+
+find_package(Protobuf REQUIRED)
+
+

--- a/recipes/googleapis/all/CMakeLists.txt
+++ b/recipes/googleapis/all/CMakeLists.txt
@@ -8,3 +8,4 @@ conan_basic_setup(TARGETS)
 
 find_package(Protobuf REQUIRED)
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/recipes/googleapis/all/CMakeLists.txt
+++ b/recipes/googleapis/all/CMakeLists.txt
@@ -6,6 +6,6 @@ project(googleapis)
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup(TARGETS)
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf REQUIRED CONFIG)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/recipes/googleapis/all/conandata.yml
+++ b/recipes/googleapis/all/conandata.yml
@@ -7,6 +7,9 @@
 #     (master branch) https://github.com/grpc/grpc/blob/master/CMakeLists.txt#L347
 
 sources:
+  "cci.20220711":
+    url: "https://github.com/googleapis/googleapis/archive/220b13e335ea8e0153c84c56a135a19d15384621.zip"
+    sha256: "0a8aac018f49f8595fc0fbfe53f46d73b2fb42661a425746be802302928e6ac2"
   "cci.20220531":  # Used by google-cloud-cpp 1.41.0
     url: "https://github.com/googleapis/googleapis/archive/f19049fdd8dfc8b6eba387f4ef6d1d8b4d0103e7.zip"
     sha256: "d4ebe22c0a8a884adbeb63f72ab1fee4b15bad0a535de37cabba427a37711ee8"

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -147,6 +147,9 @@ class GoogleAPIS(ConanFile):
         copy(self, pattern="*.dylib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
         copy(self, pattern="*.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
 
+    def package_id(self):
+        self.info.requires["protobuf"].full_package_mode()
+
     def package_info(self):
         # We are not creating components, we can just collect the libraries
         self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -1,7 +1,12 @@
 import os
+import functools
+import glob
 from conan import ConanFile
+from conans import CMake, tools
 from conan.tools.files import get, copy
+from conan.tools.layout import cmake_layout
 
+from helpers import parse_proto_libraries
 
 class GoogleAPIS(ConanFile):
     name = "googleapis"
@@ -11,18 +16,84 @@ class GoogleAPIS(ConanFile):
     homepage = "https://github.com/googleapis/googleapis"
     topics = "google", "protos", "api"
     settings = "os", "arch", "compiler", "build_type"
-    short_paths = True
+    generators = "cmake", "cmake_find_package"
+    options = {
+        "shared": [True, False], 
+        "fPIC": [True, False]
+        }
+    default_options = {
+        "shared": False, 
+        "fPIC": True
+        }
+    exports = "helpers.py"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
 
     def source(self):
         get(self, **self.conan_data["sources"][str(self.version)], destination=self.source_folder, strip_root=True)
 
-    def package_id(self):
-        self.info.header_only()
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def requirements(self):
+        self.requires('protobuf/3.21.1')
+
+    def build_requirements(self):
+        self.build_requires('protobuf/3.21.1')
+
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure()
+        return cmake
+
+    @functools.lru_cache(1)
+    def _parse_proto_libraries(self):
+        # Generate the libraries to build dynamically
+        proto_libraries = []
+        for filename in glob.iglob(os.path.join(self.source_folder, 'google', '**', 'BUILD.bazel'), recursive=True):
+            proto_libraries += parse_proto_libraries(filename, self.source_folder, self.output.error)
+            
+        for filename in glob.iglob(os.path.join(self.source_folder, 'grafeas', '**', 'BUILD.bazel'), recursive=True):
+            proto_libraries += parse_proto_libraries(filename, self.source_folder, self.output.error)
+            
+        # print(json.dumps(proto_libraries, indent=4))
+        all_deps = [f"{it.qname}:{it.name}" for it in proto_libraries]
+        all_deps += ["protobuf::libprotobuf"]
+        for it in proto_libraries:
+            self.output.info(it.dumps())
+            it.validate(self.source_folder, all_deps)
+
+        return proto_libraries
+
+    def build(self):
+        proto_libraries = self._parse_proto_libraries()
+        with open(os.path.join(self.source_folder, "CMakeLists.txt"), "a") as f:
+            for it in proto_libraries:
+                f.write(it.cmake_content)
+        cmake = self._configure_cmake()
+        cmake.build()
 
     def package(self):
         copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, pattern="*.proto", src=self.source_folder, dst=os.path.join(self.package_folder, "res"))
+        copy(self, pattern="*.pb.h", src=self.build_folder, dst=os.path.join(self.package_folder, "include"))
+        
+        copy(self, pattern="*.lib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
+        copy(self, pattern="*.dll", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"))
+        copy(self, pattern="*.so*", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), symlinks=True)
+        copy(self, pattern="*.dylib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
+        copy(self, pattern="*.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
-        self.cpp_info.libs = []
-        self.cpp_info.includedirs = []
+        proto_libraries = self._parse_proto_libraries()
+        self.cpp_info.libs = [it.cmake_target for it in proto_libraries]

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -28,6 +28,7 @@ class GoogleAPIS(ConanFile):
         "fPIC": True
         }
     exports = "helpers.py"
+    short_paths = True
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -45,10 +45,6 @@ class GoogleAPIS(ConanFile):
             self.options["protobuf"].shared = True
 
     def validate(self):
-        # TODO: Remove, just for testing configurations in CCI
-        if self.settings.os in ["Linux", "Macos"]:
-            raise ConanInvalidConfiguration("REMOVE!! Building just Windows")
-
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
         if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) <= "5":

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -125,14 +125,10 @@ class GoogleAPIS(ConanFile):
         if tools.Version(self.deps_cpp_info["protobuf"].version) <= "3.21.2" and self.settings.os == "Macos":
             deactivate_library("//google/storagetransfer/v1:storagetransfer_proto")
         #  - Inconvenient macro names from /usr/include/math.h : DOMAIN
-        if self.settings.os == "Linux" and self.settings.compiler == "clang" and self.settings.compiler.libcxx == "libc++":
+        if (self.settings.os == "Linux" and self.settings.compiler == "clang" and self.settings.compiler.libcxx == "libc++") or \
+            self.settings.compiler in ["Visual Studio", "msvc"]:
             deactivate_library("//google/cloud/channel/v1:channel_proto")
             deactivate_library("//google/cloud/channel/v1:channel_cc_proto")
-        if self.version in ["cci.20220711", "cci.20220531"]:
-            #  - Inconvenient macro names from '10.0.17763.0\ucrt\corecrt_math.h' : DOMAIN
-            if self.settings.compiler in ["Visual Studio", "msvc"]:
-                deactivate_library("//google/cloud/channel/v1:channel_proto")
-                deactivate_library("//google/cloud/channel/v1:channel_cc_proto")
 
         return proto_libraries
 

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -51,6 +51,8 @@ class GoogleAPIS(ConanFile):
             tools.check_min_cppstd(self, 11)
         if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) <= "5":
             raise ConanInvalidConfiguration("Build with GCC 5 fails")
+        if self.options.shared and not self.options["protobuf"].shared:
+            raise ConanInvalidConfiguration("If built as shared, protobuf must be shared as well. Please, use `protobuf:shared=True`")
 
     def requirements(self):
         self.requires('protobuf/3.21.1')

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -45,6 +45,7 @@ class GoogleAPIS(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+            self.options["protobuf"].shared = True
 
     def validate(self):
         if self.settings.compiler.cppstd:

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -5,7 +5,6 @@ from io import StringIO
 from conan import ConanFile
 from conans import CMake, tools
 from conan.tools.files import get, copy
-from conan.tools.layout import cmake_layout
 from conans.errors import ConanInvalidConfiguration
 
 from helpers import parse_proto_libraries
@@ -18,7 +17,7 @@ class GoogleAPIS(ConanFile):
     homepage = "https://github.com/googleapis/googleapis"
     topics = "google", "protos", "api"
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package_multi"
     options = {
         "shared": [True, False], 
         "fPIC": [True, False]
@@ -29,9 +28,6 @@ class GoogleAPIS(ConanFile):
         }
     exports = "helpers.py"
     short_paths = True
-
-    def layout(self):
-        cmake_layout(self)
 
     def export_sources(self):
         self.copy("CMakeLists.txt")

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -53,6 +53,9 @@ class GoogleAPIS(ConanFile):
             tools.check_min_cppstd(self, 11)
         if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) <= "5":
             raise ConanInvalidConfiguration("Build with GCC 5 fails")
+
+        if self.settings.compiler in ["Visual Studio", "msvc"] and self.options.shared:
+            raise ConanInvalidConfiguration("Source code generated from protos is missing some export macro")
         if self.options.shared and not self.options["protobuf"].shared:
             raise ConanInvalidConfiguration("If built as shared, protobuf must be shared as well. Please, use `protobuf:shared=True`")
 

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -45,6 +45,10 @@ class GoogleAPIS(ConanFile):
             self.options["protobuf"].shared = True
 
     def validate(self):
+        # TODO: Remove, just for testing configurations in CCI
+        if self.settings.os in ["Linux", "Macos"]:
+            raise ConanInvalidConfiguration("REMOVE!! Building just Windows")
+
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
         if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) <= "5":

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -113,10 +113,14 @@ class GoogleAPIS(ConanFile):
             activate_library(it)
 
         # Tweaks
-        #  - Inconvenient macro names from usr/include/sys/syslimits.h in some macOS SDKs.
+        #  - Inconvenient macro names from usr/include/sys/syslimits.h in some macOS SDKs: GID_MAX
         #    Patched here: https://github.com/protocolbuffers/protobuf/commit/f138d5de2535eb7dd7c8d0ad5eb16d128ab221fd
         if tools.Version(self.deps_cpp_info["protobuf"].version) <= "3.21.2" and self.settings.os == "Macos":
             all_dict["//google/storagetransfer/v1:storagetransfer_proto"].is_used = False
+        #  - Inconvenient macro names from /usr/include/math.h : DOMAIN
+        if self.settings.os == "Linux" and self.settings.compiler == "clang" and self.settings.compiler.libcxx == "libc++":
+            all_dict["//google/cloud/channel/v1:channel_proto"].is_used = False
+            all_dict["//google/cloud/channel/v1:channel_cc_proto"].is_used = False
 
         return proto_libraries
 

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -6,6 +6,7 @@ from conan import ConanFile
 from conans import CMake, tools
 from conan.tools.files import get, copy
 from conan.tools.layout import cmake_layout
+from conans.errors import ConanInvalidConfiguration
 
 from helpers import parse_proto_libraries
 
@@ -48,6 +49,8 @@ class GoogleAPIS(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
+        if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) <= "5":
+            raise ConanInvalidConfiguration("Build with GCC 5 fails")
 
     def requirements(self):
         self.requires('protobuf/3.21.1')

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -128,7 +128,7 @@ class GoogleAPIS(ConanFile):
         if self.settings.os == "Linux" and self.settings.compiler == "clang" and self.settings.compiler.libcxx == "libc++":
             deactivate_library("//google/cloud/channel/v1:channel_proto")
             deactivate_library("//google/cloud/channel/v1:channel_cc_proto")
-        if self.version == "cci.20220711":
+        if self.version in ["cci.20220711", "cci.20220531"]:
             #  - Inconvenient macro names from '10.0.17763.0\ucrt\corecrt_math.h' : DOMAIN
             if self.settings.compiler in ["Visual Studio", "msvc"]:
                 deactivate_library("//google/cloud/channel/v1:channel_proto")

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -105,11 +105,11 @@ class GoogleAPIS(ConanFile):
         copy(self, pattern="*.proto", src=self.source_folder, dst=os.path.join(self.package_folder, "res"))
         copy(self, pattern="*.pb.h", src=self.build_folder, dst=os.path.join(self.package_folder, "include"))
         
-        copy(self, pattern="*.lib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
-        copy(self, pattern="*.dll", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"))
-        copy(self, pattern="*.so*", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
-        copy(self, pattern="*.dylib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
-        copy(self, pattern="*.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
+        copy(self, pattern="*.lib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, pattern="*.dll", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
+        copy(self, pattern="*.so*", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, pattern="*.dylib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, pattern="*.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
 
     def package_info(self):
         # We are not creating components, we can just collect the libraries

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -112,5 +112,5 @@ class GoogleAPIS(ConanFile):
         copy(self, pattern="*.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
-        proto_libraries = self._parse_proto_libraries()
-        self.cpp_info.libs = [it.cmake_target for it in filter(lambda u: u.srcs, proto_libraries)]
+        # We are not creating components, we can just collect the libraries
+        self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -70,7 +70,6 @@ class GoogleAPIS(ConanFile):
         all_deps = [f"{it.qname}:{it.name}" for it in proto_libraries]
         all_deps += ["protobuf::libprotobuf"]
         for it in proto_libraries:
-            self.output.info(it.dumps())
             it.validate(self.source_folder, all_deps)
 
         # Mark the libraries we need recursively (C++ context)
@@ -85,9 +84,11 @@ class GoogleAPIS(ConanFile):
         for it in filter(lambda u: u.is_used, proto_libraries):
             activate_library(it)
 
-        # Force some extra libraries
-        if self.version == "cci.20220711":
-            pass
+        # Tweaks
+        #  - Inconvenient macro names from usr/include/sys/syslimits.h in some macOS SDKs.
+        #    Patched here: https://github.com/protocolbuffers/protobuf/commit/f138d5de2535eb7dd7c8d0ad5eb16d128ab221fd
+        if tools.Version(self.deps_cpp_info["protobuf"].version) <= "3.21.2" and self.settings.os == "Macos":
+            all_dict["//google/storagetransfer/v1:storagetransfer_proto"].is_used = False
 
         return proto_libraries
 

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -124,6 +124,11 @@ class GoogleAPIS(ConanFile):
         if self.settings.os == "Linux" and self.settings.compiler == "clang" and self.settings.compiler.libcxx == "libc++":
             deactivate_library("//google/cloud/channel/v1:channel_proto")
             deactivate_library("//google/cloud/channel/v1:channel_cc_proto")
+        if self.version == "cci.20220711":
+            #  - Inconvenient macro names from '10.0.17763.0\ucrt\corecrt_math.h' : DOMAIN
+            if self.settings.compiler in ["Visual Studio"] and self.settings.compiler.version == "16":
+                deactivate_library("//google/cloud/channel/v1:channel_proto")
+                deactivate_library("//google/cloud/channel/v1:channel_cc_proto")
 
         return proto_libraries
 
@@ -149,3 +154,5 @@ class GoogleAPIS(ConanFile):
     def package_info(self):
         # We are not creating components, we can just collect the libraries
         self.cpp_info.libs = tools.collect_libs(self)
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.extend(["m"])

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -130,7 +130,7 @@ class GoogleAPIS(ConanFile):
             deactivate_library("//google/cloud/channel/v1:channel_cc_proto")
         if self.version == "cci.20220711":
             #  - Inconvenient macro names from '10.0.17763.0\ucrt\corecrt_math.h' : DOMAIN
-            if self.settings.compiler in ["Visual Studio"] and self.settings.compiler.version == "16":
+            if self.settings.compiler in ["Visual Studio", "msvc"]:
                 deactivate_library("//google/cloud/channel/v1:channel_proto")
                 deactivate_library("//google/cloud/channel/v1:channel_cc_proto")
 

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -69,7 +69,7 @@ class GoogleAPIS(ConanFile):
         # Validate that all files exist and all dependencies are found
         all_deps = [f"{it.qname}:{it.name}" for it in proto_libraries]
         all_deps += ["protobuf::libprotobuf"]
-        for it in filter(lambda u: u.is_cc, proto_libraries):
+        for it in proto_libraries:
             self.output.info(it.dumps())
             it.validate(self.source_folder, all_deps)
 
@@ -82,7 +82,7 @@ class GoogleAPIS(ConanFile):
                     continue
                 activate_library(all_dict[it_dep])
             
-        for it in filter(lambda u: u.is_cc, proto_libraries):
+        for it in filter(lambda u: u.is_used, proto_libraries):
             activate_library(it)
 
         # Force some extra libraries
@@ -112,4 +112,4 @@ class GoogleAPIS(ConanFile):
 
     def package_info(self):
         proto_libraries = self._parse_proto_libraries()
-        self.cpp_info.libs = [it.cmake_target for it in proto_libraries]
+        self.cpp_info.libs = [it.cmake_target for it in filter(lambda u: u.srcs, proto_libraries)]

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -113,14 +113,17 @@ class GoogleAPIS(ConanFile):
             activate_library(it)
 
         # Tweaks
+        def deactivate_library(key):
+            if key in all_dict:
+                all_dict[key].is_used = False
         #  - Inconvenient macro names from usr/include/sys/syslimits.h in some macOS SDKs: GID_MAX
         #    Patched here: https://github.com/protocolbuffers/protobuf/commit/f138d5de2535eb7dd7c8d0ad5eb16d128ab221fd
         if tools.Version(self.deps_cpp_info["protobuf"].version) <= "3.21.2" and self.settings.os == "Macos":
-            all_dict["//google/storagetransfer/v1:storagetransfer_proto"].is_used = False
+            deactivate_library("//google/storagetransfer/v1:storagetransfer_proto")
         #  - Inconvenient macro names from /usr/include/math.h : DOMAIN
         if self.settings.os == "Linux" and self.settings.compiler == "clang" and self.settings.compiler.libcxx == "libc++":
-            all_dict["//google/cloud/channel/v1:channel_proto"].is_used = False
-            all_dict["//google/cloud/channel/v1:channel_cc_proto"].is_used = False
+            deactivate_library("//google/cloud/channel/v1:channel_proto")
+            deactivate_library("//google/cloud/channel/v1:channel_cc_proto")
 
         return proto_libraries
 

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -77,7 +77,7 @@ class GoogleAPIS(ConanFile):
 
     def build(self):
         proto_libraries = self._parse_proto_libraries()
-        with open(os.path.join(self.source_folder, "CMakeLists.txt"), "a") as f:
+        with open(os.path.join(self.source_folder, "CMakeLists.txt"), "a", encoding="utf-8") as f:
             for it in proto_libraries:
                 f.write(it.cmake_content)
         cmake = self._configure_cmake()
@@ -90,7 +90,7 @@ class GoogleAPIS(ConanFile):
         
         copy(self, pattern="*.lib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
         copy(self, pattern="*.dll", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"))
-        copy(self, pattern="*.so*", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), symlinks=True)
+        copy(self, pattern="*.so*", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
         copy(self, pattern="*.dylib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
         copy(self, pattern="*.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
 

--- a/recipes/googleapis/all/helpers.py
+++ b/recipes/googleapis/all/helpers.py
@@ -1,0 +1,157 @@
+import os
+import re
+import textwrap
+
+class _ProtoLibrary:
+    name: str = None
+    qname: str = None
+    srcs: list = None
+    deps: list = None
+
+    def __init__(self) -> None:
+        self.srcs = []
+        self.deps = set(["protobuf::libprotobuf"])  # Add to all libraries even if not explicitly set
+
+    def validate(self, source_folder, all_deps):
+        # Check all files exists
+        for it in self.srcs:
+            assert os.path.exists(os.path.join(source_folder, it)), f"{self.qname}:{self.name} - file '{it}' doesn't exist"
+        # Check all deps exists
+        for it in self.deps:
+            assert it in all_deps, f"{self.qname}:{self.name} - dep '{it}' not found"
+
+    def dumps(self):
+        import json
+        return json.dumps({
+            "name": self.name,
+            "qname": self.qname,
+            "srcs": self.srcs,
+            "deps": list(self.deps)
+        }, indent=4)
+
+    @property
+    def cmake_target(self):
+        return f'{self.qname.replace("/", "_")}_{self.name}'
+
+    @property
+    def cmake_deps(self):
+        def to_cmake_target(item):
+            if item.startswith("//"):
+                return item.replace("/", "_").replace(":", "_")
+            return item
+        return [to_cmake_target(it) for it in self.deps]
+
+    @property
+    def cmake_content(self):
+        content = f"\n\n# {self.cmake_target}\n"
+        content += "\n".join([f"#{it}" for it in self.dumps().split('\n')])
+        content += "\n"        
+        if not self.srcs:
+            content += textwrap.dedent(f"""\
+                add_library({self.cmake_target} INTERFACE)
+            """)
+        else:
+            content += textwrap.dedent(f"""\
+                set({self.cmake_target}_PROTOS {" ".join(["${CMAKE_SOURCE_DIR}/"+it for it in self.srcs])})
+                add_library({self.cmake_target} ${{{self.cmake_target}_PROTOS}})
+                target_include_directories({self.cmake_target} PUBLIC ${{CMAKE_BINARY_DIR}})
+                protobuf_generate(LANGUAGE cpp 
+                                TARGET {self.cmake_target} 
+                                PROTOS ${{{self.cmake_target}_PROTOS}}
+                                IMPORT_DIRS ${{CMAKE_SOURCE_DIR}}
+                                # PROTOC_OUT_DIR ${{CMAKE_BINARY_DIR}}
+                                )
+            """)
+
+        if self.deps:
+            content += textwrap.dedent(f"""\
+                target_link_libraries({self.cmake_target} {"PUBLIC" if self.srcs else "INTERFACE"} {" ".join(self.cmake_deps)})
+            """)
+
+        return content
+
+def parse_proto_libraries(filename, source_folder, error):
+    # Generate the libraries to build dynamically
+    re_name = re.compile(r'name = "(.*)"')
+    re_srcs_oneline = re.compile(r'srcs = \["(.*)"\],')
+    re_deps_oneline = re.compile(r'deps = \["(.*)"\],')
+    re_add_varname = re.compile(r'] \+ (.*),')
+
+    proto_libraries = []
+
+    basedir = os.path.dirname(filename)
+    proto_library = None
+    
+    def parsing_sources(line):
+        proto_path = os.path.relpath(os.path.join(basedir, line.strip(",").strip("\"")), source_folder)
+        proto_library.srcs.append(proto_path)
+
+    def parsing_deps(line):
+        line = line.strip(",").strip("\"")
+        if line.startswith("@com_google_protobuf//:"):
+            proto_library.deps.add("protobuf::libprotobuf")
+        elif line.startswith("@com_google_googleapis//"):
+            proto_library.deps.add(line[len("@com_google_googleapis"):])
+        elif line.startswith(":"):
+            proto_library.deps.add(f"//{os.path.relpath(basedir, source_folder)}{line}")
+        elif line.startswith("//google/"):
+            proto_library.deps.add(line)
+        elif line.startswith("//grafeas/"):
+            proto_library.deps.add(line)
+        else:
+            error(f"Unrecognized dep: {line} -- {os.path.relpath(filename, source_folder)}")
+
+    def collecting_items(collection, line):
+        line = line.strip(",").strip("\"")
+        collection.append(line)
+
+    with open(filename, 'r') as f:
+        action = None
+        parsing_variable = None
+        variables = {}
+        for line in f.readlines():
+            line = line.strip()
+            
+            if line == "proto_library(":
+                assert proto_library == None
+                proto_library = _ProtoLibrary()
+            elif line == '_PROTO_SUBPACKAGE_DEPS = [':
+                variables["_PROTO_SUBPACKAGE_DEPS"] = []
+                parsing_variable = lambda u: collecting_items(variables["_PROTO_SUBPACKAGE_DEPS"], u)
+            elif parsing_variable != None:
+                if line == "]":
+                    parsing_variable = None
+                else:
+                    parsing_variable(line)
+            elif proto_library != None:
+                if line.startswith("name ="):
+                    proto_library.name = re_name.search(line).group(1)
+                    proto_library.qname = f"//{os.path.relpath(basedir, source_folder)}"
+                elif line.startswith("srcs = "):
+                    m = re_srcs_oneline.search(line)
+                    if m:
+                        parsing_sources(m.group(1))
+                    else:
+                        action = parsing_sources
+                elif line.startswith("deps = "):
+                    m = re_deps_oneline.search(line)
+                    if m:
+                        parsing_deps(m.group(1))
+                    else:
+                        action = parsing_deps
+                elif line.startswith("visibility = "):
+                    pass
+                elif line == ")":
+                    proto_libraries.append(proto_library)
+                    proto_library = None
+                    action = None
+                elif line == "],":
+                    action = None 
+                elif line.startswith("] + "):
+                    varname = re_add_varname.search(line).group(1)
+                    for it in variables[varname]:
+                        action(it) 
+                elif action:
+                    action(line)
+
+    return proto_libraries

--- a/recipes/googleapis/all/helpers.py
+++ b/recipes/googleapis/all/helpers.py
@@ -88,6 +88,7 @@ def parse_proto_libraries(filename, source_folder, error):
     proto_libraries = []
 
     basedir = os.path.dirname(filename)
+    current_folder_str = os.path.relpath(basedir, source_folder).replace('\\', '/')  # We need forward slashes because of Windows
     proto_library = None
     
     def parsing_sources(line):
@@ -101,7 +102,7 @@ def parse_proto_libraries(filename, source_folder, error):
         elif line.startswith("@com_google_googleapis//"):
             proto_library.deps.add(line[len("@com_google_googleapis"):])
         elif line.startswith(":"):
-            proto_library.deps.add(f"//{os.path.relpath(basedir, source_folder).replace('\\', '/')}{line}")
+            proto_library.deps.add(f"//{current_folder_str}{line}")
         elif line.startswith("//google/"):
             proto_library.deps.add(line)
         elif line.startswith("//grafeas/"):
@@ -137,7 +138,7 @@ def parse_proto_libraries(filename, source_folder, error):
             elif proto_library != None:
                 if line.startswith("name ="):
                     proto_library.name = re_name.search(line).group(1)
-                    proto_library.qname = f"//{os.path.relpath(basedir, source_folder).replace('\\', '/')}"
+                    proto_library.qname = f"//{current_folder_str}"
                 elif line.startswith("srcs = "):
                     m = re_srcs_oneline.search(line)
                     if m:

--- a/recipes/googleapis/all/helpers.py
+++ b/recipes/googleapis/all/helpers.py
@@ -36,13 +36,16 @@ class _ProtoLibrary:
 
     @property
     def cmake_target(self):
-        return f'{self.qname.replace("/", "_")}_{self.name}'
+        qname = self.qname
+        if self.qname.startswith("//"):
+            qname = qname[2:]
+        return f'{qname.replace("/", "_")}_{self.name}'
 
     @property
     def cmake_deps(self):
         def to_cmake_target(item):
             if item.startswith("//"):
-                return item.replace("/", "_").replace(":", "_")
+                return item[2:].replace("/", "_").replace(":", "_")
             return item
         return [to_cmake_target(it) for it in self.deps]
 

--- a/recipes/googleapis/all/helpers.py
+++ b/recipes/googleapis/all/helpers.py
@@ -92,7 +92,7 @@ def parse_proto_libraries(filename, source_folder, error):
     proto_library = None
     
     def parsing_sources(line):
-        proto_path = os.path.relpath(os.path.join(basedir, line.strip(",").strip("\"")), source_folder)
+        proto_path = os.path.relpath(os.path.join(basedir, line.strip(",").strip("\"")), source_folder).replace('\\', '/')
         proto_library.srcs.append(proto_path)
 
     def parsing_deps(line):

--- a/recipes/googleapis/all/helpers.py
+++ b/recipes/googleapis/all/helpers.py
@@ -101,7 +101,7 @@ def parse_proto_libraries(filename, source_folder, error):
         elif line.startswith("@com_google_googleapis//"):
             proto_library.deps.add(line[len("@com_google_googleapis"):])
         elif line.startswith(":"):
-            proto_library.deps.add(f"//{os.path.relpath(basedir, source_folder)}{line}")
+            proto_library.deps.add(f"//{os.path.relpath(basedir, source_folder).replace('\\', '/')}{line}")
         elif line.startswith("//google/"):
             proto_library.deps.add(line)
         elif line.startswith("//grafeas/"):
@@ -137,7 +137,7 @@ def parse_proto_libraries(filename, source_folder, error):
             elif proto_library != None:
                 if line.startswith("name ="):
                     proto_library.name = re_name.search(line).group(1)
-                    proto_library.qname = f"//{os.path.relpath(basedir, source_folder)}"
+                    proto_library.qname = f"//{os.path.relpath(basedir, source_folder).replace('\\', '/')}"
                 elif line.startswith("srcs = "):
                     m = re_srcs_oneline.search(line)
                     if m:

--- a/recipes/googleapis/all/helpers.py
+++ b/recipes/googleapis/all/helpers.py
@@ -60,6 +60,7 @@ class _ProtoLibrary:
                 set({self.cmake_target}_PROTOS {" ".join(["${CMAKE_SOURCE_DIR}/"+it for it in self.srcs])})
                 add_library({self.cmake_target} ${{{self.cmake_target}_PROTOS}})
                 target_include_directories({self.cmake_target} PUBLIC ${{CMAKE_BINARY_DIR}})
+                target_compile_features({self.cmake_target} PUBLIC cxx_std_11)
                 protobuf_generate(LANGUAGE cpp 
                                 TARGET {self.cmake_target} 
                                 PROTOS ${{{self.cmake_target}_PROTOS}}

--- a/recipes/googleapis/all/test_package/CMakeLists.txt
+++ b/recipes/googleapis/all/test_package/CMakeLists.txt
@@ -4,16 +4,7 @@ project(test_package CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(protobuf REQUIRED CONFIG)
+find_package(googleapis REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE protobuf::protobuf)
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
-
-message("GOOGLEAPIS_RES_DIR -- ${GOOGLEAPIS_RES_DIR}")
-protobuf_generate(
-    LANGUAGE cpp 
-    TARGET ${PROJECT_NAME} 
-    PROTOS ${GOOGLEAPIS_RES_DIR}/google/type/color.proto
-    IMPORT_DIRS ${GOOGLEAPIS_RES_DIR})
+target_link_libraries(${PROJECT_NAME} PRIVATE googleapis::googleapis)

--- a/recipes/googleapis/all/test_package/conanfile.py
+++ b/recipes/googleapis/all/test_package/conanfile.py
@@ -10,15 +10,10 @@ class TestPackageConan(ConanFile):
     generators = "CMakeDeps", "VirtualRunEnv"
 
     def requirements(self):
-        self.requires("protobuf/3.21.1")
         self.requires(self.tested_reference_str)
-
-    def build_requirements(self):
-        self.tool_requires("protobuf/3.21.1")
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["GOOGLEAPIS_RES_DIR"] = self.dependencies["googleapis"].cpp_info.resdirs[0].replace("\\", "/")
         tc.generate()
 
     def layout(self):

--- a/recipes/googleapis/config.yml
+++ b/recipes/googleapis/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20220711":
+    folder: all
   "cci.20220531":
     folder: all
   "cci.20210730":


### PR DESCRIPTION
I found myself trapped here (https://github.com/conan-io/conan-center-index/pull/11624#issuecomment-1181555046), it was not possible to use different versions of `googleapis` for different versions of `google-cloud-cpp` libraries because of the different package id computed for `grpc` after the override. 

One alternative would be to heavily patch the build-system files of `google-cloud-cpp` to work with any version of `googleapis` (and keep building the protos inside), alternatively, we can keep patching the `google-cloud-cpp` but to use precompiled binaries of `googleapis`.

The second approach is probably more sound (and CC-friendly) as both libraries `grpc` and `google-cloud-cpp` can link to the same binaries (instead of building the same protos twice) and probably the ABI of `googleapis` is more compatible than the build-system files that are hardcoded in `google-cloud-cpp` ([these files depend on the protos](https://github.com/googleapis/google-cloud-cpp/tree/main/external/googleapis/protolists))

---

**Here I'm making a proposal, probably someone has a better idea (and less hacky).**

PS1.- Tried using Bazel, but I feel like entering the rabbit hole... maybe someone with more experience using it...

--- 

Some TODOs:

- [x] Use stricter pkg-id mode for `protobuf`