### PR TITLE
openssl - remove old versions

### DIFF
--- a/recipes/openssl/1.x.x/conandata.yml
+++ b/recipes/openssl/1.x.x/conandata.yml
@@ -1,105 +1,15 @@
 sources:
-  1.0.2s:
-    sha256: cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96
-    url: [
-      "https://www.openssl.org/source/openssl-1.0.2s.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.0.2s.tar.gz"
-    ]
-  1.0.2t:
-    sha256: 14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc
-    url: [
-      "https://www.openssl.org/source/openssl-1.0.2t.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.0.2t.tar.gz"
-    ]
   1.0.2u:
     sha256: ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
     url: [
       "https://www.openssl.org/source/openssl-1.0.2u.tar.gz",
       "https://www.openssl.org/source/old/openssl-1.0.2u.tar.gz"
     ]
-  1.1.0k:
-    sha256: efa4965f4f773574d6cbda1cf874dbbe455ab1c0d4f906115f867d30444470b1
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.0k.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.0k.tar.gz"
-    ]
   1.1.0l:
     sha256: 74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148
     url: [
       "https://www.openssl.org/source/openssl-1.1.0l.tar.gz",
       "https://www.openssl.org/source/old/openssl-1.1.0l.tar.gz"
-    ]
-  1.1.1c:
-    sha256: f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1c.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1c.tar.gz"
-    ]
-  1.1.1d:
-    sha256: 1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1d.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1d.tar.gz"
-    ]
-  1.1.1e:
-    sha256: 694f61ac11cb51c9bf73f54e771ff6022b0327a43bbdfa1b2f19de1662a6dcbe
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1e.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1e.tar.gz"
-    ]
-  1.1.1f:
-    sha256: 186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1f.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1f.tar.gz"
-    ]
-  1.1.1g:
-    sha256: ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1g.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1g.tar.gz"
-    ]
-  1.1.1h:
-    sha256: 5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1h.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1h.tar.gz"
-    ]
-  1.1.1i:
-    sha256: e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1i.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1i.tar.gz"
-    ]
-  1.1.1j:
-    sha256: aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1j.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1j.tar.gz"
-    ]
-  1.1.1k:
-    sha256: 892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1k.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1k.tar.gz"
-    ]
-  1.1.1l:
-    sha256: 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1l.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1l.tar.gz"
-    ]
-  1.1.1m:
-    sha256: f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1m.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1m.tar.gz"
-    ]
-  1.1.1n:
-    sha256: 40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a
-    url: [
-      "https://www.openssl.org/source/openssl-1.1.1n.tar.gz",
-      "https://www.openssl.org/source/old/openssl-1.1.1n.tar.gz"
     ]
   1.1.1o:
     sha256: 9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f
@@ -120,38 +30,8 @@ sources:
       "https://www.openssl.org/source/old/openssl-1.1.1q.tar.gz"
     ]
 patches:
-  1.0.2s:
-    - patch_file: patches/1.0.2u-darwin-arm64.patch
-      base_path: source_subfolder
-  1.0.2t:
-    - patch_file: patches/1.0.2u-darwin-arm64.patch
-      base_path: source_subfolder
   1.0.2u:
     - patch_file: patches/1.0.2u-darwin-arm64.patch
-      base_path: source_subfolder
-  1.1.1g:
-    - patch_file: patches/1.1.1-tvos-watchos.patch
-      base_path: source_subfolder
-  1.1.1h:
-    - patch_file: patches/1.1.1-tvos-watchos.patch
-      base_path: source_subfolder
-  1.1.1i:
-    - patch_file: patches/1.1.1-tvos-watchos.patch
-      base_path: source_subfolder
-  1.1.1j:
-    - patch_file: patches/1.1.1-tvos-watchos.patch
-      base_path: source_subfolder
-  1.1.1k:
-    - patch_file: patches/1.1.1-tvos-watchos.patch
-      base_path: source_subfolder
-  1.1.1l:
-    - patch_file: patches/1.1.1-tvos-watchos.patch
-      base_path: source_subfolder
-  1.1.1m:
-    - patch_file: patches/1.1.1-tvos-watchos.patch
-      base_path: source_subfolder
-  1.1.1n:
-    - patch_file: patches/1.1.1-tvos-watchos.patch
       base_path: source_subfolder
   1.1.1o:
     - patch_file: patches/1.1.1-tvos-watchos.patch

--- a/recipes/openssl/3.x.x/conandata.yml
+++ b/recipes/openssl/3.x.x/conandata.yml
@@ -8,12 +8,3 @@ sources:
   3.0.3:
     url: https://www.openssl.org/source/openssl-3.0.3.tar.gz
     sha256: ee0078adcef1de5f003c62c80cc96527721609c6f3bb42b7795df31f8b558c0b
-  3.0.2:
-    url: "https://www.openssl.org/source/openssl-3.0.2.tar.gz"
-    sha256: "98e91ccead4d4756ae3c9cde5e09191a8e586d9f4d50838e7ec09d6411dfdb63"
-  3.0.1:
-    url: "https://www.openssl.org/source/openssl-3.0.1.tar.gz"
-    sha256: "c311ad853353bce796edad01a862c50a8a587f62e7e2100ef465ab53ec9b06d1"
-  3.0.0:
-    url: "https://www.openssl.org/source/openssl-3.0.0.tar.gz"
-    sha256: "59eedfcb46c25214c9bd37ed6078297b4df01d012267fe9e9eee31f61bc70536"

--- a/recipes/openssl/config.yml
+++ b/recipes/openssl/config.yml
@@ -6,12 +6,7 @@ versions:
     folder: "3.x.x"
   3.0.3:
     folder: "3.x.x"
-  3.0.2:
-    folder: "3.x.x"
-  3.0.1:
-    folder: "3.x.x"
-  3.0.0:
-    folder: "3.x.x"
+
   # 1.1.1x releases
   1.1.1q:
     folder: "1.x.x"
@@ -19,39 +14,9 @@ versions:
     folder: "1.x.x"
   1.1.1o:
     folder: "1.x.x"
-  1.1.1n:
-    folder: "1.x.x"
-  1.1.1m:
-    folder: "1.x.x"
-  1.1.1l:
-    folder: "1.x.x"
-  1.1.1k:
-    folder: "1.x.x"
-  1.1.1j:
-    folder: "1.x.x"
-  1.1.1i:
-    folder: "1.x.x"
-  1.1.1h:
-    folder: "1.x.x"
-  1.1.1g:
-    folder: "1.x.x"
-  1.1.1f:
-    folder: "1.x.x"
-  1.1.1e:
-    folder: "1.x.x"
-  1.1.1d:
-    folder: "1.x.x"
-  1.1.1c:
-    folder: "1.x.x"
   # 1.1.0x releases
   1.1.0l:
     folder: "1.x.x"
-  1.1.0k:
-    folder: "1.x.x"
   # 1.0.2x releases
   1.0.2u:
-    folder: "1.x.x"
-  1.0.2t:
-    folder: "1.x.x"
-  1.0.2s:
     folder: "1.x.x"


### PR DESCRIPTION
Remove old `openssl` versions. If some version is _important_ for whatever reason, please share it here. Thanks!