### PR TITLE
bitmagic: add version 7.12.3

### DIFF
--- a/recipes/bitmagic/all/conandata.yml
+++ b/recipes/bitmagic/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.12.3":
+    url: "https://github.com/tlk00/BitMagic/archive/refs/tags/v7.12.3.tar.gz"
+    sha256: "5e59507a01a8295bb57aebcf557a4a25b992244736f7924300cdb9635f1b2780"
   "7.11.2":
     url: "https://github.com/tlk00/BitMagic/archive/refs/tags/v7.11.2.tar.gz"
     sha256: "09faf5b9da4e0cee4947e05b7af0bd834e63e90c8877c115b719b4f390709a6f"
@@ -20,9 +23,3 @@ sources:
   "7.5.0":
     url: "https://github.com/tlk00/BitMagic/archive/refs/tags/v7.5.0.tar.gz"
     sha256: "dec7d316baf3be9cb058d9da302a7e4cb694ac429d4bd29138c24b1b0157a9e8"
-  "7.4.0":
-    url: "https://github.com/tlk00/BitMagic/archive/refs/tags/v7.4.0.tar.gz"
-    sha256: "80304bcfde1f263b2a680f6cf7b22aa72c757d7214688ec74de626778d332fb9"
-  "7.3.1":
-    url: "https://github.com/tlk00/BitMagic/archive/refs/tags/v7.3.1.tar.gz"
-    sha256: "a45a764c3519d64afdc734a6606645007e102aef799390a36426d2dc77919303"

--- a/recipes/bitmagic/all/conanfile.py
+++ b/recipes/bitmagic/all/conanfile.py
@@ -11,26 +11,23 @@ class BitmagicConan(ConanFile):
                   "promote combination of hardware optimizations and on the fly compression to fit " \
                   "inverted indexes and binary fingerprints into memory, minimize disk and network footprint."
     license = "Apache-2.0"
-    topics = ("bitmagic", "information-retrieval", "algorithm", "bit-manipulation",
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://bitmagic.io"
+    topics = ("information-retrieval", "algorithm", "bit-manipulation",
               "integer-compression", "sparse-vector", "sparse-matrix", "bit-array",
               "bit-vector", "indexing-engine", "adjacency-matrix", "associative-array")
-    homepage = "http://bitmagic.io"
-    url = "https://github.com/conan-io/conan-center-index"
-    settings = "compiler"
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
+    def package_id(self):
+        self.info.header_only()
+
     def _minimum_compilers_version(self, cppstd):
         standards = {
-            "11": {
-                "Visual Studio": "15",
-                "gcc": "4.8",
-                "clang": "4",
-                "apple-clang": "9",
-            },
             "17": {
                 "Visual Studio": "16",
                 "gcc": "7",
@@ -42,7 +39,7 @@ class BitmagicConan(ConanFile):
 
     @property
     def _cppstd(self):
-        return "11" if tools.Version(self.version) < "7.5.0" else "17"
+        return "17"
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -54,9 +51,6 @@ class BitmagicConan(ConanFile):
                 raise ConanInvalidConfiguration("{} requires C++{}, which your compiler does not support.".format(self.name, self._cppstd))
         else:
             self.output.warn("{0} requires C++{1}. Your compiler is unknown. Assuming it supports C++{1}.".format(self.name, self._cppstd))
-
-    def package_id(self):
-        self.info.header_only()
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/bitmagic/all/test_package/CMakeLists.txt
+++ b/recipes/bitmagic/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
@@ -8,3 +8,4 @@ find_package(bitmagic REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} bitmagic::bitmagic)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/bitmagic/config.yml
+++ b/recipes/bitmagic/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.12.3":
+    folder: all
   "7.11.2":
     folder: all
   "7.10.3":
@@ -12,8 +14,4 @@ versions:
   "7.6.0":
     folder: all
   "7.5.0":
-    folder: all
-  "7.4.0":
-    folder: all
-  "7.3.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **bitmagic/7.12.3**

- add version 7.12.3
- remove version 7.3.1, 7.4.0
- remove condition for C++11 (because bitmagic supports C++17 since 7.5.0)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
