### PR TITLE
redboltz-mqtt_cpp: add recipe

### DIFF
--- a/recipes/redboltz-mqtt_cpp/all/conandata.yml
+++ b/recipes/redboltz-mqtt_cpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "13.0.0":
+    url: "https://github.com/redboltz/mqtt_cpp/archive/refs/tags/v13.0.0.tar.gz"
+    sha256: "5d06caa1218feb23d0a63892ced7b0edfd1f686002676175f6e384275a27a1e7"

--- a/recipes/redboltz-mqtt_cpp/all/conanfile.py
+++ b/recipes/redboltz-mqtt_cpp/all/conanfile.py
@@ -24,10 +24,26 @@ class MqttCPPConan(ConanFile):
     def package_id(self):
         self.info.header_only()
 
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "6",
+            "Visual Studio": "15.0",
+            "clang": "5",
+            "apple-clang": "10",
+        }
+    
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, 14)
 
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version:
+            if tools.Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration("{} requires C++14, which your compiler does not support.".format(self.name))
+        else:
+            self.output.warn("{} requires C++14. Your compiler is unknown. Assuming it supports C++14.".format(self.name))
+            
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)

--- a/recipes/redboltz-mqtt_cpp/all/conanfile.py
+++ b/recipes/redboltz-mqtt_cpp/all/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.43.0"

--- a/recipes/redboltz-mqtt_cpp/all/conanfile.py
+++ b/recipes/redboltz-mqtt_cpp/all/conanfile.py
@@ -1,0 +1,47 @@
+from conans import ConanFile, tools
+import os
+
+required_conan_version = ">=1.43.0"
+
+class MqttCPPConan(ConanFile):
+    name = "redboltz-mqtt_cpp"
+    description = "MQTT client/server for C++14 based on Boost.Asio"
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/redboltz/mqtt_cpp"
+    topics = ("mqtt", "boost", "asio")
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+    no_copy_source = True
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def requirements(self):
+        self.requires("boost/1.79.0")
+
+    def package_id(self):
+        self.info.header_only()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 14)
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "mqtt_cpp")
+        self.cpp_info.set_property("cmake_target_name", "mqtt_cpp::mqtt_cpp")
+
+        #  TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "mqtt_cpp"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "mqtt_cpp"
+        self.cpp_info.names["cmake_find_package"] = "mqtt_cpp"
+        self.cpp_info.names["cmake_find_package_multi"] = "mqtt_cpp"

--- a/recipes/redboltz-mqtt_cpp/all/conanfile.py
+++ b/recipes/redboltz-mqtt_cpp/all/conanfile.py
@@ -33,7 +33,7 @@ class MqttCPPConan(ConanFile):
                   destination=self._source_subfolder, strip_root=True)
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="LICENSE_1_0.txt", dst="licenses", src=self._source_subfolder)
         self.copy(pattern="*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
 
     def package_info(self):

--- a/recipes/redboltz-mqtt_cpp/all/test_package/CMakeLists.txt
+++ b/recipes/redboltz-mqtt_cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(mqtt_cpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} mqtt_cpp::mqtt_cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/redboltz-mqtt_cpp/all/test_package/conanfile.py
+++ b/recipes/redboltz-mqtt_cpp/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/redboltz-mqtt_cpp/all/test_package/test_package.cpp
+++ b/recipes/redboltz-mqtt_cpp/all/test_package/test_package.cpp
@@ -1,0 +1,14 @@
+#include <mqtt_client_cpp.hpp>
+
+int main() {
+    MQTT_NS::setup_log();
+
+    boost::asio::io_context ioc;
+
+    auto c = MQTT_NS::make_async_client(ioc, "localhost", "40000");
+    
+    c->set_client_id("test_package");
+    c->set_clean_session(true);
+
+    return 0;
+}

--- a/recipes/redboltz-mqtt_cpp/config.yml
+++ b/recipes/redboltz-mqtt_cpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "13.0.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **redboltz-mqtt_cpp/13.0.0**

There is "paho-mqtt-cpp" in cci recipes.
So I think this recipe's name should have a prefix, "redboltz".

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
