### PR TITLE
skyr-url: support shared build and gcc in 1.13.0

### DIFF
--- a/recipes/skyr-url/all/CMakeLists.txt
+++ b/recipes/skyr-url/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.4)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)

--- a/recipes/skyr-url/all/CMakeLists.txt
+++ b/recipes/skyr-url/all/CMakeLists.txt
@@ -4,4 +4,6 @@ project(cmake_wrapper)
 include(conanbuildinfo.cmake)
 conan_basic_setup()
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 add_subdirectory("source_subfolder")

--- a/recipes/skyr-url/all/conandata.yml
+++ b/recipes/skyr-url/all/conandata.yml
@@ -5,3 +5,11 @@ sources:
   "1.12.0":
     url: "https://github.com/cpp-netlib/url/archive/v1.12.0.tar.gz"
     sha256: "42ede3666a4c40828aa74e4b35bf43dfc79de9329e6463ff90f9bb727b3a06f0"
+
+patches:
+  "1.13.0":
+    - patch_file: "patches/1.13.0-0001-fix-cmake.patch"
+      base_path: "source_subfolder"
+  "1.12.0":
+    - patch_file: "patches/1.12.0-0001-fix-cmake.patch"
+      base_path: "source_subfolder"

--- a/recipes/skyr-url/all/conandata.yml
+++ b/recipes/skyr-url/all/conandata.yml
@@ -3,5 +3,5 @@ sources:
     url: "https://github.com/cpp-netlib/url/archive/v1.13.0.tar.gz"
     sha256: "0c9e594f09a9abda5815b07b548ac520b2fc1044fc74b589fc4c5bd18ea4330c"
   "1.12.0":
-    url: https://github.com/cpp-netlib/url/archive/v1.12.0.tar.gz
-    sha256: 42ede3666a4c40828aa74e4b35bf43dfc79de9329e6463ff90f9bb727b3a06f0
+    url: "https://github.com/cpp-netlib/url/archive/v1.12.0.tar.gz"
+    sha256: "42ede3666a4c40828aa74e4b35bf43dfc79de9329e6463ff90f9bb727b3a06f0"

--- a/recipes/skyr-url/all/conanfile.py
+++ b/recipes/skyr-url/all/conanfile.py
@@ -1,20 +1,31 @@
 from conans import ConanFile, tools, CMake
 from conans.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc
 import os
+import functools
 
-required_conan_version = ">=1.28.0"
+required_conan_version = ">=1.45.0"
 
 class SkyrUrlConan(ConanFile):
     name = "skyr-url"
-    homepage = "https://cpp-netlib.github.io/url"
     description = "A C++ library that implements the WhatWG URL specification"
-    topics = ("conan", "whatwg", "url", "parser")
-    url = "https://github.com/conan-io/conan-center-index"
     license = "BSL-1.0"
-    settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False], "with_json": [True, False], "with_fs": [True, False]}
-    default_options = {"shared": False, "fPIC": True, "with_json": True, "with_fs": True}
-    exports_sources = "CMakeLists.txt"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://cpp-netlib.github.io/url"
+    topics = ("whatwg", "url", "parser")
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_json": [True, False],
+        "with_fs": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_json": True,
+        "with_fs": True,
+    }
     generators = "cmake", "cmake_find_package_multi"
     _cmake = None
 
@@ -40,12 +51,19 @@ class SkyrUrlConan(ConanFile):
             "apple-clang": "10",
         }
 
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
-        if self.settings.get_safe("compiler.cppstd"):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
             tools.check_min_cppstd(self, self._minimum_cpp_standard)
         min_version = self._minimum_compilers_version.get(str(self.settings.compiler))
         if not min_version:
@@ -59,40 +77,36 @@ class SkyrUrlConan(ConanFile):
         if self.options.with_fs and self.settings.compiler == "apple-clang":
             raise ConanInvalidConfiguration("apple-clang currently does not support with filesystem")
 
-        if self.options.shared:
-            # https://github.com/cpp-netlib/url/blob/dd345361ed86e4c1cabfe94743a8e769b346840c/src/CMakeLists.txt#L17
-            raise ConanInvalidConfiguration("shared is currently not supported by upstream")
-
-        if tools.Version(self.version) >= "1.13.0" and not self.settings.compiler == "Visual Studio":
-            # There's tedious compilation errors in C3i against ranges-v3
-            raise ConanInvalidConfiguration("{}/{} with {} is currently not supported".format(self.name, self.version, self.settings.compiler))
-
     def requirements(self):
         self.requires("tl-expected/1.0.0")
-        self.requires("range-v3/0.11.0")
+        self.requires("range-v3/0.12.0")
         if self.options.with_json:
-            self.requires("nlohmann_json/3.9.1")
+            self.requires("nlohmann_json/3.10.5")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "url-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["skyr_BUILD_TESTS"] = False
-        self._cmake.definitions["skyr_FULL_WARNINGS"] = False
-        self._cmake.definitions["skyr_WARNINGS_AS_ERRORS"] = False
-        self._cmake.definitions["skyr_ENABLE_JSON_FUNCTIONS"] = self.options.with_json
-        self._cmake.definitions["skyr_ENABLE_FILESYSTEM_FUNCTIONS"] = self.options.with_fs
-        if self.settings.compiler == "Visual Studio":
-            self._cmake.definitions["skyr_USE_STATIC_CRT"] = "MT" in self.settings.compiler.runtime
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        cmake = CMake(self)
+        cmake.definitions["skyr_BUILD_TESTS"] = False
+        cmake.definitions["skyr_FULL_WARNINGS"] = False
+        cmake.definitions["skyr_WARNINGS_AS_ERRORS"] = False
+        cmake.definitions["skyr_ENABLE_JSON_FUNCTIONS"] = self.options.with_json
+        cmake.definitions["skyr_ENABLE_FILESYSTEM_FUNCTIONS"] = self.options.with_fs
+        if is_msvc(self):
+            cmake.definitions["skyr_USE_STATIC_CRT"] = "MT" in self.settings.compiler.runtime
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
 
     def build(self):
+        tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
+            "add_library(skyr-url STATIC)",
+            "add_library(skyr-url)")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
+            "        range-v3",
+            "        range-v3::range-v3")
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/skyr-url/all/conanfile.py
+++ b/recipes/skyr-url/all/conanfile.py
@@ -100,7 +100,7 @@ class SkyrUrlConan(ConanFile):
         cmake.definitions["skyr_ENABLE_JSON_FUNCTIONS"] = self.options.with_json
         cmake.definitions["skyr_ENABLE_FILESYSTEM_FUNCTIONS"] = self.options.with_fs
         if is_msvc(self):
-            cmake.definitions["skyr_USE_STATIC_CRT"] = "MT" in self.settings.compiler.runtime
+            cmake.definitions["skyr_USE_STATIC_CRT"] = is_msvc_static_runtime(self)
         cmake.configure(build_folder=self._build_subfolder)
         return cmake
 

--- a/recipes/skyr-url/all/conanfile.py
+++ b/recipes/skyr-url/all/conanfile.py
@@ -76,6 +76,8 @@ class SkyrUrlConan(ConanFile):
 
         if self.options.with_fs and self.settings.compiler == "apple-clang":
             raise ConanInvalidConfiguration("apple-clang currently does not support with filesystem")
+        if self.settings.compiler.get_safe("libcxx") == "libstdc++":
+            raise ConanInvalidConfiguration("{} supports only libstdc++'s new ABI".format(self.name))
 
     def requirements(self):
         self.requires("tl-expected/1.0.0")

--- a/recipes/skyr-url/all/conanfile.py
+++ b/recipes/skyr-url/all/conanfile.py
@@ -117,12 +117,18 @@ class SkyrUrlConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.filenames["cmake_find_package"] = "skyr-url"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "skyr-url"
-        self.cpp_info.names["cmake_find_package"] = "skyr"
-        self.cpp_info.names["cmake_find_package_multi"] = "skyr"
+        self.cpp_info.set_property("cmake_file_name", "skyr-url")
+        self.cpp_info.set_property("cmake_target_name", "skyr::skyr-url")
+
         self.cpp_info.components["url"].name = "skyr-url"
         self.cpp_info.components["url"].libs = tools.collect_libs(self)
         self.cpp_info.components["url"].requires = ["tl-expected::tl-expected", "range-v3::range-v3"]
         if self.options.with_json:
             self.cpp_info.components["url"].requires.append("nlohmann_json::nlohmann_json")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["url"].system_libs.append("m")
+
+        self.cpp_info.filenames["cmake_find_package"] = "skyr-url"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "skyr-url"
+        self.cpp_info.names["cmake_find_package"] = "skyr"
+        self.cpp_info.names["cmake_find_package_multi"] = "skyr"

--- a/recipes/skyr-url/all/conanfile.py
+++ b/recipes/skyr-url/all/conanfile.py
@@ -53,6 +53,8 @@ class SkyrUrlConan(ConanFile):
 
     def export_sources(self):
         self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -103,12 +105,8 @@ class SkyrUrlConan(ConanFile):
         return cmake
 
     def build(self):
-        tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
-            "add_library(skyr-url STATIC)",
-            "add_library(skyr-url)")
-        tools.replace_in_file(os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
-            "        range-v3",
-            "        range-v3::range-v3")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 
@@ -125,6 +123,6 @@ class SkyrUrlConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "skyr"
         self.cpp_info.components["url"].name = "skyr-url"
         self.cpp_info.components["url"].libs = tools.collect_libs(self)
-        self.cpp_info.components["url"].requires = ["tl-expected::tl-expected", "range-v3::range-v3" ]
+        self.cpp_info.components["url"].requires = ["tl-expected::tl-expected", "range-v3::range-v3"]
         if self.options.with_json:
             self.cpp_info.components["url"].requires.append("nlohmann_json::nlohmann_json")

--- a/recipes/skyr-url/all/conanfile.py
+++ b/recipes/skyr-url/all/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, tools, CMake
 from conans.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import is_msvc
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 import os
 import functools
 

--- a/recipes/skyr-url/all/patches/1.12.0-0001-fix-cmake.patch
+++ b/recipes/skyr-url/all/patches/1.12.0-0001-fix-cmake.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 835d112..712a288 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -101,8 +101,9 @@ endif()
+ install(TARGETS ${skyr_TARGETS}
+         EXPORT ${PROJECT_NAME}-targets
+         INCLUDES DESTINATION "${CMAKE_INSTALL_DATADIR}"
+-        ARCHIVE DESTINATION lib
+-        LIBRARY DESTINATION lib)
++        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
+ install(EXPORT ${PROJECT_NAME}-targets
+         DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}"
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 887d312..9db70d7 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -14,7 +14,7 @@ configure_file(
+ # skyr-url
+ #################################################
+ 
+-add_library(skyr-url STATIC)
++add_library(skyr-url)
+ 
+ target_sources(skyr-url
+     PRIVATE
+@@ -138,7 +138,7 @@ target_link_libraries(
+         skyr-url
+         PUBLIC
+         tl::expected
+-        range-v3
++        range-v3::range-v3
+         PRIVATE
+         $<${libcxx}:c++>
+ )

--- a/recipes/skyr-url/all/patches/1.13.0-0001-fix-cmake.patch
+++ b/recipes/skyr-url/all/patches/1.13.0-0001-fix-cmake.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b63ddc2..c87ced9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -101,8 +101,9 @@ endif()
+ install(TARGETS ${skyr_TARGETS}
+         EXPORT ${PROJECT_NAME}-targets
+         INCLUDES DESTINATION "${CMAKE_INSTALL_DATADIR}"
+-        ARCHIVE DESTINATION lib
+-        LIBRARY DESTINATION lib)
++        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
+ install(EXPORT ${PROJECT_NAME}-targets
+         DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}"
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 1bb02fa..f21f2c3 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -14,7 +14,7 @@ configure_file(
+ # skyr-url
+ #################################################
+ 
+-add_library(skyr-url STATIC)
++add_library(skyr-url)
+ 
+ target_sources(skyr-url
+     PRIVATE
+@@ -136,7 +136,7 @@ target_link_libraries(
+         skyr-url
+         PUBLIC
+         tl::expected
+-        range-v3
++        range-v3::range-v3
+         PRIVATE
+         $<${libcxx}:c++>
+ )

--- a/recipes/skyr-url/all/test_package/CMakeLists.txt
+++ b/recipes/skyr-url/all/test_package/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(skyr-url CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} skyr::skyr-url)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/skyr-url/all/test_package/conanfile.py
+++ b/recipes/skyr-url/all/test_package/conanfile.py
@@ -3,7 +3,7 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
@@ -12,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/skyr-url/all/test_package/conanfile.py
+++ b/recipes/skyr-url/all/test_package/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conan.tools.build import cross_building
 import os
 
 
@@ -12,6 +13,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **skyr-url/***

- apply patches to CMakeLists.txt for shared build
- update dependencies
- remove gcc validation error in 1.13.0
- use `is_msvc()`
- use `lru_cache` in `_configure_cmake()`

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
