### PR TITLE
openssl: Enable valid block of options for openssl >= 1.1.0

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -178,12 +178,6 @@ class OpenSSLConan(ConanFile):
             self.copy(patch["patch_file"])
 
     def config_options(self):
-        if self._full_version >= "1.1.0":
-            del self.options.no_md2
-            del self.options.no_rc4
-            del self.options.no_rc5
-            del self.options.no_zlib
-
         if self._full_version < "1.1.0":
             del self.options.no_camellia
             del self.options.no_cast

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -1,3 +1,4 @@
+from conan.tools.build import cross_building
 from conan.tools.files import rename
 from conan.tools.microsoft import is_msvc, msvc_runtime_flag
 from conans.errors import ConanInvalidConfiguration
@@ -171,7 +172,7 @@ class OpenSSLConan(ConanFile):
     def _win_bash(self):
         return self._settings_build.os == "Windows" and \
                not self._use_nmake and \
-               (self._is_mingw or tools.cross_building(self, skip_x64_x86=True))
+               (self._is_mingw or cross_building(self, skip_x64_x86=True))
 
     def export_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -1,3 +1,4 @@
+from conan.tools.build import cross_building
 from conan.tools.files import rename
 from conan.tools.microsoft import is_msvc, msvc_runtime_flag
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
@@ -612,7 +613,7 @@ class OpenSSLConan(ConanFile):
     def _win_bash(self):
         return self._settings_build.os == "Windows" and \
                not self._use_nmake and \
-            (self._is_mingw or tools.cross_building(self, skip_x64_x86=True))
+            (self._is_mingw or cross_building(self, skip_x64_x86=True))
 
     @property
     def _make_program(self):


### PR DESCRIPTION
The options zlib, rc4, rc5, and md2 have been deleted since commit fdc5ed56acf3 for versions != 1.0.2 and in a later commit for versions >= 1.1.0. Commit e3603397c434 introduced 3.x.x/conanfile.py where these options were no longer deleted. This means the options were only deleted for openssl >= 1.1.0 and openssl < 3.0.0 and there doesn't seem to be a reason for it.

Specify library name and version:  **lib/1.1.1**

In #11439 I fixed the no_md2 option, but today I noticed the fix did not work for openssl/1.1.1 builds as the no_md2 option was deleted for openssl >= 1.1.0 and openssl < 3.0.0.

I've tested this change with this:

```
conan create . 1.1.1q@ts/test_no_md2 --build=missing --build=openssl -o openssl:shared=True -o openssl:no_md2=False -o openssl:no_rc4=True -o openssl:no_rc5=True -o openssl:no_zlib=True
```

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
