### PR TITLE
etl: add version 20.31.0

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.31.0":
+    url: "https://github.com/ETLCPP/etl/archive/20.31.0.tar.gz"
+    sha256: "1f10bbcdcc148646a4421830fbde8565403f55cd4f9a7c7047c5c085fd375fad"
   "20.30.1":
     url: "https://github.com/ETLCPP/etl/archive/20.30.1.tar.gz"
     sha256: "10b50ca3ae406ae379e85504546843fc9d97be18924e71d8eb7e8e5a418e91cd"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.31.0":
+    folder: all
   "20.30.1":
     folder: all
   "20.29.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **etl/20.31.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
