### PR TITLE
pybind11: add version 2.10.0

### DIFF
--- a/recipes/pybind11/all/conandata.yml
+++ b/recipes/pybind11/all/conandata.yml
@@ -11,3 +11,6 @@ sources:
   2.9.2:
     url: "https://github.com/pybind/pybind11/archive/v2.9.2.tar.gz"
     sha256: "6bd528c4dbe2276635dc787b6b1f2e5316cf6b49ee3e150264e455a0d68d19c1"
+  "2.10.0":
+    url: "https://github.com/pybind/pybind11/archive/v2.10.0.tar.gz"
+    sha256: "eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec"

--- a/recipes/pybind11/config.yml
+++ b/recipes/pybind11/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "2.9.2":
     folder: all
+  "2.10.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **pybind11/2.10.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
