### PR TITLE
trantor: add version 1.5.6

### DIFF
--- a/recipes/trantor/all/conandata.yml
+++ b/recipes/trantor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.6":
+    url: "https://github.com/an-tao/trantor/archive/v1.5.6.tar.gz"
+    sha256: "827aca30e120244a8ede9d07446481328d9a3869228f01fc4978b19301d66e65"
   "1.5.5":
     url: "https://github.com/an-tao/trantor/archive/refs/tags/v1.5.5.tar.gz"
     sha256: "5a549c6efebe7ecba73a944cfba4a9713130704d4ccc82af534a2e108b9a0e71"

--- a/recipes/trantor/config.yml
+++ b/recipes/trantor/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.5.6":
+    folder: "all"
   "1.5.5":
     folder: "all"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **trantor/1.5.6**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
