### PR TITLE
wt: update dependencies and support gcc 12

### DIFF
--- a/recipes/wt/all/conandata.yml
+++ b/recipes/wt/all/conandata.yml
@@ -24,3 +24,9 @@ patches:
   "4.5.0":
     - patch_file: "patches/wt_4_5_0_gcc_11.patch"
       base_path: "source_subfolder"
+  "4.4.0":
+    - patch_file: "patches/wt_4_5_0_gcc_11.patch"
+      base_path: "source_subfolder"
+  "4.3.1":
+    - patch_file: "patches/wt_4_5_0_gcc_11.patch"
+      base_path: "source_subfolder"

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -100,17 +100,17 @@ class WtConan(ConanFile):
 
     def requirements(self):
         if tools.Version(self.version) >= "4.6.0":
-            self.requires("boost/1.78.0")
+            self.requires("boost/1.79.0")
         else:
             self.requires("boost/1.76.0")
         if self.options.connector_http:
             self.requires("zlib/1.2.12")
         if self.options.with_ssl:
-            self.requires("openssl/1.1.1n")
+            self.requires("openssl/1.1.1q")
         if self.options.get_safe("with_sqlite"):
-            self.requires("sqlite3/3.38.1")
+            self.requires("sqlite3/3.39.1")
         if self.options.get_safe("with_mysql"):
-            self.requires("libmysqlclient/8.0.25")
+            self.requires("libmysqlclient/8.0.29")
         if self.options.get_safe("with_postgres"):
             self.requires("libpq/14.2")
         if self.options.get_safe("with_mssql") and self.settings.os != "Windows":

--- a/recipes/wt/all/test_package/CMakeLists.txt
+++ b/recipes/wt/all/test_package/CMakeLists.txt
@@ -5,11 +5,11 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 
 set(WT_COMPONENTS Wt HTTP)
 set(WT_TARGETS Wt::Wt Wt::HTTP)
-if(WITH_DBO)
+if(TARGET Wt::Dbo)
     target_compile_definitions(${PROJECT_NAME} PRIVATE WITH_DBO)
     list(APPEND WT_COMPONENTS Dbo)
     list(APPEND WT_TARGETS Wt::Dbo)

--- a/recipes/wt/all/test_package/conanfile.py
+++ b/recipes/wt/all/test_package/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, CMake, tools
+from conan.tools.build import cross_building
 import os
 
 
@@ -12,7 +13,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             args = " --docroot . --http-listen http://127.0.0.1:8080"
             self.run(bin_path + args, run_environment=True)

--- a/recipes/wt/all/test_package/conanfile.py
+++ b/recipes/wt/all/test_package/conanfile.py
@@ -8,7 +8,6 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["WITH_DBO"] = self.options["wt"].with_dbo
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **wt/***

- update dependencies
- use `target_compile_features` in test_package (because gcc12 failed to compile test_package)
- use `TARGET` instead of cmake options `WITH_DBO` in test_package

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
