### PR TITLE
sdl_mixer: update openssl

### DIFF
--- a/recipes/sdl_mixer/all/conanfile.py
+++ b/recipes/sdl_mixer/all/conanfile.py
@@ -72,7 +72,7 @@ class SDLMixerConan(ConanFile):
             self.requires("ogg/1.3.5")
             self.requires("vorbis/1.3.7")
         if self.options.opus:
-            self.requires("openssl/1.1.1n")
+            self.requires("openssl/1.1.1q")
             self.requires("opus/1.3.1")
             self.requires("opusfile/0.12")
         if self.options.mikmod:


### PR DESCRIPTION
Specify library name and version:  **sdl_mixer/***

There are several updatable packages, but this recipe updates openssl only.
Other updatable packages have lots of conflict recipe which required by sdl_mixer dependant packages.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
