### PR TITLE
wayland: set components version

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -107,6 +107,7 @@ class WaylandConan(ConanFile):
 
         self.cpp_info.components["wayland-scanner"].includedirs = []
         self.cpp_info.components["wayland-scanner"].libdirs = []
+        self.cpp_info.components["wayland-scanner"].version = self.version
 
         self.cpp_info.components["wayland-scanner"].requires = ["expat::expat"]
         if self.options.enable_dtd_validation:
@@ -134,6 +135,7 @@ class WaylandConan(ConanFile):
             self.cpp_info.components["wayland-server"].resdirs = ["res"]
             if self.version >= Version("1.21.0") and self.settings.os == "Linux":
                 self.cpp_info.components["wayland-server"].system_libs += ["rt"]
+            self.cpp_info.components["wayland-server"].version = self.version
 
             # todo Remove in Conan version 1.50.0 where these are set by default for the PkgConfigDeps generator.
             self.cpp_info.components["wayland-server"].includedirs = ["include"]
@@ -155,6 +157,7 @@ class WaylandConan(ConanFile):
             self.cpp_info.components["wayland-client"].resdirs = ["res"]
             if self.version >= Version("1.21.0") and self.settings.os == "Linux":
                 self.cpp_info.components["wayland-client"].system_libs += ["rt"]
+            self.cpp_info.components["wayland-client"].version = self.version
 
             # todo Remove in Conan version 1.50.0 where these are set by default for the PkgConfigDeps generator.
             self.cpp_info.components["wayland-client"].includedirs = ["include"]
@@ -172,6 +175,7 @@ class WaylandConan(ConanFile):
             self.cpp_info.components["wayland-cursor"].set_property("pkg_config_name", "wayland-cursor")
             self.cpp_info.components["wayland-cursor"].names["pkg_config"] = "wayland-cursor"
             self.cpp_info.components["wayland-cursor"].requires = ["wayland-client"]
+            self.cpp_info.components["wayland-cursor"].version = self.version
 
             # todo Remove in Conan version 1.50.0 where these are set by default for the PkgConfigDeps generator.
             self.cpp_info.components["wayland-cursor"].includedirs = ["include"]
@@ -181,6 +185,7 @@ class WaylandConan(ConanFile):
             self.cpp_info.components["wayland-egl"].set_property("pkg_config_name", "wayland-egl")
             self.cpp_info.components["wayland-egl"].names["pkg_config"] = "wayland-egl"
             self.cpp_info.components["wayland-egl"].requires = ["wayland-client"]
+            self.cpp_info.components["wayland-egl"].version = "18.1.0"
 
             # todo Remove in Conan version 1.50.0 where these are set by default for the PkgConfigDeps generator.
             self.cpp_info.components["wayland-egl"].includedirs = ["include"]


### PR DESCRIPTION
otherwise, generated pkg_config files have `Version: None`

Specify library name and version:  **wayland/***

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
