### PR TITLE
:cat: [openssl] add some missing options

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -80,6 +80,16 @@ class OpenSSLConan(ConanFile):
         "no_ts": [True, False],
         "no_whirlpool": [True, False],
         "no_zlib": [True, False],
+        "no_afalgeng": [True, False],
+        "no_autoalginit": [True, False],
+        "no_autoerrinit": [True, False],
+        "no_ssl_trace": [True, False],
+        "no_static_engine": [True, False],
+        "no_err": [True, False],
+        "no_makedepend": [True, False],
+        "no_padlockeng": [True, False],
+        "no_ui_console": [True, False],
+        "no_uplink": [True, False],
         "openssldir": "ANY",
     }
     default_options = {key: False for key in options.keys()}


### PR DESCRIPTION
Specify library name and version:  **openssl/3.0.5**

adding some missing OpenSSL build options

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
