### PR TITLE
openmpi - more requirements

### DIFF
--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -39,8 +39,11 @@ class OpenMPIConan(ConanFile):
             raise ConanInvalidConfiguration("OpenMPI doesn't support Windows")
 
     def requirements(self):
-        # FIXME : self.requires("libevent/2.1.12") - try to use libevent from conan
+        self.requires("libevent/2.1.12")
         self.requires("zlib/1.2.11")
+        # used for hwloc component...
+        self.requires("libudev/system")
+        self.requires("libpciaccess/0.16")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
@@ -84,7 +87,7 @@ class OpenMPIConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ['mpi', 'open-rte', 'open-pal']
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs = ["dl", "pthread", "rt", "util", "udev", "pciaccess"]
+            self.cpp_info.system_libs = ["m", "dl", "pthread", "rt", "util"]
 
         self.output.info("Creating MPI_HOME environment variable: {}".format(self.package_folder))
         self.env_info.MPI_HOME = self.package_folder

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -84,7 +84,7 @@ class OpenMPIConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ['mpi', 'open-rte', 'open-pal']
         if self.settings.os == "Linux":
-            self.cpp_info.system_libs = ["dl", "pthread", "rt", "util"]
+            self.cpp_info.system_libs = ["dl", "pthread", "rt", "util", "udev", "pciaccess"]
 
         self.output.info("Creating MPI_HOME environment variable: {}".format(self.package_folder))
         self.env_info.MPI_HOME = self.package_folder

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -41,7 +41,16 @@ class OpenMPIConan(ConanFile):
             raise ConanInvalidConfiguration("OpenMPI doesn't support Windows")
 
     def requirements(self):
-        self.requires("libevent/2.1.12")
+        # TODO FIX :
+        #  OpenMPI will compile with this, but,
+        #  hdf5 (as a consumer) wont compile with this enabled,
+        #   find_package(MPI) fails, probably because the configure test
+        #   tries to link to the mpi libs, but probably doesn't also
+        #   link in the required libevent libraries ...
+        #   I was not able to confirm this theory.
+        # self.requires("libevent/2.1.12")
+        # -------------------------------------
+
         self.requires("zlib/1.2.11")
         # used for hwloc component...
         self.requires("libudev/system")

--- a/recipes/openmpi/all/conanfile.py
+++ b/recipes/openmpi/all/conanfile.py
@@ -1,5 +1,7 @@
-from conans import ConanFile, tools, AutoToolsBuildEnvironment
-from conans.errors import ConanInvalidConfiguration
+from conans import AutoToolsBuildEnvironment
+from conan import ConanFile
+from conan.tools.files import get, chdir, rm, rmdir
+from conan.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.29.1"
@@ -46,7 +48,7 @@ class OpenMPIConan(ConanFile):
         self.requires("libpciaccess/0.16")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
+        get(self, **self.conan_data["sources"][self.version])
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
@@ -70,19 +72,19 @@ class OpenMPIConan(ConanFile):
         return self._autotools
 
     def build(self):
-        with tools.chdir(self._source_subfolder):
+        with chdir(self, self._source_subfolder):
             autotools = self._configure_autotools()
             autotools.make()
 
     def package(self):
         self.copy(pattern="LICENSE", src=self._source_subfolder, dst="licenses")
-        with tools.chdir(self._source_subfolder):
+        with chdir(self, self._source_subfolder):
             autotools = self._configure_autotools()
             autotools.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.rmdir(os.path.join(self.package_folder, "etc"))
-        tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "etc"))
+        rm(self, pattern="*.la", folder=os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
         self.cpp_info.libs = ['mpi', 'open-rte', 'open-pal']


### PR DESCRIPTION
I found these were required while building cgns like so:

`conan create . 4.3.0@cci/test -o cgns:shared=True -o cgns:with_hdf5=True -o cgns:parallel=False -o hdf5:parallel=True -o hdf5:enable_cxx=False --build=missing`

I needed libudev and libpciaccess,
otherwise it complained about unresolved symbols including:

```
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `pci_device_probe'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `pci_device_get_vendor_name'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `udev_device_get_property_value'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `pci_slot_match_iterator_create'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `pci_iterator_destroy'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `pci_device_next'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `pci_system_init'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `udev_device_unref'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `udev_device_new_from_subsystem_sysname'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `pci_system_cleanup'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `pci_device_cfg_read'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `pci_device_get_device_name'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `udev_new'
/usr/bin/ld: /build/conandata/conan-data/cgns/4.3.0/ccitest/shared/package/d119f4ebdc23c0fcf69efad1aef71967dd875de6/lib/libcgns.so: undefined reference to `udev_unref'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
