### PR TITLE
mcap: add version 0.1.2, revert addition of 0.2.2

### DIFF
--- a/recipes/mcap/all/conandata.yml
+++ b/recipes/mcap/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   0.1.1:
     url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.1/main.tar.gz
     sha256: a9ea899315851bfacdb234b7acc917b1a9c67593f0d68e1920321a8f6fa2cfbf
+  0.1.2:
+    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.2/main.tar.gz
+    sha256: 0f456d6c53730445c3dbf57afd285493cf748c66a02f77d6e48c075128fd0896

--- a/recipes/mcap/all/conandata.yml
+++ b/recipes/mcap/all/conandata.yml
@@ -5,6 +5,3 @@ sources:
   0.1.1:
     url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.1/main.tar.gz
     sha256: a9ea899315851bfacdb234b7acc917b1a9c67593f0d68e1920321a8f6fa2cfbf
-  "0.2.2":
-    url: "https://github.com/foxglove/mcap/archive/releases/typescript/core/v0.2.2.tar.gz"
-    sha256: "39a2ebf458a112410febd9ae579dd18aeb27b9281c703ca4ce246baa9582dea1"

--- a/recipes/mcap/config.yml
+++ b/recipes/mcap/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   0.1.1:
     folder: all
+  0.1.2:
+    folder: all

--- a/recipes/mcap/config.yml
+++ b/recipes/mcap/config.yml
@@ -3,5 +3,3 @@ versions:
     folder: all
   0.1.1:
     folder: all
-  "0.2.2":
-    folder: all


### PR DESCRIPTION
Reverts conan-io/conan-center-index#11755 and replaces it with an update to v0.1.2

This tag was for a TypeScript language release, not C++. I have a PR to fix the bot here: https://github.com/qchateau/conan-center-bot/pull/72