### PR TITLE
Fix packaging of boost if os=Emscripten and header_only=True

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1362,7 +1362,7 @@ class BoostConan(ConanFile):
         if self.options.header_only:
             self.copy(pattern="*", dst="include/boost", src="%s/boost" % self._boost_dir)
 
-        if self.settings.os == "Emscripten":
+        if self.settings.os == "Emscripten" and not self.options.header_only:
             self._create_emscripten_libs()
 
         if self._is_msvc and self._shared:
@@ -1391,6 +1391,10 @@ class BoostConan(ConanFile):
         staged_libs = os.path.join(
             self.package_folder, "lib"
         )
+        if not os.path.exists(staged_libs):
+            self.output.warn("Lib folder doesn't exist, can't collect libraries: "
+                             "{0}".format(staged_libs))
+            return
         for bc_file in os.listdir(staged_libs):
             if bc_file.startswith("lib") and bc_file.endswith(".bc"):
                 a_file = bc_file[:-3] + ".a"


### PR DESCRIPTION
Specify library name and version:  **boost/\***

Fixes https://github.com/conan-io/conan-center-index/issues/11861

Seems like `_create_emscripten_libs` was originally called inside `build` and was naturally skipped if `header_only=True`, but after https://github.com/conan-io/conan-center-index/commit/11d4960a30abb45f897029380cfdc44f5d1c7db6 it moved to `package()` and causes failure.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
