### PR TITLE
capnproto: add 0.10.2

### DIFF
--- a/recipes/capnproto/all/conandata.yml
+++ b/recipes/capnproto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10.2":
+    url: "https://github.com/capnproto/capnproto/archive/v0.10.2.tar.gz"
+    sha256: "756262841fa66260c9969e900701cc86720c2548584fb96c8153348fd7edfe69"
   "0.10.1":
     url: "https://github.com/capnproto/capnproto/archive/v0.10.1.tar.gz"
     sha256: "2e9c918f02c198557c75ca7c635fe281337c9755b752a6ab3a841bcc1cf5176b"
@@ -15,6 +18,9 @@ sources:
     url: "https://github.com/capnproto/capnproto/archive/v0.7.0.tar.gz"
     sha256: 76c7114a3d142ad08b7208b3964a26e72a6320ee81331d3f0b87569fc9c47a28
 patches:
+  "0.10.2":
+    - patch_file: patches/0014-disable-tests-for-0.10.1.patch
+      base_path: source_subfolder
   "0.10.1":
     - patch_file: patches/0014-disable-tests-for-0.10.1.patch
       base_path: source_subfolder

--- a/recipes/capnproto/config.yml
+++ b/recipes/capnproto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.10.2":
+    folder: all
   "0.10.1":
     folder: all
   "0.10.0":


### PR DESCRIPTION
Specify library name and version:  **capnproto/0.10.2**

This bumps capnproto; existing tests patch was compatible.

Current hooks throw exception `[HOOK - conan-center.py] post_package_info(): ERROR: [CMAKE FILE NOT IN BUILD FOLDERS (KB-H019)] Exception raised from hook: list indices must be integers or slices, not str (type=TypeError) (https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md#KB-H019)`, which is exceptionally unhelpful without a stacktrace and I am unable to track down what is causing this. However, the same error already happens before my changes in this PR.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
