### PR TITLE
daw_header_libraries: add version 2.68.1

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.68.1":
+    url: "https://github.com/beached/header_libraries/archive/v2.68.1.tar.gz"
+    sha256: "51bdb042959373729009f91449c492f58bb63262146463a767f17d3de6fb2687"
   "2.65.1":
     url: "https://github.com/beached/header_libraries/archive/v2.65.1.tar.gz"
     sha256: "fd52024bb361d1ac8011cd03def39b4d6aea35015f26163f3865ca65df91ca57"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.68.1":
+    folder: all
   "2.65.1":
     folder: all
   "2.65.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **daw_header_libraries/2.68.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
