### PR TITLE
numcpp: add version 2.8.0

### DIFF
--- a/recipes/numcpp/all/conandata.yml
+++ b/recipes/numcpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.8.0":
+    url: "https://github.com/dpilger26/NumCpp/archive/Version_2.8.0.tar.gz"
+    sha256: "b59260a4e0920f3705b4b18ad9923d98b41ad69ebbab9ebd2f446932c2ffe17c"
   "2.7.0":
     url: "https://github.com/dpilger26/NumCpp/archive/Version_2.7.0.tar.gz"
     sha256: "3805ef996ba73502a6525c9ddc529ebd0fa6967385e508db71843c08c50105b0"

--- a/recipes/numcpp/config.yml
+++ b/recipes/numcpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.8.0":
+    folder: "all"
   "2.7.0":
     folder: "all"
   "2.6.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **numcpp/2.8.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
