### PR TITLE
luau: add version 0.537

### DIFF
--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,9 +1,17 @@
 sources:
+  "0.537":
+    url: "https://github.com/Roblox/luau/archive/0.537.tar.gz"
+    sha256: "24122d3192083b2133de47d8039fb744b8007c6667fc1b6f254a2a8d72e15d53"
   "0.536":
     url: "https://github.com/Roblox/luau/archive/refs/tags/0.536.tar.gz"
     sha256: "e6de36e83e9c537d92bcc94852ab498e3c15a310fd2c4cc4e21c616d8ae1a84f"
 
 patches:
+  "0.537":
+    - patch_file: "patches/0.536-0001-fix-cmake.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0.536-0002-rename-lerp.patch"
+      base_path: "source_subfolder"
   "0.536":
     - patch_file: "patches/0.536-0001-fix-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.537":
+    folder: all
   "0.536":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **luau/***


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
