### PR TITLE
numcpp: add version 2.8.0

### DIFF
--- a/recipes/numcpp/all/conandata.yml
+++ b/recipes/numcpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.8.0":
+    url: "https://github.com/dpilger26/NumCpp/archive/Version_2.8.0.tar.gz"
+    sha256: "3868cf24b0981d5b5bfeaea65719f541f82d331ef7b79ba0d73cedb4dc7ddd47"
   "2.7.0":
     url: "https://github.com/dpilger26/NumCpp/archive/Version_2.7.0.tar.gz"
     sha256: "3805ef996ba73502a6525c9ddc529ebd0fa6967385e508db71843c08c50105b0"

--- a/recipes/numcpp/config.yml
+++ b/recipes/numcpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.8.0":
+    folder: "all"
   "2.7.0":
     folder: "all"
   "2.6.2":


### PR DESCRIPTION
Specify library name and version:  **numcpp/2.8.0**

Second trial.
https://github.com/conan-io/conan-center-index/pull/11881
https://github.com/dpilger26/NumCpp/issues/151

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
