### PR TITLE
valijson: add version 0.7

### DIFF
--- a/recipes/valijson/all/conandata.yml
+++ b/recipes/valijson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.7":
+    url: "https://github.com/tristanpenman/valijson/archive/v0.7.tar.gz"
+    sha256: "bc24736709acfb252a5fdcb5145f1f2670c7aecaba3356f6f8ba54903800fa5c"
   "0.6":
     url: "https://github.com/tristanpenman/valijson/archive/v0.6.zip"
     sha256: d655dd7ca502978238e72a4febcd064cb1ffaece18cd5d78c7f17df420387b59

--- a/recipes/valijson/config.yml
+++ b/recipes/valijson/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: "all"
   "0.6":
     folder: "all"
+  "0.7":
+    folder: "all"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **valijson/0.7**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
