### PR TITLE
xorg/system: Fix my really stupid typo in Python f-string

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -83,7 +83,7 @@ class ConanXOrg(ConanFile):
             self.cpp_info.components[name].set_property(
                 "component_version", pkg_config.version)
             self.cpp_info.components[name].set_property("pkg_config_custom_content",
-                                                        "\n".join("f{key}={value}" for key, value in pkg_config.variables.items() if key not in ["pcfiledir","prefix", "includedir"]))
+                                                        "\n".join(f"{key}={value}" for key, value in pkg_config.variables.items() if key not in ["pcfiledir","prefix", "includedir"]))
         
         if self.settings.os == "Linux":
             self.cpp_info.components["sm"].requires.append("uuid")


### PR DESCRIPTION
Specify library name and version:  **xorg/system**

The `f` goes before the `"`...

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
