### PR TITLE
tesseract: add version 5.2.0

### DIFF
--- a/recipes/tesseract/all/CMakeLists.txt
+++ b/recipes/tesseract/all/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup(TARGETS KEEP_RPATHS)
+conan_basic_setup(KEEP_RPATHS)
 
 if(NOT CMAKE_SYSTEM_PROCESSOR)
     set(CMAKE_SYSTEM_PROCESSOR ${CONAN_TESSERACT_SYSTEM_PROCESSOR})

--- a/recipes/tesseract/all/CMakeLists.txt
+++ b/recipes/tesseract/all/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
 include(conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS KEEP_RPATHS)
 
 if(NOT CMAKE_SYSTEM_PROCESSOR)
     set(CMAKE_SYSTEM_PROCESSOR ${CONAN_TESSERACT_SYSTEM_PROCESSOR})

--- a/recipes/tesseract/all/conandata.yml
+++ b/recipes/tesseract/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.2.0":
+    url: "https://github.com/tesseract-ocr/tesseract/archive/5.2.0.tar.gz"
+    sha256: "eba4deb2f92a3f89a6623812074af8c53b772079525b3c263aa70bbf7b748b3c"
   "5.1.0":
     url: "https://github.com/tesseract-ocr/tesseract/archive/5.1.0.tar.gz"
     sha256: "fdec8528d5a0ecc28ab5fff985e0b8ced60726f6ef33f54126f2868e323d4bd2"
@@ -9,6 +12,11 @@ sources:
     url: "https://github.com/tesseract-ocr/tesseract/archive/4.1.1.tar.gz"
     sha256: "2a66ff0d8595bff8f04032165e6c936389b1e5727c3ce5a27b3e059d218db1cb"
 patches:
+  "5.2.0":
+     - patch_file: "patches/0002-Link-with-targets-5.2.0.patch"
+       base_path: "source_subfolder"
+     - patch_file: "patches/0004-control-optimizations-5.2.0.patch"
+       base_path: "source_subfolder"
   "5.1.0":
      - patch_file: "patches/0002-Link-with-targets-5.1.0.patch"
        base_path: "source_subfolder"

--- a/recipes/tesseract/all/conanfile.py
+++ b/recipes/tesseract/all/conanfile.py
@@ -1,5 +1,6 @@
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
+from conan.tools.build import cross_building
 import os
 import textwrap
 import functools
@@ -130,7 +131,7 @@ class TesseractConan(ConanFile):
             cmake.definitions["DISABLE_CURL"] = not self.options.with_libcurl
             cmake.definitions["DISABLE_ARCHIVE"] = not self.options.with_libarchive
 
-        if tools.cross_building(self):
+        if cross_building(self):
             cmake_system_processor = {
                 "armv8": "aarch64",
                 "armv8.3": "aarch64",

--- a/recipes/tesseract/all/conanfile.py
+++ b/recipes/tesseract/all/conanfile.py
@@ -2,6 +2,7 @@ from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os
 import textwrap
+import functools
 
 required_conan_version = ">=1.43.0"
 
@@ -9,10 +10,10 @@ required_conan_version = ">=1.43.0"
 class TesseractConan(ConanFile):
     name = "tesseract"
     description = "Tesseract Open Source OCR Engine"
-    url = "https://github.com/conan-io/conan-center-index"
-    topics = ("ocr", "image", "multimedia", "graphics")
     license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/tesseract-ocr/tesseract"
+    topics = ("ocr", "image", "multimedia", "graphics")
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -35,7 +36,6 @@ class TesseractConan(ConanFile):
     }
 
     generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
-    _cmake = None
 
     @property
     def _source_subfolder(self):
@@ -68,10 +68,10 @@ class TesseractConan(ConanFile):
         self.requires("leptonica/1.82.0")
         # libarchive is required for 4.x so default value is true
         if self.options.get_safe("with_libarchive", default=True):
-            self.requires("libarchive/3.5.2")
+            self.requires("libarchive/3.6.1")
         # libcurl is not required for 4.x
         if self.options.get_safe("with_libcurl", default=False):
-            self.requires("libcurl/7.80.0")
+            self.requires("libcurl/7.84.0")
 
     def validate(self):
         # Check compiler version
@@ -103,10 +103,9 @@ class TesseractConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
+    @functools.lru_cache(1)
     def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        cmake = self._cmake = CMake(self)
+        cmake = CMake(self)
         cmake.definitions["BUILD_TRAINING_TOOLS"] = self.options.with_training
         cmake.definitions["INSTALL_CONFIGS"] = self.options.with_training
 
@@ -136,7 +135,7 @@ class TesseractConan(ConanFile):
                 "armv8": "aarch64",
                 "armv8.3": "aarch64",
             }.get(str(self.settings.arch), str(self.settings.arch))
-            self._cmake.definitions["CONAN_TESSERACT_SYSTEM_PROCESSOR"] = cmake_system_processor
+            cmake.definitions["CONAN_TESSERACT_SYSTEM_PROCESSOR"] = cmake_system_processor
 
         cmake.configure(build_folder=self._build_subfolder)
         return cmake

--- a/recipes/tesseract/all/patches/0002-Link-with-targets-5.2.0.patch
+++ b/recipes/tesseract/all/patches/0002-Link-with-targets-5.2.0.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bd2649d..5abcc97 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -792,7 +792,7 @@ if(OpenCL_FOUND)
+   target_link_libraries(libtesseract PUBLIC OpenCL::OpenCL)
+ endif()
+ if(LibArchive_FOUND)
+-  target_link_libraries(libtesseract PUBLIC ${LibArchive_LIBRARIES})
++  target_link_libraries(libtesseract PUBLIC LibArchive::LibArchive)
+ endif(LibArchive_FOUND)
+ if(CURL_FOUND)
+   if(NOT CURL_LIBRARIES)
+@@ -827,7 +827,7 @@ if(SW_BUILD)
+     FILE ${CMAKE_CURRENT_BINARY_DIR}/TesseractTargets.cmake
+     NAMESPACE Tesseract::)
+ else()
+-  target_link_libraries(libtesseract PUBLIC ${Leptonica_LIBRARIES})
++  target_link_libraries(libtesseract PUBLIC leptonica)
+   export(
+     TARGETS libtesseract
+     FILE ${CMAKE_CURRENT_BINARY_DIR}/TesseractTargets.cmake

--- a/recipes/tesseract/all/patches/0004-control-optimizations-5.2.0.patch
+++ b/recipes/tesseract/all/patches/0004-control-optimizations-5.2.0.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5abcc97..fca45ed 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -144,7 +144,7 @@ else()
+ endif()
+ 
+ check_cxx_compiler_flag("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
+-if(COMPILER_SUPPORTS_MARCH_NATIVE)
++if(ENABLE_OPTIMIZATIONS AND COMPILER_SUPPORTS_MARCH_NATIVE)
+   set(MARCH_NATIVE_FLAGS "${MARCH_NATIVE_FLAGS} -march=native")
+   if(NOT CLANG AND MSVC)
+     # clang-cl does not know this argument
+@@ -155,7 +155,7 @@ endif()
+ 
+ message(STATUS "CMAKE_SYSTEM_PROCESSOR=<${CMAKE_SYSTEM_PROCESSOR}>")
+ 
+-if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|x86_64|AMD64|amd64|i386|i686")
++if(ENABLE_OPTIMIZATIONS AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86|x86_64|AMD64|amd64|i386|i686")
+ 
+   set(HAVE_NEON FALSE)
+   if(MSVC)
+@@ -255,7 +255,7 @@ else()
+   set(HAVE_NEON FALSE)
+   set(HAVE_SSE4_1 FALSE)
+ 
+-endif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|x86_64|AMD64|amd64|i386|i686")
++endif(ENABLE_OPTIMIZATIONS AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86|x86_64|AMD64|amd64|i386|i686")
+ 
+ # Compiler specific environments
+ if(CMAKE_COMPILER_IS_GNUCXX OR MINGW)

--- a/recipes/tesseract/all/test_package/CMakeLists.txt
+++ b/recipes/tesseract/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
@@ -12,4 +12,4 @@ if(TARGET Tesseract::libtesseract)
 else()
     target_link_libraries(${PROJECT_NAME} libtesseract)
 endif()
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/tesseract/all/test_package/conanfile.py
+++ b/recipes/tesseract/all/test_package/conanfile.py
@@ -1,9 +1,10 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
@@ -12,6 +13,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/tesseract/config.yml
+++ b/recipes/tesseract/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.2.0":
+    folder: all
   "5.1.0":
     folder: all
   "5.0.0":


### PR DESCRIPTION
Specify library name and version:  **tesseract/***

- add version 5.2.0
- use `lru_cache()` in `_configure_cmake()`
- update dependencies
- use `conan.tools.build.cross_building`

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
