### PR TITLE
Fix folly CXX_STD

### DIFF
--- a/recipes/folly/all/test_package/conanfile.py
+++ b/recipes/folly/all/test_package/conanfile.py
@@ -1,18 +1,31 @@
-from conans import ConanFile, CMake, tools
 import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout
 
+required_conan_version = ">=1.43.0"
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["FOLLY_VERSION"] = self.dependencies["folly"].ref.version
+        tc.generate()
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["FOLLY_VERSION"] = self.deps_cpp_info["folly"].version
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(command=bin_path, run_environment=True)
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/folly/all/test_v1_package/CMakeLists.txt
+++ b/recipes/folly/all/test_v1_package/CMakeLists.txt
@@ -1,7 +1,10 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.1)
 project(test_package CXX)
 
-find_package(folly REQUIRED CONFIG)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(folly CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} Folly::folly)

--- a/recipes/folly/all/test_v1_package/conanfile.py
+++ b/recipes/folly/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+# pylint: skip-file
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.definitions["FOLLY_VERSION"] = self.deps_cpp_info["folly"].version
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(command=bin_path, run_environment=True)

--- a/recipes/folly/all/test_v1_package/test_package.cpp
+++ b/recipes/folly/all/test_v1_package/test_package.cpp
@@ -1,0 +1,29 @@
+#include <cstdlib>
+#include <iostream>
+#include <utility>
+#include <folly/Format.h>
+#include <folly/futures/Future.h>
+#include <folly/executors/ThreadedExecutor.h>
+#include <folly/Uri.h>
+#include <folly/FBString.h>
+#if FOLLY_HAVE_ELF
+#include <folly/experimental/symbolizer/Elf.h>
+#endif
+
+static void print_uri(const folly::fbstring& value) {
+    const folly::Uri uri(value);
+    std::cout << "The authority from " << value << " is " << uri.authority() << std::endl;
+}
+
+int main() {
+    folly::ThreadedExecutor executor;
+    folly::Promise<std::string> promise;
+    folly::Future<std::string> future = promise.getSemiFuture().via(&executor);
+    folly::Future<folly::Unit> unit = std::move(future).thenValue(print_uri);
+    promise.setValue("https://github.com/bincrafters");
+    std::move(unit).get();
+#if FOLLY_HAVE_ELF
+    folly::symbolizer::ElfFile elffile;
+#endif
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Specify library name and version:  **folly/all**

* Fixes https://github.com/conan-io/conan-center-index/issues/11937
* updates `fmt` dependency to latest 7.x.x supported in CCI (7.1.3)
* Migrate test_package to comply with v2 linter 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
