### PR TITLE
import is used which is only available from conan >= 1.46.0

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     from io import StringIO
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.46.0"
 
 
 # When adding (or removing) an option, also add this option to the list in


### PR DESCRIPTION
Specify library name and version:  **boost/all**

fixes #11955 

in fact the import in question wasn't released until v1.46.x: https://github.com/conan-io/conan/blob/release/1.46/conan/tools/build/__init__.py

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
