### PR TITLE
cpp-httplib: add version 0.11.0

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.0":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.11.0.tar.gz"
+    sha256: "9f533b0aa67066bd8f049e080eef75ad710a2f3ba3d80edbb13957389a5eeca7"
   "0.10.9":
     url: "https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.10.9.tar.gz"
     sha256: "95ac0740ef760829a079c01a44164fd74af3fdc0748a40fc6beefd0276fd2345"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.0":
+    folder: all
   "0.10.9":
     folder: all
   "0.10.8":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cpp-httplib/0.11.0**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
