### PR TITLE
[wayland] Re-add env_info.PATH

### DIFF
--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -42,7 +42,7 @@ class FmtConan(ConanFile):
     def generate(self):
         if not self.options.header_only:
             tc = CMakeToolchain(self)
-            tc.generate()  
+            tc.generate()
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -42,7 +42,7 @@ class FmtConan(ConanFile):
     def generate(self):
         if not self.options.header_only:
             tc = CMakeToolchain(self)
-            tc.generate()
+            tc.generate()  
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -125,7 +125,7 @@ class WaylandConan(ConanFile):
         bindir = os.path.join(self.package_folder, "bin")
         self.buildenv_info.prepend_path("PATH", bindir)
         self.runenv_info.prepend_path("PATH", bindir)
-	# TODO: Remove in Conan 2.0 where Environment class will be required.
+        # TODO: Remove in Conan 2.0 where Environment class will be required.
         self.output.info("Appending PATH environment variable: {}".format(bindir))
         self.env_info.PATH.append(bindir)
 

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -125,6 +125,9 @@ class WaylandConan(ConanFile):
         bindir = os.path.join(self.package_folder, "bin")
         self.buildenv_info.prepend_path("PATH", bindir)
         self.runenv_info.prepend_path("PATH", bindir)
+	# TODO: Remove in Conan 2.0 where Environment class will be required.
+        self.output.info("Appending PATH environment variable: {}".format(bindir))
+        self.env_info.PATH.append(bindir)
 
         if self.options.enable_libraries:
             self.cpp_info.components["wayland-server"].libs = ["wayland-server"]

--- a/recipes/wayland/all/test_package/CMakeLists.txt
+++ b/recipes/wayland/all/test_package/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.15)
 project(test_package)
 
 find_package(wayland COMPONENTS wayland-client REQUIRED)
+find_program(WAYLAND_SCANNER wayland-scanner)
+if (NOT WAYLAND_SCANNER)
+    message(FATAL_ERROR "Could not find wayland-scanner executable")
+endif()
 
 add_executable(test_package test_package.c)
 target_link_libraries(test_package PRIVATE wayland::wayland-client)


### PR DESCRIPTION
Specify library name and version:  **waylan/1.21.0**

The PR #11580 replaced `env_info` by `buildenv_info` and `runenv_info`, which follows the migration guide and is correct: https://docs.conan.io/en/latest/reference/conanfile/tools/env/environment.html#environment-definition

However, those new attributes need `Environment` or similar class, which is not wide supported yet on CCI, causing missing PATH.

Related issue: https://github.com/conan-io/conan-center-index/pull/11974

/cc @paulocoutinhox 

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
