### PR TITLE
[cmake] Add bootstrap option

### DIFF
--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -1,5 +1,8 @@
 import os
-from conans import tools, ConanFile, CMake
+from conan import ConanFile
+from conan.tools.scm import Version
+from conan.tools.files import rmdir, get
+from conans import tools, CMake
 from conans.errors import ConanInvalidConfiguration, ConanException
 
 required_conan_version = ">=1.35.0"
@@ -58,13 +61,13 @@ class CMakeConan(ConanFile):
                 "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
             return
 
-        version = tools.Version(self.settings.compiler.version)
+        version = Version(self.settings.compiler.version)
         if version < minimal_version[compiler]:
             raise ConanInvalidConfiguration(
                 "{} requires a compiler that supports at least C++{}".format(self.name, minimal_cpp_standard))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def _configure_cmake(self):
         if not self._cmake:
@@ -99,7 +102,7 @@ class CMakeConan(ConanFile):
         self.copy("Copyright.txt", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "doc"))
+        rmdir(self, os.path.join(self.package_folder, "doc"))
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -118,5 +118,5 @@ class CMakeConan(ConanFile):
         self.env_info.CMAKE_MODULE_PATH = mod_path
         if not os.path.exists(mod_path):
             raise ConanException("Module path not found: %s" % mod_path)
-            
+
         self.cpp_info.includedirs = []


### PR DESCRIPTION
This PR adds the possibility to bootstrap the CMake recipe *without* having CMake installed.
For this the option `bootstrap` is provided.

This option is intentionally disabled by default and no automatic logic is provided.
If somebody needs this it can be implemented independently.

See #4334

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
