### PR TITLE
[boost] add support for multiple boost_python versions

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1439,7 +1439,7 @@ class BoostConan(ConanFile):
 
             libformatdata = {}
             if not self.options.without_python:
-                pyversion = Version(self._python.version)
+                pyversion = Version(self._python.version.v)
                 libformatdata["py_major"] = pyversion.major
                 libformatdata["py_minor"] = pyversion.minor
 
@@ -1572,7 +1572,7 @@ class BoostConan(ConanFile):
                     self.cpp_info.components["stacktrace"].defines.append("BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED")
 
             if not self.options.without_python:
-                pyversion = Version(self._python.version)
+                pyversion = Version(self._python.version.v)
                 self.cpp_info.components[f"python{pyversion.major}{pyversion.minor}"].requires = ["python"]
                 if not self._shared:
                     self.cpp_info.components["python"].defines.append("BOOST_PYTHON_STATIC_LIB")

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1451,8 +1451,9 @@ class BoostConan(ConanFile):
             def expand_python_lib_names(name):
                 """ A list of names, one for each enabled python version """
                 libs = []
-                for p in self._pythons:
-                    xy_version = tools.Version(p.version.v)
+                enabled_pythons = [version for version in PYTHON_VERSIONS if self.options.get_safe(f"python{version.xy}")]
+                for p in enabled_pythons:
+                    xy_version = tools.Version(p.v)
                     xy_formatdata = {
                         "py_major": xy_version.major,
                         "py_minor": xy_version.minor

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1,19 +1,19 @@
-from conan.tools.build import cross_building
-from conan.tools.files import rename, rmdir, get
-from conan.tools.files.patches import apply_conandata_patches
-from conan.tools.microsoft import msvc_runtime_flag
-from conan import ConanFile
-from conan.errors import ConanException, ConanInvalidConfiguration
-from conans import tools
-from conan.tools.scm import Version
-
 import glob
 import os
 import re
-import sys
 import shlex
 import shutil
+import sys
+
 import yaml
+from conan import ConanFile
+from conan.errors import ConanException, ConanInvalidConfiguration
+from conan.tools.build import cross_building
+from conan.tools.files import get, rename, rmdir
+from conan.tools.files.patches import apply_conandata_patches
+from conan.tools.microsoft import msvc_runtime_flag
+from conan.tools.scm import Version
+from conans import tools
 
 try:
     from cStringIO import StringIO
@@ -59,7 +59,9 @@ CONFIGURE_OPTIONS = (
     "wave",
 )
 
-PYTHON_VERSIONS = ("2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10")
+PYTHON_VERSIONS = (
+    "2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"
+)
 
 
 class BoostConan(ConanFile):
@@ -358,7 +360,7 @@ class BoostConan(ConanFile):
     @property
     def _stacktrace_addr2line_available(self):
         if (self.settings.os in ["iOS", "watchOS", "tvOS"] or self.settings.get_safe("os.subsystem") == "catalyst"):
-             # sandboxed environment - cannot launch external processes (like addr2line), system() function is forbidden
+            # sandboxed environment - cannot launch external processes (like addr2line), system() function is forbidden
             return False
         return not self.options.header_only and not self.options.without_stacktrace and self.settings.os != "Windows"
 
@@ -563,7 +565,7 @@ class BoostConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+            destination=self._source_subfolder, strip_root=True)
         apply_conandata_patches(self)
 
     ##################### BUILDING METHODS ###########################
@@ -585,7 +587,6 @@ class BoostConan(ConanFile):
         if self._detected_python is None:
             self._detected_python = self._detect_python()
         return self._detected_python
-
 
     def _clean(self):
         src = os.path.join(self.source_folder, self._source_subfolder)
@@ -889,7 +890,6 @@ class BoostConan(ConanFile):
                 cxx_flags.append("-g")
             elif self._is_msvc:
                 cxx_flags.append("/Z7")
-
 
         # Standalone toolchain fails when declare the std lib
         if self.settings.os not in ("Android", "Emscripten"):
@@ -1564,8 +1564,8 @@ class BoostConan(ConanFile):
                     # from the aforementioned flag)
                     if arch.startswith("x86") or arch.startswith("wasm"):
                         self.cpp_info.components["_libboost"].cxxflags.append("-pthread")
-                        self.cpp_info.components["_libboost"].sharedlinkflags.extend(["-pthread","--shared-memory"])
-                        self.cpp_info.components["_libboost"].exelinkflags.extend(["-pthread","--shared-memory"])
+                        self.cpp_info.components["_libboost"].sharedlinkflags.extend(["-pthread", "--shared-memory"])
+                        self.cpp_info.components["_libboost"].exelinkflags.extend(["-pthread", "--shared-memory"])
             elif self.settings.os == "iOS":
                 if self.options.multithreading:
                     # https://github.com/conan-io/conan-center-index/issues/3867
@@ -1744,7 +1744,7 @@ class PythonTool:
         with_dyld = self._get_var("WITH_DYLD")
         if libdir and multiarch and masd:
             if masd.startswith(os.sep):
-                masd = masd[len(os.sep) :]
+                masd = masd[len(os.sep):]
             libdir = os.path.join(libdir, masd)
 
         if not libdir:

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -59,6 +59,8 @@ CONFIGURE_OPTIONS = (
     "wave",
 )
 
+PYTHON_VERSIONS = ("2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10")
+
 
 class BoostConan(ConanFile):
     name = "boost"
@@ -108,6 +110,8 @@ class BoostConan(ConanFile):
         "system_use_utf8": [True, False],
     }
     options.update({f"without_{_name}": [True, False] for _name in CONFIGURE_OPTIONS})
+    # extra boost_python libs to build
+    options.update({f"python{_name.replace('.', '')}_executable": "ANY" for _name in PYTHON_VERSIONS})
 
     default_options = {
         "shared": False,
@@ -147,6 +151,8 @@ class BoostConan(ConanFile):
     }
     default_options.update({f"without_{_name}": False for _name in CONFIGURE_OPTIONS})
     default_options.update({f"without_{_name}": True for _name in ("graph_parallel", "mpi", "python")})
+    # extra boost_python libs to build
+    default_options.update({f"python{_name.replace('.', '')}_executable": "None" for _name in PYTHON_VERSIONS})
 
     short_paths = True
     no_copy_source = True
@@ -1063,6 +1069,11 @@ class BoostConan(ConanFile):
                 return f'\nusing python : {version} : "{executable}" : "{includes}" : "{library_dir}" ;'
 
             contents += create_python_config(self._python)
+
+            for version in PYTHON_VERSIONS:
+                option = self.options.get_safe(f"python{version.replace('.', '')}_executable")
+                if option:
+                    contents += create_python_config(PythonTool(version, option.value, self))
 
         if not self.options.without_mpi:
             # https://www.boost.org/doc/libs/1_72_0/doc/html/mpi/getting_started.html


### PR DESCRIPTION
Fixes #12038.

fixes #12122

Specify library name and version:  **boost >=1.70**

Boost (`>=1.67`) supports [building multiple versions of boost_pythonXY](https://www.boost.org/doc/libs/1_79_0/tools/build/doc/html/index.html#bbv2.reference.tools.libraries.python) for various python versions.

This adds support for building these libraries.

Python versions are specified using `boost:pythonXY=True` and `boost:pythonXY_executable`.
The options are provided for python 2.7 and 3.5+.

Example:
```shell
conan create ... -o boost:without_python=False -o boost:python27=True -o boost:python27_executable=`which python2.7`  -o boost:python38=True -o boost:python38_executable=`which python3.8` recipes/boost/all 1.76.0@
```

As part of these changes python-related methods were refactored to `class PythonTool`.

## Example Usage
### Implicit: `boost:without_python=False`
Enable current python (as used for conan invocation) and set correct `pythonXY`.

e.g.
```
docker python:X.Y conan create ... -o boost:without_python=False
```

### Explicit: `boost:pythonXY_version=True`

Build one or more specific versions. Disables detection of current python.
Requires a matching `boost:pythonXY_executable` option.
Does not imply `boost:without_python=False` which must also be specified explicitly.

e.g.
```
conan create -o boost:without_python=False -o boost:python27=True -o boost:python27_executable=python2.7 -o boost:python310=True -o boost:python310=python ...
```

---
# Workflow

This does *not* work:

```bash
conan install --build missing -r conancenter . -pr=default
conan install -o boost:without_atomic=True -o boost:without_chrono=True -o boost:without_container=True -o boost:without_context=True -o boost:without_contract=True -o boost:without_coroutine=True -o boost:without_date_time=True -o boost:without_exception=True -o boost:without_fiber=True -o boost:without_filesystem=True -o boost:without_graph=True -o boost:without_graph_parallel=True -o boost:without_iostreams=True -o boost:without_json=True -o boost:without_locale=True -o boost:without_log=True -o boost:without_math=True -o boost:without_mpi=True -o boost:without_nowide=True -o boost:without_program_options=True -o boost:without_python=False -o boost:without_random=True -o boost:without_regex=True -o boost:without_serialization=True -o boost:without_stacktrace=True -o boost:without_system=True -o boost:without_test=True -o boost:without_thread=True -o boost:without_timer=True -o boost:without_type_erasure=True -o boost:without_wave=True -o boost:python310=True -o boost:python310_executable=`which python3` -o boost:python39=True -o boost:python39_executable=$HOME/src/conan-center-index/conan-venv39/bin/python .
conan build .
conan package .
conan export-pkg  -o boost:without_atomic=True -o boost:without_chrono=True -o boost:without_container=True -o boost:without_context=True -o boost:without_contract=True -o boost:without_coroutine=True -o boost:without_date_time=True -o boost:without_exception=True -o boost:without_fiber=True -o boost:without_filesystem=True -o boost:without_graph=True -o boost:without_graph_parallel=True -o boost:without_iostreams=True -o boost:without_json=True -o boost:without_locale=True -o boost:without_log=True -o boost:without_math=True -o boost:without_mpi=True -o boost:without_nowide=True -o boost:without_program_options=True -o boost:without_python=False -o boost:without_random=True -o boost:without_regex=True -o boost:without_serialization=True -o boost:without_stacktrace=True -o boost:without_system=True -o boost:without_test=True -o boost:without_thread=True -o boost:without_timer=True -o boost:without_type_erasure=True -o boost:without_wave=True -o boost:python310=True -o boost:python310_executable=`which python3` -o boost:python39=True -o boost:python39_executable=$HOME/src/conan-center-index/conan-venv39/bin/python . boost/1.76.0@gnome/test

conan test test_package boost/1.76.0@gnome/test  # fails with missing libs!
```

Alternatively:
```
conan create -k -o boost:without_atomic=True -o boost:without_chrono=True -o boost:without_container=True -o boost:without_context=True -o boost:without_contract=True -o boost:without_coroutine=True -o boost:without_date_time=True -o boost:without_exception=True -o boost:without_fiber=True -o boost:without_filesystem=True -o boost:without_graph=True -o boost:without_graph_parallel=True -o boost:without_iostreams=True -o boost:without_json=True -o boost:without_locale=True -o boost:without_log=True -o boost:without_math=True -o boost:without_mpi=True -o boost:without_nowide=True -o boost:without_program_options=True -o boost:without_python=False -o boost:without_random=True -o boost:without_regex=True -o boost:without_serialization=True -o boost:without_stacktrace=True -o boost:without_system=True -o boost:without_test=True -o boost:without_thread=True -o boost:without_timer=True -o boost:without_type_erasure=True -o boost:without_wave=True -o boost:python310=True -o boost:python310_executable=`which python3` -o boost:python39=True -o boost:python39_executable=$HOME/src/conan-center-index/conan-venv39/bin/python . 1.76.0@gnome/test

# then trial install with
conan install --build=never ...
```

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
