### PR TITLE
opencore-amr/0.1.6: bump library version

### DIFF
--- a/recipes/opencore-amr/all/conandata.yml
+++ b/recipes/opencore-amr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.6":
+    url: "https://downloads.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-0.1.6.tar.gz"
+    sha256: "483eb4061088e2b34b358e47540b5d495a96cd468e361050fae615b1809dc4a1"
   "0.1.5":
     url: "https://downloads.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-0.1.5.tar.gz"
     sha256: "2c006cb9d5f651bfb5e60156dbff6af3c9d35c7bbcc9015308c0aff1e14cd341"

--- a/recipes/opencore-amr/all/conanfile.py
+++ b/recipes/opencore-amr/all/conanfile.py
@@ -97,7 +97,7 @@ class OpencoreAmrConan(ConanFile):
     def package(self):
         self._autotools.install()
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        files.rm(self, os.path.join(self.package_folder, "lib"), "*.la")
+        files.rm(self, "*.la", os.path.join(self.package_folder, "lib"))
         files.rmdir(self, os.path.join(
             self.package_folder, "lib", "pkgconfig"))
         if self.settings.compiler == "Visual Studio" and self.options.shared:

--- a/recipes/opencore-amr/all/conanfile.py
+++ b/recipes/opencore-amr/all/conanfile.py
@@ -44,7 +44,7 @@ class OpencoreAmrConan(ConanFile):
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
         if self.settings.compiler == "Visual Studio":
-            self.build_requires("automake/1.16.4")
+            self.build_requires("automake/1.16.5")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/opencore-amr/all/conanfile.py
+++ b/recipes/opencore-amr/all/conanfile.py
@@ -1,8 +1,11 @@
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conan import ConanFile, tools
+from conan.tools.microsoft import is_msvc
+from conans import AutoToolsBuildEnvironment
+from conans.tools import environment_append, get_env, os_info, vcvars, unix_path
 from contextlib import contextmanager
 import os
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.47.0"
 
 
 class OpencoreAmrConan(ConanFile):
@@ -18,7 +21,7 @@ class OpencoreAmrConan(ConanFile):
         "fPIC": [True, False],
     }
     default_options = {
-        "shared": False, 
+        "shared": False,
         "fPIC": True,
     }
 
@@ -41,26 +44,26 @@ class OpencoreAmrConan(ConanFile):
             del self.options.fPIC
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+        if self._settings_build.os == "Windows" and not get_env("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
         if self.settings.compiler == "Visual Studio":
             self.build_requires("automake/1.16.5")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        tools.files.get(self, **self.conan_data["sources"][self.version],
+                        destination=self._source_subfolder, strip_root=True)
 
     @contextmanager
     def _build_context(self):
-        if self.settings.compiler == "Visual Studio":
-            with tools.vcvars(self):
+        if is_msvc(self):
+            with vcvars(self):
                 env = {
                     "CC": "cl -nologo",
                     "CXX": "cl -nologo",
                     "LD": "link -nologo",
-                    "AR": "{} lib".format(tools.unix_path(self.deps_user_info["automake"].ar_lib)),
+                    "AR": "{} lib".format(unix_path(self.deps_user_info["automake"].ar_lib)),
                 }
-                with tools.environment_append(env):
+                with environment_append(env):
                     yield
         else:
             yield
@@ -68,17 +71,20 @@ class OpencoreAmrConan(ConanFile):
     def _configure_autotools(self):
         if self._autotools:
             return self._autotools
-        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        yes_no = lambda v: "yes" if v else "no"
+        self._autotools = AutoToolsBuildEnvironment(
+            self, win_bash=os_info.is_windows)
+
+        def yes_no(v): return "yes" if v else "no"
         args = [
             "--enable-shared={}".format(yes_no(self.options.shared)),
             "--enable-static={}".format(yes_no(not self.options.shared)),
         ]
-        if self.settings.compiler == "Visual Studio":
+        if is_msvc(self):
             self._autotools.cxx_flags.append("-EHsc")
-            if tools.Version(self.settings.compiler.version) >= "12":
+            if tools.scm.Version(self.settings.compiler.version) >= "12":
                 self._autotools.flags.append("-FS")
-        self._autotools.configure(args=args, configure_dir=self._source_subfolder)
+        self._autotools.configure(
+            args=args, configure_dir=self._source_subfolder)
         return self._autotools
 
     def build(self):
@@ -89,18 +95,20 @@ class OpencoreAmrConan(ConanFile):
     def package(self):
         self._autotools.install()
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        tools.files.rm(self, os.path.join(self.package_folder, "lib"), "*.la")
+        tools.files.rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         if self.settings.compiler == "Visual Studio" and self.options.shared:
             for lib in ("opencore-amrwb", "opencore-amrnb"):
-                tools.rename(os.path.join(self.package_folder, "lib", "{}.dll.lib".format(lib)),
-                             os.path.join(self.package_folder, "lib", "{}.lib".format(lib)))
+                tools.files.rename(self, os.path.join(self.package_folder, "lib", "{}.dll.lib".format(lib)),
+                                   os.path.join(self.package_folder, "lib", "{}.lib".format(lib)))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "opencore-amr")
-        self.cpp_info.set_property("cmake_target_name", "opencore-amr::opencore-amr")
+        self.cpp_info.set_property(
+            "cmake_target_name", "opencore-amr::opencore-amr")
         for lib in ("opencore-amrwb", "opencore-amrnb"):
-            self.cpp_info.components[lib].set_property("cmake_target_name", f'opencore-amr::{lib}')
+            self.cpp_info.components[lib].set_property(
+                "cmake_target_name", f'opencore-amr::{lib}')
             self.cpp_info.components[lib].set_property("pkg_config_name", lib)
             self.cpp_info.components[lib].libs = [lib]
             # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generator removed

--- a/recipes/opencore-amr/all/conanfile.py
+++ b/recipes/opencore-amr/all/conanfile.py
@@ -93,8 +93,8 @@ class OpencoreAmrConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         if self.settings.compiler == "Visual Studio" and self.options.shared:
             for lib in ("opencore-amrwb", "opencore-amrnb"):
-                tools.files.rename(os.path.join(self.package_folder, "lib", "{}.dll.lib".format(lib)),
-                                   os.path.join(self.package_folder, "lib", "{}.lib".format(lib)))
+                tools.rename(os.path.join(self.package_folder, "lib", "{}.dll.lib".format(lib)),
+                             os.path.join(self.package_folder, "lib", "{}.lib".format(lib)))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "opencore-amr")

--- a/recipes/opencore-amr/all/conanfile.py
+++ b/recipes/opencore-amr/all/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, AutoToolsBuildEnvironment, tools
 from contextlib import contextmanager
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.43.0"
 
 
 class OpencoreAmrConan(ConanFile):
@@ -93,10 +93,15 @@ class OpencoreAmrConan(ConanFile):
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         if self.settings.compiler == "Visual Studio" and self.options.shared:
             for lib in ("opencore-amrwb", "opencore-amrnb"):
-                tools.rename(os.path.join(self.package_folder, "lib", "{}.dll.lib".format(lib)),
-                             os.path.join(self.package_folder, "lib", "{}.lib".format(lib)))
+                tools.files.rename(os.path.join(self.package_folder, "lib", "{}.dll.lib".format(lib)),
+                                   os.path.join(self.package_folder, "lib", "{}.lib".format(lib)))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "opencore-amr")
+        self.cpp_info.set_property("cmake_target_name", "opencore-amr::opencore-amr")
         for lib in ("opencore-amrwb", "opencore-amrnb"):
-            self.cpp_info.components[lib].names["pkg_config"] = lib
+            self.cpp_info.components[lib].set_property("cmake_target_name", f'opencore-amr::{lib}')
+            self.cpp_info.components[lib].set_property("pkg_config_name", lib)
             self.cpp_info.components[lib].libs = [lib]
+            # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generator removed
+            self.cpp_info.components[lib].names["pkg_config"] = lib

--- a/recipes/opencore-amr/config.yml
+++ b/recipes/opencore-amr/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.1.6":
+    folder: "all"
   "0.1.5":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **opencore-amr/0.1.6**

Added new version of the library. Tested locally with msvc15.

I also started recipe migration for Conan 2.0 but not sure if I am doing it right.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
