### PR TITLE
[gtest/all] Fix wrong required_conan_version

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -4,7 +4,7 @@ from conans.errors import ConanInvalidConfiguration
 import os
 import functools
 
-required_conan_version = ">=1.45.0"
+required_conan_version = ">=1.49.0"
 
 
 class GTestConan(ConanFile):


### PR DESCRIPTION
Error log:

```log
[2022-08-02T06:40:25.251Z] ERROR: gtest/1.10.0: Cannot load recipe.
[2022-08-02T06:40:25.251Z] Error loading conanfile at '/home/jenkins/workspace/indings_CI_branches_release_16.3/conanhome/.conan/data/gtest/1.10.0/_/_/export/conanfile.py': Unable to load conanfile in /home/jenkins/workspace/indings_CI_branches_release_16.3/conanhome/.conan/data/gtest/1.10.0/_/_/export/conanfile.py
[2022-08-02T06:40:25.251Z]   File "/usr/lib/python3.6/imp.py", line 172, in load_source
[2022-08-02T06:40:25.251Z]     module = _load(spec)
[2022-08-02T06:40:25.251Z]   File "<frozen importlib._bootstrap>", line 684, in _load
[2022-08-02T06:40:25.251Z]   File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
[2022-08-02T06:40:25.251Z]   File "<frozen importlib._bootstrap_external>", line 678, in exec_module
[2022-08-02T06:40:25.251Z]   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
[2022-08-02T06:40:25.251Z]   File "/home/jenkins/workspace/indings_CI_branches_release_16.3/conanhome/.conan/data/gtest/1.10.0/_/_/export/conanfile.py", line 1, in <module>
[2022-08-02T06:40:25.251Z]     from conan.tools.microsoft import is_msvc, msvc_runtime_flag
[2022-08-02T06:40:25.251Z] ImportError: cannot import name 'is_msvc'
```

Conan Version: 1.45.0
I used git blame to determine 1.49.0 is the correct minimum version

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
