### PR TITLE
[zlib-ng] Adapt recipe to be cross-compatible with Conan v1 and v2

### DIFF
--- a/recipes/zlib-ng/all/CMakeLists.txt
+++ b/recipes/zlib-ng/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.11)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory("source_subfolder")

--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -30,7 +30,6 @@ class ZlibNgConan(ConanFile):
                        "with_new_strategies": True,
                        "with_native_instructions": False,
                        "fPIC": True}
-    generators = "CMakeToolchain",
 
     @property
     def _source_subfolder(self):
@@ -62,6 +61,7 @@ class ZlibNgConan(ConanFile):
         tc.variables["WITH_OPTIM"] = self.options.with_optim
         tc.variables["WITH_NEW_STRATEGIES"] = self.options.with_new_strategies
         tc.variables["WITH_NATIVE_INSTRUCTIONS"] = self.options.with_native_instructions
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)
@@ -69,7 +69,8 @@ class ZlibNgConan(ConanFile):
         cmake.build()
 
     def package(self):
-        files.copy(self, "LICENSE.md", src=self._source_subfolder, dst="licenses")
+        license_folder = os.path.join(self.package_folder, "licenses")
+        files.copy(self, "LICENSE.md", src=self._source_subfolder, dst=license_folder)
         cmake = CMake(self)
         cmake.install()
         files.rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))

--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
 
-equired_conan_version = ">=1.50.0"
+required_conan_version = ">=1.50.0"
 
 class ZlibNgConan(ConanFile):
     name = "zlib-ng"

--- a/recipes/zlib-ng/all/conanfile.py
+++ b/recipes/zlib-ng/all/conanfile.py
@@ -1,11 +1,12 @@
-from conans import CMake, tools
 from conan import ConanFile
-from conans.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration
+from conan.tools import files
+from conan.tools.cmake import CMake, CMakeToolchain
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
-import functools
 
-equired_conan_version = ">=1.33.0"
+equired_conan_version = ">=1.50.0"
 
 class ZlibNgConan(ConanFile):
     name = "zlib-ng"
@@ -15,7 +16,6 @@ class ZlibNgConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/zlib-ng/zlib-ng/"
     settings = "os", "arch", "compiler", "build_type"
-    exports_sources = ["CMakeLists.txt"]
     options = {"shared": [True, False],
                "zlib_compat": [True, False],
                "with_gzfileop": [True, False],
@@ -30,15 +30,11 @@ class ZlibNgConan(ConanFile):
                        "with_new_strategies": True,
                        "with_native_instructions": False,
                        "fPIC": True}
-    generators = "cmake",
+    generators = "CMakeToolchain",
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -51,35 +47,32 @@ class ZlibNgConan(ConanFile):
         del self.settings.compiler.cppstd
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
+        files.get(self, **self.conan_data["sources"][self.version],
             destination=self._source_subfolder, strip_root=True)
 
     def validate(self):
-        if self.options.zlib_compat and not self.options.with_gzfileop:
+        if self.info.options.zlib_compat and not self.info.options.with_gzfileop:
             raise ConanInvalidConfiguration("The option 'with_gzfileop' must be True when 'zlib_compat' is True.")
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["ZLIB_ENABLE_TESTS"] = False
-        cmake.definitions["ZLIB_COMPAT"] = self.options.zlib_compat
-        cmake.definitions["WITH_GZFILEOP"] = self.options.with_gzfileop
-        cmake.definitions["WITH_OPTIM"] = self.options.with_optim
-        cmake.definitions["WITH_NEW_STRATEGIES"] = self.options.with_new_strategies
-        cmake.definitions["WITH_NATIVE_INSTRUCTIONS"] = self.options.with_native_instructions
-
-        cmake.configure()
-        return cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ZLIB_ENABLE_TESTS"] = False
+        tc.variables["ZLIB_COMPAT"] = self.options.zlib_compat
+        tc.variables["WITH_GZFILEOP"] = self.options.with_gzfileop
+        tc.variables["WITH_OPTIM"] = self.options.with_optim
+        tc.variables["WITH_NEW_STRATEGIES"] = self.options.with_new_strategies
+        tc.variables["WITH_NATIVE_INSTRUCTIONS"] = self.options.with_native_instructions
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=self._source_subfolder)
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE.md", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        files.copy(self, "LICENSE.md", src=self._source_subfolder, dst="licenses")
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        files.rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         #FIXME: CMake targets are https://github.com/zlib-ng/zlib-ng/blob/29fd4672a2279a0368be936d7cd44d013d009fae/CMakeLists.txt#L914
@@ -88,8 +81,8 @@ class ZlibNgConan(ConanFile):
         if self.settings.os == "Windows":
             # The library name of zlib-ng is complicated in zlib-ng>=2.0.4:
             # https://github.com/zlib-ng/zlib-ng/blob/2.0.4/CMakeLists.txt#L994-L1016
-            base = "zlib" if is_msvc(self) or tools.Version(self.version) < "2.0.4" or self.options.shared else "z"
-            static_flag = "static" if is_msvc(self) and not self.options.shared and tools.Version(self.version) >= "2.0.4" else ""
+            base = "zlib" if is_msvc(self) or Version(self.version) < "2.0.4" or self.options.shared else "z"
+            static_flag = "static" if is_msvc(self) and not self.options.shared and Version(self.version) >= "2.0.4" else ""
             build_type = "d" if self.settings.build_type == "Debug" else ""
             self.cpp_info.libs = ["{}{}{}{}".format(base, static_flag, suffix, build_type)]
         else:

--- a/recipes/zlib-ng/all/test_package/CMakeLists.txt
+++ b/recipes/zlib-ng/all/test_package/CMakeLists.txt
@@ -1,9 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+find_package(zlib-ng REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} CONAN_PKG::zlib-ng)
+target_link_libraries(${PROJECT_NAME} zlib-ng::zlib-ng)
 set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)

--- a/recipes/zlib-ng/all/test_package/conanfile.py
+++ b/recipes/zlib-ng/all/test_package/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.build import cross_building
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeDeps", "CMakeToolchain"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/zlib-ng/all/test_package/conanfile.py
+++ b/recipes/zlib-ng/all/test_package/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.cmake import CMake, cmake_layout
 from conan.tools.build import cross_building
 
 
-class helloTestConan(ConanFile):
+class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeDeps", "CMakeToolchain"
 

--- a/recipes/zlib-ng/all/test_package/conanfile.py
+++ b/recipes/zlib-ng/all/test_package/conanfile.py
@@ -1,17 +1,26 @@
 import os
-from conans import ConanFile, CMake, tools
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import cross_building
 
 
-class TestPackageConan(ConanFile):
+class helloTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
+    def layout(self):
+        cmake_layout(self)
+
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if not cross_building(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/zlib-ng/all/test_package_v1/CMakeLists.txt
+++ b/recipes/zlib-ng/all/test_package_v1/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/../test_package/test_package.c)
+target_link_libraries(${PROJECT_NAME} CONAN_PKG::zlib-ng)
+set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)

--- a/recipes/zlib-ng/all/test_package_v1/conanfile.py
+++ b/recipes/zlib-ng/all/test_package_v1/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/zlib-ng/all/test_package_v1/conanfile.py
+++ b/recipes/zlib-ng/all/test_package_v1/conanfile.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 import os
 from conans import ConanFile, CMake, tools
 


### PR DESCRIPTION
Specify library name and version:  **zlib-ng/all**

Adapt recipe to be cross-compatible with v1 and v2. 
Tested with Conan 1.51.0 and Conan 2.0.0-beta2