### PR TITLE
Support Macos for userspace-rcu

### DIFF
--- a/recipes/userspace-rcu/all/conanfile.py
+++ b/recipes/userspace-rcu/all/conanfile.py
@@ -38,8 +38,8 @@ class UserspaceRCUConan(ConanFile):
     generators = "PkgConfigDeps"
 
     def validate(self):
-        if self.settings.os not in ["Linux", "FreeBSD"]:
-            raise ConanInvalidConfiguration("Only Linux/FreeBSD supported")
+        if self.settings.os not in ["Linux", "FreeBSD", "Macos"]:
+            raise ConanInvalidConfiguration("Windows build unsupported")
 
     def configure(self):
         del self.settings.compiler.libcxx


### PR DESCRIPTION
**userspace-rcu/0.11.4**

Library should be supported by MacOS.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
