### PR TITLE
opentdf-client 1.1.0 upgraded conan recipe

### DIFF
--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan import ConanFile, tools, os
+from conan import ConanFile, tools
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 
 class OpenTDFConan(ConanFile):
@@ -54,9 +54,9 @@ class OpenTDFConan(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
-        self.copy("*", dst="lib", src=os.path.join(self._source_subfolder,"tdf-lib-cpp/lib"))
-        self.copy("*", dst="include", src=os.path.join(self._source_subfolder,"tdf-lib-cpp/include"))
-        self.copy("LICENSE", dst="licenses", src=os.path.join(self._source_subfolder,"tdf-lib-cpp"))
+        self.copy("*", dst="lib", src=join(self._source_subfolder,"tdf-lib-cpp/lib"))
+        self.copy("*", dst="include", src=join(self._source_subfolder,"tdf-lib-cpp/include"))
+        self.copy("LICENSE", dst="licenses", src=join(self._source_subfolder,"tdf-lib-cpp"))
 
     def package_info(self):
         self.cpp_info.components["libopentdf"].libs = ["opentdf_static"]

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -1,24 +1,20 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
-import os
-
-required_conan_version = ">=1.40.0"
-
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 
 class OpenTDFConan(ConanFile):
+
     name = "opentdf-client"
+    settings = "os", "compiler", "build_type", "arch"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.virtru.com"
     topics = ("opentdf", "opentdf-client", "tdf", "virtru")
     description = "openTDF core c++ client library for creating and accessing TDF protected data"
     license = "BSD-3-Clause-Clear"
-    generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"build_python": [True, False], "fPIC": [True, False]}
-    default_options = {"build_python": False, "fPIC": True}
-    exports_sources = ["CMakeLists.txt"]
+    options = {"fPIC": [True, False], "without_libiconv": [True, False], "without_zlib": [True, False], "branch_version": [True, False]}
+    default_options = {"fPIC": True, "without_libiconv": True, "without_zlib": True, "branch_version": False}
 
-    _cmake = None
+    exports_sources = ["CMakeLists.txt"]
 
     @property
     def _source_subfolder(self):
@@ -32,67 +28,62 @@ class OpenTDFConan(ConanFile):
     def _minimum_cpp_standard(self):
         return 17
 
-    @property
-    def _minimum_compilers_version(self):
-        return {
-            "Visual Studio": "17",
-            "gcc": "7.5.0",
-            "clang": "12",
-            "apple-clang": "12.0.0",
-        }
-
-    def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, self._minimum_cpp_standard)
-        min_version = self._minimum_compilers_version.get(str(self.settings.compiler))
-        if not min_version:
-            self.output.warn("{} recipe lacks information about the {} compiler support.".format(
-                self.name, self.settings.compiler))
-        else:
-            if tools.Version(self.settings.compiler.version) < min_version:
-                raise ConanInvalidConfiguration("{} requires C++{} support. The current compiler {} {} does not support it.".format(
-                    self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
-
-    def requirements(self):
-        self.requires("openssl/1.1.1l@")
-        self.requires("boost/1.76.0@")
-        self.requires("zlib/1.2.11@")
-        self.requires("ms-gsl/2.1.0@")
-        self.requires("libxml2/2.9.10@")
-        self.requires("libarchive/3.5.1@")
-        self.requires("nlohmann_json/3.10.4@")
-        self.requires("jwt-cpp/0.4.0@")
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+    def layout(self):
+        cmake_layout(self)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def source(self):
+        if self.options.branch_version:
+            git = tools.Git(folder=self._source_subfolder)
+            git.clone("git@github.com:opentdf/client-cpp.git", self.version)
+        else:
+            tools.files.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
         cmake.install()
         self.copy("*", dst="lib", src=os.path.join(self._source_subfolder,"tdf-lib-cpp/lib"))
         self.copy("*", dst="include", src=os.path.join(self._source_subfolder,"tdf-lib-cpp/include"))
         self.copy("LICENSE", dst="licenses", src=os.path.join(self._source_subfolder,"tdf-lib-cpp"))
 
-    # TODO - this only advertises the static lib, add dynamic lib also
     def package_info(self):
         self.cpp_info.components["libopentdf"].libs = ["opentdf_static"]
         self.cpp_info.components["libopentdf"].names["cmake_find_package"] = "opentdf-client"
         self.cpp_info.components["libopentdf"].names["cmake_find_package_multi"] = "opentdf-client"
         self.cpp_info.components["libopentdf"].names["pkg_config"] = "opentdf-client"
-        self.cpp_info.components["libopentdf"].requires = ["openssl::openssl", "boost::boost", "zlib::zlib", "ms-gsl::ms-gsl", "libxml2::libxml2", "libarchive::libarchive", "jwt-cpp::jwt-cpp", "nlohmann_json::nlohmann_json"]
+        self.cpp_info.components["libopentdf"].requires = ["openssl::openssl", "boost::boost", "ms-gsl::ms-gsl", "libxml2::libxml2", "jwt-cpp::jwt-cpp", "nlohmann_json::nlohmann_json"]
 
+    def configure(self):
+        if self.options.without_zlib:
+            self.options["libxml2"].zlib = False
+        if self.options.without_libiconv:
+            self.options["boost"].without_locale = True
+            self.options["boost"].without_log = True
+
+    def requirements(self):
+        self.requires("openssl/1.1.1q@")
+        self.requires("boost/1.76.0@")
+        self.requires("ms-gsl/2.1.0@")
+        self.requires("libxml2/2.9.10@")
+        self.requires("nlohmann_json/3.10.4@")
+        self.requires("jwt-cpp/0.4.0@")
+        # We do not require zlib but conan-center provides default build binaries, and boost+libxml2
+        # specify differerent versions, which causes a build fail due to the dependency conflict.
+        # Overriding the version here allows a clean build with the stock build settings.
+        if not self.options.without_zlib:
+            self.requires("zlib/1.2.12@")
+        # Same for libiconv
+        if not self.options.without_libiconv:
+            self.requires("libiconv/2.17@")

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan import ConanFile
+from conan import ConanFile, tools, os
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 
 class OpenTDFConan(ConanFile):

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -43,7 +43,7 @@ class OpenTDFConan(ConanFile):
 
     def source(self):
         if self.options.branch_version:
-            git = Git(folder=self._source_subfolder)
+            git = Git(self, folder=self._source_subfolder)
             git.clone("git@github.com:opentdf/client-cpp.git", self.version)
         else:
             tools.files.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -43,7 +43,7 @@ class OpenTDFConan(ConanFile):
 
     def source(self):
         if self.options.branch_version:
-            git = tools.Git(folder=self._source_subfolder)
+            git = conan.tools.scm.Git(folder=self._source_subfolder)
             git.clone("git@github.com:opentdf/client-cpp.git", self.version)
         else:
             tools.files.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
@@ -56,9 +56,9 @@ class OpenTDFConan(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
-        conan.tools.files.copy(self, "*", os.path.join(self._source_subfolder,"tdf-lib-cpp/lib"), "lib")
-        conan.tools.files.copy(self, "*", os.path.join(self._source_subfolder,"tdf-lib-cpp/include"), "include")
-        conan.tools.files.copy(self, "LICENSE", os.path.join(self._source_subfolder,"tdf-lib-cpp"), "licenses")
+        self.copy("*", dst="lib", src=os.path.join(self._source_subfolder,"tdf-lib-cpp/lib"))
+        self.copy("*", dst="include", src=os.path.join(self._source_subfolder,"tdf-lib-cpp/include"))
+        self.copy("LICENSE", dst="licenses", src=os.path.join(self._source_subfolder,"tdf-lib-cpp"))
 
     def package_info(self):
         self.cpp_info.components["libopentdf"].libs = ["opentdf_static"]

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -1,4 +1,6 @@
+import os
 from conan import ConanFile, tools
+from conan.tools.scm import Git
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 
 class OpenTDFConan(ConanFile):
@@ -54,9 +56,9 @@ class OpenTDFConan(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
-        self.copy("*", dst="lib", src=join(self._source_subfolder,"tdf-lib-cpp/lib"))
-        self.copy("*", dst="include", src=join(self._source_subfolder,"tdf-lib-cpp/include"))
-        self.copy("LICENSE", dst="licenses", src=join(self._source_subfolder,"tdf-lib-cpp"))
+        conan.tools.files.copy(self, "*", os.path.join(self._source_subfolder,"tdf-lib-cpp/lib"), "lib")
+        conan.tools.files.copy(self, "*", os.path.join(self._source_subfolder,"tdf-lib-cpp/include"), "include")
+        conan.tools.files.copy(self, "LICENSE", os.path.join(self._source_subfolder,"tdf-lib-cpp"), "licenses")
 
     def package_info(self):
         self.cpp_info.components["libopentdf"].libs = ["opentdf_static"]

--- a/recipes/opentdf-client/all/conanfile.py
+++ b/recipes/opentdf-client/all/conanfile.py
@@ -43,7 +43,7 @@ class OpenTDFConan(ConanFile):
 
     def source(self):
         if self.options.branch_version:
-            git = conan.tools.scm.Git(folder=self._source_subfolder)
+            git = Git(folder=self._source_subfolder)
             git.clone("git@github.com:opentdf/client-cpp.git", self.version)
         else:
             tools.files.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)


### PR DESCRIPTION
Specify library name and version:  opentdf-client/1.1.0

Updates to dependencies to support opentdf-client 1.1.0

**Partial decrypt/random access, IOProvider, S3**

- Remove use of libarchive, uses local zip implementation
- Architectural change - core code uses pluggable IOProvider objects to read/write data
- IOProvider objects for buffers, files, Amazon S3 (also works with Google Cloud Storage)
- Partial decrypt/random access - now able to retrieve just some of plaintext from a TDF based on offset+length

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
