### PR TITLE
[linter] Add first rule for test_package files

### DIFF
--- a/linter/check_no_test_package_name.py
+++ b/linter/check_no_test_package_name.py
@@ -5,7 +5,7 @@ from astroid import nodes, Const, AssignName
 
 class NoPackageName(BaseChecker):
     """
-       Conanfile used for testing a package should provide a name
+       Conanfile used for testing a package should NOT provide a name
     """
 
     __implements__ = IAstroidChecker

--- a/linter/check_no_test_package_name.py
+++ b/linter/check_no_test_package_name.py
@@ -1,0 +1,30 @@
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+from astroid import nodes, Const, AssignName
+
+
+class NoPackageName(BaseChecker):
+    """
+       Conanfile used for testing a package should provide a name
+    """
+
+    __implements__ = IAstroidChecker
+
+    name = "conan-test-package-name"
+    msgs = {
+        "E9007": (
+            "No 'name' attribute in test_package conanfile",
+            "conan-test-no-name",
+            "No 'name' attribute in test_package conanfile."
+        )
+    }
+
+    def visit_classdef(self, node: nodes) -> None:
+        if node.basenames == ['ConanFile']:
+            for attr in node.body:
+                children = list(attr.get_children())
+                if len(children) == 2 and \
+                   isinstance(children[0], AssignName) and \
+                   children[0].name == "name" and \
+                   isinstance(children[1], Const):
+                    self.add_message("conan-test-no-name", node=attr, line=attr.lineno)

--- a/linter/conanv2_test_transition.py
+++ b/linter/conanv2_test_transition.py
@@ -1,14 +1,14 @@
 """
 
-Pylint plugin/rules for conanfiles in Conan Center Index
+Pylint plugin/rules for test_package folder in Conan Center Index
 
 """
 
 from pylint.lint import PyLinter
-from linter.check_package_name import PackageName
 from linter.check_import_conanfile import ImportConanFile
+from linter.check_no_test_package_name import NoPackageName
 
 
 def register(linter: PyLinter) -> None:
-    linter.register_checker(PackageName(linter))
+    linter.register_checker(NoPackageName(linter))
     linter.register_checker(ImportConanFile(linter))

--- a/linter/pylintrc_testpackage
+++ b/linter/pylintrc_testpackage
@@ -1,5 +1,5 @@
 [MASTER]
-load-plugins=linter.conanv2_transition,
+load-plugins=linter.conanv2_test_transition,
              linter.transform_conanfile,
              linter.transform_imports
 py-version=3.6

--- a/recipes/aaf/all/test_package/conanfile.py
+++ b/recipes/aaf/all/test_package/conanfile.py
@@ -3,6 +3,7 @@ import os
 
 
 class TestPackageConan(ConanFile):
+    name = "linter-tell-me-something"
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 

--- a/recipes/aaf/all/test_package/conanfile.py
+++ b/recipes/aaf/all/test_package/conanfile.py
@@ -3,7 +3,6 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    name = "linter-tell-me-something"
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
 


### PR DESCRIPTION
Rules for recipe `conanfile.py` and for `test_package/conanfile.py` should be different. Here I'm introducing the first difference (easy one):
 * recipe files require a `name` attribute
 * that `name` attribute is forbidden in test-package ones

This should serve as a starting point to add more rules.
