### PR TITLE
Fix issue 12028 - Conan cannot install boost on Windows based on Linux profiles

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -420,7 +420,7 @@ class BoostConan(ConanFile):
             )
 
         if self._stacktrace_addr2line_available:
-            if os.path.abspath(str(self.options.addr2line_location)) != str(self.options.addr2line_location):
+            if not os.path.isabs(str(self.options.addr2line_location)):
                 raise ConanInvalidConfiguration("addr2line_location must be an absolute path to addr2line")
 
         # Check, when a boost module is enabled, whether the boost modules it depends on are enabled as well.


### PR DESCRIPTION
Library:  **boost/all**

Related to issue #12028 

Fix the way to checked if `path_to_addr2line` is absolute
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
