### PR TITLE
cpp-httplib: add version 0.11.1

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.1":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.11.1.tar.gz"
+    sha256: "1ce2f0393ba779ec34885c5cd937141b4b5b730e2bc2efc34eb8554289c24d61"
   "0.11.0":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.11.0.tar.gz"
     sha256: "9f533b0aa67066bd8f049e080eef75ad710a2f3ba3d80edbb13957389a5eeca7"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.1":
+    folder: all
   "0.11.0":
     folder: all
   "0.10.9":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cpp-httplib/0.11.1**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
