### PR TITLE
Fixing issue #12040: Can't find SQLite3 using CMake with cmake_paths generator

### DIFF
--- a/recipes/sqlite3/all/conanfile.py
+++ b/recipes/sqlite3/all/conanfile.py
@@ -223,4 +223,4 @@ class Sqlite3Conan(ConanFile):
         self.cpp_info.components["sqlite"].set_property("cmake_target_name", "SQLite::SQLite3")
         self.cpp_info.components["sqlite"].set_property("pkg_config_name", "sqlite3")
 
-        self.cpp_info.components["sqlite"].builddirs = [os.path.join("lib", "cmake")]
+        self.cpp_info.components["sqlite"].builddirs.append(os.path.join("lib", "cmake"))


### PR DESCRIPTION
- Package: sqlite3/3.39.2
- Fixing bug:  #12040

fixes #12040

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
