### PR TITLE
[android-ndk/r25] add 2022 LTS version

### DIFF
--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -1,4 +1,17 @@
 sources:
+  "r25":
+    "Windows":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r25-windows.zip"
+        sha256: "bdb25e75647532f979844f549a33eaf75c54a2cb4367f349be187ae9bfee9234"
+    "Linux":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r25-linux.zip"
+        sha256: "cd661aeda5d9b7cfb6e64bd80737c274d7c1c0d026df2f85be3bf3327b25e545"
+    "Macos":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r25-darwin.zip"
+        sha256: "2373424b91bba4cdd15e4c82e05f77a44ba3617aa3329843958ea3d0e25e62d0"
   "r24":
     "Windows":
       "x86_64":

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -45,7 +45,7 @@ class AndroidNDKConan(ConanFile):
             raise ConanInvalidConfiguration(f"os,arch={self.settings.os},{self.settings.arch} is not supported by {self.name} (no binaries are available)")
 
     def build(self):
-        if self.version in ['r23', 'r23b', 'r23c', 'r24']:
+        if self.version in ['r23', 'r23b', 'r23c', 'r24', 'r25']:
             data = self.conan_data["sources"][self.version][str(self.settings.os)][str(self._arch)]
             unzip_fix_symlinks(url=data["url"], target_folder=self._source_subfolder, sha256=data["sha256"])
         else:

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -26,7 +26,7 @@ class AndroidNDKConan(ConanFile):
 
     @property
     def _is_universal2(self):
-        return self.version in ["r23b", "r23c", "r24"] and self.settings.os == "Macos" and self.settings.arch in ["x86_64", "armv8"]
+        return self.version in ["r23b", "r23c", "r24", "r25"] and self.settings.os == "Macos" and self.settings.arch in ["x86_64", "armv8"]
 
     @property
     def _arch(self):

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -1,5 +1,5 @@
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile, tools
+from conan.errors import ConanInvalidConfiguration
 import os
 import re
 import shutil
@@ -132,22 +132,24 @@ class AndroidNDKConan(ConanFile):
                 filename = os.path.join(root, filename)
                 with open(filename, "rb") as f:
                     sig = f.read(4)
-                    if type(sig) is str:
+                    if isinstance(sig, str):
                         sig = [ord(s) for s in sig]
                     else:
-                        sig = [s for s in sig]
+                        sig = list(sig)
                     if len(sig) > 2 and sig[0] == 0x23 and sig[1] == 0x21:
                         self.output.info(f"chmod on script file: '{filename}'")
                         self._chmod_plus_x(filename)
                     elif sig == [0x7F, 0x45, 0x4C, 0x46]:
                         self.output.info(f"chmod on ELF file: '{filename}'")
                         self._chmod_plus_x(filename)
-                    elif sig == [0xCA, 0xFE, 0xBA, 0xBE] or \
-                         sig == [0xBE, 0xBA, 0xFE, 0xCA] or \
-                         sig == [0xFE, 0xED, 0xFA, 0xCF] or \
-                         sig == [0xCF, 0xFA, 0xED, 0xFE] or \
-                         sig == [0xFE, 0xEF, 0xFA, 0xCE] or \
-                         sig == [0xCE, 0xFA, 0xED, 0xFE]:
+                    elif sig in (
+                        [202, 254, 186, 190],
+                        [190, 186, 254, 202],
+                        [254, 237, 250, 207],
+                        [207, 250, 237, 254],
+                        [254, 239, 250, 206],
+                        [206, 250, 237, 254]
+                    ):
                         self.output.info(f"chmod on Mach-O file: '{filename}'")
                         self._chmod_plus_x(filename)
 

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -47,9 +47,9 @@ class AndroidNDKConan(ConanFile):
     def build(self):
         if self.version in ['r23', 'r23b', 'r23c', 'r24', 'r25']:
             data = self.conan_data["sources"][self.version][str(self.settings.os)][str(self._arch)]
-            unzip_fix_symlinks(url=data["url"], target_folder=self._source_subfolder, sha256=data["sha256"])
+            self.unzip_fix_symlinks(url=data["url"], target_folder=self._source_subfolder, sha256=data["sha256"])
         else:
-            tools.files.get(**self.conan_data["sources"][self.version][str(self.settings.os)][str(self._arch)],
+            tools.files.get(self, **self.conan_data["sources"][self.version][str(self.settings.os)][str(self._arch)],
                   destination=self._source_subfolder, strip_root=True)
 
     def package_id(self):
@@ -341,37 +341,37 @@ class AndroidNDKConan(ConanFile):
         self.env_info.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE = "BOTH"
 
 
-def unzip_fix_symlinks(url, target_folder, sha256):
-    # Python's built-in module 'zipfile' won't handle symlinks (https://bugs.python.org/issue37921)
-    # Most of the logic borrowed from this PR https://github.com/conan-io/conan/pull/8100
-
-    filename = "android_sdk.zip"
-    tools.files.download(url, filename, sha256=sha256)
-    tools.files.unzip(filename, destination=target_folder, strip_root=True)
-
-    def is_symlink_zipinfo(zi):
-        return (zi.external_attr >> 28) == 0xA
-
-    full_path = os.path.normpath(target_folder)
-    import zipfile
-    with zipfile.ZipFile(filename, "r") as z:
-        zip_info = z.infolist()
-
-        names = [n.replace("\\", "/") for n in z.namelist()]
-        common_folder = os.path.commonprefix(names).split("/", 1)[0]
-
-        for file_ in zip_info:
-            if is_symlink_zipinfo(file_):
-                rel_path = os.path.relpath(file_.filename, common_folder)
-                full_name = os.path.join(full_path, rel_path)
-                target = tools.files.load(full_name)
-                os.unlink(full_name)
-
-                try:
-                    os.symlink(target, full_name)
-                except OSError:
-                    if not os.path.isabs(target):
-                        target = os.path.normpath(os.path.join(os.path.dirname(full_name), target))
-                    shutil.copy2(target, full_name)
-
-    os.unlink(filename)
+    def unzip_fix_symlinks(self, url, target_folder, sha256):
+        # Python's built-in module 'zipfile' won't handle symlinks (https://bugs.python.org/issue37921)
+        # Most of the logic borrowed from this PR https://github.com/conan-io/conan/pull/8100
+    
+        filename = "android_sdk.zip"
+        tools.files.download(self, url, filename, sha256=sha256)
+        tools.files.unzip(self, filename, destination=target_folder, strip_root=True)
+    
+        def is_symlink_zipinfo(zi):
+            return (zi.external_attr >> 28) == 0xA
+    
+        full_path = os.path.normpath(target_folder)
+        import zipfile
+        with zipfile.ZipFile(filename, "r") as z:
+            zip_info = z.infolist()
+    
+            names = [n.replace("\\", "/") for n in z.namelist()]
+            common_folder = os.path.commonprefix(names).split("/", 1)[0]
+    
+            for file_ in zip_info:
+                if is_symlink_zipinfo(file_):
+                    rel_path = os.path.relpath(file_.filename, common_folder)
+                    full_name = os.path.join(full_path, rel_path)
+                    target = tools.files.load(self, full_name)
+                    os.unlink(full_name)
+    
+                    try:
+                        os.symlink(target, full_name)
+                    except OSError:
+                        if not os.path.isabs(target):
+                            target = os.path.normpath(os.path.join(os.path.dirname(full_name), target))
+                        shutil.copy2(target, full_name)
+    
+        os.unlink(filename)

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -143,12 +143,12 @@ class AndroidNDKConan(ConanFile):
                         self.output.info(f"chmod on ELF file: '{filename}'")
                         self._chmod_plus_x(filename)
                     elif sig in (
-                        [202, 254, 186, 190],
-                        [190, 186, 254, 202],
-                        [254, 237, 250, 207],
-                        [207, 250, 237, 254],
-                        [254, 239, 250, 206],
-                        [206, 250, 237, 254]
+                        [0xCA, 0xFE, 0xBA, 0xBE],
+                        [0xBE, 0xBA, 0xFE, 0xCA],
+                        [0xFE, 0xED, 0xFA, 0xCF],
+                        [0xCF, 0xFA, 0xED, 0xFE],
+                        [0xFE, 0xEF, 0xFA, 0xCE],
+                        [0xCE, 0xFA, 0xED, 0xFE]
                     ):
                         self.output.info(f"chmod on Mach-O file: '{filename}'")
                         self._chmod_plus_x(filename)

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -49,7 +49,7 @@ class AndroidNDKConan(ConanFile):
             data = self.conan_data["sources"][self.version][str(self.settings.os)][str(self._arch)]
             unzip_fix_symlinks(url=data["url"], target_folder=self._source_subfolder, sha256=data["sha256"])
         else:
-            tools.get(**self.conan_data["sources"][self.version][str(self.settings.os)][str(self._arch)],
+            tools.files.get(**self.conan_data["sources"][self.version][str(self.settings.os)][str(self._arch)],
                   destination=self._source_subfolder, strip_root=True)
 
     def package_id(self):
@@ -346,8 +346,8 @@ def unzip_fix_symlinks(url, target_folder, sha256):
     # Most of the logic borrowed from this PR https://github.com/conan-io/conan/pull/8100
 
     filename = "android_sdk.zip"
-    tools.download(url, filename, sha256=sha256)
-    tools.unzip(filename, destination=target_folder, strip_root=True)
+    tools.files.download(url, filename, sha256=sha256)
+    tools.files.unzip(filename, destination=target_folder, strip_root=True)
 
     def is_symlink_zipinfo(zi):
         return (zi.external_attr >> 28) == 0xA
@@ -364,7 +364,7 @@ def unzip_fix_symlinks(url, target_folder, sha256):
             if is_symlink_zipinfo(file_):
                 rel_path = os.path.relpath(file_.filename, common_folder)
                 full_name = os.path.join(full_path, rel_path)
-                target = tools.load(full_name)
+                target = tools.files.load(full_name)
                 os.unlink(full_name)
 
                 try:

--- a/recipes/android-ndk/config.yml
+++ b/recipes/android-ndk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "r25":
+    folder: all
   "r24":
     folder: all
   "r23c":


### PR DESCRIPTION
Specify library name and version:  **android-ndk/r25**

This is an LTS version that works on M1 Macs, this version will be the only one until the 2023 release. 
So this version seems relevant to me.

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
