### PR TITLE
[linter] Fix enabled/disabled items for test_package

### DIFF
--- a/linter/pylintrc_testpackage
+++ b/linter/pylintrc_testpackage
@@ -15,9 +15,10 @@ disable=fixme,
         missing-class-docstring,
         invalid-name,
         wrong-import-order,  # TODO: Remove
-        import-outside-toplevel,  # TODO: Remove
-        conan-bad-name,
-        conan-missing-name
+        import-outside-toplevel  # TODO: Remove
+
+enable=conan-test-no-name,
+       conan-import-conanfile
 
 [REPORTS]
 evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error) / statement) * 10))


### PR DESCRIPTION
`conan-bad-name` and `conan-missing-name` are identifiers defined in a rule that is not included for `test_package/conanfile.py` files.