### PR TITLE
expat: fix CMAKE_POLICY_DEFAULT_CMP0042 injection + add test_v1_package

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -39,9 +39,9 @@ sources:
     sha256: "42241742da97d40557857726cc4f02008cd14f2b44134c6e33af043967cd9d15"
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_2_7/expat-2.2.7.tar.gz"
 patches:
+  "2.3.0":
+    - patch_file: "patches/0001-2.3.0-relax-vs-restriction.patch"
   "2.2.7":
     - patch_file: "patches/0002-2.2.7-fix-set-cmake-policies.patch"
       patch_description: "cmake_minimum_required(VERSION) should be called before project() for cmake policies to work"
       patch_type: "conan"
-  "2.3.0":
-    - patch_file: "patches/0001-2.3.0-relax-vs-restriction.patch"

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -40,8 +40,7 @@ class ExpatConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        if not is_msvc(self):
-            del self.settings.compiler.libcxx
+        del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
     def layout(self):

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -40,8 +40,14 @@ class ExpatConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+        try:
+           del self.settings.compiler.libcxx
+        except Exception:
+           pass
+        try:
+           del self.settings.compiler.cppstd
+        except Exception:
+           pass
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.47.0"
+required_conan_version = ">=1.50.0"
 
 
 class ExpatConan(ConanFile):

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile, tools
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, collect_libs, copy, rmdir
-from conan.tools.microsoft import msvc_runtime_flag, is_msvc
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
 
@@ -74,7 +74,7 @@ class ExpatConan(ConanFile):
             # EXPAT_CHAR_TYPE was added in 2.2.8
             tc.variables["EXPAT_CHAR_TYPE"] = self.options.char_type
             if is_msvc(self):
-                tc.variables["EXPAT_MSVC_STATIC_CRT"] = "MT" in msvc_runtime_flag(self)
+                tc.variables["EXPAT_MSVC_STATIC_CRT"] = is_msvc_static_runtime(self)
         if Version(self.version) >= "2.2.10":
             tc.variables["EXPAT_BUILD_PKGCONFIG"] = False
         tc.generate()

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -60,7 +60,7 @@ class ExpatConan(ConanFile):
             tc.variables["BUILD_tests"] = "Off"
             tc.variables["BUILD_tools"] = "Off"
             # Generate a relocatable shared lib on Macos
-            tc.variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+            tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         else:
             # These options were renamed in 2.2.8 to be more consistent
             tc.variables["EXPAT_BUILD_DOCS"] = "Off"

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile, tools
-from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, collect_libs, copy, rmdir
 from conan.tools.microsoft import msvc_runtime_flag, is_msvc
 from conan.tools.scm import Version
@@ -43,6 +43,9 @@ class ExpatConan(ConanFile):
         if not is_msvc(self):
             del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def source(self):
         tools.files.get(self,

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -86,7 +86,7 @@ class ExpatConan(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, "COPYING", self.build_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -86,7 +86,7 @@ class ExpatConan(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -57,20 +57,20 @@ class ExpatConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         if Version(self.version) < "2.2.8":
-            tc.variables["BUILD_doc"] = "Off"
-            tc.variables["BUILD_examples"] = "Off"
+            tc.variables["BUILD_doc"] = False
+            tc.variables["BUILD_examples"] = False
             tc.variables["BUILD_shared"] = self.options.shared
-            tc.variables["BUILD_tests"] = "Off"
-            tc.variables["BUILD_tools"] = "Off"
+            tc.variables["BUILD_tests"] = False
+            tc.variables["BUILD_tools"] = False
             # Generate a relocatable shared lib on Macos
             tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         else:
             # These options were renamed in 2.2.8 to be more consistent
-            tc.variables["EXPAT_BUILD_DOCS"] = "Off"
-            tc.variables["EXPAT_BUILD_EXAMPLES"] = "Off"
+            tc.variables["EXPAT_BUILD_DOCS"] = False
+            tc.variables["EXPAT_BUILD_EXAMPLES"] = False
             tc.variables["EXPAT_SHARED_LIBS"] = self.options.shared
-            tc.variables["EXPAT_BUILD_TESTS"] = "Off"
-            tc.variables["EXPAT_BUILD_TOOLS"] = "Off"
+            tc.variables["EXPAT_BUILD_TESTS"] = False
+            tc.variables["EXPAT_BUILD_TOOLS"] = False
             # EXPAT_CHAR_TYPE was added in 2.2.8
             tc.variables["EXPAT_CHAR_TYPE"] = self.options.char_type
             if is_msvc(self):

--- a/recipes/expat/all/test_v1_package/CMakeLists.txt
+++ b/recipes/expat/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(EXPAT REQUIRED)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE EXPAT::EXPAT)

--- a/recipes/expat/all/test_v1_package/conanfile.py
+++ b/recipes/expat/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+# pylint: skip-file
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
- `CMAKE_POLICY_DEFAULT_CMP*` must be injected through `CMakeToolchain` with `cache_variables`, not `variables`, otherwise it has no effect.
- add a `test_v1_package`
- add `cmake_layout` (the default one is an in source build, and everything is mixed-up in source & build: patches, source code, build artifacts)

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
