### PR TITLE
fast_float: add version 3.5.1

### DIFF
--- a/recipes/fast_float/all/conandata.yml
+++ b/recipes/fast_float/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.5.1":
+    url: "https://github.com/fastfloat/fast_float/archive/v3.5.1.tar.gz"
+    sha256: "8558bf9c66ccd2f7d03c94461a107f49ad9cf6e4f6c0c84e148fec0aa32b4dd9"
   "3.4.0":
     url: "https://github.com/fastfloat/fast_float/archive/v3.4.0.tar.gz"
     sha256: "a242877d2fae81ca412033f5ebf5dbc43cb029c56b4af78e33106b9a69f8f58e"

--- a/recipes/fast_float/config.yml
+++ b/recipes/fast_float/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.5.1":
+    folder: all
   "3.4.0":
     folder: all
   "3.2.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **fast_float/3.5.1**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
