### PR TITLE
log4cplus: add thread_pool option

### DIFF
--- a/recipes/log4cplus/all/conanfile.py
+++ b/recipes/log4cplus/all/conanfile.py
@@ -20,7 +20,8 @@ class Log4cplusConan(ConanFile):
                "working_locale": [True, False],
                "working_c_locale": [True, False],
                "decorated_name": [True, False],
-               "unicode": [True, False]}
+               "unicode": [True, False],
+               "thread_pool": [True, False]}
     default_options = {"shared": False,
                        "fPIC": True,
                        "single_threaded": False,
@@ -29,7 +30,8 @@ class Log4cplusConan(ConanFile):
                        "working_locale": False,
                        "working_c_locale": False,
                        "decorated_name": False,
-                       "unicode": True}
+                       "unicode": True,
+                       "thread_pool": True}
     short_paths = True
 
     _cmake = None
@@ -65,6 +67,7 @@ class Log4cplusConan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        self._cmake.definitions["LOG4CPLUS_ENABLE_THREAD_POOL"] = self.options.thread_pool
         self._cmake.definitions["UNICODE"] = self.options.unicode
         self._cmake.definitions["LOG4CPLUS_BUILD_TESTING"] = False
         self._cmake.definitions["WITH_UNIT_TESTS"] = False

--- a/recipes/log4cplus/all/conanfile.py
+++ b/recipes/log4cplus/all/conanfile.py
@@ -1,4 +1,5 @@
 import os
+from conan.tools import files
 from conans import ConanFile, CMake, tools
 
 
@@ -60,7 +61,7 @@ class Log4cplusConan(ConanFile):
 
     def source(self):
         archive_name = self.name + "-" + self.version
-        tools.get(**self.conan_data["sources"][self.version])
+        files.get(self, **self.conan_data["sources"][self.version])
         os.rename(archive_name, self._source_subfolder)
 
     def _configure_cmake(self):
@@ -96,7 +97,7 @@ class Log4cplusConan(ConanFile):
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)


### PR DESCRIPTION
log4cplus all versions

As we need to disable the thread pool feature on Windows, I'm adding an option to do so.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
