### PR TITLE
[android-ndk] Export NDK path for CMakeToolchain

### DIFF
--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -5,7 +5,7 @@ import os
 import re
 import shutil
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.46.0"
 
 
 class AndroidNDKConan(ConanFile):

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -338,6 +338,8 @@ class AndroidNDKConan(ConanFile):
         self.env_info.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "BOTH"
         self.env_info.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE = "BOTH"
 
+        self.conf_info.define("tools.android:ndk_path", self.package_folder)
+
 
 def unzip_fix_symlinks(url, target_folder, sha256):
     # Python's built-in module 'zipfile' won't handle symlinks (https://bugs.python.org/issue37921)

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -48,7 +48,7 @@ class AndroidNDKConan(ConanFile):
     def build(self):
         if self.version in ['r23', 'r23b', 'r23c', 'r24', 'r25']:
             data = self.conan_data["sources"][self.version][str(self.settings.os)][str(self._arch)]
-            self._unzip_fix_symlinks(self, url=data["url"], target_folder=self._source_subfolder, sha256=data["sha256"])
+            self._unzip_fix_symlinks(url=data["url"], target_folder=self._source_subfolder, sha256=data["sha256"])
         else:
             get(self, **self.conan_data["sources"][self.version][str(self.settings.os)][str(self._arch)],
                   destination=self._source_subfolder, strip_root=True)

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -23,7 +23,7 @@ class AndroidNDKConan(ConanFile):
 
     @property
     def _source_subfolder(self):
-        return "source_subfolder"
+        return os.path.join(self.source_folder, "source_subfolder")
 
     @property
     def _is_universal2(self):

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -5,7 +5,7 @@ import os
 import re
 import shutil
 
-required_conan_version = ">=1.46.0"
+required_conan_version = ">=1.47.0"
 
 
 class AndroidNDKConan(ConanFile):

--- a/recipes/android-ndk/all/test_package/CMakeLists.txt
+++ b/recipes/android-ndk/all/test_package/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(test_package)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package CXX)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME})

--- a/recipes/android-ndk/all/test_package/conanfile.py
+++ b/recipes/android-ndk/all/test_package/conanfile.py
@@ -1,19 +1,21 @@
 import os
 from conan import ConanFile
-from conans import CMake
+from conan.tools.cmake import CMake, cmake_layout
 from conan.tools.build import cross_building
 
 
 class TestPackgeConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    test_type = "explicit"
-    generators = "cmake"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
 
     def build_requirements(self):
-        self.build_requires(self.tested_reference_str)
+        self.tool_requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
-        # It only makes sense to build a library, if the target os is Android
+        # INFO: It only makes sense to build a library, if the target OS is Android
         if self.settings.os == "Android":
             cmake = CMake(self)
             cmake.configure()
@@ -22,11 +24,11 @@ class TestPackgeConan(ConanFile):
     def test(self):
         if not cross_building(self):
             if self.settings.os == "Windows":
-                self.run("ndk-build.cmd --version", run_environment=True)
+                self.run("ndk-build.cmd --version", env="conanrun")
             else:
-                self.run("ndk-build --version", run_environment=True)
+                self.run("ndk-build --version", env="conanrun")
 
-        # Run the project that was built using Android NDK
+        # INFO: Run the project that was built using Android NDK
         if self.settings.os == "Android":
             test_file = os.path.join("bin", "test_package")
             assert os.path.exists(test_file)

--- a/recipes/android-ndk/all/test_package/conanfile.py
+++ b/recipes/android-ndk/all/test_package/conanfile.py
@@ -1,9 +1,11 @@
 import os
-from conans import ConanFile, tools, CMake
+from conan import ConanFile
+from conans import CMake
+from conan.tools.build import cross_building
 
 
 class TestPackgeConan(ConanFile):
-    settings = "os", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     test_type = "explicit"
     generators = "cmake"
 
@@ -18,7 +20,7 @@ class TestPackgeConan(ConanFile):
             cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not cross_building(self):
             if self.settings.os == "Windows":
                 self.run("ndk-build.cmd --version", run_environment=True)
             else:
@@ -28,4 +30,3 @@ class TestPackgeConan(ConanFile):
         if self.settings.os == "Android":
             test_file = os.path.join("bin", "test_package")
             assert os.path.exists(test_file)
-            # self.run("android-emulator {}".format(test_file), run_environment=True)

--- a/recipes/android-ndk/all/test_v1_package/CMakeLists.txt
+++ b/recipes/android-ndk/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.0)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/../test_package/test_package.cpp)
+target_link_libraries(${PROJECT_NAME})

--- a/recipes/android-ndk/all/test_v1_package/conanfile.py
+++ b/recipes/android-ndk/all/test_v1_package/conanfile.py
@@ -1,0 +1,32 @@
+import os
+from conan import ConanFile
+from conans import CMake
+from conan.tools.build import cross_building
+
+
+class TestPackgeConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    test_type = "explicit"
+    generators = "cmake"
+
+    def build_requirements(self):
+        self.build_requires(self.tested_reference_str)
+
+    def build(self):
+        # It only makes sense to build a library, if the target os is Android
+        if self.settings.os == "Android":
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            if self.settings.os == "Windows":
+                self.run("ndk-build.cmd --version", run_environment=True)
+            else:
+                self.run("ndk-build --version", run_environment=True)
+
+        # Run the project that was built using Android NDK
+        if self.settings.os == "Android":
+            test_file = os.path.join("bin", "test_package")
+            assert os.path.exists(test_file)


### PR DESCRIPTION
Specify library name and version:  **android-ndk/r24**

Since CMakeToolchain has been added to Conan Center, it consumes user configuration to determine which Android NDK path should be use: https://docs.conan.io/en/1.51/reference/conanfile/tools/cmake/cmaketoolchain.html#conf 

To keep same compatibility, that configuration need to be expose by the recipe too.

fixes #11863
fixes #11952

/cc @paulocoutinhox @n00b42

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
