### PR TITLE
opentelemetry-proto: add version 0.19.0

### DIFF
--- a/recipes/opentelemetry-proto/all/conandata.yml
+++ b/recipes/opentelemetry-proto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.19.0":
+    url: "https://github.com/open-telemetry/opentelemetry-proto/archive/v0.19.0.tar.gz"
+    sha256: "464bc2b348e674a1a03142e403cbccb01be8655b6de0f8bfe733ea31fcd421be"
   "0.18.0":
     url: "https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v0.18.0.tar.gz"
     sha256: "134ce87f0a623daac19b9507b92da0d9b82929e3db796bba631e422f6ea8d3b3"

--- a/recipes/opentelemetry-proto/config.yml
+++ b/recipes/opentelemetry-proto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.19.0":
+    folder: all
   "0.18.0":
     folder: all
   "0.17.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **opentelemetry-proto/0.19.0**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
