### PR TITLE
at-spi2-core: add version 2.45.90

### DIFF
--- a/recipes/at-spi2-core/config.yml
+++ b/recipes/at-spi2-core/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "2.45.1":
     folder: new
+  "2.45.90":
+    folder: new

--- a/recipes/at-spi2-core/new/conandata.yml
+++ b/recipes/at-spi2-core/new/conandata.yml
@@ -1,8 +1,14 @@
 sources:
+  "2.45.90":
+    url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.45/at-spi2-core-2.45.90.tar.xz"
+    sha256: "e9050ad3c24937548396b2377f2fcdb9321ce2daffad35e7554e8f6ad850ab0d"
   "2.45.1":
     sha256: "ba95f346e93108fbb3462c62437081d582154db279b4052dedc52a706828b192"
     url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.45/at-spi2-core-2.45.1.tar.xz"
 patches:
+  "2.45.90":
+    - base_path: "source_subfolder"
+      patch_file: "patches/93.patch"
   "2.45.1":
     - base_path: "source_subfolder"
       patch_file: "patches/93.patch"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **at-spi2-core/2.45.90**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
