### PR TITLE
aws-c-common: add version 0.7.5

### DIFF
--- a/recipes/aws-c-common/all/conandata.yml
+++ b/recipes/aws-c-common/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.7.5":
+    url: "https://github.com/awslabs/aws-c-common/archive/v0.7.5.tar.gz"
+    sha256: "e34fd3d3d32e3597f572205aaabbe995e162f4015e14c7328987b596bd25812c"
   "0.7.4":
     url: "https://github.com/awslabs/aws-c-common/archive/v0.7.4.tar.gz"
     sha256: "e9462a141b5db30006704f537d19b92357a59be38d590272e6118976b0356ccd"

--- a/recipes/aws-c-common/config.yml
+++ b/recipes/aws-c-common/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.7.5":
+    folder: all
   "0.7.4":
     folder: all
   "0.7.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **aws-c-common/0.7.5**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
