### PR TITLE
luau: add version 0.539

### DIFF
--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.539":
+    url: "https://github.com/Roblox/luau/archive/0.539.tar.gz"
+    sha256: "d0a33bbafc88d6d89f23e43229e523b117cd761f1fdbd86977800b5725cc647f"
   "0.538":
     url: "https://github.com/Roblox/luau/archive/0.538.tar.gz"
     sha256: "8a1240e02a7daacf1e5cff249040a3298c013157fc496c66adce6dcb21cc30be"
@@ -10,6 +13,11 @@ sources:
     sha256: "e6de36e83e9c537d92bcc94852ab498e3c15a310fd2c4cc4e21c616d8ae1a84f"
 
 patches:
+  "0.539":
+    - patch_file: "patches/0.536-0001-fix-cmake.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0.536-0002-rename-lerp.patch"
+      base_path: "source_subfolder"
   "0.538":
     - patch_file: "patches/0.536-0001-fix-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.539":
+    folder: all
   "0.538":
     folder: all
   "0.537":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **luau/0.539**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
