### PR TITLE
highway: add version 1.0.0

### DIFF
--- a/recipes/highway/all/conandata.yml
+++ b/recipes/highway/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/google/highway/archive/1.0.0.tar.gz"
+    sha256: "ab4f5f864932268356f9f6aa86f612fa4430a7db3c8de0391076750197e876b8"
   "0.17.0":
     url: "https://github.com/google/highway/archive/0.17.0.tar.gz"
     sha256: "25158fd5c090b70ecea47fc246c860d150f07f801d2434e1e51ec14a6c15822c"

--- a/recipes/highway/config.yml
+++ b/recipes/highway/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "0.17.0":
     folder: all
   "0.16.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **highway/1.0.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
