### PR TITLE
[boost] Fix scm.Version usage

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     from io import StringIO
 
-required_conan_version = ">=1.46.0"
+required_conan_version = ">=1.47.0"
 
 
 # When adding (or removing) an option, also add this option to the list in


### PR DESCRIPTION
Specify library name and version:  **boost/1.79.0**

The new `scm.Version` no longer parses `semver`, it only splits the version string.

fixes #12044

/cc @markferry

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
