### PR TITLE
blend2d: migration to Conan v2 and fix compilation error in gcc12 with c++20

### DIFF
--- a/recipes/blend2d/all/CMakeLists.txt
+++ b/recipes/blend2d/all/CMakeLists.txt
@@ -4,7 +4,4 @@ project(cmake_wrapper LANGUAGES CXX)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(CMAKE_CXX_STANDARD 11)
 
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory(source_subfolder)
+add_subdirectory(src)

--- a/recipes/blend2d/all/conandata.yml
+++ b/recipes/blend2d/all/conandata.yml
@@ -1,15 +1,15 @@
 sources:
   "0.0.18":
     url: "https://blend2d.com/download/blend2d-beta18.zip"
-    sha256: ""
+    sha256: "02d23b185183705215241d7b161937bbda5b427c54cc5aa4c03238ef8dd1e60b"
   "0.0.17":
     url: "https://blend2d.com/download/blend2d-beta17.zip"
     sha256: "06ee8fb0bea281d09291e498900093139426501a1a7f09dba0ec801dd340635e"
 
 patches:
   "0.0.18":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0.0.17-0001-disable-embed-asmjit.patch"
+    - patch_file: "patches/0.0.17-0001-disable-embed-asmjit.patch"
+    # fix gcc12 compilation error, backport from upstream
+    - patch_file: "patches/0.0.18-0002-fix-gcc12-compilationerror.patch"
   "0.0.17":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0.0.17-0001-disable-embed-asmjit.patch"
+    - patch_file: "patches/0.0.17-0001-disable-embed-asmjit.patch"

--- a/recipes/blend2d/all/conanfile.py
+++ b/recipes/blend2d/all/conanfile.py
@@ -1,15 +1,23 @@
-from conans import ConanFile, CMake, tools
 import os
 
-required_conan_version = ">=1.33.0"
+from conan import ConanFile
+from conan import tools
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
+from conan.tools.scm import Version
+from conan.tools.files import apply_conandata_patches
+from conan.tools.microsoft import is_msvc
+from conan.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.50.0"
 
 class Blend2dConan(ConanFile):
     name = "blend2d"
     description = "2D Vector Graphics Engine Powered by a JIT Compiler"
-    topics = ("2d-graphics", "rasterization", "asmjit", "jit")
     license = "Zlib"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://blend2d.com/"
+    topics = ("2d-graphics", "rasterization", "asmjit", "jit")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -19,22 +27,11 @@ class Blend2dConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-    generators = "cmake", "cmake_find_package_multi"
-
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        tools.files.copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
+        for p in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.files.copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -44,47 +41,50 @@ class Blend2dConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    def layout(self):
+        cmake_layout(self, src_folder='src')
+
     def requirements(self):
         self.requires("asmjit/cci.20220210")
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 11)
+        if self.info.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
 
         # In Visual Studio < 16, there are compilation error. patch is already provided.
         # https://github.com/blend2d/blend2d/commit/63db360c7eb2c1c3ca9cd92a867dbb23dc95ca7d
-        if self._is_msvc and tools.Version(self.settings.compiler.version) < "16":
-            raise tools.ConanInvalidConfiguration("This recipe does not support this compiler version")
+        if is_msvc(self) and tools.Version(self.settings.compiler.version) < "16":
+            raise ConanInvalidConfiguration("This recipe does not support this compiler version")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+        tools.files.get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["BLEND2D_TEST"] = False
-        self._cmake.definitions["BLEND2D_EMBED"] = False
-        self._cmake.definitions["BLEND2D_STATIC"] = not self.options.shared
-        self._cmake.definitions["BLEND2D_NO_STDCXX"] = False
+    def generate(self):
+        toolchain = CMakeToolchain(self)
+        toolchain.variables["BUILD_TESTING"] = False
+        toolchain.variables["BLEND2D_TEST"] = False
+        toolchain.variables["BLEND2D_EMBED"] = False
+        toolchain.variables["BLEND2D_STATIC"] = not self.options.shared
+        toolchain.variables["BLEND2D_NO_STDCXX"] = False
         if not self.options.shared:
-            self._cmake.definitions["CMAKE_C_FLAGS"] = "-DBL_STATIC"
-            self._cmake.definitions["CMAKE_CXX_FLAGS"] = "-DBL_STATIC"
-        self._cmake.configure()
-        return self._cmake
+            toolchain.variables["CMAKE_C_FLAGS"] = "-DBL_STATIC"
+            toolchain.variables["CMAKE_CXX_FLAGS"] = "-DBL_STATIC"
+        toolchain.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE.md", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        tools.files.copy(self, "LICENSE.md", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        tools.files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.libs = ["blend2d"]

--- a/recipes/blend2d/all/conanfile.py
+++ b/recipes/blend2d/all/conanfile.py
@@ -53,7 +53,7 @@ class Blend2dConan(ConanFile):
 
         # In Visual Studio < 16, there are compilation error. patch is already provided.
         # https://github.com/blend2d/blend2d/commit/63db360c7eb2c1c3ca9cd92a867dbb23dc95ca7d
-        if is_msvc(self) and tools.Version(self.settings.compiler.version) < "16":
+        if is_msvc(self) and Version(self.settings.compiler.version) < "16":
             raise ConanInvalidConfiguration("This recipe does not support this compiler version")
 
     def source(self):
@@ -92,3 +92,5 @@ class Blend2dConan(ConanFile):
             self.cpp_info.system_libs.extend(["pthread", "rt",])
         if not self.options.shared:
             self.cpp_info.defines.append("BL_STATIC")
+
+        self.cpp_info.requires.append("asmjit::asmjit")

--- a/recipes/blend2d/all/patches/0.0.17-0001-disable-embed-asmjit.patch
+++ b/recipes/blend2d/all/patches/0.0.17-0001-disable-embed-asmjit.patch
@@ -1,19 +1,19 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 52d295a..97dcd32 100644
+index 52d295a..b1a78a5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -398,10 +398,10 @@ if (NOT BLEND2D_NO_JIT)
      set(ASMJIT_EMBED TRUE CACHE BOOL "")
    endif()
-
+ 
 -  include("${ASMJIT_DIR}/CMakeLists.txt")
 -  list(APPEND BLEND2D_DEPS ${ASMJIT_LIBS})
 -  list(APPEND BLEND2D_PRIVATE_CFLAGS ${ASMJIT_CFLAGS})
 -  list(APPEND BLEND2D_PRIVATE_CFLAGS -DASMJIT_NO_STDCXX)
 +  find_package(asmjit CONFIG REQUIRED)
-+  list(APPEND BLEND2D_DEPS ${asmjit_LIBRARIES_DEBUG}${asmjit_LIBRARIES_RELEASE})
++  list(APPEND BLEND2D_DEPS asmjit::asmjit)
 +  list(APPEND BLEND2D_PRIVATE_CFLAGS ${asmjit_DEFINITIONS_DEBUG}${asmjit_DEFINITIONS_RELEASE})
 +
-
+ 
    # A possibility to reduce the resulting binary size by disabling asmjit logging.
    if (BLEND2D_NO_JIT_LOGGING)

--- a/recipes/blend2d/all/patches/0.0.18-0002-fix-gcc12-compilationerror.patch
+++ b/recipes/blend2d/all/patches/0.0.18-0002-fix-gcc12-compilationerror.patch
@@ -1,0 +1,39 @@
+diff --git a/src/blend2d/support/arenaallocator_p.h b/src/blend2d/support/arenaallocator_p.h
+index d09b6da..eebd854 100644
+--- a/src/blend2d/support/arenaallocator_p.h
++++ b/src/blend2d/support/arenaallocator_p.h
+@@ -445,7 +445,7 @@ public:
+ template<size_t N>
+ class BLArenaAllocatorTmp : public BLArenaAllocator {
+ public:
+-  BL_NONCOPYABLE(BLArenaAllocatorTmp<N>)
++  BL_NONCOPYABLE(BLArenaAllocatorTmp)
+ 
+   BL_INLINE explicit BLArenaAllocatorTmp(size_t blockSize, size_t blockAlignment = 1) noexcept
+     : BLArenaAllocator(blockSize, blockAlignment, _storage.data, N) {}
+diff --git a/src/blend2d/support/arenahashmap_p.h b/src/blend2d/support/arenahashmap_p.h
+index 29882e1..911d985 100644
+--- a/src/blend2d/support/arenahashmap_p.h
++++ b/src/blend2d/support/arenahashmap_p.h
+@@ -185,7 +185,7 @@ public:
+ template<typename NodeT>
+ class BLArenaHashMap : public BLArenaHashMapBase {
+ public:
+-  BL_NONCOPYABLE(BLArenaHashMap<NodeT>)
++  BL_NONCOPYABLE(BLArenaHashMap)
+ 
+   typedef NodeT Node;
+ 
+diff --git a/src/blend2d/support/scopedbuffer_p.h b/src/blend2d/support/scopedbuffer_p.h
+index e14df50..379f519 100644
+--- a/src/blend2d/support/scopedbuffer_p.h
++++ b/src/blend2d/support/scopedbuffer_p.h
+@@ -82,7 +82,7 @@ public:
+ template<size_t N>
+ class BLScopedBufferTmp : public BLScopedBuffer {
+ public:
+-  BL_NONCOPYABLE(BLScopedBufferTmp<N>)
++  BL_NONCOPYABLE(BLScopedBufferTmp)
+ 
+   uint8_t _storage[N];
+ 

--- a/recipes/blend2d/all/test_package/CMakeLists.txt
+++ b/recipes/blend2d/all/test_package/CMakeLists.txt
@@ -1,8 +1,5 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(PackageTest CXX)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
 
 find_package(blend2d CONFIG REQUIRED)
 

--- a/recipes/blend2d/all/test_package/CMakeLists.txt
+++ b/recipes/blend2d/all/test_package/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.8)
-project(PackageTest CXX)
+project(test_package CXX)
 
 find_package(blend2d CONFIG REQUIRED)
 
-add_executable(test_package test_package.cpp)
-target_link_libraries(test_package blend2d::blend2d)
-target_compile_features(test_package PRIVATE cxx_std_11)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE blend2d::blend2d)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/blend2d/all/test_package/CMakeLists.txt
+++ b/recipes/blend2d/all/test_package/CMakeLists.txt
@@ -3,8 +3,6 @@ project(test_package CXX)
 
 find_package(blend2d CONFIG REQUIRED)
 
-set(CMAKE_VERBOSE_MAKEFILE ON)
-
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE blend2d::blend2d)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/blend2d/all/test_package/conanfile.py
+++ b/recipes/blend2d/all/test_package/conanfile.py
@@ -1,11 +1,18 @@
+from conan import ConanFile
+from conan.tools.build import cross_building
+from conan.tools.cmake import CMake, cmake_layout
 import os
-
-from conans import ConanFile, CMake, tools
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -13,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if not cross_building(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/blend2d/all/test_v1_package/CMakeLists.txt
+++ b/recipes/blend2d/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(blend2d CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
+target_link_libraries(${PROJECT_NAME} blend2d::blend2d)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/blend2d/all/test_v1_package/CMakeLists.txt
+++ b/recipes/blend2d/all/test_v1_package/CMakeLists.txt
@@ -7,5 +7,5 @@ conan_basic_setup(TARGETS)
 find_package(blend2d CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} blend2d::blend2d)
+target_link_libraries(${PROJECT_NAME} PRIVATE blend2d::blend2d)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/blend2d/all/test_v1_package/conanfile.py
+++ b/recipes/blend2d/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/blend2d/all/test_v1_package/conanfile.py
+++ b/recipes/blend2d/all/test_v1_package/conanfile.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 import os
 
 from conans import ConanFile, CMake, tools


### PR DESCRIPTION
Specify library name and version:  **blend2d/***

- migratioon to Conan v2
- add sha256 in 0.0.18
- add test_v1_package
- fix compilation error in gcc12 with c++20 (backport from upstream)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
