### PR TITLE
docs: fix markup for automatic table of contents

### DIFF
--- a/.github/workflows/on-push-do-doco.yml
+++ b/.github/workflows/on-push-do-doco.yml
@@ -1,5 +1,7 @@
 name: docs_markdown_toc
 on:
+  workflow_dispatch:
+    inputs: {}
   push:
     branches:
       - master
@@ -20,6 +22,7 @@ jobs:
           --toc-level 5
       shell: bash
     - name: Create Pull Request
+      if: github.event_name == 'push'
       uses: peter-evans/create-pull-request@v3
       with:
         branch: bot/action-doc-toc

--- a/.github/workflows/on-push-do-doco.yml
+++ b/.github/workflows/on-push-do-doco.yml
@@ -1,7 +1,5 @@
 name: docs_markdown_toc
 on:
-  workflow_dispatch:
-    inputs: {}
   push:
     branches:
       - master
@@ -22,7 +20,6 @@ jobs:
           --toc-level 5
       shell: bash
     - name: Create Pull Request
-      if: github.event_name == 'push'
       uses: peter-evans/create-pull-request@v3
       with:
         branch: bot/action-doc-toc

--- a/docs/conandata_yml_format.md
+++ b/docs/conandata_yml_format.md
@@ -9,6 +9,9 @@ In the context of conan-center-index, this file is mandatory and consists of two
  * `sources`: Library sources origin with their verification checksums.
  * `patches`: Details about the different patches the library needs for several reasons.
 
+<!-- toc -->
+## Contents<!-- endToc -->
+
 ## sources
 
 `sources` is a top level dictionary, containing entries of sources and checksums for each of the supported versions.

--- a/docs/consuming_recipes.md
+++ b/docs/consuming_recipes.md
@@ -4,6 +4,8 @@ Recipes in this repository are evolving continously, contributors are creating p
 fixing issues and adding new features every day. It is expected that from time to time these
 new recipe revisions stop to work in your project.
 
+<!-- toc -->
+## Contents<!-- endToc -->
 
 ## Breaking changes
 

--- a/docs/policy_patching.md
+++ b/docs/policy_patching.md
@@ -7,6 +7,12 @@ needed. Packages from Conan Center should fulfill the expectations of anyone
 reading the changelog of the library, the documentation, or any statement by
 the library maintainers.
 
+
+<!-- toc -->
+## Contents<!-- endToc -->
+
+## Rules
+
 These are the rules that apply to regular version of Conan packages:
 
 **Build system patches.-** In order to add libraries into ConanCenter sometimes

--- a/docs/v2_migration.md
+++ b/docs/v2_migration.md
@@ -1,6 +1,7 @@
 # Preparing recipes for Conan 2.0
 
-<!-- toc --><!-- endToc -->
+<!-- toc -->
+## Contents<!-- endToc -->
 
 > ⚠️  Refer to [road to Conan v2](v2_roadmap.md) to know the steps that
 > will be taken in ConanCenter and this repository to start running

--- a/docs/v2_roadmap.md
+++ b/docs/v2_roadmap.md
@@ -1,6 +1,7 @@
 # Road to Conan v2
 
-<!-- toc --><!-- endToc -->
+<!-- toc -->
+## Contents<!-- endToc -->
 
 > ⚠️ **Note.-** This document is not a [guide about how to migrate recipes to Conan v2](v2_migration.md).
 


### PR DESCRIPTION
I noticed it was missing on a few pages when I was poking in the docs 😄 

Tested on my fork https://github.com/prince-chrismc/conan-center-index/pull/31/files