### PR TITLE
[linter] Do not promote migration of `Version` class (yet)

### DIFF
--- a/docs/v2_linter.md
+++ b/docs/v2_linter.md
@@ -43,7 +43,6 @@ Here is a list of different imports and their new equivalent (note that the inte
 | conans.tools.get | [conan.tools.files.get](https://docs.conan.io/en/latest/reference/conanfile/tools/files/downloads.html#conan-tools-files-get) |
 | conans.tools.cross_building | [conan.tools.build.cross_building](https://docs.conan.io/en/latest/reference/conanfile/tools/build.html#conan-tools-build-cross-building) |
 | conans.tools.rmdir | [conan.tools.files.rmdir](https://docs.conan.io/en/latest/reference/conanfile/tools/files/basic.html#conan-tools-files-rmdir) |
-| conans.tools.Version | [conan.tools.scm.Version](https://docs.conan.io/en/latest/reference/conanfile/tools/scm/other.html#version) |
 
 
 # Disable linter for `test_v1_*/conanfile.py`

--- a/linter/transform_imports.py
+++ b/linter/transform_imports.py
@@ -22,8 +22,8 @@ def transform_tools(module):
         del module.locals['cross_building']
     if 'rmdir' in module.locals:
         del module.locals['rmdir']
-    if 'Version' in module.locals:
-        del module.locals['Version']
+    #if 'Version' in module.locals:
+    #    del module.locals['Version']
 
 
 astroid.MANAGER.register_transform(


### PR DESCRIPTION
Do not promote the new `Version` class as its interface will be broken in the upcoming Conan release (1.52). The future interface might be backported to 1.50.x and 1.51.x, but better not to use the current one.

Please, @jcar87, explain what is the future `Version` class to be used and the expected interface (maybe it is already documented and it can be just linked).
