### PR TITLE
[wayland] Cross-building is now supported

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -56,7 +56,7 @@ class WaylandConan(ConanFile):
         self.tool_requires("meson/0.63.0")
         self.tool_requires("pkgconf/1.7.4")
         if cross_building(self):
-            self.tool_requires(f"wayland/{self.version}")
+            self.tool_requires(self.ref)
 
     def layout(self):
         basic_layout(self)
@@ -82,8 +82,9 @@ class WaylandConan(ConanFile):
             if cross_building(self):
                 native_generators_folder = os.path.join(self.generators_folder, "native")
                 mkdir(self, native_generators_folder)
-                for pc_name, pc_content in get_pc_files_and_content(self, self.dependencies.build["wayland"]).items():
-                    save(self, os.path.join(native_generators_folder, pc_name), pc_content)
+                for target in ["wayland", "expat", "libxml2", "libiconv"]:
+                    for pc_name, pc_content in get_pc_files_and_content(self, self.dependencies.build[target]).items():
+                        save(self, os.path.join(native_generators_folder, pc_name), pc_content)
                 tc.project_options["build.pkg_config_path"] = native_generators_folder
         tc.generate()
 
@@ -165,7 +166,7 @@ class WaylandConan(ConanFile):
             # todo Remove in Conan version 1.50.0 where these are set by default for the PkgConfigDeps generator.
             self.cpp_info.components["wayland-client"].includedirs = ["include"]
             self.cpp_info.components["wayland-client"].libdirs = ["lib"]
-            
+
             pkgconfig_variables = {
                 'datarootdir': '${prefix}/res',
                 'pkgdatadir': '${datarootdir}/wayland',
@@ -201,3 +202,7 @@ class WaylandConan(ConanFile):
             # todo Remove in Conan version 1.50.0 where these are set by default for the PkgConfigDeps generator.
             self.cpp_info.components["wayland-egl-backend"].includedirs = ["include"]
             self.cpp_info.components["wayland-egl-backend"].libdirs = ["lib"]
+
+            bindir = os.path.join(self.package_folder, "bin")
+            self.output.info("Appending PATH environment variable: {}".format(bindir))
+            self.env_info.PATH.append(bindir)

--- a/recipes/wayland/all/test_package/CMakeLists.txt
+++ b/recipes/wayland/all/test_package/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
-project(test_package)
+project(test_package C)
 
 find_package(wayland COMPONENTS wayland-client REQUIRED)
-find_program(WAYLAND_SCANNER wayland-scanner)
-if (NOT WAYLAND_SCANNER)
-    message(FATAL_ERROR "Could not find wayland-scanner executable")
-endif()
 
 add_executable(test_package test_package.c)
 target_link_libraries(test_package PRIVATE wayland::wayland-client)

--- a/recipes/wayland/all/test_package/conanfile.py
+++ b/recipes/wayland/all/test_package/conanfile.py
@@ -9,16 +9,16 @@ from conan.tools.layout import cmake_layout
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeToolchain", "CMakeDeps", "PkgConfigDeps", "VirtualBuildEnv", "VirtualRunEnv"
+    generators = "CMakeToolchain", "CMakeDeps", "PkgConfigDeps", "VirtualRunEnv"
 
     def layout(self):
         cmake_layout(self)
 
     def build(self):
-        cmake = CMake(self)
-        cmake.configure()
-        cmake.build()
         if not cross_building(self):
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
             pkg_config = PkgConfig(self, "wayland-scanner", self.generators_folder)
             self.run('%s --version' % pkg_config.variables["wayland_scanner"], env="conanrun")
 

--- a/recipes/wayland/all/test_v1_package/CMakeLists.txt
+++ b/recipes/wayland/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(wayland REQUIRED CONFIG)
+
+add_executable(test_package ../test_package/test_package.c)
+target_link_libraries(test_package PRIVATE wayland::wayland-client)

--- a/recipes/wayland/all/test_v1_package/conanfile.py
+++ b/recipes/wayland/all/test_v1_package/conanfile.py
@@ -1,0 +1,21 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import cross_building
+from conans import CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            self.run("wayland-scanner --version", run_environment=True)
+            cmd = os.path.join(self.build_folder, "bin", "test_package")
+            self.run(cmd, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **wayland/1.20.0**

- Exported all required .pc files when cross-building
- Add test_v1_package: Test compatibility with Conan v1
- Keep env_info.PATH: Needed for Conan v1 generators

fixes #11332

Full log, cross-building to armv8:

<details>
<summary>Details</summary>

```
$ conan create  . 1.20.0@ -pr:b=default -pr:h=armv8
Exporting package recipe
wayland/1.20.0 exports: File 'conandata.yml' found. Exporting it...
wayland/1.20.0 exports: Copied 1 '.yml' file: conandata.yml
wayland/1.20.0: The stored package has not changed
wayland/1.20.0: Exported revision: 2f1f60bc8f84caa450d2a179f2f83719
Configuration (profile_host):
[settings]
arch=armv8
arch_build=x86_64
build_type=Release
compiler=gcc
compiler.libcxx=libstdc++
compiler.version=9
os=Linux
os_build=Linux
[options]
[build_requires]
[env]
AR=/usr/bin/aarch64-linux-gnu-ar
AS=/usr/bin/aarch64-linux-gnu-as
CC=/usr/bin/aarch64-linux-gnu-gcc-9
CMAKE_CXX_COMPILER=/usr/bin/aarch64-linux-gnu-g++-9
CMAKE_C_COMPILER=/usr/bin/aarch64-linux-gnu-gcc-9
CXX=/usr/bin/aarch64-linux-gnu-g++-9
FC=/usr/bin/aarch64-linux-gnu-gfortran-9
LD=/usr/bin/aarch64-linux-gnu-ld
RANLIB=/usr/bin/aarch64-linux-gnu-ranlib
STRIP=/usr/bin/aarch64-linux-gnu-strip
Configuration (profile_build):
[settings]
arch=x86_64
arch_build=x86_64
build_type=Release
compiler=gcc
compiler.libcxx=libstdc++
compiler.version=9
os=Linux
os_build=Linux
[options]
[build_requires]
[env]
AR=/usr/bin/ar
AS=/usr/bin/as
CC=/usr/bin/gcc
CMAKE_CXX_COMPILER=/usr/bin/g++
CMAKE_C_COMPILER=/usr/bin/gcc
CXX=/usr/bin/g++
FC=/usr/bin/gfortran
LD=/usr/bin/ld
RANLIB=/usr/bin/ranlib
STRIP=/usr/bin/strip
wayland/1.20.0: Forced build from source
wayland/1.20.0: Forced build from source
wayland/1.20.0 (test package): Installing package
Requirements
    expat/2.4.8 from 'conancenter' - Cache
    libffi/3.4.2 from 'conancenter' - Cache
    libiconv/1.17 from 'conancenter' - Cache
    libxml2/2.9.14 from 'conancenter' - Cache
    wayland/1.20.0 from local cache - Cache
    zlib/1.2.12 from 'conancenter' - Cache
Packages
    expat/2.4.8:64e14ba01fb4fb8378be3e157f0431990505c9b8 - Cache
    libffi/3.4.2:c3baf9fae083edda2e0c5ef3337b6a111016a898 - Cache
    libiconv/1.17:c3baf9fae083edda2e0c5ef3337b6a111016a898 - Cache
    libxml2/2.9.14:1c1367ff75b86aa047844065de9d46463e6879ec - Cache
    wayland/1.20.0:6569b6a2de57596196a2fc4d3eb0814de859d0e1 - Build
    zlib/1.2.12:c3baf9fae083edda2e0c5ef3337b6a111016a898 - Cache
Build requirements
    expat/2.4.8 from 'conancenter' - Cache
    libffi/3.4.2 from 'conancenter' - Cache
    libiconv/1.17 from 'conancenter' - Cache
    libxml2/2.9.14 from 'conancenter' - Cache
    meson/0.63.0 from 'conancenter' - Cache
    ninja/1.10.2 from 'conancenter' - Cache
    pkgconf/1.7.4 from 'conancenter' - Cache
    wayland/1.20.0 from local cache - Cache
    zlib/1.2.12 from 'conancenter' - Cache
Build requirements packages
    expat/2.4.8:c215f67ac7fc6a34d9d0fb90b0450016be569d86 - Cache
    libffi/3.4.2:6af9cc7cb931c5ad942174fd7838eb655717c709 - Cache
    libiconv/1.17:6af9cc7cb931c5ad942174fd7838eb655717c709 - Cache
    libxml2/2.9.14:e9a3e7dd6ab9bf161be4ac8c0925d9a6ba8f2645 - Cache
    meson/0.63.0:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Cache
    ninja/1.10.2:24647d9fe8ec489125dfbae4b3ebefaf7581674c - Cache
    pkgconf/1.7.4:24647d9fe8ec489125dfbae4b3ebefaf7581674c - Cache
    wayland/1.20.0:f154a7e0d26bf39a64459f3df3d93e77d5145cf6 - Build
    zlib/1.2.12:6af9cc7cb931c5ad942174fd7838eb655717c709 - Cache

Cross-build from 'Linux:x86_64' to 'Linux:armv8'
Installing (downloading, building) binaries...
expat/2.4.8: Already installed!
expat/2.4.8: Already installed!
libffi/3.4.2: Already installed!
libffi/3.4.2: Already installed!
libiconv/1.17: Already installed!
libiconv/1.17: Appending PATH environment var: /home/conan/.conan/data/libiconv/1.17/_/_/package/c3baf9fae083edda2e0c5ef3337b6a111016a898/bin
libiconv/1.17: Already installed!
libiconv/1.17: Appending PATH environment var: /home/conan/.conan/data/libiconv/1.17/_/_/package/6af9cc7cb931c5ad942174fd7838eb655717c709/bin
ninja/1.10.2: Already installed!
pkgconf/1.7.4: Already installed!
pkgconf/1.7.4: Appending PATH env var: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin
pkgconf/1.7.4: Setting PKG_CONFIG env var: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/pkgconf
pkgconf/1.7.4: Appending AUTOMAKE_CONAN_INCLUDES env var: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/aclocal
pkgconf/1.7.4: Appending PATH env var: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin
pkgconf/1.7.4: Setting PKG_CONFIG env var: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/pkgconf
pkgconf/1.7.4: Appending AUTOMAKE_CONAN_INCLUDES env var: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/aclocal
zlib/1.2.12: Already installed!
zlib/1.2.12: Already installed!
libxml2/2.9.14: Already installed!
libxml2/2.9.14: Appending PATH environment variable: /home/conan/.conan/data/libxml2/2.9.14/_/_/package/e9a3e7dd6ab9bf161be4ac8c0925d9a6ba8f2645/bin
libxml2/2.9.14: Already installed!
libxml2/2.9.14: Appending PATH environment variable: /home/conan/.conan/data/libxml2/2.9.14/_/_/package/1c1367ff75b86aa047844065de9d46463e6879ec/bin
meson/0.63.0: Already installed!
meson/0.63.0: Appending PATH environment variable: /home/conan/.conan/data/meson/0.63.0/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin
meson/0.63.0: Appending PATH environment variable: /home/conan/.conan/data/meson/0.63.0/_/_/package/5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9/bin
wayland/1.20.0: Applying build-requirement: meson/0.63.0
wayland/1.20.0: Applying build-requirement: pkgconf/1.7.4
wayland/1.20.0: Applying build-requirement: ninja/1.10.2
wayland/1.20.0: Copying sources to build folder
wayland/1.20.0: Building your package in /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6
wayland/1.20.0: Generator 'PkgConfigDeps' calling 'generate()'
wayland/1.20.0: Generator 'VirtualRunEnv' calling 'generate()'
wayland/1.20.0: Generator 'VirtualBuildEnv' calling 'generate()'
wayland/1.20.0: Calling generate()
wayland/1.20.0: Aggregating env generators
wayland/1.20.0: Calling build()
wayland/1.20.0: Meson configure cmd: meson setup --native-file "/home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/conan/conan_meson_native.ini" "/home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release" "/home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/." -Dprefix="/home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6"
Capturing current environment in /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/conan/deactivate_conanbuildenv-release-x86_64.sh
Configuring environment variables
The Meson build system
Version: 0.63.0
Source dir: /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6
Build dir: /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release
Build type: native build
Project name: wayland
Project version: 1.20.0
C compiler for the host machine: gcc (gcc 9.2.1 "gcc (Ubuntu 9.2.1-9ubuntu2) 9.2.1 20191008")
C linker for the host machine: gcc ld.bfd 2.33
Host machine cpu family: x86_64
Host machine cpu: x86_64
Compiler for C supports arguments -Wno-unused-parameter: YES 
Compiler for C supports arguments -Wstrict-prototypes: YES 
Compiler for C supports arguments -Wmissing-prototypes: YES 
Compiler for C supports arguments -fvisibility=hidden: YES 
Has header "sys/prctl.h" : YES 
Has header "sys/procctl.h" : NO 
Has header "sys/ucred.h" : NO 
Checking for function "accept4" : YES 
Checking for function "mkostemp" : YES 
Checking for function "posix_fallocate" : YES 
Checking for function "prctl" : YES 
Checking for function "memfd_create" : YES 
Checking for function "mremap" : YES 
Checking for function "strndup" : YES 
Checking whether type "struct xucred" has member "cr_pid" : NO 
Found pkg-config: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/pkgconf (1.7.4)
Run-time dependency libffi found: YES 3.4.2
Header "sys/signalfd.h" has symbol "SFD_CLOEXEC" : YES 
Header "sys/timerfd.h" has symbol "TFD_CLOEXEC" : YES 
Header "time.h" has symbol "CLOCK_MONOTONIC" : YES 
Checking for function "clock_gettime" : YES 
Configuring config.h using configuration
Configuring wayland-version.h using configuration
Run-time dependency expat found: YES 2.4.8
Run-time dependency libxml-2.0 found: YES 2.9.14
Program embed.py found: YES (/opt/pyenv/versions/3.7.5/bin/python3 /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/src/embed.py)
Library m found: YES
Run-time dependency threads found: YES
Program nm found: YES (/usr/bin/nm)
Program wayland-egl-symbols-check found: YES (/home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/egl/wayland-egl-symbols-check)
Build targets in project: 14
NOTICE: Future-deprecated features used:
 * 0.55.0: {'ExternalProgram.path'}
 * 0.62.0: {'pkgconfig.generate variable for builtin directories'}

wayland 1.20.0

  User defined options
    Native files: /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/conan/conan_meson_native.ini
    prefix      : /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6

Found ninja-1.10.2 at /home/conan/.conan/data/ninja/1.10.2/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/ninja
wayland/1.20.0: Meson build cmd: meson compile -C "/home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release" -j5
Capturing current environment in /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/conan/deactivate_conanbuildenv-release-x86_64.sh
Configuring environment variables
[26/29] Compiling C object src/libwayland-server.a.p/wayland-server.c.o
../src/wayland-server.c: In function ‘wl_display_terminate’:
../src/wayland-server.c:1392:6: warning: variable ‘ret’ set but not used [-Wunused-but-set-variable]
 1392 |  int ret;
      |      ^~~
[29/29] Linking static target cursor/libwayland-cursor.a
wayland/1.20.0: Package 'f154a7e0d26bf39a64459f3df3d93e77d5145cf6' built
wayland/1.20.0: Build folder /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release
wayland/1.20.0: Generated conaninfo.txt
wayland/1.20.0: Generated conanbuildinfo.txt
wayland/1.20.0: Generating the package
wayland/1.20.0: Package folder /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6
wayland/1.20.0: Calling package()
wayland/1.20.0: Meson configure cmd: meson setup --native-file "/home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/conan/conan_meson_native.ini" "/home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release" "/home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/." -Dprefix="/home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6" --reconfigure
Capturing current environment in /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/conan/deactivate_conanbuildenv-release-x86_64.sh
Configuring environment variables
The Meson build system
Version: 0.63.0
Source dir: /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6
Build dir: /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release
Build type: native build
Project name: wayland
Project version: 1.20.0
C compiler for the host machine: gcc (gcc 9.2.1 "gcc (Ubuntu 9.2.1-9ubuntu2) 9.2.1 20191008")
C linker for the host machine: gcc ld.bfd 2.33
Host machine cpu family: x86_64
Host machine cpu: x86_64
Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
Compiler for C supports arguments -Wstrict-prototypes: YES (cached)
Compiler for C supports arguments -Wmissing-prototypes: YES (cached)
Compiler for C supports arguments -fvisibility=hidden: YES (cached)
Has header "sys/prctl.h" : YES (cached)
Has header "sys/procctl.h" : NO (cached)
Has header "sys/ucred.h" : NO (cached)
Checking for function "accept4" : YES (cached)
Checking for function "mkostemp" : YES (cached)
Checking for function "posix_fallocate" : YES (cached)
Checking for function "prctl" : YES (cached)
Checking for function "memfd_create" : YES (cached)
Checking for function "mremap" : YES (cached)
Checking for function "strndup" : YES (cached)
Checking whether type "struct xucred" has member "cr_pid" : NO (cached)
Found pkg-config: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/pkgconf (1.7.4)
Run-time dependency libffi found: YES 3.4.2
Header "sys/signalfd.h" has symbol "SFD_CLOEXEC" : YES (cached)
Header "sys/timerfd.h" has symbol "TFD_CLOEXEC" : YES (cached)
Header "time.h" has symbol "CLOCK_MONOTONIC" : YES (cached)
Checking for function "clock_gettime" : YES (cached)
Configuring config.h using configuration
Configuring wayland-version.h using configuration
Run-time dependency expat found: YES 2.4.8
Run-time dependency libxml-2.0 found: YES 2.9.14
Program embed.py found: YES (/opt/pyenv/versions/3.7.5/bin/python3 /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/src/embed.py)
Library m found: YES
Run-time dependency threads found: YES
Program nm found: YES (/usr/bin/nm)
Program wayland-egl-symbols-check found: YES (/home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/egl/wayland-egl-symbols-check)
Build targets in project: 14
NOTICE: Future-deprecated features used:
 * 0.55.0: {'ExternalProgram.path'}
 * 0.62.0: {'pkgconfig.generate variable for builtin directories'}

wayland 1.20.0

  User defined options
    Native files: /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/conan/conan_meson_native.ini
    prefix      : /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6

Found ninja-1.10.2 at /home/conan/.conan/data/ninja/1.10.2/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/ninja
Cleaning... 0 files.                                                                                
Capturing current environment in /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/conan/deactivate_conanbuildenv-release-x86_64.sh
Configuring environment variables
ninja: Entering directory `/home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release'
ninja: no work to do.
Installing src/wayland-scanner to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/bin
Installing src/wayland-server-protocol.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include
Installing src/wayland-client-protocol.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include
Installing src/libwayland-server.a to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/lib
Installing src/libwayland-client.a to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/lib
Installing cursor/libwayland-cursor.a to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/lib
Installing egl/libwayland-egl.a to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/lib
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/src/wayland-util.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/src/wayland-server.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/src/wayland-server-core.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/src/wayland-client.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/src/wayland-client-core.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/cursor/wayland-cursor.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/egl/wayland-egl.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/egl/wayland-egl-core.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/egl/wayland-egl-backend.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/src/wayland-version.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/include
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/meson-private/wayland-scanner.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/meson-private/wayland-server.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/meson-private/wayland-client.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/meson-private/wayland-cursor.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/meson-private/wayland-egl.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/build-release/meson-private/wayland-egl-backend.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/wayland-scanner.mk to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/res/wayland
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/protocol/wayland.xml to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/res/wayland
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/protocol/wayland.dtd to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/res/wayland
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/wayland-scanner.m4 to /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/res/aclocal
wayland/1.20.0 package(): Packaged 2 files: COPYING, wayland-scanner
wayland/1.20.0 package(): Packaged 1 '.m4' file: wayland-scanner.m4
wayland/1.20.0 package(): Packaged 1 '.dtd' file: wayland.dtd
wayland/1.20.0 package(): Packaged 1 '.xml' file: wayland.xml
wayland/1.20.0 package(): Packaged 1 '.mk' file: wayland-scanner.mk
wayland/1.20.0 package(): Packaged 4 '.a' files: libwayland-server.a, libwayland-egl.a, libwayland-client.a, libwayland-cursor.a
wayland/1.20.0 package(): Packaged 12 '.h' files
wayland/1.20.0: Package 'f154a7e0d26bf39a64459f3df3d93e77d5145cf6' created
wayland/1.20.0: Created package revision b64122c714e71b9380fd5f6002827064
wayland/1.20.0: Appending PATH environment variable: /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/bin
wayland/1.20.0: Appending PATH environment variable: /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/bin
wayland/1.20.0: Applying build-requirement: meson/0.63.0
wayland/1.20.0: Applying build-requirement: pkgconf/1.7.4
wayland/1.20.0: Applying build-requirement: wayland/1.20.0
wayland/1.20.0: Applying build-requirement: ninja/1.10.2
wayland/1.20.0: Applying build-requirement: libffi/3.4.2
wayland/1.20.0: Applying build-requirement: libxml2/2.9.14
wayland/1.20.0: Applying build-requirement: expat/2.4.8
wayland/1.20.0: Applying build-requirement: zlib/1.2.12
wayland/1.20.0: Applying build-requirement: libiconv/1.17
wayland/1.20.0: Copying sources to build folder
wayland/1.20.0: Building your package in /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1
wayland/1.20.0: Generator 'PkgConfigDeps' calling 'generate()'
wayland/1.20.0: Generator 'VirtualRunEnv' calling 'generate()'
wayland/1.20.0: Generator 'VirtualBuildEnv' calling 'generate()'
wayland/1.20.0: Calling generate()
wayland/1.20.0: Aggregating env generators
wayland/1.20.0: Calling build()
wayland/1.20.0: Meson configure cmd: meson setup --cross-file "/home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/conan/conan_meson_cross.ini" "/home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release" "/home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/." -Dprefix="/home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1"
Capturing current environment in /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/conan/deactivate_conanbuildenv-release-armv8.sh
Configuring environment variables
The Meson build system
Version: 0.63.0
Source dir: /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1
Build dir: /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release
Build type: cross build
Project name: wayland
Project version: 1.20.0
C compiler for the host machine: /usr/bin/aarch64-linux-gnu-gcc-9 (gcc 9.2.1 "aarch64-linux-gnu-gcc-9 (Ubuntu 9.2.1-9ubuntu2) 9.2.1 20191008")
C linker for the host machine: /usr/bin/aarch64-linux-gnu-gcc-9 ld.bfd 2.33
C compiler for the build machine: cc (gcc 9.2.1 "cc (Ubuntu 9.2.1-9ubuntu2) 9.2.1 20191008")
C linker for the build machine: cc ld.bfd 2.33
Build machine cpu family: x86_64
Build machine cpu: x86_64
Host machine cpu family: aarch64
Host machine cpu: armv8
Target machine cpu family: aarch64
Target machine cpu: armv8
Compiler for C supports arguments -Wno-unused-parameter: YES 
Compiler for C supports arguments -Wstrict-prototypes: YES 
Compiler for C supports arguments -Wmissing-prototypes: YES 
Compiler for C supports arguments -fvisibility=hidden: YES 
Has header "sys/prctl.h" : YES 
Has header "sys/procctl.h" : NO 
Has header "sys/ucred.h" : NO 
Checking for function "accept4" : YES 
Checking for function "mkostemp" : YES 
Checking for function "posix_fallocate" : YES 
Checking for function "prctl" : YES 
Checking for function "memfd_create" : YES 
Checking for function "mremap" : YES 
Checking for function "strndup" : YES 
Checking whether type "struct xucred" has member "cr_pid" : NO 
Found pkg-config: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/pkgconf (1.7.4)
Run-time dependency libffi found: YES 3.4.2
Header "sys/signalfd.h" has symbol "SFD_CLOEXEC" : YES 
Header "sys/timerfd.h" has symbol "TFD_CLOEXEC" : YES 
Header "time.h" has symbol "CLOCK_MONOTONIC" : YES 
Checking for function "clock_gettime" : YES 
Configuring config.h using configuration
Configuring wayland-version.h using configuration
Run-time dependency expat found: YES 2.4.8
Run-time dependency libxml-2.0 found: YES 2.9.14
Program embed.py found: YES (/opt/pyenv/versions/3.7.5/bin/python3 /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/src/embed.py)
Found pkg-config: /usr/bin/pkg-config (0.29.1)
Build-time dependency wayland-scanner found: YES 1.20.0
Program /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/bin/wayland-scanner found: YES (/home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/bin/wayland-scanner)
Library m found: YES
Run-time dependency threads found: YES
Program nm found: YES (/usr/bin/nm)
Program wayland-egl-symbols-check found: YES (/home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/egl/wayland-egl-symbols-check)
Build targets in project: 14
NOTICE: Future-deprecated features used:
 * 0.55.0: {'ExternalProgram.path'}
 * 0.56.0: {'dependency.get_pkgconfig_variable'}
 * 0.62.0: {'pkgconfig.generate variable for builtin directories'}

wayland 1.20.0

  User defined options
    Cross files: /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/conan/conan_meson_cross.ini
    prefix     : /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1

Found ninja-1.10.2 at /home/conan/.conan/data/ninja/1.10.2/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/ninja
wayland/1.20.0: Meson build cmd: meson compile -C "/home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release" -j5
Capturing current environment in /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/conan/deactivate_conanbuildenv-release-armv8.sh
Configuring environment variables
[16/29] Compiling C object src/libwayland-server.a.p/wayland-server.c.o
../src/wayland-server.c: In function ‘wl_display_terminate’:
../src/wayland-server.c:1392:6: warning: variable ‘ret’ set but not used [-Wunused-but-set-variable]
 1392 |  int ret;
      |      ^~~
[29/29] Linking target src/wayland-scanner
wayland/1.20.0: Package '6569b6a2de57596196a2fc4d3eb0814de859d0e1' built
wayland/1.20.0: Build folder /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release
wayland/1.20.0: Generated conaninfo.txt
wayland/1.20.0: Generated conanbuildinfo.txt
wayland/1.20.0: Generating the package
wayland/1.20.0: Package folder /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1
wayland/1.20.0: Calling package()
wayland/1.20.0: Meson configure cmd: meson setup --cross-file "/home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/conan/conan_meson_cross.ini" "/home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release" "/home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/." -Dprefix="/home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1" --reconfigure
Capturing current environment in /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/conan/deactivate_conanbuildenv-release-armv8.sh
Configuring environment variables
The Meson build system
Version: 0.63.0
Source dir: /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1
Build dir: /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release
Build type: cross build
Project name: wayland
Project version: 1.20.0
C compiler for the host machine: /usr/bin/aarch64-linux-gnu-gcc-9 (gcc 9.2.1 "aarch64-linux-gnu-gcc-9 (Ubuntu 9.2.1-9ubuntu2) 9.2.1 20191008")
C linker for the host machine: /usr/bin/aarch64-linux-gnu-gcc-9 ld.bfd 2.33
C compiler for the build machine: cc (gcc 9.2.1 "cc (Ubuntu 9.2.1-9ubuntu2) 9.2.1 20191008")
C linker for the build machine: cc ld.bfd 2.33
Build machine cpu family: x86_64
Build machine cpu: x86_64
Host machine cpu family: aarch64
Host machine cpu: armv8
Target machine cpu family: aarch64
Target machine cpu: armv8
Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
Compiler for C supports arguments -Wstrict-prototypes: YES (cached)
Compiler for C supports arguments -Wmissing-prototypes: YES (cached)
Compiler for C supports arguments -fvisibility=hidden: YES (cached)
Has header "sys/prctl.h" : YES (cached)
Has header "sys/procctl.h" : NO (cached)
Has header "sys/ucred.h" : NO (cached)
Checking for function "accept4" : YES (cached)
Checking for function "mkostemp" : YES (cached)
Checking for function "posix_fallocate" : YES (cached)
Checking for function "prctl" : YES (cached)
Checking for function "memfd_create" : YES (cached)
Checking for function "mremap" : YES (cached)
Checking for function "strndup" : YES (cached)
Checking whether type "struct xucred" has member "cr_pid" : NO (cached)
Found pkg-config: /home/conan/.conan/data/pkgconf/1.7.4/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/pkgconf (1.7.4)
Run-time dependency libffi found: YES 3.4.2
Header "sys/signalfd.h" has symbol "SFD_CLOEXEC" : YES (cached)
Header "sys/timerfd.h" has symbol "TFD_CLOEXEC" : YES (cached)
Header "time.h" has symbol "CLOCK_MONOTONIC" : YES (cached)
Checking for function "clock_gettime" : YES (cached)
Configuring config.h using configuration
Configuring wayland-version.h using configuration
Run-time dependency expat found: YES 2.4.8
Run-time dependency libxml-2.0 found: YES 2.9.14
Program embed.py found: YES (/opt/pyenv/versions/3.7.5/bin/python3 /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/src/embed.py)
Found pkg-config: /usr/bin/pkg-config (0.29.1)
Build-time dependency wayland-scanner found: YES 1.20.0
Program /home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/bin/wayland-scanner found: YES (/home/conan/.conan/data/wayland/1.20.0/_/_/package/f154a7e0d26bf39a64459f3df3d93e77d5145cf6/bin/wayland-scanner)
Library m found: YES
Run-time dependency threads found: YES
Program nm found: YES (/usr/bin/nm)
Program wayland-egl-symbols-check found: YES (/home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/egl/wayland-egl-symbols-check)
Build targets in project: 14
NOTICE: Future-deprecated features used:
 * 0.55.0: {'ExternalProgram.path'}
 * 0.56.0: {'dependency.get_pkgconfig_variable'}
 * 0.62.0: {'pkgconfig.generate variable for builtin directories'}

wayland 1.20.0

  User defined options
    Cross files: /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/conan/conan_meson_cross.ini
    prefix     : /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1

Found ninja-1.10.2 at /home/conan/.conan/data/ninja/1.10.2/_/_/package/24647d9fe8ec489125dfbae4b3ebefaf7581674c/bin/ninja
Cleaning... 0 files.                                                                                
Capturing current environment in /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/conan/deactivate_conanbuildenv-release-armv8.sh
Configuring environment variables
ninja: Entering directory `/home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release'
ninja: no work to do.
Installing src/wayland-scanner to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/bin
Installing src/wayland-server-protocol.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include
Installing src/wayland-client-protocol.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include
Installing src/libwayland-server.a to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/lib
Installing src/libwayland-client.a to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/lib
Installing cursor/libwayland-cursor.a to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/lib
Installing egl/libwayland-egl.a to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/lib
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/src/wayland-util.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/src/wayland-server.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/src/wayland-server-core.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/src/wayland-client.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/src/wayland-client-core.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/cursor/wayland-cursor.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/egl/wayland-egl.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/egl/wayland-egl-core.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/egl/wayland-egl-backend.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include/
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/src/wayland-version.h to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/include
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/meson-private/wayland-scanner.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/meson-private/wayland-server.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/meson-private/wayland-client.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/meson-private/wayland-cursor.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/meson-private/wayland-egl.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/build-release/meson-private/wayland-egl-backend.pc to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/lib/pkgconfig
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/wayland-scanner.mk to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/res/wayland
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/protocol/wayland.xml to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/res/wayland
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/protocol/wayland.dtd to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/res/wayland
Installing /home/conan/.conan/data/wayland/1.20.0/_/_/build/6569b6a2de57596196a2fc4d3eb0814de859d0e1/wayland-scanner.m4 to /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/res/aclocal
wayland/1.20.0 package(): Packaged 2 files: COPYING, wayland-scanner
wayland/1.20.0 package(): Packaged 1 '.m4' file: wayland-scanner.m4
wayland/1.20.0 package(): Packaged 1 '.dtd' file: wayland.dtd
wayland/1.20.0 package(): Packaged 1 '.xml' file: wayland.xml
wayland/1.20.0 package(): Packaged 1 '.mk' file: wayland-scanner.mk
wayland/1.20.0 package(): Packaged 4 '.a' files: libwayland-server.a, libwayland-egl.a, libwayland-client.a, libwayland-cursor.a
wayland/1.20.0 package(): Packaged 12 '.h' files
wayland/1.20.0: Package '6569b6a2de57596196a2fc4d3eb0814de859d0e1' created
wayland/1.20.0: Created package revision f740156cd5e238bd098f2d3711008faf
wayland/1.20.0: Appending PATH environment variable: /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/bin
wayland/1.20.0: Appending PATH environment variable: /home/conan/.conan/data/wayland/1.20.0/_/_/package/6569b6a2de57596196a2fc4d3eb0814de859d0e1/bin
wayland/1.20.0 (test package): Generator txt created conanbuildinfo.txt
wayland/1.20.0 (test package): Generator 'CMakeToolchain' calling 'generate()'
wayland/1.20.0 (test package): Generator 'CMakeDeps' calling 'generate()'
wayland/1.20.0 (test package): Generator 'PkgConfigDeps' calling 'generate()'
wayland/1.20.0 (test package): Generator 'VirtualRunEnv' calling 'generate()'
wayland/1.20.0 (test package): Aggregating env generators
wayland/1.20.0 (test package): Generated conaninfo.txt
wayland/1.20.0 (test package): Generated graphinfo
Using lockfile: '/home/conan/project/wayland/all/test_package/conan.lock'
Using cached profile from lockfile
wayland/1.20.0 (test package): Calling build()
wayland/1.20.0 (test package): Running test()
```

</details>

/cc @Zvicii @jwillikers @andoalon 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
