### PR TITLE
update protobuf 3.21.1 to 3.21.4 dependencies

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -284,7 +284,7 @@ class ArrowConan(ConanFile):
         if self._with_thrift():
             self.requires("thrift/0.16.0")
         if self._with_protobuf():
-            self.requires("protobuf/3.21.1")
+            self.requires("protobuf/3.21.4")
         if self._with_jemalloc():
             self.requires("jemalloc/5.2.1")
         if self._with_boost():
@@ -296,7 +296,7 @@ class ArrowConan(ConanFile):
         if self.options.get_safe("with_gcs"):
             self.requires("google-cloud-cpp/1.40.1")
         if self._with_grpc():
-            self.requires("grpc/1.47.0")
+            self.requires("grpc/1.47.1")
         if self.options.with_json:
             self.requires("rapidjson/1.1.0")
         if self._with_llvm():

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -56,7 +56,7 @@ class GoogleAPIS(ConanFile):
             raise ConanInvalidConfiguration("If built as shared, protobuf must be shared as well. Please, use `protobuf:shared=True`")
 
     def requirements(self):
-        self.requires('protobuf/3.21.1')
+        self.requires('protobuf/3.21.4')
 
     @property
     def _cmake_new_enough(self):
@@ -73,7 +73,7 @@ class GoogleAPIS(ConanFile):
             return True
 
     def build_requirements(self):
-        self.build_requires('protobuf/3.21.1')
+        self.build_requires('protobuf/3.21.4')
         # CMake >= 3.20 is required. There is a proto with dots in the name 'k8s.min.proto' and CMake fails to generate project files
         if not self._cmake_new_enough:
             self.build_requires('cmake/3.23.2')

--- a/recipes/grpc-proto/all/conanfile.py
+++ b/recipes/grpc-proto/all/conanfile.py
@@ -51,11 +51,11 @@ class GRPCProto(ConanFile):
             raise ConanInvalidConfiguration("If built as shared, protobuf and googleapis must be shared as well. Please, use `protobuf:shared=True` and `googleapis:shared=True`")
 
     def requirements(self):
-        self.requires('protobuf/3.21.1')
+        self.requires('protobuf/3.21.4')
         self.requires('googleapis/cci.20220711')
 
     def build_requirements(self):
-        self.build_requires('protobuf/3.21.1')
+        self.build_requires('protobuf/3.21.4')
 
     @functools.lru_cache(1)
     def _configure_cmake(self):

--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -88,7 +88,7 @@ class grpcConan(ConanFile):
         self.requires("abseil/20211102.0")
         self.requires("c-ares/1.18.1")
         self.requires("openssl/1.1.1o")
-        self.requires("protobuf/3.21.1")
+        self.requires("protobuf/3.21.4")
         self.requires("re2/20220201")
         self.requires("zlib/1.2.12")
         self.requires("googleapis/cci.20220531")
@@ -117,7 +117,7 @@ class grpcConan(ConanFile):
 
     def build_requirements(self):
         if hasattr(self, "settings_build"):
-            self.build_requires('protobuf/3.21.1')
+            self.build_requires('protobuf/3.21.4')
             # when cross compiling we need pre compiled grpc plugins for protoc
             if tools.build.cross_building(self):
                 self.build_requires('grpc/{}'.format(self.version))

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -42,12 +42,12 @@ class OpenTelemetryCppConan(ConanFile):
 
     def requirements(self):
         self.requires("abseil/20211102.0")
-        self.requires("grpc/1.45.2")
+        self.requires("grpc/1.48.0")
         self.requires("libcurl/7.83.1")
         self.requires("nlohmann_json/3.10.5")
         self.requires("openssl/1.1.1o")
         self.requires("opentelemetry-proto/0.18.0")
-        self.requires("protobuf/3.21.1")
+        self.requires("protobuf/3.21.4")
         self.requires("thrift/0.15.0")
         if tools.Version(self.version) >= "1.3.0":
             self.requires("boost/1.79.0")


### PR DESCRIPTION
Specify library name and version:  

upgrading protobuf to 3.21.4 dependencies, continuation of #12079

is that even possible to handle in one update?
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
