### PR TITLE
Up Conan version + recover linter for Version

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -3,7 +3,7 @@
 id: 'conan-io/conan-center-index'
 
 conan:
-  version: 1.50.1
+  version: 1.50.2
 
 artifactory:
   url: "https://c3i.jfrog.io/c3i"

--- a/docs/v2_linter.md
+++ b/docs/v2_linter.md
@@ -43,6 +43,7 @@ Here is a list of different imports and their new equivalent (note that the inte
 | conans.tools.get | [conan.tools.files.get](https://docs.conan.io/en/latest/reference/conanfile/tools/files/downloads.html#conan-tools-files-get) |
 | conans.tools.cross_building | [conan.tools.build.cross_building](https://docs.conan.io/en/latest/reference/conanfile/tools/build.html#conan-tools-build-cross-building) |
 | conans.tools.rmdir | [conan.tools.files.rmdir](https://docs.conan.io/en/latest/reference/conanfile/tools/files/basic.html#conan-tools-files-rmdir) |
+| conans.tools.Version | [conan.tools.scm.Version](https://docs.conan.io/en/latest/reference/conanfile/tools/scm/other.html#version) |
 
 
 # Disable linter for `test_v1_*/conanfile.py`

--- a/linter/transform_imports.py
+++ b/linter/transform_imports.py
@@ -22,8 +22,8 @@ def transform_tools(module):
         del module.locals['cross_building']
     if 'rmdir' in module.locals:
         del module.locals['rmdir']
-    #if 'Version' in module.locals:
-    #    del module.locals['Version']
+    if 'Version' in module.locals:
+        del module.locals['Version']
 
 
 astroid.MANAGER.register_transform(


### PR DESCRIPTION
Conan `1.50.2` exposes the proper `conan.tool.scm.Version` API 🎉 