### PR TITLE
SystemC: Patch Accellera release to enable work with Address Sanitizer

### DIFF
--- a/recipes/systemc/all/conandata.yml
+++ b/recipes/systemc/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "2.3.3":
     url: https://github.com/accellera-official/systemc/archive/2.3.3.tar.gz
     sha256: 5781b9a351e5afedabc37d145e5f7edec08f3fd5de00ffeb8fa1f3086b1f7b3f
+  "2.3.3_asan":
+    url: https://github.com/accellera-official/systemc/archive/2.3.3.tar.gz
+    sha256: 5781b9a351e5afedabc37d145e5f7edec08f3fd5de00ffeb8fa1f3086b1f7b3f
 patches:
   "2.3.3":
     - patch_file: "patches/0001-cmake.patch"
@@ -9,4 +12,13 @@ patches:
     - patch_file: "patches/0002-sc_string_view.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0003-mingw.patch"
+      base_path: "source_subfolder"
+  "2.3.3_asan":
+    - patch_file: "patches/0001-cmake.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0002-sc_string_view.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0003-mingw.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0004-asan.patch"
       base_path: "source_subfolder"

--- a/recipes/systemc/all/patches/0004-asan.patch
+++ b/recipes/systemc/all/patches/0004-asan.patch
@@ -1,0 +1,339 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -149,6 +149,10 @@
+ # ENABLE_PTHREADS               Use POSIX threads for SystemC processes instead
+ #                               of QuickThreads on Unix or Fiber on Windows.
+ #
++# ENABLE_LEGACY_MEM_MGMT        Use std::malloc or posix_memalign to allocate the
++#                               stack of the coroutines instead of mmap. ASAN will
++#                               not work with this.
++#
+ # OVERRIDE_DEFAULT_STACK_SIZE   Define the default stack size used for SystemC
+ #                               (thread) processes. (> 0)
+ #
+@@ -317,6 +321,10 @@ option (INSTALL_TO_LIB_BUILD_TYPE_DIR
+         "Install the libraries to lib-${CMAKE_BUILD_TYPE} to enable parallel installation of the different build variants. (default: OFF)"
+         OFF)
+ 
++option (ENABLE_LEGACY_MEM_MGMT
++        "Use of std::malloc or posix_memalign instead of mmap to allocate coroutine stack. Breaks ASAN."
++        OFF)
++
+ if (NOT INSTALL_TO_LIB_BUILD_TYPE_DIR)
+   option (INSTALL_TO_LIB_TARGET_ARCH_DIR "Install the libraries to lib-<target-arch> to facilitate linking applications, which build systems assume to find SystemC in lib-<target-arch>. (default: OFF)" OFF)
+ else (NOT INSTALL_TO_LIB_BUILD_TYPE_DIR)
+@@ -506,6 +514,10 @@ else (ENABLE_PTHREADS)
+ endif (ENABLE_PTHREADS)
+ 
+ if (QT_ARCH)
++  # QuickThreads stack protection can benefit from posix_memalign
++  include(CheckSymbolExists)
++  check_symbol_exists(posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN)
++
+   # To build QuickThreads, enable the assembler support.
+   enable_language (ASM)
+ else (QT_ARCH)
+@@ -660,6 +672,7 @@ if (ENABLE_PTHREADS)
+ else (ENABLE_PTHREADS)
+   message (STATUS "ENABLE_PTHREADS = ${ENABLE_PTHREADS}")
+ endif (ENABLE_PTHREADS)
++message (STATUS "ENABLE_LEGACY_MEM_MGMT = ${ENABLE_LEGACY_MEM_MGMT}")
+ if (OVERRIDE_DEFAULT_STACK_SIZE GREATER 0)
+   message ("OVERRIDE_DEFAULT_STACK_SIZE = ${OVERRIDE_DEFAULT_STACK_SIZE}")
+ endif (OVERRIDE_DEFAULT_STACK_SIZE GREATER 0)
+
+--- src/CMakeLists.txt
++++ src/CMakeLists.txt
+@@ -474,6 +474,8 @@ target_compile_definitions (
+   $<$<BOOL:${ENABLE_PHASE_CALLBACKS_TRACING}>:
+     SC_ENABLE_SIMULATION_PHASE_CALLBACKS_TRACING>
+   $<$<BOOL:${ENABLE_PTHREADS}>:SC_USE_PTHREADS>
++  $<$<BOOL:${HAVE_POSIX_MEMALIGN}>:SC_HAVE_POSIX_MEMALIGN>
++  $<$<BOOL:${ENABLE_LEGACY_MEM_MGMT}>:SC_LEGACY_MEM_MGMT>
+   $<$<BOOL:${OVERRIDE_DEFAULT_STACK_SIZE}>:
+     SC_OVERRIDE_DEFAULT_STACK_SIZE=${OVERRIDE_DEFAULT_STACK_SIZE}>
+   $<$<AND:$<BOOL:${WIN32}>,$<BOOL:${MSVC}>>:_LIB>)
+@@ -493,9 +495,11 @@ target_include_directories(systemc
+   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ 
+ if (APPLE)
+-  # It's OK that _sc_main is an undefined symbol.
+-  set_target_properties (systemc PROPERTIES LINK_FLAGS -Wl,-U,_sc_main)
+-endif (APPLE)
++  # It's OK that _sc_main, __sanitizer_start_switch_fiber, and
++  # __sanitizer_finish_switch_fiber are undefined symbols.
++  set_target_properties (systemc PROPERTIES LINK_FLAGS
++    -Wl,-U,_sc_main,-U,___sanitizer_start_switch_fiber,-U,___sanitizer_finish_switch_fiber)
++endif(APPLE)
+ 
+ target_link_libraries (systemc PUBLIC $<$<BOOL:${CMAKE_USE_PTHREADS_INIT}>:Threads::Threads>)
+ 
+--- src/sysc/kernel/sc_cor_qt.cpp
++++ src/sysc/kernel/sc_cor_qt.cpp
+@@ -31,9 +31,14 @@
+ #include <unistd.h>
+ #include <sys/mman.h>
+ #include <sys/types.h>
++#include <cerrno>
++#include <cstring>
++#include <cstdlib>
++#include <sstream>
+ 
+ #include "sysc/kernel/sc_cor_qt.h"
+ #include "sysc/kernel/sc_simcontext.h"
++#include "sysc/utils/sc_report.h"
+ 
+ namespace sc_core {
+ 
+@@ -49,6 +54,47 @@ static sc_cor_qt main_cor;
+ 
+ static sc_cor_qt* curr_cor = 0;
+ 
++// ----------------------------------------------------------------------------
++
++// ----------------------------------------------------------------------------
++//  Sanitizer helpers
++// ----------------------------------------------------------------------------
++
++static void __sanitizer_start_switch_fiber(void** fake, void* stack_base,
++    size_t size) __attribute__((weakref("__sanitizer_start_switch_fiber")));
++static void __sanitizer_finish_switch_fiber(void* fake, void** stack_base,
++    size_t* size) __attribute__((weakref("__sanitizer_finish_switch_fiber")));
++
++static void __sanitizer_start_switch_cor_qt( sc_cor_qt* next ) {
++    if (&__sanitizer_start_switch_fiber != NULL) {
++        __sanitizer_start_switch_fiber( NULL, next->m_stack,
++                                        next->m_stack_size );
++    }
++}
++
++static void __sanitizer_finish_switch_cor_qt() {
++    if (&__sanitizer_finish_switch_fiber != NULL) {
++        __sanitizer_finish_switch_fiber( NULL, NULL, NULL );
++    }
++}
++
++// ----------------------------------------------------------------------------
++
++static std::size_t sc_pagesize()
++{
++    static std::size_t pagesize = 0;
++
++    if( pagesize == 0 ) {
++#     if defined(__ppc__)
++        pagesize = getpagesize();
++#     else
++        pagesize = sysconf( _SC_PAGESIZE );
++#     endif
++    }
++
++    sc_assert( pagesize != 0 );
++    return pagesize;
++}
+ 
+ // ----------------------------------------------------------------------------
+ //  CLASS : sc_cor_qt
+@@ -56,6 +102,17 @@ static sc_cor_qt* curr_cor = 0;
+ //  Coroutine class implemented with QuickThreads.
+ // ----------------------------------------------------------------------------
+ 
++sc_cor_qt::~sc_cor_qt()
++{
++#ifdef SC_LEGACY_MEM_MGMT
++    std::free( m_stack );
++#else
++    if ( m_stack ) {
++        ::munmap( m_stack, m_stack_size );
++    }
++#endif
++}
++
+ // switch stack protection on/off
+ 
+ void
+@@ -64,28 +121,23 @@ sc_cor_qt::stack_protect( bool enable )
+     // Code needs to be tested on HP-UX and disabled if it doesn't work there
+     // Code still needs to be ported to WIN32
+ 
+-    static std::size_t pagesize;
++    const std::size_t pagesize = sc_pagesize();
++    sc_assert( m_stack_size > ( 2 * pagesize ) );
+ 
+-    if( pagesize == 0 ) {
+-#       if defined(__ppc__)
+-	    pagesize = getpagesize();
+-#       else
+-	    pagesize = sysconf( _SC_PAGESIZE );
+-#       endif
++    std::size_t sp_addr = reinterpret_cast<std::size_t>(m_stack);
++#ifndef SC_HAVE_POSIX_MEMALIGN
++    const std::size_t round_up_mask = pagesize - 1;
++    if( sp_addr & round_up_mask ) { // misaligned allocation
++        sp_addr = (sp_addr + round_up_mask) & ~round_up_mask;
+     }
+-
+-    sc_assert( pagesize != 0 );
+-    sc_assert( m_stack_size > ( 2 * pagesize ) );
++#endif // SC_HAVE_POSIX_MEMALIGN
+ 
+ #ifdef QUICKTHREADS_GROW_DOWN
+     // Stacks grow from high address down to low address
+-    caddr_t redzone = caddr_t( ( ( std::size_t( m_stack ) + pagesize - 1 ) /
+-				 pagesize ) * pagesize );
++    caddr_t redzone = caddr_t( sp_addr );
+ #else
+     // Stacks grow from low address up to high address
+-    caddr_t redzone = caddr_t( ( ( std::size_t( m_stack ) +
+-				   m_stack_size - pagesize ) /
+-				 pagesize ) * pagesize );
++    caddr_t redzone = caddr_t( sp_addr + m_stack_size - pagesize );
+ #endif
+ 
+     int ret;
+@@ -101,12 +153,27 @@ sc_cor_qt::stack_protect( bool enable )
+     // execute. If that does not work then settle for read - write
+ 
+     else {
+-        ret = mprotect( redzone, pagesize - 1, PROT_READ|PROT_WRITE|PROT_EXEC);
+-        if ( ret != 0 )
+-            ret = mprotect( redzone, pagesize - 1, PROT_READ | PROT_WRITE );
++        ret = mprotect( redzone, pagesize - 1, PROT_READ | PROT_WRITE );
+     }
+ 
+-    sc_assert( ret == 0 );
++    if( ret != 0 ) // ignore mprotect error with warning
++    {
++        static bool mprotect_fail_warned_once = false;
++        if( mprotect_fail_warned_once == false )
++        {
++            mprotect_fail_warned_once = true;
++
++            int mprotect_errno = errno;
++            std::stringstream sstr;
++            sstr << "unsuccessful stack protection ignored: "
++                 << std::strerror(mprotect_errno)
++                 << ", address=0x" << std::hex << redzone
++                 << ", enable=" << std::boolalpha << enable;
++
++            SC_REPORT_WARNING( SC_ID_STACK_SETUP_FAILED_
++                             , sstr.str().c_str() );
++        }
++    }
+ }
+ 
+ 
+@@ -118,18 +185,45 @@ sc_cor_qt::stack_protect( bool enable )
+ 
+ int sc_cor_pkg_qt::instance_count = 0;
+ 
++// support functions
+ 
+-// support function
+-
+-inline
+-void*
+-stack_align( void* sp, int alignment, std::size_t* stack_size )
++// allocate aligned stack memory
++static inline void*
++stack_alloc( void** buf, std::size_t* stack_size )
+ {
+-    int round_up_mask = alignment - 1;
++    const std::size_t alignment     = sc_pagesize();
++    const std::size_t round_up_mask = alignment - 1;
++    sc_assert( 0 == ( alignment & round_up_mask ) ); // power of 2
++    sc_assert( buf );
++
++    // round up to multiple of alignment
+     *stack_size = (*stack_size + round_up_mask) & ~round_up_mask;
+-    return ( (void*)(((qt_word_t) sp + round_up_mask) & ~round_up_mask) );
+-}
+ 
++#ifdef SC_LEGACY_MEM_MGMT
++    #ifdef SC_HAVE_POSIX_MEMALIGN
++        if( 0 != posix_memalign( buf, alignment, *stack_size ) ) {
++            *buf = NULL; // allocation failed
++        }
++        return *buf;
++    #endif
++    *buf = std::malloc( *stack_size );
++    std::size_t sp_addr = reinterpret_cast<std::size_t>( *buf );
++    if( sp_addr & round_up_mask ) // misaligned allocation
++    {
++        sc_assert( *stack_size > (alignment * 2) );
++        sp_addr = (sp_addr + round_up_mask) & ~round_up_mask;
++        *stack_size -= alignment;
++    }
++    return reinterpret_cast<void*>( sp_addr );
++#else
++    *buf = ::mmap( NULL, *stack_size, PROT_READ | PROT_WRITE,
++                   MAP_PRIVATE | MAP_ANON, -1, 0 );
++    if ( *buf == MAP_FAILED ) {
++        *buf = NULL;
++    }
++    return *buf;
++#endif
++}
+ 
+ // constructor
+ 
+@@ -173,10 +267,15 @@ sc_cor_pkg_qt::create( std::size_t stack_size, sc_cor_fn* fn, void* arg )
+     sc_cor_qt* cor = new sc_cor_qt();
+     cor->m_pkg = this;
+     cor->m_stack_size = stack_size;
+-    cor->m_stack = new char[cor->m_stack_size];
+-    void* sto = stack_align( cor->m_stack, QUICKTHREADS_STKALIGN,
+-                             &cor->m_stack_size );
+-    cor->m_sp = QUICKTHREADS_SP(sto, cor->m_stack_size - QUICKTHREADS_STKALIGN);
++
++    void* aligned_sp = stack_alloc( &cor->m_stack, &cor->m_stack_size );
++    if( aligned_sp == NULL )
++    {
++        SC_REPORT_ERROR( SC_ID_STACK_SETUP_FAILED_
++                       , "failed to allocate stack memory" );
++        sc_abort();
++    }
++    cor->m_sp = QUICKTHREADS_SP( aligned_sp, cor->m_stack_size );
+     cor->m_sp = QUICKTHREADS_ARGS( cor->m_sp, arg, cor, (qt_userf_t*) fn,
+ 			           sc_cor_qt_wrapper );
+     return cor;
+@@ -190,6 +289,7 @@ void*
+ sc_cor_qt_yieldhelp( qt_t* sp, void* old_cor, void* )
+ {
+     reinterpret_cast<sc_cor_qt*>( old_cor )->m_sp = sp;
++    __sanitizer_finish_switch_cor_qt();
+     return 0;
+ }
+ 
+@@ -199,6 +299,7 @@ sc_cor_pkg_qt::yield( sc_cor* next_cor )
+     sc_cor_qt* new_cor = static_cast<sc_cor_qt*>( next_cor );
+     sc_cor_qt* old_cor = curr_cor;
+     curr_cor = new_cor;
++    __sanitizer_start_switch_cor_qt( new_cor );
+     QUICKTHREADS_BLOCK( sc_cor_qt_yieldhelp, old_cor, 0, new_cor->m_sp );
+ }
+ 
+--- src/sysc/kernel/sc_cor_qt.h
++++ src/sysc/kernel/sc_cor_qt.h
+@@ -58,8 +58,7 @@ public:
+ 	{}
+ 
+     // destructor
+-    virtual ~sc_cor_qt()
+-        { delete[] (char*) m_stack; }
++    virtual ~sc_cor_qt();
+ 
+     // switch stack protection on/off
+     virtual void stack_protect( bool enable );
+
+--- src/sysc/kernel/sc_kernel_ids.h
++++ src/sysc/kernel/sc_kernel_ids.h
+@@ -85,7 +85,8 @@ SC_DEFINE_MESSAGE(SC_ID_DEFAULT_TIME_UNIT_CHANGED_   , 516,
+ 	"default time unit changed to time resolution" )
+ SC_DEFINE_MESSAGE(SC_ID_INCONSISTENT_API_CONFIG_     , 517,
+ 	"inconsistent library configuration detected" )
+-// available message number 518
++SC_DEFINE_MESSAGE(SC_ID_STACK_SETUP_FAILED_          , 518,
++	"stack setup failed" )
+ SC_DEFINE_MESSAGE(SC_ID_WAIT_NOT_ALLOWED_            , 519,
+ 	"wait() is only allowed in SC_THREADs and SC_CTHREADs" )
+ SC_DEFINE_MESSAGE(SC_ID_NEXT_TRIGGER_NOT_ALLOWED_    , 520,

--- a/recipes/systemc/config.yml
+++ b/recipes/systemc/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.3.3":
     folder: "all"
+  "2.3.3_asan":
+    folder: "all"


### PR DESCRIPTION
Patch Accellera release to enable work with Aderess Sanitizer

Specify library name and version:  **systemc/2.3.3_asan**

SystemC 2.3.3 does not work with AddressSanitizer (https://forums.accellera.org/topic/7085-systemc-233-member-access-within-misaligned-address-error/). 
This issue is planed to be resolved in the upcomming Accellera release (https://github.com/accellera-official/systemc/pull/17) of the library. Currently it is not clear when the next release will take place.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
