### PR TITLE
[glib] build as shared by default

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -225,122 +225,84 @@ class GLibConan(ConanFile):
             os.unlink(pdb_file)
 
     def package_info(self):
-        self.cpp_info.components["glib-2.0"].libs = ["glib-2.0"]
-        self.cpp_info.components["glib-2.0"].names["pkg_config"] = "glib-2.0"
         self.cpp_info.components["glib-2.0"].set_property("pkg_config_name", "glib-2.0")
+        self.cpp_info.components["glib-2.0"].libs = ["glib-2.0"]
+        self.cpp_info.components["glib-2.0"].includedirs += [
+            os.path.join("include", "glib-2.0"),
+            os.path.join("lib", "glib-2.0", "include")
+        ]
+
+        self.cpp_info.components["gmodule-no-export-2.0"].set_property("pkg_config_name", "gmodule-no-export-2.0")
+        self.cpp_info.components["gmodule-no-export-2.0"].libs = ["gmodule-2.0"]
+        self.cpp_info.components["gmodule-no-export-2.0"].requires.append("glib-2.0")
+
+        self.cpp_info.components["gmodule-export-2.0"].set_property("pkg_config_name", "gmodule-export-2.0")
+        self.cpp_info.components["gmodule-export-2.0"].requires += ["gmodule-no-export-2.0", "glib-2.0"]
+
+        self.cpp_info.components["gmodule-2.0"].set_property("pkg_config_name", "gmodule-2.0")
+        self.cpp_info.components["gmodule-2.0"].requires += ["gmodule-no-export-2.0", "glib-2.0"]
+
+        self.cpp_info.components["gobject-2.0"].set_property("pkg_config_name", "gobject-2.0")
+        self.cpp_info.components["gobject-2.0"].libs = ["gobject-2.0"]
+        self.cpp_info.components["gobject-2.0"].requires += ["glib-2.0", "libffi::libffi"]
+
+        self.cpp_info.components["gthread-2.0"].set_property("pkg_config_name", "gthread-2.0")
+        self.cpp_info.components["gthread-2.0"].libs = ["gthread-2.0"]
+        self.cpp_info.components["gthread-2.0"].requires.append("glib-2.0")
+
+        self.cpp_info.components["gio-2.0"].set_property("pkg_config_name", "gio-2.0")
+        self.cpp_info.components["gio-2.0"].libs = ["gio-2.0"]
+        self.cpp_info.components["gio-2.0"].requires += ["glib-2.0", "gobject-2.0", "gmodule-2.0", "zlib::zlib"]
+
+        self.cpp_info.components["gresource"].set_property("pkg_config_name", "gresource")
+        self.cpp_info.components["gresource"].libs = []  # this is actually an executable
+
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["glib-2.0"].system_libs.append("pthread")
+            self.cpp_info.components["gmodule-no-export-2.0"].system_libs.append("pthread")
+            self.cpp_info.components["gmodule-no-export-2.0"].system_libs.append("dl")
+            self.cpp_info.components["gmodule-export-2.0"].sharedlinkflags.append("-Wl,--export-dynamic")
+            self.cpp_info.components["gmodule-2.0"].sharedlinkflags.append("-Wl,--export-dynamic")
+            self.cpp_info.components["gthread-2.0"].system_libs.append("pthread")
+            self.cpp_info.components["gio-2.0"].system_libs.append("dl")
+
         if self.settings.os == "Windows":
-            self.cpp_info.components["glib-2.0"].system_libs.extend(
-                ["ws2_32", "ole32", "shell32", "user32", "advapi32"]
-            )
+            self.cpp_info.components["glib-2.0"].system_libs += ["ws2_32", "ole32", "shell32", "user32", "advapi32"]
+            self.cpp_info.components["gio-2.0"].system_libs.extend(["iphlpapi", "dnsapi", "shlwapi"])
+            self.cpp_info.components["gio-windows-2.0"].requires = ["gobject-2.0", "gmodule-no-export-2.0", "gio-2.0"]
+            self.cpp_info.components["gio-windows-2.0"].includedirs = [os.path.join("include", "gio-win32-2.0")]
+        else:
+            self.cpp_info.components["gio-unix-2.0"].requires += ["gobject-2.0", "gio-2.0"]
+            self.cpp_info.components["gio-unix-2.0"].includedirs = [os.path.join("include", "gio-unix-2.0")]
+
         if self.settings.os == "Macos":
             self.cpp_info.components["glib-2.0"].system_libs.append("resolv")
-            self.cpp_info.components["glib-2.0"].frameworks.extend(
-                ["Foundation", "CoreServices", "CoreFoundation"]
-            )
-        self.cpp_info.components["glib-2.0"].includedirs.append(
-            os.path.join("include", "glib-2.0")
-        )
-        self.cpp_info.components["glib-2.0"].includedirs.append(
-            os.path.join("lib", "glib-2.0", "include")
-        )
+            self.cpp_info.components["glib-2.0"].frameworks += ["Foundation", "CoreServices", "CoreFoundation"]
+            self.cpp_info.components["gio-2.0"].frameworks.append("AppKit")
+
+            if tools.is_apple_os(self.settings.os):
+                self.cpp_info.components["glib-2.0"].requires.append("libiconv::libiconv")
+
         if self.options.with_pcre:
             if tools.Version(self.version) >= "2.73.2":
                 self.cpp_info.components["glib-2.0"].requires.append("pcre2::pcre2")
             else:
                 self.cpp_info.components["glib-2.0"].requires.append("pcre::pcre")
+
         if self.settings.os != "Linux":
-            self.cpp_info.components["glib-2.0"].requires.append(
-                "libgettext::libgettext"
-            )
-        if tools.is_apple_os(self.settings.os):
-            self.cpp_info.components["glib-2.0"].requires.append("libiconv::libiconv")
-
-        self.cpp_info.components["gmodule-no-export-2.0"].libs = ["gmodule-2.0"]
-        self.cpp_info.components["gmodule-no-export-2.0"].set_property("pkg_config_name", "gmodule-no-export-2.0")
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["gmodule-no-export-2.0"].system_libs.append(
-                "pthread"
-            )
-            self.cpp_info.components["gmodule-no-export-2.0"].system_libs.append("dl")
-        self.cpp_info.components["gmodule-no-export-2.0"].requires.append("glib-2.0")
-
-        self.cpp_info.components["gmodule-export-2.0"].requires.extend(
-            ["gmodule-no-export-2.0", "glib-2.0"]
-        )
-        self.cpp_info.components["gmodule-export-2.0"].set_property("pkg_config_name", "gmodule-export-2.0")
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["gmodule-export-2.0"].sharedlinkflags.append(
-                "-Wl,--export-dynamic"
-            )
-
-        self.cpp_info.components["gmodule-2.0"].set_property("pkg_config_name", "gmodule-2.0")
-        self.cpp_info.components["gmodule-2.0"].requires.extend(
-            ["gmodule-no-export-2.0", "glib-2.0"]
-        )
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["gmodule-2.0"].sharedlinkflags.append(
-                "-Wl,--export-dynamic"
-            )
-
-        self.cpp_info.components["gobject-2.0"].set_property("pkg_config_name", "gobject-2.0")
-        self.cpp_info.components["gobject-2.0"].libs = ["gobject-2.0"]
-        self.cpp_info.components["gobject-2.0"].requires.append("glib-2.0")
-        self.cpp_info.components["gobject-2.0"].requires.append("libffi::libffi")
-
-        self.cpp_info.components["gthread-2.0"].set_property("pkg_config_name", "gthread-2.0")
-        self.cpp_info.components["gthread-2.0"].libs = ["gthread-2.0"]
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["gthread-2.0"].system_libs.append("pthread")
-        self.cpp_info.components["gthread-2.0"].requires.append("glib-2.0")
-
-        self.cpp_info.components["gio-2.0"].set_property("pkg_config_name", "gio-2.0")
-        self.cpp_info.components["gio-2.0"].libs = ["gio-2.0"]
-        if self.settings.os == "Linux":
+            self.cpp_info.components["glib-2.0"].requires.append("libgettext::libgettext")
             self.cpp_info.components["gio-2.0"].system_libs.append("resolv")
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["gio-2.0"].system_libs.append("dl")
-        if self.settings.os == "Windows":
-            self.cpp_info.components["gio-2.0"].system_libs.extend(["iphlpapi", "dnsapi", "shlwapi"])
-        self.cpp_info.components["gio-2.0"].requires.extend(
-            ["glib-2.0", "gobject-2.0", "gmodule-2.0", "zlib::zlib"]
-        )
-        if self.settings.os == "Macos":
-            self.cpp_info.components["gio-2.0"].frameworks.append("AppKit")
+
         if self.options.get_safe("with_mount"):
             self.cpp_info.components["gio-2.0"].requires.append("libmount::libmount")
+
         if self.options.get_safe("with_selinux"):
-            self.cpp_info.components["gio-2.0"].requires.append(
-                "libselinux::libselinux"
-            )
-        if self.settings.os == "Windows":
-            self.cpp_info.components["gio-windows-2.0"].requires = [
-                "gobject-2.0",
-                "gmodule-no-export-2.0",
-                "gio-2.0",
-            ]
-            self.cpp_info.components["gio-windows-2.0"].includedirs = [
-                os.path.join("include", "gio-win32-2.0")
-            ]
-        else:
-            self.cpp_info.components["gio-unix-2.0"].requires.extend(
-                ["gobject-2.0", "gio-2.0"]
-            )
-            self.cpp_info.components["gio-unix-2.0"].includedirs = [
-                os.path.join("include", "gio-unix-2.0")
-            ]
-        self.env_info.GLIB_COMPILE_SCHEMAS = os.path.join(
-            self.package_folder, "bin", "glib-compile-schemas"
-        )
+            self.cpp_info.components["gio-2.0"].requires.append("libselinux::libselinux")
 
-        self.cpp_info.components["gresource"].set_property("pkg_config_name", "gresource")
-        self.cpp_info.components["gresource"].libs = []  # this is actually an executable
         if self.options.get_safe("with_elf"):
-            self.cpp_info.components["gresource"].requires.append(
-                "libelf::libelf"
-            )  # this is actually an executable
+            self.cpp_info.components["gresource"].requires.append("libelf::libelf")  # this is actually an executable
 
+        self.env_info.GLIB_COMPILE_SCHEMAS = os.path.join(self.package_folder, "bin", "glib-compile-schemas")
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info(f"Appending PATH env var with: {bin_path}")
         self.env_info.PATH.append(bin_path)
@@ -371,4 +333,4 @@ class GLibConan(ConanFile):
         }
         self.cpp_info.components["glib-2.0"].set_property(
             "pkg_config_custom_content",
-            "\n".join(f"{key}={value}" for key,value in pkgconfig_variables.items()))
+            "\n".join(f"{key}={value}" for key, value in pkgconfig_variables.items()))

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -216,7 +216,7 @@ class GLibConan(ConanFile):
             meson = self._configure_meson()
             meson.install()
             self._fix_library_names()
-        files.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        files.rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         shutil.move(
             os.path.join(self.package_folder, "share"),
             os.path.join(self.package_folder, "res"),

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -29,7 +29,7 @@ class GLibConan(ConanFile):
         "with_mount": [True, False],
     }
     default_options = {
-        "shared": False,
+        "shared": True,
         "fPIC": True,
         "with_pcre": True,
         "with_elf": True,

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.tools.build import cross_building
+from conan.tools import files
 from conan.tools.microsoft import is_msvc
 from conans import tools, Meson, VisualStudioBuildEnvironment
 from conans.errors import ConanInvalidConfiguration
@@ -109,7 +110,7 @@ class GLibConan(ConanFile):
         self.build_requires("pkgconf/1.7.4")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        files.get(self, **self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     @functools.lru_cache(1)
     def _configure_meson(self):
@@ -215,7 +216,7 @@ class GLibConan(ConanFile):
             meson = self._configure_meson()
             meson.install()
             self._fix_library_names()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        files.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
         shutil.move(
             os.path.join(self.package_folder, "share"),
             os.path.join(self.package_folder, "res"),

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -1,15 +1,16 @@
-from conan import ConanFile
-from conan.tools.build import cross_building
-from conan.tools import files, scm
-from conan.tools.microsoft import is_msvc
-from conans import tools, Meson, VisualStudioBuildEnvironment
-from conans.errors import ConanInvalidConfiguration
 import functools
 import os
 import glob
 import shutil
 
-required_conan_version = ">=1.45.0"
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import cross_building
+from conan.tools import files, scm
+from conan.tools.microsoft import is_msvc
+from conans import tools, Meson, VisualStudioBuildEnvironment
+
+required_conan_version = ">=1.50.0"
 
 
 class GLibConan(ConanFile):

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -289,9 +289,10 @@ class GLibConan(ConanFile):
             else:
                 self.cpp_info.components["glib-2.0"].requires.append("pcre::pcre")
 
-        if self.settings.os != "Linux":
-            self.cpp_info.components["glib-2.0"].requires.append("libgettext::libgettext")
+        if self.settings.os == "Linux":
             self.cpp_info.components["gio-2.0"].system_libs.append("resolv")
+        else:
+            self.cpp_info.components["glib-2.0"].requires.append("libgettext::libgettext")
 
         if self.options.get_safe("with_mount"):
             self.cpp_info.components["gio-2.0"].requires.append("libmount::libmount")


### PR DESCRIPTION
Specify library name and version:  **glib**

Attempt to solve miscellaneous Glib related issues by making the library shared by default.

See #11684 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
