### PR TITLE
qxmpp: Use version ranges instead of explicit versions

### DIFF
--- a/recipes/qxmpp/all/conanfile.py
+++ b/recipes/qxmpp/all/conanfile.py
@@ -46,10 +46,10 @@ class QxmppConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("qt/6.2.3")
+        self.requires("qt/[>=6.2.3]")
         if self.options.with_gstreamer:
-            self.requires("gstreamer/1.19.2")
-            self.requires("glib/2.70.1")
+            self.requires("gstreamer/[>=1.19.2]")
+            self.requires("glib/[>=2.70.1]")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)


### PR DESCRIPTION
Specify library name and version:  **qxmpp/1.4.0**

I noticed this when attempting to compile random recipes from CCI on MacOS for evaluation. See #12180 for a log of the original openssl conflict.

Fixes #12180.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
