### PR TITLE
Add Abseil LTS 20220623

### DIFF
--- a/recipes/abseil/all/conandata.yml
+++ b/recipes/abseil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20220623.0":
+    url: "https://github.com/abseil/abseil-cpp/archive/20220623.0.tar.gz"
+    sha256: "4208129b49006089ba1d6710845a45e31c59b0ab6bff9e5788a87f55c5abd602"
   "20211102.0":
     url: "https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz"
     sha256: "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4"
@@ -12,6 +15,9 @@ sources:
     url: "https://github.com/abseil/abseil-cpp/archive/20200225.3.tar.gz"
     sha256: "66d4d009050f39c104b03f79bdca9d930c4964016f74bf24867a43fbdbd00d23"
 patches:
+  "20220623.0":
+    - patch_file: "patches/0003-absl-string-libm.patch"
+      base_path: "source_subfolder"
   "20211102.0":
     - patch_file: "patches/0003-absl-string-libm.patch"
       base_path: "source_subfolder"

--- a/recipes/abseil/config.yml
+++ b/recipes/abseil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20220623.0":
+    folder: all
   "20211102.0":
     folder: all
   "20210324.2":


### PR DESCRIPTION
Specify library name and version:  **abseil/20220623.0**

This PR adds the latest LTS version of Google's Abseil library. I'm not affiliated with either Google or Abseil, just want to use the new version in projects I'm working on.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
