### PR TITLE
Use validate in gn

### DIFF
--- a/recipes/gn/all/conanfile.py
+++ b/recipes/gn/all/conanfile.py
@@ -7,7 +7,7 @@ import sys
 import textwrap
 import time
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.41.0"
 
 
 class GnConan(ConanFile):

--- a/recipes/gn/all/conanfile.py
+++ b/recipes/gn/all/conanfile.py
@@ -2,12 +2,13 @@ from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 from contextlib import contextmanager
 import conan.tools.files as tools_files
+import conan.tools.scm as tools_scm
 import os
 import sys
 import textwrap
 import time
 
-required_conan_version = ">=1.41.0"
+required_conan_version = ">=1.46.0"
 
 
 class GnConan(ConanFile):
@@ -37,7 +38,7 @@ class GnConan(ConanFile):
             tools.check_min_cppstd(self, 17)
         else:
             if self._minimum_compiler_version_supporting_cxx17:
-                if tools.Version(self.settings.compiler.version) < self._minimum_compiler_version_supporting_cxx17:
+                if tools_scm.Version(self.settings.compiler.version) < self._minimum_compiler_version_supporting_cxx17:
                     raise ConanInvalidConfiguration("gn requires a compiler supporting c++17")
             else:
                 self.output.warn("gn recipe does not recognize the compiler. gn requires a compiler supporting c++17. Assuming it does.")

--- a/recipes/gn/all/conanfile.py
+++ b/recipes/gn/all/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 from contextlib import contextmanager
+import conan.tools.files as tools_files
 import os
 import sys
 import textwrap
@@ -45,7 +46,7 @@ class GnConan(ConanFile):
         del self.info.settings.compiler
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder)
+        tools_files.get(self, **self.conan_data["sources"][self.version], destination=self._source_subfolder)
 
     def build_requirements(self):
         # FIXME: add cpython build requirements for `build/gen.py`.

--- a/recipes/gn/all/conanfile.py
+++ b/recipes/gn/all/conanfile.py
@@ -2,6 +2,7 @@ from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 from contextlib import contextmanager
 import os
+import sys
 import textwrap
 import time
 
@@ -104,7 +105,7 @@ class GnConan(ConanFile):
                 ]
                 if self.settings.build_type == "Debug":
                     conf_args.append("-d")
-                self.run("python build/gen.py {}".format(" ".join(conf_args)), run_environment=True)
+                self.run("{} build/gen.py {}".format(sys.executable, " ".join(conf_args)), run_environment=True)
                 # Try sleeping one second to avoid time skew of the generated ninja.build file (and having to re-run build/gen.py)
                 time.sleep(1)
                 build_args = [

--- a/recipes/gn/all/conanfile.py
+++ b/recipes/gn/all/conanfile.py
@@ -32,7 +32,7 @@ class GnConan(ConanFile):
             "apple-clang": 10,
         }.get(str(self.settings.compiler))
 
-    def configure(self):
+    def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 17)
         else:

--- a/recipes/gn/all/conanfile.py
+++ b/recipes/gn/all/conanfile.py
@@ -124,3 +124,4 @@ class GnConan(ConanFile):
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bin_path))
         self.env_info.PATH.append(bin_path)
+        self.cpp_info.includedirs = []


### PR DESCRIPTION
Specify library name and version:  **gn/cci.20210429**

Trying to resolve an issue I ran into while trying to make https://github.com/conan-io/conan-center-index/pull/12189 build.

For the other PR, I got this error: `Do not raise ConanInvalidConfiguration from build() method. Please, move that same check to validate() method.`

Checking the log, I saw this message: `ERROR: gn/cci.20210429: Invalid configuration: gn requires a compiler supporting c++17`

My assumption is that the root cause is that `gn` validates its configuration in `configure()` instead of `validate()`.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
