### PR TITLE
cpr: add version 1.9.1

### DIFF
--- a/recipes/cpr/all/conandata.yml
+++ b/recipes/cpr/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.9.1":
+    url: "https://github.com/libcpr/cpr/archive/1.9.1.tar.gz"
+    sha256: "389b9bb78cba0d63a064eac224c120069acdd2ed9172f7d06547ce1e74384330"
   "1.9.0":
     url: "https://github.com/libcpr/cpr/archive/refs/tags/1.9.0.tar.gz"
     sha256: "67023cde8979e8371f5ee7d6e586d6d0761af4a3a3a3be6270256353c9bf411f"
@@ -18,6 +21,9 @@ sources:
     url: "https://github.com/libcpr/cpr/archive/1.4.0.tar.gz"
     sha256: "13baffba95445e02291684e31906b04df41d8c6a3020a1a55253047c6756a004"
 patches:
+  "1.9.1":
+    - patch_file: "patches/005-1.9.0-fix-curl-components.patch"
+      base_path: "source_subfolder"
   "1.9.0":
     - patch_file: "patches/005-1.9.0-fix-curl-components.patch"
       base_path: "source_subfolder"

--- a/recipes/cpr/config.yml
+++ b/recipes/cpr/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.1":
+    folder: all
   "1.9.0":
     folder: all
   "1.8.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cpr/1.9.1**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
