### PR TITLE
metall: conan v2 support + remove options + header only

### DIFF
--- a/recipes/metall/all/CMakeLists.txt
+++ b/recipes/metall/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory(source_subfolder)

--- a/recipes/metall/all/conandata.yml
+++ b/recipes/metall/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.20":
-    url: "https://github.com/LLNL/metall/archive/refs/tags/v0.20.tar.gz"
-    sha256: "cafe54c682004a66a059f54e2d7128ea7622e9941ea492297d04c260675e9af4"
   "0.21":
     url: "https://github.com/LLNL/metall/archive/refs/tags/v0.21.tar.gz"
     sha256: "feaff7a935f98d3cc1e2b21f6eae40edc674a5bd0133306afd3851148aaed026"
+  "0.20":
+    url: "https://github.com/LLNL/metall/archive/refs/tags/v0.20.tar.gz"
+    sha256: "cafe54c682004a66a059f54e2d7128ea7622e9941ea492297d04c260675e9af4"

--- a/recipes/metall/all/conanfile.py
+++ b/recipes/metall/all/conanfile.py
@@ -30,7 +30,7 @@ class MetallConan(ConanFile):
         self.requires("boost/1.79.0")
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/metall/all/conanfile.py
+++ b/recipes/metall/all/conanfile.py
@@ -1,63 +1,23 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
-from conans import ConanFile, tools, CMake
-from conans.errors import ConanInvalidConfiguration
-from conans.tools import rmdir
-
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.50.0"
 
 
-class Recipe(ConanFile):
+class MetallConan(ConanFile):
     name = "metall"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/LLNL/metall"
     description = "Meta allocator for persistent memory"
     license = "MIT", "Apache-2.0"
     topics = "cpp", "allocator", "memory-allocator", "persistent-memory", "ecp", "exascale-computing"
-    settings = "build_type", "compiler", "os", "arch"
-    options = {
-        # Disable freeing file space
-        "disable_free_file_space": [True, False],
-        # Disable small object cache
-        "disable_small_object_cache": [True, False],
-        # Use VM space aware algorithm in the bin directory
-        "use_sorted_bin": [True, False],
-        # Set the default VM reserve size (use the internally defined value if 0 is specified)
-        "default_vm_reserve_size": "ANY",
-        # Set the max segment size (use the internally defined value if 0 is specified)
-        "max_segment_size": "ANY",
-        # Set the initial segment size (use the internally defined value if 0 is specified)
-        "initial_segment_size": "ANY",
-        # Experimental: Use the anonymous map when creating a new map region
-        "use_anonymous_new_map": [True, False],
-        # Experimental: Build programs that require the NUMA policy library (numa.h)
-        "build_numa": [True, False],
-        # Experimental: Try to free the associated pages and file space when objects equal to or larger than that
-        # is deallocated
-        "free_small_object_size_hint": "ANY",
-    }
-
-    default_options = {
-        "disable_free_file_space": False,
-        "disable_small_object_cache": False,
-        "use_sorted_bin": False,
-        "default_vm_reserve_size": 0,
-        "max_segment_size": 0,
-        "initial_segment_size": 0,
-        "use_anonymous_new_map": False,
-        "build_numa": False,
-        "free_small_object_size_hint": 0,
-    }
-    requires = "boost/1.79.0",
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self.folders.base_source,
-                  strip_root=True)
-
-    @property
-    def _min_cppstd(self):
-        return "17"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
 
     @property
     def _compilers_minimum_version(self):
@@ -66,9 +26,15 @@ class Recipe(ConanFile):
             "clang": "9",
         }
 
+    def requirements(self):
+        self.requires("boost/1.79.0")
+
+    def package_id(self):
+        self.info.header_only()
+
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, self._min_cppstd)
+            check_min_cppstd(self, 17)
 
         if self.settings.os not in ["Linux", "Macos"]:
             raise ConanInvalidConfiguration(
@@ -82,55 +48,42 @@ class Recipe(ConanFile):
 
         minimum_version = self._compilers_minimum_version.get(
             str(self.settings.compiler), False)
-        if not minimum_version:
-            self.output.warn(
-                "{} {} requires C++17. Your compiler is unknown. Assuming it supports C++17.".format(self.name,
-                                                                                                     self.version))
-        elif lazy_lt_semver(str(self.settings.compiler.version), minimum_version):
+        if minimum_version and lazy_lt_semver(str(self.settings.compiler.version), minimum_version):
             raise ConanInvalidConfiguration(
                 "{} {} requires C++17, which your compiler does not support.".format(self.name, self.version))
 
-    _cmake = None
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions['DISABLE_FREE_FILE_SPACE'] = self.options.disable_free_file_space
-        self._cmake.definitions['DISABLE_SMALL_OBJECT_CACHE'] = self.options.disable_small_object_cache
-        self._cmake.definitions['USE_SORTED_BIN'] = self.options.use_sorted_bin
-        self._cmake.definitions['DEFAULT_VM_RESERVE_SIZE'] = self.options.default_vm_reserve_size
-        self._cmake.definitions['MAX_SEGMENT_SIZE'] = self.options.max_segment_size
-        self._cmake.definitions['INITIAL_SEGMENT_SIZE'] = self.options.initial_segment_size
-        self._cmake.definitions['USE_ANONYMOUS_NEW_MAP'] = self.options.use_anonymous_new_map
-        self._cmake.definitions['BUILD_NUMA'] = self.options.build_numa
-        self._cmake.definitions['FREE_SMALL_OBJECT_SIZE_HINT'] = self.options.free_small_object_size_hint
-        self._cmake.configure()
-
-        return self._cmake
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
 
     def build(self):
-        self._configure_cmake().build()
+        pass
 
     def package(self):
-        self._configure_cmake().install()
-        rmdir(os.path.join(self.package_folder, "share"))
-        self.copy("LICENSE*", src=self.folders.base_source, dst="licenses")
-        self.copy("COPYRIGHT", src=self.folders.base_source, dst="licenses")
+        copy(self, "*", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
+        copy(self, "LICENSE*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "COPYRIGHT", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
 
     def package_info(self):
-        name = "Metall"
-        self.cpp_info.set_property("cmake_file_name", name)
-        self.cpp_info.names["cmake_find_package"] = name
-        self.cpp_info.names["cmake_find_package_multi"] = name
-        self.cpp_info.set_property("cmake_target_name", f"{name}::{name}")
+        self.cpp_info.set_property("cmake_file_name", "Metall")
+        self.cpp_info.set_property("cmake_target_name", "Metall::Metall")
 
-        # TODO: to remove in conan v2 once pkg_config generators removed
-        self.cpp_info.names["pkg_config"] = name
+        self.cpp_info.names["cmake_find_package"] = "Metall"
+        self.cpp_info.names["cmake_find_package_multi"] = "Metall"
 
-        if self.settings.os in ["Linux"]:
-            self.cpp_info.system_libs = ["pthread"]
+        self.cpp_info.bindirs = []
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")
 
         if self.settings.compiler == "gcc" or (self.settings.os == "Linux" and self.settings.compiler == "clang"):
-            if tools.Version(self.settings.compiler.version) < 9:
+            if Version(self.settings.compiler.version) < "9":
                 self.cpp_info.system_libs += ["stdc++fs"]
+
+        self.cpp_info.requires = ["boost::headers"]

--- a/recipes/metall/all/test_package/conanfile.py
+++ b/recipes/metall/all/test_package/conanfile.py
@@ -1,19 +1,15 @@
-import os
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain
-from conan.tools.layout import cmake_layout
-from conans import tools
-
-required_conan_version = ">=1.43.0"
+from conan.tools.build import cross_building
+from conan.tools.cmake import CMake, cmake_layout
+import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake_find_package", "CMakeDeps"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
 
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.generate()
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def layout(self):
         cmake_layout(self)
@@ -24,5 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), run_environment=True)
+        if not cross_building(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/metall/all/test_v1_package/CMakeLists.txt
+++ b/recipes/metall/all/test_v1_package/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(Metall REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE Metall::Metall)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/metall/all/test_v1_package/conanfile.py
+++ b/recipes/metall/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+# pylint: skip-file
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/metall/config.yml
+++ b/recipes/metall/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.20":
-    folder: all
   "0.21":
+    folder: all
+  "0.20":
     folder: all


### PR DESCRIPTION
- this lib is header only
- options were useless (no build nor consume effect in previous recipe), they are removed
- fix test_package (weird mix of cmake_find_package & CMakeDeps)
- add test_v1_package

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
