### PR TITLE
mpir: patch for Visual Studio 2019 and 2022

### DIFF
--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -109,7 +109,6 @@ class MpirConan(ConanFile):
                 "Debug" if "d" in msvc_runtime_flag(self) else "",
                 "DLL" if "MD" in msvc_runtime_flag(self) else "",
             )
-            self.output.info(f"--++--++--++--++--++--++--++--++--++--++ props_path: {props_path}")
             replace_in_file(self, props_path, old_runtime, new_runtime)
         msbuild = MSBuild(self)
         for vcxproj_path in self._vcxproj_paths:

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -182,13 +182,14 @@ class MpirConan(ConanFile):
             for root, _, files in os.walk("build.vc16"):
                 for file in files:
                     tools.replace_in_file(os.path.join(root, file), "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>")
-                    tools.replace_in_file(os.path.join(root, file), 'prebuild gc Win32 15', 'prebuild gc Win32 16')
-                    tools.replace_in_file(os.path.join(root, file), 'prebuild core2 x64 15', 'prebuild core2 x64 16')
+                    tools.replace_in_file(os.path.join(root, file), "prebuild skylake\\avx x64 15", "prebuild skylake\\avx x64 16")
+                    tools.replace_in_file(os.path.join(root, file), "prebuild p3 Win32 15", "prebuild p3 Win32 16")
+                    tools.replace_in_file(os.path.join(root, file), "prebuild gc Win32 15", "prebuild gc Win32 16")
+                    tools.replace_in_file(os.path.join(root, file), "prebuild gc x64 15", "prebuild gc x64 16")
+                    tools.replace_in_file(os.path.join(root, file), "prebuild haswell\\avx x64 15", "prebuild haswell\\avx x64 16")
+                    tools.replace_in_file(os.path.join(root, file), "prebuild core2 x64 15", "prebuild core2 x64 16")
+
                     tools.replace_in_file(os.path.join(root, file), 'postbuild "$(TargetPath)" 15', 'postbuild "$(TargetPath)" 16')
-                    tools.replace_in_file(os.path.join(root, file), 'prebuild gc x64 15', 'prebuild gc x64 16')
-                    tools.replace_in_file(os.path.join(root, file), 'prebuild haswell\avx x64 15', 'prebuild haswell\avx x64 16')
-                    tools.replace_in_file(os.path.join(root, file), 'prebuild p3 Win32 15', 'prebuild p3 Win32 16')
-                    tools.replace_in_file(os.path.join(root, file), 'prebuild skylake\avx x64 15', 'prebuild skylake\avx x64 16')
                     tools.replace_in_file(os.path.join(root, file), 'check_config $(Platform) $(Configuration) 15', 'check_config $(Platform) $(Configuration) 16')
 
             # for root, _, files in os.walk(self.build_folder):

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -181,16 +181,23 @@ class MpirConan(ConanFile):
 
             for root, _, files in os.walk("build.vc16"):
                 for file in files:
-                    tools.replace_in_file(os.path.join(root, file), "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>")
-                    tools.replace_in_file(os.path.join(root, file), "prebuild skylake\\avx x64 15", "prebuild skylake\\avx x64 16")
-                    tools.replace_in_file(os.path.join(root, file), "prebuild p3 Win32 15", "prebuild p3 Win32 16")
-                    tools.replace_in_file(os.path.join(root, file), "prebuild gc Win32 15", "prebuild gc Win32 16")
-                    tools.replace_in_file(os.path.join(root, file), "prebuild gc x64 15", "prebuild gc x64 16")
-                    tools.replace_in_file(os.path.join(root, file), "prebuild haswell\\avx x64 15", "prebuild haswell\\avx x64 16")
-                    tools.replace_in_file(os.path.join(root, file), "prebuild core2 x64 15", "prebuild core2 x64 16")
+                    full_file = os.path.join(root, file)
+                    tools.replace_in_file(full_file, "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>")
+                    tools.replace_in_file(full_file, "prebuild skylake\\avx x64 15", "prebuild skylake\\avx x64 16")
+                    tools.replace_in_file(full_file, "prebuild p3 Win32 15", "prebuild p3 Win32 16")
+                    tools.replace_in_file(full_file, "prebuild gc Win32 15", "prebuild gc Win32 16")
+                    tools.replace_in_file(full_file, "prebuild gc x64 15", "prebuild gc x64 16")
+                    tools.replace_in_file(full_file, "prebuild haswell\\avx x64 15", "prebuild haswell\\avx x64 16")
+                    tools.replace_in_file(full_file, "prebuild core2 x64 15", "prebuild core2 x64 16")
 
-                    tools.replace_in_file(os.path.join(root, file), 'postbuild "$(TargetPath)" 15', 'postbuild "$(TargetPath)" 16')
-                    tools.replace_in_file(os.path.join(root, file), 'check_config $(Platform) $(Configuration) 15', 'check_config $(Platform) $(Configuration) 16')
+                    tools.replace_in_file(full_file, 'postbuild "$(TargetPath)" 15', 'postbuild "$(TargetPath)" 16')
+                    tools.replace_in_file(full_file, 'check_config $(Platform) $(Configuration) 15', 'check_config $(Platform) $(Configuration) 16')
+
+                    self.output.info(f"full_file: {full_file}")
+
+                    with open(full_file, mode='r') as file:
+                        all_of_it = file.read()
+                        self.output.info(f"all_of_it: {all_of_it}")
 
             # for root, _, files in os.walk(self.build_folder):
             #     if "Makefile" in files:

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -1,7 +1,8 @@
 from conan.tools.microsoft import msvc_runtime_flag
 from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
 from conans.errors import ConanInvalidConfiguration
-from conan.tools import files
+# from conan.tools import files
+import conan
 import contextlib
 import os
 
@@ -153,7 +154,7 @@ class MpirConan(ConanFile):
     def _patch_sources(self):
         if self._is_msvc:
             # self.copy("*", src="build.vc15", dst="build.vc16")
-            files.copy("*", src="build.vc15", dst="build.vc16")
+            conan.tools.files.copy("*", src="build.vc15", dst="build.vc16")
             for root, _, files in os.walk("build.vc16"):
                 for file in files:
                     tools.replace_in_file(os.path.join(root, file), "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>")

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -152,67 +152,46 @@ class MpirConan(ConanFile):
             self._autotools.configure(args=args)
         return self._autotools
 
+    def _patch_new_msvc_version(self, ver, toolset):
+        new_dir = os.path.join(self._source_subfolder, f'build.vc{ver}')
+        conan.tools.files.copy(self, pattern="*", src=os.path.join(self._source_subfolder, 'build.vc15'), dst=new_dir)
+
+        for root, _, files in os.walk(new_dir):
+            for file in files:
+                full_file = os.path.join(root, file)
+                tools.replace_in_file(full_file, "<PlatformToolset>v141</PlatformToolset>", f"<PlatformToolset>{toolset}</PlatformToolset>", strict=False)
+                tools.replace_in_file(full_file, "prebuild skylake\\avx x64 15", f"prebuild skylake\\avx x64 {ver}", strict=False)
+                tools.replace_in_file(full_file, "prebuild p3 Win32 15", f"prebuild p3 Win32 {ver}", strict=False)
+                tools.replace_in_file(full_file, "prebuild gc Win32 15", f"prebuild gc Win32 {ver}", strict=False)
+                tools.replace_in_file(full_file, "prebuild gc x64 15", f"prebuild gc x64 {ver}", strict=False)
+                tools.replace_in_file(full_file, "prebuild haswell\\avx x64 15", f"prebuild haswell\\avx x64 {ver}", strict=False)
+                tools.replace_in_file(full_file, "prebuild core2 x64 15", f"prebuild core2 x64 {ver}", strict=False)
+                tools.replace_in_file(full_file, 'postbuild "$(TargetPath)" 15', f'postbuild "$(TargetPath)" {ver}', strict=False)
+                tools.replace_in_file(full_file, 'check_config $(Platform) $(Configuration) 15', f'check_config $(Platform) $(Configuration) {ver}', strict=False)
+
     def _patch_sources(self):
         if self._is_msvc:
+            self._patch_new_msvc_version(16, "v142")
+            self._patch_new_msvc_version(17, "v143")
 
-            # self.output.info(f"build.vc15 exists: {os.path.isfile('build.vc15')}")
-            # self.output.info(f"source/build.vc15 exists: {os.path.isfile(os.path.join(self._source_subfolder, 'build.vc15'))}")
+            # conan.tools.files.copy(self, pattern="*", src=os.path.join(self._source_subfolder, 'build.vc15'), dst=os.path.join(self._source_subfolder, 'build.vc16'))
 
-            conan.tools.files.copy(self, pattern="*", src=os.path.join(self._source_subfolder, 'build.vc15'), dst=os.path.join(self._source_subfolder, 'build.vc16'))
-
-            self.output.info(f"vc16: {os.path.join(self._source_subfolder, 'build.vc16')}")
-
-            # self.output.info(f"build.vc16 exists: {os.path.isfile('build.vc16')}")
-            # self.output.info(f"source/build.vc16 exists: {os.path.isfile(os.path.join(self._source_subfolder, 'build.vc16'))}")
-
-
-            # self.output.info("build.vc15 *********************************")
-            # for root, _, files in os.walk("build.vc15"):
+            # vc16dir = os.path.join(self._source_subfolder, 'build.vc16')
+            # for root, _, files in os.walk(vc16dir):
             #     for file in files:
-            #         self.output.info(f"file: {os.path.join(root, file)}")
+            #         full_file = os.path.join(root, file)
+            #         tools.replace_in_file(full_file, "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>", strict=False)
+            #         tools.replace_in_file(full_file, "prebuild skylake\\avx x64 15", "prebuild skylake\\avx x64 16", strict=False)
+            #         tools.replace_in_file(full_file, "prebuild p3 Win32 15", "prebuild p3 Win32 16", strict=False)
+            #         tools.replace_in_file(full_file, "prebuild gc Win32 15", "prebuild gc Win32 16", strict=False)
+            #         tools.replace_in_file(full_file, "prebuild gc x64 15", "prebuild gc x64 16", strict=False)
+            #         tools.replace_in_file(full_file, "prebuild haswell\\avx x64 15", "prebuild haswell\\avx x64 16", strict=False)
+            #         tools.replace_in_file(full_file, "prebuild core2 x64 15", "prebuild core2 x64 16", strict=False)
 
-            # self.output.info("source/build.vc15 *********************************")
-            # for root, _, files in os.walk(os.path.join(self._source_subfolder, "build.vc15")):
-            #     for file in files:
-            #         self.output.info(f"file: {os.path.join(root, file)}")
+            #         tools.replace_in_file(full_file, 'postbuild "$(TargetPath)" 15', 'postbuild "$(TargetPath)" 16', strict=False)
+            #         tools.replace_in_file(full_file, 'check_config $(Platform) $(Configuration) 15', 'check_config $(Platform) $(Configuration) 16', strict=False)
 
-
-            # self.output.info("build.vc16 *********************************")
-            # for root, _, files in os.walk("build.vc16"):
-            #     for file in files:
-            #         self.output.info(f"file: {os.path.join(root, file)}")
-
-            vc16dir = os.path.join(self._source_subfolder, 'build.vc16')
-            self.output.info(f"vc16dir: {vc16dir}")
-            for root, _, files in os.walk(vc16dir):
-                for file in files:
-                    full_file = os.path.join(root, file)
-                    tools.replace_in_file(full_file, "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>", strict=False)
-                    tools.replace_in_file(full_file, "prebuild skylake\\avx x64 15", "prebuild skylake\\avx x64 16", strict=False)
-                    tools.replace_in_file(full_file, "prebuild p3 Win32 15", "prebuild p3 Win32 16", strict=False)
-                    tools.replace_in_file(full_file, "prebuild gc Win32 15", "prebuild gc Win32 16", strict=False)
-                    tools.replace_in_file(full_file, "prebuild gc x64 15", "prebuild gc x64 16", strict=False)
-                    tools.replace_in_file(full_file, "prebuild haswell\\avx x64 15", "prebuild haswell\\avx x64 16", strict=False)
-                    tools.replace_in_file(full_file, "prebuild core2 x64 15", "prebuild core2 x64 16", strict=False)
-
-                    tools.replace_in_file(full_file, 'postbuild "$(TargetPath)" 15', 'postbuild "$(TargetPath)" 16', strict=False)
-                    tools.replace_in_file(full_file, 'check_config $(Platform) $(Configuration) 15', 'check_config $(Platform) $(Configuration) 16', strict=False)
-
-                    self.output.info(f"full_file: {full_file}")
-
-                    # with open(full_file, mode='r') as file:
-                    #     all_of_it = file.read()
-                    #     self.output.info(f"all_of_it: {all_of_it}")
-
-            # for root, _, files in os.walk(self.build_folder):
-            #     if "Makefile" in files:
-            #         tools.replace_in_file(os.path.join(root, "Makefile"), "-Dstrtod=fixstrtod", "", strict=False)
-
-
-            # fn = os.path.join("CPP", "Build.mak")
-            # os.chmod(fn, 0o644)
-            # tools.replace_in_file(fn, "-MT", "-{}".format(str(self.settings.compiler.runtime)))
-            # tools.replace_in_file(fn, "-MD", "-{}".format(str(self.settings.compiler.runtime)))
+            #         self.output.info(f"full_file: {full_file}")
 
 
     def build(self):

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -1,12 +1,14 @@
-from conan.tools.microsoft import msvc_runtime_flag
-from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
-from conans.errors import ConanInvalidConfiguration
-# from conan.tools import files
-import conan
+from conan import ConanFile
+from conan.tools.microsoft import msvc_runtime_flag, is_msvc
+from conan.tools.build import cross_building
+from conan.tools.files import get, copy, replace_in_file, chdir, rmdir, rm
+from conan.tools.scm import Version
+from conans import tools, AutoToolsBuildEnvironment, MSBuild
+from conan.errors import ConanInvalidConfiguration
 import contextlib
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.50.0"
 
 class MpirConan(ConanFile):
     name = "mpir"
@@ -43,10 +45,6 @@ class MpirConan(ConanFile):
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
-    @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -54,7 +52,7 @@ class MpirConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-        if self._is_msvc and self.options.shared:
+        if is_msvc(self) and self.options.shared:
             del self.options.enable_cxx
         if not self.options.get_safe("enable_cxx", False):
             del self.settings.compiler.libcxx
@@ -63,18 +61,18 @@ class MpirConan(ConanFile):
             self.provides.append("gmp")
 
     def validate(self):
-        if hasattr(self, "settings_build") and tools.cross_building(self, skip_x64_x86=True):
+        if hasattr(self, "settings_build") and cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building doesn't work (yet)")
 
     def build_requirements(self):
-        self.build_requires("yasm/1.3.0")
-        if not self._is_msvc:
-            self.build_requires("m4/1.4.19")
+        self.tool_requires("yasm/1.3.0")
+        if not is_msvc(self):
+            self.tool_requires("m4/1.4.19")
             if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
-                self.build_requires("msys2/cci.latest")
+                self.tool_requires("msys2/cci.latest")
 
     def source(self):
-        tools.get(keep_permissions=True, **self.conan_data["sources"][self.version],
+        get(self, keep_permissions=True, **self.conan_data["sources"][self.version],
                   strip_root=True, destination=self._source_subfolder)
 
     @property
@@ -87,7 +85,7 @@ class MpirConan(ConanFile):
 
     @property
     def _vcxproj_paths(self):
-        compiler_version = self.settings.compiler.version if tools.Version(self.settings.compiler.version) <= "16" else "16"
+        compiler_version = self.settings.compiler.version if Version(self.settings.compiler.version) <= "16" else "16"
         build_subdir = "build.vc{}".format(compiler_version)
         vcxproj_paths = [
             os.path.join(self._source_subfolder, build_subdir,
@@ -112,7 +110,7 @@ class MpirConan(ConanFile):
                 "DLL" if "MD" in msvc_runtime_flag(self) else "",
             )
             self.output.info(f"--++--++--++--++--++--++--++--++--++--++ props_path: {props_path}")
-            tools.replace_in_file(props_path, old_runtime, new_runtime)
+            replace_in_file(self, props_path, old_runtime, new_runtime)
         msbuild = MSBuild(self)
         for vcxproj_path in self._vcxproj_paths:
             msbuild.build(vcxproj_path, platforms=self._platforms, upgrade_project=False)
@@ -154,85 +152,65 @@ class MpirConan(ConanFile):
 
     def _patch_new_msvc_version(self, ver, toolset):
         new_dir = os.path.join(self._source_subfolder, f'build.vc{ver}')
-        conan.tools.files.copy(self, pattern="*", src=os.path.join(self._source_subfolder, 'build.vc15'), dst=new_dir)
+        copy(self, pattern="*", src=os.path.join(self._source_subfolder, 'build.vc15'), dst=new_dir)
 
         for root, _, files in os.walk(new_dir):
             for file in files:
                 full_file = os.path.join(root, file)
-                tools.replace_in_file(full_file, "<PlatformToolset>v141</PlatformToolset>", f"<PlatformToolset>{toolset}</PlatformToolset>", strict=False)
-                tools.replace_in_file(full_file, "prebuild skylake\\avx x64 15", f"prebuild skylake\\avx x64 {ver}", strict=False)
-                tools.replace_in_file(full_file, "prebuild p3 Win32 15", f"prebuild p3 Win32 {ver}", strict=False)
-                tools.replace_in_file(full_file, "prebuild gc Win32 15", f"prebuild gc Win32 {ver}", strict=False)
-                tools.replace_in_file(full_file, "prebuild gc x64 15", f"prebuild gc x64 {ver}", strict=False)
-                tools.replace_in_file(full_file, "prebuild haswell\\avx x64 15", f"prebuild haswell\\avx x64 {ver}", strict=False)
-                tools.replace_in_file(full_file, "prebuild core2 x64 15", f"prebuild core2 x64 {ver}", strict=False)
-                tools.replace_in_file(full_file, 'postbuild "$(TargetPath)" 15', f'postbuild "$(TargetPath)" {ver}', strict=False)
-                tools.replace_in_file(full_file, 'check_config $(Platform) $(Configuration) 15', f'check_config $(Platform) $(Configuration) {ver}', strict=False)
+                replace_in_file(self, full_file, "<PlatformToolset>v141</PlatformToolset>", f"<PlatformToolset>{toolset}</PlatformToolset>", strict=False)
+                replace_in_file(self, full_file, "prebuild skylake\\avx x64 15", f"prebuild skylake\\avx x64 {ver}", strict=False)
+                replace_in_file(self, full_file, "prebuild p3 Win32 15", f"prebuild p3 Win32 {ver}", strict=False)
+                replace_in_file(self, full_file, "prebuild gc Win32 15", f"prebuild gc Win32 {ver}", strict=False)
+                replace_in_file(self, full_file, "prebuild gc x64 15", f"prebuild gc x64 {ver}", strict=False)
+                replace_in_file(self, full_file, "prebuild haswell\\avx x64 15", f"prebuild haswell\\avx x64 {ver}", strict=False)
+                replace_in_file(self, full_file, "prebuild core2 x64 15", f"prebuild core2 x64 {ver}", strict=False)
+                replace_in_file(self, full_file, 'postbuild "$(TargetPath)" 15', f'postbuild "$(TargetPath)" {ver}', strict=False)
+                replace_in_file(self, full_file, 'check_config $(Platform) $(Configuration) 15', f'check_config $(Platform) $(Configuration) {ver}', strict=False)
 
     def _patch_sources(self):
-        if self._is_msvc:
+        if is_msvc(self):
             self._patch_new_msvc_version(16, "v142")
             self._patch_new_msvc_version(17, "v143")
 
-            # conan.tools.files.copy(self, pattern="*", src=os.path.join(self._source_subfolder, 'build.vc15'), dst=os.path.join(self._source_subfolder, 'build.vc16'))
-
-            # vc16dir = os.path.join(self._source_subfolder, 'build.vc16')
-            # for root, _, files in os.walk(vc16dir):
-            #     for file in files:
-            #         full_file = os.path.join(root, file)
-            #         tools.replace_in_file(full_file, "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>", strict=False)
-            #         tools.replace_in_file(full_file, "prebuild skylake\\avx x64 15", "prebuild skylake\\avx x64 16", strict=False)
-            #         tools.replace_in_file(full_file, "prebuild p3 Win32 15", "prebuild p3 Win32 16", strict=False)
-            #         tools.replace_in_file(full_file, "prebuild gc Win32 15", "prebuild gc Win32 16", strict=False)
-            #         tools.replace_in_file(full_file, "prebuild gc x64 15", "prebuild gc x64 16", strict=False)
-            #         tools.replace_in_file(full_file, "prebuild haswell\\avx x64 15", "prebuild haswell\\avx x64 16", strict=False)
-            #         tools.replace_in_file(full_file, "prebuild core2 x64 15", "prebuild core2 x64 16", strict=False)
-
-            #         tools.replace_in_file(full_file, 'postbuild "$(TargetPath)" 15', 'postbuild "$(TargetPath)" 16', strict=False)
-            #         tools.replace_in_file(full_file, 'check_config $(Platform) $(Configuration) 15', 'check_config $(Platform) $(Configuration) 16', strict=False)
-
-            #         self.output.info(f"full_file: {full_file}")
-
-
     def build(self):
         self._patch_sources()
-        if self._is_msvc:
+        if is_msvc(self):
             self._build_visual_studio()
         else:
-            with tools.chdir(self._source_subfolder), self._build_context():
+            with chdir(self, self._source_subfolder), self._build_context():
                 # relocatable shared lib on macOS
-                tools.replace_in_file("configure", "-install_name \\$rpath/", "-install_name @rpath/")
+                replace_in_file(self, "configure", "-install_name \\$rpath/", "-install_name @rpath/")
                 autotools = self._configure_autotools()
                 autotools.make()
 
     def package(self):
-        self.copy("COPYING*", dst="licenses", src=self._source_subfolder)
-        if self._is_msvc:
-            lib_folder = os.path.join(self._source_subfolder, self._dll_or_lib,
+        copy(self, "COPYING*", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        if is_msvc(self):
+            lib_folder = os.path.join(self.build_folder, self._source_subfolder, self._dll_or_lib,
                                     self._platforms.get(str(self.settings.arch)),
                                     str(self.settings.build_type))
-
-            self.copy("mpir.h", dst="include", src=lib_folder, keep_path=True)
+            include_folder = os.path.join(self.package_folder, "include")
+            copy(self, "mpir.h", dst=include_folder, src=lib_folder, keep_path=True)
             if self.options.enable_gmpcompat:
-                self.copy("gmp.h", dst="include", src=lib_folder, keep_path=True)
+                copy(self, "gmp.h", dst=include_folder, src=lib_folder, keep_path=True)
             if self.options.get_safe("enable_cxx"):
-                self.copy("mpirxx.h", dst="include", src=lib_folder, keep_path=True)
+                copy(self, "mpirxx.h", dst=include_folder, src=lib_folder, keep_path=True)
                 if self.options.enable_gmpcompat:
-                    self.copy("gmpxx.h", dst="include", src=lib_folder, keep_path=True)
-            self.copy(pattern="*.dll*", dst="bin", src=lib_folder, keep_path=False)
-            self.copy(pattern="*.lib", dst="lib", src=lib_folder, keep_path=False)
+                    copy(self, "gmpxx.h", dst=include_folder, src=lib_folder, keep_path=True)
+            copy(self, pattern="*.dll*", dst=os.path.join(self.package_folder, "bin"), src=lib_folder, keep_path=False)
+            copy(self, pattern="*.lib", dst=os.path.join(self.package_folder, "lib"), src=lib_folder, keep_path=False)
         else:
-            with tools.chdir(self._source_subfolder), self._build_context():
+            with chdir(self, self._source_subfolder), self._build_context():
                 autotools = self._configure_autotools()
                 autotools.install()
-            tools.rmdir(os.path.join(self.package_folder, "share"))
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+            rmdir(self, os.path.join(self.package_folder, "share"))
+            rm(self, "*.la", os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
         if self.options.get_safe("enable_cxx"):
             self.cpp_info.libs.append("mpirxx")
         self.cpp_info.libs.append("mpir")
-        if self.options.enable_gmpcompat and not self._is_msvc:
+        if self.options.enable_gmpcompat and not is_msvc(self):
             if self.options.get_safe("enable_cxx"):
                 self.cpp_info.libs.append("gmpxx")
             self.cpp_info.libs.append("gmp")

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -179,12 +179,17 @@ class MpirConan(ConanFile):
             #     for file in files:
             #         self.output.info(f"file: {os.path.join(root, file)}")
 
-
-
             for root, _, files in os.walk("build.vc16"):
                 for file in files:
                     tools.replace_in_file(os.path.join(root, file), "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>")
-
+                    tools.replace_in_file(os.path.join(root, file), 'prebuild gc Win32 15', 'prebuild gc Win32 16')
+                    tools.replace_in_file(os.path.join(root, file), 'prebuild core2 x64 15', 'prebuild core2 x64 16')
+                    tools.replace_in_file(os.path.join(root, file), 'postbuild "$(TargetPath)" 15', 'postbuild "$(TargetPath)" 16')
+                    tools.replace_in_file(os.path.join(root, file), 'prebuild gc x64 15', 'prebuild gc x64 16')
+                    tools.replace_in_file(os.path.join(root, file), 'prebuild haswell\avx x64 15', 'prebuild haswell\avx x64 16')
+                    tools.replace_in_file(os.path.join(root, file), 'prebuild p3 Win32 15', 'prebuild p3 Win32 16')
+                    tools.replace_in_file(os.path.join(root, file), 'prebuild skylake\avx x64 15', 'prebuild skylake\avx x64 16')
+                    tools.replace_in_file(os.path.join(root, file), 'check_config $(Platform) $(Configuration) 15', 'check_config $(Platform) $(Configuration) 16')
 
             # for root, _, files in os.walk(self.build_folder):
             #     if "Makefile" in files:
@@ -214,9 +219,6 @@ class MpirConan(ConanFile):
             lib_folder = os.path.join(self._source_subfolder, self._dll_or_lib,
                                     self._platforms.get(str(self.settings.arch)),
                                     str(self.settings.build_type))
-
-            self.output.info(f"***** package ***** MSVC")
-            self.output.info(f"lib_folder: {lib_folder}")
 
             self.copy("mpir.h", dst="include", src=lib_folder, keep_path=True)
             if self.options.enable_gmpcompat:

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -155,12 +155,12 @@ class MpirConan(ConanFile):
         if self._is_msvc:
             # self.copy("*", src="build.vc15", dst="build.vc16")
 
-            self.output.info(f"build.vc15 exists: {os.path.isfile("build.vc15")}")
-            self.output.info(f"source/build.vc15 exists: {os.path.isfile(os.path.join(self._source_subfolder, "build.vc15"))}")
+            self.output.info(f"build.vc15 exists: {os.path.isfile('build.vc15')}")
+            self.output.info(f"source/build.vc15 exists: {os.path.isfile(os.path.join(self._source_subfolder, 'build.vc15'))}")
 
             conan.tools.files.copy(self, pattern="*", src="build.vc15", dst="build.vc16")
-            self.output.info(f"build.vc16 exists: {os.path.isfile("build.vc16")}")
-            self.output.info(f"source/build.vc16 exists: {os.path.isfile(os.path.join(self._source_subfolder, "build.vc16"))}")
+            self.output.info(f"build.vc16 exists: {os.path.isfile('build.vc16')}")
+            self.output.info(f"source/build.vc16 exists: {os.path.isfile(os.path.join(self._source_subfolder, 'build.vc16'))}")
 
 
             self.output.info("build.vc15 *********************************")

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan.tools.microsoft import msvc_runtime_flag
-from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
+from conan.errors import ConanInvalidConfiguration
 import contextlib
 import os
 

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -73,7 +73,7 @@ class MpirConan(ConanFile):
                 self.build_requires("msys2/cci.latest")
 
     def source(self):
-        tools.files.get(keep_permissions=True, **self.conan_data["sources"][self.version],
+        tools.get(keep_permissions=True, **self.conan_data["sources"][self.version],
                   strip_root=True, destination=self._source_subfolder)
 
     @property

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -62,18 +62,18 @@ class MpirConan(ConanFile):
             self.provides.append("gmp")
 
     def validate(self):
-        if hasattr(self, "settings_build") and tools.cross_building(self, skip_x64_x86=True):
+        if hasattr(self, "settings_build") and tools.build.cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building doesn't work (yet)")
 
     def build_requirements(self):
         self.build_requires("yasm/1.3.0")
         if not self._is_msvc:
             self.build_requires("m4/1.4.19")
-            if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            if self._settings_build.os == "Windows" and not tools.build.get_env("CONAN_BASH_PATH"):
                 self.build_requires("msys2/cci.latest")
 
     def source(self):
-        tools.get(keep_permissions=True, **self.conan_data["sources"][self.version],
+        tools.files.get(keep_permissions=True, **self.conan_data["sources"][self.version],
                   strip_root=True, destination=self._source_subfolder)
 
     @property

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan.tools.microsoft import msvc_runtime_flag
-from conan import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
-from conan.errors import ConanInvalidConfiguration
+from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
+from conans.errors import ConanInvalidConfiguration
 import contextlib
 import os
 
@@ -62,14 +62,14 @@ class MpirConan(ConanFile):
             self.provides.append("gmp")
 
     def validate(self):
-        if hasattr(self, "settings_build") and tools.build.cross_building(self, skip_x64_x86=True):
+        if hasattr(self, "settings_build") and tools.cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building doesn't work (yet)")
 
     def build_requirements(self):
         self.build_requires("yasm/1.3.0")
         if not self._is_msvc:
             self.build_requires("m4/1.4.19")
-            if self._settings_build.os == "Windows" and not tools.build.get_env("CONAN_BASH_PATH"):
+            if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
                 self.build_requires("msys2/cci.latest")
 
     def source(self):

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -158,7 +158,9 @@ class MpirConan(ConanFile):
             self.output.info(f"build.vc15 exists: {os.path.isfile('build.vc15')}")
             self.output.info(f"source/build.vc15 exists: {os.path.isfile(os.path.join(self._source_subfolder, 'build.vc15'))}")
 
-            conan.tools.files.copy(self, pattern="*", src="build.vc15", dst="build.vc16")
+            # conan.tools.files.copy(self, pattern="*", src="build.vc15", dst="build.vc16")
+            conan.tools.files.copy(self, pattern="*", src=os.path.join(self._source_subfolder, 'build.vc15'), dst=os.path.join(self._source_subfolder, 'build.vc16'))
+
             self.output.info(f"build.vc16 exists: {os.path.isfile('build.vc16')}")
             self.output.info(f"source/build.vc16 exists: {os.path.isfile(os.path.join(self._source_subfolder, 'build.vc16'))}")
 

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -154,7 +154,33 @@ class MpirConan(ConanFile):
     def _patch_sources(self):
         if self._is_msvc:
             # self.copy("*", src="build.vc15", dst="build.vc16")
+
+            self.output.info(f"build.vc15 exists: {os.path.isfile("build.vc15")}")
+            self.output.info(f"source/build.vc15 exists: {os.path.isfile(os.path.join(self._source_subfolder, "build.vc15"))}")
+
             conan.tools.files.copy(self, pattern="*", src="build.vc15", dst="build.vc16")
+            self.output.info(f"build.vc16 exists: {os.path.isfile("build.vc16")}")
+            self.output.info(f"source/build.vc16 exists: {os.path.isfile(os.path.join(self._source_subfolder, "build.vc16"))}")
+
+
+            self.output.info("build.vc15 *********************************")
+            for root, _, files in os.walk("build.vc15"):
+                for file in files:
+                    self.output.info(f"file: {os.path.join(root, file)}")
+
+            self.output.info("source/build.vc15 *********************************")
+            for root, _, files in os.walk(os.path.join(self._source_subfolder, "build.vc15")):
+                for file in files:
+                    self.output.info(f"file: {os.path.join(root, file)}")
+
+
+            self.output.info("build.vc16 *********************************")
+            for root, _, files in os.walk("build.vc16"):
+                for file in files:
+                    self.output.info(f"file: {os.path.join(root, file)}")
+
+
+
             for root, _, files in os.walk("build.vc16"):
                 for file in files:
                     tools.replace_in_file(os.path.join(root, file), "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>")

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -1,11 +1,11 @@
 from conan.tools.microsoft import msvc_runtime_flag
 from conans import ConanFile, tools, AutoToolsBuildEnvironment, MSBuild
 from conans.errors import ConanInvalidConfiguration
+from conan.tools import files
 import contextlib
 import os
 
 required_conan_version = ">=1.33.0"
-
 
 class MpirConan(ConanFile):
     name = "mpir"
@@ -152,7 +152,8 @@ class MpirConan(ConanFile):
 
     def _patch_sources(self):
         if self._is_msvc:
-            self.copy("*", src="build.vc15", dst="build.vc16")
+            # self.copy("*", src="build.vc15", dst="build.vc16")
+            files.copy("*", src="build.vc15", dst="build.vc16")
             for root, _, files in os.walk("build.vc16"):
                 for file in files:
                     tools.replace_in_file(os.path.join(root, file), "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>")

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -153,33 +153,31 @@ class MpirConan(ConanFile):
 
     def _patch_sources(self):
         if self._is_msvc:
-            # self.copy("*", src="build.vc15", dst="build.vc16")
 
-            self.output.info(f"build.vc15 exists: {os.path.isfile('build.vc15')}")
-            self.output.info(f"source/build.vc15 exists: {os.path.isfile(os.path.join(self._source_subfolder, 'build.vc15'))}")
+            # self.output.info(f"build.vc15 exists: {os.path.isfile('build.vc15')}")
+            # self.output.info(f"source/build.vc15 exists: {os.path.isfile(os.path.join(self._source_subfolder, 'build.vc15'))}")
 
-            # conan.tools.files.copy(self, pattern="*", src="build.vc15", dst="build.vc16")
             conan.tools.files.copy(self, pattern="*", src=os.path.join(self._source_subfolder, 'build.vc15'), dst=os.path.join(self._source_subfolder, 'build.vc16'))
 
-            self.output.info(f"build.vc16 exists: {os.path.isfile('build.vc16')}")
-            self.output.info(f"source/build.vc16 exists: {os.path.isfile(os.path.join(self._source_subfolder, 'build.vc16'))}")
+            # self.output.info(f"build.vc16 exists: {os.path.isfile('build.vc16')}")
+            # self.output.info(f"source/build.vc16 exists: {os.path.isfile(os.path.join(self._source_subfolder, 'build.vc16'))}")
 
 
-            self.output.info("build.vc15 *********************************")
-            for root, _, files in os.walk("build.vc15"):
-                for file in files:
-                    self.output.info(f"file: {os.path.join(root, file)}")
+            # self.output.info("build.vc15 *********************************")
+            # for root, _, files in os.walk("build.vc15"):
+            #     for file in files:
+            #         self.output.info(f"file: {os.path.join(root, file)}")
 
-            self.output.info("source/build.vc15 *********************************")
-            for root, _, files in os.walk(os.path.join(self._source_subfolder, "build.vc15")):
-                for file in files:
-                    self.output.info(f"file: {os.path.join(root, file)}")
+            # self.output.info("source/build.vc15 *********************************")
+            # for root, _, files in os.walk(os.path.join(self._source_subfolder, "build.vc15")):
+            #     for file in files:
+            #         self.output.info(f"file: {os.path.join(root, file)}")
 
 
-            self.output.info("build.vc16 *********************************")
-            for root, _, files in os.walk("build.vc16"):
-                for file in files:
-                    self.output.info(f"file: {os.path.join(root, file)}")
+            # self.output.info("build.vc16 *********************************")
+            # for root, _, files in os.walk("build.vc16"):
+            #     for file in files:
+            #         self.output.info(f"file: {os.path.join(root, file)}")
 
 
 
@@ -216,6 +214,10 @@ class MpirConan(ConanFile):
             lib_folder = os.path.join(self._source_subfolder, self._dll_or_lib,
                                     self._platforms.get(str(self.settings.arch)),
                                     str(self.settings.build_type))
+
+            self.output.info(f"***** package ***** MSVC")
+            self.output.info(f"lib_folder: {lib_folder}")
+
             self.copy("mpir.h", dst="include", src=lib_folder, keep_path=True)
             if self.options.enable_gmpcompat:
                 self.copy("gmp.h", dst="include", src=lib_folder, keep_path=True)

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -183,7 +183,7 @@ class MpirConan(ConanFile):
                 autotools.make()
 
     def package(self):
-        copy(self, "COPYING*", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "COPYING*", dst=os.path.join(self.package_folder, "licenses"), src=os.path.join(self.source_folder, self._source_subfolder))
         if is_msvc(self):
             lib_folder = os.path.join(self.build_folder, self._source_subfolder, self._dll_or_lib,
                                     self._platforms.get(str(self.settings.arch)),

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -154,7 +154,7 @@ class MpirConan(ConanFile):
     def _patch_sources(self):
         if self._is_msvc:
             # self.copy("*", src="build.vc15", dst="build.vc16")
-            conan.tools.files.copy("*", src="build.vc15", dst="build.vc16")
+            conan.tools.files.copy(self, pattern="*", src="build.vc15", dst="build.vc16")
             for root, _, files in os.walk("build.vc16"):
                 for file in files:
                     tools.replace_in_file(os.path.join(root, file), "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>")

--- a/recipes/mpir/all/conanfile.py
+++ b/recipes/mpir/all/conanfile.py
@@ -111,6 +111,7 @@ class MpirConan(ConanFile):
                 "Debug" if "d" in msvc_runtime_flag(self) else "",
                 "DLL" if "MD" in msvc_runtime_flag(self) else "",
             )
+            self.output.info(f"--++--++--++--++--++--++--++--++--++--++ props_path: {props_path}")
             tools.replace_in_file(props_path, old_runtime, new_runtime)
         msbuild = MSBuild(self)
         for vcxproj_path in self._vcxproj_paths:
@@ -159,6 +160,8 @@ class MpirConan(ConanFile):
 
             conan.tools.files.copy(self, pattern="*", src=os.path.join(self._source_subfolder, 'build.vc15'), dst=os.path.join(self._source_subfolder, 'build.vc16'))
 
+            self.output.info(f"vc16: {os.path.join(self._source_subfolder, 'build.vc16')}")
+
             # self.output.info(f"build.vc16 exists: {os.path.isfile('build.vc16')}")
             # self.output.info(f"source/build.vc16 exists: {os.path.isfile(os.path.join(self._source_subfolder, 'build.vc16'))}")
 
@@ -179,25 +182,27 @@ class MpirConan(ConanFile):
             #     for file in files:
             #         self.output.info(f"file: {os.path.join(root, file)}")
 
-            for root, _, files in os.walk("build.vc16"):
+            vc16dir = os.path.join(self._source_subfolder, 'build.vc16')
+            self.output.info(f"vc16dir: {vc16dir}")
+            for root, _, files in os.walk(vc16dir):
                 for file in files:
                     full_file = os.path.join(root, file)
-                    tools.replace_in_file(full_file, "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>")
-                    tools.replace_in_file(full_file, "prebuild skylake\\avx x64 15", "prebuild skylake\\avx x64 16")
-                    tools.replace_in_file(full_file, "prebuild p3 Win32 15", "prebuild p3 Win32 16")
-                    tools.replace_in_file(full_file, "prebuild gc Win32 15", "prebuild gc Win32 16")
-                    tools.replace_in_file(full_file, "prebuild gc x64 15", "prebuild gc x64 16")
-                    tools.replace_in_file(full_file, "prebuild haswell\\avx x64 15", "prebuild haswell\\avx x64 16")
-                    tools.replace_in_file(full_file, "prebuild core2 x64 15", "prebuild core2 x64 16")
+                    tools.replace_in_file(full_file, "<PlatformToolset>v141</PlatformToolset>", "<PlatformToolset>v142</PlatformToolset>", strict=False)
+                    tools.replace_in_file(full_file, "prebuild skylake\\avx x64 15", "prebuild skylake\\avx x64 16", strict=False)
+                    tools.replace_in_file(full_file, "prebuild p3 Win32 15", "prebuild p3 Win32 16", strict=False)
+                    tools.replace_in_file(full_file, "prebuild gc Win32 15", "prebuild gc Win32 16", strict=False)
+                    tools.replace_in_file(full_file, "prebuild gc x64 15", "prebuild gc x64 16", strict=False)
+                    tools.replace_in_file(full_file, "prebuild haswell\\avx x64 15", "prebuild haswell\\avx x64 16", strict=False)
+                    tools.replace_in_file(full_file, "prebuild core2 x64 15", "prebuild core2 x64 16", strict=False)
 
-                    tools.replace_in_file(full_file, 'postbuild "$(TargetPath)" 15', 'postbuild "$(TargetPath)" 16')
-                    tools.replace_in_file(full_file, 'check_config $(Platform) $(Configuration) 15', 'check_config $(Platform) $(Configuration) 16')
+                    tools.replace_in_file(full_file, 'postbuild "$(TargetPath)" 15', 'postbuild "$(TargetPath)" 16', strict=False)
+                    tools.replace_in_file(full_file, 'check_config $(Platform) $(Configuration) 15', 'check_config $(Platform) $(Configuration) 16', strict=False)
 
                     self.output.info(f"full_file: {full_file}")
 
-                    with open(full_file, mode='r') as file:
-                        all_of_it = file.read()
-                        self.output.info(f"all_of_it: {all_of_it}")
+                    # with open(full_file, mode='r') as file:
+                    #     all_of_it = file.read()
+                    #     self.output.info(f"all_of_it: {all_of_it}")
 
             # for root, _, files in os.walk(self.build_folder):
             #     if "Makefile" in files:

--- a/recipes/mpir/all/test_package/CMakeLists.txt
+++ b/recipes/mpir/all/test_package/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(mpir CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} mpir::mpir)

--- a/recipes/mpir/all/test_package/conanfile.py
+++ b/recipes/mpir/all/test_package/conanfile.py
@@ -1,10 +1,11 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +13,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **MPIR/3.0.0**

MPIR recipe does not work if you have just Visual Studio 2022 or 2019 installed.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
