### PR TITLE
Fixes #12213.  Adds code to test package to test rdkafka++ library.

### DIFF
--- a/recipes/librdkafka/all/test_package/test_package.cpp
+++ b/recipes/librdkafka/all/test_package/test_package.cpp
@@ -1,11 +1,15 @@
 #include <iostream>
 #include <librdkafka/rdkafka.h>
+#include <librdkafka/rdkafkacpp.h>
 
 int main(int argc, char const *argv[]) {
   rd_kafka_conf_t *conf = rd_kafka_conf_new();
+  auto confpp = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
+
   std::cout << std::endl
             << "----------------->Tests are done.<---------------------" << std::endl
-	    << "Using version " << rd_kafka_version_str() << std::endl
+            << "Using version (from C lib) " << rd_kafka_version_str() << std::endl
+            << "Using version (from C++ lib) " << RdKafka::version() << std::endl
             << "///////////////////////////////////////////////////////" << std::endl;
   return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **librdkafka/1.9.2*

Fixes #12213.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
