### PR TITLE
make openssl depend on linux-headers

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -228,6 +228,8 @@ class OpenSSLConan(ConanFile):
     def requirements(self):
         if self._full_version < "1.1.0" and self.options.get_safe("no_zlib") == False:
             self.requires("zlib/1.2.12")
+        if self.settings.os == "Linux":
+            self.requires("linux-headers-generic/5.14.9")
 
     def validate(self):
         if self.settings.os == "Emscripten":
@@ -881,6 +883,9 @@ class OpenSSLConan(ConanFile):
 
         if self._full_version < "1.1.0" and not self.options.get_safe("no_zlib"):
             self.cpp_info.components["crypto"].requires = ["zlib::zlib"]
+
+        if self.settings.os == "Linux":
+            self.cpp_info.components["crypto"].requires = ["linux-headers-generic::linux-headers-generic"]
 
         if self.settings.os == "Windows":
             self.cpp_info.components["crypto"].system_libs.extend(["crypt32", "ws2_32", "advapi32", "user32", "bcrypt"])


### PR DESCRIPTION
Specify library name and version:  **openssl/1.1.1q**

implements https://github.com/conan-io/conan-center-index/issues/12216
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
