### PR TITLE
qt-advanced-docking-system: Make patch of qt-include dynamic on actual qt-version

### DIFF
--- a/recipes/qt-advanced-docking-system/all/CMakeLists.txt
+++ b/recipes/qt-advanced-docking-system/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory("source_subfolder")

--- a/recipes/qt-advanced-docking-system/all/conandata.yml
+++ b/recipes/qt-advanced-docking-system/all/conandata.yml
@@ -6,3 +6,5 @@ patches:
   "3.8.2":
     - patch_file: "patches/fix-cmake-license-install.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-cmake-find-package-qt6-compat.patch"
+      base_path: "source_subfolder"

--- a/recipes/qt-advanced-docking-system/all/conandata.yml
+++ b/recipes/qt-advanced-docking-system/all/conandata.yml
@@ -8,3 +8,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/fix-cmake-find-package-qt6-compat.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/fix-cmake-qt-requires-cpp17.patch"
+      base_path: "source_subfolder"

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -59,7 +59,6 @@ class QtADS(ConanFile):
         
         cmake = CMake(self)
         cmake.configure({
-            "CMAKE_FIND_DEBUG_MODE": "ON",
             "ADS_VERSION": self.version,
             "BUILD_EXAMPLES": "OFF",
             "BUILD_STATIC": not self.options.shared,
@@ -70,8 +69,8 @@ class QtADS(ConanFile):
         cmake = CMake(self)
         cmake.install()
         self.copy("LICENSE", dst="licenses", src="ads")
-        files.rmdir(os.path.join(self.package_folder, "license"))
-        files.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        files.rmdir(self, os.path.join(self.package_folder, "license"))
+        files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         if self.options.shared:

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -39,7 +39,9 @@ class QtADS(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        files.get(**self.conan_data["sources"][self.version], strip_root=True,
+        files.get(self,
+                  **self.conan_data["sources"][self.version], 
+                  strip_root=True,
                   destination="ads")
         
     def _patch_sources(self):

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -11,7 +11,7 @@ class QtADS(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System"
     topics = ("qt", "gui")
-    description = (
+    description = (source_subfolder
         "Qt Advanced Docking System lets you create customizable layouts "
         "using a full featured window docking system similar to what is found "
         "in many popular integrated development environments (IDEs) such as "
@@ -42,7 +42,7 @@ class QtADS(ConanFile):
         files.get(self,
                   **self.conan_data["sources"][self.version], 
                   strip_root=True,
-                  destination="ads")
+                  destination="source_subfolder")
         
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -51,7 +51,7 @@ class QtADS(ConanFile):
         qt = self.dependencies["qt"]
         files.replace_in_file(
             self,
-            f"{self.source_folder}/ads/src/ads_globals.cpp",
+            f"{self.source_folder}/source_subfolder/src/ads_globals.cpp",
             "#include <qpa/qplatformnativeinterface.h>",
             f"#include <{qt.ref.version}/QtGui/qpa/qplatformnativeinterface.h>"
         )
@@ -64,13 +64,13 @@ class QtADS(ConanFile):
             "ADS_VERSION": self.version,
             "BUILD_EXAMPLES": "OFF",
             "BUILD_STATIC": not self.options.shared,
-            }, build_script_folder="ads")
+            }, build_script_folder="source_subfolder")
         cmake.build()
 
     def package(self):
         cmake = CMake(self)
         cmake.install()
-        self.copy("LICENSE", dst="licenses", src="ads")
+        self.copy("LICENSE", dst="licenses", src="source_subfolder")
         files.rmdir(self, os.path.join(self.package_folder, "license"))
         files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -11,7 +11,7 @@ class QtADS(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System"
     topics = ("qt", "gui")
-    description = (source_subfolder
+    description = (
         "Qt Advanced Docking System lets you create customizable layouts "
         "using a full featured window docking system similar to what is found "
         "in many popular integrated development environments (IDEs) such as "

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -27,7 +27,6 @@ class QtADS(ConanFile):
     generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
 
     _cmake = None
-    _qt_version = "5.15.2"
 
     @property
     def _source_subfolder(self):
@@ -42,7 +41,7 @@ class QtADS(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires(f"qt/{self._qt_version}")
+        self.requires(f"qt/5.15.2")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True,
@@ -64,10 +63,11 @@ class QtADS(ConanFile):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
 
+        qt = self.dependencies["qt"]
         tools.replace_in_file(
             f"{self.source_folder}/{self._source_subfolder}/src/ads_globals.cpp",
             "#include <qpa/qplatformnativeinterface.h>",
-            f"#include <{self._qt_version}/QtGui/qpa/qplatformnativeinterface.h>"
+            f"#include <{qt.ref.version}/QtGui/qpa/qplatformnativeinterface.h>"
         )
 
     def build(self):

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -41,7 +41,7 @@ class QtADS(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires(f"qt/5.15.2")
+        self.requires("qt/5.15.2")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True,

--- a/recipes/qt-advanced-docking-system/all/patches/fix-cmake-find-package-qt6-compat.patch
+++ b/recipes/qt-advanced-docking-system/all/patches/fix-cmake-find-package-qt6-compat.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index f73a7df..555551f 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ cmake_minimum_required(VERSION 3.5)
+ project(QtAdvancedDockingSystem LANGUAGES CXX VERSION ${VERSION_SHORT})
+ find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+-find_package(Qt${QT_VERSION_MAJOR} 5.5 COMPONENTS Core Gui Widgets REQUIRED)
++find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Widgets REQUIRED)
+ if (UNIX AND NOT APPLE)
+     include_directories(${Qt${QT_VERSION_MAJOR}Gui_PRIVATE_INCLUDE_DIRS})
+ endif()

--- a/recipes/qt-advanced-docking-system/all/patches/fix-cmake-qt-requires-cpp17.patch
+++ b/recipes/qt-advanced-docking-system/all/patches/fix-cmake-qt-requires-cpp17.patch
@@ -1,0 +1,30 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index dea76a0..555551f 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -67,8 +67,6 @@ target_link_libraries(qtadvanceddocking PUBLIC Qt${QT_VERSION_MAJOR}::Core
+ set_target_properties(qtadvanceddocking PROPERTIES
+     AUTOMOC ON
+     AUTORCC ON
+-    CXX_STANDARD 14
+-    CXX_STANDARD_REQUIRED ON
+     CXX_EXTENSIONS OFF
+     VERSION ${VERSION_SHORT}
+     EXPORT_NAME "qtadvanceddocking"
+@@ -76,6 +74,16 @@ set_target_properties(qtadvanceddocking PROPERTIES
+     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/lib"
+     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${ads_PlatformDir}/bin"
+ )
++if(QT_VERSION_MAJOR STREQUAL "5")
++    set_target_properties(qtadvanceddocking PROPERTIES
++        CXX_STANDARD 14
++        CXX_STANDARD_REQUIRED ON)
++elseif(QT_VERSION_MAJOR STREQUAL "6")
++    set_target_properties(qtadvanceddocking PROPERTIES
++        CXX_STANDARD 17
++        CXX_STANDARD_REQUIRED ON)
++endif()
++
+ include(CMakePackageConfigHelpers)
+ write_basic_package_version_file(
+     "qtadvanceddockingConfigVersion.cmake"

--- a/recipes/qt-advanced-docking-system/all/test_package/CMakeLists.txt
+++ b/recipes/qt-advanced-docking-system/all/test_package/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 project(PackageTest CXX)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
Specify library name and version:  **qt-advanced-docking-system/3.8.2**

The patch of the qpa/qplatformnativeinterface.h include should be assembled dynamically based on the actually selected qt version not the one that is defined as a requirement of qt-advanced-docking-system. For example when building with qt6 building ADS fails due to the patch pointing statically to the qt 5.15.2 includes. This patch resolves to the proper included filename dynamically.

Note that for the build to succeed with qt6 another change to the package sources is actually required. This patch has already been merged upstream: https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/commit/6302ab03d8cdba72be369db46cbd728940e77157.

There is no issue about this issue yet and I hope we do not need one since the patch is very small.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
