### PR TITLE
xbyak: add version 6.61.2

### DIFF
--- a/recipes/xbyak/all/conandata.yml
+++ b/recipes/xbyak/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.61.2":
+    url: "https://github.com/herumi/xbyak/archive/v6.61.2.tar.gz"
+    sha256: "97b88064c9e7cd12bd235e7e600cb017481851d929ccdc95924e9d9e56a0bc3c"
   "6.60.2":
     url: "https://github.com/herumi/xbyak/archive/v6.60.2.tar.gz"
     sha256: "c7fd461cf8e0e1acec13970681f5e7b073a2e63f59841252fb298c3c3a09a395"

--- a/recipes/xbyak/config.yml
+++ b/recipes/xbyak/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.61.2":
+    folder: all
   "6.60.2":
     folder: all
   "6.60":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **xbyak/6.61.2**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
