### PR TITLE
[cairo] v2 support

### DIFF
--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -113,8 +113,7 @@ class CairoConan(ConanFile):
                   destination=self._source_subfolder, strip_root=True)
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            files.patch(self, **patch)
+        files.apply_conandata_patches(self)
         if microsoft.is_msvc(self):
             self._build_msvc()
         else:
@@ -237,8 +236,10 @@ class CairoConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "cairo-all-do-no-use")
+        self.cpp_info.names["pkg_config"] = "cairo-all-do-not-use"
 
         self.cpp_info.components["cairo_"].set_property("pkg_config_name", "cairo")
+        self.cpp_info.components["cairo_"].names["pkg_config"] = "cairo"
         self.cpp_info.components["cairo_"].libs = ["cairo"]
         self.cpp_info.components["cairo_"].includedirs.insert(0, os.path.join("include", "cairo"))
         self.cpp_info.components["cairo_"].requires = ["pixman::pixman", "libpng::libpng", "zlib::zlib"]
@@ -272,34 +273,42 @@ class CairoConan(ConanFile):
 
         if self.settings.os == "Windows":
             self.cpp_info.components["cairo-win32"].set_property("pkg_config_name", "cairo-win32")
+            self.cpp_info.components["cairo-win32"].names["pkg_config"] = "cairo-win32"
             self.cpp_info.components["cairo-win32"].requires = ["cairo_", "pixman::pixman", "libpng::libpng"]
 
         if self.options.get_safe("with_glib", True):
             self.cpp_info.components["cairo-gobject"].set_property("pkg_config_name", "cairo-gobject")
+            self.cpp_info.components["cairo-gobject"].names["pkg_config"] = "cairo-gobject"
             self.cpp_info.components["cairo-gobject"].libs = ["cairo-gobject"]
             self.cpp_info.components["cairo-gobject"].requires = ["cairo_", "glib::gobject-2.0", "glib::glib-2.0"]
         if self.settings.os != "Windows":
             if self.options.with_fontconfig:
                 self.cpp_info.components["cairo-fc"].set_property("pkg_config_name", "cairo-fc")
+                self.cpp_info.components["cairo-fc"].names["pkg_config"] = "cairo-fc"
                 self.cpp_info.components["cairo-fc"].requires = ["cairo_", "fontconfig::fontconfig"]
             if self.options.get_safe("with_freetype", True):
                 self.cpp_info.components["cairo-ft"].set_property("pkg_config_name", "cairo-ft")
+                self.cpp_info.components["cairo-ft"].names["pkg_config"] = "cairo-ft"
                 self.cpp_info.components["cairo-ft"].requires = ["cairo_", "freetype::freetype"]
 
             self.cpp_info.components["cairo-pdf"].set_property("pkg_config_name", "cairo-pdf")
+            self.cpp_info.components["cairo-pdf"].names["pkg_config"] = "cairo-pdf"
             self.cpp_info.components["cairo-pdf"].requires = ["cairo_", "zlib::zlib"]
 
         if self.settings.os == "Linux":
             if self.options.with_xlib:
                 self.cpp_info.components["cairo-xlib"].set_property("pkg_config_name", "cairo-xlib")
+                self.cpp_info.components["cairo-xlib"].names["pkg_config"] = "cairo-xlib"
                 self.cpp_info.components["cairo-xlib"].requires = ["cairo_", "xorg::x11", "xorg::xext"]
 
         if tools.is_apple_os(self.settings.os):
             self.cpp_info.components["cairo-quartz"].set_property("pkg_config_name", "cairo-quartz")
+            self.cpp_info.components["cairo-quartz"].names["pkg_config"] = "cairo-quartz"
             self.cpp_info.components["cairo-quartz"].requires = ["cairo_"]
             self.cpp_info.components["cairo-quartz"].frameworks.extend(["CoreFoundation", "CoreGraphics", "ApplicationServices"])
 
             self.cpp_info.components["cairo-quartz-font"].set_property("pkg_config_name", "cairo-quartz-font")
+            self.cpp_info.components["cairo-quartz-font"].names["pkg_config"] = "cairo-quartz-font"
             self.cpp_info.components["cairo-quartz-font"].requires = ["cairo_"]
 
     def package_id(self):

--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -75,9 +75,16 @@ class CairoConan(ConanFile):
             del self.options.fPIC
         del self.settings.compiler.cppstd
         del self.settings.compiler.libcxx
+
+    def validate(self):
         if microsoft.is_msvc(self):
             if self.settings.build_type not in ["Debug", "Release"]:
                 raise ConanInvalidConfiguration("MSVC build supports only Debug or Release build type")
+            if self.options.get_safe("with_glib") and self.options["glib"].shared \
+                    and microsoft.is_msvc_static_runtime(self):
+                raise ConanInvalidConfiguration(
+                    "Linking shared glib with the MSVC static runtime is not supported"
+                )
 
     def requirements(self):
         if self.options.get_safe("with_freetype", True):
@@ -294,7 +301,7 @@ class CairoConan(ConanFile):
 
             self.cpp_info.components["cairo-quartz-font"].set_property("pkg_config_name", "cairo-quartz-font")
             self.cpp_info.components["cairo-quartz-font"].requires = ["cairo_"]
-            
+
     def package_id(self):
         if self.options.get_safe("with_glib") and not self.options["glib"].shared:
             self.info.requires["glib"].full_package_mode()

--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -248,7 +248,7 @@ class CairoConan(ConanFile):
                 self.cpp_info.components["cairo_"].requires.append("fontconfig::fontconfig")
 
         if self.settings.os == "Linux":
-            self.cpp_info.components["cairo_"].system_libs = ["pthread"]
+            self.cpp_info.components["cairo_"].system_libs = ["pthread", "rt"]
             self.cpp_info.components["cairo_"].cflags = ["-pthread"]
             self.cpp_info.components["cairo_"].cxxflags = ["-pthread"]
             if self.options.with_xcb:
@@ -288,7 +288,7 @@ class CairoConan(ConanFile):
         if tools.is_apple_os(self.settings.os):
             self.cpp_info.components["cairo-quartz"].set_property("pkg_config_name", "cairo-quartz")
             self.cpp_info.components["cairo-quartz"].requires = ["cairo_"]
-            self.cpp_info.components["cairo-quartz"].frameworks.extend(["CoreFoundation", "CoreGraphics"])
+            self.cpp_info.components["cairo-quartz"].frameworks.extend(["CoreFoundation", "CoreGraphics", "ApplicationServices"])
 
             self.cpp_info.components["cairo-quartz-font"].set_property("pkg_config_name", "cairo-quartz-font")
             self.cpp_info.components["cairo-quartz-font"].requires = ["cairo_"]

--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -102,11 +102,11 @@ class CairoConan(ConanFile):
 
     def build_requirements(self):
         if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires("msys2/cci.latest")
+            self.tool_requires("msys2/cci.latest")
         if not microsoft.is_msvc(self):
-            self.build_requires("libtool/2.4.6")
-            self.build_requires("pkgconf/1.7.4")
-            self.build_requires("gtk-doc-stub/cci.20181216")
+            self.tool_requires("libtool/2.4.6")
+            self.tool_requires("pkgconf/1.7.4")
+            self.tool_requires("gtk-doc-stub/cci.20181216")
 
     def source(self):
         files.get(self, **self.conan_data["sources"][self.version],

--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -227,9 +227,13 @@ class CairoConan(ConanFile):
         files.rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
+        self.cpp_info.set_property("pkg_config_name", "cairo-all-do-no-use")
+
+        self.cpp_info.components["cairo_"].set_property("pkg_config_name", "cairo")
         self.cpp_info.components["cairo_"].libs = ["cairo"]
         self.cpp_info.components["cairo_"].includedirs.insert(0, os.path.join("include", "cairo"))
         self.cpp_info.components["cairo_"].requires = ["pixman::pixman", "libpng::libpng", "zlib::zlib"]
+
         if self.options.get_safe("with_freetype", True):
             self.cpp_info.components["cairo_"].requires.append("freetype::freetype")
 
@@ -242,6 +246,7 @@ class CairoConan(ConanFile):
                 self.cpp_info.components["cairo_"].requires.extend(["glib::gobject-2.0", "glib::glib-2.0"])
             if self.options.with_fontconfig:
                 self.cpp_info.components["cairo_"].requires.append("fontconfig::fontconfig")
+
         if self.settings.os == "Linux":
             self.cpp_info.components["cairo_"].system_libs = ["pthread"]
             self.cpp_info.components["cairo_"].cflags = ["-pthread"]
@@ -252,27 +257,38 @@ class CairoConan(ConanFile):
                 self.cpp_info.components["cairo_"].requires.extend(["xorg::xcb-render"])
             if self.options.with_xlib:
                 self.cpp_info.components["cairo_"].requires.extend(["xorg::x11", "xorg::xext"])
+
         if tools.is_apple_os(self.settings.os):
             self.cpp_info.components["cairo_"].frameworks.append("CoreGraphics")
 
         if self.settings.os == "Windows":
+            self.cpp_info.components["cairo-win32"].set_property("pkg_config_name", "cairo-win32")
             self.cpp_info.components["cairo-win32"].requires = ["cairo_", "pixman::pixman", "libpng::libpng"]
 
         if self.options.get_safe("with_glib", True):
+            self.cpp_info.components["cairo-gobject"].set_property("pkg_config_name", "cairo-gobject")
             self.cpp_info.components["cairo-gobject"].libs = ["cairo-gobject"]
             self.cpp_info.components["cairo-gobject"].requires = ["cairo_", "glib::gobject-2.0", "glib::glib-2.0"]
         if self.settings.os != "Windows":
             if self.options.with_fontconfig:
+                self.cpp_info.components["cairo-fc"].set_property("pkg_config_name", "cairo-fc")
                 self.cpp_info.components["cairo-fc"].requires = ["cairo_", "fontconfig::fontconfig"]
             if self.options.get_safe("with_freetype", True):
+                self.cpp_info.components["cairo-ft"].set_property("pkg_config_name", "cairo-ft")
                 self.cpp_info.components["cairo-ft"].requires = ["cairo_", "freetype::freetype"]
+
+            self.cpp_info.components["cairo-pdf"].set_property("pkg_config_name", "cairo-pdf")
             self.cpp_info.components["cairo-pdf"].requires = ["cairo_", "zlib::zlib"]
 
         if self.settings.os == "Linux":
             if self.options.with_xlib:
+                self.cpp_info.components["cairo-xlib"].set_property("pkg_config_name", "cairo-xlib")
                 self.cpp_info.components["cairo-xlib"].requires = ["cairo_", "xorg::x11", "xorg::xext"]
 
         if tools.is_apple_os(self.settings.os):
+            self.cpp_info.components["cairo-quartz"].set_property("pkg_config_name", "cairo-quartz")
             self.cpp_info.components["cairo-quartz"].requires = ["cairo_"]
             self.cpp_info.components["cairo-quartz"].frameworks.extend(["CoreFoundation", "CoreGraphics"])
+
+            self.cpp_info.components["cairo-quartz-font"].set_property("pkg_config_name", "cairo-quartz-font")
             self.cpp_info.components["cairo-quartz-font"].requires = ["cairo_"]

--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -294,3 +294,7 @@ class CairoConan(ConanFile):
 
             self.cpp_info.components["cairo-quartz-font"].set_property("pkg_config_name", "cairo-quartz-font")
             self.cpp_info.components["cairo-quartz-font"].requires = ["cairo_"]
+            
+    def package_id(self):
+        if self.options.get_safe("with_glib") and not self.options["glib"].shared:
+            self.info.requires["glib"].full_package_mode()

--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -2,10 +2,10 @@ import os
 import shutil
 
 from conan import ConanFile
-from conan.tools import files, microsoft
+from conan.errors import ConanInvalidConfiguration
+from conan.tools import files, microsoft, scm
 from conans import AutoToolsBuildEnvironment, VisualStudioBuildEnvironment
 from conans import tools
-from conans.errors import ConanInvalidConfiguration
 
 
 class CairoConan(ConanFile):
@@ -115,8 +115,8 @@ class CairoConan(ConanFile):
         with tools.chdir(self._source_subfolder):
             # https://cairographics.org/end_to_end_build_for_win32/
             win32_common = os.path.join("build", "Makefile.win32.common")
-            files.replace_in_file(self, win32_common, "-MD ", "-%s " % self.settings.compiler.runtime)
-            files.replace_in_file(self, win32_common, "-MDd ", "-%s " % self.settings.compiler.runtime)
+            files.replace_in_file(self, win32_common, "-MD ", f"-{self.settings.compiler.runtime} ")
+            files.replace_in_file(self, win32_common, "-MDd ", f"-{self.settings.compiler.runtime} ")
             files.replace_in_file(self, win32_common, "$(ZLIB_PATH)/lib/zlib1.lib",
                                                 self.deps_cpp_info["zlib"].libs[0] + ".lib")
             files.replace_in_file(self, win32_common, "$(LIBPNG_PATH)/lib/libpng16.lib",
@@ -197,7 +197,7 @@ class CairoConan(ConanFile):
             src = os.path.join(self._source_subfolder, "src")
             cairo_gobject = os.path.join(self._source_subfolder, "util", "cairo-gobject")
             inc = os.path.join("include", "cairo")
-            self.copy(pattern="cairo-version.h", dst=inc, src=(src if tools.Version(self.version) >= "1.17.4" else self._source_subfolder))
+            self.copy(pattern="cairo-version.h", dst=inc, src=(src if scm.Version(self.version) >= "1.17.4" else self._source_subfolder))
             self.copy(pattern="cairo-features.h", dst=inc, src=src)
             self.copy(pattern="cairo.h", dst=inc, src=src)
             self.copy(pattern="cairo-deprecated.h", dst=inc, src=src)

--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -224,9 +224,7 @@ class CairoConan(ConanFile):
         self.copy("COPYING*", src=self._source_subfolder, dst="licenses", keep_path=False)
         tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
 
-
     def package_info(self):
-        self.cpp_info.components["cairo_"].names["pkg_config"] = "cairo"
         self.cpp_info.components["cairo_"].libs = ["cairo"]
         self.cpp_info.components["cairo_"].includedirs.insert(0, os.path.join("include", "cairo"))
         self.cpp_info.components["cairo_"].requires = ["pixman::pixman", "libpng::libpng", "zlib::zlib"]
@@ -255,33 +253,24 @@ class CairoConan(ConanFile):
         if tools.is_apple_os(self.settings.os):
             self.cpp_info.components["cairo_"].frameworks.append("CoreGraphics")
 
-
         if self.settings.os == "Windows":
-            self.cpp_info.components["cairo-win32"].names["pkg_config"] = "cairo-win32"
             self.cpp_info.components["cairo-win32"].requires = ["cairo_", "pixman::pixman", "libpng::libpng"]
 
         if self.options.get_safe("with_glib", True):
-            self.cpp_info.components["cairo-gobject"].names["pkg_config"] = "cairo-gobject"
             self.cpp_info.components["cairo-gobject"].libs = ["cairo-gobject"]
             self.cpp_info.components["cairo-gobject"].requires = ["cairo_", "glib::gobject-2.0", "glib::glib-2.0"]
         if self.settings.os != "Windows":
             if self.options.with_fontconfig:
-                self.cpp_info.components["cairo-fc"].names["pkg_config"] = "cairo-fc"
                 self.cpp_info.components["cairo-fc"].requires = ["cairo_", "fontconfig::fontconfig"]
             if self.options.get_safe("with_freetype", True):
-                self.cpp_info.components["cairo-ft"].names["pkg_config"] = "cairo-ft"
                 self.cpp_info.components["cairo-ft"].requires = ["cairo_", "freetype::freetype"]
-            self.cpp_info.components["cairo-pdf"].names["pkg_config"] = "cairo-pdf"
             self.cpp_info.components["cairo-pdf"].requires = ["cairo_", "zlib::zlib"]
 
         if self.settings.os == "Linux":
             if self.options.with_xlib:
-                self.cpp_info.components["cairo-xlib"].names["pkg_config"] = "cairo-xlib"
                 self.cpp_info.components["cairo-xlib"].requires = ["cairo_", "xorg::x11", "xorg::xext"]
 
         if tools.is_apple_os(self.settings.os):
-            self.cpp_info.components["cairo-quartz"].names["pkg_config"] = "cairo-quartz"
             self.cpp_info.components["cairo-quartz"].requires = ["cairo_"]
             self.cpp_info.components["cairo-quartz"].frameworks.extend(["CoreFoundation", "CoreGraphics"])
-            self.cpp_info.components["cairo-quartz-font"].names["pkg_config"] = "cairo-quartz-font"
             self.cpp_info.components["cairo-quartz-font"].requires = ["cairo_"]

--- a/recipes/cairo/all/conanfile.py
+++ b/recipes/cairo/all/conanfile.py
@@ -7,6 +7,8 @@ from conan.tools import files, microsoft, scm
 from conans import AutoToolsBuildEnvironment, VisualStudioBuildEnvironment
 from conans import tools
 
+required_conan_version = ">=1.50.0"
+
 
 class CairoConan(ConanFile):
     name = "cairo"

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -228,7 +228,6 @@ class CairoConan(ConanFile):
         tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*.pdb")
 
     def package_info(self):
-        self.cpp_info.components["cairo_"].names["pkg_config"] = "cairo"
         self.cpp_info.components["cairo_"].libs = ["cairo"]
         self.cpp_info.components["cairo_"].includedirs.insert(0, os.path.join("include", "cairo"))
         if self.settings.os == "Linux":

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -248,6 +248,9 @@ class CairoConan(ConanFile):
 
         self.cpp_info.set_property("pkg_config_name", "cairo-all-do-no-use")
         self.cpp_info.names["pkg_config"] = "cairo-all-do-no-use"
+
+        self.cpp_info.components["cairo_"].set_property("pkg_config_name", "cairo")
+        self.cpp_info.components["cairo_"].names["pkg_config_name"] = "cairo"
         self.cpp_info.components["cairo_"].libs = ["cairo"]
         self.cpp_info.components["cairo_"].includedirs.insert(0, os.path.join("include", "cairo"))
 

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -7,7 +7,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools import files, microsoft
 from conans import tools, Meson, VisualStudioBuildEnvironment
 
-required_conan_version = ">=1.38.0"
+required_conan_version = ">=1.50.0"
 
 
 class CairoConan(ConanFile):

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -151,8 +151,7 @@ class CairoConan(ConanFile):
             yield
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        files.get(self, **self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
     def _configure_meson(self):
         def boolean(value):

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -121,8 +121,8 @@ class CairoConan(ConanFile):
             self.requires("egl/system")
 
     def build_requirements(self):
-        self.build_requires("meson/0.63.1")
-        self.build_requires("pkgconf/1.7.4")
+        self.tool_requires("meson/0.63.1")
+        self.tool_requires("pkgconf/1.7.4")
 
     def validate(self):
         if self.options.get_safe("with_xlib_xrender") and not self.options.get_safe("with_xlib"):

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -341,4 +341,5 @@ class CairoConan(ConanFile):
         self.cpp_info.components["cairo_"].system_libs += list(base_system_libs)
 
     def package_id(self):
-        self.info.requires["glib"].full_package_mode()
+        if self.options.get_safe("with_glib") and not self.options["glib"].shared:
+            self.info.requires["glib"].full_package_mode()

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -250,7 +250,7 @@ class CairoConan(ConanFile):
         self.cpp_info.names["pkg_config"] = "cairo-all-do-no-use"
 
         self.cpp_info.components["cairo_"].set_property("pkg_config_name", "cairo")
-        self.cpp_info.components["cairo_"].names["pkg_config_name"] = "cairo"
+        self.cpp_info.components["cairo_"].names["pkg_config"] = "cairo"
         self.cpp_info.components["cairo_"].libs = ["cairo"]
         self.cpp_info.components["cairo_"].includedirs.insert(0, os.path.join("include", "cairo"))
 

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -234,51 +234,67 @@ class CairoConan(ConanFile):
         base_system_libs = {}
 
         def add_component_and_base_requirements(component, requirements, system_libs=None):
+            self.cpp_info.components[component].set_property("pkg_config_name", component)
             self.cpp_info.components[component].requires += ["cairo_"] + requirements
             base_requirements.update(set(requirements))
             if system_libs is not None:
                 self.cpp_info.components[component].system_libs += system_libs
                 base_system_libs.update(set(system_libs))
 
+        self.cpp_info.set_property("pkg_config_name", "cairo-all-do-no-use")
         self.cpp_info.components["cairo_"].libs = ["cairo"]
         self.cpp_info.components["cairo_"].includedirs.insert(0, os.path.join("include", "cairo"))
+
         if self.settings.os == "Linux":
             self.cpp_info.components["cairo_"].system_libs.extend(["m", "dl", "pthread"])
             if self.options.get_safe("with_symbol_lookup"):
                 self.cpp_info.components["cairo_"].system_libs.append("bfd")
             self.cpp_info.components["cairo_"].cflags = ["-pthread"]
             self.cpp_info.components["cairo_"].cxxflags = ["-pthread"]
+
         if self.options.with_lzo:
             self.cpp_info.components["cairo_"].requires.append("lzo::lzo")
+
         if self.options.with_zlib:
             self.cpp_info.components["cairo_"].requires.append("zlib::zlib")
+
         if self.options.with_png:
             add_component_and_base_requirements("cairo-png", ["libpng::libpng"])
             add_component_and_base_requirements("cairo-svg", ["libpng::libpng"])
+
         if self.options.with_fontconfig:
             add_component_and_base_requirements("cairo-fc", ["fontconfig::fontconfig"])
+
         if self.options.with_freetype:
             add_component_and_base_requirements("cairo-ft", ["freetype::freetype"])
+
         if self.options.get_safe("with_xlib"):
             add_component_and_base_requirements("cairo-xlib", ["xorg::x11", "xorg::xext"])
+
         if self.options.get_safe("with_xlib_xrender"):
             add_component_and_base_requirements("cairo-xlib-xrender", ["xorg::xrender"])
+
         if self.options.get_safe("with_xcb"):
             add_component_and_base_requirements("cairo-xcb", ["xorg::xcb", "xorg::xcb-render"])
             add_component_and_base_requirements("cairo-xcb-shm", ["xorg::xcb", "xorg::xcb-shm"])
+
             if self.options.get_safe("with_xlib"):
                 add_component_and_base_requirements("cairo-xlib-xcb", ["xorg::x11-xcb"])
 
         if tools.is_apple_os(self.settings.os):
-            self.cpp_info.components["cairo_"].frameworks.append("CoreGraphics")
+            self.cpp_info.components["cairo-quartz"].set_property("pkg_config_name", "cairo-quartz")
             self.cpp_info.components["cairo-quartz"].requires = ["cairo_"]
             self.cpp_info.components["cairo-quartz-image"].requires = ["cairo_"]
             self.cpp_info.components["cairo-quartz-font"].requires = ["cairo_"]
+            self.cpp_info.components["cairo_"].frameworks.append("CoreGraphics")
 
         if self.settings.os == "Windows":
-            self.cpp_info.components["cairo_"].system_libs.extend(["gdi32", "msimg32", "user32"])
+            self.cpp_info.components["cairo-win32"].set_property("pkg_config_name", "cairo-win32")
             self.cpp_info.components["cairo-win32"].requires = ["cairo_"]
+            self.cpp_info.components["cairo-win32-font"].set_property("pkg_config_name", "cairo-win32-font")
             self.cpp_info.components["cairo-win32-font"].requires = ["cairo_"]
+            self.cpp_info.components["cairo_"].system_libs.extend(["gdi32", "msimg32", "user32"])
+
             if not self.options.shared:
                 self.cpp_info.components["cairo_"].defines.append("CAIRO_WIN32_STATIC_BUILD=1")
 
@@ -303,6 +319,7 @@ class CairoConan(ConanFile):
             add_component_and_base_requirements("cairo-script", ["zlib::zlib"])
             add_component_and_base_requirements("cairo-ps", ["zlib::zlib"])
             add_component_and_base_requirements("cairo-pdf", ["zlib::zlib"])
+            self.cpp_info.components["cairo-script-interpreter"].set_property("pkg_config_name", "cairo-script-interpreter")
             self.cpp_info.components["cairo-script-interpreter"].libs = ["cairo-script-interpreter"]
             self.cpp_info.components["cairo-script-interpreter"].requires = ["cairo_"]
 
@@ -311,10 +328,12 @@ class CairoConan(ConanFile):
                 add_component_and_base_requirements("cairo-util_", ["expat::expat"])
 
         if self.options.tee:
+            self.cpp_info.components["cairo-tee"].set_property("pkg_config_name", "cairo-tee")
             self.cpp_info.components["cairo-tee"].requires = ["cairo_"]
 
         # util directory
         if self.options.with_glib:
+            self.cpp_info.components["cairo-gobject"].set_property("pkg_config_name", "cairo-gobject")
             self.cpp_info.components["cairo-gobject"].libs = ["cairo-gobject"]
             self.cpp_info.components["cairo-gobject"].requires = ["cairo_", "glib::gobject-2.0", "glib::glib-2.0"]
 

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -3,9 +3,9 @@ import glob
 import os
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools import files, microsoft
 from conans import tools, Meson, VisualStudioBuildEnvironment
-from conans.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.38.0"
 

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -127,10 +127,16 @@ class CairoConan(ConanFile):
     def validate(self):
         if self.options.get_safe("with_xlib_xrender") and not self.options.get_safe("with_xlib"):
             raise ConanInvalidConfiguration("'with_xlib_xrender' option requires 'with_xlib' option to be enabled as well!")
-        if self.options.with_glib and not self.options["glib"].shared and self.options.shared:
-            raise ConanInvalidConfiguration(
-                "Linking a shared library against static glib can cause unexpected behaviour."
-            )
+        if self.options.with_glib:
+            if self.options["glib"].shared:
+                if microsoft.is_msvc_static_runtime(self):
+                    raise ConanInvalidConfiguration(
+                        "Linking shared glib with the MSVC static runtime is not supported"
+                    )
+            elif self.options.shared:
+                raise ConanInvalidConfiguration(
+                    "Linking a shared library against static glib can cause unexpected behaviour."
+                )
 
     @contextlib.contextmanager
     def _build_context(self):

--- a/recipes/cairo/meson/conanfile.py
+++ b/recipes/cairo/meson/conanfile.py
@@ -107,7 +107,7 @@ class CairoConan(ConanFile):
         if self.options.with_png:
             self.requires("libpng/1.6.37")
         if self.options.with_glib:
-            self.requires("glib/2.73.0")
+            self.requires("glib/2.73.3")
         if self.settings.os == "Linux":
             if self.options.with_xlib or self.options.with_xlib_xrender or self.options.with_xcb:
                 self.requires("xorg/system")
@@ -121,7 +121,7 @@ class CairoConan(ConanFile):
             self.requires("egl/system")
 
     def build_requirements(self):
-        self.build_requires("meson/0.62.1")
+        self.build_requires("meson/0.63.1")
         self.build_requires("pkgconf/1.7.4")
 
     def validate(self):


### PR DESCRIPTION
Specify library name and version:  **cairo/**

The cairo package sets the name of the base pkg-config component file to "cairo" which renames the default parent component (the one containing all the sub-components).

The result is that dependent packages using the pkg-config generator and linking to "cairo" only get the base cairo component and not additional components such as `cairo-gobject`. This can result linking errors in dependent packages (specifically in the MSVC build of gtkmm which expects `cairo` to also include `cairo-gobject`)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
