### PR TITLE
libcap/2.65 + conan v2 compatibility

### DIFF
--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -26,42 +26,26 @@ sources:
 
 patches:
   "2.45":
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
+    - patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
+    - patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
   "2.46":
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
+    - patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
+    - patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
   "2.48":
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
+    - patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
+    - patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
   "2.50":
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
+    - patch_file: "patches/2.45/0001-Make.Rules-Remove-hardcoded-fPIC.patch"
+    - patch_file: "patches/2.45/0002-Make.Rules-Make-compile-tools-configurable.patch"
   "2.57":
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
+    - patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
+    - patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
   "2.58":
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
+    - patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
+    - patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
   "2.62":
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
+    - patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
+    - patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
   "2.65":
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
+    - patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
+    - patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"

--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -20,6 +20,9 @@ sources:
   "2.62":
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.62.tar.xz"
     sha256: "190c5baac9bee06a129eae20d3e827de62f664fe3507f0bf6c50a9a59fbd83a2"
+  "2.65":
+    url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.65.tar.xz"
+    sha256: "73e350020cc31fe15360879d19384ffa3395a825f065fcf6bda3a5cdf965bebd"
 
 patches:
   "2.45":
@@ -53,6 +56,11 @@ patches:
     - base_path: "source_subfolder"
       patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
   "2.62":
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
+    - base_path: "source_subfolder"
+      patch_file: "patches/2.57/0002-Make.Rules-Make-compile-tools-configurable.patch"
+  "2.65":
     - base_path: "source_subfolder"
       patch_file: "patches/2.57/0001-libcap-Remove-hardcoded-fPIC.patch"
     - base_path: "source_subfolder"

--- a/recipes/libcap/all/conanfile.py
+++ b/recipes/libcap/all/conanfile.py
@@ -13,7 +13,7 @@ class LibcapConan(ConanFile):
     homepage = "https://git.kernel.org/pub/scm/libs/libcap/libcap.git"
     description = "This is a library for getting and setting POSIX.1e" \
                   " (formerly POSIX 6) draft 15 capabilities"
-    topics = ("conan", "libcap", "capabilities")
+    topics = ("libcap", "capabilities")
     settings = "os", "compiler", "build_type", "arch"
     options = {
         "shared": [True, False],

--- a/recipes/libcap/all/conanfile.py
+++ b/recipes/libcap/all/conanfile.py
@@ -60,7 +60,7 @@ class LibcapConan(ConanFile):
         self._autotools_env["prefix"] = "/"
         self._autotools_env["lib"] = "lib"
 
-        if tools.cross_building(self.settings) and not tools.get_env("BUILD_CC"):
+        if tools.cross_building(self) and not tools.get_env("BUILD_CC"):
             native_cc = tools.which("cc")
             self.output.info("Using native compiler '{}'".format(native_cc))
             self._autotools_env["BUILD_CC"] = native_cc

--- a/recipes/libcap/all/conanfile.py
+++ b/recipes/libcap/all/conanfile.py
@@ -1,9 +1,13 @@
 import os
 
-from conans import ConanFile, tools, AutoToolsBuildEnvironment
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import cross_building
+from conan.tools.files import apply_conandata_patches, copy, chdir, get, rmdir
+from conan.tools.layout import basic_layout
+from conan.tools.gnu import Autotools, AutotoolsToolchain
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.47.0"
 
 
 class LibcapConan(ConanFile):
@@ -27,81 +31,79 @@ class LibcapConan(ConanFile):
     }
     exports_sources = "patches/**"
 
-    _autotools = None
-    _autotools_env = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def configure(self):
-        if self.settings.os != "Linux":
-            raise ConanInvalidConfiguration("Only Linux supported")
         if self.options.shared:
             del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
+
+    def validate(self):
+        if self.info.settings.os != "Linux":
+            raise ConanInvalidConfiguration("Only Linux supported")
+
+    def layout(self):
+        basic_layout(self, src_folder="source")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_autotools(self):
-        if self._autotools:
-            return self._autotools, self._autotools_env
-        self._autotools = AutoToolsBuildEnvironment(self)
-        self._autotools.fpic = self.options.get_safe("fPIC", True)
-        self._autotools_env = self._autotools.vars
-        self._autotools_env["SHARED"] = \
-            "yes" if self.options.shared else "no"
-        self._autotools_env["PTHREADS"] = \
-            "yes" if self.options.psx_syscals else "no"
-        self._autotools_env["DESTDIR"] = self.package_folder
-        self._autotools_env["prefix"] = "/"
-        self._autotools_env["lib"] = "lib"
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        tc.fpic = self.options.get_safe("fPIC", True)
+        env = tc.environment()
+        env.define("SHARED", "yes" if self.options.shared else "no")
+        env.define("PTHREADS", "yes" if self.options.psx_syscals else "no")
+        env.define("DESTDIR", self.package_folder)
+        env.define("prefix", "/")
+        env.define("lib", "lib")
 
-        if tools.cross_building(self) and not tools.get_env("BUILD_CC"):
-            native_cc = tools.which("cc")
+        if cross_building(self) and not env.vars(self).get("BUILD_CC"):
+            native_cc = "cc"
             self.output.info("Using native compiler '{}'".format(native_cc))
-            self._autotools_env["BUILD_CC"] = native_cc
+            env.define("BUILD_CC", native_cc)
 
-        return self._autotools, self._autotools_env
-
-    def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+        tc.generate(env)
 
     def build(self):
-        self._patch_sources()
+        apply_conandata_patches(self)
 
-        with tools.chdir(os.path.join(self._source_subfolder, self.name)):
-            env_build, env_build_vars = self._configure_autotools()
-            env_build.make(vars=env_build_vars)
+        autotools = Autotools(self)
+        with chdir(self, os.path.join(self.source_folder, self.name)):
+            autotools.make()
 
     def package(self):
-        self.copy("License", dst="licenses", src=self._source_subfolder)
+        copy(self, "License", self.source_folder,
+             os.path.join(self.package_folder, "licenses"), keep_path=False)
 
-        with tools.chdir(os.path.join(self._source_subfolder, self.name)):
-            env_build, env_build_vars = self._configure_autotools()
-
-            env_build.make(target="install-common-cap", vars=env_build_vars)
+        autotools = Autotools(self)
+        with chdir(self, os.path.join(self.source_folder, self.name)):
+            autotools.make(target="install-common-cap")
             install_cap = ("install-shared-cap" if self.options.shared
                            else "install-static-cap")
-            env_build.make(target=install_cap, vars=env_build_vars)
+            autotools.make(target=install_cap)
 
             if self.options.psx_syscals:
-                env_build.make(target="install-common-psx",
-                               vars=env_build_vars)
+                autotools.make(target="install-common-psx")
                 install_psx = ("install-shared-psx" if self.options.shared
                                else "install-static-psx")
-                env_build.make(target=install_psx, vars=env_build_vars)
+                autotools.make(target=install_psx)
 
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
+        self.cpp_info.components["cap"].set_property("pkg_config_name",
+                                                     "libcap")
         self.cpp_info.components["cap"].names["pkg_config"] = "libcap"
         self.cpp_info.components["cap"].libs = ["cap"]
         if self.options.psx_syscals:
+            self.cpp_info.components["psx"].set_property("pkg_config_name",
+                                                         "libpsx")
             self.cpp_info.components["psx"].names["pkg_config"] = "libpsx"
             self.cpp_info.components["psx"].libs = ["psx"]
             self.cpp_info.components["psx"].system_libs = ["pthread"]

--- a/recipes/libcap/all/test_package/CMakeLists.txt
+++ b/recipes/libcap/all/test_package/CMakeLists.txt
@@ -4,5 +4,8 @@ project(PackageTest C)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(CAP REQUIRED IMPORTED_TARGET libcap)
+
 add_executable(example example.c)
-target_link_libraries(example ${CONAN_LIBS})
+target_link_libraries(example PRIVATE PkgConfig::CAP)

--- a/recipes/libcap/all/test_package/CMakeLists.txt
+++ b/recipes/libcap/all/test_package/CMakeLists.txt
@@ -1,8 +1,5 @@
-cmake_minimum_required(VERSION 3.1)
-project(PackageTest C)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest LANGUAGES C)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(CAP REQUIRED IMPORTED_TARGET libcap)

--- a/recipes/libcap/all/test_package/conanfile.py
+++ b/recipes/libcap/all/test_package/conanfile.py
@@ -13,6 +13,6 @@ class LibcapTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "example")
             self.run(bin_path, run_environment=True)

--- a/recipes/libcap/all/test_package/conanfile.py
+++ b/recipes/libcap/all/test_package/conanfile.py
@@ -1,11 +1,33 @@
 import os
 
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake
+from conan.tools.env import Environment
+from conan.tools.cmake import cmake_layout
+
+required_conan_version = ">=1.38.0"
 
 
 class LibcapTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "pkg_config"
+    generators = "CMakeToolchain", "PkgConfigDeps", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("pkgconf/1.7.4")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        env = Environment()
+        env.prepend_path("PKG_CONFIG_PATH", self.generators_folder)
+        envvars = env.vars(self)
+        envvars.save_script("pkg_config")
 
     def build(self):
         cmake = CMake(self)
@@ -13,6 +35,6 @@ class LibcapTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "example")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "example")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libcap/all/test_package/conanfile.py
+++ b/recipes/libcap/all/test_package/conanfile.py
@@ -5,7 +5,7 @@ from conans import ConanFile, CMake, tools
 
 class LibcapTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "pkg_config"
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/libcap/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libcap/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+project(PackageTest C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(CAP REQUIRED IMPORTED_TARGET libcap)
+
+add_executable(example ../test_package/example.c)
+target_link_libraries(example PRIVATE PkgConfig::CAP)

--- a/recipes/libcap/all/test_v1_package/conanfile.py
+++ b/recipes/libcap/all/test_v1_package/conanfile.py
@@ -1,0 +1,23 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import cross_building
+from conans import CMake
+
+
+class LibcapTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "pkg_config"
+
+    def build_requirements(self):
+        self.tool_requires("pkgconf/1.7.4")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libcap/config.yml
+++ b/recipes/libcap/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "2.62":
     folder: all
+  "2.65":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libcap/2.65**

libcap was updated to the latest release. And a few warnings from conan-center hooks were fixed.
Also, as I see it, there is ongoing refactoring in the repo. A lot of packages were rewritten to be compatible with conan v2. So I did a little refactoring of the recipe too (have a few concerns though).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
