### PR TITLE
Glibmm msvc defs

### DIFF
--- a/recipes/glibmm/all/conanfile.py
+++ b/recipes/glibmm/all/conanfile.py
@@ -22,6 +22,7 @@ class GlibmmConan(ConanFile):
 
     generators = "pkg_config"
     exports_sources = "patches/**"
+    short_paths = True
 
     def _abi_version(self):
         return "2.68" if scm.Version(self.version) >= "2.68.0" else "2.4"

--- a/recipes/glibmm/all/conanfile.py
+++ b/recipes/glibmm/all/conanfile.py
@@ -8,6 +8,8 @@ from conan.tools import files, microsoft, scm, build
 from conans import Meson, tools
 from conans.errors import ConanInvalidConfiguration
 
+required_conan_version = ">=1.49.0"
+
 
 class GlibmmConan(ConanFile):
     name = "glibmm"

--- a/recipes/glibmm/all/conanfile.py
+++ b/recipes/glibmm/all/conanfile.py
@@ -42,26 +42,25 @@ class GlibmmConan(ConanFile):
 
         version = str(self.settings.compiler.version)
         toolset_map = {
+            "14": "v140",
             "15": "v141",
             "16": "v142",
             "17": "v143"
         }
-        if version in toolset_map:
-            return toolset_map.get(version)
-
-        raise ConanInvalidConfiguration("Cannot get MSVC compiler toolset information")
+        return toolset_map.get(version)
 
     @property
     def _abi_msvc_toolset_suffix(self):
-        if scm.Version(self.version) < "2.68.0":
+        if scm.Version(self.version) < "2.68.0" or self.options.shared:
             return self._abi_version
 
         toolset = self._get_msvc_toolset()
+        if toolset is None:
+            return self._abi_version
+
         match = re.match("v([0-9]+)", str(toolset))
         if match is not None:
             return f"vc{match.group(1)}-{self._abi_version}"
-
-        raise ConanInvalidConfiguration("Cannot get MSVC compiler toolset information")
 
     def validate(self):
         if hasattr(self, "settings_build") and build.cross_building(self):

--- a/recipes/glibmm/all/conanfile.py
+++ b/recipes/glibmm/all/conanfile.py
@@ -90,7 +90,7 @@ class GlibmmConan(ConanFile):
         self.build_requires("pkgconf/1.7.4")
 
     def requirements(self):
-        self.requires("glib/2.73.0")
+        self.requires("glib/2.73.3")
 
         if self._abi_version() == "2.68":
             self.requires("libsigcpp/3.0.7")

--- a/recipes/glibmm/all/conanfile.py
+++ b/recipes/glibmm/all/conanfile.py
@@ -198,7 +198,7 @@ class GlibmmConan(ConanFile):
             os.path.join("include", glibmm_component)
         ]
         self.cpp_info.components[glibmm_component].requires = [
-            "glib::gobject-2.0", "libsigcpp::sigc++"
+            "glib::gobject-2.0", "libsigcpp::libsigcpp"
         ]
 
         giomm_component = f"giomm-{self._abi_version()}"

--- a/recipes/glibmm/all/conanfile.py
+++ b/recipes/glibmm/all/conanfile.py
@@ -6,7 +6,7 @@ import shutil
 from conan import ConanFile
 from conan.tools import files, microsoft, scm, build
 from conans import Meson, tools
-from conans.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.49.0"
 


### PR DESCRIPTION
Specify library name and version:  **glibmm**

Add the `glibmm_generate_extra_defs` component so that it can be found and linked to by dependent packages, and rename accordingly with the appropriate MSVC toolset suffix.

Some refactoring to simplify the `package_info` method

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
