### PR TITLE
linter v2 - Request migration of `conans.errors` to `conan.errors`

### DIFF
--- a/docs/v2_linter.md
+++ b/docs/v2_linter.md
@@ -43,6 +43,8 @@ Here is a list of different imports and their new equivalent (note that the inte
 | conans.tools.get | [conan.tools.files.get](https://docs.conan.io/en/latest/reference/conanfile/tools/files/downloads.html#conan-tools-files-get) |
 | conans.tools.cross_building | [conan.tools.build.cross_building](https://docs.conan.io/en/latest/reference/conanfile/tools/build.html#conan-tools-build-cross-building) |
 | conans.tools.rmdir | [conan.tools.files.rmdir](https://docs.conan.io/en/latest/reference/conanfile/tools/files/basic.html#conan-tools-files-rmdir) |
+| conans.errors.ConanInvalidConfiguration | [conan.errors.ConanInvalidConfiguration](https://docs.conan.io/en/latest/migrating_to_2.0/recipes.html#migrating-the-recipes) |
+| conans.errors.ConanException | [conan.errors.ConanException](https://docs.conan.io/en/latest/migrating_to_2.0/recipes.html#migrating-the-recipes) |
 
 
 # Disable linter for `test_v1_*/conanfile.py`

--- a/linter/transform_imports.py
+++ b/linter/transform_imports.py
@@ -25,7 +25,17 @@ def transform_tools(module):
     #if 'Version' in module.locals:
     #    del module.locals['Version']
 
+def transform_errors(module):
+    if 'ConanInvalidConfiguration' in module.locals:
+        del module.locals['ConanInvalidConfiguration']
+    if 'ConanException' in module.locals:
+        del module.locals['ConanInvalidConfiguration']
+
 
 astroid.MANAGER.register_transform(
     astroid.Module, transform_tools,
     lambda node: node.qname() == "conans.tools")
+
+astroid.MANAGER.register_transform(
+    astroid.Module, transform_errors,
+    lambda node: node.qname() == "conans.errors")

--- a/linter/transform_imports.py
+++ b/linter/transform_imports.py
@@ -29,7 +29,7 @@ def transform_errors(module):
     if 'ConanInvalidConfiguration' in module.locals:
         del module.locals['ConanInvalidConfiguration']
     if 'ConanException' in module.locals:
-        del module.locals['ConanInvalidConfiguration']
+        del module.locals['ConanException']
 
 
 astroid.MANAGER.register_transform(

--- a/recipes/7zip/19.00/conanfile.py
+++ b/recipes/7zip/19.00/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.33.0"
 class SevenZipConan(ConanFile):
     name = "7zip"
     url = "https://github.com/conan-io/conan-center-index"
-    description = "7-Zip is a file archiver with a high compression ratio"
+    description = "7-Zip is a file archiver with a high compression ratio -- test"
     license = ("LGPL-2.1", "BSD-3-Clause", "Unrar")
     homepage = "https://www.7-zip.org"
     topics = ("7zip", "zip", "compression", "decompression")

--- a/recipes/7zip/19.00/conanfile.py
+++ b/recipes/7zip/19.00/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.33.0"
 class SevenZipConan(ConanFile):
     name = "7zip"
     url = "https://github.com/conan-io/conan-center-index"
-    description = "7-Zip is a file archiver with a high compression ratio -- test"
+    description = "7-Zip is a file archiver with a high compression ratio"
     license = ("LGPL-2.1", "BSD-3-Clause", "Unrar")
     homepage = "https://www.7-zip.org"
     topics = ("7zip", "zip", "compression", "decompression")


### PR DESCRIPTION
Exceptions should be imported from new module `conan.errors`
