### PR TITLE
libwebp: add version 1.2.4

### DIFF
--- a/recipes/libwebp/all/conandata.yml
+++ b/recipes/libwebp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.4":
+    url: "https://github.com/webmproject/libwebp/archive/v1.2.4.tar.gz"
+    sha256: "dfe7bff3390cd4958da11e760b65318f0a48c32913e4d5bc5e8d55abaaa2d32e"
   "1.2.3":
     url: "https://github.com/webmproject/libwebp/archive/v1.2.3.tar.gz"
     sha256: "021169407825d7ad918ff4554c6af885e7cf116d9b641cfd7f04c1173ffb9eb0"
@@ -18,6 +21,8 @@ sources:
     url: "https://github.com/webmproject/libwebp/archive/v1.0.3.tar.gz"
     sha256: "082d114bcb18a0e2aafc3148d43367c39304f86bf18ba0b2e766447e111a4a91"
 patches:
+  "1.2.4":
+    - patch_file: "patches/0001-fix-dll-export.patch"
   "1.2.3":
     - patch_file: "patches/0001-fix-dll-export.patch"
   "1.2.2":

--- a/recipes/libwebp/config.yml
+++ b/recipes/libwebp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.4":
+    folder: all
   "1.2.3":
     folder: all
   "1.2.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libwebp/1.2.4**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
