### PR TITLE
libjpeg-turbo: add version 2.1.4

### DIFF
--- a/recipes/libjpeg-turbo/all/conandata.yml
+++ b/recipes/libjpeg-turbo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.4":
+    url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.1.4.tar.gz"
+    sha256: "a78b05c0d8427a90eb5b4eb08af25309770c8379592bb0b8a863373128e6143f"
   "2.1.3":
     url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.1.3.tar.gz"
     sha256: "dbda0c685942aa3ea908496592491e5ec8160d2cf1ec9d5fd5470e50768e7859"
@@ -19,6 +22,9 @@ sources:
     sha256: "b3090cd37b5a8b3e4dbd30a1311b3989a894e5d3c668f14cbc6739d77c9402b7"
 
 patches:
+  "2.1.4":
+    - patch_file: "patches/2.1.3-0001-fix-cmake.patch"
+      base_path: "source_subfolder"
   "2.1.3":
     - patch_file: "patches/2.1.3-0001-fix-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/libjpeg-turbo/config.yml
+++ b/recipes/libjpeg-turbo/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.4":
+    folder: all
   "2.1.3":
     folder: all
   "2.1.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libjpeg-turbo/2.1.4**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
