### PR TITLE
clipper: update checksum for v4.10.0 

### DIFF
--- a/recipes/clipper/all/conandata.yml
+++ b/recipes/clipper/all/conandata.yml
@@ -3,8 +3,8 @@ sources:
     url: "https://sourceforge.net/projects/polyclipping/files/clipper_ver6.4.2.zip"
     sha256: "a14320d82194807c4480ce59c98aa71cd4175a5156645c4e2b3edd330b930627"
   "5.1.6":
-    url: "https://sourceforge.net/projects/polyclipping/files/Older%20versions/clipper_ver5.1.6.zip"
-    sha256: "3655a090f55c16815eaebb4c3f863ff6c028d4b9c22111f81d4eac86bdb2f867"
+    url: "https://github.com/marcusl/clipper-archive/raw/main/clipper_ver5.1.6.zip"
+    sha256: "9aed086401e0a6ff78481e20da199d467b32ed1728aba1b74c5735e5ce84723f"
   "4.10.0":
     url: "https://github.com/marcusl/clipper-archive/raw/main/clipper_ver4.10.0.zip"
     sha256: "85f5a7d281e45cd1d9baa2d6154a64fcbc557340cab6b091ed9a07aab369e752"

--- a/recipes/clipper/all/conandata.yml
+++ b/recipes/clipper/all/conandata.yml
@@ -6,7 +6,7 @@ sources:
     url: "https://sourceforge.net/projects/polyclipping/files/Older%20versions/clipper_ver5.1.6.zip"
     sha256: "3655a090f55c16815eaebb4c3f863ff6c028d4b9c22111f81d4eac86bdb2f867"
   "4.10.0":
-    url: "https://github.com/marcusl/clipper-archive/raw/main/clipper_ver4.10.0.zip"
+    url: "https://sourceforge.net/projects/polyclipping/files/Older%20versions/clipper_ver4.10.0.zip"
     sha256: "4530e01006d02507a41f7eeaefa758c8067a94a7a0d6e0381fadfa40bc0cf248"
 patches:
   "6.4.2":

--- a/recipes/clipper/all/conandata.yml
+++ b/recipes/clipper/all/conandata.yml
@@ -6,8 +6,8 @@ sources:
     url: "https://sourceforge.net/projects/polyclipping/files/Older%20versions/clipper_ver5.1.6.zip"
     sha256: "3655a090f55c16815eaebb4c3f863ff6c028d4b9c22111f81d4eac86bdb2f867"
   "4.10.0":
-    url: "https://sourceforge.net/projects/polyclipping/files/Older%20versions/clipper_ver4.10.0.zip"
-    sha256: "b71269a1e38ffd58b07e0dddf60c6794978cd3d9055c5d70c6c2cc1c7a841848"
+    url: "https://github.com/marcusl/clipper-archive/raw/main/clipper_ver4.10.0.zip"
+    sha256: "85f5a7d281e45cd1d9baa2d6154a64fcbc557340cab6b091ed9a07aab369e752"
 patches:
   "6.4.2":
     - patch_file: "patches/0001-include-install-directory-6.x.patch"

--- a/recipes/clipper/all/conandata.yml
+++ b/recipes/clipper/all/conandata.yml
@@ -4,10 +4,10 @@ sources:
     sha256: "a14320d82194807c4480ce59c98aa71cd4175a5156645c4e2b3edd330b930627"
   "5.1.6":
     url: "https://github.com/marcusl/clipper-archive/raw/main/clipper_ver5.1.6.zip"
-    sha256: "9aed086401e0a6ff78481e20da199d467b32ed1728aba1b74c5735e5ce84723f"
+    sha256: "929f31e9ac18f3e4f8ad230b879ae997877621056bb95915a713cfc64aa7bf55"
   "4.10.0":
     url: "https://github.com/marcusl/clipper-archive/raw/main/clipper_ver4.10.0.zip"
-    sha256: "85f5a7d281e45cd1d9baa2d6154a64fcbc557340cab6b091ed9a07aab369e752"
+    sha256: "4530e01006d02507a41f7eeaefa758c8067a94a7a0d6e0381fadfa40bc0cf248"
 patches:
   "6.4.2":
     - patch_file: "patches/0001-include-install-directory-6.x.patch"

--- a/recipes/clipper/all/conandata.yml
+++ b/recipes/clipper/all/conandata.yml
@@ -3,8 +3,8 @@ sources:
     url: "https://sourceforge.net/projects/polyclipping/files/clipper_ver6.4.2.zip"
     sha256: "a14320d82194807c4480ce59c98aa71cd4175a5156645c4e2b3edd330b930627"
   "5.1.6":
-    url: "https://github.com/marcusl/clipper-archive/raw/main/clipper_ver5.1.6.zip"
-    sha256: "929f31e9ac18f3e4f8ad230b879ae997877621056bb95915a713cfc64aa7bf55"
+    url: "https://sourceforge.net/projects/polyclipping/files/Older%20versions/clipper_ver5.1.6.zip"
+    sha256: "3655a090f55c16815eaebb4c3f863ff6c028d4b9c22111f81d4eac86bdb2f867"
   "4.10.0":
     url: "https://github.com/marcusl/clipper-archive/raw/main/clipper_ver4.10.0.zip"
     sha256: "4530e01006d02507a41f7eeaefa758c8067a94a7a0d6e0381fadfa40bc0cf248"


### PR DESCRIPTION
Older source versions are removed from Sourceforge's archive, so previous link was no longer valid, see #12064

I've recreated the archive, the original author restored it to the original location so we just need to update the checksum now.

 **clipper/4.10.0**

fixes #12064


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
