### PR TITLE
Fix openssl old version access to shared option of zlib

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -1,5 +1,6 @@
-from conan.tools.files import rename
+from conan.tools.files import rename, get, rmdir
 from conan.tools.microsoft import is_msvc, msvc_runtime_flag
+from conan.tools.build import cross_building
 from conans.errors import ConanInvalidConfiguration
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
 from contextlib import contextmanager
@@ -171,7 +172,7 @@ class OpenSSLConan(ConanFile):
     def _win_bash(self):
         return self._settings_build.os == "Windows" and \
                not self._use_nmake and \
-               (self._is_mingw or tools.cross_building(self, skip_x64_x86=True))
+               (self._is_mingw or cross_building(self, skip_x64_x86=True))
 
     def export_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
@@ -244,8 +245,8 @@ class OpenSSLConan(ConanFile):
             self.build_requires("msys2/cci.latest")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
 
     @property
     def _target_prefix(self):
@@ -813,7 +814,7 @@ class OpenSSLConan(ConanFile):
                 if file.endswith(".a"):
                     os.unlink(os.path.join(libdir, file))
 
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
         self._create_cmake_module_variables(
             os.path.join(self.package_folder, self._module_file_rel_path)

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -539,7 +539,7 @@ class OpenSSLConan(ConanFile):
                 # clang-cl doesn't like backslashes in #define CFLAGS (builldinf.h -> cversion.c)
                 include_path = self._adjust_path(include_path)
                 lib_path = self._adjust_path(lib_path)
-            
+
                 if self.options["zlib"].shared:
                     args.append("zlib-dynamic")
                 else:

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -539,8 +539,8 @@ class OpenSSLConan(ConanFile):
                 # clang-cl doesn't like backslashes in #define CFLAGS (builldinf.h -> cversion.c)
                 include_path = self._adjust_path(include_path)
                 lib_path = self._adjust_path(lib_path)
-
-                if zlib_info.shared:
+            
+                if self.options["zlib"].shared:
                     args.append("zlib-dynamic")
                 else:
                     args.append("zlib")

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -1,7 +1,7 @@
 from conan.tools.files import rename, get, rmdir
 from conan.tools.microsoft import is_msvc, msvc_runtime_flag
 from conan.tools.build import cross_building
-from conans.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration
 from conans import ConanFile, AutoToolsBuildEnvironment, tools
 from contextlib import contextmanager
 from functools import total_ordering

--- a/recipes/openssl/1.x.x/test_package/conanfile.py
+++ b/recipes/openssl/1.x.x/test_package/conanfile.py
@@ -1,4 +1,5 @@
-from conans import CMake, tools, ConanFile
+from conans import CMake, ConanFile
+from conan.tools.scm import Version
 from conan.tools.build import cross_building
 import os
 
@@ -24,7 +25,7 @@ class TestPackageConan(ConanFile):
             cmake = CMake(self)
             if self.settings.os == "Android":
                 cmake.definitions["CONAN_LIBCXX"] = ""
-            openssl_version = tools.Version(self.deps_cpp_info["openssl"].version)
+            openssl_version = Version(self.deps_cpp_info["openssl"].version)
             if openssl_version.major == "1" and openssl_version.minor == "1":
                 cmake.definitions["OPENSSL_WITH_ZLIB"] = False
             else:

--- a/recipes/openssl/1.x.x/test_package/conanfile.py
+++ b/recipes/openssl/1.x.x/test_package/conanfile.py
@@ -1,4 +1,5 @@
 from conans import CMake, tools, ConanFile
+from conan.tools.build import cross_building
 import os
 
 
@@ -32,7 +33,7 @@ class TestPackageConan(ConanFile):
             cmake.build()
 
     def test(self):
-        if not self._skip_test and not tools.cross_building(self):
+        if not self._skip_test and not cross_building(self):
             bin_path = os.path.join("bin", "digest")
             self.run(bin_path, run_environment=True)
         assert os.path.exists(os.path.join(self.deps_cpp_info["openssl"].rootpath, "licenses", "LICENSE"))


### PR DESCRIPTION
This access to the cpp_info was creating a new config shared in that object and that finally turned into this error for some users: https://github.com/conan-io/conan/issues/11856