### PR TITLE
Revert "boost: add BOOST_FILESYSTEM_VERSION"

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -5,8 +5,7 @@ from conan.tools.microsoft import msvc_runtime_flag
 from conan import ConanFile
 from conan.errors import ConanException, ConanInvalidConfiguration
 from conans import tools
-# TODO: Update to conan.tools.scm.Version after Conan 1.50.2
-from conans.tools import Version
+from conan.tools.scm import Version
 
 import glob
 import os

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -79,7 +79,6 @@ class BoostConan(ConanFile):
         "system_no_deprecated": [True, False],
         "asio_no_deprecated": [True, False],
         "filesystem_no_deprecated": [True, False],
-        "filesystem_version": [None, "3", "4"],
         "fPIC": [True, False],
         "layout": ["system", "versioned", "tagged", "b2-default"],
         "magic_autolink": [True, False],  # enables BOOST_ALL_NO_LIB
@@ -117,7 +116,6 @@ class BoostConan(ConanFile):
         "system_no_deprecated": False,
         "asio_no_deprecated": False,
         "filesystem_no_deprecated": False,
-        "filesystem_version": None,
         "fPIC": True,
         "layout": "system",
         "magic_autolink": False,
@@ -552,7 +550,6 @@ class BoostConan(ConanFile):
             self.info.options.header_only = True
         else:
             del self.info.options.debug_level
-            del self.info.options.filesystem_version
             del self.info.options.pch
             del self.info.options.python_executable  # PATH to the interpreter is not important, only version matters
             if self.options.without_python:
@@ -1428,9 +1425,6 @@ class BoostConan(ConanFile):
 
         if self.options.filesystem_no_deprecated:
             self.cpp_info.components["headers"].defines.append("BOOST_FILESYSTEM_NO_DEPRECATED")
-
-        if self.options.filesystem_version is not None:
-            self.cpp_info.components["headers"].defines.append(f"BOOST_FILESYSTEM_VERSION={self.options.filesystem_version}")
 
         if self.options.segmented_stacks:
             self.cpp_info.components["headers"].defines.extend(["BOOST_USE_SEGMENTED_STACKS", "BOOST_USE_UCONTEXT"])


### PR DESCRIPTION
Reverts conan-io/conan-center-index#11988

https://github.com/conan-io/conan-center-index/pull/11988#issuecomment-1218367469

/Cc @garethsb 

@Nekto89 I needed to revert your PR. At least, 2 users complained that boost recipe is broken. Probably, that option is consumed automatically in more points, need further investigation. 