### PR TITLE
cmake_build_modules property has to be in the root self.cpp_info

### DIFF
--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -71,7 +71,7 @@ class PyBind11Conan(ConanFile):
             self.cpp_info.components["main"].names["cmake_find_package"] = "pybind11"
             self.cpp_info.components["main"].builddirs = [cmake_base_path]
             cmake_file = os.path.join(cmake_base_path, "pybind11Common.cmake")
-            self.cpp_info.components["main"].set_property("cmake_build_modules", [cmake_file])
+            self.cpp_info.set_property("cmake_build_modules", [cmake_file])
             for generator in ["cmake_find_package", "cmake_find_package_multi"]:
                 self.cpp_info.components["main"].build_modules[generator].append(cmake_file)
             self.cpp_info.components["headers"].includedirs = [os.path.join("include", "pybind11")]

--- a/recipes/pybind11/all/conanfile.py
+++ b/recipes/pybind11/all/conanfile.py
@@ -1,5 +1,5 @@
 from conans import ConanFile, CMake
-from conans.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import get, copy, replace_in_file
 from conan.tools.scm import Version
 import os


### PR DESCRIPTION
Specify library name and version:  **pybind11/all**

The property `cmake_build_modules` has to be assigned at the root `self.cpp_info`.

This is described in the migration guide: https://docs.conan.io/en/latest/migrating_to_2.0/recipes.html
And in the documentation of CMakeDeps: https://docs.conan.io/en/latest/reference/conanfile/tools/cmake/cmakedeps.html#properties
In the changelog: https://docs.conan.io/en/latest/changelog.html#jul-2022
Also in the 2.0 beta docs.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
