### PR TITLE
[protobuf] Use legacy tools to import is_apple_os

### DIFF
--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -2,10 +2,11 @@ from conan.tools.files import rename, get, apply_conandata_patches, replace_in_f
 from conan.tools.microsoft import msvc_runtime_flag
 from conan.tools.scm import Version
 from conan.tools.build import cross_building
-from conan.tools.apple.apple import is_apple_os
 from conan.errors import ConanInvalidConfiguration
 from conan import ConanFile
 from conans import CMake
+# TODO: Update to conan.tools.apple after 1.51.3
+from conans.tools import is_apple_os
 
 import functools
 import os


### PR DESCRIPTION
Specify library name and version:  **protobuf/3.21.4**

Since Conan [1.51.3](https://docs.conan.io/en/latest/changelog.html#aug-2022), the private import `from conan.tools.apple.apple import is_apple_os` is no longer available. Need to use the legacy version and wait for infrastructure update.

fixes https://github.com/conan-io/conan-center-index/issues/12334

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
