### PR TITLE
[dbus] Use legacy tools to import is_apple_os 

### DIFF
--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -3,11 +3,12 @@ import textwrap
 
 from conan import ConanFile
 from conan.tools.apple.apple import is_apple_os
-from conan.tools.files import apply_conandata_patches, copy, get, mkdir, rename, rmdir, save
+from conan.tools.files import apply_conandata_patches, copy, get, mkdir, rename, rmdir, save, rm
 from conans import CMake
-from conans.tools import remove_files_by_mask
+# TODO: Update to conan.tools.apple after 1.51.3
+from conans.tools import is_apple_os
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.50.0"
 
 
 class DbusConan(ConanFile):
@@ -110,7 +111,7 @@ class DbusConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "lib", "systemd"))
-        remove_files_by_mask(self.package_folder, "*.la")
+        rm(self, "*.la", self.package_folder)
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self._create_cmake_module_alias_targets(

--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -2,7 +2,6 @@ import os
 import textwrap
 
 from conan import ConanFile
-from conan.tools.apple.apple import is_apple_os
 from conan.tools.files import apply_conandata_patches, copy, get, mkdir, rename, rmdir, save, rm
 from conans import CMake
 # TODO: Update to conan.tools.apple after 1.51.3


### PR DESCRIPTION
Specify library name and version:  **dbus/1.12.20**

Since Conan [1.51.3](https://docs.conan.io/en/latest/changelog.html#aug-2022), the private import `from conan.tools.apple.apple import is_apple_os` is no longer available. Need to use the legacy version and wait for infrastructure update.

Related to https://github.com/conan-io/conan-center-index/pull/12335

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
