### PR TITLE
Automated version bump failed - Manual update to publish 1.1.3

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.3":
+    url: "https://github.com/opentdf/client-cpp/archive/1.1.3.tar.gz"
+    sha256: "67855999010f9c1496e170ad885f73b854f91eb1539e3c20d74b162295d5c732"
   "1.1.2":
     url: "https://github.com/opentdf/client-cpp/archive/1.1.2.tar.gz"
     sha256: "4e41a18ef9d47aa9f964beffa78fdd4290a5f50336c6e4dc3c9bf2dd4b075d10"

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.3":
+    folder: all
   "1.1.2":
     folder: all
   "1.1.0":


### PR DESCRIPTION
Specify library name and version:  **opentdf-client/1.1.3**

Minor update to fix return types on a couple of new CKS-related methods

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
