### PR TITLE
Make libui build on Windows

### DIFF
--- a/recipes/libui/all/conanfile.py
+++ b/recipes/libui/all/conanfile.py
@@ -1,6 +1,6 @@
-from conans import ConanFile, CMake, tools
-from conans.tools import os_info
 import os
+
+from conans import CMake, ConanFile, tools
 
 
 class libuiConan(ConanFile):
@@ -36,7 +36,8 @@ class libuiConan(ConanFile):
         tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def requirements(self):
-        self.requires("gtk/3.24.24")
+        if self.settings.os == "Linux":
+            self.requires("gtk/3.24.24")
 
     def _configure_cmake(self):
         cmake = CMake(self)

--- a/recipes/libui/all/conanfile.py
+++ b/recipes/libui/all/conanfile.py
@@ -37,7 +37,7 @@ class libuiConan(ConanFile):
 
     def requirements(self):
         if self.settings.os == "Linux":
-            self.requires("gtk/3.24.24")
+            self.requires("gtk/system")
 
     def _configure_cmake(self):
         cmake = CMake(self)


### PR DESCRIPTION
Specify library name and version:  **libui/0.4.1**

This change allows libui/0.4.1 to build on Windows. I tested this recipe locally on a Windows 10 machine and it works well.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
