### PR TITLE
feat: update xapian-core dependency of doxygen to most recent version

### DIFF
--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -54,7 +54,7 @@ class DoxygenConan(ConanFile):
         del self.settings.compiler.cppstd
     def requirements(self):
         if self.options.enable_search:
-            self.requires("xapian-core/1.4.18")
+            self.requires("xapian-core/1.4.19")
             self.requires("zlib/1.2.12")
 
     def build_requirements(self):

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -5,7 +5,7 @@ from conans import CMake
 from conan.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.50.2"
 
 
 class DoxygenConan(ConanFile):

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -119,6 +119,7 @@ class DoxygenConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libdirs = []
+        self.cpp_info.includedirs = []
         bin_path = os.path.join(self.package_folder, "bin")
         self.output.info(f"Appending PATH environment variable: {bin_path}")
         self.env_info.PATH.append(bin_path)

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -73,7 +73,7 @@ class DoxygenConan(ConanFile):
             if Version(self.settings.compiler.version) < minimum_compiler_version:
                 raise ConanInvalidConfiguration(f"Compiler version too old. At least {minimum_compiler_version} is required.")
         if (self.settings.compiler == "Visual Studio" and
-                Version(self.settings.compiler.version.value) <= 14 and
+                Version(self.settings.compiler.version) <= "14" and
                 Version(self.version) == "1.8.18"):
             raise ConanInvalidConfiguration(f"Doxygen version {self.version} broken with VS {self.settings.compiler.version}.")
 

--- a/recipes/doxygen/all/conanfile.py
+++ b/recipes/doxygen/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.scm import Version
-from conan.tools import files
+from conan import tools
 from conans import CMake
 from conan.errors import ConanInvalidConfiguration
 import os
@@ -88,7 +88,7 @@ class DoxygenConan(ConanFile):
         self.compatible_packages.append(compatible_pkg)
 
     def source(self):
-        files.get(**self.conan_data["sources"][self.version],
+        tools.files.get(self, **self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
     def _configure_cmake(self):
@@ -108,7 +108,7 @@ class DoxygenConan(ConanFile):
         if os.path.isfile("Findbison.cmake"):
             os.unlink("Findbison.cmake")
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            files.patch(**patch)
+            tools.files.patch(self, **patch)
         cmake = self._configure_cmake()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **doxygen/1.9.4**

xapian-core package is available as version 1.4.19.
Doxygen should use this most recent version.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
