### PR TITLE
qt/6.2.x: Add directwrite lib for Windows builds of QtGui

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -1016,7 +1016,7 @@ class QtConan(ConanFile):
                 _create_plugin("QWindowsIntegrationPlugin", "qwindows", "platforms", ["Core", "Gui"])
                 _create_plugin("QWindowsVistaStylePlugin", "qwindowsvistastyle", "styles", ["Core", "Gui"])
                 self.cpp_info.components["qtQWindowsIntegrationPlugin"].system_libs = ["advapi32", "dwmapi", "gdi32", "imm32",
-                    "ole32", "oleaut32", "shell32", "shlwapi", "user32", "winmm", "winspool", "wtsapi32"]
+                    "ole32", "oleaut32", "shell32", "shlwapi", "user32", "winmm", "winspool", "wtsapi32", "dwrite"]
             elif self.settings.os == "Android":
                 _create_plugin("QAndroidIntegrationPlugin", "qtforandroid", "platforms", ["Core", "Gui"])
                 self.cpp_info.components["qtQAndroidIntegrationPlugin"].system_libs = ["android", "jnigraphics"]


### PR DESCRIPTION
Specify library name and version:  **qt/6.3.x**

As discovered in https://github.com/conan-io/conan-center-index/pull/12218 the qt builds are failing in Windows with a link error:

> Qt6Guid.lib(qwindowsfontdatabasebase.cpp.obj) : error LNK2019: unresolved external symbol __imp_DWriteCreateFactory referenced in function "public: static void __cdecl QWindowsFontDatabaseBase::createDirectWriteFactory(struct IDWriteFactory * *)" (?createDirectWriteFactory@QWindowsFontDatabaseBase@@SAXPEAPEAUIDWriteFactory@@@Z) [C:\J\w\prod\BuildSingleReference\conan-center-index\recipes\qt-advanced-docking-system\all\test_package\build\7770fe3f8c8a71348b99aef6a9f77685daa6ca19\example.vcxproj]
> C:\J\w\prod\BuildSingleReference\conan-center-index\recipes\qt-advanced-docking-system\all\test_package\build\7770fe3f8c8a71348b99aef6a9f77685daa6ca19\bin\example.exe : fatal error LNK1120: 1 unresolved externals [C:\J\w\prod\BuildSingleReference\conan-center-index\recipes\qt-advanced-docking-system\all\test_package\build\7770fe3f8c8a71348b99aef6a9f77685daa6ca19\example.vcxproj]

It seems lib direct write is missing on windows. I think this is located within the QtGui component since the related classes are located in QtGui (altough the error is originated in Qt6Guid.lib, but I figured this is not an independent component), see:

https://doc-snapshots.qt.io/qt6-6.3/qfontdatabase.html (which is the OSAL for QWindowsFontDatabaseBase which is triggering the error).

I am really not sure whether this is the right fix for this, feedback is very appreciated!

Best regards,
Sebastian

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
