### PR TITLE
[harfbuzz]: Use full_package_mode only with static glib

### DIFF
--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -84,7 +84,7 @@ class HarfbuzzConan(ConanFile):
         if self.options.with_icu:
             self.requires("icu/71.1")
         if self.options.with_glib:
-            self.requires("glib/2.73.1")
+            self.requires("glib/2.73.3")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
@@ -156,5 +156,5 @@ class HarfbuzzConan(ConanFile):
                 self.cpp_info.system_libs.append(libcxx)
 
     def package_id(self):
-        if self.options.with_glib:
+        if self.options.with_glib and not self.options["glib"].shared:
             self.info.requires["glib"].full_package_mode()


### PR DESCRIPTION
Specify library name and version:  **harfbuzz**

This patch makes harfbuzz use full_package_mode only when linking against static glib. This should stop causing the brittle builds. Or maybe we can remove the full_package_mode stuff entirely?

My set of patches have caused waves of problems, I should've seen this coming! I propose to change all of these patches in this way.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
