### PR TITLE
luau: add version 0.541

### DIFF
--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.541":
+    url: "https://github.com/Roblox/luau/archive/0.541.tar.gz"
+    sha256: "02d50b8c0396a353ed641a61959851d6858607d535ed7373478b8fbc2a508eba"
   "0.540":
     url: "https://github.com/Roblox/luau/archive/0.540.tar.gz"
     sha256: "84b3e52b3b0ccf4d5bc0e0c04055f3a9b2f045c1281e203a858335a6fe76b0ff"
@@ -16,6 +19,11 @@ sources:
     sha256: "e6de36e83e9c537d92bcc94852ab498e3c15a310fd2c4cc4e21c616d8ae1a84f"
 
 patches:
+  "0.541":
+    - patch_file: "patches/0.536-0001-fix-cmake.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0.536-0002-rename-lerp.patch"
+      base_path: "source_subfolder"
   "0.540":
     - patch_file: "patches/0.536-0001-fix-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.541":
+    folder: all
   "0.540":
     folder: all
   "0.539":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **luau/0.541**



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
