### PR TITLE
update grpc recipe to support RelWithDebInfo and MinSizeRel build types

### DIFF
--- a/recipes/grpc/all/CMakeLists.txt
+++ b/recipes/grpc/all/CMakeLists.txt
@@ -7,8 +7,16 @@ conan_basic_setup(KEEP_RPATHS)
 find_package(grpc-proto CONFIG REQUIRED)
 find_package(googleapis CONFIG REQUIRED)
 
-set(googleapis_RES_DIRS $<$<CONFIG:Debug>:${googleapis_RES_DIRS_DEBUG}> $<$<CONFIG:Release>:${googleapis_RES_DIRS_RELEASE}>)
-set(grpc-proto_RES_DIRS $<$<CONFIG:Debug>:${grpc-proto_RES_DIRS_DEBUG}> $<$<CONFIG:Release>:${grpc-proto_RES_DIRS_RELEASE}>)
+set(googleapis_RES_DIRS
+    $<$<CONFIG:Release>:${googleapis_RES_DIRS_RELEASE}>
+    $<$<CONFIG:RelWithDebInfo>:${googleapis_RES_DIRS_RELWITHDEBINFO}}>
+    $<$<CONFIG:MinSizeRel>:${googleapis_RES_DIRS_MINSIZEREL}>
+    $<$<CONFIG:Debug>:${googleapis_RES_DIRS_DEBUG}>)
+set(grpc-proto_RES_DIRS
+    $<$<CONFIG:Release>:${grpc-proto_RES_DIRS_RELEASE}>
+    $<$<CONFIG:RelWithDebInfo>:${grpc-proto_RES_DIRS_RELWITHDEBINFO}}>
+    $<$<CONFIG:MinSizeRel>:${grpc-proto_RES_DIRS_MINSIZEREL}>
+    $<$<CONFIG:Debug>:${grpc-proto_RES_DIRS_DEBUG}>)
 
 add_subdirectory("source_subfolder")
 

--- a/recipes/grpc/all/CMakeLists.txt
+++ b/recipes/grpc/all/CMakeLists.txt
@@ -9,12 +9,12 @@ find_package(googleapis CONFIG REQUIRED)
 
 set(googleapis_RES_DIRS
     $<$<CONFIG:Release>:${googleapis_RES_DIRS_RELEASE}>
-    $<$<CONFIG:RelWithDebInfo>:${googleapis_RES_DIRS_RELWITHDEBINFO}}>
+    $<$<CONFIG:RelWithDebInfo>:${googleapis_RES_DIRS_RELWITHDEBINFO}>
     $<$<CONFIG:MinSizeRel>:${googleapis_RES_DIRS_MINSIZEREL}>
     $<$<CONFIG:Debug>:${googleapis_RES_DIRS_DEBUG}>)
 set(grpc-proto_RES_DIRS
     $<$<CONFIG:Release>:${grpc-proto_RES_DIRS_RELEASE}>
-    $<$<CONFIG:RelWithDebInfo>:${grpc-proto_RES_DIRS_RELWITHDEBINFO}}>
+    $<$<CONFIG:RelWithDebInfo>:${grpc-proto_RES_DIRS_RELWITHDEBINFO}>
     $<$<CONFIG:MinSizeRel>:${grpc-proto_RES_DIRS_MINSIZEREL}>
     $<$<CONFIG:Debug>:${grpc-proto_RES_DIRS_DEBUG}>)
 


### PR DESCRIPTION
Specify library name and version:  grpc

update to support all default CMake build types

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
