### PR TITLE
[conan v2] Migrate box2d recipe - take 2

### DIFF
--- a/recipes/box2d/all/conanfile.py
+++ b/recipes/box2d/all/conanfile.py
@@ -19,11 +19,17 @@ class Box2dConan(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
 
     def layout(self):
         cmake_layout(self, src_folder="Box2D")


### PR DESCRIPTION
When deleting options/settings we need to add try/catch to avoid failures with conan v2 commands. In this case, the folloeing error was raising with `conan graph info` command:

```
conan graph info --requires box2d/2.3.1@#3f0bf2bd11b95e7834b5f98058862a1c -f json -pr:h /home/conan/w/prod-v2_cci_PR-12067/9/10bcc10b-d364-464d-96e7-fc4cd3d8a1aa/profile_windows_192_release_dynamic_msvc_release_64.*-shared-True.txt -pr:b /home/conan/w/prod-v2_cci_PR-12067/9/10bcc10b-d364-464d-96e7-fc4cd3d8a1aa/profile_windows_192_release_dynamic_msvc_release_64.*-shared-True.txt

   -------- Input profiles --------
   Profile host:
   [settings]
   arch=x86_64
   build_type=Release
   compiler=msvc
   compiler.runtime=dynamic
   compiler.runtime_type=Release
   compiler.version=192
   os=Windows
   [options]
   */*:shared=True
   
   Profile build:
   [settings]
   arch=x86_64
   build_type=Release
   compiler=msvc
   compiler.runtime=dynamic
   compiler.runtime_type=Release
   compiler.version=192
   os=Windows
   [options]
   */*:shared=True
   
   
   -------- Computing dependency graph --------
   ERROR: box2d/2.3.1: Error in configure() method, line 26
   	del self.options.fPIC
   	ConanException: option 'fPIC' doesn't exist
   Possible options are ['shared']
```
