### PR TITLE
g3log: add 1.3.4 + conan v2 support + fix cmake imported target

### DIFF
--- a/recipes/g3log/all/CMakeLists.txt
+++ b/recipes/g3log/all/CMakeLists.txt
@@ -1,8 +1,0 @@
-cmake_minimum_required(VERSION 3.1.0)
-
-project(cmake_wrapper)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory("source_subfolder")

--- a/recipes/g3log/all/conandata.yml
+++ b/recipes/g3log/all/conandata.yml
@@ -11,4 +11,3 @@ sources:
 patches:
   "1.3.2":
     - patch_file: "patches/0002-remove-explicit-stdlib-setting.patch"
-      base_path: "source_subfolder"

--- a/recipes/g3log/all/conandata.yml
+++ b/recipes/g3log/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.4":
+    url: "https://github.com/KjellKod/g3log/archive/refs/tags/1.3.4.tar.gz"
+    sha256: "2fe8815e5f5afec6b49bdfedfba1e86b8e58a5dc89fd97f4868fb7f3141aed19"
   "1.3.3":
     url: "https://github.com/KjellKod/g3log/archive/1.3.3.tar.gz"
     sha256: "d8cae14e1508490145d710f10178b2da9b86ce03fb2428a684fff35576fe5d5c"

--- a/recipes/g3log/all/conanfile.py
+++ b/recipes/g3log/all/conanfile.py
@@ -2,9 +2,10 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, get, rmdir
+from conan.tools.files import apply_conandata_patches, copy, get, rmdir, save
 from conan.tools.microsoft import is_msvc
 import os
+import textwrap
 
 required_conan_version = ">=1.50.0"
 
@@ -120,7 +121,34 @@ class G3logConan(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
+        # TODO: to remove in conan v2 once legacy generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"g3log": "g3log::g3log"},
+        )
+
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
+
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "g3log")
+        self.cpp_info.set_property("cmake_target_name", "g3log")
         self.cpp_info.libs = ["g3logger"]
         if self.settings.os in ["Linux", "Android"]:
             self.cpp_info.system_libs.append("pthread")
+
+        # TODO: to remove in conan v2 once legacy generators removed
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/g3log/all/conanfile.py
+++ b/recipes/g3log/all/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, get, rmdir, save
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 import textwrap
 
@@ -145,7 +146,7 @@ class G3logConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "g3log")
         self.cpp_info.set_property("cmake_target_name", "g3log")
-        self.cpp_info.libs = ["g3logger"]
+        self.cpp_info.libs = ["g3logger" if Version(self.version) < "1.3.4" else "g3log"]
         if self.settings.os in ["Linux", "Android"]:
             self.cpp_info.system_libs.append("pthread")
 

--- a/recipes/g3log/all/conanfile.py
+++ b/recipes/g3log/all/conanfile.py
@@ -1,8 +1,12 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, get, rmdir
+from conan.tools.microsoft import is_msvc
 import os
-from os import path
-from conans import ConanFile, CMake, tools
-from conans.tools import Version
-from conans.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.50.0"
 
 
 class G3logConan(ConanFile):
@@ -10,87 +14,113 @@ class G3logConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/KjellKod/g3log"
     license = "The Unlicense"
-    description = """G3log is an asynchronous, "crash safe", logger that is easy to use with default logging sinks or you can add your own."""
-    topics = ("conan", "g3log", "log")
-    settings = "os", "compiler", "build_type", "arch"
+    description = (
+        "G3log is an asynchronous, \"crash safe\", logger that is easy to use "
+        "with default logging sinks or you can add your own."
+    )
+    topics = ("g3log", "log")
+
+    settings = "os", "arch", "compiler", "build_type"
     options = {
-      "shared": [True, False],
-      "fPIC": [True, False],
-      "use_dynamic_logging_levels": [True, False],
-      "change_debug_to_dbug": [True, False],
-      "use_dynamic_max_message_size": [True, False],
-      "log_full_filename": [True, False],
-      "enable_fatal_signal_handling": [True, False],
-      "enable_vectored_exception_handling": [True, False],
-      "debug_break_at_fatal_signal": [True, False]
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "use_dynamic_logging_levels": [True, False],
+        "change_debug_to_dbug": [True, False],
+        "use_dynamic_max_message_size": [True, False],
+        "log_full_filename": [True, False],
+        "enable_fatal_signal_handling": [True, False],
+        "enable_vectored_exception_handling": [True, False],
+        "debug_break_at_fatal_signal": [True, False],
     }
-    default_options = {key: False for key in options.keys()}
-    default_options["use_dynamic_max_message_size"] = True
-    default_options["enable_fatal_signal_handling"] = True
-    default_options["enable_vectored_exception_handling"] = True
-    default_options["fPIC"] = True
-    generators = "cmake"
-    exports_sources = ["CMakeLists.txt", "patches/*"]
-    _source_subfolder = "source_subfolder"
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "use_dynamic_logging_levels": False,
+        "change_debug_to_dbug": False,
+        "use_dynamic_max_message_size": True,
+        "log_full_filename": False,
+        "enable_fatal_signal_handling": True,
+        "enable_vectored_exception_handling": True,
+        "debug_break_at_fatal_signal": False,
+    }
 
-    def _has_support_for_cpp14(self):
-        supported_compilers = [("apple-clang", 5.1), ("clang", 3.4), ("gcc", 6.1), ("Visual Studio", 15.0)]
-        compiler, version = self.settings.compiler, Version(self.settings.compiler.version)
-        return any(compiler == sc[0] and version >= sc[1] for sc in supported_compilers)
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "6.1",
+            "clang": "3.4",
+            "apple-clang": "5.1",
+            "Visual Studio": "15",
+        }
 
-    def configure(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, "14")
-        if not self._has_support_for_cpp14():
-            raise ConanInvalidConfiguration("g3log requires C++14 or higher support standard."
-                                            " {} {} is not supported."
-                                            .format(self.settings.compiler,
-                                                    self.settings.compiler.version))
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        dir_postfix = self.conan_data["sources"][self.version]["url"].split("/")[-1][:-7]
-        os.rename("g3log-{}".format(dir_postfix), self._source_subfolder)
+    def export_sources(self):
+        for p in self.conan_data.get("patches", {}).get(self.version, []):
+            copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if self.settings.compiler != "Visual Studio":
+        if not is_msvc(self):
             del self.options.enable_vectored_exception_handling
             del self.options.debug_break_at_fatal_signal
 
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions['VERSION'] = self.version
-        cmake.definitions["G3_SHARED_LIB"] = self.options.shared
-        cmake.definitions["USE_DYNAMIC_LOGGING_LEVELS"] = self.options.use_dynamic_logging_levels
-        cmake.definitions["CHANGE_G3LOG_DEBUG_TO_DBUG"] = self.options.change_debug_to_dbug
-        cmake.definitions["USE_G3_DYNAMIC_MAX_MESSAGE_SIZE"] = self.options.use_dynamic_max_message_size
-        cmake.definitions["G3_LOG_FULL_FILENAME"] = self.options.log_full_filename
-        cmake.definitions["ENABLE_FATAL_SIGNALHANDLING"] = self.options.enable_fatal_signal_handling
-        if self.settings.compiler == "Visual Studio":
-            cmake.definitions["ENABLE_VECTORED_EXCEPTIONHANDLING"] = self.options.enable_vectored_exception_handling
-            cmake.definitions["DEBUG_BREAK_AT_FATAL_SIGNAL"] = self.options.debug_break_at_fatal_signal
-        cmake.definitions["ADD_FATAL_EXAMPLE"] = "OFF"
-        cmake.definitions["ADD_G3LOG_PERFORMANCE"] = "OFF"
-        cmake.definitions["ADD_G3LOG_UNIT_TEST"] = "OFF"
-        cmake.configure()
-        return cmake
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def validate(self):
+        if self.info.settings.compiler.cppstd:
+            check_min_cppstd(self, "14")
+
+        def loose_lt_semver(v1, v2):
+            lv1 = [int(v) for v in v1.split(".")]
+            lv2 = [int(v) for v in v2.split(".")]
+            min_length = min(len(lv1), len(lv2))
+            return lv1[:min_length] < lv2[:min_length]
+
+        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
+        if minimum_version and loose_lt_semver(str(self.info.settings.compiler.version), minimum_version):
+            raise ConanInvalidConfiguration(
+                "{} requires C++14, which your compiler does not support.".format(self.name)
+            )
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["VERSION"] = self.version
+        tc.variables["G3_SHARED_LIB"] = self.options.shared
+        tc.variables["USE_DYNAMIC_LOGGING_LEVELS"] = self.options.use_dynamic_logging_levels
+        tc.variables["CHANGE_G3LOG_DEBUG_TO_DBUG"] = self.options.change_debug_to_dbug
+        tc.variables["USE_G3_DYNAMIC_MAX_MESSAGE_SIZE"] = self.options.use_dynamic_max_message_size
+        tc.variables["G3_LOG_FULL_FILENAME"] = self.options.log_full_filename
+        tc.variables["ENABLE_FATAL_SIGNALHANDLING"] = self.options.enable_fatal_signal_handling
+        if is_msvc(self):
+            tc.variables["ENABLE_VECTORED_EXCEPTIONHANDLING"] = self.options.enable_vectored_exception_handling
+            tc.variables["DEBUG_BREAK_AT_FATAL_SIGNAL"] = self.options.debug_break_at_fatal_signal
+        tc.variables["ADD_FATAL_EXAMPLE"] = "OFF"
+        tc.variables["ADD_G3LOG_PERFORMANCE"] = "OFF"
+        tc.variables["ADD_G3LOG_UNIT_TEST"] = "OFF"
+        tc.generate()
 
     def build(self):
-        if "patches" in self.conan_data and self.version in self.conan_data["patches"]:
-            for patch in self.conan_data["patches"][self.version]:
-                tools.patch(**patch)
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.libs = ["g3logger"]
-        if str(self.settings.os) in ["Linux", "Android"]:
-            self.cpp_info.system_libs.append('pthread')
+        if self.settings.os in ["Linux", "Android"]:
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/g3log/all/test_package/CMakeLists.txt
+++ b/recipes/g3log/all/test_package/CMakeLists.txt
@@ -4,5 +4,5 @@ project(test_package LANGUAGES CXX)
 find_package(g3log REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE g3log::g3log)
+target_link_libraries(${PROJECT_NAME} PRIVATE g3log)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/g3log/all/test_package/conanfile.py
+++ b/recipes/g3log/all/test_package/conanfile.py
@@ -1,9 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import cross_building
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
+
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -11,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if not cross_building(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/g3log/all/test_v1_package/CMakeLists.txt
+++ b/recipes/g3log/all/test_v1_package/CMakeLists.txt
@@ -7,5 +7,5 @@ conan_basic_setup(TARGETS)
 find_package(g3log REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE g3log::g3log)
+target_link_libraries(${PROJECT_NAME} PRIVATE g3log)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/g3log/all/test_v1_package/CMakeLists.txt
+++ b/recipes/g3log/all/test_v1_package/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(g3log REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE g3log::g3log)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/g3log/all/test_v1_package/conanfile.py
+++ b/recipes/g3log/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/g3log/config.yml
+++ b/recipes/g3log/config.yml
@@ -7,4 +7,3 @@ versions:
     folder: all
   "1.3.2":
     folder: all
-

--- a/recipes/g3log/config.yml
+++ b/recipes/g3log/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.4":
+    folder: all
   "1.3.3":
     folder: all
   "1.3.2-86":


### PR DESCRIPTION
CMake imported target is not namespace: it's `g3log`.
Actually upstream config file & target names were `g3logger` before 1.3.4, but they were changed to `g3log` in 1.3.4 for consistency with project name, so I've decided to use these new names (and it avoids to break consumers in the meantime since find/config file generated by cmake_find_package* generators were already g3log).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
