### PR TITLE
remove cmake from build requirement of diligent-core

### DIFF
--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -86,9 +86,6 @@ class DiligentCoreConan(ConanFile):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             tools.patch(**patch)
 
-    def build_requirements(self):
-        self.build_requires("cmake/3.22.0")
-
     def requirements(self):
         self.requires("opengl/system")
 


### PR DESCRIPTION
Specify library name and version:  **diligent-core**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
