### PR TITLE
Package info fixes for conan v2 octo-encryption-cpp

### DIFF
--- a/recipes/octo-encryption-cpp/all/conanfile.py
+++ b/recipes/octo-encryption-cpp/all/conanfile.py
@@ -79,16 +79,8 @@ class OctoEncryptionCPPConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "octo-encryption-cpp")
         self.cpp_info.set_property("cmake_target_name", "octo::octo-encryption-cpp")
         self.cpp_info.set_property("pkg_config_name", "octo-encryption-cpp")
-        self.cpp_info.components["libocto-encryption-cpp"].libs = ["octo-encryption-cpp"]
-        self.cpp_info.components["libocto-encryption-cpp"].requires = [
-            "openssl::openssl"
-        ]
-        self.cpp_info.filenames["cmake_find_package"] = "octo-encryption-cpp"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "octo-encryption-cpp"
+        self.cpp_info.libs = ["octo-encryption-cpp"]
         self.cpp_info.names["cmake_find_package"] = "octo-encryption-cpp"
         self.cpp_info.names["cmake_find_package_multi"] = "octo-encryption-cpp"
         self.cpp_info.names["pkg_config"] = "octo-encryption-cpp"
-        self.cpp_info.components["libocto-encryption-cpp"].names["cmake_find_package"] = "octo-encryption-cpp"
-        self.cpp_info.components["libocto-encryption-cpp"].names["cmake_find_package_multi"] = "octo-encryption-cpp"
-        self.cpp_info.components["libocto-encryption-cpp"].set_property("cmake_target_name", "octo::octo-encryption-cpp")
-        self.cpp_info.components["libocto-encryption-cpp"].set_property("pkg_config_name", "octo-encryption-cpp")
+        self.cpp_info.requires = ["openssl::openssl"]


### PR DESCRIPTION
Specify library name and version:  **octo-encryption-cpp/1.1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

Package info fixes to comply with conan v2

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
