### PR TITLE
SDL: improve linker settings for Apple platforms + v2 linter changes

### DIFF
--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -9,7 +9,7 @@ from conans import CMake, tools
 import functools
 import os
 
-required_conan_version = ">=1.45.0"
+required_conan_version = ">=1.51.3"
 
 
 class SDLConan(ConanFile):

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -1,6 +1,11 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.files import get, replace_in_file, rm, rmdir
+from conan.tools.files import patch as apply_patch
 from conan.tools.microsoft import is_msvc
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan.tools.scm import Version
+from conans import CMake, tools
 import functools
 import os
 
@@ -148,7 +153,7 @@ class SDLConan(ConanFile):
             raise ConanInvalidConfiguration("On macOS iconv can't be disabled")
 
         # SDL>=2.0.18 requires xcode 12 or higher because it uses CoreHaptics.
-        if tools.Version(self.version) >= "2.0.18" and tools.is_apple_os(self.settings.os) and tools.Version(self.settings.compiler.version) < "12":
+        if Version(self.version) >= "2.0.18" and is_apple_os(self) and Version(self.settings.compiler.version) < "12":
             raise ConanInvalidConfiguration("{}/{} requires xcode 12 or higher".format(self.name, self.version))
 
         if self.settings.os == "Linux":
@@ -162,7 +167,7 @@ class SDLConan(ConanFile):
                 raise ConanInvalidConfiguration("Package for 'directfb' is not available (yet)")
 
     def package_id(self):
-        if tools.Version(self.version) < "2.0.22":
+        if Version(self.version) < "2.0.22":
             del self.info.options.sdl2main
 
     def build_requirements(self):
@@ -172,20 +177,21 @@ class SDLConan(ConanFile):
             self.build_requires("wayland/1.20.0")  # Provides wayland-scanner
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True,
+            destination=self._source_subfolder)
 
     def _patch_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+            apply_patch(**patch)
 
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+        replace_in_file(self, os.path.join(self._source_subfolder, "CMakeLists.txt"),
                         'check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)',
                         '# check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)')
 
         # Ensure to find wayland-scanner from wayland recipe in build requirements (or requirements if 1 profile)
-        if self.options.get_safe("wayland") and tools.Version(self.version) >= "2.0.18":
+        if self.options.get_safe("wayland") and Version(self.version) >= "2.0.18":
             wayland_bin_path = " ".join("\"{}\"".format(path) for path in self.deps_env_info["wayland"].PATH)
-            tools.replace_in_file(
+            replace_in_file(self,
                 os.path.join(self._source_subfolder, "cmake", "sdlchecks.cmake"),
                 "find_program(WAYLAND_SCANNER NAMES wayland-scanner REQUIRED)",
                 "find_program(WAYLAND_SCANNER NAMES wayland-scanner REQUIRED PATHS {} NO_DEFAULT_PATH)".format(wayland_bin_path),
@@ -205,7 +211,7 @@ class SDLConan(ConanFile):
         cmake.definitions["SDL_SHARED"] = self.options.shared
         cmake.definitions["SDL_STATIC"] = not self.options.shared
 
-        if tools.Version(self.version) < "2.0.18":
+        if Version(self.version) < "2.0.18":
             cmake.definitions["VIDEO_OPENGL"] = self.options.opengl
             cmake.definitions["VIDEO_OPENGLES"] = self.options.opengles
             cmake.definitions["VIDEO_VULKAN"] = self.options.vulkan
@@ -337,7 +343,7 @@ class SDLConan(ConanFile):
             elif self.settings.os == "Windows":
                 cmake.definitions["SDL_DIRECTX"] = self.options.directx
 
-        if tools.Version(self.version) >= "2.0.22":
+        if Version(self.version) >= "2.0.22":
             cmake.definitions["SDL2_DISABLE_SDL2MAIN"] = not self.options.sdl2main
 
         # Add extra information collected from the deps
@@ -360,12 +366,12 @@ class SDLConan(ConanFile):
             self.copy(pattern="COPYING.txt", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "sdl2-config")
-        tools.rmdir(os.path.join(self.package_folder, "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "libdata"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        rm(self, os.path.join(self.package_folder, "bin"), "sdl2-config")
+        rmdir(self, os.path.join(self.package_folder, "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "libdata"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "SDL2")
@@ -423,7 +429,7 @@ class SDLConan(ConanFile):
                 self.cpp_info.components["libsdl2"].requires.append("egl::egl")
             if self.options.libunwind:
                 self.cpp_info.components["libsdl2"].requires.append("libunwind::libunwind")
-        elif tools.is_apple_os(self.settings.os) and not self.options.shared:
+        elif is_apple_os(self) and not self.options.shared:
             self.cpp_info.components["libsdl2"].frameworks = [
                 "CoreVideo", "CoreAudio", "AudioToolbox",
                 "AVFoundation", "Foundation", "QuartzCore",
@@ -431,7 +437,7 @@ class SDLConan(ConanFile):
             add_core_haptics = False
             if self.settings.os == "Macos":
                 self.cpp_info.components["libsdl2"].frameworks.extend(["Cocoa", "Carbon", "IOKit", "ForceFeedback"])
-                if tools.Version(self.version) >= "2.0.18":
+                if Version(self.version) >= "2.0.18":
                     self.cpp_info.components["libsdl2"].frameworks.append("GameController")
             elif self.settings.os in ["iOS", "tvOS", "watchOS"]:
                 self.cpp_info.components["libsdl2"].frameworks.extend([
@@ -439,9 +445,9 @@ class SDLConan(ConanFile):
                     "CoreGraphics", "CoreBluetooth",
                 ])
                 add_core_haptics = True
-            if tools.Version(self.version) >= "2.0.14":
+            if Version(self.version) >= "2.0.14":
                 self.cpp_info.components["libsdl2"].frameworks.append("Metal")
-            if tools.Version(self.version) >= "2.0.18":
+            if Version(self.version) >= "2.0.18":
                 add_core_haptics = True
             if add_core_haptics:
                 self.cpp_info.components["libsdl2"].sharedlinkflags.append("-Wl,-weak_framework,CoreHaptics")

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -142,7 +142,7 @@ class SDLConan(ConanFile):
             if self.options.nas:
                 self.requires("nas/1.9.4")
             if self.options.wayland:
-                self.requires("wayland/1.20.0")
+                self.requires("wayland/1.21.0")
                 self.requires("xkbcommon/1.4.1")
                 self.requires("egl/system")
             if self.options.libunwind:

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.files import get, replace_in_file, rm, rmdir
-from conan.tools.files import patch as apply_patch
+from conan.tools.files import patch
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 from conans import CMake, tools

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -180,8 +180,7 @@ class SDLConan(ConanFile):
             destination=self._source_subfolder)
 
     def _patch_sources(self):
-        for data in self.conan_data.get("patches", {}).get(self.version, []):
-            patch(self, **data)
+        apply_conandata_patches(self)
 
         replace_in_file(self, os.path.join(self._source_subfolder, "CMakeLists.txt"),
                         'check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)',

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -181,7 +181,7 @@ class SDLConan(ConanFile):
             destination=self._source_subfolder)
 
     def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+        for data in self.conan_data.get("patches", {}).get(self.version, []):
             apply_patch(**patch)
 
         replace_in_file(self, os.path.join(self._source_subfolder, "CMakeLists.txt"),

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -366,7 +366,7 @@ class SDLConan(ConanFile):
             self.copy(pattern="COPYING.txt", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        rm(self, os.path.join(self.package_folder, "bin"), "sdl2-config")
+        rm(self, "sdl2-config", os.path.join(self.package_folder, "bin"))
         rmdir(self, os.path.join(self.package_folder, "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -423,7 +423,7 @@ class SDLConan(ConanFile):
                 self.cpp_info.components["libsdl2"].requires.append("egl::egl")
             if self.options.libunwind:
                 self.cpp_info.components["libsdl2"].requires.append("libunwind::libunwind")
-        elif tools.is_apple_os(self.settings.os):
+        elif tools.is_apple_os(self.settings.os) and not self.options.shared:
             self.cpp_info.components["libsdl2"].frameworks = [
                 "CoreVideo", "CoreAudio", "AudioToolbox",
                 "AVFoundation", "Foundation", "QuartzCore",

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -428,6 +428,7 @@ class SDLConan(ConanFile):
                 "CoreVideo", "CoreAudio", "AudioToolbox",
                 "AVFoundation", "Foundation", "QuartzCore",
             ]
+            add_core_haptics = False
             if self.settings.os == "Macos":
                 self.cpp_info.components["libsdl2"].frameworks.extend(["Cocoa", "Carbon", "IOKit", "ForceFeedback"])
                 if tools.Version(self.version) >= "2.0.18":
@@ -435,12 +436,16 @@ class SDLConan(ConanFile):
             elif self.settings.os in ["iOS", "tvOS", "watchOS"]:
                 self.cpp_info.components["libsdl2"].frameworks.extend([
                     "UIKit", "OpenGLES", "GameController", "CoreMotion",
-                    "CoreGraphics", "CoreBluetooth", "CoreHaptics",
+                    "CoreGraphics", "CoreBluetooth",
                 ])
+                add_core_haptics = True
             if tools.Version(self.version) >= "2.0.14":
                 self.cpp_info.components["libsdl2"].frameworks.append("Metal")
             if tools.Version(self.version) >= "2.0.18":
-                self.cpp_info.components["libsdl2"].frameworks.append("CoreHaptics")
+                add_core_haptics = True
+            if add_core_haptics:
+                self.cpp_info.components["libsdl2"].sharedlinkflags.append("-Wl,-weak_framework,CoreHaptics")
+                self.cpp_info.components["libsdl2"].exelinkflags.append("-Wl,-weak_framework,CoreHaptics")
         elif self.settings.os == "Windows":
             self.cpp_info.components["libsdl2"].system_libs = ["user32", "gdi32", "winmm", "imm32", "ole32", "oleaut32", "version", "uuid", "advapi32", "setupapi", "shell32"]
             if self.settings.compiler == "gcc":

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -1,8 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
-from conan.tools.files import get, replace_in_file, rm, rmdir
-from conan.tools.files import patch
+from conan.tools.files import apply_conandata_patches, get, replace_in_file, rm, rmdir
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 from conans import CMake, tools

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -182,7 +182,7 @@ class SDLConan(ConanFile):
 
     def _patch_sources(self):
         for data in self.conan_data.get("patches", {}).get(self.version, []):
-            patch(**data)
+            patch(self, **data)
 
         replace_in_file(self, os.path.join(self._source_subfolder, "CMakeLists.txt"),
                         'check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)',

--- a/recipes/sdl/all/conanfile.py
+++ b/recipes/sdl/all/conanfile.py
@@ -182,7 +182,7 @@ class SDLConan(ConanFile):
 
     def _patch_sources(self):
         for data in self.conan_data.get("patches", {}).get(self.version, []):
-            apply_patch(**patch)
+            patch(**data)
 
         replace_in_file(self, os.path.join(self._source_subfolder, "CMakeLists.txt"),
                         'check_library_exists(c iconv_open "" HAVE_BUILTIN_ICONV)',


### PR DESCRIPTION
Specify library name and version:  **sdl/2.0.20**

- shared library no longer enforces linked frameworks on consumers, as this info is already encoded in the library itself
- CoreHaptics appeared fairly recently (iOS 13 / macOS 10.15) and should be weakly linked to avoid "dylib not found" error when deploying to older OS versions
- also performed v2 migration based on linter report

Note that simple `-weak_framework CoreHaptics` doesn't work (as well as quoting it): it's translated into

    -weak_framework  -lCoreHaptics

Looks like something that should be adjusted in Conan.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
