### PR TITLE
cryptopp: update to 8.7.0

### DIFF
--- a/recipes/cryptopp/all/conandata.yml
+++ b/recipes/cryptopp/all/conandata.yml
@@ -4,8 +4,8 @@ sources:
       url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_7_0.tar.gz"
       sha256: "8d6a4064b8e9f34cd3e838f5a12c40067ee7b95ee37d9173ec273cb0913e7ca2"
     cmake:
-      url: "https://github.com/abdes/cryptopp-cmake/archive/26f786e98212f0e8c952df55a22d132458b5f78b.tar.gz"
-      sha256: "ffdb1db16983dc3d35f5210f442cb78d63fa7a64f0908b08d822f7b352b97c3f"
+      url: "https://github.com/abdes/cryptopp-cmake/archive/75db4db150f7b85a9a21069501b39e8652c5c2fd.tar.gz"
+      sha256: "20517438c56cb5eaf9bb3f7091ef1a427ad00978beffa99484db3bc21bdb03b6"
   "8.6.0":
     source:
       url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_6_0.tar.gz"

--- a/recipes/cryptopp/all/conandata.yml
+++ b/recipes/cryptopp/all/conandata.yml
@@ -4,8 +4,8 @@ sources:
       url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_7_0.tar.gz"
       sha256: "8d6a4064b8e9f34cd3e838f5a12c40067ee7b95ee37d9173ec273cb0913e7ca2"
     cmake:
-      url: "https://github.com/chausner/cryptopp-cmake/archive/764e1b804c0fcf8bbb85a4656e2bcc0f89b4261e.tar.gz"
-      sha256: "89ed6921dbe45e688a73782ac68c36f4a13f47b7c2ed18653e1304940e77bc45"
+      url: "https://github.com/abdes/cryptopp-cmake/archive/ff211af98505c260c1d3a36a8e36e563727b11ee.tar.gz"
+      sha256: "5a966e8a1af4aa39a4bc1f223562b4af97bd55385e9385b48b1f15fd0dc26b38"
   "8.6.0":
     source:
       url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_6_0.tar.gz"

--- a/recipes/cryptopp/all/conandata.yml
+++ b/recipes/cryptopp/all/conandata.yml
@@ -4,8 +4,8 @@ sources:
       url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_7_0.tar.gz"
       sha256: "8d6a4064b8e9f34cd3e838f5a12c40067ee7b95ee37d9173ec273cb0913e7ca2"
     cmake:
-      url: "https://github.com/abdes/cryptopp-cmake/archive/75db4db150f7b85a9a21069501b39e8652c5c2fd.tar.gz"
-      sha256: "20517438c56cb5eaf9bb3f7091ef1a427ad00978beffa99484db3bc21bdb03b6"
+      url: "https://github.com/abdes/cryptopp-cmake/archive/c7fa777bb92d2e6adc1d13bb9215790be0984cda.tar.gz"
+      sha256: "f85294b27650abee4bd33962f947d972e5b033b7c573fb9259d149b2bf5e1497"
   "8.6.0":
     source:
       url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_6_0.tar.gz"

--- a/recipes/cryptopp/all/conandata.yml
+++ b/recipes/cryptopp/all/conandata.yml
@@ -1,4 +1,11 @@
 sources:
+  "8.7.0":
+    source:
+      url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_7_0.tar.gz"
+      sha256: "8d6a4064b8e9f34cd3e838f5a12c40067ee7b95ee37d9173ec273cb0913e7ca2"
+    cmake:
+      url: "https://github.com/abdes/cryptopp-cmake/archive/26f786e98212f0e8c952df55a22d132458b5f78b.tar.gz"
+      sha256: "ffdb1db16983dc3d35f5210f442cb78d63fa7a64f0908b08d822f7b352b97c3f"
   "8.6.0":
     source:
       url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_6_0.tar.gz"

--- a/recipes/cryptopp/all/conandata.yml
+++ b/recipes/cryptopp/all/conandata.yml
@@ -4,8 +4,8 @@ sources:
       url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_7_0.tar.gz"
       sha256: "8d6a4064b8e9f34cd3e838f5a12c40067ee7b95ee37d9173ec273cb0913e7ca2"
     cmake:
-      url: "https://github.com/abdes/cryptopp-cmake/archive/c7fa777bb92d2e6adc1d13bb9215790be0984cda.tar.gz"
-      sha256: "f85294b27650abee4bd33962f947d972e5b033b7c573fb9259d149b2bf5e1497"
+      url: "https://github.com/chausner/cryptopp-cmake/archive/764e1b804c0fcf8bbb85a4656e2bcc0f89b4261e.tar.gz"
+      sha256: "89ed6921dbe45e688a73782ac68c36f4a13f47b7c2ed18653e1304940e77bc45"
   "8.6.0":
     source:
       url: "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_6_0.tar.gz"

--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -133,7 +133,10 @@ class CryptoPPConan(ConanFile):
                 dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
-        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        if Version(self.version) < "8.7.0":
+            rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        else:
+            rmdir(self, os.path.join(self.package_folder, "share"))
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self._create_cmake_module_alias_targets(
             os.path.join(self.package_folder, self._module_file_rel_path),

--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -128,9 +128,6 @@ class CryptoPPConan(ConanFile):
 
     def package(self):
         copy(self, "License.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        if Version(self.version) >= "8.7.0":
-            copy(self, "LICENSE", src=os.path.join(self.source_folder, "cryptopp-cmake"),
-                dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
         if Version(self.version) < "8.7.0":

--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -36,10 +36,6 @@ class CryptoPPConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
-    def build_requirements(self):
-        if Version(self.version) >= "8.7.0":
-            self.tool_requires("cmake/3.21.0")
-
     def validate(self):
         if self.options.shared and Version(self.version) >= "8.7.0":
             raise ConanInvalidConfiguration("cryptopp 8.7.0 and higher do not support shared builds")

--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -36,6 +36,10 @@ class CryptoPPConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def build_requirements(self):
+        if Version(self.version) >= "8.7.0":
+            self.tool_requires("cmake/3.21.0")
+
     def validate(self):
         if self.options.shared and Version(self.version) >= "8.7.0":
             raise ConanInvalidConfiguration("cryptopp 8.7.0 and higher do not support shared builds")

--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -91,8 +91,6 @@ class CryptoPPConan(ConanFile):
             tc.cache_variables["CRYPTOPP_USE_INTERMEDIATE_OBJECTS_TARGET"] = False
             if self.settings.os == "Android":
                 tc.cache_variables["CRYPTOPP_NATIVE_ARCH"] = True
-            if self.settings.os == "Macos" and self.settings.arch == "armv8" and Version(self.version) <= "8.4.0":
-                tc.cache_variables["CMAKE_CXX_FLAGS"] = "-march=armv8-a"
         tc.generate()
 
     def _patch_sources(self):
@@ -126,8 +124,9 @@ class CryptoPPConan(ConanFile):
 
     def package(self):
         copy(self, "License.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        copy(self, "LICENSE", src=os.path.join(self.source_folder, "cryptopp-cmake"),
-             dst=os.path.join(self.package_folder, "licenses"))
+        if Version(self.version) >= "8.7.0":
+            copy(self, "LICENSE", src=os.path.join(self.source_folder, "cryptopp-cmake"),
+                dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))

--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, collect_libs, copy, get, rename, replace_in_file, rmdir, save
 from conan.tools.scm import Version
@@ -35,6 +36,10 @@ class CryptoPPConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def validate(self):
+        if self.options.shared and Version(self.version) >= "8.7.0":
+            raise ConanInvalidConfiguration("cryptopp 8.7.0 and higher do not support shared builds")
+
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
@@ -43,36 +48,51 @@ class CryptoPPConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def source(self):
-        # Get sources
+        # Get cryptopp sources
         get(self, **self.conan_data["sources"][self.version]["source"],
             destination=self.source_folder, strip_root=True)
 
-        # Get CMakeLists
-        base_source_dir = os.path.join(self.source_folder, os.pardir)
-        get(self, **self.conan_data["sources"][self.version]["cmake"], destination=base_source_dir)
-        src_folder = os.path.join(
-            base_source_dir,
-            f"cryptopp-cmake-CRYPTOPP_{self.version.replace('.', '_')}",
-        )
-        for file in ("CMakeLists.txt", "cryptopp-config.cmake"):
-            rename(self, src=os.path.join(src_folder, file), dst=os.path.join(self.source_folder, file))
-        rmdir(self, src_folder)
+        if Version(self.version) < "8.7.0":
+            # Get CMakeLists
+            base_source_dir = os.path.join(self.source_folder, os.pardir)
+            get(self, **self.conan_data["sources"][self.version]["cmake"], destination=base_source_dir)
+            src_folder = os.path.join(
+                base_source_dir,
+                f"cryptopp-cmake-CRYPTOPP_{self.version.replace('.', '_')}",
+            )
+            for file in ("CMakeLists.txt", "cryptopp-config.cmake"):
+                rename(self, src=os.path.join(src_folder, file), dst=os.path.join(self.source_folder, file))
+            rmdir(self, src_folder)
+        else:
+            # Get cryptopp-cmake sources
+            get(self, **self.conan_data["sources"][self.version]["cmake"],
+                destination=os.path.join(self.source_folder, "cryptopp-cmake"), strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["BUILD_STATIC"] = not self.options.shared
-        tc.variables["BUILD_SHARED"] = self.options.shared
-        tc.variables["BUILD_TESTING"] = False
-        tc.variables["BUILD_DOCUMENTATION"] = False
-        tc.variables["USE_INTERMEDIATE_OBJECTS_TARGET"] = False
-        if self.settings.os == "Android":
-            tc.variables["CRYPTOPP_NATIVE_ARCH"] = True
-        if self.settings.os == "Macos" and self.settings.arch == "armv8" and Version(self.version) <= "8.4.0":
-            tc.variables["CMAKE_CXX_FLAGS"] = "-march=armv8-a"
-        # For msvc shared
-        tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
-        # Relocatable shared libs on macOS
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        if Version(self.version) < "8.7.0":
+            tc.variables["BUILD_STATIC"] = not self.options.shared
+            tc.variables["BUILD_SHARED"] = self.options.shared
+            tc.variables["BUILD_TESTING"] = False
+            tc.variables["BUILD_DOCUMENTATION"] = False
+            tc.variables["USE_INTERMEDIATE_OBJECTS_TARGET"] = False
+            if self.settings.os == "Android":
+                tc.variables["CRYPTOPP_NATIVE_ARCH"] = True
+            if self.settings.os == "Macos" and self.settings.arch == "armv8" and Version(self.version) <= "8.4.0":
+                tc.variables["CMAKE_CXX_FLAGS"] = "-march=armv8-a"
+            # For msvc shared
+            tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
+            # Relocatable shared libs on macOS
+            tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        else:
+            tc.cache_variables["CRYPTOPP_SOURCES"] = self.source_folder
+            tc.cache_variables["CRYPTOPP_BUILD_TESTING"] = False
+            tc.cache_variables["CRYPTOPP_BUILD_DOCUMENTATION"] = False
+            tc.cache_variables["CRYPTOPP_USE_INTERMEDIATE_OBJECTS_TARGET"] = False
+            if self.settings.os == "Android":
+                tc.cache_variables["CRYPTOPP_NATIVE_ARCH"] = True
+            if self.settings.os == "Macos" and self.settings.arch == "armv8" and Version(self.version) <= "8.4.0":
+                tc.cache_variables["CMAKE_CXX_FLAGS"] = "-march=armv8-a"
         tc.generate()
 
     def _patch_sources(self):
@@ -88,17 +108,26 @@ class CryptoPPConan(ConanFile):
                     dst=self.source_folder,
                 )
         # Honor fPIC option
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                              "SET(CMAKE_POSITION_INDEPENDENT_CODE 1)", "")
+        if Version(self.version) < "8.7.0":
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                                "SET(CMAKE_POSITION_INDEPENDENT_CODE 1)", "")
+        else:
+            replace_in_file(self, os.path.join(self.source_folder, "cryptopp-cmake", "cryptopp", "CMakeLists.txt"),
+                                "set(CMAKE_POSITION_INDEPENDENT_CODE 1)", "")
 
     def build(self):
         self._patch_sources()
         cmake = CMake(self)
-        cmake.configure()
+        if Version(self.version) < "8.7.0":
+            cmake.configure()
+        else:
+            cmake.configure(build_script_folder="cryptopp-cmake")
         cmake.build()
 
     def package(self):
         copy(self, "License.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "LICENSE", src=os.path.join(self.source_folder, "cryptopp-cmake"),
+             dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))

--- a/recipes/cryptopp/config.yml
+++ b/recipes/cryptopp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.7.0":
+    folder: "all"
   "8.6.0":
     folder: "all"
   "8.5.0":


### PR DESCRIPTION
Specify library name and version:  **cryptopp/8.7.0**

This updates the recipe for cryptopp to the latest version (8.7.0). The CMake wrapper repo has been changed from `noloader/cryptopp-cmake` to `abdes/cryptopp-cmake` since the former is [no longer maintained](https://github.com/noloader/cryptopp-cmake#important) anymore and the latter is recommended by the maintainers now.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
