### PR TITLE
migrate access_private to conan v2

### DIFF
--- a/recipes/access_private/all/conanfile.py
+++ b/recipes/access_private/all/conanfile.py
@@ -3,6 +3,8 @@ import os
 from conan import ConanFile, tools
 
 
+required_conan_version = "1.50.0"
+
 class AccessPrivateConan(ConanFile):
     name = "access_private"
     description = "Access private members and statics of a C++ class"

--- a/recipes/access_private/all/conanfile.py
+++ b/recipes/access_private/all/conanfile.py
@@ -1,6 +1,6 @@
 import os
 
-from conans import ConanFile, tools
+from conan import ConanFile, tools
 
 
 class AccessPrivateConan(ConanFile):
@@ -19,10 +19,10 @@ class AccessPrivateConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 11)
+            tools.build.check_min_cppstd(self, 11)
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
+        tools.files.get(self, **self.conan_data["sources"][self.version])
         url = self.conan_data["sources"][self.version]["url"]
         extracted_dir = "access_private-" + \
             os.path.splitext(os.path.basename(url))[0]

--- a/recipes/access_private/all/test_package/conanfile.py
+++ b/recipes/access_private/all/test_package/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
-from conans import ConanFile, CMake, tools
+from conan import ConanFile, tools
+from conans import CMake
 
 
 class TestPackageConan(ConanFile):
@@ -13,6 +14,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.build.cross_building(self, self.settings):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/access_private/all/test_package/conanfile.py
+++ b/recipes/access_private/all/test_package/conanfile.py
@@ -14,6 +14,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.build.cross_building(self, self.settings):
+        if not tools.build.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
This conan v2 migration PR was generated by automatoc script version 4.
It uses simple find and replace technics. Feel free to extend it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
