### PR TITLE
sqlite3: full conan v2 support

### DIFF
--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -37,7 +37,7 @@ set(MAX_BLOB_SIZE CACHE STRING "Set the maximum number of bytes in a string or B
 option(DISABLE_DEFAULT_VFS "Disable default VFS implementation")
 option(ENABLE_DBPAGE_VTAB "The SQLITE_DBPAGE extension implements an eponymous-only virtual table that provides direct access to the underlying database file by interacting with the pager. SQLITE_DBPAGE is capable of both reading and writing any page of the database. Because interaction is through the pager layer, all changes are transactional.")
 
-add_library(${PROJECT_NAME} src/sqlite3.c)
+add_library(${PROJECT_NAME} ${SQLITE3_SRC_DIR}/sqlite3.c)
 set_target_properties(${PROJECT_NAME} PROPERTIES C_VISIBILITY_PRESET hidden)
 if(BUILD_SHARED_LIBS)
     if(WIN32)
@@ -162,11 +162,11 @@ install(TARGETS ${PROJECT_NAME}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-install(DIRECTORY src/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+install(DIRECTORY ${SQLITE3_SRC_DIR}/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING PATTERN "*.h")
 
 if(SQLITE3_BUILD_EXECUTABLE)
-    add_executable(sqlite3-bin src/shell.c)
+    add_executable(sqlite3-bin ${SQLITE3_SRC_DIR}/shell.c)
     target_link_libraries(sqlite3-bin PRIVATE ${PROJECT_NAME})
     if(ENABLE_DBPAGE_VTAB)
         target_compile_definitions(sqlite3-bin PRIVATE SQLITE_ENABLE_DBPAGE_VTAB)
@@ -177,8 +177,5 @@ if(SQLITE3_BUILD_EXECUTABLE)
     if(NOT HAVE_SYSTEM)
         target_compile_definitions(sqlite3-bin PRIVATE SQLITE_NOHAVE_SYSTEM)
     endif()
-    install(TARGETS sqlite3-bin
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR}
-    )
+    install(TARGETS sqlite3-bin DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/recipes/sqlite3/all/conanfile.py
+++ b/recipes/sqlite3/all/conanfile.py
@@ -1,13 +1,13 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import get, load, save
 from conan.tools.scm import Version
-from conans import tools as tools_legacy
 import os
 import textwrap
 
-required_conan_version = ">=1.47.0"
+required_conan_version = ">=1.51.3"
 
 
 class Sqlite3Conan(ConanFile):
@@ -142,7 +142,7 @@ class Sqlite3Conan(ConanFile):
         tc.variables["HAVE_FDATASYNC"] = True
         tc.variables["HAVE_GMTIME_R"] = True
         tc.variables["HAVE_LOCALTIME_R"] = self.settings.os != "Windows"
-        tc.variables["HAVE_POSIX_FALLOCATE"] = not (self.settings.os in ["Windows", "Android"] or tools_legacy.is_apple_os(self.settings.os))
+        tc.variables["HAVE_POSIX_FALLOCATE"] = not (self.settings.os in ["Windows", "Android"] or is_apple_os(self))
         tc.variables["HAVE_STRERROR_R"] = True
         tc.variables["HAVE_USLEEP"] = True
         tc.variables["DISABLE_GETHOSTUUID"] = self.options.disable_gethostuuid

--- a/recipes/sqlite3/all/conanfile.py
+++ b/recipes/sqlite3/all/conanfile.py
@@ -118,6 +118,7 @@ class Sqlite3Conan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.variables["SQLITE3_SRC_DIR"] = self.source_folder.replace("\\", "/")
         tc.variables["SQLITE3_VERSION"] = self.version
         tc.variables["SQLITE3_BUILD_EXECUTABLE"] = self.options.build_executable
         tc.variables["THREADSAFE"] = self.options.threadsafe

--- a/recipes/sqlite3/all/conanfile.py
+++ b/recipes/sqlite3/all/conanfile.py
@@ -93,13 +93,13 @@ class Sqlite3Conan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
         try:
-           del self.settings.compiler.libcxx
+            del self.settings.compiler.libcxx
         except Exception:
-           pass
+            pass
         try:
-           del self.settings.compiler.cppstd
+            del self.settings.compiler.cppstd
         except Exception:
-           pass
+            pass
 
     def validate(self):
         if self.info.options.build_executable:


### PR DESCRIPTION
This PR replaces the last conan v1 tool (conans.tools.is_apple_os) by its conan v2 counterpart.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
