### PR TITLE
boost-ext-ut: Default disable_module option in config_options method

### DIFF
--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -60,7 +60,7 @@ class UTConan(ConanFile):
 
         if is_msvc(self) and not self.options.get_safe("disable_module"):
             raise ConanInvalidConfiguration("The 'disable_module' option must be enabled when using MSVC.")
-        is not is_msvc(self):
+        if not is_msvc(self):
             min_version = self._minimum_compilers_version.get(
                 str(self.settings.compiler))
             if not min_version:

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -50,7 +50,7 @@ class UTConan(ConanFile):
         cmake_layout(self)
 
     def validate(self):
-        if self.info.settings.compiler.get_safe("cppstd"):
+        if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
         if Version(self.version) <= "1.1.8" and is_msvc(self):
             raise ConanInvalidConfiguration(f"{self.name} version 1.1.8 may not be built with MSVC. "

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -60,7 +60,7 @@ class UTConan(ConanFile):
 
         if is_msvc(self) and not self.options.get_safe("disable_module"):
             raise ConanInvalidConfiguration("The 'disable_module' option must be enabled when using MSVC.")
-        else:
+        is not is_msvc(self):
             min_version = self._minimum_compilers_version.get(
                 str(self.settings.compiler))
             if not min_version:

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -58,7 +58,7 @@ class UTConan(ConanFile):
 
         check_min_vs(self, "192")
 
-        if is_msvc(self) and "disable_module" in self.options.values:
+        if is_msvc(self) and not self.options.get_safe("disable_module"):
             raise ConanInvalidConfiguration("The 'disable_module' option must be enabled when using MSVC.")
         else:
             min_version = self._minimum_compilers_version.get(

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -67,9 +67,7 @@ class UTConan(ConanFile):
     def config_options(self):
         if Version(self.version) <= "1.1.8":
             del self.options.disable_module
-
-    def configure(self):
-        if is_msvc(self) and "disable_module" in self.options.values:
+        elif is_msvc(self):
             self.options.disable_module = True
 
     def source(self):

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -58,8 +58,10 @@ class UTConan(ConanFile):
 
         check_min_vs(self, "192")
 
-        if is_msvc(self) and not self.options.get_safe("disable_module"):
-            raise ConanInvalidConfiguration("The 'disable_module' option must be enabled when using MSVC.")
+        if is_msvc(self):
+            check_min_vs(self, "192")
+            if not self.options.get_safe("disable_module", True):
+                self.output.warn("The 'disable_module' option must be enabled when using MSVC.")
         if not is_msvc(self):
             min_version = self._minimum_compilers_version.get(
                 str(self.settings.compiler))

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -56,8 +56,6 @@ class UTConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.name} version 1.1.8 may not be built with MSVC. "
                                             "Please use at least version 1.1.9 with MSVC.")
 
-        check_min_vs(self, "192")
-
         if is_msvc(self):
             check_min_vs(self, "192")
             if not self.options.get_safe("disable_module", True):


### PR DESCRIPTION
Specify library name and version:  **boost-ext-ut/***

This allows overriding the default value for the option `disable_module`.

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
