### PR TITLE
brotli: Add configuration options

### DIFF
--- a/recipes/brotli/all/conanfile.py
+++ b/recipes/brotli/all/conanfile.py
@@ -107,24 +107,6 @@ class BrotliConan(ConanFile):
         self.cpp_info.components["brotlicommon"].set_property("pkg_config_name", "libbrotlicommon")
         self.cpp_info.components["brotlicommon"].includedirs.append(includedir)
         self.cpp_info.components["brotlicommon"].libs = [self._get_decorated_lib("brotlicommon")]
-        if self.options.get_safe("target_bits") == 32:
-            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_32_BIT")
-        if self.options.get_safe("target_bits") == 64:
-            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_64_BIT")
-        if self.options.get_safe("endianness") == "big":
-            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_BIG_ENDIAN")
-        if self.options.get_safe("endianness") == "neutral":
-            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_ENDIAN_NEUTRAL")
-        if self.options.get_safe("endianness") == "little":
-            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_LITTLE_ENDIAN")
-        if self.options.enable_portable:
-            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_PORTABLE")
-        if not(self.options.enable_rbit):
-            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_NO_RBIT")
-        if self.options.enable_debug:
-            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_DEBUG")
-        if self.options.enable_log:
-            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_ENABLE_LOG")
         if self.settings.os == "Windows" and self.options.shared:
             self.cpp_info.components["brotlicommon"].defines.append("BROTLI_SHARED_COMPILATION")
         # brotlidec

--- a/recipes/brotli/all/conanfile.py
+++ b/recipes/brotli/all/conanfile.py
@@ -18,10 +18,22 @@ class BrotliConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "target_bits": [64, 32, None],
+        "endianness": ["big", "little", "neutral", None],
+        "enable_portable": [True, False],
+        "enable_rbit": [True, False],
+        "enable_debug": [True, False],
+        "enable_log": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "target_bits": None,
+        "endianness": None,
+        "enable_portable": False,
+        "enable_rbit": True,
+        "enable_debug": False,
+        "enable_log": False,
     }
 
     def export_sources(self):
@@ -55,6 +67,24 @@ class BrotliConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["BROTLI_BUNDLED_MODE"] = False
         tc.variables["BROTLI_DISABLE_TESTS"] = True
+        if self.options.get_safe("target_bits") == 32:
+            tc.preprocessor_definitions["BROTLI_BUILD_32_BIT"] = 1
+        elif self.options.get_safe("target_bits") == 64:
+            tc.preprocessor_definitions["BROTLI_BUILD_64_BIT"] = 1
+        if self.options.get_safe("endianness") == "big":
+            tc.preprocessor_definitions["BROTLI_BUILD_BIG_ENDIAN"] = 1
+        elif self.options.get_safe("endianness") == "neutral":
+            tc.preprocessor_definitions["BROTLI_BUILD_ENDIAN_NEUTRAL"] = 1
+        elif self.options.get_safe("endianness") == "little":
+            tc.preprocessor_definitions["BROTLI_BUILD_LITTLE_ENDIAN"] = 1
+        if self.options.enable_portable:
+            tc.preprocessor_definitions["BROTLI_BUILD_PORTABLE"] = 1
+        if not(self.options.enable_rbit):
+            tc.preprocessor_definitions["BROTLI_BUILD_NO_RBIT"] = 1
+        if self.options.enable_debug:
+            tc.preprocessor_definitions["BROTLI_DEBUG"] = 1
+        if self.options.enable_log:
+            tc.preprocessor_definitions["BROTLI_ENABLE_LOG"] = 1
         # To install relocatable shared libs on Macos
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
         tc.generate()
@@ -77,6 +107,24 @@ class BrotliConan(ConanFile):
         self.cpp_info.components["brotlicommon"].set_property("pkg_config_name", "libbrotlicommon")
         self.cpp_info.components["brotlicommon"].includedirs.append(includedir)
         self.cpp_info.components["brotlicommon"].libs = [self._get_decorated_lib("brotlicommon")]
+        if self.options.get_safe("target_bits") == 32:
+            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_32_BIT")
+        if self.options.get_safe("target_bits") == 64:
+            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_64_BIT")
+        if self.options.get_safe("endianness") == "big":
+            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_BIG_ENDIAN")
+        if self.options.get_safe("endianness") == "neutral":
+            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_ENDIAN_NEUTRAL")
+        if self.options.get_safe("endianness") == "little":
+            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_LITTLE_ENDIAN")
+        if self.options.enable_portable:
+            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_PORTABLE")
+        if not(self.options.enable_rbit):
+            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_BUILD_NO_RBIT")
+        if self.options.enable_debug:
+            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_DEBUG")
+        if self.options.enable_log:
+            self.cpp_info.components["brotlicommon"].defines.append("BROTLI_ENABLE_LOG")
         if self.settings.os == "Windows" and self.options.shared:
             self.cpp_info.components["brotlicommon"].defines.append("BROTLI_SHARED_COMPILATION")
         # brotlidec

--- a/recipes/brotli/all/conanfile.py
+++ b/recipes/brotli/all/conanfile.py
@@ -79,7 +79,7 @@ class BrotliConan(ConanFile):
             tc.preprocessor_definitions["BROTLI_BUILD_LITTLE_ENDIAN"] = 1
         if self.options.enable_portable:
             tc.preprocessor_definitions["BROTLI_BUILD_PORTABLE"] = 1
-        if not(self.options.enable_rbit):
+        if not self.options.enable_rbit:
             tc.preprocessor_definitions["BROTLI_BUILD_NO_RBIT"] = 1
         if self.options.enable_debug:
             tc.preprocessor_definitions["BROTLI_DEBUG"] = 1


### PR DESCRIPTION
Specify library name and version:  **brotli/1.0.9**

We'd like to use configuration options in brotli, so I made [these options](https://github.com/google/brotli/blob/v1.0.9/c/common/platform.h#L10-L20) configurable.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
