### PR TITLE
Added tixi3 3.3.0 conan package

### DIFF
--- a/recipes/tixi3/all/conandata.yml
+++ b/recipes/tixi3/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "3.3.0":
+    sha256: "988d79ccd53c815d382cff0c244c0bb8e393986377dfb45385792766adf6f6a9"
+    url: "https://github.com/DLR-SC/tixi/archive/refs/tags/v3.3.0.tar.gz"
+patches:
+  "3.3.0":
+     - patch_file: "patches/link_curl.patch"

--- a/recipes/tixi3/all/conandata.yml
+++ b/recipes/tixi3/all/conandata.yml
@@ -5,4 +5,8 @@ sources:
 patches:
   "3.3.0":
     - patch_file: "patches/link_curl.patch"
+      patch_description: "Fix CMake target name for libcurl"
+      patch_type: "conan"
     - patch_file: "patches/disable_tixi_examples.patch"
+      patch_description: "Keep build examples as optional"
+      patch_type: "conan"

--- a/recipes/tixi3/all/conandata.yml
+++ b/recipes/tixi3/all/conandata.yml
@@ -4,4 +4,4 @@ sources:
     url: "https://github.com/DLR-SC/tixi/archive/refs/tags/v3.3.0.tar.gz"
 patches:
   "3.3.0":
-     - patch_file: "patches/link_curl.patch"
+    - patch_file: "patches/link_curl.patch"

--- a/recipes/tixi3/all/conandata.yml
+++ b/recipes/tixi3/all/conandata.yml
@@ -5,3 +5,4 @@ sources:
 patches:
   "3.3.0":
     - patch_file: "patches/link_curl.patch"
+    - patch_file: "patches/disable_tixi_examples.patch"

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -77,7 +77,7 @@ class Tixi3Conan(ConanFile):
         files.rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.includedirs = ['include/tixi3']
+        self.cpp_info.includedirs.append(os.path.join("include", "tixi3"))
         self.cpp_info.libs = ['tixi3']
 
         if self.settings.os == "Windows":

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan.tools.cmake import CMake
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps
 from conan.tools import files
 from conan import ConanFile
 import os
@@ -25,7 +25,12 @@ class Tixi3Conan(ConanFile):
     }
 
     source_subfolder = "_src_"
-    generators = ["CMakeDeps", "CMakeToolchain"]
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def requirements(self):
         self.requires("libxml2/2.9.14")

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -46,17 +46,21 @@ class Tixi3Conan(ConanFile):
 
     def export_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+            self.copy(patch["patch_file"], src=self.recipe_folder, dst=self.export_sources_folder)
 
     def source(self):
         files.get(self, **self.conan_data["sources"][self.version],
                   strip_root=True, destination=self.source_subfolder)
+
+    def _patch_source(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             files.patch(self,
                 patch_file=patch["patch_file"],
                 base_path=self.source_subfolder)
 
     def build(self):
+        self._patch_source()
+
         cmake = CMake(self)
         cmake.configure(build_script_folder=self.source_subfolder)
         cmake.build()

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -106,7 +106,11 @@ class Tixi3Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.includedirs.append(os.path.join("include", "tixi3"))
-        self.cpp_info.libs = ['tixi3']
+
+        if self.settings.build_type != "Debug":
+            self.cpp_info.libs = ['tixi3']
+        else:
+            self.cpp_info.libs = ['tixi3-d']
 
         if self.settings.os == "Windows":
             self.cpp_info.system_libs = ['Shlwapi']

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -11,11 +11,10 @@ required_conan_version = ">=1.45.0"
 class Tixi3Conan(ConanFile):
     name = "tixi3"
     url = "https://github.com/conan-io/conan-center-index"
-    description = "libxslt is a software library implementing XSLT processor, based on libxml2"
+    description = "A simple xml interface based on libxml2 and libxslt"
     topics = ("tixi3", "xml")
-    homepage = "https://xmlsoft.org"
-    license = "MIT"
-    # version = "3.3.0"
+    homepage = "https://github.com/DLR-SC/tixi"
+    license = "Apache-2.0"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -26,14 +25,14 @@ class Tixi3Conan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-    
-    source_subfolder="_src_"
-    generators=["CMakeDeps", "CMakeToolchain"]
 
-    @property
+    source_subfolder = "_src_"
+    generators = ["CMakeDeps", "CMakeToolchain"]
 
-    def _build_subfolder(self):
-        return "build_subfolder"
+    def requirements(self):
+        self.requires("libxml2/2.9.14")
+        self.requires("libxslt/1.1.34")
+        self.requires("libcurl/7.84.0")
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -42,26 +41,23 @@ class Tixi3Conan(ConanFile):
     def configure(self):
         # tixi is a c library
         del self.settings.compiler.libcxx
-        
+
         if self.options.shared:
             del self.options.fPIC
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
-    def requirements(self):
-        self.requires("libxml2/2.9.14")
-        self.requires("libxslt/1.1.34")
-        self.requires("libcurl/7.84.0")
-
     def export_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
             self.copy(patch["patch_file"])
 
-
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self.source_subfolder)
+        tools.get(**self.conan_data["sources"][self.version],
+                  strip_root=True, destination=self.source_subfolder)
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(patch_file=patch["patch_file"], base_path=self.source_subfolder)
+            tools.patch(
+                patch_file=patch["patch_file"],
+                base_path=self.source_subfolder)
 
     def build(self):
         cmake = CMake(self)
@@ -71,21 +67,20 @@ class Tixi3Conan(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
-        
+
         # remove package generated cmake config files
         tools.rmdir(os.path.join(self.package_folder, "lib", "tixi3"))
-        
+
         # copy the LICENSE file
         self.copy("LICENSE", dst="licenses", src=self.source_subfolder)
-        
-        # remove share directory, which only contains documentation, expamples...
+
+        # remove share directory, which only contains documentation,
+        # expamples...
         tools.rmdir(os.path.join(self.package_folder, "share"))
 
-
-
     def package_info(self):
-        self.cpp_info.includedirs = ['include/tixi3'] 
-        self.cpp_info.libs = ['tixi3']  # The libs to link against
+        self.cpp_info.includedirs = ['include/tixi3']
+        self.cpp_info.libs = ['tixi3']
         self.cpp_info.set_property("cmake_target_aliases", ["tixi3"])
-        self.cpp_info.libdirs = ['lib']  # Directories where libraries can be found
-        self.cpp_info.bindirs = ['bin']  
+        self.cpp_info.libdirs = ['lib']
+        self.cpp_info.bindirs = ['bin']

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -93,5 +93,3 @@ class Tixi3Conan(ConanFile):
 
         self.cpp_info.set_property("cmake_file_name", "tixi3")
         self.cpp_info.set_property("cmake_target_name", "tixi3")
-        self.cpp_info.libdirs = ['lib']
-        self.cpp_info.bindirs = ['bin']

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -83,6 +83,7 @@ class Tixi3Conan(ConanFile):
         if self.settings.os == "Windows":
             self.cpp_info.system_libs = ['Shlwapi']
 
-        self.cpp_info.set_property("cmake_target_aliases", ["tixi3"])
+        self.cpp_info.set_property("cmake_file_name", "tixi3")
+        self.cpp_info.set_property("cmake_target_name", "tixi3")
         self.cpp_info.libdirs = ['lib']
         self.cpp_info.bindirs = ['bin']

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -62,7 +62,7 @@ class Tixi3Conan(ConanFile):
 
     def export_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"], src=self.recipe_folder, dst=self.export_sources_folder)
+            files.copy(self, patch["patch_file"], src=self.recipe_folder, dst=self.export_sources_folder)
 
     def source(self):
         files.get(self, **self.conan_data["sources"][self.version],
@@ -116,6 +116,8 @@ class Tixi3Conan(ConanFile):
 
         if self.settings.os == "Windows":
             self.cpp_info.system_libs = ['shlwapi']
+
+        self.cpp_info.frameworks.extend(["Foundation"])
 
         self.cpp_info.set_property("cmake_file_name", "tixi3")
         self.cpp_info.set_property("cmake_target_name", "tixi3")

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -39,11 +39,10 @@ class Tixi3Conan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        # tixi is a c library
-        del self.settings.compiler.libcxx
-
         if self.options.shared:
             del self.options.fPIC
+
+        # tixi is a c library
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -1,8 +1,6 @@
-from conan.tools.microsoft import is_msvc, msvc_runtime_flag
-from conans import ConanFile, tools
-from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conans.errors import ConanInvalidConfiguration
-import functools
+from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools import files
+from conan import ConanFile
 import os
 
 required_conan_version = ">=1.45.0"
@@ -51,10 +49,10 @@ class Tixi3Conan(ConanFile):
             self.copy(patch["patch_file"])
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
+        files.get(self, **self.conan_data["sources"][self.version],
                   strip_root=True, destination=self.source_subfolder)
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(
+            files.patch(self,
                 patch_file=patch["patch_file"],
                 base_path=self.source_subfolder)
 
@@ -68,14 +66,15 @@ class Tixi3Conan(ConanFile):
         cmake.install()
 
         # remove package generated cmake config files
-        tools.rmdir(os.path.join(self.package_folder, "lib", "tixi3"))
+        files.rmdir(self, 
+            os.path.join(self.package_folder, "lib", "tixi3"))
 
         # copy the LICENSE file
         self.copy("LICENSE", dst="licenses", src=self.source_subfolder)
 
         # remove share directory, which only contains documentation,
         # expamples...
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        files.rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.includedirs = ['include/tixi3']

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -44,11 +44,20 @@ class Tixi3Conan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except:
+                pass
 
         # tixi is a c library
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+        try:
+            del self.settings.compiler.libcxx
+        except:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except:
+            pass
 
     def export_sources(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -11,7 +11,7 @@ class Tixi3Conan(ConanFile):
     name = "tixi3"
     url = "https://github.com/conan-io/conan-center-index"
     description = "A simple xml interface based on libxml2 and libxslt"
-    topics = ("tixi3", "xml")
+    topics = ("xml", "xml2", "xslt")
     homepage = "https://github.com/DLR-SC/tixi"
     license = "Apache-2.0"
 
@@ -27,6 +27,7 @@ class Tixi3Conan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.variables["TIXI_BUILD_EXAMPLES"] = False
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
@@ -72,9 +73,7 @@ class Tixi3Conan(ConanFile):
         files.apply_conandata_patches(self)
 
         cmake = CMake(self)
-        cmake.configure(variables={
-            "TIXI_BUILD_EXAMPLES": "OFF"
-        })
+        cmake.configure()
         cmake.build()
 
     def _create_cmake_module_alias_targets(self, module_file, targets):

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -79,6 +79,10 @@ class Tixi3Conan(ConanFile):
     def package_info(self):
         self.cpp_info.includedirs = ['include/tixi3']
         self.cpp_info.libs = ['tixi3']
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs = ['Shlwapi']
+
         self.cpp_info.set_property("cmake_target_aliases", ["tixi3"])
         self.cpp_info.libdirs = ['lib']
         self.cpp_info.bindirs = ['bin']

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools import files
 from conan import ConanFile
 import os
@@ -24,8 +24,6 @@ class Tixi3Conan(ConanFile):
         "fPIC": True,
     }
 
-    source_subfolder = "_src_"
-
     def generate(self):
         tc = CMakeToolchain(self)
         tc.generate()
@@ -36,6 +34,9 @@ class Tixi3Conan(ConanFile):
         self.requires("libxml2/2.9.14")
         self.requires("libxslt/1.1.34")
         self.requires("libcurl/7.84.0")
+
+    def layout(self):
+        cmake_layout(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -55,19 +56,17 @@ class Tixi3Conan(ConanFile):
 
     def source(self):
         files.get(self, **self.conan_data["sources"][self.version],
-                  strip_root=True, destination=self.source_subfolder)
+                  strip_root=True, destination=self.export_sources_folder)
 
     def _patch_source(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            files.patch(self,
-                patch_file=patch["patch_file"],
-                base_path=self.source_subfolder)
+            files.patch(self, patch_file=patch["patch_file"])
 
     def build(self):
         self._patch_source()
 
         cmake = CMake(self)
-        cmake.configure(build_script_folder=self.source_subfolder)
+        cmake.configure()
         cmake.build()
 
     def package(self):
@@ -79,7 +78,7 @@ class Tixi3Conan(ConanFile):
             os.path.join(self.package_folder, "lib", "tixi3"))
 
         # copy the LICENSE file
-        self.copy("LICENSE", dst="licenses", src=self.source_subfolder)
+        self.copy("LICENSE", dst="licenses", src=self.export_sources_folder)
 
         # remove share directory, which only contains documentation,
         # expamples...

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -58,12 +58,8 @@ class Tixi3Conan(ConanFile):
         files.get(self, **self.conan_data["sources"][self.version],
                   strip_root=True, destination=self.export_sources_folder)
 
-    def _patch_source(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            files.patch(self, patch_file=patch["patch_file"])
-
     def build(self):
-        self._patch_source()
+        files.apply_conandata_patches(self)
 
         cmake = CMake(self)
         cmake.configure()

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -47,17 +47,17 @@ class Tixi3Conan(ConanFile):
         if self.options.shared:
             try:
                 del self.options.fPIC
-            except:
+            except Exception:
                 pass
 
         # tixi is a c library
         try:
             del self.settings.compiler.libcxx
-        except:
+        except Exception:
             pass
         try:
             del self.settings.compiler.cppstd
-        except:
+        except Exception:
             pass
 
     def export_sources(self):

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -1,0 +1,91 @@
+from conan.tools.microsoft import is_msvc, msvc_runtime_flag
+from conans import ConanFile, tools
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conans.errors import ConanInvalidConfiguration
+import functools
+import os
+
+required_conan_version = ">=1.45.0"
+
+
+class Tixi3Conan(ConanFile):
+    name = "tixi3"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "libxslt is a software library implementing XSLT processor, based on libxml2"
+    topics = ("tixi3", "xml")
+    homepage = "https://xmlsoft.org"
+    license = "MIT"
+    # version = "3.3.0"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    
+    source_subfolder="_src_"
+    generators=["CMakeDeps", "CMakeToolchain"]
+
+    @property
+
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        # tixi is a c library
+        del self.settings.compiler.libcxx
+        
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def requirements(self):
+        self.requires("libxml2/2.9.14")
+        self.requires("libxslt/1.1.34")
+        self.requires("libcurl/7.84.0")
+
+    def export_sources(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
+
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self.source_subfolder)
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(patch_file=patch["patch_file"], base_path=self.source_subfolder)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=self.source_subfolder)
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+        
+        # remove package generated cmake config files
+        tools.rmdir(os.path.join(self.package_folder, "lib", "tixi3"))
+        
+        # copy the LICENSE file
+        self.copy("LICENSE", dst="licenses", src=self.source_subfolder)
+        
+        # remove share directory, which only contains documentation, expamples...
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+
+
+    def package_info(self):
+        self.cpp_info.includedirs = ['include/tixi3'] 
+        self.cpp_info.libs = ['tixi3']  # The libs to link against
+        self.cpp_info.set_property("cmake_target_aliases", ["tixi3"])
+        self.cpp_info.libdirs = ['lib']  # Directories where libraries can be found
+        self.cpp_info.bindirs = ['bin']  

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -72,7 +72,9 @@ class Tixi3Conan(ConanFile):
         files.apply_conandata_patches(self)
 
         cmake = CMake(self)
-        cmake.configure()
+        cmake.configure(variables={
+            "TIXI_BUILD_EXAMPLES": "OFF"
+        })
         cmake.build()
 
     def _create_cmake_module_alias_targets(self, module_file, targets):

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -115,7 +115,7 @@ class Tixi3Conan(ConanFile):
             self.cpp_info.libs = ['tixi3-d']
 
         if self.settings.os == "Windows":
-            self.cpp_info.system_libs = ['Shlwapi']
+            self.cpp_info.system_libs = ['shlwapi']
 
         self.cpp_info.set_property("cmake_file_name", "tixi3")
         self.cpp_info.set_property("cmake_target_name", "tixi3")

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.cmake import CMake
 from conan.tools import files
 from conan import ConanFile
 import os

--- a/recipes/tixi3/all/conanfile.py
+++ b/recipes/tixi3/all/conanfile.py
@@ -56,7 +56,7 @@ class Tixi3Conan(ConanFile):
 
     def source(self):
         files.get(self, **self.conan_data["sources"][self.version],
-                  strip_root=True, destination=self.export_sources_folder)
+                  strip_root=True, destination=self.source_folder)
 
     def build(self):
         files.apply_conandata_patches(self)
@@ -69,15 +69,8 @@ class Tixi3Conan(ConanFile):
         cmake = CMake(self)
         cmake.install()
 
-        # remove package generated cmake config files
-        files.rmdir(self, 
-            os.path.join(self.package_folder, "lib", "tixi3"))
-
-        # copy the LICENSE file
-        self.copy("LICENSE", dst="licenses", src=self.export_sources_folder)
-
-        # remove share directory, which only contains documentation,
-        # expamples...
+        files.rmdir(self, os.path.join(self.package_folder, "lib", "tixi3"))
+        files.copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         files.rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):

--- a/recipes/tixi3/all/patches/disable_tixi_examples.patch
+++ b/recipes/tixi3/all/patches/disable_tixi_examples.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3ab74e9..39878ca 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -109,10 +109,15 @@ if(TIXI_BUILD_TESTS)
+ endif(TIXI_BUILD_TESTS)
+ 
+ #demos
+-add_subdirectory(examples/Demo)
+-if (TIXI_ENABLE_FORTRAN)
+-  add_subdirectory(examples/fortran77)
+-endif(TIXI_ENABLE_FORTRAN)
++option (TIXI_BUILD_EXAMPLES "Build tixi examples" ON)
++
++if (TIXI_BUILD_EXAMPLES)
++  add_subdirectory(examples/Demo)
++
++  if (TIXI_ENABLE_FORTRAN)
++    add_subdirectory(examples/fortran77)
++  endif(TIXI_ENABLE_FORTRAN)
++endif(TIXI_BUILD_EXAMPLES)
+ 
+ # create the doc
+ include(createDoc)

--- a/recipes/tixi3/all/patches/link_curl.patch
+++ b/recipes/tixi3/all/patches/link_curl.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 6a9c821..f1b62a7 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -20,7 +20,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fmessage-length=0")
+ endif()
+ 
+-set(TIXI_LIBS curllib LibXslt::LibXslt LibXml2::LibXml2)
++set(TIXI_LIBS CURL::libcurl LibXslt::LibXslt LibXml2::LibXml2)
+ if(WIN32)
+     set(TIXI_LIBS ${TIXI_LIBS} Shlwapi)
+ endif(WIN32)

--- a/recipes/tixi3/all/test_package/CMakeLists.txt
+++ b/recipes/tixi3/all/test_package/CMakeLists.txt
@@ -4,4 +4,4 @@ project(Tixi-Conan-TestPackage)
 find_package(tixi3 REQUIRED)
 
 add_executable(tixi3_conan_test main.cpp)
-target_link_libraries(tixi3_conan_test PRIVATE tixi3::tixi3)
+target_link_libraries(tixi3_conan_test PRIVATE tixi3)

--- a/recipes/tixi3/all/test_package/CMakeLists.txt
+++ b/recipes/tixi3/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.23)
+project(Tixi-Conan-TestPackage)
+
+find_package(tixi3 REQUIRED)
+
+add_executable(tixi3_conan_test main.cpp)
+target_link_libraries(tixi3_conan_test PRIVATE tixi3::tixi3)

--- a/recipes/tixi3/all/test_package/CMakeLists.txt
+++ b/recipes/tixi3/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(Tixi-Conan-TestPackage)
+project(Tixi-Conan-TestPackage CXX)
 
 find_package(tixi3 REQUIRED)
 

--- a/recipes/tixi3/all/test_package/CMakeLists.txt
+++ b/recipes/tixi3/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.12)
 project(Tixi-Conan-TestPackage)
 
 find_package(tixi3 REQUIRED)

--- a/recipes/tixi3/all/test_package/conanfile.py
+++ b/recipes/tixi3/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
 
-from conan import ConanFile, tools
+from conan import ConanFile
 from conan.tools.cmake import CMake
 from conan.tools.build import cross_building
 import os

--- a/recipes/tixi3/all/test_package/conanfile.py
+++ b/recipes/tixi3/all/test_package/conanfile.py
@@ -1,5 +1,7 @@
 
-from conans import ConanFile, CMake, tools
+from conan import ConanFile, tools
+from conan.tools.cmake import CMake
+from conan.tools.build import cross_building
 import os
 
 
@@ -13,6 +15,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not cross_building(self):
             bin_path = os.path.join(".", "tixi3_conan_test")
             self.run(bin_path, run_environment=True)

--- a/recipes/tixi3/all/test_package/conanfile.py
+++ b/recipes/tixi3/all/test_package/conanfile.py
@@ -19,4 +19,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            self.run(os.path.join(self.cpp.build.bindirs[0], "tixi3_conan_test"), env="conanrun")
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "tixi3_conan_test")
+            self.run(bin_path, run_environment=True)

--- a/recipes/tixi3/all/test_package/conanfile.py
+++ b/recipes/tixi3/all/test_package/conanfile.py
@@ -1,7 +1,7 @@
 
 from conan import ConanFile
-from conan.tools.cmake import CMake
-from conan.tools.build import cross_building
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
 import os
 
 
@@ -9,12 +9,14 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain"
 
+    def layout(self):
+        cmake_layout(self)
+
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
-            bin_path = os.path.join(".", "tixi3_conan_test")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "tixi3_conan_test"), env="conanrun")

--- a/recipes/tixi3/all/test_package/conanfile.py
+++ b/recipes/tixi3/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join(".", "tixi3_conan_test")
+            self.run(bin_path, run_environment=True)

--- a/recipes/tixi3/all/test_package/conanfile.py
+++ b/recipes/tixi3/all/test_package/conanfile.py
@@ -20,4 +20,4 @@ class TestPackageConan(ConanFile):
     def test(self):
         if can_run(self):
             bin_path = os.path.join(self.cpp.build.bindirs[0], "tixi3_conan_test")
-            self.run(bin_path, run_environment=True)
+            self.run(bin_path, env="conanrun")

--- a/recipes/tixi3/all/test_package/conanfile.py
+++ b/recipes/tixi3/all/test_package/conanfile.py
@@ -7,7 +7,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/tixi3/all/test_package/main.cpp
+++ b/recipes/tixi3/all/test_package/main.cpp
@@ -1,0 +1,19 @@
+#include <tixi.h>
+
+#include <iostream>
+
+int main()
+{
+    TixiDocumentHandle handle = -1;
+    char* str = nullptr;
+    
+    tixiCreateDocument("root", &handle);
+    
+    tixiAddTextElement(handle, "/root", "message", "This is a tixi test.");
+    
+    tixiExportDocumentAsString(handle, &str);
+    
+    std::cout << str << std::endl;
+    
+    tixiCloseDocument(handle);
+}

--- a/recipes/tixi3/all/test_package/main.cpp
+++ b/recipes/tixi3/all/test_package/main.cpp
@@ -5,7 +5,7 @@
 int main()
 {
     TixiDocumentHandle handle = -1;
-    char* str = nullptr;
+    char* str = NULL;
     
     tixiCreateDocument("root", &handle);
     

--- a/recipes/tixi3/all/test_package/main.cpp
+++ b/recipes/tixi3/all/test_package/main.cpp
@@ -16,4 +16,5 @@ int main()
     std::cout << str << std::endl;
     
     tixiCloseDocument(handle);
+    return 0;
 }

--- a/recipes/tixi3/all/test_v1_package/CMakeLists.txt
+++ b/recipes/tixi3/all/test_v1_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1.2)
-project(tixi3_conan_test)
+project(tixi3_conan_test CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)

--- a/recipes/tixi3/all/test_v1_package/CMakeLists.txt
+++ b/recipes/tixi3/all/test_v1_package/CMakeLists.txt
@@ -7,4 +7,4 @@ conan_basic_setup(TARGETS)
 find_package(tixi3 REQUIRED CONFIG)
 
 add_executable(tixi3_conan_test ../test_package/main.cpp)
-target_link_libraries(tixi3_conan_test tixi3::tixi3)
+target_link_libraries(tixi3_conan_test tixi3)

--- a/recipes/tixi3/all/test_v1_package/CMakeLists.txt
+++ b/recipes/tixi3/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1.2)
+project(tixi3_conan_test)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(tixi3 REQUIRED CONFIG)
+
+add_executable(tixi3_conan_test ../test_package/main.cpp)
+target_link_libraries(tixi3_conan_test tixi3::tixi3)

--- a/recipes/tixi3/all/test_v1_package/CMakeLists.txt
+++ b/recipes/tixi3/all/test_v1_package/CMakeLists.txt
@@ -7,4 +7,4 @@ conan_basic_setup(TARGETS)
 find_package(tixi3 REQUIRED CONFIG)
 
 add_executable(tixi3_conan_test ../test_package/main.cpp)
-target_link_libraries(tixi3_conan_test tixi3)
+target_link_libraries(tixi3_conan_test tixi3::tixi3)

--- a/recipes/tixi3/all/test_v1_package/conanfile.py
+++ b/recipes/tixi3/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+import os
+
+from conan.tools.build import cross_building
+from conans import ConanFile, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "tixi3_conan_test")
+            self.run(bin_path, run_environment=True)

--- a/recipes/tixi3/config.yml
+++ b/recipes/tixi3/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.3.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **tixi3/3.3.0**

Tixi3 is a xml library based on libxml2 with a very simple API and is used by multiple open source software packages, in particular used by the German Aerospace Center.

Website: https://github.com/DLR-SC/tixi

I was the main author of the library for the last 10 years and I'd like to share the conan package. 

Tixi3 is not yet used by other packages in the conan center index, but we plan to publish more packages that use tixi3.

_Note: This is my first conan package, so I might need more explanations than usually if changes are required._

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
