### PR TITLE
[harfbuzz] Only check glib shared option if glib is a dependency

### DIFF
--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -81,7 +81,7 @@ class HarfbuzzConan(ConanFile):
             if self.settings.compiler == "gcc" and scm.Version(self.settings.compiler.version) < "7":
                 raise ConanInvalidConfiguration("New versions of harfbuzz require at least gcc 7")
 
-        if self.options["glib"].shared and microsoft.is_msvc_static_runtime(self):
+        if self.options.with_glib and self.options["glib"].shared and microsoft.is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration(
                 "Linking shared glib with the MSVC static runtime is not supported"
             )


### PR DESCRIPTION
Fixes #12618

Specify library name and version:  **harfbuzz/all**

Ran into this when I was going out of my way to not have to include glib in my chain of dependencies QT/6.3.1 because on Windows that would require gettext, which requires autoconf and automake, which I can't seem to build because autoconf is not on the PATH for msys2 https://github.com/conan-io/conan-center-index/issues/10028 

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
