### PR TITLE
Use the latest vulkan-loader sdk version for Qt

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -337,7 +337,7 @@ class QtConan(ConanFile):
         if self.options.with_pcre2:
             self.requires("pcre2/10.37") # needs to be < 10.38 or qt fails to detect visual studio static library
         if self.options.get_safe("with_vulkan"):
-            self.requires("vulkan-loader/1.3.221.0")
+            self.requires("vulkan-loader/1.3.216.0")
             if tools.is_apple_os(self.settings.os):
                 self.requires("moltenvk/1.1.10")
         if self.options.with_glib:
@@ -1040,10 +1040,10 @@ class QtConan(ConanFile):
             _create_plugin("QIcoPlugin", "qico", "imageformats", ["Gui"])
             if self.options.get_safe("with_libjpeg"):
                 jpeg_reqs = ["Gui"]
-                if self.options.with_libjpeg == "libjpeg-turbo": 
-                     jpeg_reqs.append("libjpeg-turbo::libjpeg-turbo") 
-                if self.options.with_libjpeg == "libjpeg": 
-                     jpeg_reqs.append("libjpeg::libjpeg") 
+                if self.options.with_libjpeg == "libjpeg-turbo":
+                     jpeg_reqs.append("libjpeg-turbo::libjpeg-turbo")
+                if self.options.with_libjpeg == "libjpeg":
+                     jpeg_reqs.append("libjpeg::libjpeg")
                 _create_plugin("QJpegPlugin", "qjpeg", "imageformats", jpeg_reqs)
 
         if self.options.with_sqlite3:


### PR DESCRIPTION
Fixes #12601

Specify library name and version:  **qt/6.x.x**

It was referencing a non existing version of the vulkan-loader, it now uses the latest sdk version

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
