### PR TITLE
android-ndk: more conan v2 stuff

### DIFF
--- a/recipes/android-ndk/all/test_package/CMakeLists.txt
+++ b/recipes/android-ndk/all/test_package/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES CXX)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME})

--- a/recipes/android-ndk/all/test_package/conanfile.py
+++ b/recipes/android-ndk/all/test_package/conanfile.py
@@ -1,12 +1,12 @@
-import os
 from conan import ConanFile
 from conan.tools.cmake import CMake, cmake_layout
-from conan.tools.build import cross_building
+import os
 
 
 class TestPackgeConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    generators = "CMakeToolchain", "VirtualBuildEnv"
+    test_type = "explicit"
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)
@@ -22,13 +22,12 @@ class TestPackgeConan(ConanFile):
             cmake.build()
 
     def test(self):
-        if not cross_building(self):
-            if self.settings.os == "Windows":
-                self.run("ndk-build.cmd --version", env="conanrun")
-            else:
-                self.run("ndk-build --version", env="conanrun")
+        if self.settings.os == "Windows":
+            self.run("ndk-build.cmd --version")
+        else:
+            self.run("ndk-build --version")
 
         # INFO: Run the project that was built using Android NDK
         if self.settings.os == "Android":
-            test_file = os.path.join("bin", "test_package")
+            test_file = os.path.join(self.cpp.build.bindirs[0], "test_package")
             assert os.path.exists(test_file)

--- a/recipes/android-ndk/all/test_v1_package/CMakeLists.txt
+++ b/recipes/android-ndk/all/test_v1_package/CMakeLists.txt
@@ -1,8 +1,7 @@
-cmake_minimum_required(VERSION 3.0)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-add_executable(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME})
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)


### PR DESCRIPTION
- define env vars in `buildenv_info`
- prepend toolchain file to `tools.cmake.cmaketoolchain:user_toolchain`
- run build requirements executables in test package regardless of whether we cross-build or not and fix the variables context of these executions.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
