### PR TITLE
artery-font-format: add version 1.0.1

### DIFF
--- a/recipes/artery-font-format/all/conandata.yml
+++ b/recipes/artery-font-format/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.1":
+    url: "https://github.com/Chlumsky/artery-font-format/archive/v1.0.1.tar.gz"
+    sha256: "23dc9450d2364c9f1a67fcb0ae8f2bef365fabc5a3f4af55d9a646f8fbcdc537"
   "1.0":
     url: "https://github.com/Chlumsky/artery-font-format/archive/refs/tags/v1.0.tar.gz"
     sha256: "311172C09E6B74574C93C382EBB92212FFC1710DFCF04FC25376A575DFE16DA8"

--- a/recipes/artery-font-format/config.yml
+++ b/recipes/artery-font-format/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.1":
+    folder: all
   "1.0":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot)
Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **artery-font-format/1.0.1**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
