### PR TITLE
libatomic_ops: add version 7.6.14

### DIFF
--- a/recipes/libatomic_ops/all/conandata.yml
+++ b/recipes/libatomic_ops/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "7.6.12":
     url: "https://github.com/ivmai/libatomic_ops/releases/download/v7.6.12/libatomic_ops-7.6.12.tar.gz"
     sha256: "f0ab566e25fce08b560e1feab6a3db01db4a38e5bc687804334ef3920c549f3e"
+  "7.6.14":
+    url: "https://github.com/ivmai/libatomic_ops/releases/download/v7.6.14/libatomic_ops-7.6.14.tar.gz"
+    sha256: "390f244d424714735b7050d056567615b3b8f29008a663c262fb548f1802d292"

--- a/recipes/libatomic_ops/config.yml
+++ b/recipes/libatomic_ops/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "7.6.12":
     folder: all
+  "7.6.14":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **libatomic_ops/7.6.14**

I'm maintainer of libatomic_ops upstream; v7.6.14 has been released recently.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
