### PR TITLE
libpng/1.6.37: fix building shared library for iOS

### DIFF
--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -140,7 +140,7 @@ class LibpngConan(ConanFile):
         self._cmake.definitions["PNG_STATIC"] = not self.options.shared
         self._cmake.definitions["PNG_DEBUG"] = self.settings.build_type == "Debug"
         self._cmake.definitions["PNG_PREFIX"] = self.options.api_prefix
-        self._cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False # prevents configure error on non-macOS
+        self._cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False # prevents configure error on shared iOS/tvOS/watchOS
         if cross_building(self):
             self._cmake.definitions["CONAN_LIBPNG_SYSTEM_PROCESSOR"] = self._libpng_cmake_system_processor
         if self._has_neon_support:

--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -182,9 +182,10 @@ class LibpngConan(ConanFile):
         self.cpp_info.names["cmake_find_package_multi"] = "PNG"
 
         prefix = "lib" if self._is_msvc else ""
-        suffix = "d" if self.settings.build_type == "Debug" else ""
         major_min_version = f"{Version(self.version).major}{Version(self.version).minor}"
+        suffix = major_min_version if self._is_msvc else ""
+        suffix += "d" if self._is_msvc and self.settings.build_type == "Debug" else ""
 
-        self.cpp_info.libs = ["{}png{}{}".format(prefix, major_min_version, suffix)]
+        self.cpp_info.libs = [f"{prefix}png{suffix}"]
         if self.settings.os in ["Linux", "Android", "FreeBSD", "SunOS", "AIX"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conans import CMake, tools
 from conan import ConanFile
 from conan.tools.scm import Version
-from conan.tools.files import apply_conandata_patches, get, rmdir, replace_in_file
+from conan.tools.files import apply_conandata_patches, get, rm, rmdir, replace_in_file
 from conan.tools.build.cross_building import cross_building
 
 required_conan_version = ">=1.50.2"
@@ -165,7 +165,7 @@ class LibpngConan(ConanFile):
         cmake = self._configure_cmake()
         cmake.install()
         if self.options.shared:
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), "*[!.dll]")
+            rm(self, "*[!.dll]", os.path.join(self.package_folder, "bin"))
         else:
             rmdir(self, os.path.join(self.package_folder, "bin"))
         rmdir(self, os.path.join(self.package_folder, "lib", "libpng"))

--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.scm import Version
 from conan.tools.files import apply_conandata_patches, get, rm, rmdir, replace_in_file
 from conan.tools.build.cross_building import cross_building
 
-required_conan_version = ">=1.50.2"
+required_conan_version = ">=1.50.2 <1.51.0 || >=1.51.2"
 
 
 class LibpngConan(ConanFile):

--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -140,6 +140,7 @@ class LibpngConan(ConanFile):
         self._cmake.definitions["PNG_STATIC"] = not self.options.shared
         self._cmake.definitions["PNG_DEBUG"] = self.settings.build_type == "Debug"
         self._cmake.definitions["PNG_PREFIX"] = self.options.api_prefix
+        self._cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False # prevents configure error on non-macOS
         if cross_building(self):
             self._cmake.definitions["CONAN_LIBPNG_SYSTEM_PROCESSOR"] = self._libpng_cmake_system_processor
         if self._has_neon_support:


### PR DESCRIPTION
Specify library name and version:  **libpng/1.6.37**

CMake configure step fails with error:

```
CMake Error at source_subfolder/CMakeLists.txt:892 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "pngfix".
```

<details><summary>Full output:</summary>

```
libpng/1.6.37: Calling build()
-- The C compiler identification is AppleClang 12.0.0.12000032
-- The CXX compiler identification is AppleClang 12.0.0.12000032
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode12.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode12.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: called by CMake conan helper
-- Conan: called inside local cache
-- Conan: Adjusting output directories
-- Conan: Using cmake global configuration
-- Conan: Adjusting language standard
-- The ASM compiler identification is Clang with GNU-like command-line
-- Found assembler: /Applications/Xcode12.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Conan: Using autogenerated FindZLIB.cmake
-- Found ZLIB: 1.2.12 (found version "1.2.12") 
-- Library z found /Users/kambala/.conan/data/zlib/1.2.12/_/_/package/0cf8a76c214920faa3ab99ee2a1634dc13c4bd39/lib/libz.dylib
-- Found: /Users/kambala/.conan/data/zlib/1.2.12/_/_/package/0cf8a76c214920faa3ab99ee2a1634dc13c4bd39/lib/libz.dylib
-- Symbol prefix: 
CMake Error at source_subfolder/CMakeLists.txt:892 (install):
  install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
  target "pngfix".


-- Configuring incomplete, errors occurred!
See also "/Users/kambala/.conan/data/libpng/1.6.37/_/_/build/2fa0a23ec170d2ae457128c32bfe7fc75aecb372/CMakeFiles/CMakeOutput.log".
See also "/Users/kambala/.conan/data/libpng/1.6.37/_/_/build/2fa0a23ec170d2ae457128c32bfe7fc75aecb372/CMakeFiles/CMakeError.log".
libpng/1.6.37: 
libpng/1.6.37: ERROR: Package '2fa0a23ec170d2ae457128c32bfe7fc75aecb372' build failed
libpng/1.6.37: WARN: Build folder /Users/kambala/.conan/data/libpng/1.6.37/_/_/build/2fa0a23ec170d2ae457128c32bfe7fc75aecb372
ERROR: libpng/1.6.37: Error in build() method, line 159
	cmake = self._configure_cmake()
while calling '_configure_cmake', line 153
	self._cmake.configure()
	ConanException: Error 1 while executing cd '/Users/kambala/.conan/data/libpng/1.6.37/_/_/build/2fa0a23ec170d2ae457128c32bfe7fc75aecb372' && cmake -G "Ninja" -DCMAKE_BUILD_TYPE="Release" -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_OSX_SYSROOT="/Applications/Xcode12.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.4.sdk" -DCMAKE_SYSTEM_NAME="iOS" -DCMAKE_SYSTEM_VERSION="12.0" -DCMAKE_OSX_DEPLOYMENT_TARGET="12.0" -DCONAN_IN_LOCAL_CACHE="ON" -DCONAN_COMPILER="apple-clang" -DCONAN_COMPILER_VERSION="12.0" -DBUILD_SHARED_LIBS="ON" -DCMAKE_INSTALL_PREFIX="/Users/kambala/.conan/data/libpng/1.6.37/_/_/package/2fa0a23ec170d2ae457128c32bfe7fc75aecb372" -DCMAKE_INSTALL_BINDIR="bin" -DCMAKE_INSTALL_SBINDIR="bin" -DCMAKE_INSTALL_LIBEXECDIR="bin" -DCMAKE_INSTALL_LIBDIR="lib" -DCMAKE_INSTALL_INCLUDEDIR="include" -DCMAKE_INSTALL_OLDINCLUDEDIR="include" -DCMAKE_INSTALL_DATAROOTDIR="share" -DCMAKE_MODULE_PATH="/Users/kambala/.conan/data/libpng/1.6.37/_/_/build/2fa0a23ec170d2ae457128c32bfe7fc75aecb372" -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -DCONAN_EXPORTED="1" -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE="BOTH" -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY="BOTH" -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE="BOTH" -DPNG_TESTS="False" -DPNG_SHARED="True" -DPNG_STATIC="False" -DPNG_DEBUG="False" -DPNG_PREFIX="" -DCONAN_LIBPNG_SYSTEM_PROCESSOR="armv8" -DPNG_ARM_NEON="on" -Wno-dev '/Users/kambala/.conan/data/libpng/1.6.37/_/_/build/2fa0a23ec170d2ae457128c32bfe7fc75aecb372'
```

</details>

This change forces creating plain executables instead of app bundles avoiding the error.

An alternative solution could be patching libpng's CMakeLists to not build executables for iOS/tvOS/watchOS at all as they're not needed.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
