### PR TITLE
libmysqlclient/8.0.29: add sources mirror

### DIFF
--- a/recipes/libmysqlclient/all/conandata.yml
+++ b/recipes/libmysqlclient/all/conandata.yml
@@ -1,6 +1,8 @@
 sources:
   "8.0.29":
-    url: "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.29.tar.gz"
+    url:
+      - "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.29.tar.gz"
+      - "https://mirrors.huaweicloud.com/mysql/Downloads/MySQL-8.0/mysql-8.0.29.tar.gz"
     sha256: "512170fa6f78a694d6f18d197e999d2716ee68dc541d7644dd922a3663407266"
   "8.0.25":
     url: "https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.25.tar.gz"


### PR DESCRIPTION
Specify library name and version:  **libmysqlclient/8.0.29**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
