### PR TITLE
glog: Make libunwind optional, add to requirements

### DIFF
--- a/recipes/glog/all/conandata.yml
+++ b/recipes/glog/all/conandata.yml
@@ -11,4 +11,3 @@ sources:
 patches:
   "0.5.0":
     - patch_file: "patches/0001-fix-msvc-snprintf.patch"
-      base_path: "source_subfolder"

--- a/recipes/glog/all/conandata.yml
+++ b/recipes/glog/all/conandata.yml
@@ -11,3 +11,5 @@ sources:
 patches:
   "0.5.0":
     - patch_file: "patches/0001-fix-msvc-snprintf.patch"
+      patch_description: "Use stdio.h instead of cstdio.h for snprintf"
+      patch_type: "conan"

--- a/recipes/glog/all/conanfile.py
+++ b/recipes/glog/all/conanfile.py
@@ -38,7 +38,7 @@ class GlogConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if self.settings.os not in ["Linux", "FreeBSD"]:
+        if self.settings.os not in ["Linux", "FreeBSD"] or Version(self.version) < "0.5.0":
             del self.options.with_unwind
 
     def configure(self):
@@ -53,7 +53,8 @@ class GlogConan(ConanFile):
     def requirements(self):
         if self.options.with_gflags:
             self.requires("gflags/2.2.2")
-        if self.options.get_safe("with_unwind"):
+        # 0.4.0 requires libunwind unconditionally
+        if self.options.get_safe("with_unwind") or (Version(self.version) < "0.5.0" and self.settings.os in ["Linux", "FreeBSD"]):
             self.requires("libunwind/1.6.2")
 
     def build_requirements(self):

--- a/recipes/glog/all/conanfile.py
+++ b/recipes/glog/all/conanfile.py
@@ -1,7 +1,10 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, get, replace_in_file, rmdir
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.51.1"
 
 
 class GlogConan(ConanFile):
@@ -28,13 +31,9 @@ class GlogConan(ConanFile):
         "with_unwind": True,
     }
 
-    exports_sources = ["CMakeLists.txt", "patches/**"]
-    generators = "cmake", "cmake_find_package"
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def export_sources(self):
+        for p in self.conan_data.get("patches", {}).get(self.version, []):
+            copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -47,8 +46,9 @@ class GlogConan(ConanFile):
             del self.options.fPIC
         if self.options.with_gflags:
             self.options["gflags"].shared = self.options.shared
-        if self.options.with_unwind:
-            self.options["libunwind"].shared = self.options.shared
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         if self.options.with_gflags:
@@ -57,57 +57,57 @@ class GlogConan(ConanFile):
             self.requires("libunwind/1.6.2")
 
     def build_requirements(self):
-        if tools.Version(self.version) >= "0.6.0":
+        if Version(self.version) >= "0.6.0":
             self.build_requires("cmake/3.22.3")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+                  destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["WITH_GFLAGS"] = self.options.with_gflags
+        tc.variables["WITH_THREADS"] = self.options.with_threads
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        if Version(self.version) >= "0.5.0":
+            tc.variables["WITH_PKGCONFIG"] = True
+            if self.settings.os == "Emscripten":
+                tc.variables["WITH_SYMBOLIZE"] = False
+                tc.variables["HAVE_SYSCALL_H"] = False
+                tc.variables["HAVE_SYS_SYSCALL_H"] = False
+            else:
+                tc.variables["WITH_SYMBOLIZE"] = True
+            tc.variables["WITH_UNWIND"] = self.options.get_safe("with_unwind", default=False)
+        tc.variables["BUILD_TESTING"] = False
+        tc.variables["WITH_GTEST"] = False
+        tc.generate()
 
     def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+        apply_conandata_patches(self)
         # do not force PIC
-        if tools.Version(self.version) <= "0.5.0":
-            tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+        if Version(self.version) <= "0.5.0":
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                                   "set_target_properties (glog PROPERTIES POSITION_INDEPENDENT_CODE ON)",
                                   "")
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["WITH_GFLAGS"] = self.options.with_gflags
-        self._cmake.definitions["WITH_THREADS"] = self.options.with_threads
-        if tools.Version(self.version) >= "0.5.0":
-            self._cmake.definitions["WITH_PKGCONFIG"] = True
-            if self.settings.os == "Emscripten":
-                self._cmake.definitions["WITH_SYMBOLIZE"] = False
-                self._cmake.definitions["HAVE_SYSCALL_H"] = False
-                self._cmake.definitions["HAVE_SYS_SYSCALL_H"] = False
-            else:
-                self._cmake.definitions["WITH_SYMBOLIZE"] = True
-            self._cmake.definitions["WITH_UNWIND"] = self.options.get_safe("with_unwind", default=False)
-        self._cmake.definitions["BUILD_TESTING"] = False
-        self._cmake.configure()
-        return self._cmake
-
     def build(self):
         self._patch_sources()
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        self.copy("COPYING", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "glog"
-        self.cpp_info.names["cmake_find_package_multi"] = "glog"
-        self.cpp_info.names["pkgconfig"] = "libglog"
+        self.cpp_info.set_property("cmake_file_name", "glog")
+        self.cpp_info.set_property("cmake_target_name", "glog::glog")
+        self.cpp_info.set_property("pkg_config_name", "libglog")
         postfix = "d" if self.settings.build_type == "Debug" else ""
         self.cpp_info.libs = ["glog" + postfix]
         if self.settings.os == "Linux":


### PR DESCRIPTION
Fixes #8568

Specify library name and version:  **glog/0.5.0** **glog/0.6.0**

`glog` didnt specify `libunwind` as a dependency: add it to the requirements and make it optional.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
