### PR TITLE
libgd: Only add getopt-for-visual-studio if compiler is visual studio

### DIFF
--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -53,7 +53,7 @@ class LibgdConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("zlib/1.2.11")
+        self.requires("zlib/1.2.12")
         if self.options.with_png:
             self.requires("libpng/1.6.37")
             if is_msvc(self):
@@ -61,9 +61,9 @@ class LibgdConan(ConanFile):
         if self.options.with_jpeg:
             self.requires("libjpeg/9d")
         if self.options.with_tiff:
-            self.requires("libtiff/4.3.0")
+            self.requires("libtiff/4.4.0")
         if self.options.with_freetype:
-            self.requires("freetype/2.11.0")
+            self.requires("freetype/2.12.0")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -76,8 +76,11 @@ class LibgdConan(ConanFile):
         for patch_file in self.conan_data.get("patches", {}).get(self.version, []):
             patch(self, **patch_file)
         cmakelists = os.path.join(self._source_subfolder, "CMakeLists.txt")
-        replace_in_file(self, cmakelists, "${CMAKE_SOURCE_DIR}", "${CMAKE_CURRENT_SOURCE_DIR}")
-        replace_in_file(self, cmakelists, "SET(CMAKE_MODULE_PATH \"${GD_SOURCE_DIR}/cmake/modules\")", "LIST(APPEND CMAKE_MODULE_PATH \"${GD_SOURCE_DIR}/cmake/modules\")")
+        replace_in_file(self, cmakelists, "${CMAKE_SOURCE_DIR}",
+                        "${CMAKE_CURRENT_SOURCE_DIR}")
+        replace_in_file(self, cmakelists,
+                        "SET(CMAKE_MODULE_PATH \"${GD_SOURCE_DIR}/cmake/modules\")",
+                        "LIST(APPEND CMAKE_MODULE_PATH \"${GD_SOURCE_DIR}/cmake/modules\")")
         replace_in_file(self, os.path.join(self._source_subfolder, "src", "CMakeLists.txt"),
                         "RUNTIME DESTINATION bin",
                         "RUNTIME DESTINATION bin BUNDLE DESTINATION bin")

--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -1,7 +1,8 @@
+from conan.tools.microsoft import is_msvc
 from conans import ConanFile, tools, CMake
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.45.0"
 
 
 class LibgdConan(ConanFile):
@@ -55,7 +56,7 @@ class LibgdConan(ConanFile):
         self.requires("zlib/1.2.11")
         if self.options.with_png:
             self.requires("libpng/1.6.37")
-            if self.settings.compiler == "Visual Studio":
+            if is_msvc(self):
                 self.requires("getopt-for-visual-studio/20200201")
         if self.options.with_jpeg:
             self.requires("libjpeg/9d")

--- a/recipes/libgd/all/conanfile.py
+++ b/recipes/libgd/all/conanfile.py
@@ -55,7 +55,8 @@ class LibgdConan(ConanFile):
         self.requires("zlib/1.2.11")
         if self.options.with_png:
             self.requires("libpng/1.6.37")
-            self.requires("getopt-for-visual-studio/20200201")
+            if self.settings.compiler == "Visual Studio":
+                self.requires("getopt-for-visual-studio/20200201")
         if self.options.with_jpeg:
             self.requires("libjpeg/9d")
         if self.options.with_tiff:


### PR DESCRIPTION
fixes #12069

The occurred when building the libgd package having with_png=true.
This would add a dependency to getopt-for-visual-studio which
is configured to fail immediately if the compiler is not visual studio.
The CI was probably able to build this since the with_png option is by
default false.

The proposed solution is to only add getopt-for-visual-studio if the
detected compiler is in fact visual studio, and only then.

Specify library name and version:  **libgd/2.3.2**

I am submitting this PR because I use libgd in my project, but wasn't able to build it for linux when png was enabled. Investigating the recipe, I discovered that the problem is a bug in the recipe, and I would like to contribute a fix to the community.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
