### PR TITLE
lodepng: remove compiler settings

### DIFF
--- a/recipes/lodepng/all/conanfile.py
+++ b/recipes/lodepng/all/conanfile.py
@@ -35,6 +35,14 @@ class LodepngConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
 
     def validate(self):
         if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):


### PR DESCRIPTION
Specify library name and version:  **lodepng/cci.20200615**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

Removal of `libcxx` and `cppstd` to support cross compilation.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
