### PR TITLE
sdbus-cpp: conan v2 support

### DIFF
--- a/recipes/sdbus-cpp/all/CMakeLists.txt
+++ b/recipes/sdbus-cpp/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.13)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory(source_subfolder)

--- a/recipes/sdbus-cpp/all/conandata.yml
+++ b/recipes/sdbus-cpp/all/conandata.yml
@@ -1,19 +1,25 @@
 sources:
-  "0.8.3":
-    url: "https://github.com/Kistler-Group/sdbus-cpp/archive/v0.8.3.tar.gz"
-    sha256: "0fd575ae0f463773dd9141242d1133731e2b780fd6526650ce992ba711d88628"
-  "1.0.0":
-    url: "https://github.com/Kistler-Group/sdbus-cpp/archive/v1.0.0.tar.gz"
-    sha256: "3db82112c0d8a171a4115d761e3a592b62091fa7600988736652595178ae4e94"
-  "1.1.0":
-    url: "https://github.com/Kistler-Group/sdbus-cpp/archive/v1.1.0.tar.gz"
-    sha256: "35e939fdd9c796522702c9c8762dd59b5c47f3440c01ba9feb9921c042780b55"
-
   "1.2.0":
     url: "https://github.com/Kistler-Group/sdbus-cpp/archive/v1.2.0.tar.gz"
     sha256: "7f7231904abb6a996b8c18ddc5fb50078ef5dff5191649abf9f127aff41d24e9"
-patches:
+  "1.1.0":
+    url: "https://github.com/Kistler-Group/sdbus-cpp/archive/v1.1.0.tar.gz"
+    sha256: "35e939fdd9c796522702c9c8762dd59b5c47f3440c01ba9feb9921c042780b55"
+  "1.0.0":
+    url: "https://github.com/Kistler-Group/sdbus-cpp/archive/v1.0.0.tar.gz"
+    sha256: "3db82112c0d8a171a4115d761e3a592b62091fa7600988736652595178ae4e94"
   "0.8.3":
-    - patch_file: "patches/0001-xml2cpp-Add-missing-EXPAT-include-dirs-136.patch"
+    url: "https://github.com/Kistler-Group/sdbus-cpp/archive/v0.8.3.tar.gz"
+    sha256: "0fd575ae0f463773dd9141242d1133731e2b780fd6526650ce992ba711d88628"
+
+patches:
   "1.0.0":
     - patch_file: "patches/0002-correct-readme-cpack-resource-path.patch"
+      patch_description: "fix out of tree build by using proper paths in cmake file"
+      patch_type: "backport"
+      patch_source: "https://github.com/Kistler-Group/sdbus-cpp/commit/0b8f2d97524f354bcaf816b27b6139a5b0c480ba"
+  "0.8.3":
+    - patch_file: "patches/0001-xml2cpp-Add-missing-EXPAT-include-dirs-136.patch"
+      patch_description: "fix build error by adding missing headers"
+      patch_type: "backport"
+      patch_source: "https://github.com/Kistler-Group/sdbus-cpp/commit/fb008445b15b452f461c34667f4991f5ce06e481"

--- a/recipes/sdbus-cpp/all/conandata.yml
+++ b/recipes/sdbus-cpp/all/conandata.yml
@@ -14,8 +14,6 @@ sources:
     sha256: "7f7231904abb6a996b8c18ddc5fb50078ef5dff5191649abf9f127aff41d24e9"
 patches:
   "0.8.3":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0001-xml2cpp-Add-missing-EXPAT-include-dirs-136.patch"
+    - patch_file: "patches/0001-xml2cpp-Add-missing-EXPAT-include-dirs-136.patch"
   "1.0.0":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0002-correct-readme-cpack-resource-path.patch"
+    - patch_file: "patches/0002-correct-readme-cpack-resource-path.patch"

--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -12,7 +12,7 @@ required_conan_version = ">=1.51.0"
 
 class SdbusCppConan(ConanFile):
     name = "sdbus-cpp"
-    license = "LGPL-2.1-or-later"
+    license = "LicenseRef-LGPL-2.1-or-later-WITH-sdbus-cpp-LGPL-exception-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/Kistler-Group/sdbus-cpp"
     description = "High-level C++ D-Bus library for Linux designed" \
@@ -48,6 +48,9 @@ class SdbusCppConan(ConanFile):
                  self.export_sources_folder)
 
     def configure(self):
+        if Version(self.version) < "0.9.0":
+            self.license = "LGPL-2.1-or-later"
+
         if self.options.shared:
             del self.options.fPIC
 

--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -1,7 +1,11 @@
 import os
 
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, get, rmdir
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.33.0"
 
@@ -25,17 +29,11 @@ class SdbusCppConan(ConanFile):
         "fPIC": True,
         "with_code_gen": False,
     }
-    exports_sources = ("CMakeLists.txt", "patches/**")
-    generators = ("cmake", "pkg_config")
-    _cmake = None
+    exports_sources = "patches/**"
+    generators = "PkgConfigDeps"
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
+    def layout(self):
+        cmake_layout(self)
 
     @property
     def _minimum_cpp_standard(self):
@@ -53,69 +51,77 @@ class SdbusCppConan(ConanFile):
             del self.options.fPIC
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, self._minimum_cpp_standard)
-        min_version = self._minimum_compilers_version.get(str(self.settings.compiler))
+        if self.info.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._minimum_cpp_standard)
+        min_version = self._minimum_compilers_version.get(str(self.info.settings.compiler))
         if not min_version:
             self.output.warn("{} recipe lacks information about the {} compiler support.".format(
-                self.name, self.settings.compiler))
+                self.name, self.info.settings.compiler))
         else:
-            if tools.Version(self.settings.compiler.version) < min_version:
+            if Version(self.info.settings.compiler.version) < min_version:
                 raise ConanInvalidConfiguration("{} requires C++{} support. The current compiler {} {} does not support it.".format(
-                    self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
-        if self.settings.os != "Linux":
+                    self.name, self._minimum_cpp_standard, self.info.settings.compiler, self.info.settings.compiler.version))
+        if self.info.settings.os != "Linux":
             raise ConanInvalidConfiguration("Only Linux supported")
 
     def build_requirements(self):
-        self.build_requires("pkgconf/1.7.4")
+        self.tool_requires("pkgconf/1.7.4")
         if self.options.with_code_gen:
-            self.build_requires("expat/2.4.8")
+            self.tool_requires("expat/2.4.8")
 
     def requirements(self):
         self.requires("libsystemd/251.4")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["BUILD_CODE_GEN"] = self.options.with_code_gen
-        self._cmake.definitions["BUILD_DOC"] = False
-        self._cmake.definitions["BUILD_TESTS"] = False
-        self._cmake.definitions["BUILD_LIBSYSTEMD"] = False
-        self._cmake.configure()
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_CODE_GEN"] = self.options.with_code_gen
+        tc.variables["BUILD_DOC"] = False
+        tc.variables["BUILD_TESTS"] = False
+        tc.variables["BUILD_LIBSYSTEMD"] = False
+        tc.generate()
 
-    def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+        # workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/18150
+        copy(self, "*.pc", self.generators_folder,
+             os.path.join(self.generators_folder, "lib", "pkgconfig"))
 
     def build(self):
-        self._patch_sources()
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.install()
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        copy(self, "COPYING*", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "sdbus-c++")
+        self.cpp_info.components["sdbus-c++"].libs = ["sdbus-c++"]
+        self.cpp_info.components["sdbus-c++"].requires.append("libsystemd::libsystemd")
+        self.cpp_info.components["sdbus-c++"].set_property("cmake_target_name", "SDBusCpp::sdbus-c++")
+        self.cpp_info.components["sdbus-c++"].set_property("pkg_config_name", "sdbus-c++")
+
+        if self.options.with_code_gen:
+            bin_path = os.path.join(self.package_folder, "bin")
+            self.output.info("Appending PATH env var with : {}".format(bin_path))
+            self.buildenv_info.prepend_path("PATH", bin_path)
+
+            # TODO: Remove in Conan 2.0 where Environment class will be required.
+            self.env_info.PATH.append(bin_path)
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.names["cmake_find_package"] = "SDBusCpp"
         self.cpp_info.names["cmake_find_package_multi"] = "SDBusCpp"
         self.cpp_info.filenames["cmake_find_package"] = "sdbus-c++"
         self.cpp_info.filenames["cmake_find_package_multi"] = "sdbus-c++"
-        self.cpp_info.components["sdbus-c++"].libs = ["sdbus-c++"]
-        self.cpp_info.components["sdbus-c++"].requires.append("libsystemd::libsystemd")
         self.cpp_info.components["sdbus-c++"].names["cmake_find_package"] = "sdbus-c++"
         self.cpp_info.components["sdbus-c++"].names["cmake_find_package_multi"] = "sdbus-c++"
         self.cpp_info.components["sdbus-c++"].names["pkg_config"] = "sdbus-c++"
-        if self.options.with_code_gen:
-            bin_path = os.path.join(self.package_folder, "bin")
-            self.output.info("Appending PATH env var with : {}".format(bin_path))
-            self.env_info.PATH.append(bin_path)

--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -69,10 +69,10 @@ class SdbusCppConan(ConanFile):
     def build_requirements(self):
         self.build_requires("pkgconf/1.7.4")
         if self.options.with_code_gen:
-            self.build_requires("expat/2.4.1")
+            self.build_requires("expat/2.4.8")
 
     def requirements(self):
-        self.requires("libsystemd/249.4")
+        self.requires("libsystemd/251.4")
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],

--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -115,6 +115,8 @@ class SdbusCppConan(ConanFile):
             "cmake_target_name", "SDBusCpp::sdbus-c++")
         self.cpp_info.components["sdbus-c++"].set_property(
             "pkg_config_name", "sdbus-c++")
+        self.cpp_info.components["sdbus-c++"].system_libs = [
+            "pthread", "m"]
 
         if self.options.with_code_gen:
             bin_path = os.path.join(self.package_folder, "bin")

--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -77,7 +77,7 @@ class SdbusCppConan(ConanFile):
         self.requires("libsystemd/251.4")
 
     def layout(self):
-        cmake_layout(self)
+        cmake_layout(self, src_folder="src")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/sdbus-cpp/all/conanfile.py
+++ b/recipes/sdbus-cpp/all/conanfile.py
@@ -13,7 +13,7 @@ class SdbusCppConan(ConanFile):
     homepage = "https://github.com/Kistler-Group/sdbus-cpp"
     description = "High-level C++ D-Bus library for Linux designed" \
                   " to provide easy-to-use yet powerful API in modern C++"
-    topics = ("conan", "dbus", "sd-bus", "sdbus-c++", "sdbus-cpp")
+    topics = ("dbus", "sd-bus", "sdbus-c++", "sdbus-cpp")
     settings = "os", "compiler", "build_type", "arch"
     options = {
         "shared": [True, False],

--- a/recipes/sdbus-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/sdbus-cpp/all/test_package/CMakeLists.txt
@@ -1,8 +1,5 @@
-cmake_minimum_required(VERSION 3.13)
-project(PackageTest CXX)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest LANGUAGES CXX)
 
 find_package(sdbus-c++ REQUIRED)
 

--- a/recipes/sdbus-cpp/all/test_package/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_package/conanfile.py
@@ -1,11 +1,20 @@
 import os
 
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 
 
 class SdbusCppTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = ("cmake", "cmake_find_package")
+    generators = "CMakeToolchain", "CMakeDeps"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -13,6 +22,6 @@ class SdbusCppTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "example")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "example")
+            self.run(bin_path, env="conanrun")

--- a/recipes/sdbus-cpp/all/test_package/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_package/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.cmake import CMake, cmake_layout
 
 class SdbusCppTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeToolchain", "CMakeDeps"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
     def requirements(self):

--- a/recipes/sdbus-cpp/all/test_package/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_package/conanfile.py
@@ -13,6 +13,6 @@ class SdbusCppTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not tools.cross_building(self):
             bin_path = os.path.join("bin", "example")
             self.run(bin_path, run_environment=True)

--- a/recipes/sdbus-cpp/all/test_pkgconf/CMakeLists.txt
+++ b/recipes/sdbus-cpp/all/test_pkgconf/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.13)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(SDBusCpp REQUIRED IMPORTED_TARGET sdbus-c++)
+
+add_executable(example ../test_package/example.cpp)
+target_link_libraries(example PRIVATE PkgConfig::SDBusCpp)

--- a/recipes/sdbus-cpp/all/test_pkgconf/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_pkgconf/conanfile.py
@@ -1,14 +1,29 @@
 import os
 
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.files import copy
 
 
 class SdbusCppTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = ("cmake", "pkg_config")
+    generators = "CMakeToolchain", "PkgConfigDeps"
+    test_type = "explicit"
 
     def build_requirements(self):
         self.build_requires("pkgconf/1.7.4")
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        # workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/18150
+        copy(self, "*.pc", self.generators_folder,
+             os.path.join(self.generators_folder, "lib", "pkgconfig"))
 
     def build(self):
         cmake = CMake(self)
@@ -16,6 +31,6 @@ class SdbusCppTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "example")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "example")
+            self.run(bin_path, env="conanrun")

--- a/recipes/sdbus-cpp/all/test_pkgconf/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_pkgconf/conanfile.py
@@ -12,7 +12,7 @@ class SdbusCppTestConan(ConanFile):
     test_type = "explicit"
 
     def build_requirements(self):
-        self.build_requires("pkgconf/1.7.4")
+        self.tool_requires("pkgconf/1.7.4")
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/sdbus-cpp/all/test_pkgconf/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_pkgconf/conanfile.py
@@ -1,0 +1,21 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class SdbusCppTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = ("cmake", "pkg_config")
+
+    def build_requirements(self):
+        self.build_requires("pkgconf/1.7.4")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/sdbus-cpp/all/test_pkgconf/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_pkgconf/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.files import copy
 
 class SdbusCppTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeToolchain", "PkgConfigDeps"
+    generators = "CMakeToolchain", "PkgConfigDeps", "VirtualRunEnv"
     test_type = "explicit"
 
     def build_requirements(self):

--- a/recipes/sdbus-cpp/all/test_v1_package/CMakeLists.txt
+++ b/recipes/sdbus-cpp/all/test_v1_package/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(sdbus-c++ REQUIRED)
 

--- a/recipes/sdbus-cpp/all/test_v1_package/CMakeLists.txt
+++ b/recipes/sdbus-cpp/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.13)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+find_package(sdbus-c++ REQUIRED)
+
+add_executable(example ../test_package/example.cpp)
+target_link_libraries(example SDBusCpp::sdbus-c++)

--- a/recipes/sdbus-cpp/all/test_v1_package/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_v1_package/conanfile.py
@@ -1,6 +1,9 @@
 import os
 
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+
+from conans import CMake
 
 
 class SdbusCppTestConan(ConanFile):
@@ -13,6 +16,6 @@ class SdbusCppTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if can_run(self):
             bin_path = os.path.join("bin", "example")
             self.run(bin_path, run_environment=True)

--- a/recipes/sdbus-cpp/all/test_v1_package/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class SdbusCppTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = ("cmake", "cmake_find_package")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/sdbus-cpp/all/test_v1_pkgconf/CMakeLists.txt
+++ b/recipes/sdbus-cpp/all/test_v1_pkgconf/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 project(PackageTest CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SDBusCpp REQUIRED IMPORTED_TARGET sdbus-c++)

--- a/recipes/sdbus-cpp/all/test_v1_pkgconf/CMakeLists.txt
+++ b/recipes/sdbus-cpp/all/test_v1_pkgconf/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required(VERSION 3.15)
-project(PackageTest LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.13)
+project(PackageTest CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SDBusCpp REQUIRED IMPORTED_TARGET sdbus-c++)

--- a/recipes/sdbus-cpp/all/test_v1_pkgconf/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_v1_pkgconf/conanfile.py
@@ -1,0 +1,21 @@
+import os
+
+from conans import ConanFile, CMake, tools
+
+
+class SdbusCppTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = ("cmake", "pkg_config")
+
+    def build_requirements(self):
+        self.build_requires("pkgconf/1.7.4")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/sdbus-cpp/all/test_v1_pkgconf/conanfile.py
+++ b/recipes/sdbus-cpp/all/test_v1_pkgconf/conanfile.py
@@ -1,6 +1,9 @@
 import os
 
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+
+from conans import CMake
 
 
 class SdbusCppTestConan(ConanFile):
@@ -8,7 +11,7 @@ class SdbusCppTestConan(ConanFile):
     generators = ("cmake", "pkg_config")
 
     def build_requirements(self):
-        self.build_requires("pkgconf/1.7.4")
+        self.tool_requires("pkgconf/1.7.4")
 
     def build(self):
         cmake = CMake(self)
@@ -16,6 +19,6 @@ class SdbusCppTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if can_run(self):
             bin_path = os.path.join("bin", "example")
             self.run(bin_path, run_environment=True)

--- a/recipes/sdbus-cpp/config.yml
+++ b/recipes/sdbus-cpp/config.yml
@@ -1,9 +1,9 @@
 versions:
-  "0.8.3":
-    folder: all
-  "1.0.0":
+  "1.2.0":
     folder: all
   "1.1.0":
     folder: all
-  "1.2.0":
+  "1.0.0":
+    folder: all
+  "0.8.3":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **sdbus-cpp/all**

* Package dependencies/build dependencies were updated.
* The recipe has been updated to be compatible with Conan V1/V2.
* A few warning fixes and random clean-ups.
* Updated information about package license.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
