### PR TITLE
[mold] Add latest version 1.4.1

### DIFF
--- a/recipes/mold/all/CMakeLists.txt
+++ b/recipes/mold/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/mold/all/conandata.yml
+++ b/recipes/mold/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.1":
+    url: "https://github.com/rui314/mold/archive/refs/tags/v1.4.1.tar.gz"
+    sha256: "394036d299c50f936ff77ce9c6cf44a5b24bfcabf65ae7db9679f89c11a70b3f"
   "1.3.1":
     url: "https://github.com/rui314/mold/archive/refs/tags/v1.3.1.tar.gz"
     sha256: "d436e2d4c1619a97aca0e28f26c4e79c0242d10ce24e829c1b43cfbdd196fd77"

--- a/recipes/mold/all/conanfile.py
+++ b/recipes/mold/all/conanfile.py
@@ -120,6 +120,7 @@ class MoldConan(ConanFile):
         else:
             cmake = self._configure_cmake()
             cmake.install()
+            files.rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/mold/all/conanfile.py
+++ b/recipes/mold/all/conanfile.py
@@ -2,8 +2,11 @@ from conan import ConanFile
 from conan.tools.scm import Version
 from conan.tools import files
 from conan.errors import ConanInvalidConfiguration
-from conans import AutoToolsBuildEnvironment
+from conans import AutoToolsBuildEnvironment, CMake
+from conan.tools.files import get
+
 import os
+import functools
 
 required_conan_version = ">=1.47.0"
 
@@ -17,7 +20,7 @@ class MoldConan(ConanFile):
 
     settings = "os", "arch", "compiler", "build_type"
 
-    generators = "make"
+    generators = "make", "cmake", "cmake_find_package"
 
     def validate(self):
         if self.settings.build_type == "Debug":
@@ -41,11 +44,15 @@ class MoldConan(ConanFile):
     def _build_subfolder(self):
         return "build_subfolder"
 
+    def export_sources(self):
+        if Version(self.version) > "1.4.0":
+            self.copy("CMakeLists.txt")
+
     def _get_include_path(self, dependency):
         include_path = self.deps_cpp_info[dependency].rootpath
         include_path = os.path.join(include_path, "include")
         return include_path
-        
+
     def _patch_sources(self):
         if self.settings.compiler == "apple-clang" or (self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "11"):
             files.replace_in_file(self, "source_subfolder/Makefile", "-std=c++20", "-std=c++2a")
@@ -64,26 +71,53 @@ class MoldConan(ConanFile):
         files.replace_in_file(self, "source_subfolder/Makefile", "MOLD_LDFLAGS += -lmimalloc", "MOLD_LDFLAGS += -L{} -lmimalloc".format(
             self.deps_cpp_info["mimalloc"].lib_paths[0]))
 
+    @functools.lru_cache(1)
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["MOLD_USE_SYSTEM_MIMALLOC"] = True
+        cmake.definitions["MOLD_USE_SYSTEM_TBB"] = True
+        cmake.definitions["MOLD_USE_MOLD"] = False
+        cmake.configure()
+        return cmake
+
+    def build_requirements(self):
+        self.tool_requires("cmake/3.23.0")
+
     def requirements(self):
         self.requires("zlib/1.2.12")
         self.requires("openssl/1.1.1q")
-        self.requires("xxhash/0.8.1")
         self.requires("onetbb/2021.3.0")
         self.requires("mimalloc/2.0.6")
+        if Version(self.version) < "1.4.0":
+            self.requires("xxhash/0.8.1")
 
     def source(self):
         files.get(self, **self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
     def build(self):
-        self._patch_sources()
-        with files.chdir(self, self._source_subfolder):
-            autotools = AutoToolsBuildEnvironment(self)
-            autotools.make(target="mold", args=['SYSTEM_TBB=1', 'SYSTEM_MIMALLOC=1'])
+        if Version(self.version) < "1.4":
+            self._patch_sources()
+            with files.chdir(self, self._source_subfolder):
+                autotools = AutoToolsBuildEnvironment(self)
+                autotools.make(target="mold", args=['SYSTEM_TBB=1', 'SYSTEM_MIMALLOC=1'])
+        else:
+            # Error out if ZLIB is not found, we want to be predictable
+            tools.replace_in_file("source_subfolder/CMakeLists.txt", "find_package(ZLIB QUIET)", "find_package(ZLIB REQUIRED)")
+            # Since we introduce a conan wrapper, CMAKE_SOURCE_DIR points a dir above. mold_SOURD_DIR is an equivalent to the vanilla behavior
+            tools.replace_in_file("source_subfolder/CMakeLists.txt", "${CMAKE_SOURCE_DIR}/update-git-hash.py", "${mold_SOURCE_DIR}/update-git-hash.py")
+            # This is a bug upstream. You can't assing definitions to a target you don't build.
+            tools.replace_in_file("source_subfolder/CMakeLists.txt", "target_compile_definitions(mimalloc INTERFACE USE_SYSTEM_MIMALLOC)", "target_compile_definitions(mold PRIVATE USE_SYSTEM_MIMALLOC)")
+            cmake = self._configure_cmake()
+            cmake.build()
 
     def package(self):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        self.copy("mold", src=self._source_subfolder, dst="bin", keep_path=False)
+        if Version(self.version) < "1.4":
+            self.copy("mold", src=self._source_subfolder, dst="bin", keep_path=False)
+        else:
+            cmake = self._configure_cmake()
+            cmake.install()
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/mold/all/conanfile.py
+++ b/recipes/mold/all/conanfile.py
@@ -102,14 +102,13 @@ class MoldConan(ConanFile):
         else:
             # Error out if ZLIB is not found, we want to be predictable
             files.replace_in_file(self, "source_subfolder/CMakeLists.txt", "find_package(ZLIB QUIET)", "find_package(ZLIB REQUIRED)")
-            # Since we introduce a conan wrapper, CMAKE_SOURCE_DIR points a dir above. mold_SOURD_DIR is an equivalent to the vanilla behavior
+            # Since we introduce a conan wrapper, CMAKE_SOURCE_DIR points to a dir above. mold_SOURD_DIR is an equivalent to the intended behavior
             files.replace_in_file(self, "source_subfolder/CMakeLists.txt", "${CMAKE_SOURCE_DIR}/update-git-hash.py", "${mold_SOURCE_DIR}/update-git-hash.py")
-            # This is a bug upstream. You can't assing definitions to a target you don't build.
+            # This is a bug upstream. You can't assing definitions to a target you don't build. It has been addressed on main but not released.
             files.replace_in_file(self, "source_subfolder/CMakeLists.txt", "target_compile_definitions(mimalloc INTERFACE USE_SYSTEM_MIMALLOC)", "target_compile_definitions(mold PRIVATE USE_SYSTEM_MIMALLOC)")
             # Use conan's xxhash
-            files.replace_in_file(self, "source_subfolder/CMakeLists.txt", "target_link_libraries(mold PRIVATE ${CMAKE_DL_LIBS})", "find_package(xxHash REQUIRED)\ntarget_link_libraries(mold PRIVATE ${CMAKE_DL_LIBS} xxHash::xxhash)")
+            files.replace_in_file(self, "source_subfolder/CMakeLists.txt", "target_link_libraries(mold PRIVATE ${CMAKE_DL_LIBS})", "target_link_libraries(mold PRIVATE ${CMAKE_DL_LIBS})\nfind_package(xxHash REQUIRED)\ntarget_link_libraries(xxHash::xxhash)")
             files.replace_in_file(self, "source_subfolder/mold.h", '#include "third-party/xxhash/xxhash.h"', '#include "xxhash.h"')
-
 
             cmake = self._configure_cmake()
             cmake.build()

--- a/recipes/mold/config.yml
+++ b/recipes/mold/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.4.1":
+    folder: all
   "1.3.1":
     folder: all


### PR DESCRIPTION
Mold has moved to CMake on its latest release, so this PR makes the recipe a bit convoluted. 
Should we move the old recipe to a `1.3` folder and keep it as a different recipe? Deprecate 1.3 and keep only 1.4+? Keep both build systems on the same recipe as this PR proposes?