### PR TITLE
add matchit 1.0.1

### DIFF
--- a/recipes/matchit/all/conandata.yml
+++ b/recipes/matchit/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.1":
+    sha256: 2860cb85febf37220f75cef5b499148bafc9f5541fe1298e11b0c169bb3f31ac
+    url: https://github.com/BowenFu/matchit.cpp/archive/v1.0.1.tar.gz

--- a/recipes/matchit/all/conanfile.py
+++ b/recipes/matchit/all/conanfile.py
@@ -16,12 +16,7 @@ class MatchitConan(ConanFile):
     license = "Apache-2.0"
     description = ("match(it): A lightweight header-only pattern-matching"
                    " library for C++17 with macro-free APIs.")
-    topics = (
-        "conan",
-        "matchit",
-        "cpp17",
-        "header-only",
-    )
+    topics = ("lightweight", "cpp17", "header-only", "pattern-matching")
     no_copy_source = True
     settings = "compiler"
 

--- a/recipes/matchit/all/conanfile.py
+++ b/recipes/matchit/all/conanfile.py
@@ -62,5 +62,9 @@ class MatchitConan(ConanFile):
         self.info.clear()
 
     def package_info(self):
+        # TODO: Remove after Conan 2.0
         self.cpp_info.names["cmake_find_package"] = "matchit"
         self.cpp_info.names["cmake_find_package_multi"] = "matchit"
+
+        self.cpp_info.set_property("cmake_target_name", "matchit::matchit")
+        self.cpp_info.set_property("cmake_file_name", "matchit")

--- a/recipes/matchit/all/conanfile.py
+++ b/recipes/matchit/all/conanfile.py
@@ -1,0 +1,71 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=1.50.0"
+
+
+class MatchitConan(ConanFile):
+    name = "matchit"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/BowenFu/matchit.cpp"
+    license = "Apache-2.0"
+    description = ("match(it): A lightweight header-only pattern-matching"
+                   " library for C++17 with macro-free APIs.")
+    topics = (
+        "conan",
+        "matchit",
+        "cpp17",
+        "header-only",
+    )
+    no_copy_source = True
+    settings = "compiler"
+
+    _compiler_required_cpp17 = {
+        "Visual Studio": "16",
+        "gcc": "8",
+        "clang": "7",
+        "apple-clang": "12.0",
+    }
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, "17")
+
+        minimum_version = self._compiler_required_cpp17.get(
+            str(self.settings.compiler), False)
+        if minimum_version:
+            if Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(
+                    "{} requires C++17, which your compiler does not support.".format(self.name))
+        else:
+            self.output.warn(
+                "{0} requires C++17. Your compiler is unknown. Assuming it supports C++17.".format(self.name))
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True,
+            destination=self.source_folder)
+
+    def build(self):
+        pass
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "matchit.h",
+             src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"))
+
+    def package_id(self):
+        self.info.clear()
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "matchit"
+        self.cpp_info.names["cmake_find_package_multi"] = "matchit"

--- a/recipes/matchit/all/conanfile.py
+++ b/recipes/matchit/all/conanfile.py
@@ -18,7 +18,7 @@ class MatchitConan(ConanFile):
                    " library for C++17 with macro-free APIs.")
     topics = ("lightweight", "cpp17", "header-only", "pattern-matching")
     no_copy_source = True
-    settings = "compiler"
+    settings = "arch", "build_type", "compiler", "os"
 
     _compiler_required_cpp17 = {
         "Visual Studio": "16",

--- a/recipes/matchit/all/test_package/CMakeLists.txt
+++ b/recipes/matchit/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+find_package(matchit REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE matchit::matchit)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/recipes/matchit/all/test_package/CMakeLists.txt
+++ b/recipes/matchit/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package LANGUAGES CXX)
 
-find_package(matchit REQUIRED)
+find_package(matchit REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE matchit::matchit)

--- a/recipes/matchit/all/test_package/conanfile.py
+++ b/recipes/matchit/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/matchit/all/test_package/test_package.cpp
+++ b/recipes/matchit/all/test_package/test_package.cpp
@@ -1,0 +1,23 @@
+#include <matchit.h>
+#include <iostream>
+#include <tuple>
+
+int32_t main() {
+  using namespace matchit;
+  auto &strm = std::cout;
+  constexpr auto v = std::variant<int, float>{4};
+  Id<int> i;
+  Id<float> f;
+  match(v)(
+      // clang-format off
+        pattern | as<int>(i) = [&]{
+            strm << "got int: " << *i;
+        },
+        pattern | as<float>(f) = [&]{
+            strm << "got float: " << *f;
+        }
+      // clang-format on
+  );
+
+  return 0;
+}

--- a/recipes/matchit/all/test_v1_package/CMakeLists.txt
+++ b/recipes/matchit/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(matchit REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE matchit::matchit)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/recipes/matchit/all/test_v1_package/conanfile.py
+++ b/recipes/matchit/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+# legacy validation with Conan 1.x
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/matchit/config.yml
+++ b/recipes/matchit/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.1":
+    folder: "all"


### PR DESCRIPTION
**matchit/1.0.1**

It's a brand new C++ header-only library that was released recently. I've seen that it only [has](https://github.com/BowenFu/matchit.cpp#option-4-manage-with-vcpkg) vcpkg support. So I decided to add conan support too as I would prefer to use it myself. It's main purpose to represent Rust-like enum pattern matchers into C++ and provide new coding style paradigm into the language.


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
