### PR TITLE
Boost: iOS should use spinlock instead of pthread to prevent filesystem crashes

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1104,8 +1104,7 @@ class BoostConan(ConanFile):
 
         if self.settings.os == "iOS":
             if self.options.multithreading:
-                cxx_flags.append("-DBOOST_AC_USE_PTHREADS")
-                cxx_flags.append("-DBOOST_SP_USE_PTHREADS")
+                cxx_flags.append("-DBOOST_SP_USE_SPINLOCK")
 
             cxx_flags.append("-fembed-bitcode")
 
@@ -1727,7 +1726,9 @@ class BoostConan(ConanFile):
                 if self.options.multithreading:
                     # https://github.com/conan-io/conan-center-index/issues/3867
                     # runtime crashes occur when using the default platform-specific reference counter/atomic
-                    self.cpp_info.components["headers"].defines.extend(["BOOST_AC_USE_PTHREADS", "BOOST_SP_USE_PTHREADS"])
+                    # https://github.com/boostorg/filesystem/issues/147
+                    # iOS should use spinlocks to avoid filesystem crashes
+                    self.cpp_info.components["headers"].defines.append("BOOST_SP_USE_SPINLOCK")
                 else:
                     self.cpp_info.components["headers"].defines.extend(["BOOST_AC_DISABLE_THREADS", "BOOST_SP_DISABLE_THREADS"])
         self.user_info.stacktrace_addr2line_available = self._stacktrace_addr2line_available


### PR DESCRIPTION
Specify library name and version:  **boost/1.79.0**

As was discovered in https://github.com/faithfracture/Apple-Boost-BuildScript/issues/50 / https://github.com/boostorg/filesystem/issues/147, using `BOOST_SP_USE_SPINLOCK` instead of `BOOST_*_USE_PTHREADS` fixes boost.filesystem crashes on iOS.

Original issue: #3867

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
