### PR TITLE
migrate h5pp to conan v2

### DIFF
--- a/recipes/h5pp/all/conanfile.py
+++ b/recipes/h5pp/all/conanfile.py
@@ -3,7 +3,7 @@ from conan import ConanFile, tools
 from conan.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.45.0"
+required_conan_version = ">=1.46.0"
 
 
 class H5ppConan(ConanFile):

--- a/recipes/h5pp/all/conanfile.py
+++ b/recipes/h5pp/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan.tools.microsoft import is_msvc
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile, tools
+from conan.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=1.45.0"
@@ -39,7 +39,7 @@ class H5ppConan(ConanFile):
         }
 
     def config_options(self):
-        if tools.Version(self.version) < "1.10.0":
+        if tools.scm.Version(self.version) < "1.10.0":
             # These dependencies are always required before h5pp 1.10.0:
             #   * h5pp < 1.10.0 includes any version of headers indiscriminately (e.g. system headers),
             #     and can't tell if the the corresponding library will be linked. This makes the,
@@ -51,9 +51,9 @@ class H5ppConan(ConanFile):
 
     def requirements(self):
         self.requires("hdf5/1.12.1")
-        if tools.Version(self.version) < "1.10.0" or self.options.get_safe('with_eigen'):
+        if tools.scm.Version(self.version) < "1.10.0" or self.options.get_safe('with_eigen'):
             self.requires("eigen/3.4.0")
-        if tools.Version(self.version) < "1.10.0" or self.options.get_safe('with_spdlog'):
+        if tools.scm.Version(self.version) < "1.10.0" or self.options.get_safe('with_spdlog'):
             self.requires("spdlog/1.10.0")
 
     def package_id(self):
@@ -61,21 +61,21 @@ class H5ppConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 17)
+            tools.build.check_min_cppstd(self, 17)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version:
-            if tools.Version(self.settings.compiler.version) < minimum_version:
+            if tools.scm.Version(self.settings.compiler.version) < minimum_version:
                 raise ConanInvalidConfiguration("h5pp requires C++17, which your compiler does not support.")
         else:
             self.output.warn("h5pp requires C++17. Your compiler is unknown. Assuming it supports C++17.")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
+        tools.files.get(self, **self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        if tools.Version(self.version) < "1.9.0":
+        if tools.scm.Version(self.version) < "1.9.0":
             includedir = os.path.join(self._source_subfolder, "h5pp", "include")
         else:
             includedir = os.path.join(self._source_subfolder, "include")
@@ -89,7 +89,7 @@ class H5ppConan(ConanFile):
         self.cpp_info.components["h5pp_flags"].set_property("cmake_target_name", "h5pp::flags")
         self.cpp_info.components["h5pp_deps"].requires = ["hdf5::hdf5"]
 
-        if tools.Version(self.version) >= "1.10.0":
+        if tools.scm.Version(self.version) >= "1.10.0":
             if self.options.with_eigen:
                 self.cpp_info.components["h5pp_deps"].requires.append("eigen::eigen")
                 self.cpp_info.components["h5pp_flags"].defines.append("H5PP_USE_EIGEN3")
@@ -101,7 +101,7 @@ class H5ppConan(ConanFile):
             self.cpp_info.components["h5pp_deps"].requires.append("eigen::eigen")
             self.cpp_info.components["h5pp_deps"].requires.append("spdlog::spdlog")
 
-        if (self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) < "9") or \
+        if (self.settings.compiler == "gcc" and tools.scm.Version(self.settings.compiler.version) < "9") or \
            (self.settings.compiler == "clang" and self.settings.compiler.get_safe("libcxx") in ["libstdc++", "libstdc++11"]):
             self.cpp_info.components["h5pp_flags"].system_libs = ["stdc++fs"]
         if is_msvc(self):

--- a/recipes/h5pp/all/test_package/conanfile.py
+++ b/recipes/h5pp/all/test_package/conanfile.py
@@ -1,4 +1,5 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile, tools
+from conans import CMake
 import os
 
 
@@ -12,5 +13,5 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not tools.build.cross_building(self):
             self.run(os.path.join("bin","test_package"), run_environment=True)


### PR DESCRIPTION
This conan v2 migration PR was generated by automatoc script version 10.
It uses simple find and replace technics. Feel free to extend it.