### PR TITLE
migrate hunspell to conan v2

### DIFF
--- a/recipes/hunspell/all/conanfile.py
+++ b/recipes/hunspell/all/conanfile.py
@@ -1,8 +1,9 @@
 import functools
 import os
 
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile, tools
+from conans import CMake
+from conan.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.43.0"
 
@@ -39,7 +40,7 @@ class HunspellConan(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True)
+        tools.files.get(self, **self.conan_data["sources"][self.version], strip_root=True)
         # NOTE: The source contains a pre-configured hunvisapi.h and it would
         #       prevent no_copy_source and building without patches.
         h = os.path.join(self.source_folder, "src", "hunspell", "hunvisapi.h")

--- a/recipes/hunspell/all/test_package/conanfile.py
+++ b/recipes/hunspell/all/test_package/conanfile.py
@@ -1,6 +1,7 @@
 import os
 
-from conans import ConanFile, CMake, tools
+from conan import ConanFile, tools
+from conans import CMake
 
 
 class TestPackageConan(ConanFile):
@@ -13,6 +14,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not tools.build.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
This conan v2 migration PR was generated by automatoc script version 10.
It uses simple find and replace technics. Feel free to extend it.