### PR TITLE
Added recipe for cminpack

### DIFF
--- a/recipes/cminpack/all/conandata.yml
+++ b/recipes/cminpack/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.3.8":
+    sha256: "3ea7257914ad55eabc43a997b323ba0dfee0a9b010d648b6d5b0c96425102d0e"
+    url: "https://github.com/devernay/cminpack/archive/refs/tags/v1.3.8.tar.gz"

--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -29,6 +29,7 @@ class CMinpackConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_EXAMPLES"] = "OFF"
         tc.variables["CMINPACK_LIB_INSTALL_DIR"] = "lib"
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
 
     def layout(self):
@@ -61,11 +62,7 @@ class CMinpackConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        # moving this into the toolchain variables is not sufficient
-        # right now. required for setting shared option
-        cmake.configure(variables={
-            "CMAKE_POLICY_DEFAULT_CMP0077":  "NEW"
-        })
+        cmake.configure()
         cmake.build()
 
     def package(self):

--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -84,7 +84,7 @@ class CMinpackConan(ConanFile):
 
     def package_info(self):
         minpack_include_dir = os.path.join("include", "cminpack-1")
-        
+        self.cpp_info.set_property("cmake_target_name", "cminpack")
         # the double precision version
         self.cpp_info.components['cminpack-double'].libs = ['cminpack' + self._library_postfix()]
         self.cpp_info.components['cminpack-double'].includedirs.append(minpack_include_dir)

--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -98,6 +98,10 @@ class CMinpackConan(ConanFile):
             self.cpp_info.system_libs.append("m")
             self.cpp_info.components['cminpacks'].system_libs.append("m")
 
+        # required apple frameworks
+        self.cpp_info.frameworks.append("Accelerate")
+        self.cpp_info.components['cminpacks'].frameworks.append("Accelerate")
+
         if not self.options.shared and self.settings.os == "Windows":
             self.cpp_info.defines.append("CMINPACK_NO_DLL")
             self.cpp_info.components['cminpacks'].defines.append("CMINPACK_NO_DLL")

--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools import files
 from conan import ConanFile
 import os
@@ -30,8 +30,6 @@ class CMinpackConan(ConanFile):
         tc.variables["BUILD_EXAMPLES"] = "OFF"
         tc.variables["CMINPACK_LIB_INSTALL_DIR"] = "lib"
         tc.generate()
-        deps = CMakeDeps(self)
-        deps.generate()
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -29,6 +29,7 @@ class CMinpackConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_EXAMPLES"] = "OFF"
+        tc.variables["CMINPACK_LIB_INSTALL_DIR"] = "lib"
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
@@ -91,15 +92,18 @@ class CMinpackConan(ConanFile):
         minpack_include_dir = os.path.join("include", "cminpack-1")
         
         # the double precision version
-        self.cpp_info.components['cminpackd'].names["cmake_find_package"] = "cminpack"
-        self.cpp_info.components['cminpackd'].libs = ['cminpack' + self.library_postfix()]
-        self.cpp_info.components['cminpackd'].includedirs.append(minpack_include_dir)
+        self.cpp_info.libs = ['cminpack' + self.library_postfix()]
+        self.cpp_info.includedirs.append(minpack_include_dir)
         
         # the single precision version
         self.cpp_info.components['cminpacks'].libs = ['cminpacks' + self.library_postfix()]
         self.cpp_info.components['cminpacks'].includedirs.append(minpack_include_dir)
         self.cpp_info.components['cminpacks'].defines.append("__cminpack_float__")
 
+        if self.settings.os != "Windows":
+            self.cpp_info.system_libs.append("m")
+            self.cpp_info.components['cminpacks'].system_libs.append("m")
+
         if not self.options.shared and self.settings.os == "Windows":
-            self.cpp_info.components['cminpackd'].defines.append("CMINPACK_NO_DLL")
+            self.cpp_info.defines.append("CMINPACK_NO_DLL")
             self.cpp_info.components['cminpacks'].defines.append("CMINPACK_NO_DLL")

--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -13,7 +13,7 @@ class CMinpackConan(ConanFile):
                   "for solving nonlinear equations and nonlinear least squares problems"
     topics = ("nonlinear", "solver")
     homepage = "http://devernay.free.fr/hacks/cminpack/"
-    license = "BSD-like"
+    license = "LicenseRef-CopyrightMINPACK.txt"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -86,25 +86,28 @@ class CMinpackConan(ConanFile):
         minpack_include_dir = os.path.join("include", "cminpack-1")
         
         # the double precision version
-        self.cpp_info.components['cminpackd'].libs = ['cminpack' + self._library_postfix()]
-        self.cpp_info.components['cminpackd'].includedirs.append(minpack_include_dir)
-        self.cpp_info.components["cminpackd"].set_property("cmake_target_name", "cminpack::cminpack")
-        self.cpp_info.components["cminpackd"].names["cmake_find_package"] = "cminpack"
-        self.cpp_info.components["cminpackd"].names["cmake_find_package_multi"] = "cminpack"
+        self.cpp_info.components['cminpack-double'].libs = ['cminpack' + self._library_postfix()]
+        self.cpp_info.components['cminpack-double'].includedirs.append(minpack_include_dir)
+        self.cpp_info.components["cminpack-double"].set_property("cmake_target_name", "cminpack::cminpack")
+        self.cpp_info.components["cminpack-double"].names["cmake_find_package"] = "cminpack"
+        self.cpp_info.components["cminpack-double"].names["cmake_find_package_multi"] = "cminpack"
         
         # the single precision version
-        self.cpp_info.components['cminpacks'].libs = ['cminpacks' + self._library_postfix()]
-        self.cpp_info.components['cminpacks'].includedirs.append(minpack_include_dir)
-        self.cpp_info.components['cminpacks'].defines.append("__cminpack_float__")
+        self.cpp_info.components['cminpack-single'].libs = ['cminpacks' + self._library_postfix()]
+        self.cpp_info.components['cminpack-single'].includedirs.append(minpack_include_dir)
+        self.cpp_info.components['cminpack-single'].defines.append("__cminpack_float__")
+        self.cpp_info.components["cminpack-single"].set_property("cmake_target_name", "cminpack::cminpacks")
+        self.cpp_info.components["cminpack-single"].names["cmake_find_package"] = "cminpacks"
+        self.cpp_info.components["cminpack-single"].names["cmake_find_package_multi"] = "cminpacks"
 
         if self.settings.os != "Windows":
-            self.cpp_info.components['cminpackd'].system_libs.append("m")
-            self.cpp_info.components['cminpacks'].system_libs.append("m")
+            self.cpp_info.components['cminpack-double'].system_libs.append("m")
+            self.cpp_info.components['cminpack-single'].system_libs.append("m")
 
         # required apple frameworks
-        self.cpp_info.components['cminpackd'].frameworks.append("Accelerate")
-        self.cpp_info.components['cminpacks'].frameworks.append("Accelerate")
+        self.cpp_info.components['cminpack-double'].frameworks.append("Accelerate")
+        self.cpp_info.components['cminpack-single'].frameworks.append("Accelerate")
 
         if not self.options.shared and self.settings.os == "Windows":
-            self.cpp_info.components['cminpackd'].defines.append("CMINPACK_NO_DLL")
-            self.cpp_info.components['cminpacks'].defines.append("CMINPACK_NO_DLL")
+            self.cpp_info.components['cminpack-double'].defines.append("CMINPACK_NO_DLL")
+            self.cpp_info.components['cminpack-single'].defines.append("CMINPACK_NO_DLL")

--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -86,8 +86,11 @@ class CMinpackConan(ConanFile):
         minpack_include_dir = os.path.join("include", "cminpack-1")
         
         # the double precision version
-        self.cpp_info.libs = ['cminpack' + self._library_postfix()]
-        self.cpp_info.includedirs.append(minpack_include_dir)
+        self.cpp_info.components['cminpackd'].libs = ['cminpack' + self._library_postfix()]
+        self.cpp_info.components['cminpackd'].includedirs.append(minpack_include_dir)
+        self.cpp_info.components["cminpackd"].set_property("cmake_target_name", "cminpack::cminpack")
+        self.cpp_info.components["cminpackd"].names["cmake_find_package"] = "cminpack"
+        self.cpp_info.components["cminpackd"].names["cmake_find_package_multi"] = "cminpack"
         
         # the single precision version
         self.cpp_info.components['cminpacks'].libs = ['cminpacks' + self._library_postfix()]
@@ -95,13 +98,13 @@ class CMinpackConan(ConanFile):
         self.cpp_info.components['cminpacks'].defines.append("__cminpack_float__")
 
         if self.settings.os != "Windows":
-            self.cpp_info.system_libs.append("m")
+            self.cpp_info.components['cminpackd'].system_libs.append("m")
             self.cpp_info.components['cminpacks'].system_libs.append("m")
 
         # required apple frameworks
-        self.cpp_info.frameworks.append("Accelerate")
+        self.cpp_info.components['cminpackd'].frameworks.append("Accelerate")
         self.cpp_info.components['cminpacks'].frameworks.append("Accelerate")
 
         if not self.options.shared and self.settings.os == "Windows":
-            self.cpp_info.defines.append("CMINPACK_NO_DLL")
+            self.cpp_info.components['cminpackd'].defines.append("CMINPACK_NO_DLL")
             self.cpp_info.components['cminpacks'].defines.append("CMINPACK_NO_DLL")

--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -1,0 +1,105 @@
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools import files
+from conan import ConanFile
+import os
+import textwrap
+
+required_conan_version = ">=1.45.0"
+
+
+class CMinpackConan(ConanFile):
+    name = "cminpack"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "About A C/C++ rewrite of the MINPACK software (originally in FORTRAN)" \
+                  "for solving nonlinear equations and nonlinear least squares problems"
+    topics = ("nonlinear", "solver")
+    homepage = "http://devernay.free.fr/hacks/cminpack/"
+    license = "BSD-like"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_EXAMPLES"] = "OFF"
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+
+        # cminpack is a c library
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
+
+    def source(self):
+        files.get(self, **self.conan_data["sources"][self.version],
+                  strip_root=True, destination=self.source_folder)
+
+    def build(self):
+        cmake = CMake(self)
+        # moving this into the toolchain variables is not sufficient
+        # right now. required for setting shared option
+        cmake.configure(variables={
+            "CMAKE_POLICY_DEFAULT_CMP0077":  "NEW"
+        })
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+        files.rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        files.copy(self, "CopyrightMINPACK.txt", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        files.rmdir(self, os.path.join(self.package_folder, "share")) # contains cmake config files
+
+    def library_postfix(self):
+        postfix = ""
+        if not self.options.shared:
+            postfix += "_s" # for static
+        if self.settings.build_type == "Debug":
+            postfix += "_d"
+
+        return postfix
+
+    def package_info(self):
+        minpack_include_dir = os.path.join("include", "cminpack-1")
+        
+        # the double precision version
+        self.cpp_info.components['cminpackd'].names["cmake_find_package"] = "cminpack"
+        self.cpp_info.components['cminpackd'].libs = ['cminpack' + self.library_postfix()]
+        self.cpp_info.components['cminpackd'].includedirs.append(minpack_include_dir)
+        
+        # the single precision version
+        self.cpp_info.components['cminpacks'].libs = ['cminpacks' + self.library_postfix()]
+        self.cpp_info.components['cminpacks'].includedirs.append(minpack_include_dir)
+        self.cpp_info.components['cminpacks'].defines.append("__cminpack_float__")
+
+        if not self.options.shared and self.settings.os == "Windows":
+            self.cpp_info.components['cminpackd'].defines.append("CMINPACK_NO_DLL")
+            self.cpp_info.components['cminpacks'].defines.append("CMINPACK_NO_DLL")

--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -2,7 +2,6 @@ from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools import files
 from conan import ConanFile
 import os
-import textwrap
 
 required_conan_version = ">=1.45.0"
 
@@ -79,7 +78,7 @@ class CMinpackConan(ConanFile):
         files.copy(self, "CopyrightMINPACK.txt", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         files.rmdir(self, os.path.join(self.package_folder, "share")) # contains cmake config files
 
-    def library_postfix(self):
+    def _library_postfix(self):
         postfix = ""
         if not self.options.shared:
             postfix += "_s" # for static
@@ -92,11 +91,11 @@ class CMinpackConan(ConanFile):
         minpack_include_dir = os.path.join("include", "cminpack-1")
         
         # the double precision version
-        self.cpp_info.libs = ['cminpack' + self.library_postfix()]
+        self.cpp_info.libs = ['cminpack' + self._library_postfix()]
         self.cpp_info.includedirs.append(minpack_include_dir)
         
         # the single precision version
-        self.cpp_info.components['cminpacks'].libs = ['cminpacks' + self.library_postfix()]
+        self.cpp_info.components['cminpacks'].libs = ['cminpacks' + self._library_postfix()]
         self.cpp_info.components['cminpacks'].includedirs.append(minpack_include_dir)
         self.cpp_info.components['cminpacks'].defines.append("__cminpack_float__")
 

--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -91,6 +91,7 @@ class CMinpackConan(ConanFile):
         self.cpp_info.components["cminpack-double"].set_property("cmake_target_name", "cminpack::cminpack")
         self.cpp_info.components["cminpack-double"].names["cmake_find_package"] = "cminpack"
         self.cpp_info.components["cminpack-double"].names["cmake_find_package_multi"] = "cminpack"
+        self.cpp_info.components["cminpack-double"].names["pkg_config"] = "cminpack"
         
         # the single precision version
         self.cpp_info.components['cminpack-single'].libs = ['cminpacks' + self._library_postfix()]
@@ -99,6 +100,8 @@ class CMinpackConan(ConanFile):
         self.cpp_info.components["cminpack-single"].set_property("cmake_target_name", "cminpack::cminpacks")
         self.cpp_info.components["cminpack-single"].names["cmake_find_package"] = "cminpacks"
         self.cpp_info.components["cminpack-single"].names["cmake_find_package_multi"] = "cminpacks"
+        self.cpp_info.components["cminpack-single"].names["pkg_config"] = "cminpacks"
+
 
         if self.settings.os != "Windows":
             self.cpp_info.components['cminpack-double'].system_libs.append("m")

--- a/recipes/cminpack/all/test_package/CMakeLists.txt
+++ b/recipes/cminpack/all/test_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.12)
+project(CMinPack-Conan-TestPackage C)
+
+find_package(CMinpack REQUIRED)
+
+# This builds one of the original cminpack examples against
+# both types of the library
+
+add_executable(cminpack_test_double tchkderc.c)
+target_link_libraries(cminpack_test_double PRIVATE cminpack::cminpack)
+
+add_executable(cminpack_test_float tchkderc.c)
+target_link_libraries(cminpack_test_float PRIVATE cminpack::cminpacks)

--- a/recipes/cminpack/all/test_package/conanfile.py
+++ b/recipes/cminpack/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "cminpack_test_double")
+            self.run(bin_path, env="conanrun")
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "cminpack_test_float")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cminpack/all/test_package/tchkderc.c
+++ b/recipes/cminpack/all/test_package/tchkderc.c
@@ -1,0 +1,159 @@
+/*      driver for chkder example. */
+
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include <cminpack.h>
+#define real __cminpack_real__
+
+/* the following struct defines the data points */
+typedef struct  {
+    int m;
+    real *y;
+#ifdef BOX_CONSTRAINTS
+    real *xmin;
+    real *xmax;
+#endif
+} fcndata_t;
+
+int fcn(void *p, int m, int n, const real *x, real *fvec,
+	 real *fjac, int ldfjac, int iflag);
+
+int main()
+{
+#if defined(__MINGW32__) || (defined(_MSC_VER) && (_MSC_VER < 1900))
+  _set_output_format(_TWO_DIGIT_EXPONENT);
+#endif
+  int i, ldfjac;
+  real x[3], fvec[15], fjac[15*3], xp[3], fvecp[15], 
+    err[15];
+  const int m = 15;
+  const int n = 3;
+  /* auxiliary data (e.g. measurements) */
+  real y[15] = {1.4e-1, 1.8e-1, 2.2e-1, 2.5e-1, 2.9e-1, 3.2e-1, 3.5e-1,
+                  3.9e-1, 3.7e-1, 5.8e-1, 7.3e-1, 9.6e-1, 1.34, 2.1, 4.39};
+#ifdef BOX_CONSTRAINTS
+  real xmin[3] = {0., 0.1, 0.5};
+  real xmax[3] = {2., 1.5, 2.3};
+#endif
+  fcndata_t data;
+  data.m = m;
+  data.y = y;
+#ifdef BOX_CONSTRAINTS
+  data.xmin = xmin;
+  data.xmax = xmax;
+#endif
+
+  /*      the following values should be suitable for */
+  /*      checking the jacobian matrix. */
+
+  x[0] = 9.2e-1;
+  x[1] = 1.3e-1;
+  x[2] = 5.4e-1;
+
+  ldfjac = 15;
+
+  /* compute xp from x */
+  __cminpack_func__(chkder)(m, n, x, NULL, NULL, ldfjac, xp, NULL, 1, NULL);
+  /* compute fvec at x (all components of fvec should be != 0).*/
+  fcn(&data, m, n, x, fvec, NULL, ldfjac, 1);
+  /* compute fjac at x */
+  fcn(&data, m, n, x, NULL, fjac, ldfjac, 2);
+  /* compute fvecp at xp (all components of fvecp should be != 0)*/
+  fcn(&data, m, n, xp, fvecp, NULL, ldfjac, 1);
+  /* check Jacobian, put the result in err */
+  __cminpack_func__(chkder)(m, n, x, fvec, fjac, ldfjac, NULL, fvecp, 2, err);
+  /* Output values:
+     err[i] = 1.: i-th gradient is correct
+     err[i] = 0.: i-th gradient is incorrect
+     err[I] > 0.5: i-th gradient is probably correct
+  */
+
+  for (i=0; i<m; ++i) {
+    fvecp[i] = fvecp[i] - fvec[i];
+  }
+  printf("\n      fvec\n");  
+  for (i=0; i<m; ++i) {
+    printf("%s%15.7g",i%3==0?"\n     ":"", (double)fvec[i]);
+  }
+  printf("\n      fvecp - fvec\n");  
+  for (i=0; i<m; ++i) {
+    printf("%s%15.7g",i%3==0?"\n     ":"", (double)fvecp[i]);
+  }
+  printf("\n      err\n");  
+  for (i=0; i<m; ++i) {
+    printf("%s%15.7g",i%3==0?"\n     ":"", (double)err[i]);
+  }
+  printf("\n");
+  return 0;
+}
+
+int fcn(void *p, int m, int n, const real *x, real *fvec,
+	 real *fjac, int ldfjac, int iflag)
+{
+  /*      subroutine fcn for chkder example. */
+  assert(m == 15 && n == 3);
+  int i;
+  real tmp1, tmp2, tmp3, tmp4;
+  const real *y = ((fcndata_t*)p)->y;
+#ifdef BOX_CONSTRAINTS
+  const real *xmin = ((fcndata_t*)p)->xmin;
+  const real *xmax = ((fcndata_t*)p)->xmax;
+  int j;
+  real xb[3];
+  real jacfac[3];
+
+  for (j = 0; j < 3; ++j) {
+    real xmiddle = (xmin[j]+xmax[j])/2.;
+    real xwidth = (xmax[j]-xmin[j])/2.;
+    real th =  tanh((x[j]-xmiddle)/xwidth);
+    xb[j] = xmiddle + th * xwidth;
+    jacfac[j] = 1. - th * th;
+  }
+  x = xb;
+#endif
+
+  if (iflag == 0) {
+    /*      insert print statements here when nprint is positive. */
+    /* if the nprint parameter to lmder is positive, the function is
+       called every nprint iterations with iflag=0, so that the
+       function may perform special operations, such as printing
+       residuals. */
+    return 0;
+  }
+
+  if (iflag != 2) {
+    /* compute residuals */
+    for (i=0; i < 15; ++i) {
+      tmp1 = i + 1;
+      tmp2 = 15 - i;
+      tmp3 = (i > 7) ? tmp2 : tmp1;
+      fvec[i] = y[i] - (x[0] + tmp1/(x[1]*tmp2 + x[2]*tmp3));
+    }
+  } else {
+    /* compute Jacobian */
+    for (i=0; i < 15; ++i) {
+      tmp1 = i + 1;
+      tmp2 = 15 - i;
+#    ifdef TCHKDER_FIXED
+      tmp3 = (i > 7) ? tmp2 : tmp1;
+#    else
+      /* error introduced into next statement for illustration. */
+      /* corrected statement should read    tmp3 = (i > 7) ? tmp2 : tmp1 . */
+      tmp3 = (i > 7) ? tmp2 : tmp2;
+#    endif
+      tmp4 = (x[1]*tmp2 + x[2]*tmp3); tmp4 = tmp4*tmp4;
+      fjac[i + ldfjac*0] = -1.;
+      fjac[i + ldfjac*1] = tmp1*tmp2/tmp4;
+      fjac[i + ldfjac*2] = tmp1*tmp3/tmp4;
+    }
+#  ifdef BOX_CONSTRAINTS
+    for (j = 0; j < 3; ++j) {
+      for (i=0; i < 15; ++i) {
+        fjac[i + ldfjac*j] *= jacfac[j];
+      }
+    }
+#  endif
+  }
+  return 0;
+}

--- a/recipes/cminpack/all/test_v1_package/CMakeLists.txt
+++ b/recipes/cminpack/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.1.2)
+project(CMinPack-ConanV1-TestPackage C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(CMinpack REQUIRED CONFIG)
+
+# This builds one of the original cminpack examples against
+# both types of the library
+
+add_executable(cminpack_test_double ../test_package/tchkderc.c)
+target_link_libraries(cminpack_test_double PRIVATE cminpack::cminpack)
+
+add_executable(cminpack_test_float ../test_package/tchkderc.c)
+target_link_libraries(cminpack_test_float PRIVATE cminpack::cminpacks)

--- a/recipes/cminpack/all/test_v1_package/conanfile.py
+++ b/recipes/cminpack/all/test_v1_package/conanfile.py
@@ -1,0 +1,21 @@
+import os
+
+from conan.tools.build import cross_building
+from conans import ConanFile, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "cminpack_test_double")
+            self.run(bin_path, run_environment=True)
+            bin_path = os.path.join("bin", "cminpack_test_float")
+            self.run(bin_path, run_environment=True)

--- a/recipes/cminpack/config.yml
+++ b/recipes/cminpack/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.3.8":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **cminpack/1.3.8**

CMinPack is a mathematical solver used in numerical computing. It is quite popular, hence a conan package is yet missed.

The test package uses an official example from the cminpack repository.

The official cmake targets are `cminpack::cminpack` for the double precision library and `cminpack::cminpacks` for the single precision version of it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
