### PR TITLE
[linter] Add rule about importing tools from conan module

### DIFF
--- a/linter/check_import_tools.py
+++ b/linter/check_import_tools.py
@@ -1,0 +1,32 @@
+import re
+from email.mime import base
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+from astroid import nodes, Const, AssignName
+
+
+class ImportTools(BaseChecker):
+    """
+       Import tools following pattern 'from conan.tools.xxxx import yyyyy'
+    """
+
+    __implements__ = IAstroidChecker
+
+    name = "conan-import-tools"
+    msgs = {
+        "E9011": (
+            "Import tools following pattern 'from conan.tools.xxxx import yyyyy' (https://docs.conan.io/en/latest/reference/conanfile/tools.html).",
+            "conan-import-tools",
+            "Import tools following pattern 'from conan.tools.xxxx import yyyyy' (https://docs.conan.io/en/latest/reference/conanfile/tools.html).",
+        ),
+    }
+
+    def visit_importfrom(self, node: nodes.ImportFrom) -> None:
+        basename = node.modname
+        names = [name for name, _ in node.names]
+        if basename == 'conan' and 'tools' in names:
+            self.add_message("conan-import-tools", node=node)
+        elif basename == 'conan.tools':
+            self.add_message("conan-import-tools", node=node)
+        elif re.match(r'conan\.tools\.[^.]+\..+', basename):
+            self.add_message("conan-import-tools", node=node)

--- a/linter/conanv2_test_transition.py
+++ b/linter/conanv2_test_transition.py
@@ -8,6 +8,7 @@ from pylint.lint import PyLinter
 from linter.check_import_conanfile import ImportConanFile
 from linter.check_no_test_package_name import NoPackageName
 from linter.check_import_errors import ImportErrorsConanException, ImportErrorsConanInvalidConfiguration, ImportErrors
+from linter.check_import_tools import ImportTools
 
 
 def register(linter: PyLinter) -> None:
@@ -16,3 +17,4 @@ def register(linter: PyLinter) -> None:
     linter.register_checker(ImportErrors(linter))
     linter.register_checker(ImportErrorsConanException(linter))
     linter.register_checker(ImportErrorsConanInvalidConfiguration(linter))
+    linter.register_checker(ImportTools(linter))

--- a/linter/conanv2_transition.py
+++ b/linter/conanv2_transition.py
@@ -8,6 +8,7 @@ from pylint.lint import PyLinter
 from linter.check_package_name import PackageName
 from linter.check_import_conanfile import ImportConanFile
 from linter.check_import_errors import ImportErrorsConanException, ImportErrorsConanInvalidConfiguration, ImportErrors
+from linter.check_import_tools import ImportTools
 
 
 def register(linter: PyLinter) -> None:
@@ -16,3 +17,4 @@ def register(linter: PyLinter) -> None:
     linter.register_checker(ImportErrors(linter))
     linter.register_checker(ImportErrorsConanException(linter))
     linter.register_checker(ImportErrorsConanInvalidConfiguration(linter))
+    linter.register_checker(ImportTools(linter))


### PR DESCRIPTION
Enforcing documented ways to import tools: https://docs.conan.io/en/latest/reference/conanfile/tools.html. Everything else is considered not-stable.
