### PR TITLE
migrate jasper to conan v2

### DIFF
--- a/recipes/jasper/all/test_package/conanfile.py
+++ b/recipes/jasper/all/test_package/conanfile.py
@@ -1,4 +1,7 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile, tools
+from conan.tools.scm import Version
+from conan.tools import files
+from conans import CMake
 import os
 
 
@@ -12,6 +15,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not tools.build.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
This conan v2 migration PR was generated by automatoc script version 11.
It uses simple find and replace technics. Feel free to extend it.