### PR TITLE
[wayland] Using `build_requires` (Conan 1.52)

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -90,7 +90,7 @@ class WaylandConan(ConanFile):
                 tc.project_options["build.pkg_config_path"] = self.generators_folder
             elif self.dependencies["expat"].is_build_context:  # wayland is being built as build_require
                 # If wayland is the build_require, all its dependencies are treated as build_requires
-                pc.build_context_activated = ["libffi", "expat", "libxml2", "libiconv", "zlib"]
+                pc.build_context_activated = [dep.ref.name  for _, dep in self.dependencies.host.items()]
         tc.generate()
         pc.generate()
 

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -88,7 +88,7 @@ class WaylandConan(ConanFile):
                 # Only wayland is the build_require. There is no need to apply suffixes.
                 pc.build_context_activated = ["wayland"]
                 tc.project_options["build.pkg_config_path"] = self.generators_folder
-            elif self.is_build_context:  # wayland is being built as build_require
+            elif self.dependencies["expat"].is_build_context:  # wayland is being built as build_require
                 # If wayland is the build_require, all its dependencies are treated as build_requires
                 pc.build_context_activated = ["libffi", "expat", "libxml2", "libiconv", "zlib"]
         tc.generate()

--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -43,13 +43,13 @@ class WaylandConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
         try:
-           del self.settings.compiler.libcxx
+            del self.settings.compiler.libcxx
         except Exception:
-           pass
+            pass
         try:
-           del self.settings.compiler.cppstd
+            del self.settings.compiler.cppstd
         except Exception:
-           pass
+            pass
 
     def requirements(self):
         if self.options.enable_libraries:
@@ -90,7 +90,7 @@ class WaylandConan(ConanFile):
                 tc.project_options["build.pkg_config_path"] = self.generators_folder
             elif self.dependencies["expat"].is_build_context:  # wayland is being built as build_require
                 # If wayland is the build_require, all its dependencies are treated as build_requires
-                pc.build_context_activated = [dep.ref.name  for _, dep in self.dependencies.host.items()]
+                pc.build_context_activated = [dep.ref.name for _, dep in self.dependencies.host.items()]
         tc.generate()
         pc.generate()
 


### PR DESCRIPTION
Specify library name and version: **wayland/***
**Requires**: Conan 1.52 version

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
