### PR TITLE
argh: conan v2 support + fix CMake imported target (`argh` instead of `argh::argh`)

### DIFF
--- a/recipes/argh/all/conanfile.py
+++ b/recipes/argh/all/conanfile.py
@@ -1,8 +1,9 @@
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import copy, get
+from conan.tools.files import copy, get, save
 from conan.tools.layout import basic_layout
 import os
+import textwrap
 
 required_conan_version = ">=1.50.0"
 
@@ -38,8 +39,35 @@ class ArgparseConan(ConanFile):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, "argh.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include"))
 
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self._create_cmake_module_alias_targets(
+            os.path.join(self.package_folder, self._module_file_rel_path),
+            {"argh": "argh::argh"},
+        )
+
+    def _create_cmake_module_alias_targets(self, module_file, targets):
+        content = ""
+        for alias, aliased in targets.items():
+            content += textwrap.dedent(f"""\
+                if(TARGET {aliased} AND NOT TARGET {alias})
+                    add_library({alias} INTERFACE IMPORTED)
+                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
+                endif()
+            """)
+        save(self, module_file, content)
+
+    @property
+    def _module_file_rel_path(self):
+        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
+
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "argh")
+        self.cpp_info.set_property("cmake_target_name", "argh")
         self.cpp_info.bindirs = []
         self.cpp_info.frameworkdirs = []
         self.cpp_info.libdirs = []
         self.cpp_info.resdirs = []
+
+        # TODO: to remove in conan v2 once legacy generators removed
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/argh/all/conanfile.py
+++ b/recipes/argh/all/conanfile.py
@@ -1,35 +1,45 @@
-from conans import ConanFile, tools
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
 import os
+
+required_conan_version = ">=1.50.0"
 
 
 class ArgparseConan(ConanFile):
     name = "argh"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/adishavit/argh"
-    topics = ("conan", "argh", "argument", "parsing")
+    topics = ("argh", "argument", "parsing")
     license = "BSD-3"
     description = "Frustration-free command line processing"
-    settings = "compiler"
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
-    @property
-    def _source_subfolder(self):
-        return os.path.join(self.source_folder, "source_subfolder")
+    def package_id(self):
+        self.info.clear()
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, 11)
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 11)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        os.rename("argh-{}".format(self.version), self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    def build(self):
+        pass
 
     def package(self):
-        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        self.copy("argh.h", src=self._source_subfolder, dst=os.path.join("include", "argh"))
-
-    def package_id(self):
-        self.info.header_only()
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "argh.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include"))
 
     def package_info(self):
-        self.cpp_info.includedirs.append(os.path.join("include", "argh"))
+        self.cpp_info.bindirs = []
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []

--- a/recipes/argh/all/test_package/CMakeLists.txt
+++ b/recipes/argh/all/test_package/CMakeLists.txt
@@ -4,5 +4,5 @@ project(test_package LANGUAGES CXX)
 find_package(argh REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE argh::argh)
+target_link_libraries(${PROJECT_NAME} PRIVATE argh)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/argh/all/test_package/conanfile.py
+++ b/recipes/argh/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,5 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            self.run(os.path.join("bin", "test_package"))
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/argh/all/test_v1_package/CMakeLists.txt
+++ b/recipes/argh/all/test_v1_package/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(argh REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE argh::argh)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/argh/all/test_v1_package/CMakeLists.txt
+++ b/recipes/argh/all/test_v1_package/CMakeLists.txt
@@ -7,5 +7,5 @@ conan_basic_setup(TARGETS)
 find_package(argh REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE argh::argh)
+target_link_libraries(${PROJECT_NAME} PRIVATE argh)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/argh/all/test_v1_package/conanfile.py
+++ b/recipes/argh/all/test_v1_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run(os.path.join("bin", "test_package"))


### PR DESCRIPTION
CMake imported target is not namespaced, see https://github.com/adishavit/argh/blob/v1.3.2/CMakeLists.txt#L48-L52

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
