### PR TITLE
Adding intel itt api

### DIFF
--- a/recipes/ittapi/all/conandata.yml
+++ b/recipes/ittapi/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.23.0":
+    url: "https://github.com/intel/ittapi/archive/v3.23.0.tar.gz"
+    sha256: "9af1231808c602c2f7a66924c8798b1741d3aa4b15f3874d82ca7a89b5dbb1b1"

--- a/recipes/ittapi/all/conanfile.py
+++ b/recipes/ittapi/all/conanfile.py
@@ -1,5 +1,4 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
 import os
@@ -21,7 +20,7 @@ class IttApiConan(ConanFile):
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
-        "fPIC": [True, False], # @note fPIC is always enabled by the underlying CMake file. So we ignore this option.
+        "fPIC": [True, False],  # @note fPIC is always enabled by the underlying CMake file. So we ignore this option.
         "ptmark": [True, False],
     }
     default_options = {

--- a/recipes/ittapi/all/conanfile.py
+++ b/recipes/ittapi/all/conanfile.py
@@ -21,7 +21,7 @@ class IttApiConan(ConanFile):
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
-        "fPIC": [True, False],
+        "fPIC": [True, False], # @note fPIC is always enabled by the underlying CMake file. So we ignore this option.
         "ptmark": [True, False],
     }
     default_options = {
@@ -37,12 +37,6 @@ class IttApiConan(ConanFile):
         # We have no C++ files.
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
-
-    def validate(self):
-        if self.options.get_safe("fPIC", True) is False:
-            raise ConanInvalidConfiguration(
-                "fPIC is always enabled by underlying CMake file."
-            )
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -71,20 +65,8 @@ class IttApiConan(ConanFile):
         copy(self, "GPL-2.0-only.txt", src=os.path.join(self.source_folder, "LICENSES"), dst=os.path.join(self.package_folder, "licenses"))
 
     def package_info(self):
-        self.cpp_info.set_property("cmake_file_name", "ITT")
-        self.cpp_info.set_property("pkg_config_name", "itt")
-
-        ittnotify = self.cpp_info.components["ittnotify"]
-        ittnotify.set_property("cmake_target_name", "ITT::ittnotify")
         if self.settings.os == "Windows":
-            ittnotify.libs = ["libittnotify"]
+            self.cpp_info.libs = ['libittnotify']
         else:
-            ittnotify.libs = ["ittnotify"]
-            ittnotify.system_libs = ["dl"]
-
-        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
-        self.cpp_info.names["cmake_find_package"] = "ITT"
-        self.cpp_info.names["cmake_find_package_multi"] = "ITT"
-        self.cpp_info.names["pkg_config"] = "itt"
-        ittnotify.names["cmake_find_package"] = "ittnotify"
-        ittnotify.names["cmake_find_package_multi"] = "ittnotify"
+            self.cpp_info.libs = ['ittnotify']
+            self.cpp_info.system_libs = ['dl']

--- a/recipes/ittapi/all/conanfile.py
+++ b/recipes/ittapi/all/conanfile.py
@@ -58,7 +58,7 @@ class IttApiConan(ConanFile):
         if self.settings.os == "Windows":
             copy(self, "libittnotify.lib", src=f"bin/{self.settings.build_type}", dst=os.path.join(self.package_folder, "lib"))
         else:
-            copy(self, "libittnotify.a", src=f"bin", dst=os.path.join(self.package_folder, "lib"))
+            copy(self, "libittnotify.a", src="bin", dst=os.path.join(self.package_folder, "lib"))
         copy(self, "*.h", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
         copy(self, "BSD-3-Clause.txt", src=os.path.join(self.source_folder, "LICENSES"), dst=os.path.join(self.package_folder, "licenses"))
         copy(self, "GPL-2.0-only.txt", src=os.path.join(self.source_folder, "LICENSES"), dst=os.path.join(self.package_folder, "licenses"))

--- a/recipes/ittapi/all/conanfile.py
+++ b/recipes/ittapi/all/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.47.0"
 
 class IttApiConan(ConanFile):
     name = "ittapi"
-    license = "dual licensed under GPLv2 and 3-Clause BSD licenses"
+    license = ("BSD-3-Clause", "GPL-2.0-only")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/intel/ittapi"
     description = (
@@ -33,9 +33,14 @@ class IttApiConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        # We have no C++ files.
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -46,7 +51,7 @@ class IttApiConan(ConanFile):
 
     def generate(self):
         toolchain = CMakeToolchain(self)
-        toolchain.variables["ITT_API_IPT_SUPPORT"] = 1 if self.options.ptmark else 0
+        toolchain.variables["ITT_API_IPT_SUPPORT"] = self.options.ptmark
         toolchain.generate()
 
     def build(self):

--- a/recipes/ittapi/all/conanfile.py
+++ b/recipes/ittapi/all/conanfile.py
@@ -1,0 +1,90 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+import os
+
+required_conan_version = ">=1.47.0"
+
+
+class IttApiConan(ConanFile):
+    name = "ittapi"
+    license = "dual licensed under GPLv2 and 3-Clause BSD licenses"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/intel/ittapi"
+    description = (
+        "The Instrumentation and Tracing Technology (ITT) API enables your application"
+        " to generate and control the collection of trace data during its execution"
+        " across different Intel tools."
+    )
+    topics = ("itt", "ittapi", "vtune", "profiler", "profiling")
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+        "ptmark": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "ptmark": False,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        # We have no C++ files.
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def validate(self):
+        if self.options.get_safe("fPIC", True) is False:
+            raise ConanInvalidConfiguration(
+                "fPIC is always enabled by underlying CMake file."
+            )
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        toolchain = CMakeToolchain(self)
+        toolchain.variables["ITT_API_IPT_SUPPORT"] = 1 if self.options.ptmark else 0
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        if self.settings.os == "Windows":
+            copy(self, "libittnotify.lib", src=f"bin/{self.settings.build_type}", dst=os.path.join(self.package_folder, "lib"))
+        else:
+            copy(self, "libittnotify.a", src=f"bin", dst=os.path.join(self.package_folder, "lib"))
+        copy(self, "*.h", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
+        copy(self, "BSD-3-Clause.txt", src=os.path.join(self.source_folder, "LICENSES"), dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "GPL-2.0-only.txt", src=os.path.join(self.source_folder, "LICENSES"), dst=os.path.join(self.package_folder, "licenses"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "ITT")
+        self.cpp_info.set_property("pkg_config_name", "itt")
+
+        ittnotify = self.cpp_info.components["ittnotify"]
+        ittnotify.set_property("cmake_target_name", "ITT::ittnotify")
+        if self.settings.os == "Windows":
+            ittnotify.libs = ["libittnotify"]
+        else:
+            ittnotify.libs = ["ittnotify"]
+            ittnotify.system_libs = ["dl"]
+
+        # TODO: to remove in conan v2 once cmake_find_package* & pkg_config generators removed
+        self.cpp_info.names["cmake_find_package"] = "ITT"
+        self.cpp_info.names["cmake_find_package_multi"] = "ITT"
+        self.cpp_info.names["pkg_config"] = "itt"
+        ittnotify.names["cmake_find_package"] = "ittnotify"
+        ittnotify.names["cmake_find_package_multi"] = "ittnotify"

--- a/recipes/ittapi/all/test_package/CMakeLists.txt
+++ b/recipes/ittapi/all/test_package/CMakeLists.txt
@@ -5,4 +5,3 @@ find_package(ittapi REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE ittapi::ittapi)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/ittapi/all/test_package/CMakeLists.txt
+++ b/recipes/ittapi/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
+
+find_package(ITT REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE ITT::ittnotify)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/ittapi/all/test_package/CMakeLists.txt
+++ b/recipes/ittapi/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
-find_package(ITT REQUIRED CONFIG)
+find_package(ittapi REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE ITT::ittnotify)
+target_link_libraries(${PROJECT_NAME} PRIVATE ittapi::ittapi)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/ittapi/all/test_package/conanfile.py
+++ b/recipes/ittapi/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.build import cross_building
+from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
 import os
 
@@ -20,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
+        if can_run(self):
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/ittapi/all/test_package/conanfile.py
+++ b/recipes/ittapi/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import cross_building
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/ittapi/all/test_package/test_package.cpp
+++ b/recipes/ittapi/all/test_package/test_package.cpp
@@ -1,0 +1,14 @@
+#include <ittnotify.h>
+#include <iostream>
+
+// @note Domains cannot be destroyed.
+__itt_domain* itt_domain = __itt_domain_create("Global Domain");
+
+int main(){
+    __itt_string_handle* nameHandle = __itt_string_handle_create("My name");
+    __itt_task_begin(itt_domain, __itt_null, __itt_null, nameHandle);
+    std::cout << "Inside ITT range." << std::endl;
+    __itt_task_end(itt_domain);
+
+    return 0;
+}

--- a/recipes/ittapi/all/test_v1_package/CMakeLists.txt
+++ b/recipes/ittapi/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(ittapi REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE ittapi::ittapi)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/ittapi/all/test_v1_package/CMakeLists.txt
+++ b/recipes/ittapi/all/test_v1_package/CMakeLists.txt
@@ -8,4 +8,3 @@ find_package(ittapi REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE ittapi::ittapi)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/ittapi/all/test_v1_package/conanfile.py
+++ b/recipes/ittapi/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+# legacy validation with Conan 1.x
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/ittapi/config.yml
+++ b/recipes/ittapi/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.23.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **ittapi/3.23.0**

Intel ITT API (Instrumentation and Tracing Technology API) enables generation and control over profiling using Intel's VTune Profiler. This is a key API required to collect useful trace data for performance optimization work.
This API is similar in functionality to NVTX API, which targets Nvidia's Nsight Systems Profiler (`nvtx` already exists in Conan Center).

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
