### PR TITLE
fixes android-ndk regression with CMakeToolchain

### DIFF
--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -287,6 +287,10 @@ class AndroidNDKConan(ConanFile):
 
         toolchain = os.path.join(self.package_folder, "build", "cmake", "android.toolchain.cmake")
 
+        #CMakeToolchain automatically adds the standard Android toolchain file that ships with the NDK
+        #when `tools.android:ndk_path` is provided, so there's no need to add it as a `user_toolchain`
+        self.conf_info.define("tools.android:ndk_path", self.package_folder)
+
         self.buildenv_info.define_path("CC", self._define_tool_var("CC", "clang"))
         self.buildenv_info.define_path("CXX", self._define_tool_var("CXX", "clang++"))
 
@@ -318,7 +322,6 @@ class AndroidNDKConan(ConanFile):
         libcxx_str = str(self.settings_target.compiler.libcxx)
         self.buildenv_info.define("ANDROID_STL", libcxx_str if libcxx_str.startswith("c++_") else "c++_shared")
 
-        self.conf_info.define("tools.android:ndk_path", self.package_folder)
 
         # TODO: conan v1 stuff to remove later
         self.env_info.PATH.append(self.package_folder)

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -286,7 +286,6 @@ class AndroidNDKConan(ConanFile):
         self.env_info.CONAN_CMAKE_PROGRAM = cmake_wrapper
 
         toolchain = os.path.join(self.package_folder, "build", "cmake", "android.toolchain.cmake")
-        self.conf_info.prepend("tools.cmake.cmaketoolchain:user_toolchain", toolchain)
 
         self.buildenv_info.define_path("CC", self._define_tool_var("CC", "clang"))
         self.buildenv_info.define_path("CXX", self._define_tool_var("CXX", "clang++"))


### PR DESCRIPTION
Specify library name and version:  **android-ndk/r25**

A recent change of this package added the cmake toolchain file from the NDK as a user toolchain, which is problematic because the CMakeToolchain generator also adds this, resulting in breakage for packages that use this generator, as described in issue #12723 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
