### PR TITLE
boost: Add support for retrieving the toolset when using msvc

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1286,11 +1286,19 @@ class BoostConan(ConanFile):
 
     @property
     def _toolset_version(self):
-        if self._is_msvc:
+        if self.settings.get_safe("compiler") == "Visual Studio":
             toolset = tools.msvs_toolset(self)
             match = re.match(r"v(\d+)(\d)$", toolset)
             if match:
                 return f"{match.group(1)}.{match.group(2)}"
+        elif self.settings.get_safe("compiler") == "msvc":
+            toolsets = {'170': '11.0',
+                        '180': '12.0',
+                        '190': '14.0',
+                        '191': '14.1',
+                        '192': '14.2',
+                        "193": '14.3'}
+            return toolsets[self.settings.get_safe("compiler.version")]
         return ""
 
     @property

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan.tools.apple import is_apple_os
 from conan.tools.build import build_jobs, check_min_cppstd, cross_building
-from conan.tools.files import chdir, get, mkdir, rename, replace_in_file, rm, rmdir, save
-from conan.tools.files.patches import apply_conandata_patches
+from conan.tools.files import apply_conandata_patches, chdir, get, mkdir, rename, replace_in_file, rm, rmdir, save
 from conan.tools.microsoft import msvc_runtime_flag
 from conan import ConanFile
 from conan.errors import ConanException, ConanInvalidConfiguration


### PR DESCRIPTION
The `msvs_toolset()` function does not support the `msvc` compiler.
The function derives the toolset version from the `Visual Studio` version.
Since the `msvc` compiler uses a different versioning scheme, this does not work for `msvc`.

This commit just adds the corresponding logic to do this for `msvc`.
The same logic is still used for `Visual Studio`.

Specify library name and version:  **boost/***

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
