### PR TITLE
libaom-av1: add 3.4.0 + conan v2 support

### DIFF
--- a/recipes/libaom-av1/all/CMakeLists.txt
+++ b/recipes/libaom-av1/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-project(cmake_wrapper)
-
-include("conanbuildinfo.cmake")
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory("source_subfolder")

--- a/recipes/libaom-av1/all/conandata.yml
+++ b/recipes/libaom-av1/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.4.0":
+    url: "https://storage.googleapis.com/aom-releases/libaom-3.4.0.tar.gz"
+    sha256: "bd754b58c3fa69f3ffd29da77de591bd9c26970e3b18537951336d6c0252e354"
   "3.3.0":
     url: "https://storage.googleapis.com/aom-releases/libaom-3.3.0.tar.gz"
     sha256: "1dafde32bc2237bf0570294661ae61db30e818840f77dc4e90d1ebf5a6286664"
@@ -12,6 +15,8 @@ sources:
     url: "https://storage.googleapis.com/aom-releases/libaom-2.0.1.tar.gz"
     sha256: "a0cff299621e2ef885aba219c498fa39a7d9a7ddf47585a118fd66c64ad1b312"
 patches:
+  "3.4.0":
+    - patch_file: "patches/0001-3.4.0-fix-install.patch"
   "3.3.0":
     - patch_file: "patches/0001-3.3.0-fix-install.patch"
   "3.1.2":

--- a/recipes/libaom-av1/all/conandata.yml
+++ b/recipes/libaom-av1/all/conandata.yml
@@ -14,13 +14,9 @@ sources:
 patches:
   "3.3.0":
     - patch_file: "patches/0001-3.3.0-fix-install.patch"
-      base_path: "source_subfolder"
   "3.1.2":
     - patch_file: "patches/0001-3.1.1-fix-install.patch"
-      base_path: "source_subfolder"
   "3.1.1":
     - patch_file: "patches/0001-3.1.1-fix-install.patch"
-      base_path: "source_subfolder"
   "2.0.1":
     - patch_file: "patches/0001-2.0.1-fix-install.patch"
-      base_path: "source_subfolder"

--- a/recipes/libaom-av1/all/conanfile.py
+++ b/recipes/libaom-av1/all/conanfile.py
@@ -1,9 +1,13 @@
-from conans import ConanFile, tools, CMake
-from conans.errors import ConanInvalidConfiguration
-import functools
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, get, rmdir
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.36.0"
+required_conan_version = ">=1.50.0"
 
 
 class LibaomAv1Conan(ConanFile):
@@ -26,24 +30,23 @@ class LibaomAv1Conan(ConanFile):
         "assembly": False,
     }
 
-    generators = "cmake"
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "15",
+            "msvc": "191",
+            "gcc": "5",
+            "clang": "5",
+            "apple-clang": "6",
+        }
+
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        for p in self.conan_data.get("patches", {}).get(self.version, []):
+            copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -55,66 +58,60 @@ class LibaomAv1Conan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    def validate(self):
+        if self.info.settings.compiler.cppstd:
+            check_min_cppstd(self, 11)
+        # Check compiler version
+        compiler = str(self.info.settings.compiler)
+        compiler_version = Version(self.info.settings.compiler.version)
+        minimum_version = self._compilers_minimum_version.get(compiler, False)
+        if minimum_version and compiler_version < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.name} {self.version} requires a {compiler} version >= {compiler_version}",
+            )
+
     def build_requirements(self):
         if self.options.get_safe("assembly", False):
-            self.build_requires("nasm/2.15.05")
+            self.tool_requires("nasm/2.15.05")
         if self._settings_build.os == "Windows":
-            self.build_requires("strawberryperl/5.30.0.1")
+            self.tool_requires("strawberryperl/5.30.0.1")
 
-    def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 11)
-        # Check compiler version
-        compiler = str(self.settings.compiler)
-        compiler_version = tools.Version(self.settings.compiler.version.value)
-
-        minimal_version = {
-            "Visual Studio": "15",
-            "gcc": "5",
-            "clang": "5",
-            "apple-clang": "6"
-        }
-        if compiler not in minimal_version:
-            self.output.warn(
-                "%s recipe lacks information about the %s compiler standard version support" % (self.name, compiler))
-        elif compiler_version < minimal_version[compiler]:
-            raise ConanInvalidConfiguration("{} requires a {} version >= {}".format(self.name, compiler, compiler_version))
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder,
-                  strip_root=tools.Version(self.version) >= "3.3.0")
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=Version(self.version) >= "3.3.0")
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["ENABLE_EXAMPLES"] = False
-        cmake.definitions["ENABLE_TESTS"] = False
-        cmake.definitions["ENABLE_DOCS"] = False
-        cmake.definitions["ENABLE_TOOLS"] = False
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ENABLE_EXAMPLES"] = False
+        tc.variables["ENABLE_TESTS"] = False
+        tc.variables["ENABLE_DOCS"] = False
+        tc.variables["ENABLE_TOOLS"] = False
         if not self.options.get_safe("assembly", False):
             # make non-assembly build
-            cmake.definitions["AOM_TARGET_CPU"] = "generic"
+            tc.variables["AOM_TARGET_CPU"] = "generic"
         # libyuv is used for examples, tests and non-essential 'dump_obu' tool so it is disabled
         # required to be 1/0 instead of False
-        cmake.definitions["CONFIG_LIBYUV"] = 0
+        tc.variables["CONFIG_LIBYUV"] = 0
         # webm is not yet packaged
-        cmake.definitions["CONFIG_WEBM_IO"] = 0
-        # required out-of-source build
-        cmake.configure(build_folder=self._build_subfolder)
-        return cmake
+        tc.variables["CONFIG_WEBM_IO"] = 0
+        tc.generate()
+        env = VirtualBuildEnv(self)
+        env.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "aom")

--- a/recipes/libaom-av1/all/conanfile.py
+++ b/recipes/libaom-av1/all/conanfile.py
@@ -1,13 +1,12 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, get, rmdir
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.47.0"
 
 
 class LibaomAv1Conan(ConanFile):
@@ -57,10 +56,16 @@ class LibaomAv1Conan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
 
     def validate(self):
-        if self.info.settings.compiler.cppstd:
-            check_min_cppstd(self, 11)
         # Check compiler version
         compiler = str(self.info.settings.compiler)
         compiler_version = Version(self.info.settings.compiler.version)
@@ -118,5 +123,3 @@ class LibaomAv1Conan(ConanFile):
         self.cpp_info.libs = ["aom"]
         if self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.system_libs = ["pthread", "m"]
-
-        self.cpp_info.names["pkg_config"] = "aom"

--- a/recipes/libaom-av1/all/patches/0001-3.4.0-fix-install.patch
+++ b/recipes/libaom-av1/all/patches/0001-3.4.0-fix-install.patch
@@ -1,0 +1,21 @@
+--- a/build/cmake/aom_install.cmake
++++ b/build/cmake/aom_install.cmake
+@@ -27,7 +27,7 @@ endif()
+ # Note: aom.pc generation uses GNUInstallDirs:
+ # https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+ macro(setup_aom_install_targets)
+-  if(NOT XCODE)
++  if(1)
+     include("GNUInstallDirs")
+     set(AOM_PKG_CONFIG_FILE "${AOM_CONFIG_DIR}/aom.pc")
+ 
+@@ -78,7 +78,8 @@ macro(setup_aom_install_targets)
+     endif()
+ 
+     if(BUILD_SHARED_LIBS)
+-      set(AOM_INSTALL_LIBS aom aom_static)
++      set_target_properties(aom_static PROPERTIES OUTPUT_NAME aom_static)
++      set(AOM_INSTALL_LIBS aom)
+     else()
+       set(AOM_INSTALL_LIBS aom)
+     endif()

--- a/recipes/libaom-av1/all/test_package/conanfile.py
+++ b/recipes/libaom-av1/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libaom-av1/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libaom-av1/all/test_v1_package/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(libaom-av1 REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.c)
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE libaom-av1::libaom-av1)

--- a/recipes/libaom-av1/all/test_v1_package/conanfile.py
+++ b/recipes/libaom-av1/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libaom-av1/config.yml
+++ b/recipes/libaom-av1/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.4.0":
+    folder: all
   "3.3.0":
     folder: all
   "3.1.2":


### PR DESCRIPTION
Few improvements as well:
- relax constraints on compiler versions by injecting CMAKE_C_STANDARD 99 (looking at original PR, it was coming from for loops with value initialization, a C99 feature).
- libaom-av1 is a pure C library (examples are in C++, as well as few optional vendored deps which are disabled here), so remove libcxx & cppstd

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
