### PR TITLE
openssl - Annotate version required to run the tests

### DIFF
--- a/recipes/openssl/1.x.x/test_package/conanfile.py
+++ b/recipes/openssl/1.x.x/test_package/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.scm import Version
 from conan.tools.build import cross_building
 import os
 
-required_conan_version = ">=1.50.2"  # Because of changes in scm.Version class
+required_conan_version = ">=1.50.2 <1.51.0 || >=1.51.2"
 
 
 class TestPackageConan(ConanFile):

--- a/recipes/openssl/1.x.x/test_package/conanfile.py
+++ b/recipes/openssl/1.x.x/test_package/conanfile.py
@@ -3,6 +3,8 @@ from conan.tools.scm import Version
 from conan.tools.build import cross_building
 import os
 
+required_conan_version = ">=1.50.2"  # Because of changes in scm.Version class
+
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
@@ -26,7 +28,7 @@ class TestPackageConan(ConanFile):
             if self.settings.os == "Android":
                 cmake.definitions["CONAN_LIBCXX"] = ""
             openssl_version = Version(self.deps_cpp_info["openssl"].version)
-            if openssl_version >= "1.1.0":
+            if openssl_version.major == "1" and openssl_version.minor == "1":
                 cmake.definitions["OPENSSL_WITH_ZLIB"] = False
             else:
                 cmake.definitions["OPENSSL_WITH_ZLIB"] = not self.options["openssl"].no_zlib

--- a/recipes/openssl/1.x.x/test_package/conanfile.py
+++ b/recipes/openssl/1.x.x/test_package/conanfile.py
@@ -26,7 +26,7 @@ class TestPackageConan(ConanFile):
             if self.settings.os == "Android":
                 cmake.definitions["CONAN_LIBCXX"] = ""
             openssl_version = Version(self.deps_cpp_info["openssl"].version)
-            if openssl_version.major == "1" and openssl_version.minor == "1":
+            if openssl_version >= "1.1.0":
                 cmake.definitions["OPENSSL_WITH_ZLIB"] = False
             else:
                 cmake.definitions["OPENSSL_WITH_ZLIB"] = not self.options["openssl"].no_zlib


### PR DESCRIPTION
On `1.50.2` the class `scm.Version` was changed (https://github.com/conan-io/conan/pull/11823). This `test_package` fails with `1.50.1`. I've been bitten by this today, so I think it can be useful to annotate it. 