### PR TITLE
openssl: define `OPENSSL_FOUND` in `CMakeDeps` generator

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -823,9 +823,7 @@ class OpenSSLConan(ConanFile):
     @staticmethod
     def _create_cmake_module_variables(module_file):
         content = textwrap.dedent("""\
-            if(DEFINED OpenSSL_FOUND)
-                set(OPENSSL_FOUND ${OpenSSL_FOUND})
-            endif()
+            set(OPENSSL_FOUND TRUE)
             if(DEFINED OpenSSL_INCLUDE_DIR)
                 set(OPENSSL_INCLUDE_DIR ${OpenSSL_INCLUDE_DIR})
             endif()

--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -1,8 +1,9 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import cross_building
 from conan.tools.files import rename, get, rmdir
 from conan.tools.microsoft import is_msvc, msvc_runtime_flag
-from conan.tools.build import cross_building
-from conan.errors import ConanInvalidConfiguration
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conans import AutoToolsBuildEnvironment, tools
 from contextlib import contextmanager
 from functools import total_ordering
 import fnmatch

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -673,9 +673,7 @@ class OpenSSLConan(ConanFile):
     @staticmethod
     def _create_cmake_module_variables(module_file):
         content = textwrap.dedent("""\
-            if(DEFINED OpenSSL_FOUND)
-                set(OPENSSL_FOUND ${OpenSSL_FOUND})
-            endif()
+            set(OPENSSL_FOUND TRUE)
             if(DEFINED OpenSSL_INCLUDE_DIR)
                 set(OPENSSL_INCLUDE_DIR ${OpenSSL_INCLUDE_DIR})
             endif()

--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -1,8 +1,9 @@
-from conan.tools.files import rename
-from conan.tools.microsoft import is_msvc, msvc_runtime_flag
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
-from conans.errors import ConanInvalidConfiguration
+from conan.tools.files import get, rename, rmdir
+from conan.tools.microsoft import is_msvc, msvc_runtime_flag
+from conans import AutoToolsBuildEnvironment, tools
 import contextlib
 import fnmatch
 import functools
@@ -149,8 +150,8 @@ class OpenSSLConan(ConanFile):
         return self._is_clangcl or is_msvc(self)
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
 
     @property
     def _target(self):
@@ -664,7 +665,7 @@ class OpenSSLConan(ConanFile):
             else:
                 self.copy("fips.so", src=provdir,dst="lib/ossl-modules")
 
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
         self._create_cmake_module_variables(
             os.path.join(self.package_folder, self._module_file_rel_path)


### PR DESCRIPTION
`OPENSSL_FOUND` is not defined if `find_package()` consumes the config file from CMakeDeps (another side effect for https://github.com/conan-io/conan/issues/10387). This PR fixes this issue by setting `OPENSSL_FOUND` to `TRUE` unconditionally.

I've seen this issue while trying to migrate mariadb-connector-c, its CMakeLists has a strong logic based on OPENSSL_FOUND, and it miserably fails if casing is wrong.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
