### PR TITLE
bzip2: fix `BZIP2_FOUND` in CMakeDeps

### DIFF
--- a/recipes/bzip2/all/conanfile.py
+++ b/recipes/bzip2/all/conanfile.py
@@ -80,9 +80,7 @@ class Bzip2Conan(ConanFile):
     def _create_cmake_module_variables(self, module_file):
         content = textwrap.dedent("""\
             set(BZIP2_NEED_PREFIX TRUE)
-            if(NOT DEFINED BZIP2_FOUND AND DEFINED BZip2_FOUND)
-                set(BZIP2_FOUND ${BZip2_FOUND})
-            endif()
+            set(BZIP2_FOUND TRUE)
             if(NOT DEFINED BZIP2_INCLUDE_DIRS AND DEFINED BZip2_INCLUDE_DIRS)
                 set(BZIP2_INCLUDE_DIRS ${BZip2_INCLUDE_DIRS})
             endif()


### PR DESCRIPTION
same fix than https://github.com/conan-io/conan-center-index/pull/12838

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
