### PR TITLE
daw_json_link: add version 3.0.5

### DIFF
--- a/recipes/daw_json_link/all/conandata.yml
+++ b/recipes/daw_json_link/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.5":
+    url: "https://github.com/beached/daw_json_link/archive/v3.0.5.tar.gz"
+    sha256: "77abe2ca525083d59a1e4e8e9aa1d2633e5382d98a0d5d838cd2379eaf8d7edf"
   "3.0.4":
     url: "https://github.com/beached/daw_json_link/archive/v3.0.4.tar.gz"
     sha256: "bf45d116d96337b37b31daa4031ba05beb2579693dd1115bf70b15420e1905a7"

--- a/recipes/daw_json_link/config.yml
+++ b/recipes/daw_json_link/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.5":
+    folder: "all"
   "3.0.4":
     folder: "all"
   "3.0.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **daw_json_link/3.0.5**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
