### PR TITLE
tomlplusplus: add version 3.2.0

### DIFF
--- a/recipes/tomlplusplus/all/conandata.yml
+++ b/recipes/tomlplusplus/all/conandata.yml
@@ -32,3 +32,6 @@ sources:
   "3.1.0":
     url: "https://github.com/marzer/tomlplusplus/archive/v3.1.0.tar.gz"
     sha256: "dae72714fc356ca1b019298d9e6275cc41ba95546ae722ccdb6795e92f47762e"
+  "3.2.0":
+    url: "https://github.com/marzer/tomlplusplus/archive/v3.2.0.tar.gz"
+    sha256: "aeba776441df4ac32e4d4db9d835532db3f90fd530a28b74e4751a2915a55565"

--- a/recipes/tomlplusplus/config.yml
+++ b/recipes/tomlplusplus/config.yml
@@ -21,3 +21,5 @@ versions:
     folder: all
   "3.1.0":
     folder: all
+  "3.2.0":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **tomlplusplus/3.2.0**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
