### PR TITLE
roaring: add version 0.7.1

### DIFF
--- a/recipes/roaring/all/conandata.yml
+++ b/recipes/roaring/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.7.1":
+    url: "https://github.com/RoaringBitmap/CRoaring/archive/v0.7.1.tar.gz"
+    sha256: "77faa22b8c1226c9a7bdbca2dbb9c73ea6db9e98db9bfbb6391996cfa7a93d17"
   "0.6.0":
     url: "https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v0.6.0.tar.gz"
     sha256: "b8e2499ca9ac6ba0d18dbbcde4bae3752acf81f08ea6309ea2a88d27972dffcf"

--- a/recipes/roaring/config.yml
+++ b/recipes/roaring/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.7.1":
+    folder: all
   "0.6.0":
     folder: all
   "0.5.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **roaring/0.7.1**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
