### PR TITLE
earcut: add version 2.2.4

### DIFF
--- a/recipes/earcut/all/conandata.yml
+++ b/recipes/earcut/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.4":
+    url: "https://github.com/mapbox/earcut.hpp/archive/v2.2.4.tar.gz"
+    sha256: "fcfa6a47a52d4c94dc960bdb747f17e077609235517b0bb5ce8097d6b747695a"
   "2.2.3":
     url: "https://github.com/mapbox/earcut.hpp/archive/v2.2.3.tar.gz"
     sha256: "f382616de763289c698f37ec3a5b9fcd3d6d821cbef0b3c72e43bdd909c81b5a"

--- a/recipes/earcut/config.yml
+++ b/recipes/earcut/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.4":
+    folder: "all"
   "2.2.3":
     folder: "all"
   "0.12.4":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **earcut/2.2.4**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
