### PR TITLE
[docs] Clarify Unexpected error restarting

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -52,7 +52,9 @@ any further activity.
 Label [`Unexpected Error`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Unexpected+Error%22)
 is assigned by the CI when the process finishes abnormally. It tries to signal all the pull requests that failed, but
 didn't provide any meaningful message to the user. Usually it is some _random_ internal error and it won't happen next
-time the CI runs, don't hesitate to trigger a new build in this situation.
+time the CI runs. The CI will re-start your build automatically, the Github check `continuous-integration/jenkins/pr-merge` will changed to the
+status `Pending — This commit is being built` to sinalize as running. In case you restart it manually, by closing/opening the PR, your
+build will be restarted too, but it will be the last in the CI build queue.
 
 ## User-approval pending
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -53,7 +53,7 @@ Label [`Unexpected Error`](https://github.com/conan-io/conan-center-index/pulls?
 is assigned by the CI when the process finishes abnormally. It tries to signal all the pull requests that failed, but
 didn't provide any meaningful message to the user. Usually it is some _random_ internal error and it won't happen next
 time the CI runs. The CI will re-start your build automatically, the Github check `continuous-integration/jenkins/pr-merge` will changed to the
-status `Pending — This commit is being built` to sinalize as running. In case you restart it manually, by closing/opening the PR, your
+status `Pending — This commit is being built` to signalize as running. In case you restart it manually, by closing/opening the PR, your
 build will be restarted too, but it will be the last in the CI build queue.
 
 ## User-approval pending


### PR DESCRIPTION
It's not documented that the CI restarts automatically unexpected error.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
