### PR TITLE
unordered_dense: add recipe

### DIFF
--- a/recipes/unordered_dense/all/conandata.yml
+++ b/recipes/unordered_dense/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "1.3.1":
+    url: "https://github.com/martinus/unordered_dense/archive/refs/tags/v1.3.1.tar.gz"
+    sha256: "d393168833d6609c9eaf54a05b19fc3120f68b85feffb282ab225119a86df1d4"
+

--- a/recipes/unordered_dense/all/conandata.yml
+++ b/recipes/unordered_dense/all/conandata.yml
@@ -2,4 +2,3 @@ sources:
   "1.3.1":
     url: "https://github.com/martinus/unordered_dense/archive/refs/tags/v1.3.1.tar.gz"
     sha256: "d393168833d6609c9eaf54a05b19fc3120f68b85feffb282ab225119a86df1d4"
-

--- a/recipes/unordered_dense/all/conanfile.py
+++ b/recipes/unordered_dense/all/conanfile.py
@@ -47,8 +47,8 @@ class PackageConan(ConanFile):
     def validate(self):
         if self.info.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
-        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
-        if minimum_version and Version(self.info.settings.get_safe("compiler.version")) < minimum_version:
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.get_safe("compiler.version")) < minimum_version:
             raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support.")
 
     def source(self):

--- a/recipes/unordered_dense/all/conanfile.py
+++ b/recipes/unordered_dense/all/conanfile.py
@@ -1,0 +1,79 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import apply_conandata_patches, get, copy
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.layout import basic_layout
+import os
+
+
+required_conan_version = ">=1.51.3"
+
+
+class PackageConan(ConanFile):
+    name = "unordered_dense"
+    description = "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/martinus/unordered_dense"
+    topics = ("unordered_map", "unordered_set", "hashmap", "hashset", "header-only")
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _minimum_cpp_standard(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "15.7",
+            "msvc": "14.14",
+            "gcc": "7",
+            "clang": "7",
+            "apple-clang": "11",
+        }
+
+    def export_sources(self):
+        for p in self.conan_data.get("patches", {}).get(self.version, []):
+            copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.info.settings.get_safe("compiler.cppstd"):
+            check_min_cppstd(self, self._minimum_cpp_standard)
+        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
+        if minimum_version and Version(self.info.settings.get_safe("compiler.version")) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, pattern="*.h", dst=os.path.join(self.package_folder, "include", "ankerl"), src=os.path.join(self.source_folder, "include", "ankerl"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []
+
+        self.cpp_info.set_property("cmake_file_name", "unordered_dense")
+        self.cpp_info.set_property("cmake_target_name", "unordered_dense::unordered_dense")
+        self.cpp_info.set_property("pkg_config_name", "package")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "unordered_dense"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "unordered_dense"
+        self.cpp_info.names["cmake_find_package"] = "unordered_dense"
+        self.cpp_info.names["cmake_find_package_multi"] = "unordered_dense"

--- a/recipes/unordered_dense/all/conanfile.py
+++ b/recipes/unordered_dense/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, get, copy
+from conan.tools.files import get, copy
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.layout import basic_layout

--- a/recipes/unordered_dense/all/conanfile.py
+++ b/recipes/unordered_dense/all/conanfile.py
@@ -28,7 +28,7 @@ class PackageConan(ConanFile):
     def _compilers_minimum_version(self):
         return {
             "Visual Studio": "15.7",
-            "msvc": "14.14",
+            "msvc": "1914",
             "gcc": "7",
             "clang": "7",
             "apple-clang": "11",

--- a/recipes/unordered_dense/all/test_package/CMakeLists.txt
+++ b/recipes/unordered_dense/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package CXX)
+
+find_package(unordered_dense REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE unordered_dense::unordered_dense)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/unordered_dense/all/test_package/conanfile.py
+++ b/recipes/unordered_dense/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/unordered_dense/all/test_package/test_package.cpp
+++ b/recipes/unordered_dense/all/test_package/test_package.cpp
@@ -1,0 +1,14 @@
+// sited from https://github.com/martinus/unordered_dense/blob/main/example/main.cpp
+#include <ankerl/unordered_dense.h>
+
+#include <iostream>
+
+auto main() -> int {
+    auto map = ankerl::unordered_dense::map<int, std::string>();
+    map[123] = "hello";
+    map[987] = "world!";
+
+    for (auto const& [key, val] : map) {
+        std::cout << key << " => " << val << std::endl;
+    }
+}

--- a/recipes/unordered_dense/all/test_v1_package/CMakeLists.txt
+++ b/recipes/unordered_dense/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(unordered_dense REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE unordered_dense::unordered_dense)
+set_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/unordered_dense/all/test_v1_package/conanfile.py
+++ b/recipes/unordered_dense/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/unordered_dense/config.yml
+++ b/recipes/unordered_dense/config.yml
@@ -1,0 +1,4 @@
+versions:
+  # Newer versions at the top
+  "1.3.1":
+    folder: all

--- a/recipes/unordered_dense/config.yml
+++ b/recipes/unordered_dense/config.yml
@@ -1,4 +1,3 @@
 versions:
-  # Newer versions at the top
   "1.3.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **unordered_dense/1.3.1**

unordered_dense seems to be the successor of [robin-hood-hashing](https://github.com/martinus/robin-hood-hashing).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
