### PR TITLE
[docs] How to add packages based on new templates

### DIFF
--- a/docs/how_to_add_packages.md
+++ b/docs/how_to_add_packages.md
@@ -294,7 +294,8 @@ conan config install
 
 ### Linters
 
-Some linters are always executed by Github actions to validate parts of your recipe, for instance, if it uses migrated Conan tools imports.
+Linters are always executed by Github actions to validate parts of your recipe, for instance, if it uses migrated Conan tools imports.
+All executed linters are documented in [linters.md](linters.md).
 To understand how to run linters locally, read [V2 linter](v2_linter.md) documentation.
 
 ## Debugging failed builds

--- a/docs/how_to_add_packages.md
+++ b/docs/how_to_add_packages.md
@@ -45,7 +45,7 @@ This process helps conan-center-index against spam and malicious code. The proce
 
 The specific steps to add new packages are:
 * Fork the [conan-center-index](https://github.com/conan-io/conan-center-index) git repository, and then clone it locally.
-* Copy a template from [package_templates](package_templates) folder in the correct folder, which fits your project. Read their [documentation](package_templates/README.md) to find more information.
+* Copy a template from [package_templates](package_templates) folder in the recipes/ folder and rename it to the project name (it should be lower-case). Read templates [documentation](package_templates/README.md) to find more information.
 * Make sure you are using the latest [Conan client](https://conan.io/downloads) version, as recipes might evolve introducing features of the newer Conan releases.
 * Commit and Push to GitHub then submit a pull request.
 * Our automated build service will build 100+ different configurations, and provide messages that indicate if there were any issues found during the pull request on GitHub.
@@ -211,11 +211,9 @@ For C/C++ projects which use CMake for building, you can take a look on [cmake p
 
 Another common use case for CMake based projects, both header only and compiled, is _modeling components_ to match the `find_package` and export the correct targets from Conan's generators. A basic examples of this is [cpu_features](https://github.com/conan-io/conan-center-index/blob/master/recipes/cpu_features/all/conanfile.py), a moderate/intermediate example is [cpprestsdk](https://github.com/conan-io/conan-center-index/blob/master/recipes/cpprestsdk/all/conanfile.py), and a very complex example is [OpenCV](https://github.com/conan-io/conan-center-index/blob/master/recipes/opencv/4.x/conanfile.py).
 
-Note that Conan is migrating toward the version 2.0 and many repices are outdated when related to components feature. To understand who to migrate components read [properties migration](https://docs.conan.io/en/latest/migrating_to_2.0/properties.html#properties-migration).
-
 ### Autotools
 
-However, if you need to use autotools for building, you can take a look on [mpc](https://github.com/conan-io/conan-center-index/blob/master/recipes/mpc/all/conanfile.py), [libatomic_ops](https://github.com/conan-io/conan-center-index/blob/master/recipes/libatomic_ops/all/conanfile.py), [libev](https://github.com/conan-io/conan-center-index/blob/master/recipes/libev/all/conanfile.py).
+However, if you need to use autotools for building, you can take a look on [libalsa](https://github.com/conan-io/conan-center-index/blob/master/recipes/libalsa/all/conanfile.py), [kmod](https://github.com/conan-io/conan-center-index/blob/master/recipes/kmod/all/conanfile.py), [libcap](https://github.com/conan-io/conan-center-index/blob/master/recipes/libcap/all/conanfile.py).
 
 #### Components
 

--- a/docs/how_to_add_packages.md
+++ b/docs/how_to_add_packages.md
@@ -238,10 +238,10 @@ Some project requirements need to respect a version constraint. This can be enfo
 An example of this can be found in the [fcl recipe](https://github.com/conan-io/conan-center-index/blob/1b6b496fe9a9be4714f8a0db45274c29b0314fe3/recipes/fcl/all/conanfile.py#L80).
 
 ```py
-def generate(self):
+def validate(self):
     foobar = self.dependencies["foobar"]
-    tc = CMakeToolchain(self)
-    tc.variables["FOOBAR_VERSION"] = foobar.ref.version
+    if self.info.options.shared and Version(foobar.ref.version) < "1.2":
+        raise ConanInvalidConfiguration(f"{self.ref} requires 'foobar' >=1.2 to be built as shared.")
 ```
 
 ### Verifying Dependency Options

--- a/docs/how_to_add_packages.md
+++ b/docs/how_to_add_packages.md
@@ -145,7 +145,7 @@ different versions in different folders. For mainteinance reasons, we prefer to 
 it and it makes sense to split and duplicate it, there is no common rule for it.
 
 Together with the recipe, there can be other files that are needed to build the library: patches, other files related to build systems,
-... all these files will usually be listed in the `exports_sources` attribute and used during the build process.
+... all these files will usually be listed in `exports_sources`  and used during the build process.
 
 Also, **every `conanfile.py` should be accompanied by one or several folder to test the generated packages** as we will see below.
 

--- a/docs/package_templates/README.md
+++ b/docs/package_templates/README.md
@@ -1,0 +1,23 @@
+## Package Templates
+
+A brief description about each template available:
+
+#### Autotools package
+
+It's listed under [autotools_package](autotools_package) folder. It fits projects which use `autotools` or `make` to be built.
+
+#### CMake package
+
+It's listed under [cmake_package](cmake_package) folder. It fits projects which use `CMake` to be built.
+
+####  Header only
+
+It's listed under [header_only](header_only) folder. It fits projects which only copy header and have the same package ID always.
+
+#### MSBuild package
+
+It's listed under [msbuild_package](msbuild_package) folder. It fits projects which use `msbuild` to be built.
+
+#### Prebuilt tool package
+
+It's listed under [prebuilt_tool_package](prebuilt_tool_package) folder. It fits projects which only copy generated binaries (executables and libraries).


### PR DESCRIPTION
Our current documentation is fragmented, so users need to visit recursive links, which makes the learning curve a maze. I would like to centralize a good and centralize documentation, where people can read from the start and stop jumping to another pages, then provide their first recipe.

This model also updates the first recipe, it should use the current templates. It harder for users, because their will arrive in middle a migration, so need to learn about both v1 and v2, but avoids the technical debt in the future.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
