### PR TITLE
[xnnpack] Add cci.20220801

### DIFF
--- a/recipes/xnnpack/all/conandata.yml
+++ b/recipes/xnnpack/all/conandata.yml
@@ -11,3 +11,6 @@ sources:
   "cci.20220621":
     url: "https://github.com/google/XNNPACK/archive/b725ca1a40b53d8087d1be0c53cb49fa05e2f1bc.tar.gz"
     sha256: "a745c629dea5fc76e5a545e412a408fde1a523b71027f07d1b0670ec9ae54819"
+  "cci.20220801":
+    url: "https://github.com/google/XNNPACK/archive/8e3d3359f9bec608e09fac1f7054a2a14b1bd73c.tar.gz"
+    sha256: "c82327543249bd333034bbaa0300ed1fc9c7060fa73673a285042e3f042540e0"

--- a/recipes/xnnpack/config.yml
+++ b/recipes/xnnpack/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "cci.20220621":
     folder: all
+  "cci.20220801":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **xnnpack/cci.20220801**

This version is required by **tensorflow-lite/2.10.0**. See #12390.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
