### PR TITLE
[docs] Hotfix replace wrong cmake method in docs

### DIFF
--- a/docs/package_templates/autotools_package/all/test_v1_package/CMakeLists.txt
+++ b/docs/package_templates/autotools_package/all/test_v1_package/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 # don't link to ${CONAN_LIBS} or CONAN_PKG::package
 target_link_libraries(${PROJECT_NAME} PRIVATE package::package)
 # in case the target project requires a C++ standard
-# set_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+# target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/docs/package_templates/cmake_package/all/test_v1_package/CMakeLists.txt
+++ b/docs/package_templates/cmake_package/all/test_v1_package/CMakeLists.txt
@@ -13,5 +13,4 @@ add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
 # don't link to ${CONAN_LIBS} or CONAN_PKG::package
 target_link_libraries(${PROJECT_NAME} PRIVATE package::package)
 # in case the target project requires a C++ standard
-set_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
-
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/docs/package_templates/header_only/all/test_v1_package/CMakeLists.txt
+++ b/docs/package_templates/header_only/all/test_v1_package/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
 # don't link to ${CONAN_LIBS} or CONAN_PKG::package
 target_link_libraries(${PROJECT_NAME} PRIVATE package::package)
 # in case the target project requires a C++ standard
-set_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/docs/package_templates/msbuild_package/all/test_v1_package/CMakeLists.txt
+++ b/docs/package_templates/msbuild_package/all/test_v1_package/CMakeLists.txt
@@ -13,4 +13,4 @@ add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
 # don't link to ${CONAN_LIBS} or CONAN_PKG::package
 target_link_libraries(${PROJECT_NAME} PRIVATE package::package)
 # in case the target project requires a C++ standard
-set_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)


### PR DESCRIPTION
The method `set_compile_features`  does not exist. The correct one is [target_compile_features](https://cmake.org/cmake/help/latest/command/target_compile_features.html)

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
