### PR TITLE
[linter] Convert import ConanFile from conans into an error

### DIFF
--- a/linter/check_import_conanfile.py
+++ b/linter/check_import_conanfile.py
@@ -13,7 +13,7 @@ class ImportConanFile(BaseChecker):
 
     name = "conan-import-conanfile"
     msgs = {
-        "W9006": (
+        "E9006": (
             "Import ConanFile from new module: `from conan import ConanFile`. Old import is deprecated in Conan v2.",
             "conan-import-conanfile",
             "Import ConanFile from new module: `from conan import ConanFile`. Old import is deprecated in Conan v2.",


### PR DESCRIPTION
As importing the `ConanFile` from new `conan` namespace does not have a major implication on recipes, it is time to make the linter error in case it is imported from `conans`. This way we can make a step forward toward Conan 2

/cc @jgsogo @uilianries as commented on today's meeting
