### PR TITLE
[docs] Enforce to ask more details when reporting a bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -11,8 +11,8 @@ body:
       Please don't forget to update the issue title.
       Missing profile or a short log will make extremely difficult to investigate your case or provide any help,
       please, include all applicable information with details to help us reproduce your problem.
-    validations:
-      required: true
+  validations:
+    required: true
 
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -4,16 +4,20 @@ title: '[package] <LIBRARY-NAME>/<LIBRARY-VERSION>: SHORT DESCRIPTION'
 labels: bug
 body:
 - type: markdown
+  label: Description
+  description: What is not working
   attributes:
     value: |
       Please don't forget to update the issue title.
       Missing profile or a short log will make extremely difficult to investigate your case or provide any help,
       please, include all applicable information with details to help us reproduce your problem.
+  validations:
+    required: true
 
 - type: textarea
   attributes:
     label: Package and Environment Details
-    description: include every applicable attribute)
+    description: (include every applicable attribute)
     value: |
      * Package Name/Version: **zlib/1.2.8**
      * Operating System+version: **Linux Ubuntu 18.04**

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -7,7 +7,8 @@ body:
   attributes:
     value: |
       Please don't forget to update the issue title.
-      Include all applicable information to help us reproduce your problem.
+      Missing profile or a short log will make impossible to investigate your case,
+      please, include all applicable information with details to help us reproduce your problem.
 
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -4,15 +4,15 @@ title: '[package] <LIBRARY-NAME>/<LIBRARY-VERSION>: SHORT DESCRIPTION'
 labels: bug
 body:
 - type: markdown
-  label: Description
-  description: What is not working
   attributes:
+    label: Description
+    description: What is not working
     value: |
       Please don't forget to update the issue title.
       Missing profile or a short log will make extremely difficult to investigate your case or provide any help,
       please, include all applicable information with details to help us reproduce your problem.
-  validations:
-    required: true
+    validations:
+      required: true
 
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -35,7 +35,7 @@ body:
   attributes:
     label: Conan profile
     description: output of `conan profile show default` or `conan profile show <profile>` if custom profile is in use
-    pleceholder: |
+    value: |
       [settings]
       os=Macos
       os_build=Macos
@@ -56,7 +56,7 @@ body:
   attributes:
     label:  Steps to reproduce
     description: Which commands did you run?
-    placeholder: conan install -r conancenter foobar/0.1.0@ -pr:b=default -pr:h=default
+    value: conan install -r conancenter foobar/0.1.0@ -pr:b=default -pr:h=default
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -22,12 +22,12 @@ body:
      * Conan version: **conan 1.18.0**
      * Python version: **Python 3.7.4**
     placeholder: |
-     cat /etc/lsb-release | grep
-     gcc --version
-     docker info
-     cmake --version
-     conan -v
-     python3 --version
+      cat /etc/lsb-release | grep
+      gcc --version
+      docker info
+      cmake --version
+      conan -v
+      python3 --version
   validations:
     required: true
 
@@ -36,19 +36,19 @@ body:
     label: Conan profile
     description: output of `conan profile show default` or `conan profile show <profile>` if custom profile is in use
     pleceholder: |
-     [settings]
-     os=Macos
-     os_build=Macos
-     arch=armv8
-     arch_build=armv8
-     compiler=apple-clang
-     compiler.version=14
-     compiler.libcxx=libc++
-     build_type=Release
-     [options]
-     [conf]
-     [build_requires]
-     [env]
+      [settings]
+      os=Macos
+      os_build=Macos
+      arch=armv8
+      arch_build=armv8
+      compiler=apple-clang
+      compiler.version=14
+      compiler.libcxx=libc++
+      build_type=Release
+      [options]
+      [conf]
+      [build_requires]
+      [env]
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -7,7 +7,7 @@ body:
   attributes:
     value: |
       Please don't forget to update the issue title.
-      Missing profile or a short log will make impossible to investigate your case,
+      Missing profile or a short log will make extremely difficult to investigate your case or provide any help,
       please, include all applicable information with details to help us reproduce your problem.
 
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -3,7 +3,7 @@ description: 'Report a bug, something does not work as it supposed to'
 title: '[package] <LIBRARY-NAME>/<LIBRARY-VERSION>: SHORT DESCRIPTION'
 labels: bug
 body:
-- type: markdown
+- type: textarea
   attributes:
     label: Description
     description: What is not working

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -32,12 +32,12 @@ body:
 - type: textarea
   attributes:
     label:  Steps to reproduce
-    description: Include if Applicable
+    description: Which commands did you run? e.g. `conan install -r conancenter foobar/0.1.0@ -pr:b=default -pr:h=default`
 
 - type: textarea
   attributes:
     label:  Logs
-    description: Include/Attach if Applicable
+    description: Include/Attach the entire command output here.
     value: |
       <details><summary>Click to expand log</summary>
 

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -6,7 +6,7 @@ body:
 - type: textarea
   attributes:
     label: Description
-    description: What is not working
+    description: What is not working? What were you expecting? Are there any workarounds?
     value: |
       Please don't forget to update the issue title.
       Missing profile or a short log will make extremely difficult to investigate your case or provide any help,

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -8,7 +8,8 @@ body:
     label: Description
     description: What is not working? What were you expecting? Are there any workarounds?
     value: |
-      Please don't forget to update the issue title.
+      _Please don't forget to update the issue title._
+      
       Missing profile or a short log will make extremely difficult to investigate your case or provide any help,
       please, include all applicable information with details to help us reproduce your problem.
   validations:

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -29,11 +29,15 @@ body:
   attributes:
     label: Conan profile
     description: output of `conan profile show default` or `conan profile show <profile>` if custom profile is in use
+  validations:
+    required: true
 
 - type: textarea
   attributes:
     label:  Steps to reproduce
     description: Which commands did you run? e.g. `conan install -r conancenter foobar/0.1.0@ -pr:b=default -pr:h=default`
+  validations:
+    required: true
 
 - type: textarea
   attributes:
@@ -47,3 +51,5 @@ body:
       ```
 
       </details>
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/package_bug.yml
+++ b/.github/ISSUE_TEMPLATE/package_bug.yml
@@ -21,21 +21,42 @@ body:
      * Docker image: **conanio/gcc8**
      * Conan version: **conan 1.18.0**
      * Python version: **Python 3.7.4**
+    placeholder: |
+     cat /etc/lsb-release | grep
+     gcc --version
+     docker info
+     cmake --version
+     conan -v
+     python3 --version
   validations:
     required: true
-
 
 - type: textarea
   attributes:
     label: Conan profile
     description: output of `conan profile show default` or `conan profile show <profile>` if custom profile is in use
+    pleceholder: |
+     [settings]
+     os=Macos
+     os_build=Macos
+     arch=armv8
+     arch_build=armv8
+     compiler=apple-clang
+     compiler.version=14
+     compiler.libcxx=libc++
+     build_type=Release
+     [options]
+     [conf]
+     [build_requires]
+     [env]
   validations:
     required: true
 
 - type: textarea
   attributes:
     label:  Steps to reproduce
-    description: Which commands did you run? e.g. `conan install -r conancenter foobar/0.1.0@ -pr:b=default -pr:h=default`
+    description: Which commands did you run?
+    placeholder: conan install -r conancenter foobar/0.1.0@ -pr:b=default -pr:h=default
   validations:
     required: true
 


### PR DESCRIPTION
Frequently we have broken packages reported without any further information, making it impossible to be reproduced. Users should be more inclined to populate useful information.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
