### PR TITLE
opentelemetry-cpp: add versions 1.5.0 and 1.6.0

### DIFF
--- a/recipes/opentelemetry-cpp/all/CMakeLists.txt
+++ b/recipes/opentelemetry-cpp/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.4)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory("source_subfolder")

--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -24,18 +24,14 @@ sources:
 patches:
   "1.6.0":
     - patch_file: "patches/1.6.0-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
+
   "1.5.0":
     - patch_file: "patches/1.5.0-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/1.5.0-0002-fix-several-compiling-linking-errors.patch"
-      base_path: "source_subfolder"
+      patch_type: "backport"
   "1.4.1":
     - patch_file: "patches/1.4.0-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
   "1.4.0":
     - patch_file: "patches/1.4.0-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
   "1.3.0":
     - patch_file: "patches/1.3.0-0001-fix-cmake.patch"
-      base_path: "source_subfolder"

--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.6.0":
+    url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.6.0.tar.gz"
+    sha256: "802cf9132ee847bd1c72b72bd8116055fd7e78f60a44bb9c10225b41f5e35bff"
+  "1.5.0":
+    url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.5.0.tar.gz"
+    sha256: "0d3fa768c48ed0df99dd061527ce26f2e4c42f8db7a5ba036031da60e52f4cc8"
   "1.4.1":
     url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.4.1.tar.gz"
     sha256: "301b1ab74a664723560f46c29f228360aff1e2d63e930b963755ea077ae67524"
@@ -16,6 +22,14 @@ sources:
     sha256: "32f12ff15ec257e3462883f84bc291c2d5dc30055604c12ec4b46a36dfa3f189"
 
 patches:
+  "1.6.0":
+    - patch_file: "patches/1.6.0-0001-fix-cmake.patch"
+      base_path: "source_subfolder"
+  "1.5.0":
+    - patch_file: "patches/1.5.0-0001-fix-cmake.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/1.5.0-0002-fix-several-compiling-linking-errors.patch"
+      base_path: "source_subfolder"
   "1.4.1":
     - patch_file: "patches/1.4.0-0001-fix-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -47,10 +47,13 @@ class OpenTelemetryCppConan(ConanFile):
         self.requires("nlohmann_json/3.10.5")
         self.requires("openssl/1.1.1o")
         self.requires("opentelemetry-proto/0.18.0")
-        self.requires("protobuf/3.21.1")
         self.requires("thrift/0.15.0")
         if tools.Version(self.version) >= "1.3.0":
             self.requires("boost/1.79.0")
+        if tools.Version(self.version) >= "1.5.0":
+            self.requires("protobuf/3.21.4")
+        else:
+            self.requires("protobuf/3.21.1")
 
     def validate(self):
         if self.settings.arch != "x86_64":
@@ -62,6 +65,9 @@ class OpenTelemetryCppConan(ConanFile):
 
         if self.settings.os != "Linux" and self.options.shared:
             raise ConanInvalidConfiguration("Building shared libraries is only supported on Linux")
+
+        if tools.Version(self.version) >= "1.5.0":
+            tools.check_min_cppstd(self, "17")
 
     @staticmethod
     def _create_cmake_module_variables(module_file):

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -4,12 +4,13 @@ import functools
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.cmake import CMake
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.scm import Version
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import save, get, rmdir, replace_in_file
+from conan.tools.files import save, get, copy, rmdir, replace_in_file, apply_conandata_patches
+from conan.tools.microsoft import is_msvc
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.51.3"
 
 
 class OpenTelemetryCppConan(ConanFile):
@@ -18,7 +19,7 @@ class OpenTelemetryCppConan(ConanFile):
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/open-telemetry/opentelemetry-cpp"
-    topics = ("opentelemetry", "telemetry", "tracing", "metrics", "logs")
+    topics = "opentelemetry", "telemetry", "tracing", "metrics", "logs"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
@@ -28,13 +29,20 @@ class OpenTelemetryCppConan(ConanFile):
         "fPIC": True,
         "shared": False,
     }
-    generators = "cmake", "cmake_find_package_multi"
+
     short_paths = True
 
+    @property
+    def _minimum_cpp_standard(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {"Visual Studio": "16"}
+
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        for p in self.conan_data.get("patches", {}).get(self.version, []):
+            copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -42,7 +50,13 @@ class OpenTelemetryCppConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires("abseil/20211102.0")
@@ -60,48 +74,28 @@ class OpenTelemetryCppConan(ConanFile):
             self.requires("protobuf/3.21.1")
 
     def validate(self):
-        if self.settings.arch != "x86_64":
+        if self.info.settings.arch != "x86_64":
             raise ConanInvalidConfiguration("Architecture not supported")
 
-        if (self.settings.compiler == "Visual Studio" and
-           Version(self.settings.compiler.version) < "16"):
-            raise ConanInvalidConfiguration("Visual Studio 2019 or higher required")
+        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
+        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.info.settings.compiler.name} {minimum_version} or higher required")
 
-        if self.settings.os != "Linux" and self.options.shared:
+        if self.info.settings.os != "Linux" and self.info.options.shared:
             raise ConanInvalidConfiguration("Building shared libraries is only supported on Linux")
 
-        if Version(self.version) >= "1.5.0":
-            check_min_cppstd(self, "17")
-
-    def _create_cmake_module_variables(self, module_file):
-        content = textwrap.dedent("""\
-            set(OPENTELEMETRY_CPP_INCLUDE_DIRS ${opentelemetry-cpp_INCLUDE_DIRS}
-                                               ${opentelemetry-cpp_INCLUDE_DIRS_RELEASE}
-                                               ${opentelemetry-cpp_INCLUDE_DIRS_RELWITHDEBINFO}
-                                               ${opentelemetry-cpp_INCLUDE_DIRS_MINSIZEREL}
-                                               ${opentelemetry-cpp_INCLUDE_DIRS_DEBUG})
-            set(OPENTELEMETRY_CPP_LIBRARIES opentelemetry-cpp::opentelemetry-cpp)
-        """)
-        save(self, module_file, content)
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
+        if self.info.settings.compiler.cppstd:
+            check_min_cppstd(self, self._minimum_cpp_standard)
 
     def source(self):
-        get(
-            **self.conan_data["sources"][self.version],
-            destination=self._source_subfolder,
-            strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+                  destination=self.source_folder, strip_root=True)
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        variables = {
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+
+        tc.cache_variables.update({
           "BUILD_TESTING": False,
           "WITH_ABSEIL": True,
           "WITH_ETW": True,
@@ -109,14 +103,18 @@ class OpenTelemetryCppConan(ConanFile):
           "WITH_JAEGER": True,
           "WITH_OTLP": True,
           "WITH_ZIPKIN": True,
-        }
-        cmake.configure(variables=variables, build_script_folder=self._build_subfolder)
-        return cmake
+        })
+
+        tc.generate()
+
+        tc = CMakeDeps(self)
+        tc.generate()
 
     def _patch_sources(self):
+        apply_conandata_patches(self)
         protos_path = self.deps_user_info["opentelemetry-proto"].proto_root.replace("\\", "/")
         protos_cmake_path = os.path.join(
-            self._source_subfolder,
+            self.source_folder,
             "cmake",
             "opentelemetry-proto.cmake")
         if Version(self.version) >= "1.1.0":
@@ -130,24 +128,32 @@ class OpenTelemetryCppConan(ConanFile):
             protos_cmake_path,
             "set(PROTO_PATH \"${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto\")",
             f"set(PROTO_PATH \"{protos_path}\")")
-        rmdir(self, os.path.join(self._source_subfolder, "api", "include", "opentelemetry", "nostd", "absl"))
-
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            patch(**patch)
+        rmdir(self, os.path.join(self.source_folder, "api", "include", "opentelemetry", "nostd", "absl"))
 
     def build(self):
         self._patch_sources()
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
-        cmake.install()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        CMake(self).install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         self._create_cmake_module_variables(
             os.path.join(self.package_folder, self._otel_cmake_variables_path)
         )
+
+    def _create_cmake_module_variables(self, module_file):
+        content = textwrap.dedent("""\
+            set(OPENTELEMETRY_CPP_INCLUDE_DIRS ${opentelemetry-cpp_INCLUDE_DIRS}
+                                               ${opentelemetry-cpp_INCLUDE_DIRS_RELEASE}
+                                               ${opentelemetry-cpp_INCLUDE_DIRS_RELWITHDEBINFO}
+                                               ${opentelemetry-cpp_INCLUDE_DIRS_MINSIZEREL}
+                                               ${opentelemetry-cpp_INCLUDE_DIRS_DEBUG})
+            set(OPENTELEMETRY_CPP_LIBRARIES opentelemetry-cpp::opentelemetry-cpp)
+        """)
+        save(self, module_file, content)
 
     @property
     def _module_subfolder(self):

--- a/recipes/opentelemetry-cpp/all/patches/1.5.0-0001-fix-cmake.patch
+++ b/recipes/opentelemetry-cpp/all/patches/1.5.0-0001-fix-cmake.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a1b69340..d4f52514 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -209,7 +209,6 @@ if(WITH_JAEGER)
+   find_package(Thrift QUIET)
+   if(Thrift_FOUND)
+     find_package(Boost REQUIRED)
+-    include_directories(${Boost_INCLUDE_DIR})
+   else()
+     # Install Thrift and propagate via vcpkg toolchain file
+     if(WIN32 AND (NOT DEFINED CMAKE_TOOLCHAIN_FILE))

--- a/recipes/opentelemetry-cpp/all/patches/1.5.0-0002-fix-several-compiling-linking-errors.patch
+++ b/recipes/opentelemetry-cpp/all/patches/1.5.0-0002-fix-several-compiling-linking-errors.patch
@@ -1,0 +1,122 @@
+From b4d8245d65e47eea2d2c2ecbeea813b6475cffcf Mon Sep 17 00:00:00 2001
+From: WenTao Ou <owentou@tencent.com>
+Date: Wed, 3 Aug 2022 12:26:24 +0800
+Subject: [PATCH] Fix several compiling/linking errors (#1539)
+
+Signed-off-by: owentou <owentou@tencent.com>
+---
+ .../exporters/elasticsearch/es_log_exporter.h |  4 ++--
+ .../elasticsearch/src/es_log_exporter.cc      |  5 +++--
+ .../exporters/otlp/otlp_http_client.h         |  2 +-
+ .../otlp/src/otlp_grpc_metric_exporter.cc     | 19 +++++++++++++++++++
+ exporters/prometheus/src/collector.cc         |  3 ++-
+ 5 files changed, 27 insertions(+), 6 deletions(-)
+
+diff --git a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
+index ea58807e..9b75c04e 100644
+--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
++++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
+@@ -6,7 +6,7 @@
+ 
+ #  include "nlohmann/json.hpp"
+ #  include "opentelemetry/common/spin_lock_mutex.h"
+-#  include "opentelemetry/ext/http/client/curl/http_client_curl.h"
++#  include "opentelemetry/ext/http/client/http_client_factory.h"
+ #  include "opentelemetry/nostd/type_traits.h"
+ #  include "opentelemetry/sdk/logs/exporter.h"
+ #  include "opentelemetry/sdk/logs/log_record.h"
+@@ -104,7 +104,7 @@ class ElasticsearchLogExporter final : public opentelemetry::sdk::logs::LogExpor
+   ElasticsearchExporterOptions options_;
+ 
+   // Object that stores the HTTP sessions that have been created
+-  std::unique_ptr<ext::http::client::HttpClient> http_client_;
++  std::shared_ptr<ext::http::client::HttpClient> http_client_;
+   mutable opentelemetry::common::SpinLockMutex lock_;
+   bool isShutdown() const noexcept;
+ };
+diff --git a/exporters/elasticsearch/src/es_log_exporter.cc b/exporters/elasticsearch/src/es_log_exporter.cc
+index 3c21e0e2..f9a681de 100644
+--- a/exporters/elasticsearch/src/es_log_exporter.cc
++++ b/exporters/elasticsearch/src/es_log_exporter.cc
+@@ -5,6 +5,7 @@
+ 
+ #  include <sstream>  // std::stringstream
+ 
++#  include <condition_variable>
+ #  include <mutex>
+ #  include "opentelemetry/exporters/elasticsearch/es_log_exporter.h"
+ #  include "opentelemetry/exporters/elasticsearch/es_log_recordable.h"
+@@ -225,11 +226,11 @@ class AsyncResponseHandler : public http_client::EventHandler
+ 
+ ElasticsearchLogExporter::ElasticsearchLogExporter()
+     : options_{ElasticsearchExporterOptions()},
+-      http_client_{new ext::http::client::curl::HttpClient()}
++      http_client_{ext::http::client::HttpClientFactory::Create()}
+ {}
+ 
+ ElasticsearchLogExporter::ElasticsearchLogExporter(const ElasticsearchExporterOptions &options)
+-    : options_{options}, http_client_{new ext::http::client::curl::HttpClient()}
++    : options_{options}, http_client_{ext::http::client::HttpClientFactory::Create()}
+ {}
+ 
+ std::unique_ptr<sdklogs::Recordable> ElasticsearchLogExporter::MakeRecordable() noexcept
+diff --git a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+index 70aa5ddb..e5102c6c 100644
+--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
++++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+@@ -186,7 +186,7 @@ class OtlpHttpClient
+       event_handle.swap(input_handle);
+     }
+ 
+-    inline explicit HttpSessionData(HttpSessionData &&other)
++    inline HttpSessionData(HttpSessionData &&other)
+     {
+       session.swap(other.session);
+       event_handle.swap(other.event_handle);
+diff --git a/exporters/otlp/src/otlp_grpc_metric_exporter.cc b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+index dfda8695..486d61df 100644
+--- a/exporters/otlp/src/otlp_grpc_metric_exporter.cc
++++ b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+@@ -143,6 +143,25 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcMetricExporter::Export(
+   return opentelemetry::sdk::common::ExportResult::kSuccess;
+ }
+ 
++bool OtlpGrpcMetricExporter::ForceFlush(std::chrono::microseconds timeout) noexcept
++{
++  // TODO: OTLP gRPC exporter does not support concurrency exporting now.
++  return true;
++}
++
++bool OtlpGrpcMetricExporter::Shutdown(std::chrono::microseconds timeout) noexcept
++{
++  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
++  is_shutdown_ = true;
++  return true;
++}
++
++bool OtlpGrpcMetricExporter::isShutdown() const noexcept
++{
++  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
++  return is_shutdown_;
++}
++
+ }  // namespace otlp
+ }  // namespace exporter
+ OPENTELEMETRY_END_NAMESPACE
+diff --git a/exporters/prometheus/src/collector.cc b/exporters/prometheus/src/collector.cc
+index 03793a8e..834e04dc 100644
+--- a/exporters/prometheus/src/collector.cc
++++ b/exporters/prometheus/src/collector.cc
+@@ -58,7 +58,8 @@ void PrometheusCollector::AddMetricData(const sdk::metrics::ResourceMetrics &dat
+   collection_lock_.lock();
+   if (metrics_to_collect_.size() + 1 <= max_collection_size_)
+   {
+-    metrics_to_collect_.emplace_back(new sdk::metrics::ResourceMetrics{data});
++    // We can not use initializer lists here due to broken variadic capture on GCC 4.8.5
++    metrics_to_collect_.emplace_back(new sdk::metrics::ResourceMetrics(data));
+   }
+   collection_lock_.unlock();
+ }
+-- 
+2.37.3
+

--- a/recipes/opentelemetry-cpp/all/patches/1.6.0-0001-fix-cmake.patch
+++ b/recipes/opentelemetry-cpp/all/patches/1.6.0-0001-fix-cmake.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a1b69340..d4f52514 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -209,7 +209,6 @@ if(WITH_JAEGER)
+   find_package(Thrift QUIET)
+   if(Thrift_FOUND)
+     find_package(Boost REQUIRED)
+-    include_directories(${Boost_INCLUDE_DIR})
+   else()
+     # Install Thrift and propagate via vcpkg toolchain file
+     if(WIN32 AND (NOT DEFINED CMAKE_TOOLCHAIN_FILE))

--- a/recipes/opentelemetry-cpp/config.yml
+++ b/recipes/opentelemetry-cpp/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "1.6.0":
+    folder: all
+  "1.5.0":
+    folder: all
   "1.4.1":
     folder: all
   "1.4.0":


### PR DESCRIPTION
Specify library name and version:  **opentelemetry-cpp/1.5.0** and **opentelemetry-cpp/1.6.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
