### PR TITLE
[docs] package_templates/cmake_package : fix `cache_variables.definitions` and add `configure`

### DIFF
--- a/docs/package_templates/cmake_package/all/conanfile.py
+++ b/docs/package_templates/cmake_package/all/conanfile.py
@@ -100,7 +100,7 @@ class PackageConan(ConanFile):
         tc.cache_variables["PACKAGE_CUSTOM_DEFINITION"] = True
         if is_msvc(self):
             # don't use self.settings.compiler.runtime
-            tc.cache_variables.definitions["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
+            tc.cache_variables.["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
         # deps_cpp_info, deps_env_info and deps_user_info are no longer used
         if self.dependencies["dependency"].options.foobar:
             tc.cache_variables["DEPENDENCY_LIBPATH"] = self.dependencies["dependency"].cpp_info.libdirs
@@ -126,6 +126,7 @@ class PackageConan(ConanFile):
     def build(self):
         self._patch_sources() # It can be apply_conandata_patches(self) only in case no more patches are needed
         cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):


### PR DESCRIPTION
Specify library name and version:  **docs**

- `tc.cache_variables.definitions` seems to be wrong. fix it.
- there is no `configure` in `build()`. add it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
