### PR TITLE
Add libpng 1.6.38 to conandata and config

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.38":
+    url: "https://github.com/glennrp/libpng/archive/v1.6.38.tar.gz"
+    sha256: "d4160037fa5d09fa7cff555037f2a7f2fefc99ca01e21723b19bfcda33015234"
   "1.6.37":
     url: "https://github.com/glennrp/libpng/archive/v1.6.37.tar.gz"
     sha256: "ca74a0dace179a8422187671aee97dd3892b53e168627145271cad5b5ac81307"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.38":
+    folder: all
   "1.6.37":
     folder: all
   "1.5.30":


### PR DESCRIPTION
Specify library name and version:  **libpng/1.6.38**

The libpng 1.6.38 version was just released earlier this week, and we would like to stay up-to-date with the latest version for maintenance of internal products.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
