### PR TITLE
magic_enum: add version 0.8.1

### DIFF
--- a/recipes/magic_enum/all/conandata.yml
+++ b/recipes/magic_enum/all/conandata.yml
@@ -20,3 +20,6 @@ sources:
   "0.8.0":
     url: "https://github.com/Neargye/magic_enum/archive/v0.8.0.tar.gz"
     sha256: "5e7680e877dd4cf68d9d0c0e3c2a683b432a9ba84fc1993c4da3de70db894c3c"
+  "0.8.1":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.8.1.tar.gz"
+    sha256: "6b948d1680f02542d651fc82154a9e136b341ce55c5bf300736b157e23f9df11"

--- a/recipes/magic_enum/config.yml
+++ b/recipes/magic_enum/config.yml
@@ -13,3 +13,5 @@ versions:
     folder: all
   "0.8.0":
     folder: all
+  "0.8.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **magic_enum/0.8.1**



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
