### PR TITLE
biflags: new recipe

### DIFF
--- a/recipes/bitflags/all/conandata.yml
+++ b/recipes/bitflags/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.5.0":
+    url: "https://github.com/m-peko/bitflags/archive/refs/tags/v1.5.0.tar.gz"
+    sha256: 1ea19e03e05e8e78faf0126a1a100e591467828bc816224e9cda330b104e69b5

--- a/recipes/bitflags/all/conanfile.py
+++ b/recipes/bitflags/all/conanfile.py
@@ -39,7 +39,7 @@ class BitFlags(ConanFile):
             check_min_cppstd(self, self._minimum_cpp_standard)
         try:
             if Version(self.settings.compiler.version) < self._minimum_compilers_version[str(self.settings.compiler)]:
-                raise ConanInvalidConfiguration(f"{self.ref} requires a compiler that supports C++{self._minimum_cpp_standard}.)
+                raise ConanInvalidConfiguration(f"{self.ref} requires a compiler that supports C++{self._minimum_cpp_standard}.")
         except KeyError:
             self.output.warn("Unknown compiler encountered. Assuming it supports C++11.")
 

--- a/recipes/bitflags/all/conanfile.py
+++ b/recipes/bitflags/all/conanfile.py
@@ -31,12 +31,15 @@ class BitFlags(ConanFile):
     def layout(self):
         basic_layout(self)
 
+    def package_id(self):
+        self.info.clear()
+
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
         try:
             if Version(self.settings.compiler.version) < self._minimum_compilers_version[str(self.settings.compiler)]:
-                raise ConanInvalidConfiguration(f"{self.name} requires a compiler that supports C++{self._minimum_cpp_standard}. {self.settings.compiler}, {self.settings.compiler.version}")
+                raise ConanInvalidConfiguration(f"{self.ref} requires a compiler that supports C++{self._minimum_cpp_standard}.)
         except KeyError:
             self.output.warn("Unknown compiler encountered. Assuming it supports C++11.")
 
@@ -48,13 +51,9 @@ class BitFlags(ConanFile):
         copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, pattern="*", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
 
-    def package_id(self):
-        self.info.clear()
-
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "bitflags")
         self.cpp_info.set_property("cmake_target_name", "bitflags::bitflags")
-
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.names["cmake_find_package"] = "bitflags"
-        self.cpp_info.names["cmake_find_package_multi"] = "bitflags"
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []

--- a/recipes/bitflags/all/conanfile.py
+++ b/recipes/bitflags/all/conanfile.py
@@ -1,0 +1,39 @@
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.50.0"
+
+
+class BitFlags(ConanFile):
+    name = "bitflags"
+    description = "Single-header header-only C++11 / C++14 / C++17 library for easily managing set of auto-generated type-safe flags"
+    topics = ("bits", "bitflags", "header-only")
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/m-peko/bitflags"
+    license = "MIT"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True,
+            destination=self.source_folder)
+
+    def package(self):
+        copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, pattern="*", src=os.path.join(self.source_folder, "include"), dst=os.path.join(self.package_folder, "include"))
+
+    def package_id(self):
+        self.info.clear()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "bitflags")
+        self.cpp_info.set_property("cmake_target_name", "bitflags::bitflags")
+
+        # TODO: to remove in conan v2 once cmake_find_package* generators removed
+        self.cpp_info.names["cmake_find_package"] = "bitflags"
+        self.cpp_info.names["cmake_find_package_multi"] = "bitflags"

--- a/recipes/bitflags/all/test_package/CMakeLists.txt
+++ b/recipes/bitflags/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package)
+
+find_package(bitflags REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE bitflags::bitflags)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/bitflags/all/test_package/conanfile.py
+++ b/recipes/bitflags/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+required_conan_version = ">=1.50.0"
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/bitflags/all/test_package/test_package.cpp
+++ b/recipes/bitflags/all/test_package/test_package.cpp
@@ -1,0 +1,27 @@
+#include "bitflags/bitflags.hpp"
+#include <cassert>
+#include <iostream>
+
+BEGIN_BITFLAGS(Flags)
+FLAG(none)
+FLAG(flag_a)
+FLAG(flag_b)
+FLAG(flag_c)
+END_BITFLAGS(Flags)
+
+DEFINE_FLAG(Flags, none)
+DEFINE_FLAG(Flags, flag_a)
+DEFINE_FLAG(Flags, flag_b)
+DEFINE_FLAG(Flags, flag_c)
+
+int main() {
+  std::cout << +Flags::none.bits << " - " << Flags::none.name << '\n';
+  std::cout << +Flags::flag_a.bits << " - " << Flags::flag_a.name << '\n';
+  std::cout << +Flags::flag_b.bits << " - " << Flags::flag_b.name << '\n';
+  std::cout << +Flags::flag_c.bits << " - " << Flags::flag_c.name << '\n';
+
+  const auto flags = Flags::flag_a | Flags::flag_b;
+
+  assert(flags & Flags::flag_a);
+  assert(!(flags & Flags::flag_c));
+}

--- a/recipes/bitflags/all/test_v1_package/CMakeLists.txt
+++ b/recipes/bitflags/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup(TARGETS)
+
+find_package(bitflags REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE bitflags::bitflags)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/bitflags/all/test_v1_package/conanfile.py
+++ b/recipes/bitflags/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/bitflags/config.yml
+++ b/recipes/bitflags/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.5.0":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **bitflags/1.5.0**

Contribute recipe for [m-peko/bitflags](https://github.com/m-peko/bitflags), a header-only library for easily managing set of auto-generated type-safe flags.

I am not the author of this library, but some of my projects depend on it.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
