### PR TITLE
kuba-zip: add version 0.2.5

### DIFF
--- a/recipes/kuba-zip/all/conandata.yml
+++ b/recipes/kuba-zip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.5":
+    url: "https://github.com/kuba--/zip/archive/v0.2.5.tar.gz"
+    sha256: "e052f6cbe6713f69f8caec61214fda4e5ae5150d1fcba02c9e79f1a05d939305"
   "0.2.4":
     url: "https://github.com/kuba--/zip/archive/v0.2.4.tar.gz"
     sha256: "a3dd762129d58c7ca7a6462f509d29388dbdb25bec559cb4dc03f75523d69cf2"

--- a/recipes/kuba-zip/config.yml
+++ b/recipes/kuba-zip/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.5":
+    folder: "all"
   "0.2.4":
     folder: "all"
   "0.2.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **kuba-zip/0.2.5**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
