### PR TITLE
statslib: add version 3.2.0

### DIFF
--- a/recipes/statslib/all/conandata.yml
+++ b/recipes/statslib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.2.0":
+    url: "https://github.com/kthohr/stats/archive/v3.2.0.tar.gz"
+    sha256: "1360ba4fbeed96db04e28541b8044daffecdbabc5565944d5cb67136477003ed"
   "3.1.2":
     url: "https://github.com/kthohr/stats/archive/v3.1.2.tar.gz"
     sha256: "fe82c679dbed0cbea284ce077e2c2503afaec745658a3791f9fe5010e438305e"

--- a/recipes/statslib/config.yml
+++ b/recipes/statslib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.2.0":
+    folder: "all"
   "3.1.2":
     folder: "all"
   "3.1.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **statslib/3.2.0**

!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
