### PR TITLE
at-spi2-core: add version 2.46.0

### DIFF
--- a/recipes/at-spi2-core/config.yml
+++ b/recipes/at-spi2-core/config.yml
@@ -15,3 +15,5 @@ versions:
     folder: new
   "2.45.90":
     folder: new
+  "2.46.0":
+    folder: new

--- a/recipes/at-spi2-core/new/conandata.yml
+++ b/recipes/at-spi2-core/new/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.46.0":
+    url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.46/at-spi2-core-2.46.0.tar.xz"
+    sha256: "aa0c86c79f7a8d67bae49a5b7a5ab08430c608cffe6e33bf47a72f41ab03c3d0"
   "2.45.90":
     url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.45/at-spi2-core-2.45.90.tar.xz"
     sha256: "e9050ad3c24937548396b2377f2fcdb9321ce2daffad35e7554e8f6ad850ab0d"
@@ -6,6 +9,9 @@ sources:
     sha256: "ba95f346e93108fbb3462c62437081d582154db279b4052dedc52a706828b192"
     url: "https://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.45/at-spi2-core-2.45.1.tar.xz"
 patches:
+  "2.46.0":
+    - base_path: "source_subfolder"
+      patch_file: "patches/93.patch"
   "2.45.90":
     - base_path: "source_subfolder"
       patch_file: "patches/93.patch"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **at-spi2-core/2.46.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
