### PR TITLE
thrift: add version 0.17.0

### DIFF
--- a/recipes/thrift/all/conandata.yml
+++ b/recipes/thrift/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.17.0":
+    url: "https://github.com/apache/thrift/archive/v0.17.0.tar.gz"
+    sha256: "f5888bcd3b8de40c2c2ab86896867ad9b18510deb412cba3e5da76fb4c604c29"
   "0.16.0":
     url: "https://github.com/apache/thrift/archive/refs/tags/v0.16.0.tar.gz"
     sha256: "df2931de646a366c2e5962af679018bca2395d586e00ba82d09c0379f14f8e7b"
@@ -15,6 +18,8 @@ sources:
     url: "https://github.com/apache/thrift/archive/0.13.0.tar.gz"
     sha256: "8469c8d72c684c6de72ddf55fc65d1c10868a576e7dc4d1f4a21a59814b97110"
 patches:
+  "0.17.0":
+    - patch_file: "patches/cmake-0.16.0.patch"
   "0.16.0":
     - patch_file: "patches/cmake-0.16.0.patch"
   "0.15.0":

--- a/recipes/thrift/config.yml
+++ b/recipes/thrift/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.17.0":
+    folder: all
   "0.16.0":
     folder: all
   "0.15.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **thrift/0.17.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
