### PR TITLE
[mosquitto] support threading options in recipe

### DIFF
--- a/recipes/mosquitto/2.x/conanfile.py
+++ b/recipes/mosquitto/2.x/conanfile.py
@@ -26,6 +26,7 @@ class Mosquitto(ConanFile):
         "cjson": [True, False],
         "build_cpp": [True, False],
         "websockets": [True, False],
+        "threading": [True, False],
     }
     default_options = {
         "shared": False,
@@ -37,6 +38,7 @@ class Mosquitto(ConanFile):
         "cjson": True, # https://github.com/eclipse/mosquitto/commit/bbe0afbfbe7bb392361de41e275759ee4ef06b1c
         "build_cpp": True,
         "websockets": False,
+        "threading": True,
     }
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake", "cmake_find_package"
@@ -93,7 +95,7 @@ class Mosquitto(ConanFile):
         self._cmake.definitions["WITH_APPS"] = self.options.apps
         self._cmake.definitions["WITH_PLUGINS"] = False
         self._cmake.definitions["WITH_LIB_CPP"] = self.options.build_cpp
-        self._cmake.definitions["WITH_THREADING"] = self.settings.compiler != "Visual Studio"
+        self._cmake.definitions["WITH_THREADING"] = self.settings.compiler != "Visual Studio" and self.options.threading
         self._cmake.definitions["WITH_WEBSOCKETS"] = self.options.get_safe("websockets", False)
         self._cmake.definitions["STATIC_WEBSOCKETS"] = self.options.get_safe("websockets", False) and not self.options["libwebsockets"].shared
         self._cmake.definitions["DOCUMENTATION"] = False


### PR DESCRIPTION
fixes #13006

Specify library name and version:  **mosquitto/2.x**

The mosquitto recipe does not allow to set the WITH_THREADING cmake option.
This MR add a boolean "threading" option to the recipe, with the default value of "True".

fixes #13006.
---

- [ x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
