### PR TITLE
implot: add version 0.14

### DIFF
--- a/recipes/implot/all/conandata.yml
+++ b/recipes/implot/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.14":
+    url: "https://github.com/epezent/implot/archive/v0.14.tar.gz"
+    sha256: "1613af3e6554c0a74de20c6e60e9bce5ce35c2d4f9e1aa5ff963f7fe2d48af88"
   "0.13":
     url: "https://github.com/epezent/implot/archive/v0.13.tar.gz"
     sha256: "acc8b012b6761c9b7ce1599a35fd861ac6dafb01368b1e938c90a3f654bd7589"

--- a/recipes/implot/config.yml
+++ b/recipes/implot/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.14":
+    folder: "all"
   "0.13":
     folder: "all"
   "0.12":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **implot/0.14**



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
