### PR TITLE
grpc/1.46.3: Fix error compiling with 'dockcross/dockcross': get_target_property()…

### DIFF
--- a/recipes/grpc/all/cmake/grpc_plugin_template.cmake.in
+++ b/recipes/grpc/all/cmake/grpc_plugin_template.cmake.in
@@ -5,7 +5,8 @@ if(NOT TARGET @target_name@)
             PATHS ENV PATH
             NO_DEFAULT_PATH
         )
-    else()
+    endif()
+    if(NOT @find_program_variable@)
         find_program(@find_program_variable@
             NAMES @executable_name@
             PATHS "${CMAKE_CURRENT_LIST_DIR}/@relative_path@bin/"


### PR DESCRIPTION
Fix error compiling with 'dockcross/dockcross': get_target_property() called with non-existent target "gRPC::grpc_cpp_plugin"

When cross-compiling, if grpc_cpp_plugin cannot be found in PATH, try to use the compiled binary directly. Like protobuf ("lib/cmake/protobuf/protobuf-generate.cmake").
