### PR TITLE
json-c: add version 0.16

### DIFF
--- a/recipes/json-c/all/conandata.yml
+++ b/recipes/json-c/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.16":
+    url: "https://github.com/json-c/json-c/archive/json-c-0.16-20220414.tar.gz"
+    sha256: "3ecaeedffd99a60b1262819f9e60d7d983844073abc74e495cb822b251904185"
   "0.15":
     url: "https://github.com/json-c/json-c/archive/json-c-0.15-20200726.tar.gz"
     sha256: "4ba9a090a42cf1e12b84c64e4464bb6fb893666841d5843cc5bef90774028882"

--- a/recipes/json-c/config.yml
+++ b/recipes/json-c/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.16":
+    folder: all
   "0.15":
     folder: all
   "0.14":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **json-c/0.16**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
