### PR TITLE
libatomic_ops: change cmake package name to Atomic_ops

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -3,7 +3,7 @@
 id: 'conan-io/conan-center-index'
 
 conan:
-  version: 1.51.3
+  version: 1.52.0
 
 artifactory:
   url: "https://c3i.jfrog.io/c3i"

--- a/recipes/libatomic_ops/all/conandata.yml
+++ b/recipes/libatomic_ops/all/conandata.yml
@@ -1,10 +1,7 @@
 sources:
-  "7.6.10":
-    url: "https://github.com/ivmai/libatomic_ops/releases/download/v7.6.10/libatomic_ops-7.6.10.tar.gz"
-    sha256: "587edf60817f56daf1e1ab38a4b3c729b8e846ff67b4f62a6157183708f099af"
-  "7.6.12":
-    url: "https://github.com/ivmai/libatomic_ops/releases/download/v7.6.12/libatomic_ops-7.6.12.tar.gz"
-    sha256: "f0ab566e25fce08b560e1feab6a3db01db4a38e5bc687804334ef3920c549f3e"
   "7.6.14":
     url: "https://github.com/ivmai/libatomic_ops/releases/download/v7.6.14/libatomic_ops-7.6.14.tar.gz"
     sha256: "390f244d424714735b7050d056567615b3b8f29008a663c262fb548f1802d292"
+patches:
+  "7.6.14":
+    - patch_file: "patches/update-cmake-7_6_14.patch"

--- a/recipes/libatomic_ops/all/conandata.yml
+++ b/recipes/libatomic_ops/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
 patches:
   "7.6.14":
     - patch_file: "patches/enable-cmake-7_6_14.patch"
+      patch_description: "Support build with CMake"
+      patch_source: "https://github.com/ivmai/libatomic_ops/blob/044573903530c4a8e8318e20a830d4a0531b2035/CMakeLists.txt"
+      patch_type: "backport"

--- a/recipes/libatomic_ops/all/conandata.yml
+++ b/recipes/libatomic_ops/all/conandata.yml
@@ -4,4 +4,4 @@ sources:
     sha256: "390f244d424714735b7050d056567615b3b8f29008a663c262fb548f1802d292"
 patches:
   "7.6.14":
-    - patch_file: "patches/update-cmake-7_6_14.patch"
+    - patch_file: "patches/enable-cmake-7_6_14.patch"

--- a/recipes/libatomic_ops/all/patches/enable-cmake-7_6_14.patch
+++ b/recipes/libatomic_ops/all/patches/enable-cmake-7_6_14.patch
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 new file mode 100644
-index 0000000..bc20331
+index 0000000..8b26697
 --- /dev/null
 +++ b/CMakeLists.txt
-@@ -0,0 +1,336 @@
+@@ -0,0 +1,341 @@
 +#
 +# Copyright (c) 2021-2022 Ivan Maidanski
 +##
@@ -125,6 +125,11 @@ index 0000000..bc20331
 +if (NOT enable_atomic_intrinsics)
 +  # Define to avoid GCC atomic intrinsics even if available.
 +  add_compile_options(-DAO_DISABLE_GCC_ATOMICS)
++endif()
++
++# AO API symbols export control.
++if (BUILD_SHARED_LIBS)
++  add_compile_options(-DAO_DLL)
 +endif()
 +
 +if (enable_werror)
@@ -351,3 +356,375 @@ index 0000000..034b456
 +@PACKAGE_INIT@
 +include("${CMAKE_CURRENT_LIST_DIR}/Atomic_opsTargets.cmake")
 +check_required_components(libatomic_ops)
+diff --git a/configure.ac b/configure.ac
+index ccf3230..eec3863 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -234,6 +234,12 @@ else
+ fi
+ AC_SUBST(THREADDLLIBS)
+ 
++# AO API symbols export control.
++# Compile with AO_DLL defined unless building static libraries.
++if test x$enable_shared = xyes -a x$enable_static = xno; then
++  CFLAGS="-DAO_DLL $CFLAGS"
++fi
++
+ AM_CONDITIONAL(ENABLE_SHARED, test x$enable_shared = xyes)
+ AM_CONDITIONAL(HAVE_PTHREAD_H, test x$have_pthreads = xtrue)
+ AM_CONDITIONAL(NEED_ASM, test x$need_asm = xtrue)
+diff --git a/src/atomic_ops.c b/src/atomic_ops.c
+index 5e6577f..1e5f3c9 100644
+--- a/src/atomic_ops.c
++++ b/src/atomic_ops.c
+@@ -51,6 +51,10 @@
+ # define _GNU_SOURCE 1
+ #endif
+ 
++#ifndef AO_BUILD
++# define AO_BUILD
++#endif
++
+ #undef AO_REQUIRE_CAS
+ #include "atomic_ops.h" /* Without cas emulation! */
+ 
+@@ -83,6 +87,8 @@
+ 
+ /* Lock for pthreads-based implementation.      */
+ #ifndef AO_NO_PTHREADS
++  AO_API pthread_mutex_t AO_pt_lock;
++
+   pthread_mutex_t AO_pt_lock = PTHREAD_MUTEX_INITIALIZER;
+ #endif
+ 
+@@ -109,7 +115,7 @@ static AO_TS_t AO_locks[AO_HASH_SIZE] = {
+   AO_TS_INITIALIZER, AO_TS_INITIALIZER, AO_TS_INITIALIZER, AO_TS_INITIALIZER,
+ };
+ 
+-void AO_pause(int); /* defined below */
++AO_API void AO_pause(int); /* defined below */
+ 
+ static void lock_ool(volatile AO_TS_t *l)
+ {
+@@ -156,8 +162,8 @@ AO_INLINE void unlock(volatile AO_TS_t *l)
+   }
+ #endif /* !AO_USE_NO_SIGNALS */
+ 
+-AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val,
+-                                         AO_t new_val)
++AO_API AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr,
++                                                AO_t old_val, AO_t new_val)
+ {
+   AO_TS_t *my_lock = AO_locks + AO_HASH(addr);
+   AO_t fetched_val;
+@@ -177,9 +183,10 @@ AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val,
+   return fetched_val;
+ }
+ 
+-int AO_compare_double_and_swap_double_emulation(volatile AO_double_t *addr,
+-                                                AO_t old_val1, AO_t old_val2,
+-                                                AO_t new_val1, AO_t new_val2)
++AO_API int
++AO_compare_double_and_swap_double_emulation(volatile AO_double_t *addr,
++                                            AO_t old_val1, AO_t old_val2,
++                                            AO_t new_val1, AO_t new_val2)
+ {
+   AO_TS_t *my_lock = AO_locks + AO_HASH(addr);
+   int result;
+@@ -204,7 +211,7 @@ int AO_compare_double_and_swap_double_emulation(volatile AO_double_t *addr,
+   return result;
+ }
+ 
+-void AO_store_full_emulation(volatile AO_t *addr, AO_t val)
++AO_API void AO_store_full_emulation(volatile AO_t *addr, AO_t val)
+ {
+   AO_TS_t *my_lock = AO_locks + AO_HASH(addr);
+   lock(my_lock);
+@@ -237,7 +244,7 @@ static void AO_spin(int n)
+   AO_store(&spin_dummy, j);
+ }
+ 
+-void AO_pause(int n)
++AO_API void AO_pause(int n)
+ {
+   if (n < 12)
+     AO_spin(n);
+diff --git a/src/atomic_ops.h b/src/atomic_ops.h
+index 92d1f4a..1f996fe 100644
+--- a/src/atomic_ops.h
++++ b/src/atomic_ops.h
+@@ -235,6 +235,30 @@
+ # define AO_ALIGNOF_SUPPORTED 1
+ #endif
+ 
++#if defined(AO_DLL) && !defined(AO_API)
++# ifdef AO_BUILD
++#   if defined(__CEGCC__) || (defined(__MINGW32__) && !defined(__cplusplus))
++#     define AO_API __declspec(dllexport)
++#   elif defined(_MSC_VER) || defined(__BORLANDC__) || defined(__CYGWIN__) \
++         || defined(__DMC__) || defined(__MINGW32__) || defined(__WATCOMC__)
++#     define AO_API extern __declspec(dllexport)
++#   endif
++# else
++#   if defined(_MSC_VER) || defined(__BORLANDC__) || defined(__CEGCC__) \
++       || defined(__CYGWIN__) || defined(__DMC__)
++#     define AO_API __declspec(dllimport)
++#   elif defined(__MINGW32_DELAY_LOAD__)
++#     define AO_API __declspec(dllexport)
++#   elif defined(__MINGW32__) || defined(__WATCOMC__)
++#     define AO_API extern __declspec(dllimport)
++#   endif
++# endif
++#endif /* AO_DLL */
++
++#ifndef AO_API
++# define AO_API extern
++#endif
++
+ #ifdef AO_ALIGNOF_SUPPORTED
+ # define AO_ASSERT_ADDR_ALIGNED(addr) \
+     assert(((size_t)(addr) & (__alignof__(*(addr)) - 1)) == 0)
+diff --git a/src/atomic_ops/sysdeps/emul_cas.h b/src/atomic_ops/sysdeps/emul_cas.h
+index e52f75a..c322a5b 100644
+--- a/src/atomic_ops/sysdeps/emul_cas.h
++++ b/src/atomic_ops/sysdeps/emul_cas.h
+@@ -47,14 +47,15 @@
+   extern "C" {
+ #endif
+ 
+-AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val,
+-                                         AO_t new_val);
++AO_API AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr,
++                                                AO_t old_val, AO_t new_val);
+ 
+-int AO_compare_double_and_swap_double_emulation(volatile AO_double_t *addr,
+-                                                AO_t old_val1, AO_t old_val2,
+-                                                AO_t new_val1, AO_t new_val2);
++AO_API int
++AO_compare_double_and_swap_double_emulation(volatile AO_double_t *addr,
++                                            AO_t old_val1, AO_t old_val2,
++                                            AO_t new_val1, AO_t new_val2);
+ 
+-void AO_store_full_emulation(volatile AO_t *addr, AO_t val);
++AO_API void AO_store_full_emulation(volatile AO_t *addr, AO_t val);
+ 
+ #ifndef AO_HAVE_fetch_compare_and_swap_full
+ # define AO_fetch_compare_and_swap_full(addr, old, newval) \
+diff --git a/src/atomic_ops/sysdeps/generic_pthread.h b/src/atomic_ops/sysdeps/generic_pthread.h
+index 854cb77..724b148 100644
+--- a/src/atomic_ops/sysdeps/generic_pthread.h
++++ b/src/atomic_ops/sysdeps/generic_pthread.h
+@@ -39,7 +39,7 @@
+ 
+ /* We define only the full barrier variants, and count on the           */
+ /* generalization section below to fill in the rest.                    */
+-extern pthread_mutex_t AO_pt_lock;
++AO_API pthread_mutex_t AO_pt_lock;
+ 
+ #ifdef __cplusplus
+   } /* extern "C" */
+diff --git a/src/atomic_ops_malloc.c b/src/atomic_ops_malloc.c
+index adced80..19f49b2 100644
+--- a/src/atomic_ops_malloc.c
++++ b/src/atomic_ops_malloc.c
+@@ -19,6 +19,10 @@
+ # undef HAVE_MMAP
+ #endif
+ 
++#ifndef AO_BUILD
++# define AO_BUILD
++#endif
++
+ #define AO_REQUIRE_CAS
+ #include "atomic_ops_malloc.h"
+ 
+@@ -116,7 +120,7 @@ static volatile AO_t initial_heap_ptr = (AO_t)AO_initial_heap;
+ 
+ static volatile AO_t mmap_enabled = 0;
+ 
+-void
++AO_API void
+ AO_malloc_enable_mmap(void)
+ {
+ # if defined(__sun)
+@@ -200,7 +204,7 @@ AO_free_large(char * p)
+ 
+ #else /*  No MMAP */
+ 
+-void
++AO_API void
+ AO_malloc_enable_mmap(void)
+ {
+ }
+@@ -319,7 +323,7 @@ static unsigned msb(size_t s)
+   return result;
+ }
+ 
+-AO_ATTR_MALLOC AO_ATTR_ALLOC_SIZE(1)
++AO_API AO_ATTR_MALLOC AO_ATTR_ALLOC_SIZE(1)
+ void *
+ AO_malloc(size_t sz)
+ {
+@@ -349,7 +353,7 @@ AO_malloc(size_t sz)
+   return result + 1;
+ }
+ 
+-void
++AO_API void
+ AO_free(void *p)
+ {
+   AO_t *base;
+diff --git a/src/atomic_ops_malloc.h b/src/atomic_ops_malloc.h
+index f9ed900..efd8880 100644
+--- a/src/atomic_ops_malloc.h
++++ b/src/atomic_ops_malloc.h
+@@ -66,13 +66,13 @@
+ # endif
+ #endif
+ 
+-void AO_free(void *);
++AO_API void AO_free(void *);
+ 
+-AO_ATTR_MALLOC AO_ATTR_ALLOC_SIZE(1)
++AO_API AO_ATTR_MALLOC AO_ATTR_ALLOC_SIZE(1)
+ void * AO_malloc(size_t);
+ 
+ /* Allow use of mmap to grow the heap.  No-op on some platforms.        */
+-void AO_malloc_enable_mmap(void);
++AO_API void AO_malloc_enable_mmap(void);
+ 
+ #ifdef __cplusplus
+   } /* extern "C" */
+diff --git a/src/atomic_ops_stack.c b/src/atomic_ops_stack.c
+index c31c7bf..a5ac859 100644
+--- a/src/atomic_ops_stack.c
++++ b/src/atomic_ops_stack.c
+@@ -19,6 +19,10 @@
+ #include <stdlib.h>
+ #include <assert.h>
+ 
++#ifndef AO_BUILD
++# define AO_BUILD
++#endif
++
+ #define AO_REQUIRE_CAS
+ #include "atomic_ops_stack.h"
+ 
+@@ -36,7 +40,7 @@
+ 
+ #ifdef AO_USE_ALMOST_LOCK_FREE
+ 
+-  void AO_pause(int); /* defined in atomic_ops.c */
++  AO_API void AO_pause(int); /* defined in atomic_ops.c */
+ 
+ /* LIFO linked lists based on compare-and-swap.  We need to avoid       */
+ /* the case of a node deletion and reinsertion while I'm deleting       */
+@@ -58,8 +62,8 @@
+ /* to be inserted.                                                      */
+ /* Both list headers and link fields contain "perturbed" pointers, i.e. */
+ /* pointers with extra bits "or"ed into the low order bits.             */
+-void AO_stack_push_explicit_aux_release(volatile AO_t *list, AO_t *x,
+-                                        AO_stack_aux *a)
++AO_API void AO_stack_push_explicit_aux_release(volatile AO_t *list, AO_t *x,
++                                               AO_stack_aux *a)
+ {
+   AO_t x_bits = (AO_t)x;
+   AO_t next;
+@@ -139,8 +143,8 @@ void AO_stack_push_explicit_aux_release(volatile AO_t *list, AO_t *x,
+ # define AO_load_next AO_load
+ #endif
+ 
+-AO_t *
+-AO_stack_pop_explicit_aux_acquire(volatile AO_t *list, AO_stack_aux * a)
++AO_API AO_t *AO_stack_pop_explicit_aux_acquire(volatile AO_t *list,
++                                               AO_stack_aux *a)
+ {
+   unsigned i;
+   int j = 0;
+@@ -254,7 +258,7 @@ AO_stack_pop_explicit_aux_acquire(volatile AO_t *list, AO_stack_aux * a)
+   volatile /* non-static */ AO_t AO_noop_sink;
+ #endif
+ 
+-void AO_stack_push_release(AO_stack_t *list, AO_t *element)
++AO_API void AO_stack_push_release(AO_stack_t *list, AO_t *element)
+ {
+     AO_t next;
+ 
+@@ -273,7 +277,7 @@ void AO_stack_push_release(AO_stack_t *list, AO_t *element)
+ #   endif
+ }
+ 
+-AO_t *AO_stack_pop_acquire(AO_stack_t *list)
++AO_API AO_t *AO_stack_pop_acquire(AO_stack_t *list)
+ {
+ #   if defined(__clang__) && !AO_CLANG_PREREQ(3, 5)
+       AO_t *volatile cptr;
+@@ -307,7 +311,7 @@ AO_t *AO_stack_pop_acquire(AO_stack_t *list)
+ /* We have a wide CAS, but only does an AO_t-wide comparison.   */
+ /* We can't use the Treiber optimization, since we only check   */
+ /* for an unchanged version number, not an unchanged pointer.   */
+-void AO_stack_push_release(AO_stack_t *list, AO_t *element)
++AO_API void AO_stack_push_release(AO_stack_t *list, AO_t *element)
+ {
+     AO_t version;
+ 
+@@ -323,7 +327,7 @@ void AO_stack_push_release(AO_stack_t *list, AO_t *element)
+                            version+1, (AO_t) element));
+ }
+ 
+-AO_t *AO_stack_pop_acquire(AO_stack_t *list)
++AO_API AO_t *AO_stack_pop_acquire(AO_stack_t *list)
+ {
+     AO_t *cptr;
+     AO_t next;
+diff --git a/src/atomic_ops_stack.h b/src/atomic_ops_stack.h
+index e03c186..4053071 100644
+--- a/src/atomic_ops_stack.h
++++ b/src/atomic_ops_stack.h
+@@ -141,11 +141,11 @@ typedef struct AO__stack_aux {
+ /* The following two routines should not normally be used directly.     */
+ /* We make them visible here for the rare cases in which it makes sense */
+ /* to share the AO_stack_aux between stacks.                            */
+-void
++AO_API void
+ AO_stack_push_explicit_aux_release(volatile AO_t *list, AO_t *x,
+                                   AO_stack_aux *);
+ 
+-AO_t *
++AO_API AO_t *
+ AO_stack_pop_explicit_aux_acquire(volatile AO_t *list, AO_stack_aux *);
+ 
+ /* And now AO_stack_t for the real interface:                           */
+@@ -213,9 +213,9 @@ AO_INLINE void AO_stack_init(AO_stack_t *list)
+ #define AO_REAL_HEAD_PTR(x) (AO_t *)((x).AO_val2)
+ #define AO_REAL_NEXT_PTR(x) (AO_t *)(x)
+ 
+-void AO_stack_push_release(AO_stack_t *list, AO_t *new_element);
++AO_API void AO_stack_push_release(AO_stack_t *list, AO_t *new_element);
+ #define AO_HAVE_stack_push_release
+-AO_t * AO_stack_pop_acquire(AO_stack_t *list);
++AO_API AO_t *AO_stack_pop_acquire(AO_stack_t *list);
+ #define AO_HAVE_stack_pop_acquire
+ 
+ #endif /* Wide CAS case */
+diff --git a/tests/test_atomic.c b/tests/test_atomic.c
+index a301ced..a905308 100644
+--- a/tests/test_atomic.c
++++ b/tests/test_atomic.c
+@@ -192,11 +192,12 @@ int test_and_set_test(void)
+     extern "C" {
+ # endif
+ 
+-  void AO_store_full_emulation(volatile AO_t *addr, AO_t val);
+-  AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr, AO_t old_val,
+-                                           AO_t new_val);
++  AO_API void AO_store_full_emulation(volatile AO_t *addr, AO_t val);
++  AO_API AO_t AO_fetch_compare_and_swap_emulation(volatile AO_t *addr,
++                                                  AO_t old_val, AO_t new_val);
+ # ifdef AO_HAVE_double_t
+-    int AO_compare_double_and_swap_double_emulation(volatile AO_double_t *,
++    AO_API int
++    AO_compare_double_and_swap_double_emulation(volatile AO_double_t *,
+                                                 AO_t old_val1, AO_t old_val2,
+                                                 AO_t new_val1, AO_t new_val2);
+ # endif

--- a/recipes/libatomic_ops/all/patches/update-cmake-7_6_14.patch
+++ b/recipes/libatomic_ops/all/patches/update-cmake-7_6_14.patch
@@ -1,0 +1,333 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..7ac770b
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,316 @@
++#
++# Copyright (c) 2021-2022 Ivan Maidanski
++##
++# Permission is hereby granted, free of charge, to any person obtaining a copy
++# of this software and associated documentation files (the "Software"), to deal
++# in the Software without restriction, including without limitation the rights
++# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++# copies of the Software, and to permit persons to whom the Software is
++# furnished to do so, subject to the following conditions:
++#
++# The above copyright notice and this permission notice shall be included in
++# all copies or substantial portions of the Software.
++#
++# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++# SOFTWARE.
++##
++
++cmake_minimum_required(VERSION 3.1)
++
++set(PACKAGE_VERSION 7.6.14)
++# Version must match that in AC_INIT of configure.ac and that in README.
++# Version must conform to: [0-9]+[.][0-9]+[.][0-9]+
++
++# Info (current:revision:age) for the Libtool versioning system.
++# These values should match those in src/Makefile.am.
++set(LIBATOMIC_OPS_VER_INFO      2:1:1)
++set(LIBATOMIC_OPS_GPL_VER_INFO  2:3:1)
++
++project(libatomic_ops C)
++
++include(CheckCCompilerFlag)
++include(CheckFunctionExists)
++include(CMakePackageConfigHelpers)
++include(CTest)
++include(GNUInstallDirs)
++
++# Customize the build by passing "-D<option_name>=ON|OFF" in the command line.
++option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
++option(build_tests "Build tests" OFF)
++option(enable_assertions "Enable assertion checking" OFF)
++option(enable_werror "Treat warnings as errors" OFF)
++option(enable_atomic_intrinsics "Use GCC atomic intrinsics" ON)
++option(enable_docs "Build and install documentation" ON)
++option(install_headers "Install header and pkg-config metadata files" ON)
++
++# Override the default build type to RelWithDebInfo (this instructs cmake to
++# pass -O2 -g -DNDEBUG options to the compiler).
++if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
++  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE
++      STRING "Choose the type of build." FORCE)
++  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
++               STRINGS "Debug" "Release" "RelWithDebInfo" "MinSizeRel")
++endif()
++
++# Convert VER_INFO values to [SO]VERSION ones.
++if (BUILD_SHARED_LIBS)
++  # atomic_ops:
++  string(REGEX REPLACE "(.+):.+:.+"  "\\1" ao_cur ${LIBATOMIC_OPS_VER_INFO})
++  string(REGEX REPLACE ".+:(.+):.+"  "\\1" ao_rev ${LIBATOMIC_OPS_VER_INFO})
++  string(REGEX REPLACE ".+:.+:(.+)$" "\\1" ao_age ${LIBATOMIC_OPS_VER_INFO})
++  math(EXPR AO_SOVERSION "${ao_cur} - ${ao_age}")
++  set(AO_VERSION_PROP "${AO_SOVERSION}.${ao_age}.${ao_rev}")
++  message(STATUS "AO_VERSION_PROP = ${AO_VERSION_PROP}")
++  # atomic_ops_gpl:
++  string(REGEX REPLACE "(.+):.+:.+"  "\\1" ao_gpl_cur
++         ${LIBATOMIC_OPS_GPL_VER_INFO})
++  string(REGEX REPLACE ".+:(.+):.+"  "\\1" ao_gpl_rev
++         ${LIBATOMIC_OPS_GPL_VER_INFO})
++  string(REGEX REPLACE ".+:.+:(.+)$" "\\1" ao_gpl_age
++         ${LIBATOMIC_OPS_GPL_VER_INFO})
++  math(EXPR AO_GPL_SOVERSION "${ao_gpl_cur} - ${ao_gpl_age}")
++  set(AO_GPL_VERSION_PROP "${AO_GPL_SOVERSION}.${ao_gpl_age}.${ao_gpl_rev}")
++  message(STATUS "AO_GPL_VERSION_PROP = ${AO_GPL_VERSION_PROP}")
++endif(BUILD_SHARED_LIBS)
++
++# Output all warnings.
++if (MSVC)
++  # All warnings but ignoring "conditional expression is constant" ones.
++  add_compile_options(/W4 /wd4127)
++else()
++  add_compile_options(-Wall -Wextra)
++endif()
++
++find_package(Threads REQUIRED)
++message(STATUS "Thread library: ${CMAKE_THREAD_LIBS_INIT}")
++include_directories(${Threads_INCLUDE_DIR})
++set(THREADDLLIBS_LIST ${CMAKE_THREAD_LIBS_INIT})
++
++if (CMAKE_USE_PTHREADS_INIT)
++  # Required define if using POSIX threads.
++  add_compile_options(-D_REENTRANT)
++else()
++  # No pthreads library available.
++  add_compile_options(-DAO_NO_PTHREADS)
++endif()
++
++if (enable_assertions)
++  # In case NDEBUG macro is defined e.g. by cmake -DCMAKE_BUILD_TYPE=Release.
++  add_compile_options(-UNDEBUG)
++else()
++  # Define to disable assertion checking.
++  add_compile_options(-DNDEBUG)
++endif()
++
++if (NOT enable_atomic_intrinsics)
++  # Define to avoid GCC atomic intrinsics even if available.
++  add_compile_options(-DAO_DISABLE_GCC_ATOMICS)
++endif()
++
++if (enable_werror)
++  if (MSVC)
++    add_compile_options(/WX)
++  else()
++    add_compile_options(-Werror)
++  endif()
++endif(enable_werror)
++
++# Extra user-defined flags to pass to the C compiler.
++if (DEFINED CFLAGS_EXTRA)
++  separate_arguments(CFLAGS_EXTRA_LIST UNIX_COMMAND "${CFLAGS_EXTRA}")
++  add_compile_options(${CFLAGS_EXTRA_LIST})
++endif()
++
++set(SRC src/atomic_ops.c)
++
++if (CMAKE_C_COMPILER_ID STREQUAL "SunPro")
++  # SunCC compiler on SunOS (Solaris).
++  set(SRC ${SRC} src/atomic_ops_sysdeps.S)
++endif()
++
++add_library(atomic_ops ${SRC})
++target_link_libraries(atomic_ops PRIVATE ${THREADDLLIBS_LIST})
++target_include_directories(atomic_ops
++                PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
++                INTERFACE "$<INSTALL_INTERFACE:include>")
++
++set(AO_GPL_SRC src/atomic_ops_malloc.c src/atomic_ops_stack.c)
++add_library(atomic_ops_gpl ${AO_GPL_SRC})
++check_function_exists(mmap HAVE_MMAP)
++if (HAVE_MMAP)
++  target_compile_definitions(atomic_ops_gpl PRIVATE HAVE_MMAP)
++endif()
++target_link_libraries(atomic_ops_gpl PRIVATE atomic_ops)
++target_include_directories(atomic_ops_gpl
++                PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
++                INTERFACE "$<INSTALL_INTERFACE:include>")
++if (BUILD_SHARED_LIBS)
++  set_property(TARGET atomic_ops_gpl PROPERTY VERSION ${AO_GPL_VERSION_PROP})
++  set_property(TARGET atomic_ops_gpl PROPERTY SOVERSION ${AO_GPL_SOVERSION})
++endif()
++install(TARGETS atomic_ops_gpl EXPORT Atomic_opsTargets
++        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++
++if (BUILD_SHARED_LIBS)
++  check_c_compiler_flag(-Wl,--no-undefined HAVE_FLAG_WL_NO_UNDEFINED)
++  if (HAVE_FLAG_WL_NO_UNDEFINED)
++    # Declare that the libraries do not refer to external symbols.
++    target_link_libraries(atomic_ops PRIVATE -Wl,--no-undefined)
++    target_link_libraries(atomic_ops_gpl PRIVATE -Wl,--no-undefined)
++  endif()
++  set_property(TARGET atomic_ops PROPERTY VERSION ${AO_VERSION_PROP})
++  set_property(TARGET atomic_ops PROPERTY SOVERSION ${AO_SOVERSION})
++endif(BUILD_SHARED_LIBS)
++
++install(TARGETS atomic_ops EXPORT Atomic_opsTargets
++        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++
++if (install_headers)
++  install(FILES src/atomic_ops.h
++          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++  install(FILES src/atomic_ops_malloc.h
++                src/atomic_ops_stack.h
++          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++
++  install(FILES src/atomic_ops/ao_version.h
++                src/atomic_ops/generalize-arithm.h
++                src/atomic_ops/generalize-small.h
++                src/atomic_ops/generalize.h
++          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atomic_ops")
++
++  install(FILES src/atomic_ops/sysdeps/all_acquire_release_volatile.h
++                src/atomic_ops/sysdeps/all_aligned_atomic_load_store.h
++                src/atomic_ops/sysdeps/all_atomic_load_store.h
++                src/atomic_ops/sysdeps/all_atomic_only_load.h
++                src/atomic_ops/sysdeps/ao_t_is_int.h
++                src/atomic_ops/sysdeps/emul_cas.h
++                src/atomic_ops/sysdeps/generic_pthread.h
++                src/atomic_ops/sysdeps/ordered.h
++                src/atomic_ops/sysdeps/ordered_except_wr.h
++                src/atomic_ops/sysdeps/read_ordered.h
++                src/atomic_ops/sysdeps/standard_ao_double_t.h
++                src/atomic_ops/sysdeps/test_and_set_t_is_ao_t.h
++                src/atomic_ops/sysdeps/test_and_set_t_is_char.h
++          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atomic_ops/sysdeps")
++
++  install(FILES src/atomic_ops/sysdeps/armcc/arm_v6.h
++          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atomic_ops/sysdeps/armcc")
++  install(FILES src/atomic_ops/sysdeps/gcc/aarch64.h
++                src/atomic_ops/sysdeps/gcc/alpha.h
++                src/atomic_ops/sysdeps/gcc/arm.h
++                src/atomic_ops/sysdeps/gcc/avr32.h
++                src/atomic_ops/sysdeps/gcc/cris.h
++                src/atomic_ops/sysdeps/gcc/generic-arithm.h
++                src/atomic_ops/sysdeps/gcc/generic-small.h
++                src/atomic_ops/sysdeps/gcc/generic.h
++                src/atomic_ops/sysdeps/gcc/hexagon.h
++                src/atomic_ops/sysdeps/gcc/hppa.h
++                src/atomic_ops/sysdeps/gcc/ia64.h
++                src/atomic_ops/sysdeps/gcc/m68k.h
++                src/atomic_ops/sysdeps/gcc/mips.h
++                src/atomic_ops/sysdeps/gcc/powerpc.h
++                src/atomic_ops/sysdeps/gcc/riscv.h
++                src/atomic_ops/sysdeps/gcc/s390.h
++                src/atomic_ops/sysdeps/gcc/sh.h
++                src/atomic_ops/sysdeps/gcc/sparc.h
++                src/atomic_ops/sysdeps/gcc/tile.h
++                src/atomic_ops/sysdeps/gcc/x86.h
++          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atomic_ops/sysdeps/gcc")
++
++  install(FILES src/atomic_ops/sysdeps/hpc/hppa.h
++                src/atomic_ops/sysdeps/hpc/ia64.h
++          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atomic_ops/sysdeps/hpc")
++  install(FILES src/atomic_ops/sysdeps/ibmc/powerpc.h
++          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atomic_ops/sysdeps/ibmc")
++  install(FILES src/atomic_ops/sysdeps/icc/ia64.h
++          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atomic_ops/sysdeps/icc")
++
++  install(FILES src/atomic_ops/sysdeps/loadstore/acquire_release_volatile.h
++            src/atomic_ops/sysdeps/loadstore/atomic_load.h
++            src/atomic_ops/sysdeps/loadstore/atomic_store.h
++            src/atomic_ops/sysdeps/loadstore/char_acquire_release_volatile.h
++            src/atomic_ops/sysdeps/loadstore/char_atomic_load.h
++            src/atomic_ops/sysdeps/loadstore/char_atomic_store.h
++            src/atomic_ops/sysdeps/loadstore/double_atomic_load_store.h
++            src/atomic_ops/sysdeps/loadstore/int_acquire_release_volatile.h
++            src/atomic_ops/sysdeps/loadstore/int_atomic_load.h
++            src/atomic_ops/sysdeps/loadstore/int_atomic_store.h
++            src/atomic_ops/sysdeps/loadstore/ordered_loads_only.h
++            src/atomic_ops/sysdeps/loadstore/ordered_stores_only.h
++            src/atomic_ops/sysdeps/loadstore/short_acquire_release_volatile.h
++            src/atomic_ops/sysdeps/loadstore/short_atomic_load.h
++            src/atomic_ops/sysdeps/loadstore/short_atomic_store.h
++        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atomic_ops/sysdeps/loadstore")
++
++  install(FILES src/atomic_ops/sysdeps/msftc/arm.h
++                src/atomic_ops/sysdeps/msftc/common32_defs.h
++                src/atomic_ops/sysdeps/msftc/x86.h
++                src/atomic_ops/sysdeps/msftc/x86_64.h
++          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atomic_ops/sysdeps/msftc")
++  install(FILES src/atomic_ops/sysdeps/sunc/sparc.h
++                src/atomic_ops/sysdeps/sunc/x86.h
++          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atomic_ops/sysdeps/sunc")
++
++  # Provide pkg-config metadata.
++  set(prefix "${CMAKE_INSTALL_PREFIX}")
++  set(exec_prefix \${prefix})
++  set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
++  set(libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
++  string(REPLACE ";" " " THREADDLLIBS "${THREADDLLIBS_LIST}")
++  # PACKAGE_VERSION is defined above.
++  configure_file(pkgconfig/atomic_ops.pc.in pkgconfig/atomic_ops.pc @ONLY)
++  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/atomic_ops.pc"
++          DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
++endif(install_headers)
++
++if (build_tests)
++  add_executable(test_stack tests/test_stack.c)
++  target_link_libraries(test_stack
++                PRIVATE atomic_ops atomic_ops_gpl ${THREADDLLIBS_LIST})
++  add_test(NAME test_stack COMMAND test_stack)
++
++  add_executable(test_malloc tests/test_malloc.c)
++  target_link_libraries(test_malloc
++                PRIVATE atomic_ops atomic_ops_gpl ${THREADDLLIBS_LIST})
++  add_test(NAME test_malloc COMMAND test_malloc)
++endif(build_tests)
++
++if (enable_docs)
++  install(FILES AUTHORS doc/LICENSING.txt README.md
++                doc/README_details.txt doc/README_win32.txt
++          DESTINATION "${CMAKE_INSTALL_DOCDIR}")
++  install(FILES COPYING doc/README_malloc.txt doc/README_stack.txt
++          DESTINATION "${CMAKE_INSTALL_DOCDIR}")
++endif(enable_docs)
++
++# CMake config/targets files.
++install(EXPORT Atomic_opsTargets FILE Atomic_opsTargets.cmake
++        NAMESPACE Atomic_ops::
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/atomic_ops")
++
++configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in"
++        "${CMAKE_CURRENT_BINARY_DIR}/Atomic_opsConfig.cmake"
++        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/atomic_ops"
++        NO_SET_AND_CHECK_MACRO)
++
++write_basic_package_version_file(
++        "${CMAKE_CURRENT_BINARY_DIR}/Atomic_opsConfigVersion.cmake"
++        VERSION "${PACKAGE_VERSION}" COMPATIBILITY AnyNewerVersion)
++
++install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Atomic_opsConfig.cmake"
++              "${CMAKE_CURRENT_BINARY_DIR}/Atomic_opsConfigVersion.cmake"
++        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/atomic_ops")
++
++export(EXPORT Atomic_opsTargets
++       FILE "${CMAKE_CURRENT_BINARY_DIR}/Atomic_opsTargets.cmake")
+diff --git a/Config.cmake.in b/Config.cmake.in
+new file mode 100644
+index 0000000..034b456
+--- /dev/null
++++ b/Config.cmake.in
+@@ -0,0 +1,5 @@
++# The Atomic_ops CMake configuration file.
++
++@PACKAGE_INIT@
++include("${CMAKE_CURRENT_LIST_DIR}/Atomic_opsTargets.cmake")
++check_required_components(libatomic_ops)

--- a/recipes/libatomic_ops/all/patches/update-cmake-7_6_14.patch
+++ b/recipes/libatomic_ops/all/patches/update-cmake-7_6_14.patch
@@ -1,9 +1,9 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 new file mode 100644
-index 0000000..7ac770b
+index 0000000..bc20331
 --- /dev/null
 +++ b/CMakeLists.txt
-@@ -0,0 +1,316 @@
+@@ -0,0 +1,336 @@
 +#
 +# Copyright (c) 2021-2022 Ivan Maidanski
 +##
@@ -39,11 +39,20 @@ index 0000000..7ac770b
 +
 +project(libatomic_ops C)
 +
++if (POLICY CMP0057)
++  # Required for CheckLinkerFlag, at least.
++  cmake_policy(SET CMP0057 NEW)
++endif()
++
 +include(CheckCCompilerFlag)
 +include(CheckFunctionExists)
 +include(CMakePackageConfigHelpers)
 +include(CTest)
 +include(GNUInstallDirs)
++
++if (NOT (${CMAKE_VERSION} VERSION_LESS "3.18.0"))
++  include(CheckLinkerFlag)
++endif()
 +
 +# Customize the build by passing "-D<option_name>=ON|OFF" in the command line.
 +option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
@@ -166,12 +175,23 @@ index 0000000..7ac770b
 +        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 +
 +if (BUILD_SHARED_LIBS)
-+  check_c_compiler_flag(-Wl,--no-undefined HAVE_FLAG_WL_NO_UNDEFINED)
++  if (${CMAKE_VERSION} VERSION_LESS "3.18.0")
++    set(WL_NO_UNDEFINED_OPT "-Wl,--no-undefined")
++    check_c_compiler_flag(${WL_NO_UNDEFINED_OPT} HAVE_FLAG_WL_NO_UNDEFINED)
++  else()
++    set(WL_NO_UNDEFINED_OPT "LINKER:--no-undefined")
++    check_linker_flag(C "${WL_NO_UNDEFINED_OPT}" HAVE_FLAG_WL_NO_UNDEFINED)
++  endif()
 +  if (HAVE_FLAG_WL_NO_UNDEFINED)
 +    # Declare that the libraries do not refer to external symbols.
-+    target_link_libraries(atomic_ops PRIVATE -Wl,--no-undefined)
-+    target_link_libraries(atomic_ops_gpl PRIVATE -Wl,--no-undefined)
-+  endif()
++    if (${CMAKE_VERSION} VERSION_LESS "3.13.0")
++      target_link_libraries(atomic_ops PRIVATE ${WL_NO_UNDEFINED_OPT})
++      target_link_libraries(atomic_ops_gpl PRIVATE ${WL_NO_UNDEFINED_OPT})
++    else()
++      target_link_options(atomic_ops PRIVATE ${WL_NO_UNDEFINED_OPT})
++      target_link_options(atomic_ops_gpl PRIVATE ${WL_NO_UNDEFINED_OPT})
++    endif()
++  endif(HAVE_FLAG_WL_NO_UNDEFINED)
 +  set_property(TARGET atomic_ops PROPERTY VERSION ${AO_VERSION_PROP})
 +  set_property(TARGET atomic_ops PROPERTY SOVERSION ${AO_SOVERSION})
 +endif(BUILD_SHARED_LIBS)

--- a/recipes/libatomic_ops/all/test_package/CMakeLists.txt
+++ b/recipes/libatomic_ops/all/test_package/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(Atomic_ops CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE Atomic_ops::atomic_ops)

--- a/recipes/libatomic_ops/all/test_package/conanfile.py
+++ b/recipes/libatomic_ops/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
 import os
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.build import can_run
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,5 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin","test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/libatomic_ops/config.yml
+++ b/recipes/libatomic_ops/config.yml
@@ -1,7 +1,3 @@
 versions:
-  "7.6.10":
-    folder: all
-  "7.6.12":
-    folder: all
   "7.6.14":
     folder: all


### PR DESCRIPTION
This is to match cmake package/target naming of upstream.

Also, prepare for Conan 2.0.

Specify library name and version:  **libatomic_ops/7.6.14**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
