### PR TITLE
opentdf-client: add version 1.1.6

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.6":
+    url: "https://github.com/opentdf/client-cpp/archive/1.1.6.tar.gz"
+    sha256: "83992c37c9a58ae2152660a4ffbf1784fe63d7a9e7b8466d10ca1074697b3d3a"
   "1.1.5":
     url: "https://github.com/opentdf/client-cpp/archive/1.1.5.tar.gz"
     sha256: "8fd5b22b36b19cd58a18f63cbffe3d538263ef3aecde4802059951c4eb5ce044"

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.6":
+    folder: all
   "1.1.5":
     folder: all
   "1.1.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **opentdf-client/1.1.6**

Added benchmarking functions

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
