### PR TITLE
Added patch that disables Boost deprecated code which fixes compilation on Clang-15

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -276,3 +276,8 @@ patches:
       patch_type: "official"
       patch_source: "https://github.com/boostorg/filesystem/issues/250"
       base_path: "source_subfolder"
+    - patch_file: "patches/1.80.0-0005-disable-deprecated-code.patch"
+      patch_description: "Disables deprecated code in Boost which does not compile on Clang-15"
+      patch_type: "official"
+      patch_source: "https://github.com/boostorg/container_hash/issues/24"
+      base_path: "source_subfolder"

--- a/recipes/boost/all/patches/1.80.0-0005-disable-deprecated-code.patch
+++ b/recipes/boost/all/patches/1.80.0-0005-disable-deprecated-code.patch
@@ -1,0 +1,18 @@
+diff --git a/boost/config/stdlib/libcpp.hpp b/boost/config/stdlib/libcpp.hpp
+index bc8536ead..0e9f2445e 100644
+--- a/boost/config/stdlib/libcpp.hpp
++++ b/boost/config/stdlib/libcpp.hpp
+@@ -168,4 +168,13 @@
+ #  define BOOST_NO_CXX14_HDR_SHARED_MUTEX
+ #endif
+ 
++#if _LIBCPP_VERSION >= 15000
++//
++// Unary function is now deprecated in C++11 and later:
++//
++#if __cplusplus >= 201103L
++#define BOOST_NO_CXX98_FUNCTION_BASE
++#endif
++#endif
++
+ //  --- end ---


### PR DESCRIPTION
Specify library name and version:  Boost/1.80.0

This patch disables Boost deprecated code (e.g. unary function). This is needed to be able to compile Boost on Clang-15

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
