### PR TITLE
cpp-peglib: add version 1.8.2

### DIFF
--- a/recipes/cpp-peglib/1.x.x/conandata.yml
+++ b/recipes/cpp-peglib/1.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.2":
+    url: "https://github.com/yhirose/cpp-peglib/archive/v1.8.2.tar.gz"
+    sha256: "eca5d06dafb940ffee8a99060a57272ada7f2486fc21ed1663e4e49851a70e0c"
   "1.8.1":
     url: "https://github.com/yhirose/cpp-peglib/archive/v1.8.1.tar.gz"
     sha256: "15d7c39d01780bb6f27db511722936d82d04cb1f5a6c63025021ff5dfe5fe1b2"

--- a/recipes/cpp-peglib/config.yml
+++ b/recipes/cpp-peglib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.2":
+    folder: "1.x.x"
   "1.8.1":
     folder: "1.x.x"
   "1.8.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cpp-peglib/1.8.2**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
