### PR TITLE
[docs] Templates documentation: Fix link for test package

### DIFF
--- a/docs/how_to_add_packages.md
+++ b/docs/how_to_add_packages.md
@@ -154,8 +154,7 @@ Also, **every `conanfile.py` should be accompanied by one or several folder to t
 All the packages in this repository need to be tested before they join ConanCenter. A `test_package` folder with its corresponding `conanfile.py` and
 a minimal project to test the package is strictly required. You can read about it in the
 
-# FIXME: This link no longet exist and there is no dedicated section about test package in docs.
-[Conan documentation](https://docs.conan.io/en/latest/creating_packages/getting_started.html#the-test-package-folder).
+[Conan documentation](https://docs.conan.io/en/latest/creating_packages/getting_started.html).
 
 Sometimes it is useful to test the package using different build systems (CMake, Autotools,...). Instead of adding complex logic to one
 `test_package/conanfile.py` file, it is better to add another `test_<something>/conanfile.py` file with a minimal example for that build system. That


### PR DESCRIPTION
Fix for https://github.com/conan-io/conan-center-index/pull/12931

Asked for better documentation here: https://github.com/conan-io/docs/issues/2750

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
