### PR TITLE
unordered_dense: add version 1.3.2

### DIFF
--- a/recipes/unordered_dense/all/conandata.yml
+++ b/recipes/unordered_dense/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.2":
+    url: "https://github.com/martinus/unordered_dense/archive/v1.3.2.tar.gz"
+    sha256: "f12db3b93f31f7f20f4d8cac6adc551f6ae17a5b9a16040abeee427f54427953"
   "1.3.1":
     url: "https://github.com/martinus/unordered_dense/archive/refs/tags/v1.3.1.tar.gz"
     sha256: "d393168833d6609c9eaf54a05b19fc3120f68b85feffb282ab225119a86df1d4"

--- a/recipes/unordered_dense/config.yml
+++ b/recipes/unordered_dense/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.3.2":
+    folder: all
   "1.3.1":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **unordered_dense/1.3.2**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
