### PR TITLE
github_config: add an action to validate markdown links

### DIFF
--- a/.github/workflows/marldown-links.yml
+++ b/.github/workflows/marldown-links.yml
@@ -1,0 +1,25 @@
+name: Check Markdown links
+
+on: [push,  pull_request]
+
+jobs:
+  markdown-link-check-push:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: .github/workflows/mlc_config.json
+
+  markdown-link-check-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: .github/workflows/mlc_config.json
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        check-modified-files-only: 'yes'

--- a/.github/workflows/marldown-links.yml
+++ b/.github/workflows/marldown-links.yml
@@ -4,7 +4,7 @@ on: [push,  pull_request]
 
 jobs:
   markdown-link-check-push:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository_owner != 'conan-io' # We do not want to see red in CCI
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,10 +1,10 @@
 {
-    "ignorePatterns": [
-      {
-        "pattern": "^https://github.com/"
-      },
-      {
-        "pattern": "^https://docs.github.com/"
+  "httpHeaders": [
+    {
+      "urls": ["https://github.com/", "https://guides.github.com/", "https://help.github.com/", "https://docs.github.com/"],
+      "headers": {
+        "Accept-Encoding": "zstd, br, gzip, deflate"
       }
-    ]
+    }
+  ]
 }

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,10 @@
+{
+    "ignorePatterns": [
+      {
+        "pattern": "^https://github.com/"
+      },
+      {
+        "pattern": "^https://docs.github.com/"
+      }
+    ]
+}

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,4 +1,7 @@
 {
+  "retryOn429": true,
+  "retryCount": 5,
+  "fallbackRetryDelay": "30s",
   "httpHeaders": [
     {
       "urls": ["https://github.com/", "https://guides.github.com/", "https://help.github.com/", "https://docs.github.com/"],


### PR DESCRIPTION
There are a handful of broken links in the docs. It would be nice to catch them in PRs and double check master.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
