### PR TITLE
add ade/0.1.2a version to exisiting reciepe

### DIFF
--- a/recipes/ade/all/conandata.yml
+++ b/recipes/ade/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.2a":
+    url: "https://github.com/opencv/ade/archive/refs/tags/v0.1.2a.tar.gz"
+    sha256: "c022a688b0554017e46e1cbdeb0105e625ca090fc3755c15df8c4451a304e084"
   "0.1.1f":
     url: "https://github.com/opencv/ade/archive/refs/tags/v0.1.1f.tar.gz"
     sha256: "c316680efbb5dd3ac4e10bb8cea345cf26a6a25ebc22418f8f0b8ca931a550e9"

--- a/recipes/ade/config.yml
+++ b/recipes/ade/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.1.2a":
+    folder: "all"
   "0.1.1f":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **ade/0.1.2a**

only small version bump to existing reciepe

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
