### PR TITLE
argparse: add version 2.9

### DIFF
--- a/recipes/argparse/all/conandata.yml
+++ b/recipes/argparse/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.9":
+    url: "https://github.com/p-ranav/argparse/archive/v2.9.tar.gz"
+    sha256: "cd563293580b9dc592254df35b49cf8a19b4870ff5f611c7584cf967d9e6031e"
   "2.6":
     url: "https://github.com/p-ranav/argparse/archive/v2.6.tar.gz"
     sha256: "da261c3b3010c10a163f4535bbe2b160319d2a6b1e0fd2eb5a7b9f6a85c29021"

--- a/recipes/argparse/config.yml
+++ b/recipes/argparse/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.9":
+    folder: all
   "2.6":
     folder: all
   "2.5":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **argparse/2.9**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
