### PR TITLE
concurrencpp: Update to 0.1.5

### DIFF
--- a/recipes/concurrencpp/all/conandata.yml
+++ b/recipes/concurrencpp/all/conandata.yml
@@ -1,8 +1,14 @@
 sources:
+  "0.1.5":
+    url: "https://github.com/David-Haim/concurrencpp/archive/refs/tags/v.0.1.5.tar.gz"
+    sha256: "330150ebe11b3d30ffcb3efdecc184a34cf50a6bd43b68e294a496225d286651"
   "0.1.4":
     url: "https://github.com/David-Haim/concurrencpp/archive/refs/tags/v.0.1.4.tar.gz"
     sha256: "3ad9424f975b766accc6eaedf4acfe1a20b5fdbb57fa3ae71f400e13d471e86f"
 patches:
+  "0.1.5":
+    - patch_file: "patches/cmake-min-version.patch"
+    - patch_file: "patches/directory-name-0.1.5.patch"
   "0.1.4":
     - patch_file: "patches/cmake-min-version.patch"
     - patch_file: "patches/directory-name.patch"

--- a/recipes/concurrencpp/all/conanfile.py
+++ b/recipes/concurrencpp/all/conanfile.py
@@ -55,6 +55,9 @@ class ConcurrencppConan(ConanFile):
             raise ConanInvalidConfiguration("concurrencpp does not support shared builds with Visual Studio")
         if self.info.settings.compiler == "gcc":
             raise ConanInvalidConfiguration("gcc is not supported by concurrencpp")
+        if Version(self.version) >= "0.1.5" and self.info.settings.compiler == "apple-clang":
+            # apple-clang does not seem to support the C++20 synchronization library which concurrencpp 0.1.5 depends on
+            raise ConanInvalidConfiguration("apple-clang is not supported by concurrencpp 0.1.5 and higher")
 
         minimum_version = self._minimum_compilers_version.get(
             str(self.info.settings.compiler), False

--- a/recipes/concurrencpp/all/patches/directory-name-0.1.5.patch
+++ b/recipes/concurrencpp/all/patches/directory-name-0.1.5.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -104,8 +104,8 @@ include(CMakePackageConfigHelpers)
+ include(CMakePackageConfigHelpers)
+ include(GNUInstallDirs)
+ 
+-set(concurrencpp_directory "concurrencpp-${PROJECT_VERSION}")
+-set(concurrencpp_include_directory "${CMAKE_INSTALL_INCLUDEDIR}/${concurrencpp_directory}")
++set(concurrencpp_directory "concurrencpp")
++set(concurrencpp_include_directory "${CMAKE_INSTALL_INCLUDEDIR}")
+ 
+ install(TARGETS concurrencpp
+         EXPORT concurrencppTargets

--- a/recipes/concurrencpp/config.yml
+++ b/recipes/concurrencpp/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.1.5":
+    folder: all
   "0.1.4":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **concurrencpp/0.1.5**

This updates the recipe for the latest version of the library.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
