### PR TITLE
itlib: add version 1.6.3

### DIFF
--- a/recipes/itlib/all/conandata.yml
+++ b/recipes/itlib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.3":
+    url: "https://github.com/iboB/itlib/archive/v1.6.3.tar.gz"
+    sha256: "d2e320d9218269c421407d6df819ca0bfae3ea5bc897b341b9babaedc0b7103f"
   "1.6.1":
     url: "https://github.com/iboB/itlib/archive/v1.6.1.tar.gz"
     sha256: "bff70b95ca223b4fbca206d8e1c5f6c75fd5ac86d76c8f8f14f45c748d25866a"

--- a/recipes/itlib/config.yml
+++ b/recipes/itlib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.3":
+    folder: all
   "1.6.1":
     folder: all
   "1.5.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **itlib/1.6.3**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
