### PR TITLE
greg7mdp-gtl: add version 1.1.4

### DIFF
--- a/recipes/greg7mdp-gtl/all/conandata.yml
+++ b/recipes/greg7mdp-gtl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.4":
+    url: "https://github.com/greg7mdp/gtl/archive/v1.1.4.tar.gz"
+    sha256: "b51b9951d11fb73ed22360a96a3f6c691c15202c3b14c79dcdd498da80b6502d"
   "1.1.3":
     url: "https://github.com/greg7mdp/gtl/archive/refs/tags/v1.1.3.tar.gz"
     sha256: "c667690eeecf37f660d8a61bca1076e845154bc535c44ec0d2404c04c66ae228"

--- a/recipes/greg7mdp-gtl/config.yml
+++ b/recipes/greg7mdp-gtl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.4":
+    folder: all
   "1.1.3":
     folder: all
   "1.1.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **greg7mdp-gtl/1.1.4**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
