### PR TITLE
[gtest] Requires Conan 1.51.1 or higher

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.files import copy, get, replace_in_file, rm, rmdir
 from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.51.1"
 
 
 class GTestConan(ConanFile):


### PR DESCRIPTION
The `self.info.settings.get_safe` requires Conan 1.51.1: https://github.com/qpdf/qpdf#crypto-providers

Trying to build GTest with 1.50.0, you will get:

```
ERROR: gtest/1.12.1: Error in validate() method, line 80
	if self.info.settings.get_safe("compiler.cppstd"):
	TypeError: 'NoneType' object is not callable
```

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
