### PR TITLE
wasmtime: add version 1.0.1 and support conan V2

### DIFF
--- a/recipes/wasmtime/all/conandata.yml
+++ b/recipes/wasmtime/all/conandata.yml
@@ -1,4 +1,31 @@
 sources:
+  "1.0.0":
+    Windows:
+      "x86_64":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-x86_64-windows-c-api.zip"
+        sha256: "d6e2fef27ed755fca9605a9a1a2cedad8a0caa1031a09cc9e5e3a663b3410b08"
+    MinGW:
+      "x86_64":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-x86_64-mingw-c-api.zip"
+        sha256: "a99bd9289dcfe64fd6d87284ed5c53bad8e7d0917c74d4e5cad4cdf4d109c321"
+    Linux:
+      "x86_64":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-x86_64-linux-c-api.tar.xz"
+        sha256: "beaf9e43c96cf5f42d370d97596e7666de8d27eb847ec0a4ecf037ce0a5a3259"
+      "armv8":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-aarch64-linux-c-api.tar.xz"
+        sha256: "7f6fded60d935bbaa3553113164f889ba67687219c934ecebc3854040a388066"
+      "s390x":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-s390x-linux-c-api.tar.xz"
+        sha256: "91c6726d0691facbeb6a29aaf392fbf9214aa0e638ef6367b30f34c3a2d7b58a"
+    Macos:
+      "x86_64":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-aarch64-macos-c-api.tar.xz"
+        sha256: "bd0c0b4c67d03ef1102f36217682da32c09d9a1932314ce105486e267c0e715e"
+    Android:
+      "armv8":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-aarch64-linux-c-api.tar.xz"
+        sha256: "7f6fded60d935bbaa3553113164f889ba67687219c934ecebc3854040a388066"
   "0.39.1":
     Windows:
       "x86_64":
@@ -188,54 +215,3 @@ sources:
       "armv8":
         url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.32.0/wasmtime-v0.32.0-aarch64-linux-c-api.tar.xz"
         sha256: "6d9425829003a44c92af118ff2ae72a887e088ea6ac4a887ae315b41b5e96206"
-  "0.31.0":
-    Windows:
-      "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.31.0/wasmtime-v0.31.0-x86_64-windows-c-api.zip"
-        sha256: "6514d891f0648f92291945acd2bde57427b7375d94fcb7655d7c0595c763ed51"
-    MinGW:
-      "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.31.0/wasmtime-v0.31.0-x86_64-mingw-c-api.zip"
-        sha256: "734fa254c65864bec5382f72a89788ba72961e472d5ec7b67b821be20d1aa3ab"
-    Linux:
-      "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.31.0/wasmtime-v0.31.0-x86_64-linux-c-api.tar.xz"
-        sha256: "63c7c0d0862d4ac4640676b50e4f2d13d63485e8fa982779d02438095c06d52c"
-      "armv8":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.31.0/wasmtime-v0.31.0-aarch64-linux-c-api.tar.xz"
-        sha256: "2a6311ee4ec3d5a00fd656d2134cab277219e180b54694f31aeab705d11cb20c"
-      "s390x":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.31.0/wasmtime-v0.31.0-s390x-linux-c-api.tar.xz"
-        sha256: "5c5ef16543a80479d25ddf064c6668340b603be90269d1245478cfc0ae86c4ae"
-    Macos:
-      "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.31.0/wasmtime-v0.31.0-x86_64-macos-c-api.tar.xz"
-        sha256: "4f191c3413dcaaba36253783b0c82113d554968f52d02befe4e0a9f1b97c7f34"
-    Android:
-      "armv8":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.31.0/wasmtime-v0.31.0-aarch64-linux-c-api.tar.xz"
-        sha256: "2a6311ee4ec3d5a00fd656d2134cab277219e180b54694f31aeab705d11cb20c"
-  "0.30.0":
-    Windows:
-      "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.30.0/wasmtime-v0.30.0-x86_64-windows-c-api.zip"
-        sha256: "3180c482a9f83a3c07c12a72c6efce73cf02ccad50f918666c805003de6756a5"
-    MinGW:
-      "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.30.0/wasmtime-v0.30.0-x86_64-mingw-c-api.zip"
-        sha256: "557e774a7fb33de8f6eceda298cdfada7b6aaa7ad30c307d105c3aa74aef79fd"
-    Linux:
-      "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.30.0/wasmtime-v0.30.0-x86_64-linux-c-api.tar.xz"
-        sha256: "bf197fedc9fd68f9d78f6b5781e99242e58cee090fef9024dc56fa3f961707fd"
-      "armv8":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.30.0/wasmtime-v0.30.0-aarch64-linux-c-api.tar.xz"
-        sha256: "9b9f1bce6c34968923aa8f90869931b5c610d4bc3d5884a5a2ec958c15017dc1"
-    Macos:
-      "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.30.0/wasmtime-v0.30.0-x86_64-macos-c-api.tar.xz"
-        sha256: "6299f9cb37b23f4a2d51690a5343f56de271626036a945c8bbf063dab487435d"
-    Android:
-      "armv8":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.30.0/wasmtime-v0.30.0-aarch64-linux-c-api.tar.xz"
-        sha256: "9b9f1bce6c34968923aa8f90869931b5c610d4bc3d5884a5a2ec958c15017dc1"

--- a/recipes/wasmtime/all/conandata.yml
+++ b/recipes/wasmtime/all/conandata.yml
@@ -1,31 +1,34 @@
 sources:
-  "1.0.0":
+  "1.0.1":
     Windows:
       "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-x86_64-windows-c-api.zip"
-        sha256: "d6e2fef27ed755fca9605a9a1a2cedad8a0caa1031a09cc9e5e3a663b3410b08"
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-x86_64-windows-c-api.zip"
+        sha256: "7b8ae00997d3d6fef21d084141f843db9d2c562ca24aebccb5b20cdbba93c8c2"
     MinGW:
       "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-x86_64-mingw-c-api.zip"
-        sha256: "a99bd9289dcfe64fd6d87284ed5c53bad8e7d0917c74d4e5cad4cdf4d109c321"
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-x86_64-mingw-c-api.zip"
+        sha256: "ce5b516b3924fdf38e200cad2fd9438ac35bf7ddd734aea3e2dee8f319e275c3"
     Linux:
       "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-x86_64-linux-c-api.tar.xz"
-        sha256: "beaf9e43c96cf5f42d370d97596e7666de8d27eb847ec0a4ecf037ce0a5a3259"
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-x86_64-linux-c-api.tar.xz"
+        sha256: "b481b015c8805acabf2d1aad3b005a8564ac11f3c5b360bbbf71ba0f03e2c067"
       "armv8":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-aarch64-linux-c-api.tar.xz"
-        sha256: "7f6fded60d935bbaa3553113164f889ba67687219c934ecebc3854040a388066"
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-aarch64-linux-c-api.tar.xz"
+        sha256: "aa950e47fdff4970efb7a59a3ea9e96b965180f9e84be46280915086f0ad7519"
       "s390x":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-s390x-linux-c-api.tar.xz"
-        sha256: "91c6726d0691facbeb6a29aaf392fbf9214aa0e638ef6367b30f34c3a2d7b58a"
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-s390x-linux-c-api.tar.xz"
+        sha256: "b197a1d8878ae98b2a6ca769bc89aeda9352cb516f94d5a8d84453666ba57ab6"
     Macos:
       "x86_64":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-aarch64-macos-c-api.tar.xz"
-        sha256: "bd0c0b4c67d03ef1102f36217682da32c09d9a1932314ce105486e267c0e715e"
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-x86_64-macos-c-api.tar.xz"
+        sha256: "fc570e49cf3c4d66b69770ecee692e1cf27d0fa6a6363c83f3f5cca23ac9dc3b"
+      "armv8":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-aarch64-linux-c-api.tar.xz"
+        sha256: "aa950e47fdff4970efb7a59a3ea9e96b965180f9e84be46280915086f0ad7519"
     Android:
       "armv8":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.0/wasmtime-v1.0.0-aarch64-linux-c-api.tar.xz"
-        sha256: "7f6fded60d935bbaa3553113164f889ba67687219c934ecebc3854040a388066"
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-aarch64-linux-c-api.tar.xz"
+        sha256: "aa950e47fdff4970efb7a59a3ea9e96b965180f9e84be46280915086f0ad7519"
   "0.39.1":
     Windows:
       "x86_64":
@@ -49,6 +52,9 @@ sources:
       "x86_64":
         url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.39.1/wasmtime-v0.39.1-x86_64-macos-c-api.tar.xz"
         sha256: "a045371654222d7eb29ca23520ebf64d8144ea8e1ae0b38df2f39cdeb83e3649"
+      "armv8":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.39.1/wasmtime-v0.39.1-aarch64-macos-c-api.tar.xz"
+        sha256: "a5e0e3b1acf924771d84beec6462baa00d9a436df2d65748bcd202cb8470d267"
     Android:
       "armv8":
         url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.39.1/wasmtime-v0.39.1-aarch64-linux-c-api.tar.xz"
@@ -76,6 +82,9 @@ sources:
       "x86_64":
         url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.38.0/wasmtime-v0.38.0-x86_64-macos-c-api.tar.xz"
         sha256: "651c41d4de8958caf80086bab46d0f326bbfa0f328f544a632df52b050f2776c"
+      "armv8":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.38.0/wasmtime-v0.38.0-aarch64-macos-c-api.tar.xz"
+        sha256: "1e424122c73418c972287043a50555569afb09dc721fb6630503bf455cbd2856"
     Android:
       "armv8":
         url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.38.0/wasmtime-v0.38.0-aarch64-linux-c-api.tar.xz"
@@ -103,6 +112,9 @@ sources:
       "x86_64":
         url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.37.0/wasmtime-v0.37.0-x86_64-macos-c-api.tar.xz"
         sha256: "0f785932fc69105dcecbb2d7c1ceb0cd63dffa5e4b0b3f198c4c56118bdb4ecd"
+      "armv8":
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.37.0/wasmtime-v0.37.0-aarch64-macos-c-api.tar.xz"
+        sha256: "0a0f5fd2283f52b3ab725650a5dfc77a8bf53de962344fabc37418af9e5e407a"
     Android:
       "armv8":
         url: "https://github.com/bytecodealliance/wasmtime/releases/download/v0.37.0/wasmtime-v0.37.0-aarch64-linux-c-api.tar.xz"

--- a/recipes/wasmtime/all/conandata.yml
+++ b/recipes/wasmtime/all/conandata.yml
@@ -23,8 +23,8 @@ sources:
         url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-x86_64-macos-c-api.tar.xz"
         sha256: "fc570e49cf3c4d66b69770ecee692e1cf27d0fa6a6363c83f3f5cca23ac9dc3b"
       "armv8":
-        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-aarch64-linux-c-api.tar.xz"
-        sha256: "aa950e47fdff4970efb7a59a3ea9e96b965180f9e84be46280915086f0ad7519"
+        url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-aarch64-macos-c-api.tar.xz"
+        sha256: "48fe254302c6519bf289a4d1385dd425a1c65c4dd521d88dc6a1fab6f025bd19"
     Android:
       "armv8":
         url: "https://github.com/bytecodealliance/wasmtime/releases/download/v1.0.1/wasmtime-v1.0.1-aarch64-linux-c-api.tar.xz"

--- a/recipes/wasmtime/all/conanfile.py
+++ b/recipes/wasmtime/all/conanfile.py
@@ -1,10 +1,12 @@
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.scm import Version
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import is_msvc
-import os
-import shutil
 
-required_conan_version = ">=1.33.0"
+import os
+
+required_conan_version = ">=1.47.0"
 
 
 class WasmtimeConan(ConanFile):
@@ -49,11 +51,16 @@ class WasmtimeConan(ConanFile):
         del self.settings.compiler.cppstd
         del self.settings.compiler.runtime
 
+    def package_id(self):
+        del self.info.settings.compiler.version
+        if self.settings.compiler == "clang":
+            self.info.settings.compiler = "gcc"
+
     def validate(self):
         compiler = self.settings.compiler
         min_version = self._minimum_compilers_version[str(compiler)]
         try:
-            if tools.Version(compiler.version) < min_version:
+            if Version(compiler.version) < min_version:
                 msg = (
                     "{} requires C{} features which are not supported by compiler {} {} !!"
                 ).format(self.name, self._minimum_cpp_standard, compiler, compiler.version)
@@ -70,37 +77,33 @@ class WasmtimeConan(ConanFile):
         except KeyError:
             raise ConanInvalidConfiguration("Binaries for this combination of architecture/version/os are not available")
 
-        if tools.Version(self.version) <= "0.29.0":
+        if Version(self.version) <= "0.29.0":
             if (self.settings.compiler, self.settings.os) == ("gcc", "Windows") and self.options.shared:
                 # https://github.com/bytecodealliance/wasmtime/issues/3168
                 raise ConanInvalidConfiguration("Shared mingw is currently not possible")
 
-    def package_id(self):
-        del self.info.settings.compiler.version
-        if self.settings.compiler == "clang":
-            self.info.settings.compiler = "gcc"
-
     def build(self):
         # This is packaging binaries so the download needs to be in build
-        tools.get(**self.conan_data["sources"][self.version][self._sources_os_key][str(self.settings.arch)],
-                  destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version][self._sources_os_key][str(self.settings.arch)],
+            destination=self.source_folder, strip_root=True)
 
     def package(self):
-        shutil.copytree(os.path.join(self.source_folder, "include"),
-                        os.path.join(self.package_folder, "include"))
+        copy(self, pattern="*.h", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self.source_folder, "include"))
 
         srclibdir = os.path.join(self.source_folder, "lib")
+        dstlibdir = os.path.join(self.package_folder, "lib")
+        dstbindir = os.path.join(self.package_folder, "bin")
         if self.options.shared:
-            self.copy("wasmtime.dll.lib", src=srclibdir, dst="lib", keep_path=False)
-            self.copy("wasmtime.dll", src=srclibdir, dst="bin", keep_path=False)
-            self.copy("libwasmtime.dll.a", src=srclibdir, dst="lib", keep_path=False)
-            self.copy("libwasmtime.so*", src=srclibdir, dst="lib", keep_path=False)
-            self.copy("libwasmtime.dylib", src=srclibdir,  dst="lib", keep_path=False)
+            copy(self, "wasmtime.dll.lib", dst=dstlibdir, src=srclibdir, keep_path=False)
+            copy(self, "wasmtime.dll", dst=dstbindir, src=srclibdir, keep_path=False)
+            copy(self, "libwasmtime.dll.a", dst=dstlibdir, src=srclibdir, keep_path=False)
+            copy(self, "libwasmtime.so*", dst=dstlibdir, src=srclibdir, keep_path=False)
+            copy(self, "libwasmtime.dylib",  dst=dstlibdir, src=srclibdir, keep_path=False)
         else:
-            self.copy("wasmtime.lib", src=srclibdir, dst="lib", keep_path=False)
-            self.copy("libwasmtime.a", src=srclibdir, dst="lib", keep_path=False)
+            copy(self, "wasmtime.lib", dst=dstlibdir, src=srclibdir, keep_path=False)
+            copy(self, "libwasmtime.a", dst=dstlibdir, src=srclibdir, keep_path=False)
 
-        self.copy("LICENSE", dst="licenses", src=self.source_folder)
+        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
 
     def package_info(self):
         if self.options.shared:

--- a/recipes/wasmtime/all/test_package/conanfile.py
+++ b/recipes/wasmtime/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/wasmtime/all/test_v1_package/CMakeLists.txt
+++ b/recipes/wasmtime/all/test_v1_package/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 3.8)
 
 project(test_package C)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(wasmtime REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.c)
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE wasmtime::wasmtime)
 target_compile_features(${PROJECT_NAME} PRIVATE c_std_11)

--- a/recipes/wasmtime/all/test_v1_package/conanfile.py
+++ b/recipes/wasmtime/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/wasmtime/config.yml
+++ b/recipes/wasmtime/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "0.39.1":
     folder: all
   "0.38.0":
@@ -12,8 +14,4 @@ versions:
   "0.34.0":
     folder: all
   "0.32.0":
-    folder: all
-  "0.31.0":
-    folder: all
-  "0.30.0":
     folder: all

--- a/recipes/wasmtime/config.yml
+++ b/recipes/wasmtime/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.0.0":
+  "1.0.1":
     folder: all
   "0.39.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **wasmtime/***

- add version 1.0.0
- remove old versions
- support conan v2

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
