### PR TITLE
parallel-hashmap: add version 1.37

### DIFF
--- a/recipes/parallel-hashmap/all/conandata.yml
+++ b/recipes/parallel-hashmap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.37":
+    url: "https://github.com/greg7mdp/parallel-hashmap/archive/1.37.tar.gz"
+    sha256: "2ac652be0552fcb53a1163c08c1f28f29f0756594fcc587eebb4d8b363153709"
   "1.36":
     url: "https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/1.36.tar.gz"
     sha256: "33acf44158a9661a9d630d13f9250a2aa27a770cb3771df77b1ba1a661c0b766"

--- a/recipes/parallel-hashmap/config.yml
+++ b/recipes/parallel-hashmap/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.37":
+    folder: all
   "1.36":
     folder: all
   "1.35":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **parallel-hashmap/1.37**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
