### PR TITLE
mcap: add 0.3.0, 0.4.0, 0.5.0

### DIFF
--- a/recipes/mcap/all/conandata.yml
+++ b/recipes/mcap/all/conandata.yml
@@ -8,3 +8,6 @@ sources:
   0.1.2:
     url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.1.2/main.tar.gz
     sha256: 0f456d6c53730445c3dbf57afd285493cf748c66a02f77d6e48c075128fd0896
+  0.3.0:
+    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.3.0/main.tar.gz
+    sha256: ef29ea4c09520b8aaa2d78ce5e79cbbcd87511ed14d6abf3c4b249ae67a4153b

--- a/recipes/mcap/all/conandata.yml
+++ b/recipes/mcap/all/conandata.yml
@@ -11,3 +11,6 @@ sources:
   0.3.0:
     url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.3.0/main.tar.gz
     sha256: ef29ea4c09520b8aaa2d78ce5e79cbbcd87511ed14d6abf3c4b249ae67a4153b
+  0.4.0:
+    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.4.0/main.tar.gz
+    sha256: c0ab99e51005fa8b74fe9ca1ed23b205cf532b8b0723eedd243f35a28d7b466b

--- a/recipes/mcap/all/conandata.yml
+++ b/recipes/mcap/all/conandata.yml
@@ -14,3 +14,6 @@ sources:
   0.4.0:
     url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.4.0/main.tar.gz
     sha256: c0ab99e51005fa8b74fe9ca1ed23b205cf532b8b0723eedd243f35a28d7b466b
+  0.5.0:
+    url: https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v0.5.0/main.tar.gz
+    sha256: 408e255a6c6419b16de38a9ecbdd9729d60adc657767b2d52a234d1da1185349

--- a/recipes/mcap/all/conanfile.py
+++ b/recipes/mcap/all/conanfile.py
@@ -10,7 +10,7 @@ class McapConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/foxglove/mcap"
     description = "A C++ implementation of the MCAP file format"
-    license = "Apache-2.0"
+    license = "MIT"
     topics = ("mcap", "serialization", "deserialization", "recording")
 
     settings = ("os", "compiler", "build_type", "arch")

--- a/recipes/mcap/all/conanfile.py
+++ b/recipes/mcap/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.47.0"
 
 
 class McapConan(ConanFile):

--- a/recipes/mcap/all/conanfile.py
+++ b/recipes/mcap/all/conanfile.py
@@ -1,5 +1,8 @@
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools import files
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.33.0"
@@ -25,24 +28,24 @@ class McapConan(ConanFile):
         return os.path.join(self._source_subfolder, "cpp", "mcap")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        files.get(self, **self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
 
     def requirements(self):
         self.requires("lz4/1.9.3")
         self.requires("zstd/1.5.2")
-        if tools.Version(self.version) < "0.1.1":
+        if Version(self.version) < "0.1.1":
             self.requires("fmt/8.1.1")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, "17")
-        if self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) <= 11:
+            check_min_cppstd(self, "17")
+        if self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) <= "11":
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
-        if (self.settings.compiler == "gcc" or self.settings.compiler == "clang") and tools.Version(self.settings.compiler.version) <= 8:
+        if (self.settings.compiler in ("gcc", "clang")) and Version(self.settings.compiler.version) <= "8":
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
-        if tools.Version(self.version) < "0.1.1" and self.settings.compiler == "Visual Studio":
+        if Version(self.version) < "0.1.1" and self.settings.compiler == "Visual Studio":
             raise ConanInvalidConfiguration("Visual Studio compiler support is added in 0.1.1")
-        if self.settings.compiler == "Visual Studio" and tools.Version(self.settings.compiler.version) < 16:
+        if self.settings.compiler == "Visual Studio" and Version(self.settings.compiler.version) < "16":
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
 
     def package(self):

--- a/recipes/mcap/all/conanfile.py
+++ b/recipes/mcap/all/conanfile.py
@@ -48,6 +48,10 @@ class McapConan(ConanFile):
         if self.settings.compiler == "Visual Studio" and Version(self.settings.compiler.version) < "16":
             raise ConanInvalidConfiguration("Compiler version is not supported, c++17 support is required")
 
+    def configure(self):
+        if Version(self.version) < "0.3.0":
+            self.license = "Apache-2.0"
+
     def package(self):
         self.copy("LICENSE", dst="licenses", src=self._source_package_path)
         self.copy("include/*", src=self._source_package_path)

--- a/recipes/mcap/all/test_package/CMakeLists.txt
+++ b/recipes/mcap/all/test_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package CXX)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
 
 find_package(mcap REQUIRED CONFIG)
 
-add_executable(test_package test_package.cpp)
-set_target_properties(test_package PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
-target_link_libraries(test_package mcap::mcap)
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE mcap::mcap)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/mcap/all/test_package/conanfile.py
+++ b/recipes/mcap/all/test_package/conanfile.py
@@ -1,10 +1,15 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = ("os", "arch", "compiler", "build_type")
-    generators = ("cmake", "cmake_find_package_multi")
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +17,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/mcap/all/test_v1_package/CMakeLists.txt
+++ b/recipes/mcap/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(package REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE mcap::mcap)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/mcap/all/test_v1_package/CMakeLists.txt
+++ b/recipes/mcap/all/test_v1_package/CMakeLists.txt
@@ -5,7 +5,7 @@ project(test_package CXX)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(package REQUIRED CONFIG)
+find_package(mcap REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE mcap::mcap)

--- a/recipes/mcap/all/test_v1_package/conanfile.py
+++ b/recipes/mcap/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+# legacy validation with Conan 1.x
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/mcap/config.yml
+++ b/recipes/mcap/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   0.4.0:
     folder: all
+  0.5.0:
+    folder: all

--- a/recipes/mcap/config.yml
+++ b/recipes/mcap/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   0.1.2:
     folder: all
+  0.3.0:
+    folder: all

--- a/recipes/mcap/config.yml
+++ b/recipes/mcap/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   0.3.0:
     folder: all
+  0.4.0:
+    folder: all


### PR DESCRIPTION
Upgrades `mcap` to 0.5.0.
Updates the recipe with the new license info, which was changed in https://github.com/foxglove/mcap/pull/601 / https://github.com/foxglove/mcap/pull/608.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
