### PR TITLE
drmp3: update to 0.6.34

### DIFF
--- a/recipes/drmp3/all/CMakeLists.txt
+++ b/recipes/drmp3/all/CMakeLists.txt
@@ -1,34 +1,33 @@
 cmake_minimum_required(VERSION 3.4)
-project(dr_mp3 C)
+project(dr_mp3 LANGUAGES C)
 
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
+include(GNUInstallDirs)
 
 option(NO_SIMD "Build with define DR_MP3_NO_SIMD" OFF)
 option(NO_STDIO "Build with define DR_MP3_NO_STDIO" OFF)
 
-add_library(${CMAKE_PROJECT_NAME} dr_mp3.c)
+add_library(dr_mp3 dr_mp3.c)
 
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE source_subfolder)
+target_include_directories(dr_mp3 PRIVATE ${DRMP3_SRC_DIR})
 
-set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES 
-    PUBLIC_HEADER source_subfolder/dr_mp3.h
+set_target_properties(dr_mp3 PROPERTIES 
+    PUBLIC_HEADER ${DRMP3_SRC_DIR}/dr_mp3.h
     C_STANDARD 99
 )
 
 if(BUILD_SHARED_LIBS)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDRMP3_DLL)
+    target_compile_definitions(dr_mp3 PUBLIC -DDRMP3_DLL)
 endif()
 if(NO_SIMD)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDR_MP3_NO_SIMD)
+    target_compile_definitions(dr_mp3 PUBLIC -DDR_MP3_NO_SIMD)
 endif()
 if(NO_STDIO)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDR_MP3_NO_STDIO)
+    target_compile_definitions(dr_mp3 PUBLIC -DDR_MP3_NO_STDIO)
 endif()
 
-install(TARGETS ${CMAKE_PROJECT_NAME}
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    PUBLIC_HEADER DESTINATION include
+install(TARGETS dr_mp3
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )

--- a/recipes/drmp3/all/CMakeLists.txt
+++ b/recipes/drmp3/all/CMakeLists.txt
@@ -6,26 +6,26 @@ include(GNUInstallDirs)
 option(NO_SIMD "Build with define DR_MP3_NO_SIMD" OFF)
 option(NO_STDIO "Build with define DR_MP3_NO_STDIO" OFF)
 
-add_library(dr_mp3 dr_mp3.c)
+add_library(${CMAKE_PROJECT_NAME} dr_mp3.c)
 
-target_include_directories(dr_mp3 PRIVATE ${DRMP3_SRC_DIR})
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${DRMP3_SRC_DIR})
 
-set_target_properties(dr_mp3 PROPERTIES 
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES 
     PUBLIC_HEADER ${DRMP3_SRC_DIR}/dr_mp3.h
     C_STANDARD 99
 )
 
 if(BUILD_SHARED_LIBS)
-    target_compile_definitions(dr_mp3 PUBLIC -DDRMP3_DLL)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDRMP3_DLL)
 endif()
 if(NO_SIMD)
-    target_compile_definitions(dr_mp3 PUBLIC -DDR_MP3_NO_SIMD)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDR_MP3_NO_SIMD)
 endif()
 if(NO_STDIO)
-    target_compile_definitions(dr_mp3 PUBLIC -DDR_MP3_NO_STDIO)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDR_MP3_NO_STDIO)
 endif()
 
-install(TARGETS dr_mp3
+install(TARGETS ${CMAKE_PROJECT_NAME}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/recipes/drmp3/all/conandata.yml
+++ b/recipes/drmp3/all/conandata.yml
@@ -1,4 +1,8 @@
 sources:
+  # NOTE: https://github.com/mackron/dr_libs/blob/dd762b861ecadf5ddd5fb03e9ca1db6707b54fbb/dr_mp3.h#L3
+  "0.6.34":
+    url: https://github.com/mackron/dr_libs/archive/dd762b861ecadf5ddd5fb03e9ca1db6707b54fbb.zip
+    sha256: "077d6b29a78da5132065fcc9b44ca50e7e168b94250f2c25614101d3f808bcc1"
   # NOTE: https://github.com/mackron/dr_libs/blob/9497270f581f43e6b795ce5d98d8764861fb6a50/dr_mp3.h#L3
   "0.6.32":
     url: https://github.com/mackron/dr_libs/archive/9497270f581f43e6b795ce5d98d8764861fb6a50.zip

--- a/recipes/drmp3/all/conanfile.py
+++ b/recipes/drmp3/all/conanfile.py
@@ -26,7 +26,7 @@ class Drmp3Conan(ConanFile):
         "no_simd": False,
         "no_stdio": False
     }
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = ["CMakeLists.txt", "dr_mp3.c"]
 
     _cmake = None
 

--- a/recipes/drmp3/all/conanfile.py
+++ b/recipes/drmp3/all/conanfile.py
@@ -26,7 +26,7 @@ class Drmp3Conan(ConanFile):
         "no_simd": False,
         "no_stdio": False
     }
-    exports_sources = ["CMakeLists.txt", "dr_mp3.c"]
+    exports_sources = ["CMakeLists.txt"]
 
     _cmake = None
 

--- a/recipes/drmp3/all/test_package/conanfile.py
+++ b/recipes/drmp3/all/test_package/conanfile.py
@@ -1,11 +1,18 @@
+from conan import ConanFile
+from conan.tools.build import cross_building
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
-from conans import ConanFile, CMake, tools
 
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
 
-class Drmp3TestConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -13,6 +20,6 @@ class Drmp3TestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if not cross_building(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/drmp3/all/test_v1_package/CMakeLists.txt
+++ b/recipes/drmp3/all/test_v1_package/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(drmp3 CONFIG REQUIRED)
 
-add_executable(${PROJECT_NAME} test_package.c)
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 target_link_libraries(${PROJECT_NAME} drmp3::drmp3)
 set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)

--- a/recipes/drmp3/all/test_v1_package/conanfile.py
+++ b/recipes/drmp3/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/drmp3/config.yml
+++ b/recipes/drmp3/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.6.34":
+    folder: all
   "0.6.32":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **drmp3/0.6.34**

This updates the recipe for the latest version of the library and also updates it for Conan v2. See also the almost identical update for drflac: https://github.com/conan-io/conan-center-index/pull/13145

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
