### PR TITLE
fmtlog: add recipe

### DIFF
--- a/recipes/fmtlog/all/conandata.yml
+++ b/recipes/fmtlog/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "2.2.1":
+    url: "https://github.com/MengRao/fmtlog/archive/refs/tags/v2.2.1.tar.gz"
+    sha256: "9bc2f1ea37eece0f4807689962b529d2d4fa07654baef184f051319b4eac9304"
+patches:
+  "2.2.1":
+    - patch_file: "patches/2.2.1-0001-fix-cmake.patch"
+      patch_description: "make shared, static library separately"
+      patch_type: "conan"

--- a/recipes/fmtlog/all/conanfile.py
+++ b/recipes/fmtlog/all/conanfile.py
@@ -15,7 +15,7 @@ required_conan_version = ">=1.52.0"
 class PackageConan(ConanFile):
     name = "fmtlog"
     description = "fmtlog is a performant fmtlib-style logging library with latency in nanoseconds."
-    license = "MIT license"
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/MengRao/fmtlog"
     topics = ("logging", "low-latency", "topic3") # no "conan" and project name in topics

--- a/recipes/fmtlog/all/conanfile.py
+++ b/recipes/fmtlog/all/conanfile.py
@@ -75,8 +75,8 @@ class PackageConan(ConanFile):
     def validate(self):
         if self.info.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
+        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support.")
 
     def source(self):

--- a/recipes/fmtlog/all/conanfile.py
+++ b/recipes/fmtlog/all/conanfile.py
@@ -73,7 +73,7 @@ class PackageConan(ConanFile):
             self.info.clear()
 
     def validate(self):
-        if self.settings.compiler.cppstd:
+        if self.info.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.compiler.version) < minimum_version:

--- a/recipes/fmtlog/all/conanfile.py
+++ b/recipes/fmtlog/all/conanfile.py
@@ -18,7 +18,7 @@ class PackageConan(ConanFile):
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/MengRao/fmtlog"
-    topics = ("logging", "low-latency", "topic3") # no "conan" and project name in topics
+    topics = ("logging", "low-latency", "topic3")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/fmtlog/all/conanfile.py
+++ b/recipes/fmtlog/all/conanfile.py
@@ -1,0 +1,119 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.layout import basic_layout
+import os
+
+
+required_conan_version = ">=1.52.0"
+
+
+class PackageConan(ConanFile):
+    name = "fmtlog"
+    description = "fmtlog is a performant fmtlib-style logging library with latency in nanoseconds."
+    license = "MIT license"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/MengRao/fmtlog"
+    topics = ("logging", "low-latency", "topic3") # no "conan" and project name in topics
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "header_only": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "header_only": False,
+    }
+
+    @property
+    def _minimum_cpp_standard(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "7",
+            "Visual Studio": "15.7",
+            "msvc": "191",
+            "clang": "7",
+            "apple-clang": "10",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+
+    def layout(self):
+        if self.options.header_only:
+            basic_layout(self, src_folder="src")
+        else:
+            cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("fmt/9.1.0")
+
+    def package_id(self):
+        if self.options.header_only:
+            self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._minimum_cpp_standard)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+                  destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+        be = VirtualBuildEnv(self)
+        be.generate(scope="build")
+
+    def build(self):
+        if self.options.header_only:
+            return
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        if self.options.header_only:
+            copy(self, pattern="fmtlog*.h", dst=os.path.join(self.package_folder, "include", "fmtlog"), src=self.source_folder)
+        else:
+            cmake = CMake(self)
+            cmake.install()
+
+    def package_info(self):
+        if self.options.header_only:
+            self.cpp_info.defines.append("FMTLOG_HEADER_ONLY")
+        else:
+            self.cpp_info.libs = ["fmtlog-shared" if self.options.shared else "fmtlog-static"]
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/fmtlog/all/conanfile.py
+++ b/recipes/fmtlog/all/conanfile.py
@@ -91,9 +91,6 @@ class PackageConan(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
 
-        be = VirtualBuildEnv(self)
-        be.generate(scope="build")
-
     def build(self):
         if self.options.header_only:
             return

--- a/recipes/fmtlog/all/conanfile.py
+++ b/recipes/fmtlog/all/conanfile.py
@@ -84,6 +84,9 @@ class PackageConan(ConanFile):
                   destination=self.source_folder, strip_root=True)
 
     def generate(self):
+        if self.options.header_only:
+            return
+
         tc = CMakeToolchain(self)
         tc.generate()
 

--- a/recipes/fmtlog/all/conanfile.py
+++ b/recipes/fmtlog/all/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.files import apply_conandata_patches, export_conandata_patches,
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.env import VirtualBuildEnv
 from conan.tools.layout import basic_layout
 import os
 

--- a/recipes/fmtlog/all/conanfile.py
+++ b/recipes/fmtlog/all/conanfile.py
@@ -73,10 +73,11 @@ class PackageConan(ConanFile):
             self.info.clear()
 
     def validate(self):
-        if self.info.settings.get_safe("compiler.cppstd"):
+        # FIXME: self.info.settings.compiler does not work with header-only packages
+        if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
-        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
-        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support.")
 
     def source(self):

--- a/recipes/fmtlog/all/patches/2.2.1-0001-fix-cmake.patch
+++ b/recipes/fmtlog/all/patches/2.2.1-0001-fix-cmake.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c45e569..5a1d800 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,23 +12,24 @@ else()
+     link_libraries(pthread)
+ endif()
+ 
+-link_directories(.)
+-include_directories(fmt/include)
++find_package(fmt REQUIRED CONFIG)
++
++if(BUILD_SHARED_LIBS)
+ 
+ add_library(fmtlog-shared SHARED fmtlog.cc)
+-if(MSVC)
+-  target_link_libraries(fmtlog-shared fmt)
++if(1)
++  target_link_libraries(fmtlog-shared PUBLIC fmt::fmt)
+ endif()
+ install(TARGETS fmtlog-shared)
+ 
++else()
++
+ add_library(fmtlog-static fmtlog.cc)
+-if(MSVC)
+-  target_link_libraries(fmtlog-static fmt)
++if(1)
++  target_link_libraries(fmtlog-static PUBLIC fmt::fmt)
+ endif()
+ install(TARGETS fmtlog-static)
+ 
+-add_subdirectory(fmt)
+-add_subdirectory(test)
+-if(NOT MSVC)
+-  add_subdirectory(bench)
+ endif()
++
++install(FILES fmtlog.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fmtlog)

--- a/recipes/fmtlog/all/patches/2.2.1-0001-fix-cmake.patch
+++ b/recipes/fmtlog/all/patches/2.2.1-0001-fix-cmake.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c45e569..5a1d800 100644
+index c45e569..6dc75d4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -12,23 +12,24 @@ else()
@@ -9,15 +9,15 @@ index c45e569..5a1d800 100644
 -link_directories(.)
 -include_directories(fmt/include)
 +find_package(fmt REQUIRED CONFIG)
-+
-+if(BUILD_SHARED_LIBS)
  
++if(BUILD_SHARED_LIBS)
  add_library(fmtlog-shared SHARED fmtlog.cc)
 -if(MSVC)
 -  target_link_libraries(fmtlog-shared fmt)
 +if(1)
 +  target_link_libraries(fmtlog-shared PUBLIC fmt::fmt)
  endif()
++set_property(TARGET fmtlog-shared PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
  install(TARGETS fmtlog-shared)
  
 +else()

--- a/recipes/fmtlog/all/test_package/CMakeLists.txt
+++ b/recipes/fmtlog/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package CXX)
+
+find_package(fmtlog REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE fmtlog::fmtlog)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/fmtlog/all/test_package/conanfile.py
+++ b/recipes/fmtlog/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/fmtlog/all/test_package/test_package.cpp
+++ b/recipes/fmtlog/all/test_package/test_package.cpp
@@ -1,0 +1,5 @@
+#include "fmtlog/fmtlog.h"
+int main()
+{
+  FMTLOG(fmtlog::INF, "The answer is {}.", 42);
+}

--- a/recipes/fmtlog/all/test_v1_package/CMakeLists.txt
+++ b/recipes/fmtlog/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(fmtlog REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE fmtlog::fmtlog)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/fmtlog/all/test_v1_package/conanfile.py
+++ b/recipes/fmtlog/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/fmtlog/config.yml
+++ b/recipes/fmtlog/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.2.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **fmglog/2.2.1**

fmtlog is a faster logging library which uses fmt.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
