### PR TITLE
openblas:build_lapack should use gfortran from CCI

### DIFF
--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -52,7 +52,7 @@ class OpenblasConan(ConanFile):
 
     def build_requirements(self):
         if self.options.build_lapack:
-            self.requires("gfortran/10.2")
+            self.tool_requires("gfortran/10.2")
 
     def validate(self):
         if hasattr(self, "settings_build") and tools.cross_building(self, skip_x64_x86=True):

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -50,7 +50,7 @@ class OpenblasConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
-    def requirements(self):
+    def build_requirements(self):
         if self.options.build_lapack:
             self.requires("gfortran/10.2")
 

--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -50,6 +50,10 @@ class OpenblasConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    def requirements(self):
+        if self.options.build_lapack:
+            self.requires("gfortran/10.2")
+
     def validate(self):
         if hasattr(self, "settings_build") and tools.cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building not implemented")


### PR DESCRIPTION
Library name  **openblas packages**

* Openblas relies on system gfortran compiler for building with the option `build_lapack`, which on many systems may not available out of the box
* This PR changes openblas recipe to use gfortran from conan-center-index 
* Additionally update the recipe to use conan V2
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
