### PR TITLE
gdcm: conan v2 support

### DIFF
--- a/recipes/gdcm/all/CMakeLists.txt
+++ b/recipes/gdcm/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.9.2)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory(src)

--- a/recipes/gdcm/all/conandata.yml
+++ b/recipes/gdcm/all/conandata.yml
@@ -8,3 +8,5 @@ patches:
       base_path: "src"
     - patch_file: "patches/0002-openjpeg-integration.patch"
       base_path: "src"
+    - patch_file: "patches/0003-gcc-11-compilation.patch"
+      base_path: "src"

--- a/recipes/gdcm/all/conandata.yml
+++ b/recipes/gdcm/all/conandata.yml
@@ -5,11 +5,8 @@ sources:
 patches:
   "3.0.9":
     - patch_file: "patches/0001-charls-linking.patch"
-      sha256: "aaa"
     - patch_file: "patches/0002-openjpeg-integration.patch"
-      sha256: "aaa"
     - patch_file: "patches/0003-gcc-11-compilation.patch"
       patch_description: "add missing includes for GCC 11"
       patch_type: "backport"
       patch_source: "https://github.com/malaterre/GDCM/commit/4404b770be337bd0d5d3c2289abfd34426433db2"
-      sha256: "aaa"

--- a/recipes/gdcm/all/conandata.yml
+++ b/recipes/gdcm/all/conandata.yml
@@ -5,8 +5,11 @@ sources:
 patches:
   "3.0.9":
     - patch_file: "patches/0001-charls-linking.patch"
-      base_path: "src"
+      sha256: "aaa"
     - patch_file: "patches/0002-openjpeg-integration.patch"
-      base_path: "src"
+      sha256: "aaa"
     - patch_file: "patches/0003-gcc-11-compilation.patch"
-      base_path: "src"
+      patch_description: "add missing includes for GCC 11"
+      patch_type: "backport"
+      patch_source: "https://github.com/malaterre/GDCM/commit/4404b770be337bd0d5d3c2289abfd34426433db2"
+      sha256: "aaa"

--- a/recipes/gdcm/all/conandata.yml
+++ b/recipes/gdcm/all/conandata.yml
@@ -10,3 +10,6 @@ patches:
       patch_description: "add missing includes for GCC 11"
       patch_type: "backport"
       patch_source: "https://github.com/malaterre/GDCM/commit/4404b770be337bd0d5d3c2289abfd34426433db2"
+    - patch_file: "patches/0004-find-expat.patch"
+      patch_description: "enforce usage of FindEXPAT.cmake"
+      patch_type: "conan"

--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -54,8 +54,8 @@ class GDCMConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        self.requires("expat/2.4.8")
-        self.requires("openjpeg/2.4.0")
+        self.requires("expat/2.4.9")
+        self.requires("openjpeg/2.5.0")
         self.requires("zlib/1.2.12")
 
     def validate(self):

--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
 from conan.tools.microsoft import is_msvc_static_runtime
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, save
 from conan.tools.build import check_min_cppstd
@@ -223,7 +224,7 @@ class GDCMConan(ConanFile):
                 self.cpp_info.components["gdcmMSFF"].requires.append("gdcmuuid")
 
                 self.cpp_info.components["gdcmCommon"].system_libs = ["dl"]
-                if tools.is_apple_os(self.settings.os):
+                if is_apple_os(self):
                     self.cpp_info.components["gdcmCommon"].frameworks = ["CoreFoundation"]
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed

--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -96,10 +96,10 @@ class GDCMConan(ConanFile):
 
         if self.settings.os == "Windows":
             bin_dir = os.path.join(self.package_folder, "bin")
-            rm(self, "[!gs]*.dll",  bin_dir)
-            rm(self, "*.pdb",  bin_dir)
+            rm(self, "[!gs]*.dll", bin_dir)
+            rm(self, "*.pdb", bin_dir)
 
-        rm(self, os.path.join(self.package_folder, "lib", self._gdcm_subdir), "[!U]*.cmake") #leave UseGDCM.cmake untouched
+        rm(self, "[!U]*.cmake", os.path.join(self.package_folder, "lib", self._gdcm_subdir)) #leave UseGDCM.cmake untouched
         rmdir(self, os.path.join(self.package_folder, "share"))
         self._create_cmake_variables(os.path.join(self.package_folder, self._gdcm_cmake_variables_path))
 

--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -75,7 +75,7 @@ class GDCMConan(ConanFile):
         tc.cache_variables["GDCM_USE_SYSTEM_OPENJPEG"] = True
         tc.cache_variables["GDCM_USE_SYSTEM_ZLIB"] = True
         if not self.settings.compiler.cppstd:
-            tc.blocks["cppstd"].values = { "cppstd": self._minimum_cpp_standard, "cppstd_extensions": "OFF" }
+            toolchain.cache_variables["CMAKE_CXX_STANDARD"] = self._minimum_cpp_standard
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -58,7 +58,7 @@ class GDCMConan(ConanFile):
     def validate(self):
         if self.info.settings.compiler.cppstd:
             check_min_cppstd(self, self._minimum_cpp_standard)
-        if is_msvc_static_runtime(self) and self.info.options.shared(self):
+        if is_msvc_static_runtime(self) and self.info.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} does not support shared and static runtime together.")
 
     def source(self):

--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -69,7 +69,7 @@ class GDCMConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.cache_variables["GDCM_BUILD_DOCBOOK_MANPAGES"] = False
-        tc.cache_variables["GDCM_BUILD_SHARED_LIBS"] = self.info.options.shared
+        tc.cache_variables["GDCM_BUILD_SHARED_LIBS"] = bool(self.options.shared)
         # FIXME: unvendor deps https://github.com/conan-io/conan-center-index/pull/5705#discussion_r647224146
         tc.cache_variables["GDCM_USE_SYSTEM_EXPAT"] = True
         tc.cache_variables["GDCM_USE_SYSTEM_OPENJPEG"] = True

--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -78,10 +78,7 @@ class GDCMConan(ConanFile):
             tc.blocks["cppstd"].values = { "cppstd": self._minimum_cpp_standard, "cppstd_extensions": "OFF" }
         tc.generate()
         deps = CMakeDeps(self)
-        previous_value = self.dependencies["expat"].cpp_info.get_property("cmake_find_mode")
-        self.dependencies["expat"].cpp_info.set_property("cmake_find_mode", "module")
         deps.generate()
-        self.dependencies["expat"].cpp_info.set_property("cmake_find_mode", previous_value)
 
     def build(self):
         apply_conandata_patches(self)

--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -68,14 +68,14 @@ class GDCMConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.cache_variables["GDCM_BUILD_DOCBOOK_MANPAGES"] = False
-        tc.cache_variables["GDCM_BUILD_SHARED_LIBS"] = bool(self.options.shared)
+        tc.variables["GDCM_BUILD_DOCBOOK_MANPAGES"] = False
+        tc.variables["GDCM_BUILD_SHARED_LIBS"] = bool(self.options.shared)
         # FIXME: unvendor deps https://github.com/conan-io/conan-center-index/pull/5705#discussion_r647224146
-        tc.cache_variables["GDCM_USE_SYSTEM_EXPAT"] = True
-        tc.cache_variables["GDCM_USE_SYSTEM_OPENJPEG"] = True
-        tc.cache_variables["GDCM_USE_SYSTEM_ZLIB"] = True
+        tc.variables["GDCM_USE_SYSTEM_EXPAT"] = True
+        tc.variables["GDCM_USE_SYSTEM_OPENJPEG"] = True
+        tc.variables["GDCM_USE_SYSTEM_ZLIB"] = True
         if not self.settings.compiler.cppstd:
-            tc.cache_variables["CMAKE_CXX_STANDARD"] = self._minimum_cpp_standard
+            tc.variables["CMAKE_CXX_STANDARD"] = self._minimum_cpp_standard
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -1,20 +1,24 @@
-from conan.tools.microsoft import msvc_runtime_flag
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc_static_runtime
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, save
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 import textwrap
 
-required_conan_version = ">=1.43.0"
+
+required_conan_version = ">=1.52.0"
 
 
 class GDCMConan(ConanFile):
     name = "gdcm"
-    topics = ("dicom", "images")
-    homepage = "http://gdcm.sourceforge.net/"
-    url = "https://github.com/conan-io/conan-center-index"
-    license = "BSD-3-Clause"
     description = "C++ library for DICOM medical files"
-
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://gdcm.sourceforge.net/"
+    topics = ("dicom", "images")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -25,25 +29,12 @@ class GDCMConan(ConanFile):
         "fPIC": True,
     }
 
-    generators = "cmake", "cmake_find_package"
-    _cmake = None
-
     @property
-    def _source_subfolder(self):
-        return "src"
-
-    @property
-    def _build_subfolder(self):
-        return "build"
-
-    @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+    def _minimum_cpp_standard(self):
+        return 11
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -51,7 +42,13 @@ class GDCMConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires("expat/2.4.9")
@@ -59,67 +56,62 @@ class GDCMConan(ConanFile):
         self.requires("zlib/1.2.12")
 
     def validate(self):
-        if self.options.shared and self._is_msvc and "MT" in msvc_runtime_flag(self):
-            raise ConanInvalidConfiguration("shared gdcm can't be built with MT or MTd")
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, "11")
+        if self.info.settings.compiler.cppstd:
+            check_min_cppstd(self, self._minimum_cpp_standard)
+        if is_msvc_static_runtime(self) and self.info.options.shared(self):
+            raise ConanInvalidConfiguration(f"{self.ref} does not support shared and static runtime together.")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+                  destination=self.source_folder, strip_root=True)
 
-    def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-
-        self._cmake = CMake(self)
-        self._cmake.definitions["GDCM_BUILD_DOCBOOK_MANPAGES"] = False
-        self._cmake.definitions["GDCM_BUILD_SHARED_LIBS"] = self.options.shared
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["GDCM_BUILD_DOCBOOK_MANPAGES"] = False
+        tc.cache_variables["GDCM_BUILD_SHARED_LIBS"] = self.info.options.shared
         # FIXME: unvendor deps https://github.com/conan-io/conan-center-index/pull/5705#discussion_r647224146
-        self._cmake.definitions["GDCM_USE_SYSTEM_EXPAT"] = True
-        self._cmake.definitions["GDCM_USE_SYSTEM_OPENJPEG"] = True
-        self._cmake.definitions["GDCM_USE_SYSTEM_ZLIB"] = True
-        if not tools.valid_min_cppstd(self, 11):
-            self._cmake.definitions["CMAKE_CXX_STANDARD"] = 11
-
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
+        tc.cache_variables["GDCM_USE_SYSTEM_EXPAT"] = True
+        tc.cache_variables["GDCM_USE_SYSTEM_OPENJPEG"] = True
+        tc.cache_variables["GDCM_USE_SYSTEM_ZLIB"] = True
+        if not self.settings.compiler.cppstd:
+            tc.blocks["cppstd"].values = { "cppstd": self._minimum_cpp_standard, "cppstd_extensions": "OFF" }
+        tc.generate()
+        deps = CMakeDeps(self)
+        previous_value = self.dependencies["expat"].cpp_info.get_property("cmake_find_mode")
+        self.dependencies["expat"].cpp_info.set_property("cmake_find_mode", "module")
+        deps.generate()
+        self.dependencies["expat"].cpp_info.set_property("cmake_find_mode", previous_value)
 
     def build(self):
-        self._patch_sources()
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy("Copyright.txt", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, pattern="Copyright.txt", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
+
         if self.settings.os == "Windows":
             bin_dir = os.path.join(self.package_folder, "bin")
-            tools.remove_files_by_mask(bin_dir, "[!gs]*.dll")
-            tools.remove_files_by_mask(bin_dir, "*.pdb")
-        lib_dir = os.path.join(self.package_folder, "lib")
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.remove_files_by_mask(os.path.join(lib_dir, self._gdcm_subdir), "[!U]*.cmake") #leave UseGDCM.cmake untouched
+            rm(self, "[!gs]*.dll",  bin_dir)
+            rm(self, "*.pdb",  bin_dir)
+
+        rm(self, os.path.join(self.package_folder, "lib", self._gdcm_subdir), "[!U]*.cmake") #leave UseGDCM.cmake untouched
+        rmdir(self, os.path.join(self.package_folder, "share"))
         self._create_cmake_variables(os.path.join(self.package_folder, self._gdcm_cmake_variables_path))
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._gdcm_cmake_module_aliases_path),
-            {library: "GDCM::{}".format(library) for library in self._gdcm_libraries},
-        )
+        self._create_cmake_module_alias_targets()
 
     def _create_cmake_variables(self, variables_file):
-        v = tools.Version(self.version)
-        content = textwrap.dedent("""\
+        v = Version(self.version)
+        content = textwrap.dedent(f"""\
             # The GDCM version number.
-            set(GDCM_MAJOR_VERSION "{v_major}")
-            set(GDCM_MINOR_VERSION "{v_minor}")
-            set(GDCM_BUILD_VERSION "{v_patch}")
+            set(GDCM_MAJOR_VERSION "{v.major}")
+            set(GDCM_MINOR_VERSION "{v.minor}")
+            set(GDCM_BUILD_VERSION "{v.patch}")
 
             get_filename_component(SELF_DIR "${{CMAKE_CURRENT_LIST_FILE}}" PATH)
 
@@ -130,7 +122,7 @@ class GDCMConan(ConanFile):
             set(GDCM_CMAKE_DIR "")
 
             # The configuration options.
-            set(GDCM_BUILD_SHARED_LIBS "{build_shared_libs}")
+            set(GDCM_BUILD_SHARED_LIBS "{"ON" if self.options.shared else "OFF"}")
 
             set(GDCM_USE_VTK "OFF")
 
@@ -140,33 +132,25 @@ class GDCMConan(ConanFile):
             # The VTK options.
             set(GDCM_VTK_DIR "")
 
-            get_filename_component(GDCM_INCLUDE_ROOT "${{SELF_DIR}}/../../include/{gdcm_subdir}" ABSOLUTE)
+            get_filename_component(GDCM_INCLUDE_ROOT "${{SELF_DIR}}/../../include/{self._gdcm_subdir}" ABSOLUTE)
             set(GDCM_INCLUDE_DIRS ${{GDCM_INCLUDE_ROOT}})
             get_filename_component(GDCM_LIB_ROOT "${{SELF_DIR}}/../../lib" ABSOLUTE)
             set(GDCM_LIBRARY_DIRS ${{GDCM_LIB_ROOT}})
-        """.format(v_major=v.major,
-                   v_minor=v.minor,
-                   v_patch=v.patch,
-                   build_shared_libs="ON" if self.options.shared else "OFF",
-                   gdcm_subdir=self._gdcm_subdir))
-        tools.save(variables_file, content)
+        """)
+        save(self, variables_file, content)
 
-    @staticmethod
-    def _create_cmake_module_alias_targets(module_file, targets):
+    def _create_cmake_module_alias_targets(self):
+        module_file = os.path.join(self.package_folder, self._gdcm_cmake_module_aliases_path)
+        targets = {library: f"GDCM::{library}" for library in self._gdcm_libraries}
         content = ""
         for alias, aliased in targets.items():
-            content += textwrap.dedent("""\
+            content += textwrap.dedent(f"""\
                 if(TARGET {aliased} AND NOT TARGET {alias})
                     add_library({alias} INTERFACE IMPORTED)
                     set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
                 endif()
-            """.format(alias=alias, aliased=aliased))
-        tools.save(module_file, content)
-
-    @property
-    def _gdcm_subdir(self):
-        v = tools.Version(self.version)
-        return "gdcm-{}.{}".format(v.major, v.minor)
+            """)
+        save(self, module_file, content)
 
     @property
     def _gdcm_builddir(self):
@@ -202,6 +186,11 @@ class GDCMConan(ConanFile):
         else:
             gdcm_libs.append("gdcmuuid")
         return gdcm_libs
+
+    @property
+    def _gdcm_subdir(self):
+        v = Version(self.version)
+        return f"gdcm-{v.major}.{v.minor}"
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "GDCM")

--- a/recipes/gdcm/all/conanfile.py
+++ b/recipes/gdcm/all/conanfile.py
@@ -75,7 +75,7 @@ class GDCMConan(ConanFile):
         tc.cache_variables["GDCM_USE_SYSTEM_OPENJPEG"] = True
         tc.cache_variables["GDCM_USE_SYSTEM_ZLIB"] = True
         if not self.settings.compiler.cppstd:
-            toolchain.cache_variables["CMAKE_CXX_STANDARD"] = self._minimum_cpp_standard
+            tc.cache_variables["CMAKE_CXX_STANDARD"] = self._minimum_cpp_standard
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/gdcm/all/patches/0003-gcc-11-compilation.patch
+++ b/recipes/gdcm/all/patches/0003-gcc-11-compilation.patch
@@ -1,0 +1,68 @@
+From 4404b770be337bd0d5d3c2289abfd34426433db2 Mon Sep 17 00:00:00 2001
+From: Axel Braun <docb@users.sourceforge.net>
+Date: Mon, 7 Jun 2021 16:27:52 +0200
+Subject: [PATCH] gdcm fails to build with gcc11 compiler
+
+gdcm fails to build with gcc11 compiler:
+cd
+/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/build/Source/MediaStorageAndFileFormat
+&& /usr/bin/c++ -DgdcmMSFF_EXPORTS
+-I/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/Source/Common
+-I/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/build/Source/Common
+-I/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/Source/DataStructureAndEncodingDefinition
+-I/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/Source/DataDictionary
+-I/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/Source/InformationObjectDefinition
+-I/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/Source/MediaStorageAndFileFormat
+-I/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/Utilities
+-I/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/build/Utilities
+-I/usr/include/charls -I/usr/include/openjpeg-2.4 -I/usr/include/json-c
+-I/usr/include/json -O2 -Wall -D_FORTIFY_SOURCE=2
+-fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables
+-fstack-clash-protection -Werror=return-type -flto=auto -g -fpermissive
+-O2 -g -DNDEBUG -fPIC -MD -MT
+Source/MediaStorageAndFileFormat/CMakeFiles/gdcmMSFF.dir/gdcmImageChangePhotometricInterpretation.cxx.o
+-MF
+CMakeFiles/gdcmMSFF.dir/gdcmImageChangePhotometricInterpretation.cxx.o.d
+-o
+CMakeFiles/gdcmMSFF.dir/gdcmImageChangePhotometricInterpretation.cxx.o
+-c
+/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.cxx
+[  131s] In file included from
+/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.cxx:14:
+[  131s]
+/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.h:
+In function 'T gdcm::Clamp(int)':
+[  131s]
+/home/abuild/rpmbuild/BUILD/gdcm-3.0.8/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.h:67:32:
+error: 'numeric_limits' is not a member of 'std'
+[  131s]    67 |   return v < 0 ? 0 : (v > std::numeric_limits<T>::max()
+? std::numeric_limits<T>::max() : v);
+---
+ Source/MediaStorageAndFileFormat/gdcmImage.cxx                   | 1 +
+ .../gdcmImageChangePhotometricInterpretation.h                   | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/Source/MediaStorageAndFileFormat/gdcmImage.cxx b/Source/MediaStorageAndFileFormat/gdcmImage.cxx
+index f59fdd7b7..78a1f7a5c 100644
+--- a/Source/MediaStorageAndFileFormat/gdcmImage.cxx
++++ b/Source/MediaStorageAndFileFormat/gdcmImage.cxx
+@@ -20,6 +20,7 @@
+ #include "gdcmFragment.h"
+ 
+ #include <iostream>
++#include <limits>
+ 
+ namespace gdcm
+ {
+diff --git a/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.h b/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.h
+index d55a5ee47..798d3dfa6 100644
+--- a/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.h
++++ b/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.h
+@@ -16,6 +16,7 @@
+ 
+ #include "gdcmImageToImageFilter.h"
+ #include "gdcmPhotometricInterpretation.h"
++#include <limits>
+ 
+ namespace gdcm
+ {

--- a/recipes/gdcm/all/patches/0004-find-expat.patch
+++ b/recipes/gdcm/all/patches/0004-find-expat.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -423,7 +423,7 @@ endif()
+ 
+ if(GDCM_USE_SYSTEM_EXPAT)
+   # If user say so, then this is a requirement !
+-  find_package(EXPAT REQUIRED)
++  find_package(EXPAT REQUIRED MODULE)
+   set(GDCM_EXPAT_LIBRARIES ${EXPAT_LIBRARIES})
+ else()
+   set(GDCM_EXPAT_LIBRARIES "gdcmexpat")

--- a/recipes/gdcm/all/test_package/CMakeLists.txt
+++ b/recipes/gdcm/all/test_package/CMakeLists.txt
@@ -1,12 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package CXX)
 
 find_package(GDCM REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 include(${GDCM_USE_FILE})
-target_link_libraries(${PROJECT_NAME} gdcmMSFF)
+target_link_libraries(${PROJECT_NAME} PRIVATE gdcmMSFF)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/gdcm/all/test_package/conanfile.py
+++ b/recipes/gdcm/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.files import mkdir
 import os
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,10 +21,10 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
             input_file = os.path.join(self.source_folder, "DCMTK_JPEGExt_12Bits.dcm")
             test_dir = "test_dir"
-            tools.mkdir(test_dir)
+            mkdir(self, test_dir)
             output_file = os.path.join(test_dir, "output.dcm")
-            self.run([bin_path, input_file, output_file], run_environment=True)
+            self.run(f"\"{bin_path}\" \"{input_file}\" \"{output_file}\"", env="conanrun")

--- a/recipes/gdcm/all/test_package/conanfile.py
+++ b/recipes/gdcm/all/test_package/conanfile.py
@@ -27,4 +27,4 @@ class TestPackageConan(ConanFile):
             test_dir = "test_dir"
             mkdir(self, test_dir)
             output_file = os.path.join(test_dir, "output.dcm")
-            self.run(f"'{bin_path}' '{input_file}' '{output_file}'", env="conanrun")
+            self.run(f"\"{bin_path}\" \"{input_file}\" \"{output_file}\"", env="conanrun")

--- a/recipes/gdcm/all/test_package/conanfile.py
+++ b/recipes/gdcm/all/test_package/conanfile.py
@@ -27,4 +27,4 @@ class TestPackageConan(ConanFile):
             test_dir = "test_dir"
             mkdir(self, test_dir)
             output_file = os.path.join(test_dir, "output.dcm")
-            self.run(f"\"{bin_path}\" \"{input_file}\" \"{output_file}\"", env="conanrun")
+            self.run(f"'{bin_path}' '{input_file}' '{output_file}'", env="conanrun")

--- a/recipes/gdcm/all/test_package/test_package.cpp
+++ b/recipes/gdcm/all/test_package/test_package.cpp
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
     std::cerr << "Could not write: " << outfilename << std::endl;
     return 1;
   }
-
+  std::cout << "GDCM test: success\n";
   return 0;
 }
 

--- a/recipes/gdcm/all/test_v1_package/CMakeLists.txt
+++ b/recipes/gdcm/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(GDCM REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
+include(${GDCM_USE_FILE})
+target_link_libraries(${PROJECT_NAME} gdcmMSFF)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/gdcm/all/test_v1_package/conanfile.py
+++ b/recipes/gdcm/all/test_v1_package/conanfile.py
@@ -1,0 +1,23 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+from conan.tools.files import mkdir
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            input_file = os.path.join(self.source_folder, "..", "test_package", "DCMTK_JPEGExt_12Bits.dcm")
+            test_dir = "test_dir"
+            mkdir(self, test_dir)
+            output_file = os.path.join(test_dir, "output.dcm")
+            self.run([bin_path, input_file, output_file], run_environment=True)


### PR DESCRIPTION
Specify library name and version:  **gdcm/3.0.9**

conan v2 support

Fix compilation with gcc11 and bump dependencies.

Patch was taken from https://github.com/malaterre/GDCM/commit/4404b770be337bd0d5d3c2289abfd34426433db2

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
