### PR TITLE
add CMAKE_MAKE_PROGRAM to make recipe

### DIFF
--- a/recipes/make/all/conanfile.py
+++ b/recipes/make/all/conanfile.py
@@ -62,3 +62,4 @@ class MakeConan(ConanFile):
 
         self.output.info('Creating CONAN_MAKE_PROGRAM environment variable: %s' % make)
         self.env_info.CONAN_MAKE_PROGRAM = make
+        self.env_info.CMAKE_MAKE_PROGRAM = make

--- a/recipes/make/all/conanfile.py
+++ b/recipes/make/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conans import AutoToolsBuildEnvironment, tools
+from conans import AutoToolsBuildEnvironment
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import is_msvc, VCVars
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout

--- a/recipes/make/all/conanfile.py
+++ b/recipes/make/all/conanfile.py
@@ -1,8 +1,14 @@
-from conans import ConanFile, tools, AutoToolsBuildEnvironment
+from conan import ConanFile
+from conans import AutoToolsBuildEnvironment, tools
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc, VCVars
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.microsoft import is_msvc
+from conans.client.tools.env import no_op
 import os
 
-required_conan_version = ">=1.33.0"
-
+required_conan_version = ">=1.52.0"
 
 class MakeConan(ConanFile):
     name = "make"
@@ -13,45 +19,38 @@ class MakeConan(ConanFile):
     license = "GPL-3.0-or-later"
     settings = "os", "arch", "compiler", "build_type"
 
-    exports_sources = "patches/*"
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def configure(self):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
 
     def package_id(self):
         del self.info.settings.compiler
 
     def build(self):
-        for patch in self.conan_data.get("patches").get(self.version, []):
-            tools.patch(**patch)
-
-        with tools.chdir(self._source_subfolder):
-            # README.W32
-            if tools.os_info.is_windows:
-                if self.settings.compiler == "Visual Studio":
-                    command = "build_w32.bat --without-guile"
-                else:
-                    command = "build_w32.bat --without-guile gcc"
+        # README.W32
+        if is_msvc(self):
+            if self.settings.compiler == "Visual Studio":
+                command = "build_w32.bat --without-guile"
             else:
-                env_build = AutoToolsBuildEnvironment(self)
-                env_build.configure()
-                command = "./build.sh"
-            with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
-                self.run(command)
+                command = "build_w32.bat --without-guile gcc"
+        else:
+            env_build = AutoToolsBuildEnvironment(self)
+            env_build.configure()
+            command = "./build.sh"
+        with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else no_op():
+            self.run(command)
 
     def package(self):
-        self.copy(pattern="COPYING", src=self._source_subfolder, dst="licenses")
-        self.copy(pattern="make", src=self._source_subfolder, dst="bin", keep_path=False)
-        self.copy(pattern="*gnumake.exe", src=self._source_subfolder, dst="bin", keep_path=False)
+        self.copy(pattern="COPYING", dst="licenses")
+        self.copy(pattern="make", dst="bin", keep_path=False)
+        self.copy(pattern="*gnumake.exe", dst="bin", keep_path=False)
 
     def package_info(self):
         self.cpp_info.libdirs = []

--- a/recipes/make/all/conanfile.py
+++ b/recipes/make/all/conanfile.py
@@ -1,10 +1,7 @@
 from conan import ConanFile
 from conans import AutoToolsBuildEnvironment
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import is_msvc, VCVars
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
-from conan.tools.microsoft import is_msvc
 from conans.client.tools.env import no_op
 import os
 
@@ -33,7 +30,11 @@ class MakeConan(ConanFile):
     def package_id(self):
         del self.info.settings.compiler
 
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+
     def build(self):
+        self._patch_sources()
         # README.W32
         if is_msvc(self):
             if self.settings.compiler == "Visual Studio":

--- a/recipes/make/all/conanfile.py
+++ b/recipes/make/all/conanfile.py
@@ -44,7 +44,7 @@ class MakeConan(ConanFile):
             env_build = AutoToolsBuildEnvironment(self)
             env_build.configure()
             command = "./build.sh"
-        with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else no_op():
+        with VCVars(self) if is_msvc(self) else no_op():
             self.run(command)
 
     def package(self):


### PR DESCRIPTION
Specify library name and version:  **make/all**

fixes usage of cmake and make as build_requires
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
