### PR TITLE
[nettle] support Conan 2.0 and add 3.8.1

### DIFF
--- a/recipes/nettle/all/conandata.yml
+++ b/recipes/nettle/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.8.1":
+    url: "https://ftp.gnu.org/gnu/nettle/nettle-3.8.1.tar.gz"
+    sha256: "364f3e2b77cd7dcde83fd7c45219c834e54b0c75e428b6f894a23d12dd41cbfe"
   "3.6":
     url: "https://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz"
     sha256: "d24c0d0f2abffbc8f4f34dcf114b0f131ec3774895f3555922fe2f40f3d5e3f1"

--- a/recipes/nettle/all/conanfile.py
+++ b/recipes/nettle/all/conanfile.py
@@ -82,7 +82,7 @@ class NettleTLS(ConanFile):
         return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
-        self.tool_requires("libtool/2.4.6")
+        self.tool_requires("libtool/2.4.7")
         if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
             self.tool_requires("msys2/cci.latest")
 

--- a/recipes/nettle/all/conanfile.py
+++ b/recipes/nettle/all/conanfile.py
@@ -1,15 +1,23 @@
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
+from conan.tools.files import get, replace_in_file, copy, rmdir
+from conan.tools.layout import basic_layout
+from conan.tools.build import cross_building
+from conan.tools.microsoft import unix_path
+from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain, PkgConfigDeps
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.47.0"
 
 
 class NettleTLS(ConanFile):
     name = "nettle"
     description = "The Nettle and Hogweed low-level cryptographic libraries"
     homepage = "https://www.lysator.liu.se/~nisse/nettle"
-    topics = ("conan", "nettle", "crypto", "low-level-cryptographic", "cryptographic")
+    topics = ("crypto", "low-level-cryptographic", "cryptographic")
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
     url = "https://github.com/conan-io/conan-center-index"
     settings = "os", "arch", "compiler", "build_type"
@@ -30,12 +38,6 @@ class NettleTLS(ConanFile):
         "x86_shani": False,
     }
 
-    _autotools = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -47,18 +49,32 @@ class NettleTLS(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
+        if self.settings.os == "Windows":
+            self.win_bash = True
 
     def requirements(self):
         if self.options.public_key:
             self.requires("gmp/6.2.1")
 
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
     def validate(self):
-        if self.settings.compiler == "Visual Studio":
-            raise ConanInvalidConfiguration("Nettle cannot be built using Visual Studio")
-        if tools.Version(self.version) < "3.6" and self.options.get_safe("fat") and self.settings.arch == "x86_64":
+        if is_msvc(self):
+            raise ConanInvalidConfiguration(f"{self.ref} cannot be built using '{self.settings.compiler}'")
+        if Version(self.version) < "3.6" and self.info.options.get_safe("fat") and self.info.settings.arch == "x86_64":
             raise ConanInvalidConfiguration("fat support is broken on this nettle release (due to a missing x86_64/sha_ni/sha1-compress.asm source)")
 
     @property
@@ -66,65 +82,81 @@ class NettleTLS(ConanFile):
         return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
-        self.build_requires("libtool/2.4.6")
-        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires("msys2/cci.latest")
+        self.tool_requires("libtool/2.4.6")
+        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
+            self.tool_requires("msys2/cci.latest")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
-    def _configure_autotools(self):
-        if self._autotools:
-            return self._autotools
-        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+    def generate(self):
+        tc = AutotoolsToolchain(self)
         conf_args = [
             "--enable-public-key" if self.options.public_key else "--disable-public-key",
             "--enable-fat" if self.options.get_safe("fat") else "--disable-fat",
             "--enable-x86-aesni" if self.options.get_safe("x86_aesni") else "--disable-x86-aesni",
             "--enable-x86_sshni" if self.options.get_safe("x86_sshni") else "--disable-x86_sshni",
         ]
-        if self.options.shared:
-            conf_args.extend(["--enable-shared", "--disable-static"])
-        else:
-            conf_args.extend(["--disable-shared", "--enable-static"])
-        self._autotools.configure(args=conf_args, configure_dir=self._source_subfolder)
-        # srcdir in unix path causes some troubles in asm files on Windows
-        if self.settings.os == "Windows":
-            tools.replace_in_file(os.path.join(self.build_folder, "config.m4"),
-                                  tools.unix_path(os.path.join(self.build_folder, self._source_subfolder)),
-                                  os.path.join(self.build_folder, self._source_subfolder).replace("\\", "/"))
-        return self._autotools
+        tc.configure_args.extend(conf_args)
+        tc.generate()
+        tc = AutotoolsDeps(self)
+        tc.generate()
+        tc = PkgConfigDeps(self)
+        tc.generate()
+        env = VirtualBuildEnv(self)
+        env.generate()
+        if not cross_building(self):
+            env = VirtualRunEnv(self)
+            env.generate(scope="build")
 
     def _patch_sources(self):
-        makefile_in = os.path.join(self._source_subfolder, "Makefile.in")
-        tools.replace_in_file(makefile_in,
+        makefile_in = os.path.join(self.source_folder, "Makefile.in")
+        # discard subdirs
+        replace_in_file(self, makefile_in,
                               "SUBDIRS = tools testsuite examples",
                               "SUBDIRS = ")
         # Fix broken tests for compilers like apple-clang with -Werror,-Wimplicit-function-declaration
-        tools.replace_in_file(os.path.join(self._source_subfolder, "aclocal.m4"),
+        replace_in_file(self, os.path.join(self.source_folder, "aclocal.m4"),
                               "cat >conftest.c <<EOF",
                               "cat >conftest.c <<EOF\n#include <stdlib.h>")
 
     def build(self):
         self._patch_sources()
-        with tools.chdir(self._source_subfolder):
-            self.run("{} -fiv".format(tools.get_env("AUTORECONF")), win_bash=tools.os_info.is_windows)
-        autotools = self._configure_autotools()
+        autotools = Autotools(self)
+        autotools.autoreconf()
+        # srcdir in unix path causes some troubles in asm files on Windows
+        if self.settings.os == "Windows":
+            replace_in_file(self, os.path.join(self.build_folder, "config.m4"),
+                                  unix_path(self, os.path.join(self.build_folder, self.source_folder)),
+                                  os.path.join(self.build_folder, self.source_folder).replace("\\", "/"))
+        autotools.configure()
         autotools.make()
 
     def package(self):
-        self.copy(pattern="COPYING*", src=self._source_subfolder, dst="licenses")
-        autotools = self._configure_autotools()
+        copy(self, pattern="COPYING*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        autotools = Autotools(self)
         autotools.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        self.cpp_info.components["hogweed"].names["pkgconfig"] = "hogweed"
+        self.cpp_info.set_property("cmake_file_name", "Nettle")
+
+        self.cpp_info.components["hogweed"].set_property("pkg_config_name", "hogweed")
+        self.cpp_info.components["hogweed"].set_property("cmake_target_name", "Nettle::Hogweed")
         self.cpp_info.components["hogweed"].libs = ["hogweed"]
         if self.options.public_key:
             self.cpp_info.components["hogweed"].requires.append("gmp::libgmp")
 
-        self.cpp_info.components["libnettle"].libs = ["nettle"]
-        self.cpp_info.components["libnettle"].requires = ["hogweed"]
-        self.cpp_info.components["libnettle"].names["pkgconfig"] = "nettle"
+        self.cpp_info.components["nettle"].libs = ["nettle"]
+        self.cpp_info.components["nettle"].requires = ["hogweed"]
+        self.cpp_info.components["nettle"].set_property("pkg_config_name", "nettle")
+        self.cpp_info.components["nettle"].set_property("cmake_target_name", "Nettle::Nettle")
+
+        # TODO: Remove after Conan 2.0
+        self.cpp_info.names["cmake_find_package"] = "Nettle"
+        self.cpp_info.names["cmake_find_package_multi"] = "Nettle"
+        self.cpp_info.components["hogweed"].names["cmake_find_package"] = "Hogweed"
+        self.cpp_info.components["hogweed"].names["cmake_find_package_multi"] = "Hogweed"
+        self.cpp_info.components["nettle"].names["cmake_find_package"] = "Nettle"
+        self.cpp_info.components["nettle"].names["cmake_find_package_multi"] = "Nettle"

--- a/recipes/nettle/all/test_package/conanfile.py
+++ b/recipes/nettle/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/nettle/all/test_v1_package/CMakeLists.txt
+++ b/recipes/nettle/all/test_v1_package/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(Nettle REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.c)
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE Nettle::Nettle Nettle::Hogweed)

--- a/recipes/nettle/all/test_v1_package/conanfile.py
+++ b/recipes/nettle/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/nettle/config.yml
+++ b/recipes/nettle/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.8.1":
+    folder: "all"
   "3.6":
     folder: "all"
   "3.5":


### PR DESCRIPTION
Specify library name and version:  **nettle/3.8.1**

- Add latest nettle release available: 3.8.1
- Fix pkgconfig: Should generate separated files, one per library
- Add support for Conan 2.0
- Add custom cmake targets, based on libarchive and libzip

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
