### PR TITLE
bdwgc: Fix libatomic_ops dependency package/target name

### DIFF
--- a/recipes/bdwgc/all/conanfile.py
+++ b/recipes/bdwgc/all/conanfile.py
@@ -151,7 +151,7 @@ class BdwGcConan(ConanFile):
         if self.options.gc_debug:
             self.cpp_info.components["gc"].defines.append("GC_DEBUG")
         if self.settings.os == "Windows":
-            self.cpp_info.components["gc"].requires = ["libatomic_ops::libatomic_ops"]
+            self.cpp_info.components["gc"].requires = ["libatomic_ops::atomic_ops"]
 
         if self.options.cplusplus and self.options.get_safe("throw_bad_alloc_library"):
             self.cpp_info.components["gctba"].set_property("cmake_target_name", "BDWgc::gctba")

--- a/recipes/bdwgc/all/patches/update-cmake-8_0_4.patch
+++ b/recipes/bdwgc/all/patches/update-cmake-8_0_4.patch
@@ -1,6 +1,6 @@
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -21,241 +21,604 @@
+@@ -21,241 +21,603 @@
  #  this will generate gc.sln
  #
  
@@ -335,7 +335,6 @@
 +    include_directories(${Threads_INCLUDE_DIR})
 +    set(THREADDLLIBS ${CMAKE_THREAD_LIBS_INIT})
 +  endif()
-+  include_directories(libatomic_ops/src)
 +  if (MSVC)
 +    find_package(Atomic_ops CONFIG)
 +    if (Atomic_ops_FOUND)

--- a/recipes/bdwgc/all/patches/update-cmake-8_0_4.patch
+++ b/recipes/bdwgc/all/patches/update-cmake-8_0_4.patch
@@ -1,6 +1,6 @@
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -21,241 +21,606 @@
+@@ -21,241 +21,604 @@
  #  this will generate gc.sln
  #
  
@@ -337,11 +337,9 @@
 +  endif()
 +  include_directories(libatomic_ops/src)
 +  if (MSVC)
-+    # TODO: Rename the following to Atomic_ops
-+    find_package(libatomic_ops CONFIG)
-+    if (libatomic_ops_FOUND)
-+      # TODO: Rename the following to Atomic_ops::atomic_ops
-+      get_target_property(AO_INCLUDE_DIRS libatomic_ops::libatomic_ops
++    find_package(Atomic_ops CONFIG)
++    if (Atomic_ops_FOUND)
++      get_target_property(AO_INCLUDE_DIRS Atomic_ops::atomic_ops
 +                          INTERFACE_INCLUDE_DIRECTORIES)
 +      include_directories(${AO_INCLUDE_DIRS})
 +    endif()

--- a/recipes/bdwgc/all/patches/update-cmake-8_0_6.patch
+++ b/recipes/bdwgc/all/patches/update-cmake-8_0_6.patch
@@ -1,6 +1,6 @@
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -21,232 +21,602 @@
+@@ -21,232 +21,600 @@
  #  this will generate gc.sln
  #
  
@@ -323,11 +323,9 @@
 +  endif()
 +  include_directories(libatomic_ops/src)
 +  if (MSVC)
-+    # TODO: Rename the following to Atomic_ops
-+    find_package(libatomic_ops CONFIG)
-+    if (libatomic_ops_FOUND)
-+      # TODO: Rename the following to Atomic_ops::atomic_ops
-+      get_target_property(AO_INCLUDE_DIRS libatomic_ops::libatomic_ops
++    find_package(Atomic_ops CONFIG)
++    if (Atomic_ops_FOUND)
++      get_target_property(AO_INCLUDE_DIRS Atomic_ops::atomic_ops
 +                          INTERFACE_INCLUDE_DIRECTORIES)
 +      include_directories(${AO_INCLUDE_DIRS})
 +    endif()

--- a/recipes/bdwgc/all/patches/update-cmake-8_0_6.patch
+++ b/recipes/bdwgc/all/patches/update-cmake-8_0_6.patch
@@ -1,6 +1,6 @@
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -21,232 +21,600 @@
+@@ -21,232 +21,599 @@
  #  this will generate gc.sln
  #
  
@@ -321,7 +321,6 @@
 +    include_directories(${Threads_INCLUDE_DIR})
 +    set(THREADDLLIBS ${CMAKE_THREAD_LIBS_INIT})
 +  endif()
-+  include_directories(libatomic_ops/src)
 +  if (MSVC)
 +    find_package(Atomic_ops CONFIG)
 +    if (Atomic_ops_FOUND)

--- a/recipes/bdwgc/all/patches/update-cmake-8_2_2.patch
+++ b/recipes/bdwgc/all/patches/update-cmake-8_2_2.patch
@@ -1,14 +1,12 @@
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -161,6 +161,14 @@ if (enable_threads)
+@@ -161,6 +161,12 @@ if (enable_threads)
    message(STATUS "Thread library: ${CMAKE_THREAD_LIBS_INIT}")
    if (without_libatomic_ops OR BORLAND OR MSVC OR WATCOM)
      include_directories(libatomic_ops/src)
-+    # TODO: Rename the following to Atomic_ops
-+    find_package(libatomic_ops CONFIG)
-+    if (libatomic_ops_FOUND)
-+      # TODO: Rename the following to Atomic_ops::atomic_ops
-+      get_target_property(AO_INCLUDE_DIRS libatomic_ops::libatomic_ops
++    find_package(Atomic_ops CONFIG)
++    if (Atomic_ops_FOUND)
++      get_target_property(AO_INCLUDE_DIRS Atomic_ops::atomic_ops
 +                          INTERFACE_INCLUDE_DIRECTORIES)
 +      include_directories(${AO_INCLUDE_DIRS})
 +    endif()


### PR DESCRIPTION
Specify library name and version:  **bdwgc/8.2.2** (and existing older versions)

This is a fix of dependency package/target name after the corresponding change in libatomic_ops, https://github.com/conan-io/conan-center-index/pull/13042.
I'm upstream maintainer of bdwgc and libatomic_ops.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
