### PR TITLE
opentdf-client: add version 1.2.0

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.0":
+    url: "https://github.com/opentdf/client-cpp/archive/1.2.0.tar.gz"
+    sha256: "15828038809ed291ff7881206a675abc5162e1175c8b515363b9c584aebb08f7"
   "1.1.6":
     url: "https://github.com/opentdf/client-cpp/archive/1.1.6.tar.gz"
     sha256: "83992c37c9a58ae2152660a4ffbf1784fe63d7a9e7b8466d10ca1074697b3d3a"

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.0":
+    folder: all
   "1.1.6":
     folder: all
   "1.1.5":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **opentdf-client/1.2.0**

- API updates to improve use of TDFStorageType
- Added better reporting and handling of exceptions

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
