### PR TITLE
opencv(4.x): disable quirc if dnn is disabled

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -191,7 +191,7 @@ class OpenCVConan(ConanFile):
         if self.options.with_openexr:
             self.requires("openexr/2.5.7")
         if self.options.get_safe("with_tiff"):
-            self.requires("libtiff/4.3.0")
+            self.requires("libtiff/4.4.0")
         if self.options.with_eigen:
             self.requires("eigen/3.3.9")
         if self.options.get_safe("with_ffmpeg"):

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -208,7 +208,7 @@ class OpenCVConan(ConanFile):
         if self.options.get_safe("contrib_sfm"):
             self.requires("gflags/2.2.2")
             self.requires("glog/0.5.0")
-        if self.options.with_quirc:
+        if self.options.get_safe("with_quirc"):
             self.requires("quirc/1.1")
         if self.options.get_safe("with_gtk"):
             self.requires("gtk/system")
@@ -436,7 +436,7 @@ class OpenCVConan(ConanFile):
             self._cmake.definitions["WITH_OPENJPEG"] = self.options.with_jpeg2000 == "openjpeg"
         self._cmake.definitions["WITH_OPENEXR"] = self.options.with_openexr
         self._cmake.definitions["WITH_EIGEN"] = self.options.with_eigen
-        self._cmake.definitions["HAVE_QUIRC"] = self.options.with_quirc  # force usage of quirc requirement
+        self._cmake.definitions["HAVE_QUIRC"] = self.options.get_safe("with_quirc")  # force usage of quirc requirement
         self._cmake.definitions["WITH_DSHOW"] = self._is_msvc
         self._cmake.definitions["WITH_MSMF"] = self._is_msvc
         self._cmake.definitions["WITH_MSMF_DXVA"] = self._is_msvc
@@ -588,7 +588,7 @@ class OpenCVConan(ConanFile):
             return ["onetbb::onetbb"] if self.options.parallel == "tbb" else []
 
         def quirc():
-            return ["quirc::quirc"] if self.options.with_quirc else []
+            return ["quirc::quirc"] if self.options.get_safe("with_quirc") else []
 
         def gtk():
             return ["gtk::gtk"] if self.options.get_safe("with_gtk") else []

--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -160,6 +160,7 @@ class OpenCVConan(ConanFile):
             del self.options.contrib_sfm
         if not self.options.dnn:
             del self.options.dnn_cuda
+            del self.options.with_quirc
         if not self.options.with_cuda:
             del self.options.with_cublas
             del self.options.with_cudnn


### PR DESCRIPTION
Specify library name and version:  **opencv/4.5.5**
Currently, when opencv is used with the option `dnn=False` i get the following error. 
```
 ConanException: opencv/4.5.5 package_info(): Package require 'quirc' not used in components requires
```
This goes away when i set `with_quirc=False` .

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
