### PR TITLE
osmanip: add version 4.2.2

### DIFF
--- a/recipes/osmanip/all/conandata.yml
+++ b/recipes/osmanip/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.2.2":
+    url: "https://github.com/JustWhit3/osmanip/archive/v4.2.2.tar.gz"
+    sha256: "841b76bb4f44b66d714858e62661cee75c4fef553300b6da2a6720509421a5fe"
   "4.2.1":
     url: "https://github.com/JustWhit3/osmanip/archive/refs/tags/v4.2.1.tar.gz"
     sha256: "1d1ba3fac66edc7a7e4c480a0c080493d19193f9b63b70d417e2683f8741bf1c"

--- a/recipes/osmanip/config.yml
+++ b/recipes/osmanip/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.2.2":
+    folder: all
   "4.2.1":
     folder: all
   "4.1.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **osmanip/4.2.2**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
