### PR TITLE
c-blosc2: add version 2.4.2

### DIFF
--- a/recipes/c-blosc2/all/conandata.yml
+++ b/recipes/c-blosc2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.4.2":
+    url: "https://github.com/Blosc/c-blosc2/archive/v2.4.2.tar.gz"
+    sha256: "763ded7a6286abd248a79b1560ce8bfda11018b699a450b3e43c529f284a5232"
   "2.4.1":
     url: "https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.4.1.tar.gz"
     sha256: "f09a43bfac563ceda611a213c799ca5359c3b629281e0a4f3a543e692a64a931"
@@ -7,6 +10,8 @@ sources:
     sha256: "66f9977de26d6bc9ea1c0e623d873c3225e4fff709aa09b3335fd09d41d57c0e"
 
 patches:
+  "2.4.2":
+    - patch_file: "patches/2.4.1-0001-fix-cmake.patch"
   "2.4.1":
     - patch_file: "patches/2.4.1-0001-fix-cmake.patch"
   "2.2.0":

--- a/recipes/c-blosc2/config.yml
+++ b/recipes/c-blosc2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.4.2":
+    folder: all
   "2.4.1":
     folder: all
   "2.2.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **c-blosc2/2.4.2**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
