### PR TITLE
nettle: several fixes

### DIFF
--- a/recipes/nettle/all/test_package/CMakeLists.txt
+++ b/recipes/nettle/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+project(test_package LANGUAGES C)
 
-find_package(Nettle REQUIRED CONFIG)
+find_package(nettle REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE Nettle::Nettle Nettle::Hogweed)
+target_link_libraries(${PROJECT_NAME} PRIVATE nettle::libnettle nettle::hogweed)

--- a/recipes/nettle/all/test_v1_package/CMakeLists.txt
+++ b/recipes/nettle/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+project(test_package LANGUAGES C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(Nettle REQUIRED CONFIG)
+find_package(nettle REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE Nettle::Nettle Nettle::Hogweed)
+target_link_libraries(${PROJECT_NAME} PRIVATE nettle::libnettle nettle::hogweed)


### PR DESCRIPTION
addresses reviews in https://github.com/conan-io/conan-center-index/pull/13176:

- requires conan > 1.51.1
- `win_bash=True` required if build os is windows (it's not a host os logic)
- remove useless PkgConfigDeps
- relocatable shared libs on macOS
- fix install on Windows
- restore previous component names & do not suggest unofficial cmake names
- hogweed lib requires nettle lib, not the opposite

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
