### PR TITLE
Bump parallel-hashmap version to 1.3.8

### DIFF
--- a/recipes/parallel-hashmap/all/conandata.yml
+++ b/recipes/parallel-hashmap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.8":
+    url: "https://github.com/greg7mdp/parallel-hashmap/archive/v1.3.8.tar.gz"
+    sha256: "c4562ea360dc1dcaddd96a0494c753400364a52c7aa9750de49d8e6a222d28d3"
   "1.37":
     url: "https://github.com/greg7mdp/parallel-hashmap/archive/1.37.tar.gz"
     sha256: "2ac652be0552fcb53a1163c08c1f28f29f0756594fcc587eebb4d8b363153709"

--- a/recipes/parallel-hashmap/config.yml
+++ b/recipes/parallel-hashmap/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.8":
+    folder: all
   "1.37":
     folder: all
   "1.36":


### PR DESCRIPTION
Specify library name and version:  **parallel-hashmap/1.3.8**


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
