### PR TITLE
ctre: add version 3.7.1

### DIFF
--- a/recipes/ctre/all/conandata.yml
+++ b/recipes/ctre/all/conandata.yml
@@ -32,3 +32,6 @@ sources:
   "3.7":
     url: "https://github.com/hanickadot/compile-time-regular-expressions/archive/v3.7.tar.gz"
     sha256: "12be2a37f7fe39c489f646d3faee534f965871fd998258162962f36a19a455ef"
+  "3.7.1":
+    url: "https://github.com/hanickadot/compile-time-regular-expressions/archive/v3.7.1.tar.gz"
+    sha256: "d00d7eaa0e22f2fdaa947a532b81b6fc35880acf4887b50a5ac9bfb7411ced03"

--- a/recipes/ctre/config.yml
+++ b/recipes/ctre/config.yml
@@ -21,3 +21,5 @@ versions:
     folder: all
   "3.7":
     folder: all
+  "3.7.1":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **ctre/3.7.1**



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
