### PR TITLE
paho-mqtt-c: add version 1.3.11

### DIFF
--- a/recipes/paho-mqtt-c/all/conandata.yml
+++ b/recipes/paho-mqtt-c/all/conandata.yml
@@ -23,6 +23,9 @@ sources:
   "1.3.10":
     url: "https://github.com/eclipse/paho.mqtt.c/archive/v1.3.10.tar.gz"
     sha256: "c70db96e66adacae411d5d875fbb08bca6ff9945de3d215b3af93cbd22792db5"
+  "1.3.11":
+    url: "https://github.com/eclipse/paho.mqtt.c/archive/v1.3.11.tar.gz"
+    sha256: "d7bba3f8b8978802e11e2b1f28e96e6b7f4ed5d8a268af52a4d3b1bcbd1db16b"
 patches:
   "1.3.0":
     - patch_file: "patches/0001-fix-MinGW-and-OSX-builds-for-1-3-0.patch"

--- a/recipes/paho-mqtt-c/config.yml
+++ b/recipes/paho-mqtt-c/config.yml
@@ -15,3 +15,5 @@ versions:
     folder: "all"
   "1.3.10":
     folder: "all"
+  "1.3.11":
+    folder: "all"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **paho-mqtt-c/1.3.11**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
