### PR TITLE
gdal/3.5.2: fix with_jpeg=libjpeg-turbo option

### DIFF
--- a/recipes/gdal/post_3.5.0/conanfile.py
+++ b/recipes/gdal/post_3.5.0/conanfile.py
@@ -512,8 +512,10 @@ class GdalConan(ConanFile):
             print(f'self.options.with_jpeg: {self.options.with_jpeg}')
             cmake.definitions["GDAL_USE_JPEG"] = True
             cmake.definitions["GDAL_CONAN_PACKAGE_FOR_JPEG"] = self.options.with_jpeg
-            cmake.definitions["TARGET_FOR_JPEG"] = \
-                    "JPEG::JPEG" if self.options.with_jpeg == "libjpeg" else "libjpeg-turbo::libjpeg-turbo"
+            cmake.definitions["TARGET_FOR_JPEG"] = (
+                    "JPEG::JPEG" if self.options.with_jpeg == "libjpeg" else
+                    self.dependencies["libjpeg-turbo"].cpp_info.components["turbojpeg"] \
+                            .get_property("cmake_target_name"))
         else:
             cmake.definitions["JPEG_FOUND"] = False
 
@@ -808,7 +810,7 @@ class GdalConan(ConanFile):
         if self.options.with_jpeg == "libjpeg":
             self.cpp_info.requires.extend(['libjpeg::libjpeg'])
         elif self.options.with_jpeg == "libjpeg-turbo":
-            self.cpp_info.requires.extend(['libjpeg-turbo::jpeg'])
+            self.cpp_info.requires.extend(['libjpeg-turbo::turbojpeg'])
 
         if self.options.with_libkml:
             self.cpp_info.requires.extend(['libkml::kmldom', 'libkml::kmlengine'])


### PR DESCRIPTION
**gdal/3.5.2**

libjpeg-turbo was not referenced properly. For some reason it worked on my linux install, but the problem shows up on windows.
This fixes linking with static and shared libjpeg-turbo.

Closes #13270 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
