### PR TITLE
simdjson: add version 2.2.3 and set pkg_config_name in 2.2.3

### DIFF
--- a/recipes/simdjson/all/conandata.yml
+++ b/recipes/simdjson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.3":
+    url: "https://github.com/simdjson/simdjson/archive/v2.2.3.tar.gz"
+    sha256: "4c62f2d82edec3dbc63650c10453dc471de9f1be689eb5b4bde89efed89db5d8"
   "2.2.2":
     url: "https://github.com/simdjson/simdjson/archive/v2.2.2.tar.gz"
     sha256: "b0e36beab240bd827c1103b4c66672491595930067871e20946d67b07758c010"

--- a/recipes/simdjson/all/conanfile.py
+++ b/recipes/simdjson/all/conanfile.py
@@ -115,10 +115,14 @@ class SimdjsonConan(ConanFile):
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "simdjson")
         self.cpp_info.set_property("cmake_target_name", "simdjson::simdjson")
+        if Version(self.version) >= "2.2.3":
+            self.cpp_info.set_property("pkg_config_name", "simdjson")
+
         self.cpp_info.libs = ["simdjson"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["m"]

--- a/recipes/simdjson/config.yml
+++ b/recipes/simdjson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.3":
+    folder: all
   "2.2.2":
     folder: all
   "2.2.0":


### PR DESCRIPTION
Specify library name and version:  **simdjson/2.2.3**

- add version 2.2.3
- set `pkg_config_name` when version is 2.2.3 or later.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
