### PR TITLE
libtasn1: Restore ability to run test_v1_package when cross-building

### DIFF
--- a/recipes/libtasn1/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libtasn1/all/test_v1_package/CMakeLists.txt
@@ -4,7 +4,11 @@ project(test_package LANGUAGES C)
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
 conan_basic_setup(TARGETS)
 
-find_program(ASN1_PARSER NAMES asn1Parser)
+# Note: See https://github.com/conan-io/conan/issues/12237
+# `NO_CMAKE_PATH` is added to avoid searching in `CMAKE_PREFIX_PATH`
+# it should find the correct executable by falling back on the `PATH`
+# environment variable defined by Conan during the test_package run.
+find_program(ASN1_PARSER NAMES asn1Parser NO_CMAKE_PATH)
 if(NOT ASN1_PARSER)
     message(FATAL_ERROR "asn1Parser not found")
 endif()

--- a/recipes/libtasn1/all/test_v1_package/conanfile.py
+++ b/recipes/libtasn1/all/test_v1_package/conanfile.py
@@ -14,10 +14,9 @@ class TestPackageConan(ConanFile):
         self.build_requires(self.tested_reference_str)
 
     def build(self):
-        if not tools.cross_building(self):
-            cmake = CMake(self)
-            cmake.configure()
-            cmake.build()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
         if not tools.cross_building(self):


### PR DESCRIPTION
There's a possible bug in Conan (https://github.com/conan-io/conan/issues/12237) that may cause a bad interaction between `find_package()` and `find_program()` when the same dependency is listed both as `requires` and `tool_requires`, and we are cross-building. This test also uses the legacy generators, so this might not get fixed in Conan 1.x.

While I appreciate that the `test_v1_package` will be eventually removed and may be of lower priority, suppressing tests in a way that makes them look like they passed on CI is probably not a good idea, unless there are comments explaining the reasoning behind it.

This PR restores the test in that scenario, and adds `NO_CMAKE_PATH` as a workaround to the aforementioned bug.

