### PR TITLE
aws-checksums: add version 0.1.13 and update dependencies

### DIFF
--- a/recipes/aws-checksums/all/conandata.yml
+++ b/recipes/aws-checksums/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.13":
+    url: "https://github.com/awslabs/aws-checksums/archive/v0.1.13.tar.gz"
+    sha256: "0f897686f1963253c5069a0e495b85c31635ba146cd3ac38cc2ea31eaf54694d"
   "0.1.12":
     url: "https://github.com/awslabs/aws-checksums/archive/v0.1.12.tar.gz"
     sha256: "394723034b81cc7cd528401775bc7aca2b12c7471c92350c80a0e2fb9d2909fe"

--- a/recipes/aws-checksums/all/conanfile.py
+++ b/recipes/aws-checksums/all/conanfile.py
@@ -1,10 +1,9 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, get, rmdir
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, rmdir
 import os
 
-required_conan_version = ">=1.47.0"
-
+required_conan_version = ">=1.52.0"
 
 class AwsChecksums(ConanFile):
     name = "aws-checksums"
@@ -12,11 +11,10 @@ class AwsChecksums(ConanFile):
         "Cross-Platform HW accelerated CRC32c and CRC32 with fallback to efficient "
         "SW implementations. C interface with language bindings for each of our SDKs."
     )
-    topics = ("aws", "checksum", )
+    license = "Apache-2.0",
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-checksums"
-    license = "Apache-2.0",
-
+    topics = ("aws", "checksum", )
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -28,8 +26,7 @@ class AwsChecksums(ConanFile):
     }
 
     def export_sources(self):
-        for p in self.conan_data.get("patches", {}).get(self.version, []):
-            copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -37,7 +34,10 @@ class AwsChecksums(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
         try:
             del self.settings.compiler.libcxx
         except Exception:
@@ -51,7 +51,7 @@ class AwsChecksums(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.19")
+        self.requires("aws-c-common/0.8.2")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/aws-checksums/config.yml
+++ b/recipes/aws-checksums/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.1.13":
+    folder: all
   "0.1.12":
     folder: all
   "0.1.11":


### PR DESCRIPTION
Specify library name and version:  **aws-checksums/0.1.13**

- add version 0.1.13.
- use `export_conandata_patches`
- update aws-c-common to 0.8.2

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
