### PR TITLE
aws-c-io: add version 0.13.4 and support conan v2

### DIFF
--- a/recipes/aws-c-io/all/CMakeLists.txt
+++ b/recipes/aws-c-io/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(cmake_wrapper LANGUAGES C)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory(source_subfolder)

--- a/recipes/aws-c-io/all/conandata.yml
+++ b/recipes/aws-c-io/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.13.4":
+    url: "https://github.com/awslabs/aws-c-io/archive/v0.13.4.tar.gz"
+    sha256: "133bd0aa46caa2041962cd4f6d076209686ce2934af82f86d1a258df4cbdce8b"
   "0.11.2":
     url: "https://github.com/awslabs/aws-c-io/archive/v0.11.2.tar.gz"
     sha256: "b60270d23b6e2f4a5d80e64ca6538ba114cd6044b53752964c940f87e59bf0d9"

--- a/recipes/aws-c-io/all/conanfile.py
+++ b/recipes/aws-c-io/all/conanfile.py
@@ -1,17 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.files import get, copy, rmdir
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.43.0"
-
+required_conan_version = ">=1.52.0"
 
 class AwsCIO(ConanFile):
     name = "aws-c-io"
     description = "IO and TLS for application protocols"
-    topics = ("aws", "amazon", "cloud", "io", "tls",)
+    license = "Apache-2.0",
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-io"
-    license = "Apache-2.0",
-
+    topics = ("aws", "amazon", "cloud", "io", "tls",)
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -22,58 +23,63 @@ class AwsCIO(ConanFile):
         "fPIC": True,
     }
 
-    exports_sources = "CMakeLists.txt"
-    generators = "cmake", "cmake_find_package"
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.cppstd
-        del self.settings.compiler.libcxx
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         # the versions of aws-c-common and aws-c-io are tied since aws-c-common/0.6.12 and aws-c-io/0.10.10
         # Please refer https://github.com/conan-io/conan-center-index/issues/7763
-        if tools.Version(self.version) <= "0.10.9":
+        if Version(self.version) <= "0.10.9":
             self.requires("aws-c-common/0.6.11")
             self.requires("aws-c-cal/0.5.11")
         else:
-            self.requires("aws-c-common/0.6.19")
+            self.requires("aws-c-common/0.8.2")
             self.requires("aws-c-cal/0.5.13")
 
         if self.settings.os in ["Linux", "FreeBSD", "Android"]:
-            self.requires("s2n/1.3.9")
+            self.requires("s2n/1.3.15")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+                  destination=self.source_folder, strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["BUILD_TESTING"] = False
-        self._cmake.configure()
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_TESTING"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-io"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-io"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-io")

--- a/recipes/aws-c-io/all/test_package/conanfile.py
+++ b/recipes/aws-c-io/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/aws-c-io/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-c-io/all/test_v1_package/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(aws-c-io REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.c)
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 target_link_libraries(${PROJECT_NAME} AWS::aws-c-io)

--- a/recipes/aws-c-io/all/test_v1_package/conanfile.py
+++ b/recipes/aws-c-io/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/aws-c-io/config.yml
+++ b/recipes/aws-c-io/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.13.4":
+    folder: all
   "0.11.2":
     folder: all
   "0.10.20":


### PR DESCRIPTION
Specify library name and version:  **aws-c-io/***

- add version 0.13.4
- support conan v2
- update dependencies

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
