### PR TITLE
Add QArchive/2.1.1

### DIFF
--- a/recipes/qarchive/all/conandata.yml
+++ b/recipes/qarchive/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.1":
+    url: "https://github.com/antony-jr/QArchive/archive/v2.1.1.tar.gz"
+    sha256: "4ed51121a5bc9b5981d2fa3927f951a6a91ccca233d6b6dc4fef55b4ca5a2d92"
   "2.0.2":
     url: "https://github.com/antony-jr/QArchive/archive/v2.0.2.tar.gz"
     sha256: "f59207c0da2d68bbbdaca79751f08018226d3b587e3f97156b3aee994db018f6"
@@ -6,6 +9,11 @@ sources:
     url: "https://github.com/antony-jr/QArchive/archive/v2.0.1.tar.gz"
     sha256: "ee8e259795f4f991c0465c3d95cf018bea2a72e9a31f744f2344aaa43201f369"
 patches:
+  "2.1.1":
+    - patch_file: "patches/0001-cmake-conan-compatibility.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0003-export-symbols.patch"
+      base_path: "source_subfolder"
   "2.0.2":
     - patch_file: "patches/0001-cmake-conan-compatibility.patch"
       base_path: "source_subfolder"

--- a/recipes/qarchive/all/patches/0003-export-symbols.patch
+++ b/recipes/qarchive/all/patches/0003-export-symbols.patch
@@ -1,0 +1,16 @@
+--- a/include/qarchive_enums.hpp
++++ b/include/qarchive_enums.hpp
+@@ -1,11 +1,12 @@
+ #ifndef QARCHIVE_ENUMS_HPP_INCLUDED
+ #define QARCHIVE_ENUMS_HPP_INCLUDED
++#include "qarchive_global.hpp"
+ class QString;
+ namespace QArchive {
+ /* A function that converts the enum value to its variable
+  * name to be used by users.
+ */
+-QString errorCodeToString(short);
++QARCHIVE_EXPORT QString errorCodeToString(short);
+ 
+ /*
+  * Common error codes, these are most likely will be

--- a/recipes/qarchive/config.yml
+++ b/recipes/qarchive/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.1":
+    folder: all
   "2.0.2":
     folder: all
   "2.0.1":


### PR DESCRIPTION
Bumping version to 2.1.1 for QArchive.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
