### PR TITLE
Added latest versions (4.11.0 & 4.11.1) of antlr4--cppruntime

### DIFF
--- a/recipes/antlr4-cppruntime/all/CMakeLists.txt
+++ b/recipes/antlr4-cppruntime/all/CMakeLists.txt
@@ -1,7 +1,4 @@
 cmake_minimum_required(VERSION 3.0)
 project(cmake_wrapper)
 
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
 add_subdirectory(source_subfolder/runtime/Cpp)

--- a/recipes/antlr4-cppruntime/all/conandata.yml
+++ b/recipes/antlr4-cppruntime/all/conandata.yml
@@ -8,6 +8,12 @@ sources:
   "4.10.1":
     url: "https://github.com/antlr/antlr4/archive/refs/tags/4.10.1.tar.gz"
     sha256: "a320568b738e42735946bebc5d9d333170e14a251c5734e8b852ad1502efa8a2"
+  "4.11.0":
+    url: "https://github.com/antlr/antlr4/archive/refs/tags/4.11.0.tar.gz"
+    sha256: "317f4e745badd8b5272191c3a4fd34a183a242aef269c68a9b23a382590dd142"
+  "4.11.1":
+    url: "https://github.com/antlr/antlr4/archive/refs/tags/4.11.1.tar.gz"
+    sha256: "81f87f03bb83b48da62e4fc8bfdaf447efb9fb3b7f19eb5cbc37f64e171218cf"
 patches:
   "4.9.3":
     - patch_file: "patches/0001-update-cmakelist.patch"

--- a/recipes/antlr4-cppruntime/all/conanfile.py
+++ b/recipes/antlr4-cppruntime/all/conanfile.py
@@ -28,10 +28,10 @@ class Antlr4CppRuntimeConan(ConanFile):
     short_paths = True
 
     compiler_required_cpp17 = {
-            "Visual Studio": "16",
-            "gcc": "7",
-            "clang": "5",
-            "apple-clang": "9.1"
+        "Visual Studio": "16",
+        "gcc": "7",
+        "clang": "5",
+        "apple-clang": "9.1"
     }
 
 
@@ -62,11 +62,6 @@ class Antlr4CppRuntimeConan(ConanFile):
             self.requires("libuuid/1.0.3")
 
     def validate(self):
-        if str(self.settings.arch).startswith("arm"):
-            raise ConanInvalidConfiguration("arm architectures are not supported")
-            # Need to deal with missing libuuid on Arm.
-            # So far ANTLR delivers macOS binary package.
-
         compiler = self.settings.compiler
         compiler_version = tools.Version(self.settings.compiler.version)
         antlr_version = tools.Version(self.version)

--- a/recipes/antlr4-cppruntime/config.yml
+++ b/recipes/antlr4-cppruntime/config.yml
@@ -5,3 +5,7 @@ versions:
     folder: all
   "4.10.1":
     folder: all
+  "4.11.0":
+    folder: all
+  "4.11.1":
+    folder: all


### PR DESCRIPTION
antlr4-cppruntime/4.11.0
antlr4-cppruntime/4.11.1

I have added two most recent versions of antlr4 runtime. Also I have removed the restriction for arm builds. Originally author [mentioned](https://groups.google.com/g/antlr-discussion/c/e54bXs0fSfI) that it is broken but it works for me locally so I enabled it and want to run it on the build server.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
