### PR TITLE
gcem: add version 1.16.0

### DIFF
--- a/recipes/gcem/all/conandata.yml
+++ b/recipes/gcem/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.16.0":
+    url: "https://github.com/kthohr/gcem/archive/v1.16.0.tar.gz"
+    sha256: "119c742b9371c0adc7d9cd710c3cbc575459a98fb63f6be4c636215dcf8404ce"
   "1.14.1":
     url: "https://github.com/kthohr/gcem/archive/v1.14.1.tar.gz"
     sha256: "fd0860e89f47eeddf5a2280dd6fb3f9b021ce36fe8798116b3f703fa0e01409d"

--- a/recipes/gcem/config.yml
+++ b/recipes/gcem/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.16.0":
+    folder: all
   "1.14.1":
     folder: all
   "1.13.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **gcem/1.16.0**



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
