### PR TITLE
(#13323) Bump perfetto to v30.0

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -29,6 +29,9 @@ sources:
   "27.1":
     url: https://github.com/google/perfetto/archive/refs/tags/v27.1.tar.gz
     sha256: 9edbafd6e2d9feaced4c0153e2f48dbb1da38429c5b1b17dfee70a91fd3101b2
+  "30.0":
+    url: https://github.com/google/perfetto/archive/refs/tags/v30.0.tar.gz
+    sha256: d1883793a2adb2a4105fc083478bf781badd566d72da45caa99095b61f938a2e
 
 patches:
   "20.1":

--- a/recipes/perfetto/config.yml
+++ b/recipes/perfetto/config.yml
@@ -19,3 +19,5 @@ versions:
     folder: all
   "27.1":
     folder: all
+  "30.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **perfetto/30.0**

```
v30.0 - 2022-10-06:
  Trace Processor:
    * Fixed parsing of "R+" (preempted) and "I" (idle kernel thread) end states
      of sched_switch events, collected on Linux kernels v4.14 and above.
      Previously, preemption was not recognised, and idle was reported as
      "x" (task dead). See commit c60a630cfe0.
    * Add support for parsing sys_write syscalls.
    * Remove the thread_slice table: all columns have moved to the slice table
      and thread_slice exists as a view for backwards compatibility. This view
      will also be removed in the future
    * Add Base64 encode SQL function.
    * Add support for importing function graph ftrace events.
    * Add support for importing V4L2 ftrace events.
    * Add support for importing virtio-video ftrace events.
  UI:
    * Fix downloading profiles from flamegraphs.
    * Enable Pivot table support by default.
  SDK:
    * Add support for disallowing concurrent tracing sessions.
```

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
