### PR TITLE
aws-c-http: add version 0.6.22 and support conan v2

### DIFF
--- a/recipes/aws-c-http/all/CMakeLists.txt
+++ b/recipes/aws-c-http/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(cmake_wrapper LANGUAGES C)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory(source_subfolder)

--- a/recipes/aws-c-http/all/conandata.yml
+++ b/recipes/aws-c-http/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.21":
+    url: "https://github.com/awslabs/aws-c-http/archive/v0.6.21.tar.gz"
+    sha256: "2a7c254bcd51a3a466b9f6905444a997dc6bf837d6224cb9ad447a765f9b6d44"
   "0.6.13":
     url: "https://github.com/awslabs/aws-c-http/archive/v0.6.13.tar.gz"
     sha256: "8c69f8fc58b7073039e598383da3e1fd9b23f392cb992dbe769a7b80f342dbaf"

--- a/recipes/aws-c-http/all/conandata.yml
+++ b/recipes/aws-c-http/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.6.21":
-    url: "https://github.com/awslabs/aws-c-http/archive/v0.6.21.tar.gz"
-    sha256: "2a7c254bcd51a3a466b9f6905444a997dc6bf837d6224cb9ad447a765f9b6d44"
+  "0.6.22":
+    url: "https://github.com/awslabs/aws-c-http/archive/v0.6.22.tar.gz"
+    sha256: "a178fd04bd1618469cd21afc5b84cbe436d1f9d9e036fefbd3a8f00356da4d4c"
   "0.6.13":
     url: "https://github.com/awslabs/aws-c-http/archive/v0.6.13.tar.gz"
     sha256: "8c69f8fc58b7073039e598383da3e1fd9b23f392cb992dbe769a7b80f342dbaf"

--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -1,17 +1,17 @@
+from conan import ConanFile
+from conan.tools.files import get, copy, rmdir
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
-from conans import ConanFile, CMake, tools
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.52.0"
 
 class AwsCHttp(ConanFile):
     name = "aws-c-http"
     description = "C99 implementation of the HTTP/1.1 and HTTP/2 specifications"
-    topics = ("aws", "amazon", "cloud", "http", "http2", )
+    license = "Apache-2.0",
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-http"
-    license = "Apache-2.0",
-    exports_sources = "CMakeLists.txt"
-    generators = "cmake", "cmake_find_package"
+    topics = ("aws", "amazon", "cloud", "http", "http2", )
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -22,48 +22,55 @@ class AwsCHttp(ConanFile):
         "fPIC": True,
     }
 
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.cppstd
-        del self.settings.compiler.libcxx
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.19")
-        self.requires("aws-c-compression/0.2.14")
-        self.requires("aws-c-io/0.10.20")
+        self.requires("aws-c-common/0.8.2")
+        self.requires("aws-c-compression/0.2.15")
+        self.requires("aws-c-io/0.13.4")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+                  destination=self.source_folder, strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["BUILD_TESTING"] = False
-        self._cmake.configure()
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_TESTING"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-http"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-http"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-http")

--- a/recipes/aws-c-http/all/test_package/CMakeLists.txt
+++ b/recipes/aws-c-http/all/test_package/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
 find_package(aws-c-http REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} AWS::aws-c-http)
+target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-http)

--- a/recipes/aws-c-http/all/test_package/conanfile.py
+++ b/recipes/aws-c-http/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/aws-c-http/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-c-http/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(aws-c-http REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-http)

--- a/recipes/aws-c-http/all/test_v1_package/conanfile.py
+++ b/recipes/aws-c-http/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/aws-c-http/config.yml
+++ b/recipes/aws-c-http/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.21":
+    folder: all
   "0.6.13":
     folder: all
   "0.6.10":

--- a/recipes/aws-c-http/config.yml
+++ b/recipes/aws-c-http/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.6.21":
+  "0.6.22":
     folder: all
   "0.6.13":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **aws-c-http/***


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
