### PR TITLE
aws-c-event-stream: add version 0.2.15 and support conan v2

### DIFF
--- a/recipes/aws-c-event-stream/all/CMakeLists.txt
+++ b/recipes/aws-c-event-stream/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.0)
-project(cmake_wrapper LANGUAGES C)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-add_subdirectory(source_subfolder)

--- a/recipes/aws-c-event-stream/all/conandata.yml
+++ b/recipes/aws-c-event-stream/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.15":
+    url: "https://github.com/awslabs/aws-c-event-stream/archive/v0.2.15.tar.gz"
+    sha256: "4ff2ada07ede3c6afa4b8e6e20de541e717038307f29b38c27efa7c4d875ee26"
   "0.2.12":
     url: "https://github.com/awslabs/aws-c-event-stream/archive/v0.2.12.tar.gz"
     sha256: "cc4ebfe715d8df5b9e3f4a3ce9b67d5f480017a7ebbbfa1d5e64ea53ec672580"
@@ -13,7 +16,5 @@ sources:
     sha256: "f1b423a487b5d6dca118bfc0d0c6cc596dc476b282258a3228e73a8f730422d4"
 patches:
   "0.1.5":
-    - base_path: "source_subfolder"
-      patch_file: "patches/0001-disable-tests-bin.patch"
-    - base_path: "source_subfolder"
-      patch_file: "patches/0002-use-PROJECT_SOURCE_DIR.patch"
+    - patch_file: "patches/0001-disable-tests-bin.patch"
+    - patch_file: "patches/0002-use-PROJECT_SOURCE_DIR.patch"

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -1,18 +1,18 @@
-from conans import CMake, ConanFile, tools
+from conan import ConanFile
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.43.0"
-
+required_conan_version = ">=1.52.0"
 
 class AwsCEventStream(ConanFile):
     name = "aws-c-event-stream"
     description = "C99 implementation of the vnd.amazon.eventstream content-type"
-    topics = ("aws", "eventstream", "content", )
+    license = "Apache-2.0",
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-event-stream"
-    license = "Apache-2.0",
-    exports_sources = "CMakeLists.txt", "aws_eventstream_target.cmake", "patches/*"
-    generators = "cmake", "cmake_find_package"
+    topics = ("aws", "eventstream", "content", )
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -23,11 +23,8 @@ class AwsCEventStream(ConanFile):
         "fPIC": True,
     }
 
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -35,41 +32,53 @@ class AwsCEventStream(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.cppstd
-        del self.settings.compiler.libcxx
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("aws-checksums/0.1.12")
-        self.requires("aws-c-common/0.6.19")
-        if tools.Version(self.version) >= "0.2":
-            self.requires("aws-c-io/0.11.2")
+        self.requires("aws-checksums/0.1.13")
+        self.requires("aws-c-common/0.8.2")
+        if Version(self.version) >= "0.2":
+            self.requires("aws-c-io/0.13.4")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+                  destination=self.source_folder, strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["BUILD_BINARIES"] = False
-        self._cmake.definitions["BUILD_TESTING"] = False
-        self._cmake.configure()
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_BINARIES"] = False
+        tc.variables["BUILD_TESTING"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
 
-        tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-event-stream"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-event-stream"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-event-stream")
@@ -82,5 +91,5 @@ class AwsCEventStream(ConanFile):
         self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package_multi"] = "aws-c-event-stream"
         self.cpp_info.components["aws-c-event-stream-lib"].libs = ["aws-c-event-stream"]
         self.cpp_info.components["aws-c-event-stream-lib"].requires = ["aws-c-common::aws-c-common-lib", "aws-checksums::aws-checksums"]
-        if tools.Version(self.version) >= "0.2":
+        if Version(self.version) >= "0.2":
             self.cpp_info.components["aws-c-event-stream-lib"].requires.append("aws-c-io::aws-c-io-lib")

--- a/recipes/aws-c-event-stream/all/test_package/CMakeLists.txt
+++ b/recipes/aws-c-event-stream/all/test_package/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
 find_package(aws-c-event-stream REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} AWS::aws-c-event-stream)
+target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-event-stream)

--- a/recipes/aws-c-event-stream/all/test_package/conanfile.py
+++ b/recipes/aws-c-event-stream/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/aws-c-event-stream/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-c-event-stream/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(aws-c-event-stream REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-event-stream)

--- a/recipes/aws-c-event-stream/all/test_v1_package/conanfile.py
+++ b/recipes/aws-c-event-stream/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/aws-c-event-stream/config.yml
+++ b/recipes/aws-c-event-stream/config.yml
@@ -1,9 +1,11 @@
 versions:
+  "0.2.15":
+    folder: all
   "0.2.12":
     folder: all
   "0.2.11":
     folder: all
-  0.2.7:
+  "0.2.7":
     folder: all
-  0.1.5:
+  "0.1.5":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **aws-c-event-stream/***


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
