### PR TITLE
libpng 1.6.38: pass PNG_EXECUTABLES=OFF + fix v2 linter error

### DIFF
--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.scm import Version
 from conan.tools.files import apply_conandata_patches, get, rmdir, replace_in_file, copy, rm
 from conan.tools.microsoft import is_msvc
-from conan.tools.build.cross_building import cross_building
+from conan.tools.build import cross_building
 from conan.tools.apple import is_apple_os
 from conan.errors import ConanInvalidConfiguration
 import os

--- a/recipes/libpng/all/conanfile.py
+++ b/recipes/libpng/all/conanfile.py
@@ -149,6 +149,9 @@ class LibpngConan(ConanFile):
             tc.variables["PNG_INTEL_SSE"] = self._neon_msa_sse_vsx_mapping[str(self.options.sse)]
         if self._has_vsx_support:
             tc.variables["PNG_POWERPC_VSX"] = self._neon_msa_sse_vsx_mapping[str(self.options.vsx)]
+        if Version(self.version) >= "1.6.38":
+            tc.variables["PNG_EXECUTABLES"] = False
+
         tc.cache_variables["CMAKE_MACOSX_BUNDLE"] = False
         tc.generate()
         tc = CMakeDeps(self)


### PR DESCRIPTION
Specify library name and version:  **libpng/1.6.38**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

v1.6.38 introduced new CMake variable `PNG_EXECUTABLES`, now building executables can be disabled as they're removed from package anyway.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
