### PR TITLE
Declare package_type and prevent Conan 2 errors with self.env_info

### DIFF
--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -1,6 +1,7 @@
-from conan import ConanFile
+from conan import ConanFile, conan_version
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.46.0"
@@ -8,6 +9,7 @@ required_conan_version = ">=1.46.0"
 
 class NinjaConan(ConanFile):
     name = "ninja"
+    package_type = "application"
     description = "Ninja is a small build system with a focus on speed"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
@@ -47,5 +49,6 @@ class NinjaConan(ConanFile):
         self.conf_info.define("tools.cmake.cmaketoolchain:generator", "Ninja")
 
         # TODO: to remove in conan v2
-        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
-        self.env_info.CONAN_CMAKE_GENERATOR = "Ninja"
+        if Version(conan_version).major < 2:
+            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+            self.env_info.CONAN_CMAKE_GENERATOR = "Ninja"

--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.files import copy, get
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.46.0"
+required_conan_version = ">=1.52.0"
 
 
 class NinjaConan(ConanFile):


### PR DESCRIPTION
Specify library name and version:  **Ninja/1.11.1**

Added declaration of package_type to highlight that Ninja is an "application"
Added conditional logic around self.env_info settings to prevent errors when using Conan 2.0

fixes #13503

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
