### PR TITLE
aws-c-cal: add version 0.5.20

### DIFF
--- a/recipes/aws-c-cal/all/conandata.yml
+++ b/recipes/aws-c-cal/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.5.20":
+    url: "https://github.com/awslabs/aws-c-cal/archive/v0.5.20.tar.gz"
+    sha256: "acc352359bd06f8597415c366cf4ec4f00d0b0da92d637039a73323dd55b6cd0"
   "0.5.19":
     url: "https://github.com/awslabs/aws-c-cal/archive/refs/tags/v0.5.19.tar.gz"
     sha256: "23452ab7960c480f1ec0a96ac55bde32d7d27c4a664baeadc248923b19c12086"
@@ -15,6 +18,11 @@ sources:
     url: "https://github.com/awslabs/aws-c-cal/archive/v0.5.11.tar.gz"
     sha256: "ef46e121b2231a0b19afce8af4b32d77501df4d470e926990918456636cd83c0"
 patches:
+  "0.5.20":
+    - patch_file: "patches/0002-apple-corefoundation-0.5.13.patch"
+      patch_description: "Link to CoreFoundation on Apple"
+      patch_type: "backport"
+      patch_source: "https://github.com/awslabs/aws-c-cal/pull/126"
   "0.5.19":
     - patch_file: "patches/0002-apple-corefoundation-0.5.13.patch"
       patch_description: "Link to CoreFoundation on Apple"

--- a/recipes/aws-c-cal/config.yml
+++ b/recipes/aws-c-cal/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.5.20":
+    folder: all
   "0.5.19":
     folder: all
   "0.5.17":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **aws-c-cal/0.5.20**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
