### PR TITLE
sdl_image: build improvements for ImageIO option for Apple platforms

### DIFF
--- a/recipes/sdl_image/all/CMakeLists.txt
+++ b/recipes/sdl_image/all/CMakeLists.txt
@@ -93,6 +93,16 @@ if(WEBP)
     target_link_libraries(${PROJECT_NAME} PRIVATE WebP::webp)
 endif()
 
+if(APPLE AND IMAGEIO AND BUILD_SHARED_LIBS)
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        "-framework ApplicationServices"
+        "-framework CoreFoundation"
+        "-framework CoreGraphics"
+        "-framework Foundation"
+        "-framework ImageIO"
+    )
+endif()
+
 install(TARGETS ${PROJECT_NAME}
     ARCHIVE DESTINATION "lib"
     LIBRARY DESTINATION "lib"

--- a/recipes/sdl_image/all/CMakeLists.txt
+++ b/recipes/sdl_image/all/CMakeLists.txt
@@ -14,7 +14,7 @@ macro(add_image_option type)
 endmacro()
 
 if(APPLE)
-    option(IMAGEIO "use native Mac OS X frameworks for loading images" ON)
+    option(IMAGEIO "use native Apple frameworks for loading images" ON)
     if(IMAGEIO)
         set(IMAGEIO_SOURCE "${SDL_IMAGE_SRC_DIR}/IMG_ImageIO.m")
     else()
@@ -94,12 +94,22 @@ if(WEBP)
 endif()
 
 if(APPLE AND IMAGEIO AND BUILD_SHARED_LIBS)
+    if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
+        set(extraFrameworks
+            "-framework ApplicationServices"
+        )
+    else()
+        set(extraFrameworks
+            "-framework MobileCoreServices"
+            "-framework UIKit"
+        )
+    endif()
     target_link_libraries(${PROJECT_NAME} PRIVATE
-        "-framework ApplicationServices"
         "-framework CoreFoundation"
         "-framework CoreGraphics"
         "-framework Foundation"
         "-framework ImageIO"
+        ${extraFrameworks}
     )
 endif()
 

--- a/recipes/sdl_image/all/conanfile.py
+++ b/recipes/sdl_image/all/conanfile.py
@@ -84,7 +84,7 @@ class SDLImageConan(ConanFile):
         if self.options.with_libtiff:
             self.requires("libtiff/4.4.0")
         if self.options.with_libjpeg:
-            self.requires("libjpeg/9d")
+            self.requires("libjpeg/9e")
         if self.options.with_libpng:
             self.requires("libpng/1.6.37")
         if self.options.with_libwebp:

--- a/recipes/sdl_image/all/conanfile.py
+++ b/recipes/sdl_image/all/conanfile.py
@@ -1,10 +1,11 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 import os
 
-required_conan_version = ">=1.47.0"
+required_conan_version = ">=1.51.3"
 
 
 class SDLImageConan(ConanFile):
@@ -60,7 +61,7 @@ class SDLImageConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if self.settings.os != "Macos":
+        if not is_apple_os(self):
             del self.options.imageio
 
     def configure(self):
@@ -169,9 +170,15 @@ class SDLImageConan(ConanFile):
             self.cpp_info.components["_sdl_image"].requires.append("libwebp::libwebp")
         if self.options.get_safe("imageio") and not self.options.shared:
             self.cpp_info.components["_sdl_image"].frameworks = [
-                "ApplicationServices",
                 "CoreFoundation",
                 "CoreGraphics",
                 "Foundation",
                 "ImageIO",
             ]
+            if self.settings.os == "Macos":
+                self.cpp_info.components["_sdl_image"].frameworks.append("ApplicationServices")
+            else:
+                self.cpp_info.components["_sdl_image"].frameworks.extend([
+                    "MobileCoreServices",
+                    "UIKit",
+                ])

--- a/recipes/sdl_image/all/conanfile.py
+++ b/recipes/sdl_image/all/conanfile.py
@@ -167,3 +167,11 @@ class SDLImageConan(ConanFile):
             self.cpp_info.components["_sdl_image"].requires.append("libpng::libpng")
         if self.options.with_libwebp:
             self.cpp_info.components["_sdl_image"].requires.append("libwebp::libwebp")
+        if self.options.get_safe("imageio") and not self.options.shared:
+            self.cpp_info.components["_sdl_image"].frameworks = [
+                "ApplicationServices",
+                "CoreFoundation",
+                "CoreGraphics",
+                "Foundation",
+                "ImageIO",
+            ]


### PR DESCRIPTION
Specify library name and version:  **sdl_image/2.0.5**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

- other Apple platforms can now be built against ImageIO
- fixed macOS shared build with ImageIO - required frameworks weren't linked
- added framework dependencies for consumers of static lib

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
