### PR TITLE
wayland: Fix missing libffi and cross-compilation

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -3,12 +3,13 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import copy, get, replace_in_file, rmdir
+from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.52.0"
 
 
 class WaylandConan(ConanFile):
@@ -36,11 +37,12 @@ class WaylandConan(ConanFile):
         "enable_dtd_validation": True,
     }
 
-    generators = "PkgConfigDeps"
-
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
         try:
             del self.settings.compiler.libcxx
         except Exception:
@@ -52,18 +54,18 @@ class WaylandConan(ConanFile):
 
     def requirements(self):
         if self.options.enable_libraries:
-            self.requires("libffi/3.4.2")
+            self.requires("libffi/3.4.3")
         if self.options.enable_dtd_validation:
             self.requires("libxml2/2.9.14")
-        self.requires("expat/2.4.8")
+        self.requires("expat/2.4.9")
 
     def validate(self):
         if self.info.settings.os != "Linux":
             raise ConanInvalidConfiguration("Wayland can be built on Linux only")
 
     def build_requirements(self):
-        self.tool_requires("meson/0.63.2")
-        self.tool_requires("pkgconf/1.7.4")
+        self.tool_requires("meson/0.63.3")
+        self.tool_requires("pkgconf/1.9.3")
         if cross_building(self):
             self.tool_requires(self.ref)
 
@@ -74,12 +76,21 @@ class WaylandConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        pkg_config_deps = PkgConfigDeps(self)
+        if cross_building(self):
+            pkg_config_deps.build_context_activated = ["wayland"]
+        elif self.dependencies["expat"].is_build_context:  # wayland is being built as build_require
+                # If wayland is the build_require, all its dependencies are treated as build_requires
+                pkg_config_deps.build_context_activated = [dep.ref.name for _, dep in self.dependencies.host.items()]
+        pkg_config_deps.generate()
         tc = MesonToolchain(self)
         tc.project_options["libdir"] = "lib"
         tc.project_options["datadir"] = "res"
         tc.project_options["libraries"] = self.options.enable_libraries
         tc.project_options["dtd_validation"] = self.options.enable_dtd_validation
         tc.project_options["documentation"] = False
+        if cross_building(self):
+            tc.project_options["build.pkg_config_path"] = self.generators_folder
         if Version(self.version) >= "1.18.91":
             tc.project_options["scanner"] = True
         tc.generate()
@@ -93,14 +104,6 @@ class WaylandConan(ConanFile):
     def _patch_sources(self):
         replace_in_file(self, os.path.join(self.source_folder, "meson.build"),
                         "subdir('tests')", "#subdir('tests')")
-
-        if cross_building(self):
-            replace_in_file(self, f"{self.source_folder}/src/meson.build",
-                            "scanner_dep = dependency('wayland-scanner', native: true, version: meson.project_version())",
-                                "# scanner_dep = dependency('wayland-scanner', native: true, version: meson.project_version())")
-            replace_in_file(self, f"{self.source_folder}/src/meson.build",
-                            "wayland_scanner_for_build = find_program(scanner_dep.get_variable(pkgconfig: 'wayland_scanner'))",
-                                "wayland_scanner_for_build = find_program('wayland-scanner')")
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
Now that Conan 1.52.0 is available, this can be done properly.

Specify library name and version:  **wayland/***

Includes changes from PR #12781.

Fixes #13359.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
