### PR TITLE
jom: modernize

### DIFF
--- a/recipes/jom/all/conanfile.py
+++ b/recipes/jom/all/conanfile.py
@@ -34,13 +34,13 @@ class JomInstallerConan(ConanFile):
     def package(self):
         self.copy("LICENSE.GPL", dst= 'licenses', src='')
         self.copy("*.exe", dst="bin", src="")
-        
+
     def package_info(self):
         self.cpp_info.frameworkdirs = []
         self.cpp_info.libdirs = []
         self.cpp_info.resdirs = []
         self.cpp_info.includedirs = []
-        
+
         bin_folder = os.path.join(self.package_folder, "bin")
         # In case need to find packaged tools when building a package
         self.buildenv_info.append("PATH", bin_folder)

--- a/recipes/jom/all/conanfile.py
+++ b/recipes/jom/all/conanfile.py
@@ -1,7 +1,9 @@
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.files import get, download
+from conan.errors import ConanInvalidConfiguration
 import os
 
+required_conan_version = ">=1.47.0"
 
 class JomInstallerConan(ConanFile):
     name = "jom"
@@ -9,21 +11,40 @@ class JomInstallerConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "http://wiki.qt.io/Jom"
     license = "GPL-3.0"
-    topics = ("conan", "jom", "build", "makefile", "make")
+    topics = ("build", "makefile", "make")
 
-    settings = "os"
+    settings = "os", "arch", "compiler", "build_type"
 
-    def configure(self):
+    # not needed but supress warning message from conan commands
+    def layout(self):
+        pass
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.build_type
+
+    def validate(self):
         if self.settings.os != "Windows":
             raise ConanInvalidConfiguration("Only Windows supported")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        tools.download('https://code.qt.io/cgit/qt-labs/jom.git/plain/LICENSE.GPL?h=v%s' % self.version, filename='LICENSE.GPL')
+        get(self, **self.conan_data["sources"][self.version])
+        download(self, f'https://code.qt.io/cgit/qt-labs/jom.git/plain/LICENSE.GPL?h=v{self.version}', filename='LICENSE.GPL')
 
     def package(self):
         self.copy("LICENSE.GPL", dst= 'licenses', src='')
         self.copy("*.exe", dst="bin", src="")
         
     def package_info(self):
-        self.env_info.path.append(os.path.join(self.package_folder, "bin"))
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []
+        self.cpp_info.includedirs = []
+        
+        bin_folder = os.path.join(self.package_folder, "bin")
+        # In case need to find packaged tools when building a package
+        self.buildenv_info.append("PATH", bin_folder)
+        # In case need to find packaged tools at runtime
+        self.runenv_info.append("PATH", bin_folder)
+        # TODO: Legacy, to be removed on Conan 2.0
+        self.env_info.PATH.append(bin_folder)


### PR DESCRIPTION
Specify library name and version:  **jom/***

I think this is the only requirement of qt5 not yet transitioned to the new GCC11 epoch

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
