### PR TITLE
zlib: Fix CVE-2022-37434

### DIFF
--- a/recipes/zlib/all/conandata.yml
+++ b/recipes/zlib/all/conandata.yml
@@ -9,11 +9,11 @@ patches:
   "1.2.12":
     - patch_file: "patches/0001-fix-cmake.patch"
     - patch_file: "patches/0002-gzguts-xcode12-compile-fix.patch"
-      # CVE-2022-37434 https://github.com/madler/zlib/issues/686
+    # CVE-2022-37434 https://github.com/madler/zlib/issues/686
     - patch_file: "patches/0004-Fix-a-bug-when-getting-a-gzip-header-extra-field-wit.patch"
     - patch_file: "patches/0005-Fix-extra-field-processing-bug-that-dereferences-NUL.patch"
   "1.2.11":
     - patch_file: "patches/0001-fix-cmake.patch"
     - patch_file: "patches/0002-gzguts-xcode12-compile-fix.patch"
-      # https://github.com/madler/zlib/issues/268
+    # https://github.com/madler/zlib/issues/268
     - patch_file: "patches/0003-gzguts-fix-widechar-condition.patch"

--- a/recipes/zlib/all/conandata.yml
+++ b/recipes/zlib/all/conandata.yml
@@ -9,6 +9,9 @@ patches:
   "1.2.12":
     - patch_file: "patches/0001-fix-cmake.patch"
     - patch_file: "patches/0002-gzguts-xcode12-compile-fix.patch"
+      # CVE-2022-37434 https://github.com/madler/zlib/issues/686
+    - patch_file: "patches/0004-Fix-a-bug-when-getting-a-gzip-header-extra-field-wit.patch"
+    - patch_file: "patches/0005-Fix-extra-field-processing-bug-that-dereferences-NUL.patch"
   "1.2.11":
     - patch_file: "patches/0001-fix-cmake.patch"
     - patch_file: "patches/0002-gzguts-xcode12-compile-fix.patch"

--- a/recipes/zlib/all/patches/0004-Fix-a-bug-when-getting-a-gzip-header-extra-field-wit.patch
+++ b/recipes/zlib/all/patches/0004-Fix-a-bug-when-getting-a-gzip-header-extra-field-wit.patch
@@ -1,0 +1,35 @@
+From eff308af425b67093bab25f80f1ae950166bece1 Mon Sep 17 00:00:00 2001
+From: Mark Adler <fork@madler.net>
+Date: Sat, 30 Jul 2022 15:51:11 -0700
+Subject: [PATCH] Fix a bug when getting a gzip header extra field with
+ inflate().
+
+If the extra field was larger than the space the user provided with
+inflateGetHeader(), and if multiple calls of inflate() delivered
+the extra header data, then there could be a buffer overflow of the
+provided space. This commit assures that provided space is not
+exceeded.
+---
+ inflate.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/inflate.c b/inflate.c
+index 7be8c63..7a72897 100644
+--- a/inflate.c
++++ b/inflate.c
+@@ -763,9 +763,10 @@ int flush;
+                 copy = state->length;
+                 if (copy > have) copy = have;
+                 if (copy) {
++                    len = state->head->extra_len - state->length;
+                     if (state->head != Z_NULL &&
+-                        state->head->extra != Z_NULL) {
+-                        len = state->head->extra_len - state->length;
++                        state->head->extra != Z_NULL &&
++                        len < state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);
+-- 
+2.25.1
+

--- a/recipes/zlib/all/patches/0005-Fix-extra-field-processing-bug-that-dereferences-NUL.patch
+++ b/recipes/zlib/all/patches/0005-Fix-extra-field-processing-bug-that-dereferences-NUL.patch
@@ -1,0 +1,32 @@
+From 1eb7682f845ac9e9bf9ae35bbfb3bad5dacbd91d Mon Sep 17 00:00:00 2001
+From: Mark Adler <fork@madler.net>
+Date: Mon, 8 Aug 2022 10:50:09 -0700
+Subject: [PATCH] Fix extra field processing bug that dereferences NULL
+ state->head.
+
+The recent commit to fix a gzip header extra field processing bug
+introduced the new bug fixed here.
+---
+ inflate.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/inflate.c b/inflate.c
+index 7a72897..2a3c4fe 100644
+--- a/inflate.c
++++ b/inflate.c
+@@ -763,10 +763,10 @@ int flush;
+                 copy = state->length;
+                 if (copy > have) copy = have;
+                 if (copy) {
+-                    len = state->head->extra_len - state->length;
+                     if (state->head != Z_NULL &&
+                         state->head->extra != Z_NULL &&
+-                        len < state->head->extra_max) {
++                        (len = state->head->extra_len - state->length) <
++                            state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);
+-- 
+2.25.1
+


### PR DESCRIPTION
Apply CVE fix and a fix of CVE fix

https://github.com/madler/zlib/issues/686
https://github.com/openwrt/openwrt/issues/10582

Specify library name and version:  **zlib/1.2.12**

https://nvd.nist.gov/vuln/detail/CVE-2022-37434

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
