### PR TITLE
libmysqlclient: remove wrong options

### DIFF
--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -24,14 +24,10 @@ class LibMysqlClientCConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "with_ssl": [True, False],
-        "with_zlib": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_ssl": True,
-        "with_zlib": True,
     }
 
     short_paths = True
@@ -71,10 +67,8 @@ class LibMysqlClientCConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        if self.options.with_ssl:
-            self.requires("openssl/1.1.1q")
-        if self.options.with_zlib:
-            self.requires("zlib/1.2.12")
+        self.requires("openssl/1.1.1q")
+        self.requires("zlib/1.2.12")
         if self._with_zstd:
             self.requires("zstd/1.5.2")
         if self._with_lz4:
@@ -223,11 +217,9 @@ class LibMysqlClientCConan(ConanFile):
         if is_msvc(self):
             cmake.definitions["WINDOWS_RUNTIME_MD"] = "MD" in msvc_runtime_flag(self)
 
-        if self.options.with_ssl:
-            cmake.definitions["WITH_SSL"] = self.deps_cpp_info["openssl"].rootpath
+        cmake.definitions["WITH_SSL"] = self.deps_cpp_info["openssl"].rootpath
 
-        if self.options.with_zlib:
-            cmake.definitions["WITH_ZLIB"] = "system"
+        cmake.definitions["WITH_ZLIB"] = "system"
         cmake.configure(source_dir=self._source_subfolder)
         return cmake
 

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -24,10 +24,14 @@ class LibMysqlClientCConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_ssl": [True, False, "deprecated"],
+        "with_zlib": [True, False, "deprecated"],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_ssl": "deprecated",
+        "with_zlib": "deprecated",
     }
 
     short_paths = True
@@ -65,7 +69,15 @@ class LibMysqlClientCConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
+    if self.options.with_ssl != "deprecated":
+        self.output.warn("with_ssl option is deprecated, do not use anymore. SSL cannot be disabled")
+    if self.options.with_zlib != "deprecated":
+        self.output.warn("with_zlib option is deprecated, do not use anymore. Zlib cannot be disabled")
 
+    def package_id(self):
+        del self.info.options.with_ssl
+        del self.info.options.with_zlib
+        
     def requirements(self):
         self.requires("openssl/1.1.1q")
         self.requires("zlib/1.2.12")

--- a/recipes/libmysqlclient/all/conanfile.py
+++ b/recipes/libmysqlclient/all/conanfile.py
@@ -69,10 +69,10 @@ class LibMysqlClientCConan(ConanFile):
     def configure(self):
         if self.options.shared:
             del self.options.fPIC
-    if self.options.with_ssl != "deprecated":
-        self.output.warn("with_ssl option is deprecated, do not use anymore. SSL cannot be disabled")
-    if self.options.with_zlib != "deprecated":
-        self.output.warn("with_zlib option is deprecated, do not use anymore. Zlib cannot be disabled")
+        if self.options.with_ssl != "deprecated":
+            self.output.warn("with_ssl option is deprecated, do not use anymore. SSL cannot be disabled")
+        if self.options.with_zlib != "deprecated":
+            self.output.warn("with_zlib option is deprecated, do not use anymore. Zlib cannot be disabled")
 
     def package_id(self):
         del self.info.options.with_ssl


### PR DESCRIPTION
Specify library name and version:  **libmysqlclient/***

fixes https://github.com/conan-io/conan-center-index/issues/13413

zlib and openssl can actually not be disabled:
- https://github.com/mysql/mysql-server/blob/mysql-8.0.30/cmake/ssl.cmake#L23
- https://github.com/mysql/mysql-server/blob/mysql-8.0.30/cmake/zlib.cmake#L24

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
