### PR TITLE
[sqlite3] Refactor handling of math library

### DIFF
--- a/recipes/sqlite3/all/CMakeLists.txt
+++ b/recipes/sqlite3/all/CMakeLists.txt
@@ -150,9 +150,14 @@ if(NOT OMIT_LOAD_EXTENSION)
 endif()
 
 if(ENABLE_FTS5 OR ENABLE_MATH_FUNCTIONS)
-    find_library(MATH_LIBRARY m)
-    if(MATH_LIBRARY)
-        target_link_libraries(${PROJECT_NAME}  PRIVATE ${MATH_LIBRARY})
+    include(CheckLibraryExists)
+    # Check if math functionality is on the separate 'libm' library,
+    # otherwise assume that it is already part of the C runtime.
+    # The `m` library is part of the compiler toolchain, this checks
+    # if the compiler can successfully link against the library.
+    check_library_exists(m log "" HAVE_MATH_LIBRARY)    
+    if(HAVE_MATH_LIBRARY)
+        target_link_libraries(${PROJECT_NAME} PRIVATE m)
     endif()
 endif()
 


### PR DESCRIPTION
When cross-building sqlite3 for Linux/arm64 on some systems `find_library` will fail to locate the `m` library, as seen in https://github.com/conan-io/conan-center-index/issues/13418. 

The math library `libm` is part of the compiler toolchain (in this case `glibc`) and the compiler should know to correctly handle `-lm`. For some compilers/toolchains, `libm` is not a separate library, but is part of the implicitly linked C runtime.  In these cases, `-lm` may be a no-op for those compilers.

This PR uses the `check_library_exists` macro to check if the compiler will accept `-lm` for a file that calls the `log()` function - if this succeeds, then we conditionally link against `m` directly. This is a similar approach to what CMake does internally to locate the "threads" library - by testing the compiler, rather than by `find_library`. 

This should fix the issue of linking when cross-building, regardless of whether `CMAKE_SYSROOT` is defined or not, while still being correct on Linux, and now possibly other platforms with toolchains where there is no separate libm. 


Close https://github.com/conan-io/conan-center-index/issues/13418