### PR TITLE
luau: add version 0.548 and support conan v2

### DIFF
--- a/recipes/luau/all/CMakeLists.txt
+++ b/recipes/luau/all/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(conan_wrapper CXX)
+project(conan_wrapper LANGUAGES CXX)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 

--- a/recipes/luau/all/CMakeLists.txt
+++ b/recipes/luau/all/CMakeLists.txt
@@ -1,12 +1,9 @@
 cmake_minimum_required(VERSION 3.8)
 project(conan_wrapper CXX)
 
-include(conanbuildinfo.cmake)
-conan_basic_setup(TARGETS KEEP_RPATHS)
-
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-add_subdirectory(source_subfolder)
+add_subdirectory(${LUAU_SRC_DIR})
 
 ## installer
 include(GNUInstallDirs)
@@ -17,7 +14,7 @@ install(
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install(DIRECTORY "source_subfolder/Ast/include/Luau" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(DIRECTORY "${LUAU_SRC_DIR}/Ast/include/Luau" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 install(
     TARGETS Luau.Compiler
@@ -26,9 +23,9 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-install(DIRECTORY "source_subfolder/Compiler/include/Luau" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(DIRECTORY "${LUAU_SRC_DIR}/Compiler/include/Luau" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(FILES
-    "source_subfolder/Compiler/include/luacode.h"
+    "${LUAU_SRC_DIR}/Compiler/include/luacode.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 install(
@@ -37,7 +34,7 @@ install(
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install(DIRECTORY "source_subfolder/CodeGen/include/Luau" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(DIRECTORY "${LUAU_SRC_DIR}/CodeGen/include/Luau" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 
 install(
@@ -47,7 +44,7 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-install(DIRECTORY "source_subfolder/Analysis/include/Luau" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(DIRECTORY "${LUAU_SRC_DIR}/Analysis/include/Luau" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 install(
     TARGETS Luau.VM
@@ -57,9 +54,9 @@ install(
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 install(FILES
-    "source_subfolder/VM/include/lua.h"
-    "source_subfolder/VM/include/luaconf.h"
-    "source_subfolder/VM/include/lualib.h"
+    "${LUAU_SRC_DIR}/VM/include/lua.h"
+    "${LUAU_SRC_DIR}/VM/include/luaconf.h"
+    "${LUAU_SRC_DIR}/VM/include/lualib.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 if(LUAU_BUILD_CLI)

--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.548":
+    url: "https://github.com/Roblox/luau/archive/0.548.tar.gz"
+    sha256: "1ec0aa919955aaa2d88dbef115801681d3b4dbfa7a276435a03d20230918659c"
   "0.544":
     url: "https://github.com/Roblox/luau/archive/0.544.tar.gz"
     sha256: "c1e2d4e04fe6f191192d1570bd83f96531804fc484a0bc0e00b53248a01d7dee"
@@ -22,38 +25,27 @@ sources:
     sha256: "e6de36e83e9c537d92bcc94852ab498e3c15a310fd2c4cc4e21c616d8ae1a84f"
 
 patches:
+  "0.548":
+    - patch_file: "patches/0.536-0001-fix-cmake.patch"
+    - patch_file: "patches/0.536-0002-rename-lerp.patch"
   "0.544":
     - patch_file: "patches/0.536-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/0.536-0002-rename-lerp.patch"
-      base_path: "source_subfolder"
   "0.541":
     - patch_file: "patches/0.536-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/0.536-0002-rename-lerp.patch"
-      base_path: "source_subfolder"
   "0.540":
     - patch_file: "patches/0.536-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/0.536-0002-rename-lerp.patch"
-      base_path: "source_subfolder"
   "0.539":
     - patch_file: "patches/0.536-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/0.536-0002-rename-lerp.patch"
-      base_path: "source_subfolder"
   "0.538":
     - patch_file: "patches/0.536-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/0.536-0002-rename-lerp.patch"
-      base_path: "source_subfolder"
   "0.537":
     - patch_file: "patches/0.536-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/0.536-0002-rename-lerp.patch"
-      base_path: "source_subfolder"
   "0.536":
     - patch_file: "patches/0.536-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
     - patch_file: "patches/0.536-0002-rename-lerp.patch"
-      base_path: "source_subfolder"

--- a/recipes/luau/all/conanfile.py
+++ b/recipes/luau/all/conanfile.py
@@ -135,6 +135,8 @@ class LuauConan(ConanFile):
         self.cpp_info.components["CodeGen"].libs = ["Luau.CodeGen"]
         self.cpp_info.components["CodeGen"].set_property("cmake_target_name", "Luau::CodeGen")
         self.cpp_info.components["CodeGen"].requires = ["Ast"]
+        if Version(self.version) >= "0.548":
+            self.cpp_info.components["CodeGen"].requires.append("VM")
 
         if self.options.with_cli:
             bin_path = os.path.join(self.package_folder, "bin")

--- a/recipes/luau/all/conanfile.py
+++ b/recipes/luau/all/conanfile.py
@@ -12,7 +12,7 @@ required_conan_version = ">=1.52.0"
 
 class LuauConan(ConanFile):
     name = "luau"
-    description = "A fast, small, safe, gradually typed embeddable scripting language derived from Lua "
+    description = "A fast, small, safe, gradually typed embeddable scripting language derived from Lua"
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://luau-lang.org/"
@@ -38,7 +38,6 @@ class LuauConan(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            "Visual Studio": "16",
             "gcc": "8",
             "clang": "7",
             "apple-clang": "12",
@@ -73,7 +72,7 @@ class LuauConan(ConanFile):
             )
 
         if is_msvc(self) and self.options.shared:
-            raise ConanInvalidConfiguration("{} does not support shared build in MSVC".format(self.name))
+            raise ConanInvalidConfiguration(f"{self.ref} does not support shared build in MSVC")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
@@ -140,7 +139,7 @@ class LuauConan(ConanFile):
 
         if self.options.with_cli:
             bin_path = os.path.join(self.package_folder, "bin")
-            self.output.info("Appending PATH environment variable: {}".format(bin_path))
+            self.output.info(f"Appending PATH environment variable: {bin_path}")
             self.env_info.PATH.append(bin_path)
 
         if self.options.with_web:

--- a/recipes/luau/all/conanfile.py
+++ b/recipes/luau/all/conanfile.py
@@ -1,9 +1,14 @@
-from conans import ConanFile, CMake, tools
-from conan.tools.microsoft import is_msvc
-import os
-import functools
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import check_min_vs, is_msvc
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, replace_in_file
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 
-required_conan_version = ">=1.43.0"
+import os
+
+required_conan_version = ">=1.52.0"
 
 class LuauConan(ConanFile):
     name = "luau"
@@ -25,16 +30,23 @@ class LuauConan(ConanFile):
         "with_cli": False,
         "with_web": False,
     }
-    generators = "cmake"
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _minimum_cpp_standard(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "16",
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "12",
+        }
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -42,55 +54,56 @@ class LuauConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
 
-    @property
-    def _compiler_required_cpp17(self):
-        return {
-            "Visual Studio": "16",
-            "gcc": "8",
-            "clang": "7",
-            "apple-clang": "12.0",
-        }
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 17)
-
-        minimum_version = self._compiler_required_cpp17.get(str(self.settings.compiler), False)
-        if minimum_version:
-            if tools.Version(self.settings.compiler.version) < minimum_version:
-                raise tools.ConanInvalidConfiguration("{} requires C++17, which your compiler does not support.".format(self.name))
-        else:
-            self.output.warn("{0} requires C++17. Your compiler is unknown. Assuming it supports C++17.".format(self.name))
+        if self.info.settings.compiler.cppstd:
+            check_min_cppstd(self, self._minimum_cpp_standard)
+        check_min_vs(self, 191)
+        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
+        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support."
+            )
 
         if is_msvc(self) and self.options.shared:
-            raise tools.ConanInvalidConfiguration("{} does not support shared build in MSVC".format(self.name))
+            raise ConanInvalidConfiguration("{} does not support shared build in MSVC".format(self.name))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["LUAU_BUILD_CLI"] = self.options.with_cli
-        cmake.definitions["LUAU_BUILD_TESTS"] = False
-        cmake.definitions["LUAU_BUILD_WEB"] = self.options.with_web
-        cmake.definitions["LUAU_WERROR"] = False
-        cmake.definitions["LUAU_STATIC_CRT"] = False
-        cmake.configure()
-        return cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["LUAU_BUILD_CLI"] = self.options.with_cli
+        tc.variables["LUAU_BUILD_TESTS"] = False
+        tc.variables["LUAU_BUILD_WEB"] = self.options.with_web
+        tc.variables["LUAU_WERROR"] = False
+        tc.variables["LUAU_STATIC_CRT"] = False
+        tc.variables["LUAU_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        tc.generate()
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+        if Version(self.version) >= "0.548" and self.options.shared:
+            replace_in_file(self, os.path.join(self.source_folder, "VM", "include", "luaconf.h"),
+                "#define LUAI_FUNC __attribute__((visibility(\"hidden\"))) extern",
+                "#define LUAI_FUNC extern")
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()
 
     def package(self):
-        self.copy(pattern="lua_LICENSE*", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, "lua_LICENSE*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
         cmake.install()
 
     def package_info(self):

--- a/recipes/luau/all/test_package/CMakeLists.txt
+++ b/recipes/luau/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package)
+project(test_package LANGUAGES CXX)
 
 find_package(Luau REQUIRED CONFIG)
 

--- a/recipes/luau/all/test_package/conanfile.py
+++ b/recipes/luau/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake
-from conan.tools.build import cross_building
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/luau/all/test_v1_package/CMakeLists.txt
+++ b/recipes/luau/all/test_v1_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package)
+project(test_package LANGUAGES CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)

--- a/recipes/luau/all/test_v1_package/CMakeLists.txt
+++ b/recipes/luau/all/test_v1_package/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(Luau REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cpp)
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE Luau::Luau)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/luau/all/test_v1_package/conanfile.py
+++ b/recipes/luau/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.548":
+    folder: all
   "0.544":
     folder: all
   "0.541":


### PR DESCRIPTION
Specify library name and version:  **luau/***

Since luau/0.548, Luau.CodeGen depends Luau.VM and LuaU.VM.Internals.
So conan recipe has to fix LUAI_FUNC definition.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
