### PR TITLE
[googleapis] deactivate libraries that cause issues for Android builds.

### DIFF
--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -2,13 +2,17 @@ import os
 import functools
 import glob
 from io import StringIO
-from conan import ConanFile
+
 from conans import CMake, tools
+
+from conan import ConanFile
 from conan.tools.files import get, copy
 from conan.tools.scm import Version
-from conans.errors import ConanInvalidConfiguration
+
+from conan.errors import ConanInvalidConfiguration
 
 from helpers import parse_proto_libraries
+
 
 class GoogleAPIS(ConanFile):
     name = "googleapis"
@@ -20,11 +24,11 @@ class GoogleAPIS(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
     options = {
-        "shared": [True, False], 
+        "shared": [True, False],
         "fPIC": [True, False]
         }
     default_options = {
-        "shared": False, 
+        "shared": False,
         "fPIC": True
         }
     exports = "helpers.py"
@@ -48,7 +52,7 @@ class GoogleAPIS(ConanFile):
     def validate(self):
         if self.settings.compiler.cppstd:
             tools.check_min_cppstd(self, 11)
-        if self.settings.compiler == "gcc" and tools.Version(self.settings.compiler.version) <= "5":
+        if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) <= "5":
             raise ConanInvalidConfiguration("Build with GCC 5 fails")
 
         if self.settings.compiler in ["Visual Studio", "msvc"] and self.options.shared:
@@ -103,6 +107,7 @@ class GoogleAPIS(ConanFile):
 
         # Mark the libraries we need recursively (C++ context)
         all_dict = {f"{it.qname}:{it.name}": it for it in proto_libraries}
+
         def activate_library(proto_library):
             proto_library.is_used = True
             for it_dep in proto_library.deps:
@@ -159,7 +164,7 @@ class GoogleAPIS(ConanFile):
         copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, pattern="*.proto", src=self.source_folder, dst=os.path.join(self.package_folder, "res"))
         copy(self, pattern="*.pb.h", src=self.build_folder, dst=os.path.join(self.package_folder, "include"))
-        
+
         copy(self, pattern="*.lib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
         copy(self, pattern="*.dll", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
         copy(self, pattern="*.so*", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -5,6 +5,7 @@ from io import StringIO
 from conan import ConanFile
 from conans import CMake, tools
 from conan.tools.files import get, copy
+from conan.tools.scm import Version
 from conans.errors import ConanInvalidConfiguration
 
 from helpers import parse_proto_libraries
@@ -119,7 +120,7 @@ class GoogleAPIS(ConanFile):
         #  - Inconvenient macro names from usr/include/sys/syslimits.h in some macOS SDKs: GID_MAX
         #    Patched here: https://github.com/protocolbuffers/protobuf/commit/f138d5de2535eb7dd7c8d0ad5eb16d128ab221fd
         #    as of 3.21.4 issue still exist
-        if tools.Version(self.deps_cpp_info["protobuf"].version) <= "3.21.5" and self.settings.os == "Macos" or \
+        if Version(self.deps_cpp_info["protobuf"].version) <= "3.21.5" and self.settings.os == "Macos" or \
             self.settings.os == "Android":
             deactivate_library("//google/storagetransfer/v1:storagetransfer_proto")
         #  - Inconvenient macro names from /usr/include/math.h : DOMAIN
@@ -128,7 +129,7 @@ class GoogleAPIS(ConanFile):
             deactivate_library("//google/cloud/channel/v1:channel_proto")
             deactivate_library("//google/cloud/channel/v1:channel_cc_proto")
         #  - Inconvenient names for android
-        if (self.settings.os == "Android"):
+        if self.settings.os == "Android":
             deactivate_library("//google/identity/accesscontextmanager/type:type_proto")
             deactivate_library("//google/identity/accesscontextmanager/type:type_cc_proto")
             deactivate_library("//google/identity/accesscontextmanager/v1:accesscontextmanager_proto")

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -90,10 +90,10 @@ class GoogleAPIS(ConanFile):
         proto_libraries = []
         for filename in glob.iglob(os.path.join(self.source_folder, 'google', '**', 'BUILD.bazel'), recursive=True):
             proto_libraries += parse_proto_libraries(filename, self.source_folder, self.output.error)
-            
+
         for filename in glob.iglob(os.path.join(self.source_folder, 'grafeas', '**', 'BUILD.bazel'), recursive=True):
             proto_libraries += parse_proto_libraries(filename, self.source_folder, self.output.error)
-            
+
         # Validate that all files exist and all dependencies are found
         all_deps = [f"{it.qname}:{it.name}" for it in proto_libraries]
         all_deps += ["protobuf::libprotobuf"]
@@ -108,7 +108,7 @@ class GoogleAPIS(ConanFile):
                 if it_dep == "protobuf::libprotobuf":
                     continue
                 activate_library(all_dict[it_dep])
-            
+
         for it in filter(lambda u: u.is_used, proto_libraries):
             activate_library(it)
 
@@ -119,13 +119,30 @@ class GoogleAPIS(ConanFile):
         #  - Inconvenient macro names from usr/include/sys/syslimits.h in some macOS SDKs: GID_MAX
         #    Patched here: https://github.com/protocolbuffers/protobuf/commit/f138d5de2535eb7dd7c8d0ad5eb16d128ab221fd
         #    as of 3.21.4 issue still exist
-        if tools.Version(self.deps_cpp_info["protobuf"].version) <= "3.21.5" and self.settings.os == "Macos":
+        if tools.Version(self.deps_cpp_info["protobuf"].version) <= "3.21.5" and self.settings.os == "Macos" or \
+            self.settings.os == "Android":
             deactivate_library("//google/storagetransfer/v1:storagetransfer_proto")
         #  - Inconvenient macro names from /usr/include/math.h : DOMAIN
         if (self.settings.os == "Linux" and self.settings.compiler == "clang" and self.settings.compiler.libcxx == "libc++") or \
             self.settings.compiler in ["Visual Studio", "msvc"]:
             deactivate_library("//google/cloud/channel/v1:channel_proto")
             deactivate_library("//google/cloud/channel/v1:channel_cc_proto")
+        #  - Inconvenient names for android
+        if (self.settings.os == "Android"):
+            deactivate_library("//google/identity/accesscontextmanager/type:type_proto")
+            deactivate_library("//google/identity/accesscontextmanager/type:type_cc_proto")
+            deactivate_library("//google/identity/accesscontextmanager/v1:accesscontextmanager_proto")
+            deactivate_library("//google/identity/accesscontextmanager/v1:accesscontextmanager_cc_proto")
+            deactivate_library("//google/devtools/testing/v1:testing_proto")
+            deactivate_library("//google/devtools/testing/v1:testing_cc_proto")
+            deactivate_library("//google/devtools/resultstore/v2:resultstore_proto")
+            deactivate_library("//google/devtools/resultstore/v2:resultstore_cc_proto")
+            deactivate_library("//google/cloud/talent/v4beta1:talent_proto")
+            deactivate_library("//google/cloud/talent/v4beta1:talent_cc_proto")
+            deactivate_library("//google/cloud/talent/v4:talent_proto")
+            deactivate_library("//google/cloud/talent/v4:talent_cc_proto")
+            deactivate_library("//google/cloud/asset/v1:asset_proto")
+            deactivate_library("//google/cloud/asset/v1:asset_cc_proto")
 
         return proto_libraries
 

--- a/recipes/googleapis/all/test_v1_package/CMakeLists.txt
+++ b/recipes/googleapis/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(googleapis REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE googleapis::googleapis)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/googleapis/all/test_v1_package/conanfile.py
+++ b/recipes/googleapis/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+# legacy validation with Conan 1.x
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Specify library name and version:  googleapis/any

When compiling for Android, there is an additional define of `ANDROID 1` added on the command line.
This causes some of the libraries for the googleapis library to fail compilation, since some of the proto files have enums defining `ANDROID`.
This PR deactivates these libraries and therefore enables compilation of this package (and some packages that rely on it, like gRPC) to be compiled for android.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
