### PR TITLE
unordered_dense: add version 2.0.0

### DIFF
--- a/recipes/unordered_dense/all/conandata.yml
+++ b/recipes/unordered_dense/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.0":
+    url: "https://github.com/martinus/unordered_dense/archive/v2.0.0.tar.gz"
+    sha256: "e838bdcf380a1aeb6f1fee17fbdf59d7a14b6b9fb6dfca32981e4cbd60739d20"
   "1.4.0":
     url: "https://github.com/martinus/unordered_dense/archive/v1.4.0.tar.gz"
     sha256: "36b6bfe2fe2633f9d9c537b9b808b4be6b77ff51c66d370d855f477517bc3bc9"

--- a/recipes/unordered_dense/config.yml
+++ b/recipes/unordered_dense/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.0":
+    folder: all
   "1.4.0":
     folder: all
   "1.3.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **unordered_dense/2.0.0**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
