### PR TITLE
[gdk-pixbuf] remove windows glib version exception

### DIFF
--- a/recipes/gdk-pixbuf/all/conanfile.py
+++ b/recipes/gdk-pixbuf/all/conanfile.py
@@ -36,6 +36,7 @@ class GdkPixbufConan(ConanFile):
         "with_libjpeg": "libjpeg",
         "with_introspection": False,
     }
+    short_paths = True
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -116,12 +117,7 @@ class GdkPixbufConan(ConanFile):
         venv.generate()
 
     def requirements(self):
-        if not microsoft.is_msvc(self):
-            self.requires("glib/2.74.0")
-        else:
-            # Workaround due to https://github.com/conan-io/conan-center-index/issues/12342
-            # Test again when the glib recipe is updated to the new meson toolchain
-            self.requires("glib/2.73.0")
+        self.requires("glib/2.74.0")
         if self.options.with_libpng:
             self.requires("libpng/1.6.38")
         if self.options.with_libtiff:


### PR DESCRIPTION
Specify library name and version:  **gdk-pixbuf/1.0**

Removed the glib version exception for Windows as this is no longer necessary.
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
