### PR TITLE
glib: several fixes & improvements

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -1,34 +1,34 @@
 sources:
-  "2.68.3":
-    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.68.3/glib-2.68.3.tar.gz"
-    sha256: "465c0727dd5505e998ebb1dae7c38683440dc6d6beffbca6bbf3eaabdb4f6ac7"
-  "2.69.3":
-    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.69.3/glib-2.69.3.tar.gz"
-    sha256: "290f05eb5affd1bac142010d6511c7a3de361e5f69addc677cf6b3c92a757b44"
-  "2.70.4":
-    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.70.4/glib-2.70.4.tar.gz"
-    sha256: "23461c4e694b465fad32ea677b3abc9306fa8511d12e915aee09b53f362c7fff"
-  "2.71.3":
-    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.71.3/glib-2.71.3.tar.gz"
-    sha256: "08e17cf608f5ac3462092bff13828c1c0aab37c5b4827d4e17b948215b4e40ea"
-  "2.72.1":
-    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.72.1/glib-2.72.1.tar.gz"
-    sha256: "4a345987a9ee7709417f5a5c6f4eeec2497bc2a913f14c1b9bdc403409d5ffb7"
-  "2.73.0":
-    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.73.0/glib-2.73.0.tar.gz"
-    sha256: "3f573319adbdf572d79255e8bae85c7e2902d1aa6177d2646605a00c0a607eca"
-  "2.73.1":
-    url: "https://download.gnome.org/sources/glib/2.73/glib-2.73.1.tar.xz"
-    sha256: "77b21da5bd195a8e5f751206a2acab477636e3d02fe4f3796ede5788255382ae"
-  "2.73.2":
-    url: "https://download.gnome.org/sources/glib/2.73/glib-2.73.2.tar.xz"
-    sha256: "5f3ee36e34f4aaab393c3e3dc46fb01b32f7ead6c88d41d7f20d88a49cdef1d9"
-  "2.73.3":
-    url: "https://download.gnome.org/sources/glib/2.73/glib-2.73.3.tar.xz"
-    sha256: "df1a2b841667d6b48b2ef6969ebda4328243829f6e45866726f806f90f64eead"
   "2.74.0":
     url: "https://download.gnome.org/sources/glib/2.74/glib-2.74.0.tar.xz"
     sha256: "3652c7f072d7b031a6b5edd623f77ebc5dcd2ae698598abcc89ff39ca75add30"
+  "2.73.3":
+    url: "https://download.gnome.org/sources/glib/2.73/glib-2.73.3.tar.xz"
+    sha256: "df1a2b841667d6b48b2ef6969ebda4328243829f6e45866726f806f90f64eead"
+  "2.73.2":
+    url: "https://download.gnome.org/sources/glib/2.73/glib-2.73.2.tar.xz"
+    sha256: "5f3ee36e34f4aaab393c3e3dc46fb01b32f7ead6c88d41d7f20d88a49cdef1d9"
+  "2.73.1":
+    url: "https://download.gnome.org/sources/glib/2.73/glib-2.73.1.tar.xz"
+    sha256: "77b21da5bd195a8e5f751206a2acab477636e3d02fe4f3796ede5788255382ae"
+  "2.73.0":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.73.0/glib-2.73.0.tar.gz"
+    sha256: "3f573319adbdf572d79255e8bae85c7e2902d1aa6177d2646605a00c0a607eca"
+  "2.72.1":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.72.1/glib-2.72.1.tar.gz"
+    sha256: "4a345987a9ee7709417f5a5c6f4eeec2497bc2a913f14c1b9bdc403409d5ffb7"
+  "2.71.3":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.71.3/glib-2.71.3.tar.gz"
+    sha256: "08e17cf608f5ac3462092bff13828c1c0aab37c5b4827d4e17b948215b4e40ea"
+  "2.70.4":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.70.4/glib-2.70.4.tar.gz"
+    sha256: "23461c4e694b465fad32ea677b3abc9306fa8511d12e915aee09b53f362c7fff"
+  "2.69.3":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.69.3/glib-2.69.3.tar.gz"
+    sha256: "290f05eb5affd1bac142010d6511c7a3de361e5f69addc677cf6b3c92a757b44"
+  "2.68.3":
+    url: "https://gitlab.gnome.org/GNOME/glib/-/archive/2.68.3/glib-2.68.3.tar.gz"
+    sha256: "465c0727dd5505e998ebb1dae7c38683440dc6d6beffbca6bbf3eaabdb4f6ac7"
 patches:
   "2.74.0":
     - patch_file: "patches/0001-2.74.0-clang-static-assert.patch"

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -9,7 +9,6 @@ from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
-import glob
 import shutil
 
 

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -65,9 +65,18 @@ class GLibConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
 
     def requirements(self):
         self.requires("zlib/1.2.12")

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -75,7 +75,7 @@ class GLibConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/1.2.12")
+        self.requires("zlib/1.2.13")
         self.requires("libffi/3.4.3")
         if self.options.with_pcre:
             if Version(self.version) >= "2.73.2":

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -107,7 +107,7 @@ class GLibConan(ConanFile):
             raise ConanInvalidConfiguration("libelf dependency can't be disabled in glib < 2.67.0")
 
     def build_requirements(self):
-        self.tool_requires("meson/0.63.2")
+        self.tool_requires("meson/0.63.3")
         self.tool_requires("pkgconf/1.9.3")
 
     def source(self):

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import is_apple_os
+from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
 from conan.tools.files import apply_conandata_patches, chdir, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
 from conan.tools.gnu import PkgConfigDeps, AutotoolsDeps
 from conan.tools.layout import basic_layout
@@ -224,8 +224,7 @@ class GLibConan(ConanFile):
             os.path.join(self.package_folder, "res"),
         )
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
-        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
-        rm(self, "*.pc", os.path.join(self.package_folder, "lib"))
+        fix_apple_shared_install_name(self)
 
     def package_info(self):
         self.cpp_info.components["glib-2.0"].set_property("pkg_config_name", "glib-2.0")

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, chdir, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
 from conan.tools.gnu import PkgConfigDeps, AutotoolsDeps
 from conan.tools.layout import basic_layout
@@ -115,6 +116,8 @@ class GLibConan(ConanFile):
             destination=self.source_folder, strip_root=True)
 
     def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
         tc = PkgConfigDeps(self)
         tc.generate()
         tc = AutotoolsDeps(self)

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -1,11 +1,12 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.scm import Version
-from conan.tools.microsoft import is_msvc
-from conan.tools.meson import Meson, MesonToolchain
-from conan.tools.gnu import PkgConfigDeps, AutotoolsDeps
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, replace_in_file, rmdir, chdir, rm, copy
 from conan.tools.apple import is_apple_os
+from conan.tools.files import apply_conandata_patches, chdir, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
+from conan.tools.gnu import PkgConfigDeps, AutotoolsDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 import glob
 import shutil
@@ -40,14 +41,6 @@ class GLibConan(ConanFile):
     }
     short_paths = True
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
-
     def export_sources(self):
         copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
         export_conandata_patches(self)
@@ -77,6 +70,9 @@ class GLibConan(ConanFile):
             del self.settings.compiler.cppstd
         except Exception:
             pass
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires("zlib/1.2.12")
@@ -118,12 +114,7 @@ class GLibConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version],
             destination=self.source_folder, strip_root=True)
 
-    def layout(self):
-        self.folders.build = self._build_subfolder
-        self.folders.source = self._source_subfolder
-
     def generate(self):
-
         tc = PkgConfigDeps(self)
         tc.generate()
         tc = AutotoolsDeps(self)

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -131,28 +131,20 @@ class GLibConan(ConanFile):
         tc.generate()
         # it's needed so MesonToolchain reads from AutotoolsDeps, should it be automatic?
         self.buildenv.compose_env(tc.environment)
+
         tc = MesonToolchain(self)
-
-        defs = dict()
         if is_apple_os(self):
-            defs["iconv"] = "external"  # https://gitlab.gnome.org/GNOME/glib/issues/1557
-        defs["selinux"] = "enabled" if self.options.get_safe("with_selinux") else "disabled"
-        defs["libmount"] = "enabled" if self.options.get_safe("with_mount") else "disabled"
-
+            tc.project_options["iconv"] = "external"  # https://gitlab.gnome.org/GNOME/glib/issues/1557
+        tc.project_options["selinux"] = "enabled" if self.options.get_safe("with_selinux") else "disabled"
+        tc.project_options["libmount"] = "enabled" if self.options.get_safe("with_mount") else "disabled"
         if Version(self.version) < "2.69.0":
-            defs["internal_pcre"] = not self.options.with_pcre
-
+            tc.project_options["internal_pcre"] = not self.options.with_pcre
         if self.settings.os == "FreeBSD":
-            defs["xattr"] = "false"
+            tc.project_options["xattr"] = "false"
         if Version(self.version) >= "2.67.2":
-            defs["tests"] = "false"
-
+            tc.project_options["tests"] = "false"
         if Version(self.version) >= "2.67.0":
-            defs["libelf"] = "enabled" if self.options.get_safe("with_elf") else "disabled"
-
-        for name, value in defs.items():
-            tc.project_options[name] = value
-        tc.project_options["libdir"] = "lib"
+            tc.project_options["libelf"] = "enabled" if self.options.get_safe("with_elf") else "disabled"
         tc.generate()
 
     def _patch_sources(self):

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -22,6 +22,7 @@ class GLibConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gitlab.gnome.org/GNOME/glib"
     license = "LGPL-2.1"
+
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -39,10 +40,10 @@ class GLibConan(ConanFile):
         "with_mount": True,
         "with_selinux": True,
     }
+
     short_paths = True
 
     def export_sources(self):
-        copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
         export_conandata_patches(self)
 
     def config_options(self):

--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -220,11 +220,11 @@ class GLibConan(ConanFile):
             os.path.join("include", "glib-2.0"),
             os.path.join("lib", "glib-2.0", "include")
         ]
-        self.cpp_info.components["glib-2.0"].libdirs = ["lib"]
+        self.cpp_info.components["glib-2.0"].resdirs = ["res"]
 
         self.cpp_info.components["gmodule-no-export-2.0"].set_property("pkg_config_name", "gmodule-no-export-2.0")
         self.cpp_info.components["gmodule-no-export-2.0"].libs = ["gmodule-2.0"]
-        self.cpp_info.components["gmodule-no-export-2.0"].libdirs = ["lib"]
+        self.cpp_info.components["gmodule-no-export-2.0"].resdirs = ["res"]
         self.cpp_info.components["gmodule-no-export-2.0"].requires.append("glib-2.0")
 
         self.cpp_info.components["gmodule-export-2.0"].set_property("pkg_config_name", "gmodule-export-2.0")
@@ -235,17 +235,17 @@ class GLibConan(ConanFile):
 
         self.cpp_info.components["gobject-2.0"].set_property("pkg_config_name", "gobject-2.0")
         self.cpp_info.components["gobject-2.0"].libs = ["gobject-2.0"]
-        self.cpp_info.components["gobject-2.0"].libdirs = ["lib"]
+        self.cpp_info.components["gobject-2.0"].resdirs = ["res"]
         self.cpp_info.components["gobject-2.0"].requires += ["glib-2.0", "libffi::libffi"]
 
         self.cpp_info.components["gthread-2.0"].set_property("pkg_config_name", "gthread-2.0")
         self.cpp_info.components["gthread-2.0"].libs = ["gthread-2.0"]
-        self.cpp_info.components["gthread-2.0"].libdirs = ["lib"]
+        self.cpp_info.components["gthread-2.0"].resdirs = ["res"]
         self.cpp_info.components["gthread-2.0"].requires.append("glib-2.0")
 
         self.cpp_info.components["gio-2.0"].set_property("pkg_config_name", "gio-2.0")
         self.cpp_info.components["gio-2.0"].libs = ["gio-2.0"]
-        self.cpp_info.components["gio-2.0"].libdirs = ["lib"]
+        self.cpp_info.components["gio-2.0"].resdirs = ["res"]
         self.cpp_info.components["gio-2.0"].requires += ["glib-2.0", "gobject-2.0", "gmodule-2.0", "zlib::zlib"]
 
         self.cpp_info.components["gresource"].set_property("pkg_config_name", "gresource")

--- a/recipes/glib/all/test_package/conanfile.py
+++ b/recipes/glib/all/test_package/conanfile.py
@@ -45,5 +45,7 @@ class TestPackageConan(ConanFile):
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
             self.run(bin_path, env="conanrun")
 
-            pkg_config = PkgConfig(self, "gio-2.0", pkg_config_path=self.generators_folder)
-            self.run(f"{pkg_config.variables['gdbus_codegen']} -h", env="conanrun")
+            if self.settings.os != "Windows":
+                pkg_config = PkgConfig(self, "gio-2.0", pkg_config_path=self.generators_folder)
+                gdbus_codegen = pkg_config.variables["gdbus_codegen"]
+                self.run(f"{gdbus_codegen} -h", env="conanrun")

--- a/recipes/glib/all/test_package/conanfile.py
+++ b/recipes/glib/all/test_package/conanfile.py
@@ -1,22 +1,49 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeDeps, cmake_layout
+from conan.tools.env import Environment, VirtualBuildEnv
+from conan.tools.gnu import PkgConfig, PkgConfigDeps
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi", "pkg_config"
+    generators = "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        if self.settings.os != "Windows":
+            self.tool_requires("pkgconf/1.9.3")
+
+    def generate(self):
+        if self.settings.os == "Windows":
+            deps = CMakeDeps(self)
+            deps.generate()
+        else:
+            env = VirtualBuildEnv(self)
+            env.generate()
+            pkg = PkgConfigDeps(self)
+            pkg.generate()
+            # TODO: to remove when properly handled by conan (see https://github.com/conan-io/conan/issues/11962)
+            env = Environment()
+            env.prepend_path("PKG_CONFIG_PATH", self.generators_folder)
+            env.vars(self).save_script("conanbuildenv_pkg_config_path")
 
     def build(self):
-        if self.settings.os != "Windows":
-            with tools.environment_append({'PKG_CONFIG_PATH': "."}):
-                pkg_config = tools.PkgConfig("gio-2.0")
-                self.run("%s -h" % pkg_config.variables["gdbus_codegen"], run_environment=True)
-
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")
+
+            pkg_config = PkgConfig(self, "gio-2.0", pkg_config_path=self.generators_folder)
+            self.run(f"{pkg_config.variables['gdbus_codegen']} -h", env="conanrun")

--- a/recipes/glib/all/test_v1_package/CMakeLists.txt
+++ b/recipes/glib/all/test_v1_package/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
-add_executable(${PROJECT_NAME} test_package.c)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 
 if (WIN32)
     find_package(glib CONFIG REQUIRED)

--- a/recipes/glib/all/test_v1_package/CMakeLists.txt
+++ b/recipes/glib/all/test_v1_package/CMakeLists.txt
@@ -1,20 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package LANGUAGES C)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-
-if (WIN32)
-    find_package(glib CONFIG REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PRIVATE glib::glib-2.0 glib::gio-2.0 glib::gmodule-2.0 glib::gobject-2.0 glib::gthread-2.0)
-else()
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(glib-2.0 REQUIRED IMPORTED_TARGET glib-2.0)
-    pkg_check_modules(gio-2.0 REQUIRED IMPORTED_TARGET gio-2.0)
-    pkg_check_modules(gmodule-2.0 REQUIRED IMPORTED_TARGET gmodule-2.0)
-    pkg_check_modules(gobject-2.0 REQUIRED IMPORTED_TARGET gobject-2.0)
-    pkg_check_modules(gthread-2.0 REQUIRED IMPORTED_TARGET gthread-2.0)
-    target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::glib-2.0 PkgConfig::gio-2.0 PkgConfig::gmodule-2.0 PkgConfig::gobject-2.0 PkgConfig::gthread-2.0)
-endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/glib/all/test_v1_package/conanfile.py
+++ b/recipes/glib/all/test_v1_package/conanfile.py
@@ -1,0 +1,26 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi", "pkg_config"
+
+    def build_requirements(self):
+        if self.settings.os != "Windows":
+            self.build_requires("pkgconf/1.9.3")
+
+    def build(self):
+        if self.settings.os != "Windows":
+            with tools.environment_append({"PKG_CONFIG_PATH": "."}):
+                pkg_config = tools.PkgConfig("gio-2.0")
+                self.run(f"{pkg_config.variables['gdbus_codegen']} -h", run_environment=True)
+
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -1,21 +1,21 @@
 versions:
-  "2.68.3":
-    folder: all
-  "2.69.3":
-    folder: all
-  "2.70.4":
-    folder: all
-  "2.71.3":
-    folder: all
-  "2.72.1":
-    folder: all
-  "2.73.0":
-    folder: all
-  "2.73.1":
-    folder: all
-  "2.73.2":
+  "2.74.0":
     folder: all
   "2.73.3":
     folder: all
-  "2.74.0":
+  "2.73.2":
+    folder: all
+  "2.73.1":
+    folder: all
+  "2.73.0":
+    folder: all
+  "2.72.1":
+    folder: all
+  "2.71.3":
+    folder: all
+  "2.70.4":
+    folder: all
+  "2.69.3":
+    folder: all
+  "2.68.3":
     folder: all


### PR DESCRIPTION
- fix PkgConfigDeps
- bump dependencies
- relocatable shared libs on macOS (install_name set to `@rpath`)
- properly rename lib names for `compiler=msvc` as well
- no need to define libdir in MesonToolchain since min conan version is 1.52.0
- add tests for CMakeDeps & PkgConfigDeps
- use basic_layout (for consistency among CCI recipes)

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
