### PR TITLE
qcbor: add version 1.1 and support conan v2

### DIFF
--- a/recipes/qcbor/all/CMakeLists.txt
+++ b/recipes/qcbor/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.1)
-project(cmake_wrapper)
-
-include("conanbuildinfo.cmake")
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory(source_subfolder)

--- a/recipes/qcbor/all/conandata.yml
+++ b/recipes/qcbor/all/conandata.yml
@@ -1,8 +1,16 @@
 sources:
+  "1.1":
+    url: "https://github.com/laurencelundblade/QCBOR/archive/refs/tags/v1.1.tar.gz"
+    sha256: "1e7e8986bf918eafb11f5373df9b80fd56811d2cd39c7630d8171130802199b6"
   "1.0":
     url: "https://github.com/laurencelundblade/QCBOR/archive/refs/tags/v1.0.tar.gz"
     sha256: "961a46eb5a599cc040bfce4f4fade4427e046f1748f37ba4ebbc097fb9cdf1d3"
 patches:
+  "1.1":
+    - patch_file: "patches/1.1-0001-fix-cmake.patch"
+      patch_description: "link mathlib and add installation"
+      patch_type: "conan"
   "1.0":
     - patch_file: "patches/1.0-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
+      patch_description: "link mathlib and add installation"
+      patch_type: "conan"

--- a/recipes/qcbor/all/conanfile.py
+++ b/recipes/qcbor/all/conanfile.py
@@ -1,10 +1,11 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, rmdir, load, save
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+
 import os
-import functools
 import re
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.52.0"
 
 class QCBORConan(ConanFile):
     name = "qcbor"
@@ -22,16 +23,9 @@ class QCBORConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-    generators = "cmake"
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -39,35 +33,44 @@ class QCBORConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.configure()
-        return cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
         # Extract the License/s from README.md to a file
-        tmp = tools.load(os.path.join(self._source_subfolder, "inc", "qcbor", "qcbor.h"))
+        tmp = load(self, os.path.join(self.source_folder, "inc", "qcbor", "qcbor.h"))
         license_contents = re.search("( Copyright.*) =====", tmp, re.DOTALL)[1]
-        tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), license_contents)
+        save(self, os.path.join(self.package_folder, "licenses", "LICENSE"), license_contents)
 
     def package_info(self):
         self.cpp_info.libs = ["qcbor"]

--- a/recipes/qcbor/all/patches/1.1-0001-fix-cmake.patch
+++ b/recipes/qcbor/all/patches/1.1-0001-fix-cmake.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f0b67b9..4b00b8b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,3 +17,19 @@ set(SOURCE
+ add_library(qcbor ${SOURCE})
+ 
+ target_include_directories(qcbor PUBLIC inc)
++
++set_target_properties(qcbor PROPERTIES
++    WINDOWS_EXPORT_ALL_SYMBOLS ON
++)
++
++find_library(LIBM m)
++target_link_libraries(qcbor PRIVATE $<$<BOOL:${LIBM}>:${LIBM}>)
++
++include(GNUInstallDirs)
++install(TARGETS qcbor
++    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++
++install(DIRECTORY "inc/qcbor" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/recipes/qcbor/all/test_package/conanfile.py
+++ b/recipes/qcbor/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/qcbor/all/test_v1_package/CMakeLists.txt
+++ b/recipes/qcbor/all/test_v1_package/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(qcbor REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.c)
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE qcbor::qcbor)

--- a/recipes/qcbor/all/test_v1_package/conanfile.py
+++ b/recipes/qcbor/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/qcbor/config.yml
+++ b/recipes/qcbor/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.1":
+    folder: all
   "1.0":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **qcbor/***

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
