### PR TITLE
cgal: add version 5.5.1

### DIFF
--- a/recipes/cgal/all/conandata.yml
+++ b/recipes/cgal/all/conandata.yml
@@ -14,3 +14,6 @@ sources:
   "5.5":
     sha256: 98ac395ca08aacf38b7a8170a822b650aedf10355df41dd0e4bfb238408e08a6
     url: https://github.com/CGAL/cgal/releases/download/v5.5/CGAL-5.5.tar.xz
+  "5.5.1":
+    sha256: 091630def028facdcaf00eb5b68ad79eddac1b855cca6e87eef18a031566edfc
+    url: https://github.com/CGAL/cgal/releases/download/v5.5.1/CGAL-5.5.1.tar.xz

--- a/recipes/cgal/all/conanfile.py
+++ b/recipes/cgal/all/conanfile.py
@@ -11,8 +11,8 @@ class CgalConan(ConanFile):
     license = "GPL-3.0-or-later", "LGPL-3.0-or-later"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/CGAL/cgal"
-    description = "C++ library that aims to provide easy access to efficient and reliable algorithms"\
-                  "in computational geometry."
+    description = "C++ library that provides easy access to efficient and reliable algorithms"\
+                  " in computational geometry."
     topics = ("cgal", "geometry", "algorithms")
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"

--- a/recipes/cgal/config.yml
+++ b/recipes/cgal/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: all
   "5.5":
     folder: all
+  "5.5.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **cgal/5.5.1**

Add [CGAL version 5.5.1](https://www.cgal.org/2022/10/12/cgal551/), that is a bug-fix release.

Build locally with
```shell
[lrineau@fernand]~/Git/conan-center-index/recipes/cgal% conan create all/conanfile.py 5.5.1@
```

and the results are fine:
```
cgal/5.5.1 (test package): Running test()
Processing: 1/8
Processing: 2/8
Processing: 3/8
Processing: 4/8
Processing: 5/8
Processing: 6/8
Processing: 7/8
Processing: 8/8
```

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
