### PR TITLE
opengv | Extend patch so conan also handles the -march flags

### DIFF
--- a/recipes/opengv/all/conandata.yml
+++ b/recipes/opengv/all/conandata.yml
@@ -10,6 +10,6 @@ patches:
     - patch_file: "patches/0002-use-conans-eigen.patch"
       patch_description: "fix call to find_package to use conan provided file"
       patch_type: "conan"
-    - patch_file: "patches/0003-let-conan-handle-shared-and-fpic.patch"
+    - patch_file: "patches/0003-let-conan-handle-shared-fpic-and-marchs.patch"
       patch_description: "disable some options such that conan manages values"
       patch_type: "conan"

--- a/recipes/opengv/all/patches/0003-let-conan-handle-shared-fpic-and-marchs.patch
+++ b/recipes/opengv/all/patches/0003-let-conan-handle-shared-fpic-and-marchs.patch
@@ -1,6 +1,6 @@
 --- CMakeLists.txt	2020-08-06 09:02:15.000000000 -0300
 +++ CMakeLists.txt	2022-10-06 12:39:57.766560501 -0300
-@@ -19,8 +19,8 @@
+@@ -19,16 +19,16 @@
  OPTION(BUILD_TESTS "Build tests" ON)
  OPTION(BUILD_PYTHON "Build Python extension" OFF)
  
@@ -11,3 +11,14 @@
  ELSE()
    OPTION(BUILD_SHARED_LIBS "Build shared libraries" OFF)
    OPTION(BUILD_POSITION_INDEPENDENT_CODE "Build position independent code (-fPIC)" ON)
+ ENDIF()
+ 
+-IF(MSVC)
+-  add_compile_options(/wd4514 /wd4267 /bigobj)
+-  add_definitions(-D_USE_MATH_DEFINES)
++IF(1)
++  #add_compile_options(/wd4514 /wd4267 /bigobj)
++  #add_definitions(-D_USE_MATH_DEFINES)
+ ELSE()
+   IF (CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64)|(ARM64)|(aarch64)|(AARCH64)")
+     add_definitions (-march=armv8-a)


### PR DESCRIPTION
Yet another follow up to https://github.com/conan-io/conan-center-index/pull/13225

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
