### PR TITLE
openssl 1.x: add empty layout & factorize tests of CMake variables

### DIFF
--- a/recipes/openssl/1.x.x/conanfile.py
+++ b/recipes/openssl/1.x.x/conanfile.py
@@ -227,6 +227,9 @@ class OpenSSLConan(ConanFile):
         del self.settings.compiler.libcxx
         del self.settings.compiler.cppstd
 
+    def layout(self):
+        pass
+
     def requirements(self):
         if self._full_version < "1.1.0" and self.options.get_safe("no_zlib") == False:
             self.requires("zlib/1.2.12")

--- a/recipes/openssl/1.x.x/test_package/CMakeLists.txt
+++ b/recipes/openssl/1.x.x/test_package/CMakeLists.txt
@@ -5,30 +5,26 @@ option(OPENSSL_WITH_ZLIB "OpenSSL with zlib support" ON)
 
 set(OpenSSL_DEBUG 1)
 find_package(OpenSSL REQUIRED)
-if(NOT DEFINED OPENSSL_FOUND)
-    message(FATAL_ERROR "variable OPENSSL_FOUND not set")
-endif()
-if(NOT DEFINED OPENSSL_INCLUDE_DIR)
-    message(FATAL_ERROR "variable OPENSSL_INCLUDE_DIR not set")
-endif()
-if(NOT DEFINED OPENSSL_CRYPTO_LIBRARY)
-    message(FATAL_ERROR "variable OPENSSL_CRYPTO_LIBRARY not set")
-endif()
-if(NOT DEFINED OPENSSL_CRYPTO_LIBRARIES)
-    message(FATAL_ERROR "variable OPENSSL_CRYPTO_LIBRARIES not set")
-endif()
-if(NOT DEFINED OPENSSL_SSL_LIBRARY)
-    message(FATAL_ERROR "variable OPENSSL_SSL_LIBRARY not set")
-endif()
-if(NOT DEFINED OPENSSL_SSL_LIBRARIES)
-    message(FATAL_ERROR "variable OPENSSL_SSL_LIBRARIES not set")
-endif()
-if(NOT DEFINED OPENSSL_LIBRARIES)
-    message(FATAL_ERROR "variable OPENSSL_LIBRARIES not set")
-endif()
-if(NOT DEFINED OPENSSL_VERSION)
-    message(FATAL_ERROR "variable OPENSSL_VERSION not set")
-endif()
+
+# Test whether variables from https://cmake.org/cmake/help/latest/module/FindOpenSSL.html
+# are properly defined in conan generators
+set(_custom_vars
+    OPENSSL_FOUND
+    OPENSSL_INCLUDE_DIR
+    OPENSSL_CRYPTO_LIBRARY
+    OPENSSL_CRYPTO_LIBRARIES
+    OPENSSL_SSL_LIBRARY
+    OPENSSL_SSL_LIBRARIES
+    OPENSSL_LIBRARIES
+    OPENSSL_VERSION
+)
+foreach(_custom_var ${_custom_vars})
+    if(DEFINED _custom_var)
+        message(STATUS "${_custom_var}: ${${_custom_var}}")
+    else()
+        message(FATAL_ERROR "${_custom_var} not defined")
+    endif()
+endforeach()
 
 add_executable(digest digest.c)
 target_link_libraries(digest OpenSSL::SSL)

--- a/recipes/openssl/1.x.x/test_v1_package/CMakeLists.txt
+++ b/recipes/openssl/1.x.x/test_v1_package/CMakeLists.txt
@@ -8,30 +8,26 @@ option(OPENSSL_WITH_ZLIB "OpenSSL with zlib support" ON)
 
 set(OpenSSL_DEBUG 1)
 find_package(OpenSSL REQUIRED)
-if(NOT DEFINED OPENSSL_FOUND)
-    message(FATAL_ERROR "variable OPENSSL_FOUND not set")
-endif()
-if(NOT DEFINED OPENSSL_INCLUDE_DIR)
-    message(FATAL_ERROR "variable OPENSSL_INCLUDE_DIR not set")
-endif()
-if(NOT DEFINED OPENSSL_CRYPTO_LIBRARY)
-    message(FATAL_ERROR "variable OPENSSL_CRYPTO_LIBRARY not set")
-endif()
-if(NOT DEFINED OPENSSL_CRYPTO_LIBRARIES)
-    message(FATAL_ERROR "variable OPENSSL_CRYPTO_LIBRARIES not set")
-endif()
-if(NOT DEFINED OPENSSL_SSL_LIBRARY)
-    message(FATAL_ERROR "variable OPENSSL_SSL_LIBRARY not set")
-endif()
-if(NOT DEFINED OPENSSL_SSL_LIBRARIES)
-    message(FATAL_ERROR "variable OPENSSL_SSL_LIBRARIES not set")
-endif()
-if(NOT DEFINED OPENSSL_LIBRARIES)
-    message(FATAL_ERROR "variable OPENSSL_LIBRARIES not set")
-endif()
-if(NOT DEFINED OPENSSL_VERSION)
-    message(FATAL_ERROR "variable OPENSSL_VERSION not set")
-endif()
+
+# Test whether variables from https://cmake.org/cmake/help/latest/module/FindOpenSSL.html
+# are properly defined in conan generators
+set(_custom_vars
+    OPENSSL_FOUND
+    OPENSSL_INCLUDE_DIR
+    OPENSSL_CRYPTO_LIBRARY
+    OPENSSL_CRYPTO_LIBRARIES
+    OPENSSL_SSL_LIBRARY
+    OPENSSL_SSL_LIBRARIES
+    OPENSSL_LIBRARIES
+    OPENSSL_VERSION
+)
+foreach(_custom_var ${_custom_vars})
+    if(DEFINED _custom_var)
+        message(STATUS "${_custom_var}: ${${_custom_var}}")
+    else()
+        message(FATAL_ERROR "${_custom_var} not defined")
+    endif()
+endforeach()
 
 add_executable(digest ../test_package/digest.c)
 target_link_libraries(digest OpenSSL::SSL)


### PR DESCRIPTION
It's required for https://github.com/conan-io/conan-center-index/pull/12938 & https://github.com/conan-io/conan-center-index/pull/13458, and basically any recipe depending on openssl recipe and relying on `AutotoolsDeps` (see https://github.com/conan-io/conan/issues/12106)

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
