### PR TITLE
(#13469) Protobuf: Add 3.19.6

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -5,6 +5,9 @@ sources:
   "3.20.0":
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.20.0.tar.gz"
     sha256: "b07772d38ab07e55eca4d50f4b53da2d998bb221575c60a4f81100242d4b4889"
+  "3.19.6":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.19.6.tar.gz"
+    sha256: "9a301cf94a8ddcb380b901e7aac852780b826595075577bb967004050c835056"
   "3.19.4":
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.19.4.tar.gz"
     sha256: "3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568"

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -3,6 +3,8 @@ versions:
     folder: all
   "3.20.0":
     folder: all
+  "3.19.6":
+    folder: all
   "3.19.4":
     folder: all
   "3.18.1":


### PR DESCRIPTION
For mitigation of CVE 2022-3171

Closes #13469

Specify library name and version:  **protobuf/3.19.6**


---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
