### PR TITLE
aws-c-auth: add version 0.6.17 and support conan v2

### DIFF
--- a/recipes/aws-c-auth/all/CMakeLists.txt
+++ b/recipes/aws-c-auth/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(cmake_wrapper LANGUAGES C)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory(source_subfolder)

--- a/recipes/aws-c-auth/all/conandata.yml
+++ b/recipes/aws-c-auth/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.17":
+    url: "https://github.com/awslabs/aws-c-auth/archive/v0.6.17.tar.gz"
+    sha256: "b43678ad3a779c9c7fccf8f931c162eaaf4d5d64d2955ac1fcfd32e538545c0f"
   "0.6.11":
     url: "https://github.com/awslabs/aws-c-auth/archive/v0.6.11.tar.gz"
     sha256: "d8a0d373cf8b0ff148a014ae2ba24c51f2e7a598b5b0cf3a6e64482c1cd37f90"

--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -1,18 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.files import get, copy, rmdir
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+
 import os
 
-required_conan_version = ">=1.43.0"
-
+required_conan_version = ">=1.47.0"
 
 class AwsCAuth(ConanFile):
     name = "aws-c-auth"
     description = "C99 library implementation of AWS client-side authentication: standard credentials providers and signing."
-    topics = ("aws", "amazon", "cloud", "authentication", "credentials", "providers", "signing")
+    license = "Apache-2.0",
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-auth"
-    license = "Apache-2.0",
-    exports_sources = "CMakeLists.txt"
-    generators = "cmake", "cmake_find_package"
+    topics = ("aws", "amazon", "cloud", "authentication", "credentials", "providers", "signing")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -23,51 +24,57 @@ class AwsCAuth(ConanFile):
         "fPIC": True,
     }
 
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.cppstd
-        del self.settings.compiler.libcxx
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.19")
-        self.requires("aws-c-cal/0.5.13")
-        self.requires("aws-c-io/0.10.20")
-        self.requires("aws-c-http/0.6.13")
-        if tools.Version(self.version) >= "0.6.5":
-            self.requires("aws-c-sdkutils/0.1.2")
+        self.requires("aws-c-common/0.8.2")
+        self.requires("aws-c-cal/0.5.20")
+        self.requires("aws-c-io/0.13.4")
+        self.requires("aws-c-http/0.6.22")
+        if Version(self.version) >= "0.6.5":
+            self.requires("aws-c-sdkutils/0.1.3")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["BUILD_TESTING"] = False
-        self._cmake.configure()
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_TESTING"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-auth"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-auth"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-auth")
@@ -88,5 +95,5 @@ class AwsCAuth(ConanFile):
             "aws-c-io::aws-c-io-lib",
             "aws-c-http::aws-c-http-lib"
         ]
-        if tools.Version(self.version) >= "0.6.5":
+        if Version(self.version) >= "0.6.5":
             self.cpp_info.components["aws-c-auth-lib"].requires.append("aws-c-sdkutils::aws-c-sdkutils-lib")

--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -48,7 +48,7 @@ class AwsCAuth(ConanFile):
 
     def requirements(self):
         self.requires("aws-c-common/0.8.2")
-        self.requires("aws-c-cal/0.5.20")
+        self.requires("aws-c-cal/0.5.13")
         self.requires("aws-c-io/0.13.4")
         self.requires("aws-c-http/0.6.22")
         if Version(self.version) >= "0.6.5":

--- a/recipes/aws-c-auth/all/test_package/conanfile.py
+++ b/recipes/aws-c-auth/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/aws-c-auth/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-c-auth/all/test_v1_package/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(aws-c-auth REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.c)
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-auth)

--- a/recipes/aws-c-auth/all/test_v1_package/conanfile.py
+++ b/recipes/aws-c-auth/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/aws-c-auth/config.yml
+++ b/recipes/aws-c-auth/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.17":
+    folder: all
   "0.6.11":
     folder: all
   "0.6.8":


### PR DESCRIPTION
Specify library name and version:  **aws-c-auth/***

While there is newer version of `aws-c-cal/0.5.20`, this recipe requires `aws-c-cal/0.5.13`.
Because `aws-c-io` requires `aws-c-cal/0.5.13`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
