### PR TITLE
boost-ext-ut: Use upstream CMake target namespace in 1.1.9

### DIFF
--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -101,17 +101,19 @@ class UTConan(ConanFile):
         self.info.clear()
 
     def package_info(self):
+        newer_than_1_1_8 = Version(self.version) > "1.1.8"
+        namespace = "Boost" if newer_than_1_1_8 else "boost"
         self.cpp_info.set_property("cmake_file_name", "ut")
-        self.cpp_info.set_property("cmake_target_name", "boost::ut")
+        self.cpp_info.set_property("cmake_target_name", f"{namespace}::ut")
 
-        self.cpp_info.names["cmake_find_package"] = "boost"
-        self.cpp_info.names["cmake_find_package_multi"] = "boost"
+        self.cpp_info.names["cmake_find_package"] = namespace
+        self.cpp_info.names["cmake_find_package_multi"] = namespace
         self.cpp_info.filenames["cmake_find_package"] = "ut"
         self.cpp_info.filenames["cmake_find_package_multi"] = "ut"
         self.cpp_info.components["ut"].names["cmake_find_package"] = "ut"
         self.cpp_info.components["ut"].names["cmake_find_package_multi"] = "ut"
 
-        if Version(self.version) > "1.1.8":
+        if newer_than_1_1_8:
             self.cpp_info.components["ut"].includedirs = [os.path.join("include", "ut-" + self.version, "include")]
 
         if self.options.get_safe("disable_module"):

--- a/recipes/boost-ext-ut/all/test_package/CMakeLists.txt
+++ b/recipes/boost-ext-ut/all/test_package/CMakeLists.txt
@@ -3,6 +3,11 @@ project(test_package LANGUAGES CXX)
 
 find_package(ut REQUIRED CONFIG)
 
+set(namespace Boost)
+if(ut_VERSION VERSION_LESS "1.1.9")
+  set(namespace boost)
+endif()
+
 add_executable(test_package test_package.cpp)
-target_link_libraries(test_package PRIVATE boost::ut)
+target_link_libraries(test_package PRIVATE "${namespace}::ut")
 target_compile_features(test_package PRIVATE cxx_std_20)

--- a/recipes/boost-ext-ut/all/test_v1_package/CMakeLists.txt
+++ b/recipes/boost-ext-ut/all/test_v1_package/CMakeLists.txt
@@ -6,6 +6,11 @@ conan_basic_setup(TARGETS)
 
 find_package(ut REQUIRED CONFIG)
 
+set(namespace Boost)
+if(ut_VERSION VERSION_LESS "1.1.9")
+  set(namespace boost)
+endif()
+
 add_executable(test_package ../test_package/test_package.cpp)
-target_link_libraries(test_package PRIVATE boost::ut)
+target_link_libraries(test_package PRIVATE "${namespace}::ut")
 target_compile_features(test_package PRIVATE cxx_std_20)


### PR DESCRIPTION
Specify library name and version:  **boost-ext-ut/1.1.9**

https://github.com/boost-ext/ut/blob/v1.1.9/CMakeLists.txt#L139

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
