### PR TITLE
modern-cpp-kafka: add version 2022.10.12

### DIFF
--- a/recipes/modern-cpp-kafka/all/conandata.yml
+++ b/recipes/modern-cpp-kafka/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2022.10.12":
+    url: "https://github.com/morganstanley/modern-cpp-kafka/archive/v2022.10.12.tar.gz"
+    sha256: "f60c6d6328e64a8ae0c3233921078160fc4e42a3484eb823d9918895f5f1b39f"
   "2022.08.01":
     url: "https://github.com/morganstanley/modern-cpp-kafka/archive/v2022.08.01.tar.gz"
     sha256: "77998caf50ffcc55c77713571d9ce04a37020ccff7b713d14abad9eb8ceb05b3"

--- a/recipes/modern-cpp-kafka/config.yml
+++ b/recipes/modern-cpp-kafka/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2022.10.12":
+    folder: all
   "2022.08.01":
     folder: all
   "2022.06.15":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **modern-cpp-kafka/2022.10.12**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
