### PR TITLE
(#12705) OpenBlas: Add arch target option

### DIFF
--- a/recipes/openblas/all/conanfile.py
+++ b/recipes/openblas/all/conanfile.py
@@ -1,10 +1,149 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake
+from conan.tools import build
+from conan.tools.scm import Version
+from conan.tools.files import get, replace_in_file, rmdir, collect_libs
 import os
 import functools
 
 required_conan_version = ">=1.43.0"
 
+# Copypasting here content of OpenBlas/TargetList.txt
+# https://github.com/xianyi/OpenBLAS/blob/develop/TargetList.txt
+# https://github.com/xianyi/OpenBLAS#normal-compile
+openblas_target_list = [
+        "native", # We rely on architecture detection in OpenBlas cmake scripts
+
+        # 1.X86/X86_64
+        # a)Intel CPU:
+        "P2",
+        "KATMAI",
+        "COPPERMINE",
+        "NORTHWOOD",
+        "PRESCOTT",
+        "BANIAS",
+        "YONAH",
+        "CORE2",
+        "PENRYN",
+        "DUNNINGTON",
+        "NEHALEM",
+        "SANDYBRIDGE",
+        "HASWELL",
+        "SKYLAKEX",
+        "ATOM",
+        "COOPERLAKE",
+        "SAPPHIRERAPIDS",
+
+        # b)AMD CPU:
+        "ATHLON",
+        "OPTERON",
+        "OPTERON_SSE3",
+        "BARCELONA",
+        "SHANGHAI",
+        "ISTANBUL",
+        "BOBCAT",
+        "BULLDOZER",
+        "PILEDRIVER",
+        "STEAMROLLER",
+        "EXCAVATOR",
+        "ZEN",
+
+        # c)VIA CPU:
+        "SSE_GENERIC",
+        "VIAC3",
+        "NANO",
+
+        # 2.Power CPU:
+        "POWER4",
+        "POWER5",
+        "POWER6",
+        "POWER7",
+        "POWER8",
+        "POWER9",
+        "POWER10",
+        "PPCG4",
+        "PPC970",
+        "PPC970MP",
+        "PPC440",
+        "PPC440FP2",
+        "CELL",
+
+        # 3.MIPS CPU:
+        "P5600",
+        "MIPS1004K",
+        "MIPS24K",
+
+        # 4.MIPS64 CPU:
+        "MIPS64_GENERIC",
+        "SICORTEX",
+        "LOONGSON3A",
+        "LOONGSON3B",
+        "I6400",
+        "P6600",
+        "I6500",
+
+        # 5.IA64 CPU:
+        "ITANIUM2",
+
+        # 6.SPARC CPU:
+        "SPARC",
+        "SPARCV7",
+
+        # 7.ARM CPU:
+        "CORTEXA15",
+        "CORTEXA9",
+        "ARMV7",
+        "ARMV6",
+        "ARMV5",
+
+        # 8.ARM 64-bit CPU:
+        "ARMV8",
+        "CORTEXA53",
+        "CORTEXA57",
+        "CORTEXA72",
+        "CORTEXA73",
+        "CORTEXA510",
+        "CORTEXA710",
+        "CORTEXX1",
+        "CORTEXX2",
+        "NEOVERSEN1",
+        "NEOVERSEV1",
+        "NEOVERSEN2",
+        "CORTEXA55",
+        "EMAG8180",
+        "FALKOR",
+        "THUNDERX",
+        "THUNDERX2T99",
+        "TSV110",
+        "THUNDERX3T110",
+        "VORTEX",
+        "A64FX",
+        "ARMV8SVE",
+        "FT2000",
+
+        # 9.System Z:
+        "ZARCH_GENERIC",
+        "Z13",
+        "Z14",
+
+        # 10.RISC-V 64:
+        "RISCV64_GENERIC",
+        "C910V",
+
+        # 11.LOONGARCH64:
+        "LOONGSONGENERIC",
+        "LOONGSON3R5",
+        "LOONGSON2K1000",
+
+        # 12. Elbrus E2000:
+        "E2K",
+
+        # 13. Alpha
+        "EV4",
+        "EV5",
+        "EV6",
+    ]
 
 class OpenblasConan(ConanFile):
     name = "openblas"
@@ -20,6 +159,7 @@ class OpenblasConan(ConanFile):
         "build_lapack": [True, False],
         "use_thread": [True, False],
         "dynamic_arch": [True, False],
+        "target": openblas_target_list,
     }
     default_options = {
         "shared": False,
@@ -27,6 +167,7 @@ class OpenblasConan(ConanFile):
         "build_lapack": False,
         "use_thread": True,
         "dynamic_arch": False,
+        "target": "native",
     }
     generators = "cmake"
     short_paths = True
@@ -51,11 +192,11 @@ class OpenblasConan(ConanFile):
             del self.options.fPIC
 
     def validate(self):
-        if hasattr(self, "settings_build") and tools.cross_building(self, skip_x64_x86=True):
+        if hasattr(self, "settings_build") and build.cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building not implemented")
 
     def source(self):
-        tools.get(
+        get(
             **self.conan_data["sources"][self.version],
             strip_root=True,
             destination=self._source_subfolder
@@ -72,6 +213,14 @@ class OpenblasConan(ConanFile):
         cmake.definitions["DYNAMIC_ARCH"] = self.options.dynamic_arch
         cmake.definitions["USE_THREAD"] = self.options.use_thread
 
+        if self.options.target != "native":
+            cmake.definitions["TARGET"] = self.options.target
+            self.output.info(
+                    f"Setting target arch to {self.options.target} and "
+                    "passing this as value to TARGET variable of openblas cmake. "
+                    "For more information, check out "
+                    "https://github.com/xianyi/OpenBLAS#normal-compile")
+
         # Required for safe concurrent calls to OpenBLAS routines
         cmake.definitions["USE_LOCKING"] = not self.options.use_thread
 
@@ -87,7 +236,7 @@ class OpenblasConan(ConanFile):
         return cmake
 
     def build(self):
-        if tools.Version(self.version) >= "0.3.12":
+        if Version(self.version) >= "0.3.12":
             search = """message(STATUS "No Fortran compiler found, can build only BLAS but not LAPACK")"""
             replace = (
                 """message(FATAL_ERROR "No Fortran compiler found. Cannot build with LAPACK.")"""
@@ -104,7 +253,7 @@ else()
   set (NO_LAPACK 1)
 endif()"""
 
-        tools.replace_in_file(
+        replace_in_file(
             os.path.join(self._source_subfolder, "cmake", "f_check.cmake"),
             search,
             replace,
@@ -116,8 +265,8 @@ endif()"""
         self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
         cmake = self._configure_cmake()
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         # CMake config file:
@@ -132,7 +281,7 @@ endif()"""
         self.cpp_info.components["openblas_component"].includedirs.append(
             os.path.join("include", "openblas")
         )
-        self.cpp_info.components["openblas_component"].libs = tools.collect_libs(self)
+        self.cpp_info.components["openblas_component"].libs = collect_libs(self)
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["openblas_component"].system_libs.append("m")
             if self.options.use_thread:


### PR DESCRIPTION
Specify library name and version:  ***openblas/****

Now we can specify target architecture with recipe options and not rely on hardcoded in openblas cmake auto detection utilities.

closes #12705

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.