### PR TITLE
qt5: disable bitcode

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -441,6 +441,7 @@ class QtConan(ConanFile):
             "-ldbus-1d",
             "-ldbus-1"
         )
+        open(os.path.join(self.source_folder, "qt5", "qtbase", "mkspecs", "features", "uikit", "bitcode.prf"), "w").close()
 
     def _make_program(self):
         if self._is_msvc:


### PR DESCRIPTION
Specify library name and version:  **qt/5.x.x**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

Currently there's no standard way to control if a recipe must be built with bitcode or not, most recipes are built with bitcode off. But Qt 5 defaults to on which makes it impossible to build with dependencies that have bitcode off (e.g. libpng), and there seems no way to disable it through configure options. Besides, [starting with Xcode 14 bitcode is no longer required](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes):

> Deprecations
>
> Starting with Xcode 14, bitcode is no longer required for watchOS and tvOS applications, and the App Store no longer accepts bitcode submissions from Xcode 14.
>
> Xcode no longer builds bitcode by default and generates a warning message if a project explicitly enables bitcode: “Building with bitcode is deprecated. Please update your project and/or target settings to disable bitcode.” The capability to build with bitcode will be removed in a future Xcode release. IPAs that contain bitcode will have the bitcode stripped before being submitted to the App Store. Debug symbols for past bitcode submissions remain available for download. (86118779

fixes #12680

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
