### PR TITLE
wayland-protocols: Conan V2

### DIFF
--- a/recipes/wayland-protocols/all/conanfile.py
+++ b/recipes/wayland-protocols/all/conanfile.py
@@ -1,9 +1,13 @@
 from conan import ConanFile
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, replace_in_file, rmdir
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
-from conans import Meson, tools
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.50.0"
 
 
 class WaylandProtocolsConan(ConanFile):
@@ -13,64 +17,51 @@ class WaylandProtocolsConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gitlab.freedesktop.org/wayland/wayland-protocols"
     license = "MIT"
-
     settings = "os", "arch", "compiler", "build_type"
 
-    _meson = None
-
     def package_id(self):
-        self.info.header_only()
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
+        self.info.clear()
 
     def validate(self):
         if self.settings.os != "Linux":
-            raise ConanInvalidConfiguration("Wayland-protocols can be built on Linux only")
+            raise ConanInvalidConfiguration(f"{self.ref} only supports Linux")
 
     def build_requirements(self):
-        self.build_requires("meson/0.63.0")
+        self.tool_requires("meson/0.63.3")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  strip_root=True, destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.project_options["datadir"] = os.path.join(self.package_folder, "res")
+        tc.project_options["tests"] = "false"
+        tc.generate()
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
 
     def _patch_sources(self):
-        if tools.Version(self.version) <= 1.23:
+        if Version(self.version) <= "1.23":
             # fixed upstream in https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/113
-            tools.replace_in_file(os.path.join(self._source_subfolder, "meson.build"),
-                                  "dep_scanner = dependency('wayland-scanner', native: true)",
-                                  "#dep_scanner = dependency('wayland-scanner', native: true)")
-
-    def _configure_meson(self):
-        if not self._meson:
-            defs = {
-                "tests": "false",
-            }
-            self._meson = Meson(self)
-            self._meson.configure(
-                source_folder=self._source_subfolder,
-                build_folder=self._build_subfolder,
-                defs=defs,
-                args=[f'--datadir={self.package_folder}/res'],
-            )
-        return self._meson
+            replace_in_file(self, os.path.join(self.source_folder, "meson.build"),
+                            "dep_scanner = dependency('wayland-scanner', native: true)",
+                            "#dep_scanner = dependency('wayland-scanner', native: true)")
 
     def build(self):
         self._patch_sources()
-        meson = self._configure_meson()
+        meson = Meson(self)
+        meson.configure()
         meson.build()
 
     def package(self):
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        meson = self._configure_meson()
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
         meson.install()
-        tools.rmdir(os.path.join(self.package_folder, "res", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "res", "pkgconfig"))
 
     def package_info(self):
         pkgconfig_variables = {

--- a/recipes/wayland-protocols/all/test_package/conanfile.py
+++ b/recipes/wayland-protocols/all/test_package/conanfile.py
@@ -11,6 +11,10 @@ class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     test_type = "explicit"
 
+    @property
+    def _has_build_profile(self):
+        return hasattr(self, "settings_build")
+
     def requirements(self):
         self.requires(self.tested_reference_str)
         self.requires("wayland/1.21.0")
@@ -26,10 +30,12 @@ class TestPackageConan(ConanFile):
     def generate(self):
         tc = MesonToolchain(self)
         tc.project_options["build.pkg_config_path"] = self.generators_folder
+        tc.project_options["has_build_profile"] = self._has_build_profile
         tc.generate()
         pkg_config_deps = PkgConfigDeps(self)
-        pkg_config_deps.build_context_activated = ["wayland"]
-        pkg_config_deps.build_context_suffix = {"wayland": "_BUILD"}
+        if self._has_build_profile:
+            pkg_config_deps.build_context_activated = ["wayland"]
+            pkg_config_deps.build_context_suffix = {"wayland": "_BUILD"}
         pkg_config_deps.generate()
         virtual_build_env = VirtualBuildEnv(self)
         virtual_build_env.generate()

--- a/recipes/wayland-protocols/all/test_package/conanfile.py
+++ b/recipes/wayland-protocols/all/test_package/conanfile.py
@@ -1,27 +1,45 @@
-from conans import Meson, tools
 from conan import ConanFile
-from conan.tools.build import cross_building
+from conan.tools.build import can_run
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "pkg_config"
-
-    def build_requirements(self):
-        self.build_requires("wayland/1.21.0")
-        self.build_requires("meson/0.63.0")
+    test_type = "explicit"
 
     def requirements(self):
+        self.requires(self.tested_reference_str)
         self.requires("wayland/1.21.0")
+
+    def build_requirements(self):
+        self.tool_requires("meson/0.63.3")
+        self.tool_requires("pkgconf/1.9.3")
+        self.tool_requires("wayland/1.21.0")
+
+    def layout(self):
+        basic_layout(self)
+
+    def generate(self):
+        tc = MesonToolchain(self)
+        tc.project_options["build.pkg_config_path"] = self.generators_folder
+        tc.generate()
+        pkg_config_deps = PkgConfigDeps(self)
+        pkg_config_deps.build_context_activated = ["wayland"]
+        pkg_config_deps.build_context_suffix = {"wayland": "_BUILD"}
+        pkg_config_deps.generate()
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
 
     def build(self):
         meson = Meson(self)
-        env_build = tools.RunEnvironment(self)
-        with tools.environment_append(env_build.vars):
-            meson.configure()
-            meson.build()
+        meson.configure()
+        meson.build()
 
     def test(self):
-        if not cross_building(self):
-            self.run(os.path.join(".", "test_package"), run_environment=True)
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/wayland-protocols/all/test_package/meson.build
+++ b/recipes/wayland-protocols/all/test_package/meson.build
@@ -4,8 +4,13 @@ wayland_client_dep = dependency('wayland-client', version: '>=1.2.0', required: 
 wayland_protocols_dep = dependency('wayland-protocols', required: true)
 wayland_protocols_datadir = wayland_protocols_dep.get_pkgconfig_variable('pkgdatadir')
 
-wayland_scanner_dep = dependency('wayland-scanner_BUILD', native: true)
-wayland_scanner_for_build = find_program(wayland_scanner_dep.get_variable(pkgconfig: 'wayland_scanner'))
+if get_option('has_build_profile')
+    wayland_scanner_dep = dependency('wayland-scanner_BUILD', native: true)
+    wayland_scanner_for_build = find_program(wayland_scanner_dep.get_variable(pkgconfig: 'wayland_scanner'))
+else
+    wayland_scanner_for_build = find_program('wayland-scanner')
+endif
+
 wayland_scanner_code_gen = generator(
     wayland_scanner_for_build,
     output: '@BASENAME@-protocol.c',

--- a/recipes/wayland-protocols/all/test_package/meson_options.txt
+++ b/recipes/wayland-protocols/all/test_package/meson_options.txt
@@ -1,0 +1,1 @@
+option('has_build_profile', type : 'boolean', value : false)

--- a/recipes/wayland-protocols/all/test_v1_package/conanfile.py
+++ b/recipes/wayland-protocols/all/test_v1_package/conanfile.py
@@ -1,0 +1,27 @@
+from conans import Meson, tools
+from conan import ConanFile
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "pkg_config"
+
+    def build_requirements(self):
+        self.build_requires("wayland/1.21.0")
+        self.build_requires("meson/0.63.0")
+
+    def requirements(self):
+        self.requires("wayland/1.21.0")
+
+    def build(self):
+        meson = Meson(self)
+        env_build = tools.RunEnvironment(self)
+        with tools.environment_append(env_build.vars):
+            meson.configure()
+            meson.build()
+
+    def test(self):
+        if not cross_building(self):
+            self.run(os.path.join(".", "test_package"), run_environment=True)

--- a/recipes/wayland-protocols/all/test_v1_package/conanfile.py
+++ b/recipes/wayland-protocols/all/test_v1_package/conanfile.py
@@ -10,7 +10,7 @@ class TestPackageConan(ConanFile):
 
     def build_requirements(self):
         self.build_requires("wayland/1.21.0")
-        self.build_requires("meson/0.63.0")
+        self.build_requires("meson/0.63.3")
 
     def requirements(self):
         self.requires("wayland/1.21.0")

--- a/recipes/wayland-protocols/all/test_v1_package/meson.build
+++ b/recipes/wayland-protocols/all/test_v1_package/meson.build
@@ -4,15 +4,14 @@ wayland_client_dep = dependency('wayland-client', version: '>=1.2.0', required: 
 wayland_protocols_dep = dependency('wayland-protocols', required: true)
 wayland_protocols_datadir = wayland_protocols_dep.get_pkgconfig_variable('pkgdatadir')
 
-wayland_scanner_dep = dependency('wayland-scanner_BUILD', native: true)
-wayland_scanner_for_build = find_program(wayland_scanner_dep.get_variable(pkgconfig: 'wayland_scanner'))
+wayland_scanner = find_program('wayland-scanner')
 wayland_scanner_code_gen = generator(
-    wayland_scanner_for_build,
+    wayland_scanner,
     output: '@BASENAME@-protocol.c',
     arguments: ['code', '@INPUT@', '@OUTPUT@'],
 )
 wayland_scanner_client_header_gen = generator(
-    wayland_scanner_for_build,
+    wayland_scanner,
     output: '@BASENAME@-client-protocol.h',
     arguments: ['client-header', '@INPUT@', '@OUTPUT@'],
 )
@@ -25,7 +24,7 @@ xdg_shell_sources = [
 ]
 
 executable('test_package',
-            'test_package.c',
+            '../test_package/test_package.c',
             xdg_shell_sources,
             dependencies: [wayland_client_dep],
             link_args : '-lrt')


### PR DESCRIPTION
Update for Conan V2.
Use build context for PkgConfigDeps in test package.
Allows cross-compilation.

Specify library name and version:  **wayland-protocols/***

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
