### PR TITLE
wayland: Modernize test package

### DIFF
--- a/recipes/wayland/all/test_package/conanfile.py
+++ b/recipes/wayland/all/test_package/conanfile.py
@@ -1,28 +1,49 @@
 import os
 
 from conan import ConanFile
-from conan.tools.build import cross_building
-from conan.tools.cmake import CMake
-from conan.tools.gnu import PkgConfig
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.gnu import PkgConfig, PkgConfigDeps
 from conan.tools.layout import cmake_layout
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeToolchain", "CMakeDeps", "PkgConfigDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+        self.tool_requires("pkgconf/1.9.3")
 
     def layout(self):
         cmake_layout(self)
 
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        cmake_deps = CMakeDeps(self)
+        cmake_deps.generate()
+        pkg_config_deps = PkgConfigDeps(self)
+        pkg_config_deps.build_context_activated = ["wayland"]
+        pkg_config_deps.build_context_suffix = {"wayland": "_BUILD"}
+        pkg_config_deps.generate()
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
+
     def build(self):
-        if not cross_building(self):
-            cmake = CMake(self)
-            cmake.configure()
-            cmake.build()
-            pkg_config = PkgConfig(self, "wayland-scanner", self.generators_folder)
-            self.run('%s --version' % pkg_config.variables["wayland_scanner"], env="conanrun")
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+        pkg_config = PkgConfig(self, "wayland-scanner_BUILD", self.generators_folder)
+        wayland_scanner = pkg_config.variables["wayland_scanner"]
+        self.run(f"{wayland_scanner} --version", env="conanrun")
 
     def test(self):
-        if not cross_building(self):
-            cmd = os.path.join(self.cpp.build.bindirs[0], "test_package")
-            self.run(cmd, env="conanrun")
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")


### PR DESCRIPTION
Update test package for Conan V2.
Test wayland as a build requirement.
This is a common use case for wayland-scanner.
Use PkgConfigDeps build context to find wayland-scanner.

Specify library name and version:  **wayland/***

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
