### PR TITLE
aws-c-s3: add version 0.1.49 and support conan v2

### DIFF
--- a/recipes/aws-c-s3/all/CMakeLists.txt
+++ b/recipes/aws-c-s3/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.12)
-project(cmake_wrapper LANGUAGES C)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory(source_subfolder)

--- a/recipes/aws-c-s3/all/conandata.yml
+++ b/recipes/aws-c-s3/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.49":
+    url: "https://github.com/awslabs/aws-c-s3/archive/v0.1.49.tar.gz"
+    sha256: "71acbba41a02477a6c352172da561bc2138bf239b936490c773d7aaa83afc9ab"
   "0.1.37":
     url: "https://github.com/awslabs/aws-c-s3/archive/v0.1.37.tar.gz"
     sha256: "2c35100c1739300e438d47f49aaa2c374001416a79fe3c6f27d79371fb2ac90b"

--- a/recipes/aws-c-s3/all/conanfile.py
+++ b/recipes/aws-c-s3/all/conanfile.py
@@ -1,18 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.files import get, copy, rmdir
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.43.0"
-
+required_conan_version = ">=1.47.0"
 
 class AwsCS3(ConanFile):
     name = "aws-c-s3"
     description = "C99 implementation of the S3 client"
-    topics = ("aws", "amazon", "cloud", "s3")
+    license = "Apache-2.0",
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/awslabs/aws-c-s3"
-    license = "Apache-2.0",
-    exports_sources = "CMakeLists.txt"
-    generators = "cmake", "cmake_find_package"
+    topics = ("aws", "amazon", "cloud", "s3")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -23,51 +23,60 @@ class AwsCS3(ConanFile):
         "fPIC": True,
     }
 
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.cppstd
-        del self.settings.compiler.libcxx
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("aws-c-common/0.6.19")
-        self.requires("aws-c-io/0.10.20")
-        self.requires("aws-c-http/0.6.13")
-        self.requires("aws-c-auth/0.6.11")
-        if tools.Version(self.version) >= "0.1.36":
-            self.requires("aws-checksums/0.1.12")
+        self.requires("aws-c-common/0.8.2")
+        if Version(self.version) >= "0.1.49":
+            self.requires("aws-c-io/0.13.4")
+        else:
+            self.requires("aws-c-io/0.10.20")
+        self.requires("aws-c-http/0.6.22")
+        self.requires("aws-c-auth/0.6.17")
+        if Version(self.version) >= "0.1.36":
+            self.requires("aws-checksums/0.1.13")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["BUILD_TESTING"] = False
-        self._cmake.configure()
-        return self._cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_TESTING"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "aws-c-s3"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "aws-c-s3"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-s3")
@@ -88,5 +97,5 @@ class AwsCS3(ConanFile):
             "aws-c-http::aws-c-http-lib",
             "aws-c-auth::aws-c-auth-lib"
         ]
-        if tools.Version(self.version) >= "0.1.36":
+        if Version(self.version) >= "0.1.36":
             self.cpp_info.components["aws-c-s3-lib"].requires.append("aws-checksums::aws-checksums-lib")

--- a/recipes/aws-c-s3/all/conanfile.py
+++ b/recipes/aws-c-s3/all/conanfile.py
@@ -47,12 +47,14 @@ class AwsCS3(ConanFile):
 
     def requirements(self):
         self.requires("aws-c-common/0.8.2")
-        if Version(self.version) >= "0.1.49":
-            self.requires("aws-c-io/0.13.4")
-        else:
+        if Version(self.version) < "0.1.49":
             self.requires("aws-c-io/0.10.20")
-        self.requires("aws-c-http/0.6.22")
-        self.requires("aws-c-auth/0.6.17")
+            self.requires("aws-c-http/0.6.13")
+            self.requires("aws-c-auth/0.6.11")
+        else:
+            self.requires("aws-c-io/0.13.4")
+            self.requires("aws-c-http/0.6.22")
+            self.requires("aws-c-auth/0.6.17")
         if Version(self.version) >= "0.1.36":
             self.requires("aws-checksums/0.1.13")
 

--- a/recipes/aws-c-s3/all/test_package/conanfile.py
+++ b/recipes/aws-c-s3/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/aws-c-s3/all/test_v1_package/CMakeLists.txt
+++ b/recipes/aws-c-s3/all/test_v1_package/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package LANGUAGES C)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(aws-c-s3 REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.c)
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-s3)

--- a/recipes/aws-c-s3/all/test_v1_package/conanfile.py
+++ b/recipes/aws-c-s3/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/aws-c-s3/config.yml
+++ b/recipes/aws-c-s3/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.1.49":
+    folder: all
   "0.1.37":
     folder: all
   "0.1.29":


### PR DESCRIPTION
Specify library name and version:  **aws-c-s3/***

There is a "missing dependencies" issue related to the aws-c-io API breaking changes.

aws-c-io made incompatible changes to the Input Stream API in 0.11.
https://github.com/awslabs/aws-c-io/releases/tag/v0.11.0

And aws-c-s3 uses new Input Stream API since 0.1.36.
(no official release note)
https://github.com/awslabs/aws-c-s3/blob/v0.1.36/source/s3_checksum_stream.c

The version of aws-c-s3 needs to change the version of aws-c-io that it depends on, which causes missing dependencies in aws-c-auth and aws-c-http.

For this reason, I would like to split the version of aws-c-auth and aws-c-http as follows.

![aws-c-s3-dependencies](https://user-images.githubusercontent.com/465629/196021759-601d85d0-dfdd-4cd9-936d-92f7c9f8b94e.png)

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
