### PR TITLE
aws-c-http: change dependeant recipe version for aws-c-s3

### DIFF
--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -48,7 +48,7 @@ class AwsCHttp(ConanFile):
     def requirements(self):
         self.requires("aws-c-common/0.8.2")
         self.requires("aws-c-compression/0.2.15")
-        if Version(self.version) <= "0.6.13":
+        if Version(self.version) < "0.6.22":
             self.requires("aws-c-io/0.10.20")
         else:
             self.requires("aws-c-io/0.13.4")

--- a/recipes/aws-c-http/all/conanfile.py
+++ b/recipes/aws-c-http/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.scm import Version
 from conan.tools.files import get, copy, rmdir
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
@@ -47,7 +48,10 @@ class AwsCHttp(ConanFile):
     def requirements(self):
         self.requires("aws-c-common/0.8.2")
         self.requires("aws-c-compression/0.2.15")
-        self.requires("aws-c-io/0.13.4")
+        if Version(self.version) <= "0.6.13":
+            self.requires("aws-c-io/0.10.20")
+        else:
+            self.requires("aws-c-io/0.13.4")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],


### PR DESCRIPTION
Specify library name and version:  **aws-c-http/***

This PR is trying to solve missing-dependencies in aws-c-s3. https://github.com/conan-io/conan-center-index/pull/13494.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
