### PR TITLE
aws-c-auth: change dependeant recipe version for aws-c-s3

### DIFF
--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -49,8 +49,12 @@ class AwsCAuth(ConanFile):
     def requirements(self):
         self.requires("aws-c-common/0.8.2")
         self.requires("aws-c-cal/0.5.13")
-        self.requires("aws-c-io/0.13.4")
-        self.requires("aws-c-http/0.6.22")
+        if Version(self.version) <= "0.6.11":
+            self.requires("aws-c-io/0.10.20")
+            self.requires("aws-c-http/0.6.13")
+        else:
+            self.requires("aws-c-io/0.13.4")
+            self.requires("aws-c-http/0.6.22")
         if Version(self.version) >= "0.6.5":
             self.requires("aws-c-sdkutils/0.1.3")
 

--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -49,7 +49,7 @@ class AwsCAuth(ConanFile):
     def requirements(self):
         self.requires("aws-c-common/0.8.2")
         self.requires("aws-c-cal/0.5.13")
-        if Version(self.version) <= "0.6.11":
+        if Version(self.version) < "0.6.17":
             self.requires("aws-c-io/0.10.20")
             self.requires("aws-c-http/0.6.13")
         else:

--- a/recipes/aws-c-auth/all/conanfile.py
+++ b/recipes/aws-c-auth/all/conanfile.py
@@ -84,10 +84,6 @@ class AwsCAuth(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "aws-c-auth")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-auth")
 
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-auth"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-auth"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
         self.cpp_info.components["aws-c-auth-lib"].names["cmake_find_package"] = "aws-c-auth"
         self.cpp_info.components["aws-c-auth-lib"].names["cmake_find_package_multi"] = "aws-c-auth"
         self.cpp_info.components["aws-c-auth-lib"].set_property("cmake_target_name", "AWS::aws-c-auth")
@@ -97,7 +93,13 @@ class AwsCAuth(ConanFile):
             "aws-c-common::aws-c-common-lib",
             "aws-c-cal::aws-c-cal-lib",
             "aws-c-io::aws-c-io-lib",
-            "aws-c-http::aws-c-http-lib"
+            "aws-c-http::aws-c-http-lib",
         ]
         if Version(self.version) >= "0.6.5":
             self.cpp_info.components["aws-c-auth-lib"].requires.append("aws-c-sdkutils::aws-c-sdkutils-lib")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "aws-c-auth"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-auth"
+        self.cpp_info.names["cmake_find_package"] = "AWS"
+        self.cpp_info.names["cmake_find_package_multi"] = "AWS"


### PR DESCRIPTION
Specify library name and version:  **aws-c-auth/***

This PR is trying to solve missing-dependencies in aws-c-s3. https://github.com/conan-io/conan-center-index/pull/13494.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
