### PR TITLE
tcb-span: add vercion cci.20220616 and support conan v2

### DIFF
--- a/recipes/tcb-span/all/conandata.yml
+++ b/recipes/tcb-span/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20220616":
+    url: "https://github.com/tcbrindle/span/archive/836dc6a0efd9849cb194e88e4aa2387436bb079b.tar.gz"
+    sha256: "66650479f85b92c6a6230706e4ac4a1bca18a7c7102fc7e02ad332f86548c9b6"
   "cci.20200603":
     url: "https://github.com/tcbrindle/span/archive/5d8d366eca918d0ed3d2d196cbeae6abfd874736.tar.gz"
     sha256: "c294ec2314eeccbcfe12b549ca6c165fbe9f97d2d52a0ad4c9a28f73fa87861a"

--- a/recipes/tcb-span/all/conanfile.py
+++ b/recipes/tcb-span/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.tools.files import get, copy
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
 from conan.tools.layout import basic_layout
 import os
 

--- a/recipes/tcb-span/all/conanfile.py
+++ b/recipes/tcb-span/all/conanfile.py
@@ -1,34 +1,50 @@
-from conans import ConanFile, tools
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.layout import basic_layout
 import os
 
+required_conan_version = ">=1.50.0"
 
 class TcbSpanConan(ConanFile):
     name = "tcb-span"
     description = "Implementation of C++20's std::span for older C++ standards"
-    topics = ("conan", "span", "header-only", "tcb-span")
-    homepage = "https://github.com/tcbrindle/span"
-    url = "https://github.com/conan-io/conan-center-index"
     license = "BSL-1.0"
-    settings = "compiler"
-
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/tcbrindle/span"
+    topics = ("span", "header-only")
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _minimum_cpp_standard(self):
+        return 11
 
-    def configure(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 11)
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
-
-    def package(self):
-        include_folder = os.path.join(self._source_subfolder, "include")
-        self.copy(pattern="LICENSE*.txt", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="*.hpp", dst="include", src=include_folder)
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
+
+    def validate(self):
+        if self.info.settings.get_safe("compiler.cppstd"):
+            check_min_cppstd(self, self._minimum_cpp_standard)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+
+    def package(self):
+        copy(self, pattern="LICENSE*.txt", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="*.hpp",
+            dst=os.path.join(self.package_folder, "include"),
+            src=os.path.join(self.source_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []

--- a/recipes/tcb-span/all/test_package/conanfile.py
+++ b/recipes/tcb-span/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/tcb-span/all/test_v1_package/CMakeLists.txt
+++ b/recipes/tcb-span/all/test_v1_package/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(tcb-span REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cxx)
+add_executable(${PROJECT_NAME} ../test_package/test_package.cxx)
 target_link_libraries(${PROJECT_NAME} PRIVATE tcb-span::tcb-span)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/tcb-span/all/test_v1_package/conanfile.py
+++ b/recipes/tcb-span/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/tcb-span/config.yml
+++ b/recipes/tcb-span/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "cci.20220616":
+    folder: all
   "cci.20200603":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **tcb-span/***

tcb-span has many revisions in the two years since 2020-06-03.
I think it is a good time to add a new cci version.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
