### PR TITLE
minizip-ng: add version 3.0.7

### DIFF
--- a/recipes/minizip-ng/all/conandata.yml
+++ b/recipes/minizip-ng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.7":
+    url: "https://github.com/zlib-ng/minizip-ng/archive/3.0.7.tar.gz"
+    sha256: "39981a0db1bb6da504909bce63d7493286c5e50825c056564544c990d15c55cf"
   "3.0.6":
     url: "https://github.com/zlib-ng/minizip-ng/archive/3.0.6.tar.gz"
     sha256: "383fa1bdc28c482828a8a8db53f758dbd44291b641182724fda5df5b59cce543"

--- a/recipes/minizip-ng/config.yml
+++ b/recipes/minizip-ng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.7":
+    folder: all
   "3.0.6":
     folder: all
   "3.0.5":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **minizip-ng/3.0.7**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
