### PR TITLE
gstreamer: Add version 1.20

### DIFF
--- a/recipes/gstreamer/all/conandata.yml
+++ b/recipes/gstreamer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.22.3":
+    url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.22.3.tar.xz"
+    sha256: "9ffeab95053f9f6995eb3b3da225e88f21c129cd60da002d3f795db70d6d5974"
   "1.20.6":
     url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.20.6.tar.xz"
     sha256: "0545b030960680f71a95f9d39c95daae54b4d317d335e8f239d81138773c9b90"

--- a/recipes/gstreamer/all/conandata.yml
+++ b/recipes/gstreamer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.20.6":
+    url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.20.6.tar.xz"
+    sha256: "0545b030960680f71a95f9d39c95daae54b4d317d335e8f239d81138773c9b90"
   "1.19.2":
     url: "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.19.2/gstreamer-1.19.2.tar.gz"
     sha256: "6ec8494867d9b58f145c0c357da631faf21c2c72c7cd8b637b440188fe904ab8"

--- a/recipes/gstreamer/config.yml
+++ b/recipes/gstreamer/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.22.3":
+    folder: all
   "1.20.6":
     folder: all
   "1.19.2":

--- a/recipes/gstreamer/config.yml
+++ b/recipes/gstreamer/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.20.6":
+    folder: all
   "1.19.2":
     folder: all
   "1.19.1":


### PR DESCRIPTION
Specify library name and version:  **gstreamer/1.20.4**

The current recipe only contains the old 1.19 version of GStreamer, IMHO an update to the 1.20 is needed

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
