### PR TITLE
Allow building libbsd on Android

### DIFF
--- a/recipes/libbsd/all/conandata.yml
+++ b/recipes/libbsd/all/conandata.yml
@@ -6,3 +6,5 @@ patches:
   "0.10.0":
     - patch_file: "patches/0001-support-macosx.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0002-support-android.patch"
+      base_path: "source_subfolder"

--- a/recipes/libbsd/all/conanfile.py
+++ b/recipes/libbsd/all/conanfile.py
@@ -39,7 +39,7 @@ class LibBsdConan(ConanFile):
         del self.settings.compiler.cppstd
     
     def validate(self):
-        if not tools.is_apple_os(self.settings.os) and self.settings.os != "Linux":
+        if not tools.is_apple_os(self.settings.os) and self.settings.os not in ("Linux", "Android"):
             raise ConanInvalidConfiguration("libbsd is only available for GNU-like operating systems (e.g. Linux)")
 
     def source(self):

--- a/recipes/libbsd/all/patches/0002-support-android.patch
+++ b/recipes/libbsd/all/patches/0002-support-android.patch
@@ -1,0 +1,15 @@
+diff --git a/src/funopen.c b/src/funopen.c
+index 1e6f43a..c96108b 100644
+--- a/src/funopen.c
++++ b/src/funopen.c
+@@ -143,6 +143,10 @@ funopen(const void *cookie,
+  * they will not add the needed support to implement it. Just ignore this
+  * interface there, as it has never been provided anyway.
+  */
++#elif defined(__ANDROID__)
++/*
++ * The Android NDK sysroot does not have fopencookie.
++ */
+ #else
+ #error "Function funopen() needs to be ported or disabled."
+ #endif


### PR DESCRIPTION
Specify library name and version:  **libbsd/*

The only reason it might not build on Android is the existence of `fopencookie()`, which is commented out for some platforms anyway. The already existing patch for OS X also adds a case for ignoring this missing function. It seems a low impact change to permit building on Android as well.

I've submitted this change upstream as well, see https://github.com/freedesktop/libbsd/pull/1

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
