### PR TITLE
onetbb: Android: workaround for current AndroidNDK builds

### DIFF
--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, load, rmdir
+from conan.tools.files import replace_in_file, copy, get, load, rmdir
 from conan.tools.scm import Version
 import os
 import re
@@ -99,6 +99,12 @@ class OneTBBConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.configure()
+        if self.settings.os == "Android":
+            replace_in_file(self, os.path.join(self.build_folder, "src", "tbb", "CMakeFiles", "tbb.dir", "flags.make"),
+                "-Wformat =format-security", "-Wformat-security")
+            if self.options.shared == True:
+                replace_in_file(self, os.path.join(self.build_folder, "src", "tbb", "CMakeFiles", "tbb.dir", "link.txt"),
+                    "-Wformat =format-security", "-Wformat-security")
         cmake.build()
 
     def package(self):


### PR DESCRIPTION
…eading emptyspace entry  in generated ^Cags.make and link.txt

Specify library name and version:  **onetbb/2021.x**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
