### PR TITLE
opentdf-client: add version 1.3.2

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.2":
+    url: "https://github.com/opentdf/client-cpp/archive/1.3.2.tar.gz"
+    sha256: "d9a38d3aa6114159c90e0c254c78ddda921e2d520851e4def57f3cd26c564b16"
   "1.2.0":
     url: "https://github.com/opentdf/client-cpp/archive/1.2.0.tar.gz"
     sha256: "15828038809ed291ff7881206a675abc5162e1175c8b515363b9c584aebb08f7"

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.2":
+    folder: all
   "1.2.0":
     folder: all
   "1.1.6":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version: opentdf-client/1.3.2

 - Changes to support OIDC authentication 

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
