### PR TITLE
opencv-4.5.5: Force system gtk 3

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -558,7 +558,8 @@ class OpenCVConan(ConanFile):
             return False
         gtk_version = self.deps_cpp_info["gtk"].version
         if gtk_version == "system":
-            return self.options["gtk"].version == 2
+            # system gtk has to be gtk3.
+            return False
         else:
             return tools.Version(gtk_version) < "3.0.0"
 


### PR DESCRIPTION
**opencv/4.5.5**

conanfile.py reads a "gtk" option that has been removed. It was previously used to choose between gtk 2 or 3.
This pull request removes reading the removed option and disables to possibility of using system installed gtk 2.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
