### PR TITLE
aws-c-event-stream: change dependant recipe version for aws-crt-cpp

### DIFF
--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -52,7 +52,7 @@ class AwsCEventStream(ConanFile):
         self.requires("aws-checksums/0.1.13")
         self.requires("aws-c-common/0.8.2")
         if Version(self.version) >= "0.2":
-            if Version(self.version) < "0.2.15":
+            if Version(self.version) < "0.2.12":
                 self.requires("aws-c-io/0.10.20")
             else:
                 self.requires("aws-c-io/0.13.4")
@@ -86,13 +86,15 @@ class AwsCEventStream(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "aws-c-event-stream")
         self.cpp_info.set_property("cmake_target_name", "AWS::aws-c-event-stream")
-        self.cpp_info.filenames["cmake_find_package"] = "aws-c-event-stream"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-event-stream"
-        self.cpp_info.names["cmake_find_package"] = "AWS"
-        self.cpp_info.names["cmake_find_package_multi"] = "AWS"
         self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package"] = "aws-c-event-stream"
         self.cpp_info.components["aws-c-event-stream-lib"].names["cmake_find_package_multi"] = "aws-c-event-stream"
         self.cpp_info.components["aws-c-event-stream-lib"].libs = ["aws-c-event-stream"]
         self.cpp_info.components["aws-c-event-stream-lib"].requires = ["aws-c-common::aws-c-common-lib", "aws-checksums::aws-checksums"]
         if Version(self.version) >= "0.2":
             self.cpp_info.components["aws-c-event-stream-lib"].requires.append("aws-c-io::aws-c-io-lib")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "aws-c-event-stream"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "aws-c-event-stream"
+        self.cpp_info.names["cmake_find_package"] = "AWS"
+        self.cpp_info.names["cmake_find_package_multi"] = "AWS"

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -52,7 +52,10 @@ class AwsCEventStream(ConanFile):
         self.requires("aws-checksums/0.1.13")
         self.requires("aws-c-common/0.8.2")
         if Version(self.version) >= "0.2":
-            self.requires("aws-c-io/0.13.4")
+            if Version(self.version) < "0.2.15":
+                self.requires("aws-c-io/0.10.20")
+            else:
+                self.requires("aws-c-io/0.13.4")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/aws-c-event-stream/all/conanfile.py
+++ b/recipes/aws-c-event-stream/all/conanfile.py
@@ -52,7 +52,7 @@ class AwsCEventStream(ConanFile):
         self.requires("aws-checksums/0.1.13")
         self.requires("aws-c-common/0.8.2")
         if Version(self.version) >= "0.2":
-            if Version(self.version) < "0.2.12":
+            if Version(self.version) < "0.2.11":
                 self.requires("aws-c-io/0.10.20")
             else:
                 self.requires("aws-c-io/0.13.4")


### PR DESCRIPTION
Specify library name and version:  **aws-c-event-stream/***

Try to fix https://github.com/conan-io/conan-center-index/pull/13607.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
