### PR TITLE
aws-c-mqtt: change dependant recipe version for aws-crt-cpp

### DIFF
--- a/recipes/aws-c-mqtt/all/conanfile.py
+++ b/recipes/aws-c-mqtt/all/conanfile.py
@@ -1,11 +1,7 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import check_min_vs, is_msvc_static_runtime, is_msvc
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, replace_in_file
-from conan.tools.build import check_min_cppstd
+from conan.tools.files import get, copy, rmdir
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.env import VirtualBuildEnv
 
 import os
 
@@ -51,8 +47,12 @@ class AwsCMQTT(ConanFile):
     def requirements(self):
         self.requires("aws-c-common/0.8.2")
         self.requires("aws-c-cal/0.5.13")
-        self.requires("aws-c-io/0.13.4")
-        self.requires("aws-c-http/0.6.22")
+        if Version(self.version) < "0.7.12":
+            self.requires("aws-c-io/0.10.20")
+            self.requires("aws-c-http/0.6.13")
+        else:
+            self.requires("aws-c-io/0.13.4")
+            self.requires("aws-c-http/0.6.22")
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
Specify library name and version:  **aws-c-mqtt/***

Try to fix https://github.com/conan-io/conan-center-index/pull/13607.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
