### PR TITLE
docs: remove lines to make frameworkdirs and resdirs empty on header_only template

### DIFF
--- a/docs/package_templates/header_only/all/conanfile.py
+++ b/docs/package_templates/header_only/all/conanfile.py
@@ -96,9 +96,7 @@ class PackageConan(ConanFile):
     def package_info(self):
         # folders not used for header-only
         self.cpp_info.bindirs = []
-        self.cpp_info.frameworkdirs = []
         self.cpp_info.libdirs = []
-        self.cpp_info.resdirs = []
 
         # if package has an official FindPACKAGE.cmake listed in https://cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules
         # examples: bzip2, freetype, gdal, icu, libcurl, libjpeg, libpng, libtiff, openssl, sqlite3, zlib...


### PR DESCRIPTION
I want to update header_only template to remove frameworkdirs and resdirs assignment lines.
Please see https://github.com/conan-io/conan-center-index/pull/13499#discussion_r998062421.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
