### PR TITLE
xkbcommon: Use PkgConfigDeps build context for wayland

### DIFF
--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -65,7 +65,9 @@ class XkbcommonConan(ConanFile):
             pass
 
     def requirements(self):
-        self.requires("xorg/system")
+        self.requires("xkeyboard-config/system")
+        if self.options.with_x11:
+            self.requires("xorg/system")
         if self.options.get_safe("xkbregistry"):
             self.requires("libxml2/2.9.14")
         if self.options.get_safe("with_wayland"):
@@ -147,7 +149,7 @@ class XkbcommonConan(ConanFile):
     def package_info(self):
         self.cpp_info.components["libxkbcommon"].set_property("pkg_config_name", "xkbcommon")
         self.cpp_info.components["libxkbcommon"].libs = ["xkbcommon"]
-        self.cpp_info.components["libxkbcommon"].requires = ["xorg::xkeyboard-config"]
+        self.cpp_info.components["libxkbcommon"].requires = ["xkeyboard-config::xkeyboard-config"]
         self.cpp_info.components["libxkbcommon"].resdirs = ["res"]
 
         if self.options.with_x11:

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -3,6 +3,7 @@ import os
 import shutil
 
 from conan import ConanFile
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, mkdir, replace_in_file, rmdir
 from conan.tools.gnu import PkgConfigDeps
@@ -84,7 +85,8 @@ class XkbcommonConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("meson/0.63.3")
         self.tool_requires("bison/3.8.2")
-        self.tool_requires("pkgconf/1.9.3")
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/1.9.3")
         if self._has_build_profile and self.options.get_safe("with_wayland"):
             self.tool_requires("wayland/1.21.0")
             self.tool_requires("wayland-protocols/1.27")
@@ -145,6 +147,7 @@ class XkbcommonConan(ConanFile):
         copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
         meson = Meson(self)
         meson.install()
+        fix_apple_shared_install_name(self)
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -122,9 +122,9 @@ class XkbcommonConan(ConanFile):
         virtual_build_env.generate()
 
     def build(self):
+        # Conan doesn't provide a `wayland-scanner.pc` file for the package in the _build_ context
         if self.options.get_safe("with_wayland") and not self._has_build_profile:
             meson_build_file = os.path.join(self.source_folder, "meson.build")
-            # Conan doesn't provide a `wayland-scanner.pc` file for the package in the _build_ context
             replace_in_file(self, meson_build_file,
                             "wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)",
                             "# wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)")

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -1,23 +1,24 @@
 import os
 
 from conan import ConanFile
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, replace_in_file, rmdir
+from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.52.0"
 
 
 class XkbcommonConan(ConanFile):
     name = "xkbcommon"
     description = "keymap handling library for toolkits and window systems"
-    topics = ("xkbcommon", "keyboard")
+    topics = ("keyboard")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/xkbcommon/libxkbcommon"
     license = "MIT"
-
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -34,7 +35,9 @@ class XkbcommonConan(ConanFile):
         "xkbregistry": True,
     }
 
-    generators = "PkgConfigDeps", "VirtualBuildEnv"
+    @property
+    def _has_build_profile(self):
+        return hasattr(self, "settings_build")
 
     @property
     def _has_xkbregistry_option(self):
@@ -48,9 +51,18 @@ class XkbcommonConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
 
     def requirements(self):
         self.requires("xorg/system")
@@ -58,54 +70,68 @@ class XkbcommonConan(ConanFile):
             self.requires("libxml2/2.9.14")
         if self.options.get_safe("with_wayland"):
             self.requires("wayland/1.21.0")
-            self.requires("wayland-protocols/1.26")  # FIXME: This should be a build-requires
+            if not self._has_build_profile:
+                self.requires("wayland-protocols/1.27")
 
     def validate(self):
-        if self.settings.os not in ["Linux", "FreeBSD"]:
-            raise ConanInvalidConfiguration("This library is only compatible with Linux or FreeBSD")
+        if self.info.settings.os not in ["Linux", "FreeBSD"]:
+            raise ConanInvalidConfiguration(f"{self.ref} is only compatible with Linux and FreeBSD")
 
     def build_requirements(self):
-        self.tool_requires("meson/0.63.1")
-        self.tool_requires("bison/3.7.6")
-        self.tool_requires("pkgconf/1.7.4")
-        if hasattr(self, "settings_build") and self.options.get_safe("with_wayland"):
+        self.tool_requires("meson/0.63.3")
+        self.tool_requires("bison/3.8.2")
+        self.tool_requires("pkgconf/1.9.3")
+        if self._has_build_profile and self.options.get_safe("with_wayland"):
             self.tool_requires("wayland/1.21.0")
+            self.tool_requires("wayland-protocols/1.27")
 
     def layout(self):
         basic_layout(self, src_folder="src")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
 
     def generate(self):
         tc = MesonToolchain(self)
-
-        tc.project_options["libexecdir"] = "bin"
-        tc.project_options["libdir"] = "lib"
-        tc.project_options["datadir"] = "res"
-
         tc.project_options["enable-docs"] = False
         tc.project_options["enable-wayland"] = self.options.get_safe("with_wayland", False)
         tc.project_options["enable-x11"] = self.options.with_x11
-
         if self._has_xkbregistry_option:
             tc.project_options["enable-xkbregistry"] = self.options.xkbregistry
+        if self._has_build_profile:
+            tc.project_options["build.pkg_config_path"] = self.generators_folder
         tc.generate()
 
+        pkg_config_deps = PkgConfigDeps(self)
+        if self._has_build_profile and self.options.get_safe("with_wayland"):
+            pkg_config_deps.build_context_activated = ["wayland", "wayland-protocols"]
+            pkg_config_deps.build_context_suffix = {"wayland": "_BUILD"}
+        pkg_config_deps.generate()
+
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
+
     def build(self):
-        # Conan doesn't provide a `wayland-scanner.pc` file for the package in the _build_ context
-        meson_build_file = os.path.join(self.source_folder, "meson.build")
-        replace_in_file(self, meson_build_file,
-                        "wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)",
-                        "# wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)")
+        if self.options.get_safe("with_wayland"):
+            meson_build_file = os.path.join(self.source_folder, "meson.build")
+            if self._has_build_profile:
+                replace_in_file(self, meson_build_file,
+                                "wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)",
+                                "wayland_scanner_dep = dependency('wayland-scanner_BUILD', required: false, native: true)")
+            else:
+                # Conan doesn't provide a `wayland-scanner.pc` file for the package in the _build_ context
+                replace_in_file(self, meson_build_file,
+                                "wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)",
+                                "# wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)")
 
-        replace_in_file(self, meson_build_file,
-                        "if not wayland_client_dep.found() or not wayland_protocols_dep.found() or not wayland_scanner_dep.found()",
-                        "if not wayland_client_dep.found() or not wayland_protocols_dep.found()")
+                replace_in_file(self, meson_build_file,
+                                "if not wayland_client_dep.found() or not wayland_protocols_dep.found() or not wayland_scanner_dep.found()",
+                                "if not wayland_client_dep.found() or not wayland_protocols_dep.found()")
 
-        replace_in_file(self, meson_build_file,
-                        "wayland_scanner = find_program(wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'))",
-                        "wayland_scanner = find_program('wayland-scanner')")
+                replace_in_file(self, meson_build_file,
+                                "wayland_scanner = find_program(wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'))",
+                                "wayland_scanner = find_program('wayland-scanner')")
 
         meson = Meson(self)
         meson.configure()
@@ -133,10 +159,11 @@ class XkbcommonConan(ConanFile):
             self.cpp_info.components["libxkbregistry"].libs = ["xkbregistry"]
             self.cpp_info.components["libxkbregistry"].requires = ["libxml2::libxml2"]
         if self.options.get_safe("with_wayland", False):
-            # FIXME: This generates just executable, but I need to use the requirements to pass Conan checks
             self.cpp_info.components["xkbcli-interactive-wayland"].libs = []
             self.cpp_info.components["xkbcli-interactive-wayland"].includedirs = []
-            self.cpp_info.components["xkbcli-interactive-wayland"].requires = ["wayland::wayland", "wayland-protocols::wayland-protocols"]
+            self.cpp_info.components["xkbcli-interactive-wayland"].requires = ["wayland::wayland-client"]
+            if not self._has_build_profile:
+                self.cpp_info.components["xkbcli-interactive-wayland"].requires.append("wayland-protocols::wayland-protocols")
 
         if Version(self.version) >= "1.0.0":
             bindir = os.path.join(self.package_folder, "bin")

--- a/recipes/xkbcommon/all/test_package/conanfile.py
+++ b/recipes/xkbcommon/all/test_package/conanfile.py
@@ -9,6 +9,7 @@ from conan.tools.layout import cmake_layout
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)


### PR DESCRIPTION
Specify library name and version:  **xkbcommon/***

Now that PkgConfigDeps can generate pkg-config files for the build context as of Conan 1.52.0, the ` xkbcommon` recipe should make use of it for the `wayland` and `wayland-protocols` dependencies which are used as `tool_requires`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
