### PR TITLE
set cmake_find_mode as 'both' for spdlog

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -140,6 +140,7 @@ class SpdlogConan(ConanFile):
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.names["cmake_find_package"] = "spdlog"
         self.cpp_info.names["cmake_find_package_multi"] = "spdlog"
+        self.cpp_info.set_property("cmake_find_mode", "both")
 
         target = "spdlog_header_only" if self.options.header_only else "spdlog"
         self.cpp_info.set_property("cmake_file_name", "spdlog")


### PR DESCRIPTION
**spdlog**

minor set cmake_find_mode as 'both' for spdlog

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
