### PR TITLE
refine Folly recipe

### DIFF
--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -2,8 +2,9 @@ from conan.tools.microsoft import is_msvc, msvc_runtime_flag
 from conan.tools.build import can_run
 from conan.tools.scm import Version
 from conan.tools import files
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conans import CMake, tools
+from conan.errors import ConanInvalidConfiguration
 import functools
 import os
 
@@ -22,12 +23,12 @@ class FollyConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "with_sse4_2" : [True, False],
+        "use_sse4_2" : [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_sse4_2" : True
+        "use_sse4_2" : False
     }
 
     generators = "cmake", "cmake_find_package"
@@ -65,7 +66,7 @@ class FollyConan(ConanFile):
             del self.options.fPIC
 
         if str(self.settings.arch) not in ['x86', 'x86_64']:
-            del self.options.with_sse4_2
+            del self.options.use_sse4_2
 
     def configure(self):
         if self.options.shared:
@@ -150,7 +151,7 @@ class FollyConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         if can_run(self):
-            if self.options.with_sse4_2:
+            if self.options.use_sse4_2 and str(self.settings.arch) in ['x86', 'x86_64']:
                 cmake.definitions["FOLLY_SSE"] = "4"
                 cmake.definitions["FOLLY_SSE_MINOR"] = "2"
             cmake.definitions["FOLLY_HAVE_UNALIGNED_ACCESS_EXITCODE"] = "0"
@@ -275,18 +276,18 @@ class FollyConan(ConanFile):
             self.cpp_info.components["folly_test_util"].libs = ["folly_test_util"]
             self.cpp_info.components["folly_test_util"].requires = ["libfolly"]
 
-            if Version(self.version) >= "2020.08.10.00" and self.settings.os == "Linux":
-                self.cpp_info.components["folly_exception_tracer_base"].set_property("cmake_target_name", "Folly::folly_exception_tracer_base")
-                self.cpp_info.components["folly_exception_tracer_base"].set_property("pkg_config_name", "libfolly_exception_tracer_base")
-                self.cpp_info.components["folly_exception_tracer_base"].libs = ["folly_exception_tracer_base"]
-                self.cpp_info.components["folly_exception_tracer_base"].requires = ["libfolly"]
+        if Version(self.version) >= "2020.08.10.00" and self.settings.os == "Linux":
+            self.cpp_info.components["folly_exception_tracer_base"].set_property("cmake_target_name", "Folly::folly_exception_tracer_base")
+            self.cpp_info.components["folly_exception_tracer_base"].set_property("pkg_config_name", "libfolly_exception_tracer_base")
+            self.cpp_info.components["folly_exception_tracer_base"].libs = ["folly_exception_tracer_base"]
+            self.cpp_info.components["folly_exception_tracer_base"].requires = ["libfolly"]
 
-                self.cpp_info.components["folly_exception_tracer"].set_property("cmake_target_name", "Folly::folly_exception_tracer")
-                self.cpp_info.components["folly_exception_tracer"].set_property("pkg_config_name", "libfolly_exception_tracer")
-                self.cpp_info.components["folly_exception_tracer"].libs = ["folly_exception_tracer"]
-                self.cpp_info.components["folly_exception_tracer"].requires = ["folly_exception_tracer_base"]
+            self.cpp_info.components["folly_exception_tracer"].set_property("cmake_target_name", "Folly::folly_exception_tracer")
+            self.cpp_info.components["folly_exception_tracer"].set_property("pkg_config_name", "libfolly_exception_tracer")
+            self.cpp_info.components["folly_exception_tracer"].libs = ["folly_exception_tracer"]
+            self.cpp_info.components["folly_exception_tracer"].requires = ["folly_exception_tracer_base"]
 
-                self.cpp_info.components["folly_exception_counter"].set_property("cmake_target_name", "Folly::folly_exception_counter")
-                self.cpp_info.components["folly_exception_counter"].set_property("pkg_config_name", "libfolly_exception_counter")
-                self.cpp_info.components["folly_exception_counter"].libs = ["folly_exception_counter"]
-                self.cpp_info.components["folly_exception_counter"].requires = ["folly_exception_tracer"]
+            self.cpp_info.components["folly_exception_counter"].set_property("cmake_target_name", "Folly::folly_exception_counter")
+            self.cpp_info.components["folly_exception_counter"].set_property("pkg_config_name", "libfolly_exception_counter")
+            self.cpp_info.components["folly_exception_counter"].libs = ["folly_exception_counter"]
+            self.cpp_info.components["folly_exception_counter"].requires = ["folly_exception_tracer"]

--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -140,6 +140,9 @@ class FollyConan(ConanFile):
                 raise ConanInvalidConfiguration("{} requires C++{} support. The current compiler {} {} does not support it.".format(
                     self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
 
+        if self.options.get_safe("use_sse4_2") and str(self.settings.arch) not in ['x86', 'x86_64']:
+            raise ConanInvalidConfiguration(f"{self.ref} can use the option use_sse4_2 only on x86 and x86_64 archs.")
+
     # FIXME: Freeze max. CMake version at 3.16.2 to fix the Linux build
     def build_requirements(self):
         self.build_requires("cmake/3.16.9")
@@ -151,7 +154,7 @@ class FollyConan(ConanFile):
     def _configure_cmake(self):
         cmake = CMake(self)
         if can_run(self):
-            if self.options.use_sse4_2 and str(self.settings.arch) in ['x86', 'x86_64']:
+            if self.options.get_safe("use_sse4_2") and str(self.settings.arch) in ['x86', 'x86_64']:
                 cmake.definitions["FOLLY_SSE"] = "4"
                 cmake.definitions["FOLLY_SSE_MINOR"] = "2"
             cmake.definitions["FOLLY_HAVE_UNALIGNED_ACCESS_EXITCODE"] = "0"
@@ -173,6 +176,7 @@ class FollyConan(ConanFile):
             cmake.definitions["MSVC_USE_STATIC_RUNTIME"] = "MT" in msvc_runtime_flag(self)
         cmake.configure()
         return cmake
+
 
     def build(self):
         for patch in self.conan_data.get("patches", {}).get(self.version, []):

--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -110,7 +110,7 @@ class FollyConan(ConanFile):
                 raise ConanInvalidConfiguration("{} requires C++{} support. The current compiler {} {} does not support it.".format(
                     self.name, self._minimum_cpp_standard, self.settings.compiler, self.settings.compiler.version))
 
-        if self.version < "2022.01.31.00" and self.settings.os != "Linux":
+        if Version(self.version) < "2022.01.31.00" and self.settings.os != "Linux":
             raise ConanInvalidConfiguration("Conan support for non-Linux platforms starts with Folly version 2022.01.31.00")
 
         if self.settings.os == "Macos" and self.settings.arch != "x86_64":
@@ -122,7 +122,7 @@ class FollyConan(ConanFile):
         if self.settings.os in ["Macos", "Windows"] and self.options.shared:
             raise ConanInvalidConfiguration("Folly could not be built on {} as shared library".format(self.settings.os))
 
-        if self.version == "2020.08.10.00" and self.settings.compiler == "clang" and self.options.shared:
+        if Version(self.version) == "2020.08.10.00" and self.settings.compiler == "clang" and self.options.shared:
             raise ConanInvalidConfiguration("Folly could not be built by clang as a shared library")
 
         if self.options["boost"].header_only:

--- a/recipes/folly/all/test_package/CMakeLists.txt
+++ b/recipes/folly/all/test_package/CMakeLists.txt
@@ -4,7 +4,9 @@ project(test_package CXX)
 find_package(folly REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} Folly::folly)
+target_link_libraries(${PROJECT_NAME}
+    Folly::folly
+    Folly::follybenchmark)
 
 
 if (${FOLLY_VERSION} VERSION_LESS "2021.07.20.00")

--- a/recipes/folly/all/test_v1_package/conanfile.py
+++ b/recipes/folly/all/test_v1_package/conanfile.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 from conans import ConanFile, CMake, tools
 import os
 


### PR DESCRIPTION
**folly**

refine folly recipe
    
    1. add sse42 option
    some libraries depends on folly, but with simd enabled. It will causes
    compiling error if folly has no such option.
    
    2. folly project exports cmake file with components, such as folly::follybenchmark.
    To keep consistent with folly's project, add components info

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
