### PR TITLE
meson-template: several improvements

### DIFF
--- a/docs/package_templates/meson_package/all/test_package/conanfile.py
+++ b/docs/package_templates/meson_package/all/test_package/conanfile.py
@@ -11,22 +11,21 @@ class TestPackageConan(ConanFile):
     generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
     test_type = "explicit"
 
+    def layout(self):
+        basic_layout(self)
+
     def requirements(self):
         self.requires(self.tested_reference_str)
 
     def build_requirements(self):
         self.tool_requires("meson/0.63.3")
-        self.tool_requires("pkgconf/1.9.3")
-        if not self.conf.get("tools.meson.mesontoolchain:backend", default=False, check_type=str):
-            self.tools_requires("ninja/1.11.1")
-
-    def layout(self):
-        basic_layout(self)
+        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+            self.tool_requires("pkgconf/1.9.3")
 
     def build(self):
-        cmake = Meson(self)
-        cmake.configure()
-        cmake.build()
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
 
     def test(self):
         if can_run(self):

--- a/docs/package_templates/meson_package/all/test_v1_package/conanfile.py
+++ b/docs/package_templates/meson_package/all/test_v1_package/conanfile.py
@@ -9,9 +9,8 @@ class TestPackageV1Conan(ConanFile):
     generators = "pkg_config"
 
     def build_requirements(self):
-        self.build_requires("pkgconf/1.9.3")
         self.build_requires("meson/0.63.3")
-        self.build_requires("ninja/1.11.1")
+        self.build_requires("pkgconf/1.9.3")
 
     def build(self):
         meson = Meson(self)


### PR DESCRIPTION
- remove `ninja` from tool_requires, it's the job of meson recipe to require ninja or not.
- fix `install_name` of shared libs on macOS (`@rpath` instead of lib dir absolute path)
- do not add `pkgconf` to tool_requires if `tools.gnu:pkg_config` config is set

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
