### PR TITLE
updated flatbuffers 22.9.24 and 22.9.29

### DIFF
--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "22.9.29":
+    url: "https://github.com/google/flatbuffers/archive/refs/tags/v22.9.29.tar.gz"
+    sha256: "372df01795c670f6538055a7932fc7eb3e81b3653be4a216c081e9c3c26b1b6d"
+  "22.9.24":
+    url: "https://github.com/google/flatbuffers/archive/refs/tags/v22.9.24.tar.gz"
+    sha256: "40e0788873012def4d66a2fdbac15fbe012784473c01a703ccb5be33383556bf"
   "2.0.8":
     url: "https://github.com/google/flatbuffers/archive/refs/tags/v2.0.8.tar.gz"
     sha256: "f97965a727d26386afaefff950badef2db3ab6af9afe23ed6d94bfb65f95f37e"

--- a/recipes/flatbuffers/config.yml
+++ b/recipes/flatbuffers/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "22.9.29":
+    folder: all
+  "22.9.24":
+    folder: all
   "2.0.8":
     folder: all
   "2.0.6":


### PR DESCRIPTION
Added flatbuffers 22.9.24/29
I need this version since I want to align the version of the flatbuffers nuget package and the conan package. This way I can use flatc.exe from the conan package to generate the cs files. 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
