### PR TITLE
header-only template: several improvements

### DIFF
--- a/docs/package_templates/header_only/all/conanfile.py
+++ b/docs/package_templates/header_only/all/conanfile.py
@@ -1,9 +1,9 @@
-from conan import ConanFile
+from conan import ConanFile, conan_version
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
 
@@ -25,7 +25,7 @@ class PackageConan(ConanFile):
     no_copy_source = True  # do not copy sources to build folder for header only projects, unless, need to apply patches
 
     @property
-    def _minimum_cpp_standard(self):
+    def _min_cppstd(self):
         return 14
 
     # in case the project requires C++14/17/20/... the minimum compiler version should be listed
@@ -50,29 +50,30 @@ class PackageConan(ConanFile):
 
     def requirements(self):
         # prefer self.requires method instead of requires attribute
-        self.requires("dependency/0.8.1")
+        # direct dependencies of header only libs are always transitive since they are included in public headers
+        self.requires("dependency/0.8.1", transitive_headers=True)
 
     # same package ID for any package
     def package_id(self):
         self.info.clear()
 
+    @property
+    def _info(self):
+        return self if Version(conan_version).major < 2 else self.info
+
     def validate(self):
         # compiler subsettings are not available when building with self.info.clear()
-        if self.info.settings.get_safe("compiler.cppstd"):
+        if self._info.settings.compiler.get_safe("cppstd"):
             # validate the minimum cpp standard supported when installing the package. For C++ projects only
-            check_min_cppstd(self, self._minimum_cpp_standard)
-        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
-        if minimum_version and Version(self.info.settings.get_safe("compiler.version")) < minimum_version:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self._info.settings.compiler), False)
+        if minimum_version and Version(self._info.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._minimum_cpp_standard}, which your compiler does not support."
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
         # in case it does not work in another configuration, it should validated here too
-        if self.info.settings.os == "Windows":
+        if self._info.settings.os == "Windows":
             raise ConanInvalidConfiguration(f"{self.ref} can not be used on Windows.")
-
-    # if another tool than the compiler or CMake is required to build the project (pkgconf, bison, flex etc)
-    def build_requirements(self):
-        self.tool_requires("tool/x.y.z")
 
     def source(self):
         # download source package and extract to source folder
@@ -110,9 +111,7 @@ class PackageConan(ConanFile):
 
         # If they are needed on Linux, m, pthread and dl are usually needed on FreeBSD too
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.append("m")
-            self.cpp_info.system_libs.append("pthread")
-            self.cpp_info.system_libs.append("dl")
+            self.cpp_info.system_libs.extend(["dl", "m", "pthread"])
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.filenames["cmake_find_package"] = "PACKAGE"

--- a/docs/package_templates/header_only/all/test_package/CMakeLists.txt
+++ b/docs/package_templates/header_only/all/test_package/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
-
-project(test_package C) # if the project is pure C
-project(test_package CXX) # if the project uses c++
+project(test_package LANGUAGES C) # if the project is pure C
+project(test_package LANGUAGES CXX) # if the project uses c++
 
 find_package(package REQUIRED CONFIG)
 

--- a/docs/package_templates/header_only/all/test_package/conanfile.py
+++ b/docs/package_templates/header_only/all/test_package/conanfile.py
@@ -10,11 +10,11 @@ class TestPackageConan(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
-    def requirements(self):
-        self.requires(self.tested_reference_str)
-
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)

--- a/docs/package_templates/header_only/all/test_v1_package/CMakeLists.txt
+++ b/docs/package_templates/header_only/all/test_v1_package/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
-
-project(test_package C) # if the project is pure C
-project(test_package CXX) # if the project uses c++
+project(test_package LANGUAGES C) # if the project is pure C
+project(test_package LANGUAGES CXX) # if the project uses c++
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)


### PR DESCRIPTION
- handle self.info in `validate()` depending on whether conan client is v1 or v2
- transitive headers of direct dependencies
- remove build_requirements

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
