### PR TITLE
glib: Fix libdir for PkgConfigDeps

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -17,11 +17,10 @@ required_conan_version = ">=1.52.0"
 class GLibConan(ConanFile):
     name = "glib"
     description = "GLib provides the core application building blocks for libraries and applications written in C"
-    topics = ("glib", "gobject", "gio", "gmodule")
+    topics = ("gobject", "gio", "gmodule")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gitlab.gnome.org/GNOME/glib"
     license = "LGPL-2.1"
-
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -39,7 +38,6 @@ class GLibConan(ConanFile):
         "with_mount": True,
         "with_selinux": True,
     }
-
     short_paths = True
 
     @property
@@ -324,7 +322,7 @@ class GLibConan(ConanFile):
             'datadir': '${prefix}/res',
             'schemasdir': '${datadir}/glib-2.0/schemas',
             'bindir': '${prefix}/bin',
-            'giomoduledir': '${libdir}/gio/modules',
+            'giomoduledir': '${prefix}/lib/gio/modules',
             'gio': '${bindir}/gio',
             'gio_querymodules': '${bindir}/gio-querymodules',
             'glib_compile_schemas': '${bindir}/glib-compile-schemas',


### PR DESCRIPTION
Specify library name and version:  **glib/***

Required to update `gstreamer` to use PkgConfigDeps: #13400.

Related issue is here: conan-io/conan#12279.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
