### PR TITLE
[cmake-template] Simplify test_v1_package CMakeLists.txt

### DIFF
--- a/docs/package_templates/cmake_package/all/test_v1_package/CMakeLists.txt
+++ b/docs/package_templates/cmake_package/all/test_v1_package/CMakeLists.txt
@@ -5,4 +5,4 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
-                 ${CMAKE_CURRENT_BINARY_DIR}/binaries/)
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/docs/package_templates/cmake_package/all/test_v1_package/CMakeLists.txt
+++ b/docs/package_templates/cmake_package/all/test_v1_package/CMakeLists.txt
@@ -1,16 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
-
-project(test_package C) # if the project is pure C
-project(test_package CXX) # if the project uses c++
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(package REQUIRED CONFIG)
-
-# Re-use the same source file from test_package folder
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-# don't link to ${CONAN_LIBS} or CONAN_PKG::package
-target_link_libraries(${PROJECT_NAME} PRIVATE package::package)
-# in case the target project requires a C++ standard
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/binaries/)


### PR DESCRIPTION
Instead of duplicating, let's re-use from test_package/

- Don't specify LANGUAGE as it's just a wrapper and it will be filled by test_package/
- CMake 3.1 is more than enough. Also, test_package/ will have the real required version
- As test_package/ is not a sub directory, but an external folder, binary dir must be passed

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
