### PR TITLE
xkbcommon: Revert using a separate directory for the build context

### DIFF
--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import copy, get, mkdir, replace_in_file, rmdir
+from conan.tools.files import copy, get, replace_in_file, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -16,7 +16,7 @@ required_conan_version = ">=1.52.0"
 class XkbcommonConan(ConanFile):
     name = "xkbcommon"
     description = "keymap handling library for toolkits and window systems"
-    topics = ("keyboard")
+    topics = ("keyboard", "wayland", "x11", "xkb")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/xkbcommon/libxkbcommon"
     license = "MIT"


### PR DESCRIPTION
I made an oops in my previous change #13612.
This actually does end up breaking cross-compilation. The requirements of `wayland-scanner` aren't available in the build context. This causes pkg-config to fail to "find" `wayland-scanner`. The `expat` and `libxml2` files would need to be in this same directory. Omitting the separate build context directory for pkg-config files works around this issue for now. Work will need to be done upstream to ensure dependencies are also made available in the build context for PkgConfigDeps. See conan-io/conan#12342 for progress on the issue upstream.

It's important to note that pointing Meson to the generators directory for "native" pkg-config files isn't the safest thing to do. It's possible for Meson to mistakenly think dependencies in the generators directory are meant for the build context when they are of course meant for the host context whenever they lack the `_BUILD` suffix.

I've also placed `wayland-protocols` in the build context. While it provides XML files only, really, this maps to how it is used.

Specify library name and version:  **xkbcommon/***

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
