### PR TITLE
libcurl: several fixes & bump dependencies

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -186,9 +186,6 @@ class LibcurlConan(ConanFile):
         if self.options.with_c_ares:
             self.requires("c-ares/1.18.1")
 
-    def package_id(self):
-        del self.info.settings.compiler
-
     def validate(self):
         if self.info.options.with_ssl == "schannel" and self.info.settings.os != "Windows":
             raise ConanInvalidConfiguration("schannel only suppported on Windows.")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -584,8 +584,8 @@ class LibcurlConan(ConanFile):
         tc.generate()
 
     def package(self):
-        copy(self, "COPYING", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
-        copy(self, pattern="cacert.pem", src=self.build_folder, dst="res")
+        copy(self, "COPYING", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "cacert.pem", src=self.source_folder, dst=os.path.join(self.package_folder, "res"))
         if self._is_using_cmake_build:
             cmake = CMake(self)
             cmake.install()
@@ -610,6 +610,7 @@ class LibcurlConan(ConanFile):
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("pkg_config_name", "libcurl")
 
+        self.cpp_info.components["curl"].resdirs = ["res"]
         if is_msvc(self):
             self.cpp_info.components["curl"].libs = ["libcurl_imp"] if self.options.shared else ["libcurl"]
         else:

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -563,14 +563,14 @@ class LibcurlConan(ConanFile):
         tc.variables["NTLM_WB_ENABLED"] = self.options.with_ntlm_wb
 
         if self.options.with_ca_bundle is False:
-            tc.variables['CURL_CA_BUNDLE'] = 'none'
+            tc.cache_variables["CURL_CA_BUNDLE"] = "none"
         elif self.options.with_ca_bundle:
-            tc.variables['CURL_CA_BUNDLE'] = self.options.with_ca_bundle
+            tc.cache_variables["CURL_CA_BUNDLE"] = str(self.options.with_ca_bundle)
 
         if self.options.with_ca_path is False:
-            tc.variables['CURL_CA_PATH'] = 'none'
+            tc.cache_variables["CURL_CA_PATH"] = "none"
         elif self.options.with_ca_path:
-            tc.variables['CURL_CA_PATH'] = self.options.with_ca_path
+            tc.cache_variables["CURL_CA_PATH"] = str(self.options.with_ca_path)
 
         tc.generate()
 

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -158,9 +158,18 @@ class LibcurlConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
 
         # These options are not used in CMake build yet
         if self._is_using_cmake_build:

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -172,13 +172,13 @@ class LibcurlConan(ConanFile):
         if self.options.with_ssl == "openssl":
             self.requires("openssl/1.1.1q")
         elif self.options.with_ssl == "wolfssl":
-            self.requires("wolfssl/5.4.0")
+            self.requires("wolfssl/5.5.1")
         if self.options.with_nghttp2:
-            self.requires("libnghttp2/1.48.0")
+            self.requires("libnghttp2/1.49.0")
         if self.options.with_libssh2:
             self.requires("libssh2/1.10.0")
         if self.options.with_zlib:
-            self.requires("zlib/1.2.12")
+            self.requires("zlib/1.2.13")
         if self.options.with_brotli:
             self.requires("brotli/1.0.9")
         if self.options.get_safe("with_zstd"):
@@ -201,14 +201,14 @@ class LibcurlConan(ConanFile):
     def build_requirements(self):
         if self._is_using_cmake_build:
             if self._is_win_x_android:
-                self.tool_requires("ninja/1.11.0")
+                self.tool_requires("ninja/1.11.1")
         else:
-            self.tool_requires("libtool/2.4.6")
-            if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-                self.tool_requires("pkgconf/1.7.4")
+            self.tool_requires("libtool/2.4.7")
+            if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+                self.tool_requires("pkgconf/1.9.3")
             if self._settings_build.os == "Windows":
                 self.win_bash = True
-                if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
+                if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                     self.tool_requires("msys2/cci.latest")
 
     def layout(self):

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -67,8 +67,8 @@ class LibcurlConan(ConanFile):
         "with_symbol_hiding": [True, False],
         "with_unix_sockets": [True, False],
         "with_verbose_strings": [True, False],
-        "with_ca_bundle": "ANY",
-        "with_ca_path": "ANY",
+        "with_ca_bundle": [None, "ANY"],
+        "with_ca_path": [None, "ANY"],
     }
     default_options = {
         "shared": False,

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -583,7 +583,8 @@ class LibcurlConan(ConanFile):
             rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         else:
             autotools = Autotools(self)
-            autotools.install()
+            # TODO: replace by autotools.install() once https://github.com/conan-io/conan/issues/12153 fixed
+            autotools.install(args=[f"DESTDIR={unix_path(self, self.package_folder)}"])
             fix_apple_shared_install_name(self)
             rmdir(self, os.path.join(self.package_folder, "share"))
             rm(self, "*.la", os.path.join(self.package_folder, "lib"))

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -451,15 +451,15 @@ class LibcurlConan(ConanFile):
         if not self.options.with_ntlm_wb:
             tc.configure_args.append("--disable-ntlm-wb")
 
-        if self.options.with_ca_bundle is False:
+        if self.options.with_ca_bundle:
+            tc.configure_args.append(f"--with-ca-bundle={str(self.options.with_ca_bundle)}")
+        else:
             tc.configure_args.append("--without-ca-bundle")
-        elif self.options.with_ca_bundle:
-            tc.configure_args.append("--with-ca-bundle=" + str(self.options.with_ca_bundle))
 
-        if self.options.with_ca_path is False:
-            tc.configure_args.append('--without-ca-path')
-        elif self.options.with_ca_path:
-            tc.configure_args.append("--with-ca-path=" + str(self.options.with_ca_path))
+        if self.options.with_ca_path:
+            tc.configure_args.append(f"--with-ca-path={str(self.options.with_ca_path)}")
+        else:
+            tc.configure_args.append("--without-ca-path")
 
         # Cross building flags
         if cross_building(self):
@@ -571,15 +571,15 @@ class LibcurlConan(ConanFile):
                 tc.variables["CURL_DISABLE_NTLM"] = True
         tc.variables["NTLM_WB_ENABLED"] = self.options.with_ntlm_wb
 
-        if self.options.with_ca_bundle is False:
-            tc.cache_variables["CURL_CA_BUNDLE"] = "none"
-        elif self.options.with_ca_bundle:
+        if self.options.with_ca_bundle:
             tc.cache_variables["CURL_CA_BUNDLE"] = str(self.options.with_ca_bundle)
+        else:
+            tc.cache_variables["CURL_CA_BUNDLE"] = "none"
 
-        if self.options.with_ca_path is False:
-            tc.cache_variables["CURL_CA_PATH"] = "none"
-        elif self.options.with_ca_path:
+        if self.options.with_ca_path:
             tc.cache_variables["CURL_CA_PATH"] = str(self.options.with_ca_path)
+        else:
+            tc.cache_variables["CURL_CA_PATH"] = "none"
 
         tc.generate()
 


### PR DESCRIPTION
- do not delete settings.compiler from package id (comes from https://github.com/conan-io/conan-center-index/pull/12956)
- bump dependencies
- no need to copy dylib files of dependencies for conftest of autotools build, it's the job of VirtualRunEnv to inject paths of dylib files to DYLD_LIBRARY_PATH (SIP is not triggered in configure script AFAIK).
- fix installation of autotools if build machine is windows
- protect deletion of settings & options

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
