### PR TITLE
Add openapi-generator/6.0.1

### DIFF
--- a/recipes/openapi-generator/all/conandata.yml
+++ b/recipes/openapi-generator/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "6.0.1":
+    url: "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.0.1/openapi-generator-cli-6.0.1.jar"
+    sha256: "ba9279900d1fefc9f0b977264b709f7d481c278d6780090b36673b65cb1a9122"

--- a/recipes/openapi-generator/all/conandata.yml
+++ b/recipes/openapi-generator/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "6.2.0":
+    url: "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.2.0/openapi-generator-cli-6.2.0.jar"
+    sha256: "60707e2c8938a94278f6216081d7067d0f1beced8c8eb1277e625e9a59ccd2da"
+  "6.1.0":
+    url: "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.1.0/openapi-generator-cli-6.1.0.jar"
+    sha256: "3bcbff776072e4e5161307f837d34ab4713a13ed9edc20e4983c2321791ea037"
   "6.0.1":
     url: "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.0.1/openapi-generator-cli-6.0.1.jar"
     sha256: "ba9279900d1fefc9f0b977264b709f7d481c278d6780090b36673b65cb1a9122"

--- a/recipes/openapi-generator/all/conanfile.py
+++ b/recipes/openapi-generator/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.files import copy, download, save
 from conan.tools.scm import Version
 import os
+import stat
 
 
 required_conan_version = ">=1.47.0"
@@ -42,7 +43,6 @@ class OpenApiGeneratorConan(ConanFile):
                 )
 
     def package(self):
-        # a license file is always mandatory
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         copy(self, pattern="openapi-generator.jar", dst=os.path.join(self.package_folder, "res"), src=self.source_folder)
         jar = os.path.join(self.package_folder, "res", "openapi-generator.jar")
@@ -54,13 +54,16 @@ class OpenApiGeneratorConan(ConanFile):
                          """
                  )
         else:
+            bin_path = os.path.join(self.package_folder, "bin", "openapi-generator")
             save(self,
-                 path=os.path.join(self.package_folder, "bin", "openapi-generator"),
+                 path=bin_path,
                  content=f"""\
                          #!/bin/bash
                          java -jar {jar} $@
                          """
                  )
+            st = os.stat(bin_path)
+            os.chmod(bin_path, st.st_mode | stat.S_IEXEC)
 
     def package_info(self):
         # folders not used for pre-built binaries

--- a/recipes/openapi-generator/all/conanfile.py
+++ b/recipes/openapi-generator/all/conanfile.py
@@ -15,12 +15,13 @@ class OpenApiGeneratorConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://openapi-generator.tech"
     topics = ("api", "sdk", "generator", "openapi")
-    settings = "os", "compiler", "build_type"
+    settings = "os", "arch", "compiler", "build_type"
 
     def layout(self):
         pass
 
     def package_id(self):
+        del self.info.settings.arch
         del self.info.settings.compiler
         del self.info.settings.build_type
 

--- a/recipes/openapi-generator/all/conanfile.py
+++ b/recipes/openapi-generator/all/conanfile.py
@@ -1,6 +1,5 @@
 from conan import ConanFile
 from conan.tools.files import copy, download, save
-from conan.tools.scm import Version
 import os
 import stat
 
@@ -72,5 +71,3 @@ class OpenApiGeneratorConan(ConanFile):
         self.cpp_info.libdirs = []
         self.cpp_info.resdirs = []
         self.cpp_info.includedirs = []
-
-        bin_folder = os.path.join(self.package_folder, "bin")

--- a/recipes/openapi-generator/all/conanfile.py
+++ b/recipes/openapi-generator/all/conanfile.py
@@ -19,6 +19,9 @@ class OpenApiGeneratorConan(ConanFile):
     def layout(self):
         pass
 
+    def requirements(self):
+        self.requires("openjdk/16.0.1")
+
     def package_id(self):
         del self.info.settings.arch
         del self.info.settings.compiler

--- a/recipes/openapi-generator/all/conanfile.py
+++ b/recipes/openapi-generator/all/conanfile.py
@@ -1,0 +1,72 @@
+from conan import ConanFile
+from conan.tools.files import copy, download, save
+from conan.tools.scm import Version
+import os
+
+
+required_conan_version = ">=1.47.0"
+
+
+class OpenApiGeneratorConan(ConanFile):
+    name = "openapi-generator"
+    description = "Generation of API client libraries (SDK generation), server stubs, documentation and configuration automatically given an OpenAPI Spec (v2, v3)"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://openapi-generator.tech"
+    topics = ("api", "sdk", "generator", "openapi")
+    settings = "os", "compiler", "build_type"
+
+    def layout(self):
+        pass
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.build_type
+
+    def source(self):
+        pass
+
+    def build(self):
+        v = self.conan_data["sources"][self.version]
+        download(
+                self,
+                url=v["url"],
+                filename=os.path.join(self.source_folder, "openapi-generator.jar"),
+                sha256=v["sha256"],
+                )
+        download(
+                self,
+                url="https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/LICENSE",
+                filename=os.path.join(self.source_folder, "LICENSE"),
+                sha256="91a2fcdfc23cbd1188a22cc3b76647bf6eb05c87889e376a19fe478f0398ff02",
+                )
+
+    def package(self):
+        # a license file is always mandatory
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, pattern="openapi-generator.jar", dst=os.path.join(self.package_folder, "res"), src=self.source_folder)
+        jar = os.path.join(self.package_folder, "res", "openapi-generator.jar")
+        if self.info.settings.os == "Windows":
+            save(self,
+                 path=os.path.join(self.package_folder, "bin", "openapi-generator.bat"),
+                 content=f"""\
+                         java -jar {jar} %*
+                         """
+                 )
+        else:
+            save(self,
+                 path=os.path.join(self.package_folder, "bin", "openapi-generator"),
+                 content=f"""\
+                         #!/bin/bash
+                         java -jar {jar} $@
+                         """
+                 )
+
+    def package_info(self):
+        # folders not used for pre-built binaries
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []
+        self.cpp_info.includedirs = []
+
+        bin_folder = os.path.join(self.package_folder, "bin")

--- a/recipes/openapi-generator/all/test_package/conanfile.py
+++ b/recipes/openapi-generator/all/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def test(self):
+        if can_run(self):
+            self.run("openapi-generator --version")

--- a/recipes/openapi-generator/all/test_v1_package/conanfile.py
+++ b/recipes/openapi-generator/all/test_v1_package/conanfile.py
@@ -1,0 +1,10 @@
+from conans import ConanFile
+from conan.tools.build import can_run
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+
+    def test(self):
+        if can_run(self):
+            self.run("openapi-generator --version", run_environment=True)

--- a/recipes/openapi-generator/config.yml
+++ b/recipes/openapi-generator/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "6.0.1":
+    folder: all

--- a/recipes/openapi-generator/config.yml
+++ b/recipes/openapi-generator/config.yml
@@ -1,3 +1,7 @@
 versions:
+  "6.2.0":
+    folder: all
+  "6.1.0":
+    folder: all
   "6.0.1":
     folder: all


### PR DESCRIPTION
I thought adding this tool would be a nightmare due to maven dependency but being able to handle prebuilt binaries makes it awesomely simple!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
