### PR TITLE
daw_json_link: add version 3.1.1

### DIFF
--- a/recipes/daw_json_link/all/conandata.yml
+++ b/recipes/daw_json_link/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1.1":
+    url: "https://github.com/beached/daw_json_link/archive/v3.1.1.tar.gz"
+    sha256: "7d340886898b2ea3c595f0f871c81e4c7382fe53d22d80edc5629768e49fa634"
   "3.1.0":
     url: "https://github.com/beached/daw_json_link/archive/v3.1.0.tar.gz"
     sha256: "c1134fed24794cda598306d23d23c393a0df8ee13d0019cae6ed46b939dad190"

--- a/recipes/daw_json_link/config.yml
+++ b/recipes/daw_json_link/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.1.1":
+    folder: "all"
   "3.1.0":
     folder: "all"
   "3.0.5":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **daw_json_link/3.1.1**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
