### PR TITLE
libmicrohttpd: fix 32-bit MSVC build

### DIFF
--- a/recipes/libmicrohttpd/all/conandata.yml
+++ b/recipes/libmicrohttpd/all/conandata.yml
@@ -7,3 +7,6 @@ patches:
     - patch_file: "patches/0.9.75-0001-msbuild-RuntimeLibrary.patch"
       patch_description: "Remove RuntimeLibrary from vcxproject + use conantoolchain.props"
       patch_type: "conan"
+    - patch_file: "patches/0.9.75-0002-allow-release-with-debug-runtime.patch"
+      patch_description: "Remove RuntimeLibrary from vcxproject + use conantoolchain.props"
+      patch_type: "conan"

--- a/recipes/libmicrohttpd/all/conanfile.py
+++ b/recipes/libmicrohttpd/all/conanfile.py
@@ -173,13 +173,13 @@ class LibmicrohttpdConan(ConanFile):
         copy(self, "COPYING", os.path.join(self.source_folder), os.path.join(self.package_folder, "licenses"))
         if is_msvc(self):
             # 32-bit (x86) libraries are stored in the root
-            copy(self, "*.lib", os.path.join(self.build_folder, self._msvc_sln_folder, "Output"), os.path.join(self.package_folder, "lib"))
-            copy(self, "*.dll", os.path.join(self.build_folder, self._msvc_sln_folder, "Output"), os.path.join(self.package_folder, "bin"))
-            copy(self, "*.h", os.path.join(self.build_folder, self._msvc_sln_folder, "Output"), os.path.join(self.package_folder, "include"))
-            # 64-bit (x64) libraries are stored in a subfolder
-            copy(self, "*.lib", os.path.join(self.build_folder, self._msvc_sln_folder, "Output", self._msvc_platform), os.path.join(self.package_folder, "lib"))
-            copy(self, "*.dll", os.path.join(self.build_folder, self._msvc_sln_folder, "Output", self._msvc_platform), os.path.join(self.package_folder, "bin"))
-            copy(self, "*.h", os.path.join(self.build_folder, self._msvc_sln_folder, "Output", self._msvc_platform), os.path.join(self.package_folder, "include"))
+            output_dir = os.path.join(self.build_folder, self._msvc_sln_folder, "Output")
+            if self.settings.arch in ("x86_64", ):
+                # 64-bit (x64) libraries are stored in a subfolder
+                output_dir = os.path.join(output_dir, self._msvc_platform)
+            copy(self, "*.lib", output_dir, os.path.join(self.package_folder, "lib"))
+            copy(self, "*.dll", output_dir, os.path.join(self.package_folder, "bin"))
+            copy(self, "*.h", output_dir, os.path.join(self.package_folder, "include"))
         else:
             autotools = Autotools(self)
             autotools.install()

--- a/recipes/libmicrohttpd/all/conanfile.py
+++ b/recipes/libmicrohttpd/all/conanfile.py
@@ -148,7 +148,7 @@ class LibmicrohttpdConan(ConanFile):
         return os.path.join("w32", subdir)
 
     @property
-    def _msvc_arch(self):
+    def _msvc_platform(self):
         return {
             "x86": "Win32",
             "x86_64": "x64",
@@ -162,6 +162,7 @@ class LibmicrohttpdConan(ConanFile):
         if is_msvc(self):
             msbuild = MSBuild(self)
             msbuild.build_type = self._msvc_configuration
+            msbuild.platform = self._msvc_platform
             msbuild.build(sln=os.path.join(self._msvc_sln_folder, "libmicrohttpd.sln"), targets=["libmicrohttpd"])
         else:
             autotools = Autotools(self)
@@ -171,9 +172,14 @@ class LibmicrohttpdConan(ConanFile):
     def package(self):
         copy(self, "COPYING", os.path.join(self.source_folder), os.path.join(self.package_folder, "licenses"))
         if is_msvc(self):
-            copy(self, "*.lib", os.path.join(self.build_folder, self._msvc_sln_folder, "Output", self._msvc_arch), os.path.join(self.package_folder, "lib"))
-            copy(self, "*.dll", os.path.join(self.build_folder, self._msvc_sln_folder, "Output", self._msvc_arch), os.path.join(self.package_folder, "bin"))
-            copy(self, "*.h", os.path.join(self.build_folder, self._msvc_sln_folder, "Output", self._msvc_arch), os.path.join(self.package_folder, "include"))
+            # 32-bit (x86) libraries are stored in the root
+            copy(self, "*.lib", os.path.join(self.build_folder, self._msvc_sln_folder, "Output"), os.path.join(self.package_folder, "lib"))
+            copy(self, "*.dll", os.path.join(self.build_folder, self._msvc_sln_folder, "Output"), os.path.join(self.package_folder, "bin"))
+            copy(self, "*.h", os.path.join(self.build_folder, self._msvc_sln_folder, "Output"), os.path.join(self.package_folder, "include"))
+            # 64-bit (x64) libraries are stored in a subfolder
+            copy(self, "*.lib", os.path.join(self.build_folder, self._msvc_sln_folder, "Output", self._msvc_platform), os.path.join(self.package_folder, "lib"))
+            copy(self, "*.dll", os.path.join(self.build_folder, self._msvc_sln_folder, "Output", self._msvc_platform), os.path.join(self.package_folder, "bin"))
+            copy(self, "*.h", os.path.join(self.build_folder, self._msvc_sln_folder, "Output", self._msvc_platform), os.path.join(self.package_folder, "include"))
         else:
             autotools = Autotools(self)
             autotools.install()

--- a/recipes/libmicrohttpd/all/patches/0.9.75-0002-allow-release-with-debug-runtime.patch
+++ b/recipes/libmicrohttpd/all/patches/0.9.75-0002-allow-release-with-debug-runtime.patch
@@ -1,0 +1,12 @@
+This patch allows building libmicrohttpd in Release configuration with a debug runtime (e.g. MTd)
+--- src/microhttpd/mhd_assert.h
++++ src/microhttpd/mhd_assert.h
+@@ -35,7 +35,7 @@
+ #define NDEBUG 1 /* Use NDEBUG by default */
+ #endif /* !_DEBUG && !NDEBUG */
+ #if defined(_DEBUG) && defined(NDEBUG)
+-#error Both _DEBUG and NDEBUG are defined
++//#error Both _DEBUG and NDEBUG are defined
+ #endif /* _DEBUG && NDEBUG */
+ #ifdef NDEBUG
+ #  define mhd_assert(ignore) ((void) 0)


### PR DESCRIPTION
Specify library name and version:  **libmicrohttpd/all**

Fixes 32-bit MSVC build

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
