### PR TITLE
blend2d: more conan v2 stuff & fix improper imports

### DIFF
--- a/recipes/blend2d/all/CMakeLists.txt
+++ b/recipes/blend2d/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.4)
-project(cmake_wrapper LANGUAGES CXX)
-
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-set(CMAKE_CXX_STANDARD 11)
-
-add_subdirectory(src)

--- a/recipes/blend2d/all/conanfile.py
+++ b/recipes/blend2d/all/conanfile.py
@@ -1,15 +1,12 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd, valid_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.microsoft import check_min_vs
 import os
 
-from conan import ConanFile
-from conan import tools
-from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
-from conan.tools.scm import Version
-from conan.tools.files import apply_conandata_patches
-from conan.tools.microsoft import is_msvc
-from conan.errors import ConanInvalidConfiguration
+required_conan_version = ">=1.52.0"
 
-required_conan_version = ">=1.50.0"
 
 class Blend2dConan(ConanFile):
     name = "blend2d"
@@ -29,9 +26,7 @@ class Blend2dConan(ConanFile):
     }
 
     def export_sources(self):
-        tools.files.copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
-        for p in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.files.copy(self, p["patch_file"], self.recipe_folder, self.export_sources_folder)
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -39,37 +34,41 @@ class Blend2dConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
 
     def layout(self):
-        cmake_layout(self, src_folder='src')
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires("asmjit/cci.20220210")
 
     def validate(self):
-        if self.info.settings.compiler.cppstd:
+        if self.info.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, 11)
 
         # In Visual Studio < 16, there are compilation error. patch is already provided.
         # https://github.com/blend2d/blend2d/commit/63db360c7eb2c1c3ca9cd92a867dbb23dc95ca7d
-        if is_msvc(self) and Version(self.settings.compiler.version) < "16":
-            raise ConanInvalidConfiguration("This recipe does not support this compiler version")
+        check_min_vs(self, 192)
 
     def source(self):
-        tools.files.get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def generate(self):
-        toolchain = CMakeToolchain(self)
-        toolchain.variables["BUILD_TESTING"] = False
-        toolchain.variables["BLEND2D_TEST"] = False
-        toolchain.variables["BLEND2D_EMBED"] = False
-        toolchain.variables["BLEND2D_STATIC"] = not self.options.shared
-        toolchain.variables["BLEND2D_NO_STDCXX"] = False
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_TESTING"] = False
+        tc.variables["BLEND2D_TEST"] = False
+        tc.variables["BLEND2D_EMBED"] = False
+        tc.variables["BLEND2D_STATIC"] = not self.options.shared
+        tc.variables["BLEND2D_NO_STDCXX"] = False
+        tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
+        if not valid_min_cppstd(self, 11):
+            tc.variables["CMAKE_CXX_STANDARD"] = 11
         if not self.options.shared:
-            toolchain.variables["CMAKE_C_FLAGS"] = "-DBL_STATIC"
-            toolchain.variables["CMAKE_CXX_FLAGS"] = "-DBL_STATIC"
-        toolchain.generate()
+            tc.preprocessor_definitions["BL_STATIC"] = "1"
+        tc.generate()
 
         deps = CMakeDeps(self)
         deps.generate()
@@ -77,20 +76,20 @@ class Blend2dConan(ConanFile):
     def build(self):
         apply_conandata_patches(self)
         cmake = CMake(self)
-        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        tools.files.copy(self, "LICENSE.md", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "LICENSE.md", self.source_folder, os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
-        tools.files.rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "blend2d")
+        self.cpp_info.set_property("cmake_target_name", "blend2d::blend2d")
         self.cpp_info.libs = ["blend2d"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["pthread", "rt",])
         if not self.options.shared:
             self.cpp_info.defines.append("BL_STATIC")
-
-        self.cpp_info.requires.append("asmjit::asmjit")

--- a/recipes/blend2d/all/test_package/CMakeLists.txt
+++ b/recipes/blend2d/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package CXX)
+project(test_package LANGUAGES CXX)
 
 find_package(blend2d CONFIG REQUIRED)
 

--- a/recipes/blend2d/all/test_package/conanfile.py
+++ b/recipes/blend2d/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.build import cross_building
+from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
 import os
 
@@ -7,12 +7,13 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-
-    def requirements(self):
-        self.requires(self.tested_reference_str)
+    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -20,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
+        if can_run(self):
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/blend2d/all/test_v1_package/CMakeLists.txt
+++ b/recipes/blend2d/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(blend2d CONFIG REQUIRED)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE blend2d::blend2d)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/blend2d/all/test_v1_package/conanfile.py
+++ b/recipes/blend2d/all/test_v1_package/conanfile.py
@@ -1,7 +1,5 @@
-# pylint: skip-file
-import os
-
 from conans import ConanFile, CMake, tools
+import os
 
 
 class TestPackageConan(ConanFile):


### PR DESCRIPTION
- fix improper imports of conan v2 features (`from conan import tools` is strongly discouraged, https://docs.conan.io/en/latest/reference/conanfile/tools.html)
- use `export_conandata_patches`
- remove CMakeLists wrapper
- `get_safe` of compiler.cppstd
- inject `BL_STATIC` with `tc.preprocessor_definitions`
- explicit cmake names
- use `can_run` in test package
- avoid duplication of CMake code logic in test v1 package

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
