### PR TITLE
libcurl: Fix cacert.pem packaging

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -591,7 +591,7 @@ class LibcurlConan(ConanFile):
 
     def package(self):
         copy(self, "COPYING", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
-        copy(self, pattern="cacert.pem", src=self.build_folder, dst="res")
+        copy(self, "cacert.pem", dst=os.path.join(self.package_folder, "res"), src=self.source_folder)
         if self._is_using_cmake_build:
             cmake = CMake(self)
             cmake.install()


### PR DESCRIPTION
Specify library name and version:  **libcurl/xxxx**

Since [Conan V2 migration](https://github.com/conan-io/conan-center-index/pull/12956), cacert.pem isn't packaged correctly.
We have to look in `source_folder` instead of `build_folder`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
