### PR TITLE
opencv 4.x: some contrib modules require eigen library

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -226,6 +226,8 @@ class OpenCVConan(ConanFile):
         if self.options.get_safe("dnn_cuda", False) and \
             (not self.options.with_cuda or not self.options.contrib or not self.options.with_cublas or not self.options.with_cudnn):
             raise ConanInvalidConfiguration("with_cublas, with_cudnn and contrib must be enabled for dnn_cuda")
+        if self.options.get_safe("contrib_sfm") and not self.options.with_eigen:
+            raise ConanInvalidConfiguration("with_eigen must be enabled for contrib_sfm")
         if self.options.with_ipp == "opencv-icv" and \
             (not str(self.settings.arch) in ["x86", "x86_64"] or \
              not str(self.settings.os) in ["Linux", "Macos", "Windows"]):
@@ -689,9 +691,12 @@ class OpenCVConan(ConanFile):
             if self.version >= "4.3.0":
                 opencv_components.extend([
                     {"target": "opencv_intensity_transform", "lib": "intensity_transform", "requires": ["opencv_core", "opencv_imgproc"] + eigen() + ipp()},
-                    {"target": "opencv_alphamat",            "lib": "alphamat",            "requires": ["opencv_core", "opencv_imgproc"] + eigen() + ipp()},
                     {"target": "opencv_rapid",               "lib": "rapid",               "requires": ["opencv_core", "opencv_flann", "opencv_imgproc", "opencv_features2d", "opencv_calib3d"] + eigen() + ipp()},
                 ])
+                if self.options.with_eigen:
+                    opencv_components.extend([
+                        {"target": "opencv_alphamat",            "lib": "alphamat",            "requires": ["opencv_core", "opencv_imgproc"] + eigen() + ipp()},
+                    ])
 
             if self.options.get_safe("contrib_freetype"):
                 opencv_components.extend([


### PR DESCRIPTION
library name and version:  **opencv/4.x**
---
Combination of `with_contrib=True` and `with_eigen=False` makes `find_package(OpenCV)` fail with
```
-- Conan: Target declared 'opencv::opencv'
CMake Error at build/generators/cmakedeps_macros.cmake:39 (message):
  Library 'opencv_alphamat453' not found in package.  If
  'opencv_alphamat453' is a system library, declare it with
  'cpp_info.system_libs' property
```
`contrib_sfm` also requires `with_eigen`, so I added a check to `validate()`

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
