### PR TITLE
Only add m4 to build_requires when cross compiling

### DIFF
--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -36,9 +36,11 @@ class FlexConan(ConanFile):
         self.requires("m4/1.4.19")
 
     def build_requirements(self):
-        if hasattr(self, "settings_build") and tools.cross_building(self):
+        if hasattr(self, "settings_build"):
             self.build_requires("m4/1.4.19")
-            self.build_requires(f"{self.name}/{self.version}")
+            
+            if tools.cross_building(self):
+                self.build_requires(f"{self.name}/{self.version}")
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -36,8 +36,8 @@ class FlexConan(ConanFile):
         self.requires("m4/1.4.19")
 
     def build_requirements(self):
-        self.build_requires("m4/1.4.19")
         if hasattr(self, "settings_build") and tools.cross_building(self):
+            self.build_requires("m4/1.4.19")
             self.build_requires(f"{self.name}/{self.version}")
 
     def config_options(self):


### PR DESCRIPTION
Only require m4 in build_requirements when cross compiling. This allows lock bundles to work for flex. See known bug about having same dependency in requires and build_requires: https://github.com/conan-io/conan/issues/10345

Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
