### PR TITLE
Revert "actions: upgrade changed-files version"

### DIFF
--- a/.github/workflows/linter-conan-v2.yml
+++ b/.github/workflows/linter-conan-v2.yml
@@ -16,12 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Get changed files
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v20
         id: changed_files
         with:
-          base_sha: ${{ github.event.pull_request.base.sha }}
           files: |
             linter/**
       - name: Get Conan v1 version
@@ -85,12 +84,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v20
         with:
-          base_sha: ${{ github.event.pull_request.base.sha }}
           files: |
             recipes/*/*/conanfile.py
       - name: Get Conan v1 version
@@ -121,12 +119,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v20
         with:
-          base_sha: ${{ github.event.pull_request.base.sha }}
           files: |
             recipes/*/*/test_*/conanfile.py
       - name: Get Conan v1 version

--- a/.github/workflows/linter-yaml.yml
+++ b/.github/workflows/linter-yaml.yml
@@ -17,13 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Get changed files
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v20
         id: changed_files
         with:
-          base_sha: ${{ github.event.pull_request.base.sha }}
           files: |
             linter/**
 
@@ -52,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - uses: actions/setup-python@v4
         with:
@@ -65,9 +64,8 @@ jobs:
       - name: Get changed files (config)
         id: changed_files_config
         if: always()
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v20
         with:
-          base_sha: ${{ github.event.pull_request.base.sha }}
           files: |
             ${{ env.CONFIG_FILES_PATH }}
 
@@ -82,9 +80,8 @@ jobs:
       - name: Get changed files (conandata)
         id: changed_files_conandata
         if: always()
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v20
         with:
-          base_sha: ${{ github.event.pull_request.base.sha }}
           files: |
             ${{ env.CONANDATA_FILES_PATH }}
 


### PR DESCRIPTION
Reverts conan-io/conan-center-index#13602

Looks like it broke ci, again, in spite of the tests we did :/
I'm questioning the use of this extension now 