### PR TITLE
libjpeg-turbo: conan v2 support

### DIFF
--- a/recipes/libjpeg-turbo/all/CMakeLists.txt
+++ b/recipes/libjpeg-turbo/all/CMakeLists.txt
@@ -1,13 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-
 project(cmake_wrapper)
 
-include(conanbuildinfo.cmake)
-conan_basic_setup(NO_OUTPUT_DIRS)
-
 if(NOT CMAKE_SYSTEM_PROCESSOR)
-    set(CMAKE_SYSTEM_PROCESSOR ${CONAN_LIBJPEG_SYSTEM_PROCESSOR})
+    set(CMAKE_SYSTEM_PROCESSOR ${CONAN_LIBJPEG_TURBO_SYSTEM_PROCESSOR})
 endif()
 
-
-add_subdirectory("source_subfolder")
+add_subdirectory("src")

--- a/recipes/libjpeg-turbo/all/conandata.yml
+++ b/recipes/libjpeg-turbo/all/conandata.yml
@@ -20,11 +20,8 @@ sources:
   "2.0.5":
     url: "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.5.tar.gz"
     sha256: "b3090cd37b5a8b3e4dbd30a1311b3989a894e5d3c668f14cbc6739d77c9402b7"
-
 patches:
   "2.1.4":
     - patch_file: "patches/2.1.3-0001-fix-cmake.patch"
-      base_path: "source_subfolder"
   "2.1.3":
     - patch_file: "patches/2.1.3-0001-fix-cmake.patch"
-      base_path: "source_subfolder"

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -1,10 +1,13 @@
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import is_msvc
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import cross_building
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
 import os
-import functools
 
-required_conan_version = ">=1.45.0"
+required_conan_version = ">=1.52.0"
 
 
 class LibjpegTurboConan(ConanFile):
@@ -42,26 +45,29 @@ class LibjpegTurboConan(ConanFile):
         "java": False,
         "enable12bit": False,
     }
-    generators = "cmake"
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def configure(self):
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
         if self.options.shared:
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
 
         if self.options.enable12bit:
             del self.options.java
@@ -74,13 +80,24 @@ class LibjpegTurboConan(ConanFile):
         if self.options.libjpeg8_compatibility:
             del self.options.mem_src_dst
 
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
     def validate(self):
-        if self.options.enable12bit and (self.options.libjpeg7_compatibility or self.options.libjpeg8_compatibility):
+        if self.info.options.enable12bit and (self.info.options.libjpeg7_compatibility or self.info.options.libjpeg8_compatibility):
             raise ConanInvalidConfiguration("12-bit samples is not allowed with libjpeg v7/v8 API/ABI")
-        if self.options.get_safe("java", False) and not self.options.shared:
+        if self.info.options.get_safe("java") and not self.info.options.shared:
             raise ConanInvalidConfiguration("java wrapper requires shared libjpeg-turbo")
-        if is_msvc(self) and self.options.shared and str(self.settings.compiler.runtime).startswith("MT"):
-            raise ConanInvalidConfiguration("shared libjpeg-turbo can't be built with MT or MTd")
+        if self.info.options.shared and is_msvc(self) and is_msvc_static_runtime(self):
+            raise ConanInvalidConfiguration(f"{self.ref} shared can't be built with static vc runtime")
+
+    def build_requirements(self):
+        if self.options.get_safe("SIMD") and self.settings.arch in ["x86", "x86_64"]:
+            self.tool_requires("nasm/2.15.05")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
 
     @property
     def _is_arithmetic_encoding_enabled(self):
@@ -92,91 +109,86 @@ class LibjpegTurboConan(ConanFile):
         return self.options.get_safe("arithmetic_decoder", False) or \
                self.options.libjpeg7_compatibility or self.options.libjpeg8_compatibility
 
-    def build_requirements(self):
-        if self.options.get_safe("SIMD") and self.settings.arch in ["x86", "x86_64"]:
-            self.build_requires("nasm/2.14")
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
-
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self, set_cmake_flags=True)
-        cmake.definitions["ENABLE_STATIC"] = not self.options.shared
-        cmake.definitions["ENABLE_SHARED"] = self.options.shared
-        cmake.definitions["WITH_SIMD"] = self.options.get_safe("SIMD", False)
-        cmake.definitions["WITH_ARITH_ENC"] = self._is_arithmetic_encoding_enabled
-        cmake.definitions["WITH_ARITH_DEC"] = self._is_arithmetic_decoding_enabled
-        cmake.definitions["WITH_JPEG7"] = self.options.libjpeg7_compatibility
-        cmake.definitions["WITH_JPEG8"] = self.options.libjpeg8_compatibility
-        cmake.definitions["WITH_MEM_SRCDST"] = self.options.get_safe("mem_src_dst", False)
-        cmake.definitions["WITH_TURBOJPEG"] = self.options.get_safe("turbojpeg", False)
-        cmake.definitions["WITH_JAVA"] = self.options.get_safe("java", False)
-        cmake.definitions["WITH_12BIT"] = self.options.enable12bit
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ENABLE_STATIC"] = not self.options.shared
+        tc.variables["ENABLE_SHARED"] = self.options.shared
+        tc.variables["WITH_SIMD"] = self.options.get_safe("SIMD", False)
+        tc.variables["WITH_ARITH_ENC"] = self._is_arithmetic_encoding_enabled
+        tc.variables["WITH_ARITH_DEC"] = self._is_arithmetic_decoding_enabled
+        tc.variables["WITH_JPEG7"] = self.options.libjpeg7_compatibility
+        tc.variables["WITH_JPEG8"] = self.options.libjpeg8_compatibility
+        tc.variables["WITH_MEM_SRCDST"] = self.options.get_safe("mem_src_dst", False)
+        tc.variables["WITH_TURBOJPEG"] = self.options.get_safe("turbojpeg", False)
+        tc.variables["WITH_JAVA"] = self.options.get_safe("java", False)
+        tc.variables["WITH_12BIT"] = self.options.enable12bit
         if is_msvc(self):
-            cmake.definitions["WITH_CRT_DLL"] = True # avoid replacing /MD by /MT in compiler flags
-
-        if tools.Version(self.version) <= "2.1.0":
-            cmake.definitions["CMAKE_MACOSX_BUNDLE"] = False # avoid configuration error if building for iOS/tvOS/watchOS
-
-        if tools.cross_building(self):
+            tc.variables["WITH_CRT_DLL"] = True # avoid replacing /MD by /MT in compiler flags
+        if Version(self.version) <= "2.1.0":
+            tc.variables["CMAKE_MACOSX_BUNDLE"] = False # avoid configuration error if building for iOS/tvOS/watchOS
+        if cross_building(self):
             # TODO: too specific and error prone, should be delegated to a conan helper function
             cmake_system_processor = {
                 "armv8": "aarch64",
                 "armv8.3": "aarch64",
             }.get(str(self.settings.arch), str(self.settings.arch))
-            cmake.definitions["CONAN_LIBJPEG_SYSTEM_PROCESSOR"] = cmake_system_processor
-
-        cmake.configure()
-        return cmake
+            tc.variables["CONAN_LIBJPEG_TURBO_SYSTEM_PROCESSOR"] = cmake_system_processor
+        tc.generate()
 
     def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+        apply_conandata_patches(self)
 
         # use standard GNUInstallDirs.cmake - custom one is broken
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                               "include(cmakescripts/GNUInstallDirs.cmake)",
                               "include(GNUInstallDirs)")
         # do not override /MT by /MD if shared
-        tools.replace_in_file(os.path.join(self._source_subfolder, "sharedlib", "CMakeLists.txt"),
+        replace_in_file(self, os.path.join(self.source_folder, "sharedlib", "CMakeLists.txt"),
                               """string(REGEX REPLACE "/MT" "/MD" ${var} "${${var}}")""",
                               "")
 
     def build(self):
         self._patch_sources()
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE.md", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, "LICENSE.md", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
         cmake.install()
         # remove unneeded directories
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "doc"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "doc"))
         # remove binaries and pdb files
         for pattern_to_remove in ["cjpeg*", "djpeg*", "jpegtran*", "tjbench*", "wrjpgcom*", "rdjpgcom*", "*.pdb"]:
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "bin"), pattern_to_remove)
+            rm(self, pattern_to_remove, os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_find_mode", "both")
+        self.cpp_info.set_property("cmake_module_file_name", "JPEG")
         self.cpp_info.set_property("cmake_file_name", "libjpeg-turbo")
 
         cmake_target_suffix = "-static" if not self.options.shared else ""
         lib_suffix = "-static" if is_msvc(self) and not self.options.shared else ""
 
-        self.cpp_info.components["jpeg"].set_property("cmake_target_name", "libjpeg-turbo::jpeg{}".format(cmake_target_suffix))
+        self.cpp_info.components["jpeg"].set_property("cmake_module_target_name", "JPEG::JPEG")
+        self.cpp_info.components["jpeg"].set_property("cmake_target_name", f"libjpeg-turbo::jpeg{cmake_target_suffix}")
         self.cpp_info.components["jpeg"].set_property("pkg_config_name", "libjpeg")
-        self.cpp_info.components["jpeg"].names["cmake_find_package"] = "jpeg" + cmake_target_suffix
-        self.cpp_info.components["jpeg"].names["cmake_find_package_multi"] = "jpeg" + cmake_target_suffix
-        self.cpp_info.components["jpeg"].libs = ["jpeg" + lib_suffix]
+        self.cpp_info.components["jpeg"].libs = [f"jpeg{lib_suffix}"]
 
         if self.options.get_safe("turbojpeg"):
-            self.cpp_info.components["turbojpeg"].set_property("cmake_target_name", "libjpeg-turbo::turbojpeg{}".format(cmake_target_suffix))
+            self.cpp_info.components["turbojpeg"].set_property("cmake_target_name", f"libjpeg-turbo::turbojpeg{cmake_target_suffix}")
             self.cpp_info.components["turbojpeg"].set_property("pkg_config_name", "libturbojpeg")
-            self.cpp_info.components["turbojpeg"].names["cmake_find_package"] = "turbojpeg" + cmake_target_suffix
-            self.cpp_info.components["turbojpeg"].names["cmake_find_package_multi"] = "turbojpeg" + cmake_target_suffix
-            self.cpp_info.components["turbojpeg"].libs = ["turbojpeg" + lib_suffix]
+            self.cpp_info.components["turbojpeg"].libs = [f"turbojpeg{lib_suffix}"]
+
+        # TODO: to remove in conan v2
+        self.cpp_info.names["cmake_find_package"] = "JPEG"
+        self.cpp_info.names["cmake_find_package_multi"] = "libjpeg-turbo"
+        self.cpp_info.components["jpeg"].names["cmake_find_package"] = "JPEG"
+        self.cpp_info.components["jpeg"].names["cmake_find_package_multi"] = f"jpeg{cmake_target_suffix}"
+        if self.options.get_safe("turbojpeg"):
+            self.cpp_info.components["turbojpeg"].names["cmake_find_package"] = f"turbojpeg{cmake_target_suffix}"
+            self.cpp_info.components["turbojpeg"].names["cmake_find_package_multi"] = f"turbojpeg{cmake_target_suffix}"

--- a/recipes/libjpeg-turbo/all/conanfile.py
+++ b/recipes/libjpeg-turbo/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
 from conan.tools.scm import Version
@@ -110,6 +111,9 @@ class LibjpegTurboConan(ConanFile):
                self.options.libjpeg7_compatibility or self.options.libjpeg8_compatibility
 
     def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+
         tc = CMakeToolchain(self)
         tc.variables["ENABLE_STATIC"] = not self.options.shared
         tc.variables["ENABLE_SHARED"] = self.options.shared

--- a/recipes/libjpeg-turbo/all/test_package/CMakeLists.txt
+++ b/recipes/libjpeg-turbo/all/test_package/CMakeLists.txt
@@ -1,15 +1,12 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package C)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES C)
 
 find_package(libjpeg-turbo REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
 if(TARGET libjpeg-turbo::jpeg)
-  target_link_libraries(${PROJECT_NAME} PRIVATE libjpeg-turbo::jpeg)
+    target_link_libraries(${PROJECT_NAME} PRIVATE libjpeg-turbo::jpeg)
 else()
-  target_link_libraries(${PROJECT_NAME} PRIVATE libjpeg-turbo::jpeg-static)
+    target_link_libraries(${PROJECT_NAME} PRIVATE libjpeg-turbo::jpeg-static)
 endif()
-set_property(TARGET ${PROJECT_NAME} PROPERTY C_STANDARD 99)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/libjpeg-turbo/all/test_package_module/CMakeLists.txt
+++ b/recipes/libjpeg-turbo/all/test_package_module/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES C)
+
+find_package(JPEG REQUIRED)
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE JPEG::JPEG)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)

--- a/recipes/libjpeg-turbo/all/test_package_module/conanfile.py
+++ b/recipes/libjpeg-turbo/all/test_package_module/conanfile.py
@@ -23,5 +23,5 @@ class TestPackageConan(ConanFile):
     def test(self):
         if can_run(self):
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
-            img_name = os.path.join(self.source_folder, "testimg.jpg")
+            img_name = os.path.join(self.source_folder, os.pardir, "test_package", "testimg.jpg")
             self.run(f"{bin_path} {img_name}", env="conanrun")

--- a/recipes/libjpeg-turbo/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libjpeg-turbo/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/libjpeg-turbo/all/test_v1_package/conanfile.py
+++ b/recipes/libjpeg-turbo/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            img_name = os.path.join(self.source_folder, os.pardir, "test_package", "testimg.jpg")
+            self.run(f"{bin_path} {img_name}", run_environment=True)

--- a/recipes/libjpeg-turbo/all/test_v1_package_module/CMakeLists.txt
+++ b/recipes/libjpeg-turbo/all/test_v1_package_module/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package_module
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package_module)

--- a/recipes/libjpeg-turbo/all/test_v1_package_module/conanfile.py
+++ b/recipes/libjpeg-turbo/all/test_v1_package_module/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            img_name = os.path.join(self.source_folder, os.pardir, "test_package", "testimg.jpg")
+            self.run(f"{bin_path} {img_name}", run_environment=True)


### PR DESCRIPTION
This PR also enables generation of `FindJPEG.cmake` in `CMakeDeps` and `cmake_find_package` generator, as well as JPEG::JPEG target, since official `FindJPEG.cmake` is able to find libjpeg implementation of libjpeg-turbo.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
