### PR TITLE
libslz: add version 1.2.1

### DIFF
--- a/recipes/libslz/all/conandata.yml
+++ b/recipes/libslz/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.1":
+    url: "https://github.com/wtarreau/libslz/archive/v1.2.1.tar.gz"
+    sha256: "c1fa88556e97541a550e59fd1f0fc8f6b4c02444b14c13eb553c9827123122c5"
   "1.2.0":
     url: "https://github.com/wtarreau/libslz/archive/refs/tags/v1.2.0.tar.gz"
     sha256: "723a8ef648ac5b30e5074c013ff61a5e5f54a5aafc9496f7dab9f6b02030bf24"

--- a/recipes/libslz/config.yml
+++ b/recipes/libslz/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.2.1":
+    folder: all
   "1.2.0":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libslz/1.2.1**



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
