### PR TITLE
glaze: add version 0.1.0

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.0":
+    url: "https://github.com/stephenberry/glaze/archive/v0.1.0.tar.gz"
+    sha256: "bb709637217b68c835c5c17d49d6e1d10682a9fb5d3899b4452f737f64961a67"
   "0.0.7":
     url: "https://github.com/stephenberry/glaze/archive/refs/tags/v0.0.7.tar.gz"
     sha256: "124f7e8fea58c012b548ba1b643684fe428c7dbfeb8d8a5f701eb7db4356a759"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.1.0":
+    folder: all
   "0.0.7":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **glaze/0.1.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
