### PR TITLE
ninja: Remove conan_version import

### DIFF
--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -1,4 +1,4 @@
-from conan import ConanFile, conan_version
+from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
 from conan.tools.scm import Version
@@ -14,7 +14,7 @@ class NinjaConan(ConanFile):
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/ninja-build/ninja"
-    topics = ("ninja", "build")
+    topics = "build"
     settings = "os", "arch", "compiler", "build_type"
 
     def layout(self):
@@ -49,6 +49,5 @@ class NinjaConan(ConanFile):
         self.conf_info.define("tools.cmake.cmaketoolchain:generator", "Ninja")
 
         # TODO: to remove in conan v2
-        if Version(conan_version).major < 2:
-            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
-            self.env_info.CONAN_CMAKE_GENERATOR = "Ninja"
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+        self.env_info.CONAN_CMAKE_GENERATOR = "Ninja"

--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -1,6 +1,11 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
+from conan.tools.scm import Version
+try:
+    from conan import conan_version
+except ImportError
+    from conans import __version__ as conan_version
 import os
 
 required_conan_version = ">=1.52.0"
@@ -48,5 +53,6 @@ class NinjaConan(ConanFile):
         self.conf_info.define("tools.cmake.cmaketoolchain:generator", "Ninja")
 
         # TODO: to remove in conan v2
-        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
-        self.env_info.CONAN_CMAKE_GENERATOR = "Ninja"
+        if Version(conan_version).major < 2:
+            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+            self.env_info.CONAN_CMAKE_GENERATOR = "Ninja"

--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
-from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.52.0"


### PR DESCRIPTION
This breaks older versions of Conan, unfortunately.

Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
