### PR TITLE
Add cpp-sort 1.13.2, make recipe compatible with Conan v2

### DIFF
--- a/recipes/cpp-sort/all/conandata.yml
+++ b/recipes/cpp-sort/all/conandata.yml
@@ -1,40 +1,40 @@
 sources:
-  "1.5.1":
-    sha256: 39925958dbd773f15d36d74d4ded48f075c05feef7fe604c7c5c4bfae2a4ec55
-    url: https://github.com/Morwenn/cpp-sort/archive/1.5.1.tar.gz
-  "1.6.0":
-    sha256: df048d15ff555030eb90d3c96f560a75bbec8baee256f2ced647f359c892c9c8
-    url: https://github.com/Morwenn/cpp-sort/archive/1.6.0.tar.gz
-  "1.7.0":
-    sha256: 4a8230be2c63a92395e140cb7e6593171638a41c46f4cd14d6ffc354ba830e2b
-    url: https://github.com/Morwenn/cpp-sort/archive/1.7.0.tar.gz
-  "1.8.0":
-    sha256: a3de426a66cffbe9f8865feb7518ff4f4d1b3aadf3725161b8e118dcbf6fe9b9
-    url: https://github.com/Morwenn/cpp-sort/archive/1.8.0.tar.gz
-  "1.8.1":
-    sha256: 04d518dabb422614fcb4a2b4e258c515f31dd01d51c26e9eaaec76e77c4d3d40
-    url: https://github.com/Morwenn/cpp-sort/archive/1.8.1.tar.gz
-  "1.9.0":
-    sha256: e83f3daad30bd91fed668bdb56ad379c4aeea39d7dc640484fdcc55149b6d0e4
-    url: https://github.com/Morwenn/cpp-sort/archive/1.9.0.tar.gz
-  "1.10.0":
-    sha256: 48951cac0051d48fee286c3bc02804975f9d83269d80c10dfc5589e76a542765
-    url: https://github.com/Morwenn/cpp-sort/archive/1.10.0.tar.gz
-  "1.11.0":
-    sha256: a53b3ea240d6f8d8ea9da0a7e0c8e313cf5e714daedf1617473ab34f111ffeec
-    url: https://github.com/Morwenn/cpp-sort/archive/1.11.0.tar.gz
-  "1.12.0":
-    sha256: 70877c1993fa1e5eb53974ac30aeb713448c206344379f193dec8ee887c23998
-    url: https://github.com/Morwenn/cpp-sort/archive/1.12.0.tar.gz
-  "1.12.1":
-    sha256: 5b0b6f3b4d9ecc339d6c2204a18479edca49fbc4d487413e0ec747e143569e2a
-    url: https://github.com/Morwenn/cpp-sort/archive/1.12.1.tar.gz
-  "1.13.0":
-    sha256: 646eca5c592d20cbde0fbff41c65527940bb6430be68e0224fb5fcbf38b0df92
-    url: https://github.com/Morwenn/cpp-sort/archive/1.13.0.tar.gz
-  "1.13.1":
-    sha256: 139912c6004df8748bb1cfd3b94f2c6bfc2713885ed4b8e927a783d6b66963a8
-    url: https://github.com/Morwenn/cpp-sort/archive/1.13.1.tar.gz
   "1.13.2":
     sha256: f5384ed9c8abef2f26cb010df2687ac8bba52f0e1726935826a80e83c1347b23
     url: https://github.com/Morwenn/cpp-sort/archive/1.13.2.tar.gz
+  "1.13.1":
+    sha256: 139912c6004df8748bb1cfd3b94f2c6bfc2713885ed4b8e927a783d6b66963a8
+    url: https://github.com/Morwenn/cpp-sort/archive/1.13.1.tar.gz
+  "1.13.0":
+    sha256: 646eca5c592d20cbde0fbff41c65527940bb6430be68e0224fb5fcbf38b0df92
+    url: https://github.com/Morwenn/cpp-sort/archive/1.13.0.tar.gz
+  "1.12.1":
+    sha256: 5b0b6f3b4d9ecc339d6c2204a18479edca49fbc4d487413e0ec747e143569e2a
+    url: https://github.com/Morwenn/cpp-sort/archive/1.12.1.tar.gz
+  "1.12.0":
+    sha256: 70877c1993fa1e5eb53974ac30aeb713448c206344379f193dec8ee887c23998
+    url: https://github.com/Morwenn/cpp-sort/archive/1.12.0.tar.gz
+  "1.11.0":
+    sha256: a53b3ea240d6f8d8ea9da0a7e0c8e313cf5e714daedf1617473ab34f111ffeec
+    url: https://github.com/Morwenn/cpp-sort/archive/1.11.0.tar.gz
+  "1.10.0":
+    sha256: 48951cac0051d48fee286c3bc02804975f9d83269d80c10dfc5589e76a542765
+    url: https://github.com/Morwenn/cpp-sort/archive/1.10.0.tar.gz
+  "1.9.0":
+    sha256: e83f3daad30bd91fed668bdb56ad379c4aeea39d7dc640484fdcc55149b6d0e4
+    url: https://github.com/Morwenn/cpp-sort/archive/1.9.0.tar.gz
+  "1.8.1":
+    sha256: 04d518dabb422614fcb4a2b4e258c515f31dd01d51c26e9eaaec76e77c4d3d40
+    url: https://github.com/Morwenn/cpp-sort/archive/1.8.1.tar.gz
+  "1.8.0":
+    sha256: a3de426a66cffbe9f8865feb7518ff4f4d1b3aadf3725161b8e118dcbf6fe9b9
+    url: https://github.com/Morwenn/cpp-sort/archive/1.8.0.tar.gz
+  "1.7.0":
+    sha256: 4a8230be2c63a92395e140cb7e6593171638a41c46f4cd14d6ffc354ba830e2b
+    url: https://github.com/Morwenn/cpp-sort/archive/1.7.0.tar.gz
+  "1.6.0":
+    sha256: df048d15ff555030eb90d3c96f560a75bbec8baee256f2ced647f359c892c9c8
+    url: https://github.com/Morwenn/cpp-sort/archive/1.6.0.tar.gz
+  "1.5.1":
+    sha256: 39925958dbd773f15d36d74d4ded48f075c05feef7fe604c7c5c4bfae2a4ec55
+    url: https://github.com/Morwenn/cpp-sort/archive/1.5.1.tar.gz

--- a/recipes/cpp-sort/all/conandata.yml
+++ b/recipes/cpp-sort/all/conandata.yml
@@ -35,3 +35,6 @@ sources:
   "1.13.1":
     sha256: 139912c6004df8748bb1cfd3b94f2c6bfc2713885ed4b8e927a783d6b66963a8
     url: https://github.com/Morwenn/cpp-sort/archive/1.13.1.tar.gz
+  "1.13.2":
+    sha256: f5384ed9c8abef2f26cb010df2687ac8bba52f0e1726935826a80e83c1347b23
+    url: https://github.com/Morwenn/cpp-sort/archive/1.13.2.tar.gz

--- a/recipes/cpp-sort/all/conanfile.py
+++ b/recipes/cpp-sort/all/conanfile.py
@@ -34,10 +34,10 @@ class CppSortConan(ConanFile):
         }
 
     def validate(self):
-        if self.info.settings.get_safe("compiler.cppstd"):
+        if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
 
-        compiler = self.info.settings.compiler
+        compiler = self.settings.compiler
         try:
             min_version = self._minimum_compilers_version[str(compiler)]
             if Version(compiler.version) < min_version:
@@ -87,4 +87,4 @@ class CppSortConan(ConanFile):
             self.cpp_info.cxxflags = ["/permissive-"]
 
     def package_id(self):
-        self.info.clear()  # Header-only
+        self.info.clear()

--- a/recipes/cpp-sort/all/conanfile.py
+++ b/recipes/cpp-sort/all/conanfile.py
@@ -1,8 +1,12 @@
-from conans import CMake, ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
-import os
+import os.path
 
-required_conan_version = ">=1.33.0"
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.50.0"
 
 
 class CppSortConan(ConanFile):
@@ -14,10 +18,6 @@ class CppSortConan(ConanFile):
     license = "MIT"
     no_copy_source = True
     settings = "os", "compiler", "build_type", "arch"
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
 
     @property
     def _minimum_cpp_standard(self):
@@ -33,13 +33,13 @@ class CppSortConan(ConanFile):
         }
 
     def validate(self):
-        if self.settings.get_safe("compiler.cppstd"):
-            tools.check_min_cppstd(self, self._minimum_cpp_standard)
+        if self.info.settings.get_safe("compiler.cppstd"):
+            check_min_cppstd(self, self._minimum_cpp_standard)
 
-        compiler = self.settings.compiler
+        compiler = self.info.settings.compiler
         try:
             min_version = self._minimum_compilers_version[str(compiler)]
-            if tools.Version(compiler.version) < min_version:
+            if Version(compiler.version) < min_version:
                 msg = (
                     "{} requires C++{} features which are not supported by compiler {} {}."
                 ).format(self.name, self._minimum_cpp_standard, compiler, compiler.version)
@@ -51,27 +51,33 @@ class CppSortConan(ConanFile):
             ).format(self.name, compiler, self._minimum_cpp_standard)
             self.output.warn(msg)
 
+    def layout(self):
+       cmake_layout(self, src_folder="source")
+
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_TESTING"] = "OFF"
+        tc.generate()
 
     def package(self):
         # Install with CMake
         cmake = CMake(self)
-        cmake.definitions["BUILD_TESTING"] = "OFF"
-        cmake.configure(source_folder=self._source_subfolder)
+        cmake.configure()
         cmake.install()
 
         # Copy license files
-        if tools.Version(self.version) < "1.8.0":
+        if Version(self.version) < "1.8.0":
             license_files = ["license.txt"]
         else:
             license_files = ["LICENSE.txt", "NOTICE.txt"]
         for license_file in license_files:
-            self.copy(license_file, dst="licenses", src=self._source_subfolder)
+            copy(self, license_file, self.source_folder, os.path.join(self.package_folder, "licenses"))
 
         # Remove CMake config files (only files in lib)
-        tools.rmdir(os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
         self.cpp_info.names["cmake_find_package"] = "cpp-sort"
@@ -80,4 +86,4 @@ class CppSortConan(ConanFile):
             self.cpp_info.cxxflags = ["/permissive-"]
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()  # Header-only

--- a/recipes/cpp-sort/all/conanfile.py
+++ b/recipes/cpp-sort/all/conanfile.py
@@ -41,6 +41,8 @@ class CppSortConan(ConanFile):
             check_min_cppstd(self, self._minimum_cpp_standard)
 
         if is_msvc(self):
+            if Version(self.version) < "1.10.0":
+                raise ConanInvalidConfiguration("cpp-sort versions older than 1.10.0 do not support MSVC")
             check_min_vs(self, 192)
             return
 

--- a/recipes/cpp-sort/all/conanfile.py
+++ b/recipes/cpp-sort/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
+from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
 
 required_conan_version = ">=1.50.0"
@@ -13,7 +14,7 @@ required_conan_version = ">=1.50.0"
 class CppSortConan(ConanFile):
     name = "cpp-sort"
     description = "Additional sorting algorithms & related tools"
-    topics = "conan", "cpp-sort", "sorting", "algorithms"
+    topics = "cpp-sort", "sorting", "algorithms"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/Morwenn/cpp-sort"
     license = "MIT"
@@ -29,8 +30,7 @@ class CppSortConan(ConanFile):
         return {
             "apple-clang": "9.4",
             "clang": "3.8",
-            "gcc": "5.5",
-            "Visual Studio": "16"
+            "gcc": "5.5"
         }
 
     def layout(self):
@@ -39,6 +39,10 @@ class CppSortConan(ConanFile):
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
+
+        if is_msvc(self):
+            check_min_vs(self, 192)
+            return
 
         compiler = self.settings.compiler
         try:

--- a/recipes/cpp-sort/all/conanfile.py
+++ b/recipes/cpp-sort/all/conanfile.py
@@ -25,7 +25,7 @@ class CppSortConan(ConanFile):
         return 14
 
     @property
-    def _minimum_compilers_version(self):
+    def _compilers_minimum_version(self):
         return {
             "apple-clang": "9.4",
             "clang": "3.8",
@@ -33,13 +33,16 @@ class CppSortConan(ConanFile):
             "Visual Studio": "16"
         }
 
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):
             check_min_cppstd(self, self._minimum_cpp_standard)
 
         compiler = self.settings.compiler
         try:
-            min_version = self._minimum_compilers_version[str(compiler)]
+            min_version = self._compilers_minimum_version[str(compiler)]
             if Version(compiler.version) < min_version:
                 msg = (
                     "{} requires C++{} features which are not supported by compiler {} {}."
@@ -52,11 +55,8 @@ class CppSortConan(ConanFile):
             ).format(self.name, compiler, self._minimum_cpp_standard)
             self.output.warn(msg)
 
-    def layout(self):
-        cmake_layout(self, src_folder="source")
-
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -75,7 +75,7 @@ class CppSortConan(ConanFile):
         else:
             license_files = ["LICENSE.txt", "NOTICE.txt"]
         for license_file in license_files:
-            copy(self, license_file, self.source_folder, os.path.join(self.package_folder, "licenses"))
+            copy(self, license_file, src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
 
         # Remove CMake config files (only files in lib)
         rmdir(self, os.path.join(self.package_folder, "lib"))

--- a/recipes/cpp-sort/all/conanfile.py
+++ b/recipes/cpp-sort/all/conanfile.py
@@ -1,6 +1,7 @@
 import os.path
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
@@ -52,7 +53,7 @@ class CppSortConan(ConanFile):
             self.output.warn(msg)
 
     def layout(self):
-       cmake_layout(self, src_folder="source")
+        cmake_layout(self, src_folder="source")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/cpp-sort/all/test_package/CMakeLists.txt
+++ b/recipes/cpp-sort/all/test_package/CMakeLists.txt
@@ -1,9 +1,6 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 
 project(test_package LANGUAGES CXX)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
 
 find_package(cpp-sort REQUIRED CONFIG)
 

--- a/recipes/cpp-sort/all/test_package/conanfile.py
+++ b/recipes/cpp-sort/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class CppsortTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class CppsortTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cpp-sort/all/test_v1_package/CMakeLists.txt
+++ b/recipes/cpp-sort/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(cpp-sort REQUIRED CONFIG)
+
+add_executable(${CMAKE_PROJECT_NAME} cpp-sort-integrity.cpp)
+target_link_libraries(${CMAKE_PROJECT_NAME} cpp-sort::cpp-sort)
+set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY CXX_STANDARD 14)

--- a/recipes/cpp-sort/all/test_v1_package/conanfile.py
+++ b/recipes/cpp-sort/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class CppsortTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self.settings):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/cpp-sort/all/test_v1_package/cpp-sort-integrity.cpp
+++ b/recipes/cpp-sort/all/test_v1_package/cpp-sort-integrity.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018-2020 Morwenn.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <iterator>
+#include <cpp-sort/sorters/smooth_sorter.h>
+
+int main()
+{
+    int arr[] = { 5, 8, 3, 2, 9 };
+    cppsort::smooth_sort(arr);
+    assert(std::is_sorted(std::begin(arr), std::end(arr)));
+
+    // should print 2 3 5 8 9
+    for (int val: arr) {
+        std::cout << val << ' ';
+    }
+}

--- a/recipes/cpp-sort/config.yml
+++ b/recipes/cpp-sort/config.yml
@@ -23,3 +23,5 @@ versions:
     folder: all
   "1.13.1":
     folder: all
+  "1.13.2":
+    folder: all

--- a/recipes/cpp-sort/config.yml
+++ b/recipes/cpp-sort/config.yml
@@ -1,27 +1,27 @@
 versions:
-  "1.5.1":
-    folder: all
-  "1.6.0":
-    folder: all
-  "1.7.0":
-    folder: all
-  "1.8.0":
-    folder: all
-  "1.8.1":
-    folder: all
-  "1.9.0":
-    folder: all
-  "1.10.0":
-    folder: all
-  "1.11.0":
-    folder: all
-  "1.12.0":
-    folder: all
-  "1.12.1":
-    folder: all
-  "1.13.0":
+  "1.13.2":
     folder: all
   "1.13.1":
     folder: all
-  "1.13.2":
+  "1.13.0":
+    folder: all
+  "1.12.1":
+    folder: all
+  "1.12.0":
+    folder: all
+  "1.11.0":
+    folder: all
+  "1.10.0":
+    folder: all
+  "1.9.0":
+    folder: all
+  "1.8.1":
+    folder: all
+  "1.8.0":
+    folder: all
+  "1.7.0":
+    folder: all
+  "1.6.0":
+    folder: all
+  "1.5.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **cpp-sort/1.13.2**

Along with the minor version bump, this merge request significantly updates the recipe to be compatible with Conan v2. I haven't actually installed v2-beta nor written recipes or followed Conan evolution in a while, so there might be antipatterns I'm not aware of.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
