### PR TITLE
libsodium: support conan v2

### DIFF
--- a/recipes/libsodium/all/conandata.yml
+++ b/recipes/libsodium/all/conandata.yml
@@ -10,5 +10,9 @@ sources:
 patches:
   "1.0.18":
     - patch_file: "patches/0001-1.0.18-msvc_props.patch"
+      patch_type: "portability"
+      patch_description: "Switch MSVC to use PDB"
   "cci.20220430":
     - patch_file: "patches/0001-1.0.18-msvc_props.patch"
+      patch_type: "portability"
+      patch_description: "Switch MSVC to use PDB"

--- a/recipes/libsodium/all/conandata.yml
+++ b/recipes/libsodium/all/conandata.yml
@@ -10,7 +10,5 @@ sources:
 patches:
   "1.0.18":
     - patch_file: "patches/0001-1.0.18-msvc_props.patch"
-      base_path: "source_subfolder"
   "cci.20220430":
     - patch_file: "patches/0001-1.0.18-msvc_props.patch"
-      base_path: "source_subfolder"

--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -32,25 +32,20 @@ class LibsodiumConan(ConanFile):
         "PIE": False,
     }
 
-
     @property
     def _is_mingw(self):
         return self.settings.os == "Windows" and self.settings.compiler == "gcc"
-
 
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
-
     def export_sources(self):
         export_conandata_patches(self)
-
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-
 
     def configure(self):
         if self.options.shared:
@@ -67,18 +62,15 @@ class LibsodiumConan(ConanFile):
         except Exception:
             pass
 
-
     def layout(self):
         if is_msvc(self):
             vs_layout(self)
         else:
             basic_layout(self, src_folder="src")
 
-
     def validate(self):
         if self.options.shared and is_msvc(self) and "MT" in msvc_runtime_flag(self):
             raise ConanInvalidConfiguration("Cannot build shared libsodium libraries with static runtime")
-
 
     def build_requirements(self):
         if not is_msvc(self):
@@ -88,7 +80,6 @@ class LibsodiumConan(ConanFile):
                 self.win_bash = True
                 if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
                     self.tool_requires("msys2/cci.latest")
-
 
     def generate(self):
         if is_msvc(self):
@@ -122,10 +113,8 @@ class LibsodiumConan(ConanFile):
             env = VirtualBuildEnv(self)
             env.generate()
 
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
-
 
     @property
     def _msvc_sln_folder(self):
@@ -199,7 +188,6 @@ class LibsodiumConan(ConanFile):
             autotools = Autotools(self)
             autotools.configure()
             autotools.make()
-
 
     def package(self):
         copy(self, "*LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"), keep_path=False)

--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -1,9 +1,15 @@
-from conan.tools.microsoft import msvc_runtime_flag
-from conans import ConanFile, AutoToolsBuildEnvironment, tools, MSBuild
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc, VCVars, unix_path, msvc_runtime_flag
+from conan.tools.files import export_conandata_patches, apply_conandata_patches, get, chdir, rmdir, copy, rm, replace_in_file
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.layout import basic_layout, vs_layout
+from conan.tools.microsoft import is_msvc, MSBuildDeps, MSBuildToolchain, MSBuild, VCVars
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.apple import is_apple_os
 import os
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.52.0"
 
 
 class LibsodiumConan(ConanFile):
@@ -12,7 +18,7 @@ class LibsodiumConan(ConanFile):
     license = "ISC"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://doc.libsodium.org/"
-    topics = ("sodium", "libsodium", "encryption", "signature", "hashing")
+    topics = "encryption", "signature", "hashing"
 
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -28,54 +34,99 @@ class LibsodiumConan(ConanFile):
         "PIE": False,
     }
 
-    short_paths = True
-
-    _autotools = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
-
-    @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
 
     @property
     def _is_mingw(self):
         return self.settings.os == "Windows" and self.settings.compiler == "gcc"
 
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+
     def export_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        export_conandata_patches(self)
+
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
+
+
+    def layout(self):
+        if is_msvc(self):
+            vs_layout(self)
+        else:
+            basic_layout(self, src_folder="src")
+
 
     def validate(self):
-        if self.options.shared and self._is_msvc and "MT" in msvc_runtime_flag(self):
+        if self.options.shared and is_msvc(self) and "MT" in msvc_runtime_flag(self):
             raise ConanInvalidConfiguration("Cannot build shared libsodium libraries with static runtime")
 
+
     def build_requirements(self):
-        if not self._is_msvc:
+        if not is_msvc(self):
             if self._is_mingw:
-                self.build_requires("libtool/2.4.6")
-            if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
-                self.build_requires("msys2/cci.latest")
+                self.tool_requires("libtool/2.4.7")
+            if self._settings_build.os == "Windows":
+                self.win_bash = True
+                if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
+                    self.tool_requires("msys2/cci.latest")
+
+
+    def generate(self):
+        if is_msvc(self):
+            tc = MSBuildToolchain(self)
+            tc.generate()
+            tc = MSBuildDeps(self)
+            tc.generate()
+            tc = VCVars(self)
+            tc.generate()
+        else:
+            tc = AutotoolsToolchain(self)
+
+            yes_no = lambda v: "yes" if v else "no"
+            tc.configure_args.append("--enable-soname-versions={}".format(yes_no(self.options.use_soname)))
+            tc.configure_args.append("--enable-pie={}".format(yes_no(self.options.PIE)))
+
+            env = tc.environment()
+
+            if self._is_mingw:
+                # add libssp (gcc support library) for some missing symbols (e.g. __strcpy_chk)
+                autotools.libs.append("ssp")
+
+            if self.settings.os == "Emscripten":
+                # FIXME: this is an old comment/test, has not been re-tested with conan2 upgrade
+                self.output.warn("os=Emscripten is not tested/supported by this recipe")
+                # FIXME: ./dist-build/emscripten.sh does not respect options of this recipe
+
+            tc.generate(env)
+
+            env = VirtualBuildEnv(self)
+            env.generate()
+
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+
 
     @property
     def _msvc_sln_folder(self):
@@ -103,73 +154,71 @@ class LibsodiumConan(ConanFile):
 
         return folder.get(str(self.settings.compiler.version))
 
+    @property
+    def _msvc_platform(self):
+        return {
+            "x86": "Win32",
+            "x86_64": "x64",
+        }[str(self.settings.arch)]
+
     def _build_msvc(self):
         msvc_sln_folder = self._msvc_sln_folder or ("vs2022" if self.version != "1.0.18" else "vs2019")
         upgrade_project = self._msvc_sln_folder is None
-        sln_path = os.path.join(self.build_folder, self._source_subfolder, "builds", "msvc", msvc_sln_folder, "libsodium.sln")
+        sln_path = os.path.join(self.build_folder, self.source_folder, "builds", "msvc", msvc_sln_folder, "libsodium.sln")
+
         build_type = "{}{}".format(
             "Dyn" if self.options.shared else "Static",
             "Debug" if self.settings.build_type == "Debug" else "Release",
         )
+
+        platform = {
+            "x86": "Win32",
+            "x86_64": "x64",
+        }[str(self.settings.arch)]
+
         msbuild = MSBuild(self)
-        msbuild.build(sln_path, upgrade_project=upgrade_project, platforms={"x86": "Win32"}, build_type=build_type)
+        msbuild.build_type = build_type
+        msbuild.platform = platform
+        msbuild.build(sln_path) # , platforms={"x86": "Win32"}) # , build_type=build_type)
 
-    def _configure_autotools(self):
-        if self._autotools:
-            return self._autotools
-        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        if self._is_mingw:
-            self._autotools.libs.append("ssp")
-
-        if self.settings.os == "Emscripten":
-            self.output.warn("os=Emscripten is not tested/supported by this recipe")
-            # FIXME: ./dist-build/emscripten.sh does not respect options of this recipe
-
-        yes_no = lambda v: "yes" if v else "no"
-        args = [
-            "--enable-shared={}".format(yes_no(self.options.shared)),
-            "--enable-static={}".format(yes_no(not self.options.shared)),
-            "--enable-soname-versions={}".format(yes_no(self.options.use_soname)),
-            "--enable-pie={}".format(yes_no(self.options.PIE)),
-        ]
-
-        self._autotools.configure(args=args, configure_dir=self._source_subfolder)
-        return self._autotools
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        if self._is_msvc:
+        apply_conandata_patches(self)
+        if is_msvc(self):
             self._build_msvc()
         else:
-            if self._is_mingw:
-                self.run("{} -fiv".format(tools.get_env("AUTORECONF")), cwd=self._source_subfolder, win_bash=tools.os_info.is_windows)
-            if tools.is_apple_os(self.settings.os):
-                # Relocatable shared lib for Apple platforms
-                tools.replace_in_file(
-                    os.path.join(self._source_subfolder, "configure"),
-                    "-install_name \\$rpath/",
-                    "-install_name @rpath/"
-                )
-            autotools = self._configure_autotools()
+# FIXME needed?            if self._is_mingw:
+# FIXME needed?                self.run("{} -fiv".format(tools.get_env("AUTORECONF")), cwd=self.source_folder, win_bash=tools.os_info.is_windows)
+# FIXME needed?            if is_apple_os(self):
+# FIXME needed?                # Relocatable shared lib for Apple platforms
+# FIXME needed?                replace_in_file(self,
+# FIXME needed?                    os.path.join(self.source_folder, "configure"),
+# FIXME needed?                    "-install_name \\$rpath/",
+# FIXME needed?                    "-install_name @rpath/"
+# FIXME needed?                )
+            autotools = Autotools(self)
+            autotools.autoreconf()
+            autotools.configure()
             autotools.make()
 
+
     def package(self):
-        self.copy("*LICENSE", dst="licenses", keep_path=False)
-        if self._is_msvc:
-            self.copy("*.lib", dst="lib", keep_path=False)
-            self.copy("*.dll", dst="bin", keep_path=False)
-            inc_src = os.path.join(self._source_subfolder, "src", self.name, "include")
-            self.copy("*.h", src=inc_src, dst="include", keep_path=True, excludes=("*/private/*"))
+        copy(self, "*LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"), keep_path=False)
+        if is_msvc(self):
+            copy(self, "*.lib", src=self.source_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+            copy(self, "*.dll", src=self.source_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
+            inc_src = os.path.join(self.source_folder, "src", self.name, "include")
+            copy(self, "*.h", src=inc_src, dst=os.path.join(self.package_folder, "include"), keep_path=True, excludes=("*/private/*"))
         else:
-            autotools = self._configure_autotools()
-            autotools.install()
-            tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-            tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+            autotools = Autotools(self)
+            # TODO: replace by autotools.install() once https://github.com/conan-io/conan/issues/12153 fixed
+            autotools.install(args=[f"DESTDIR={unix_path(self, self.package_folder)}"])
+            rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+            rm(self, "*.la", os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "libsodium")
-        self.cpp_info.libs = ["{}sodium".format("lib" if self._is_msvc else "")]
+        self.cpp_info.libs = ["{}sodium".format("lib" if is_msvc(self) else "")]
         if not self.options.shared:
             self.cpp_info.defines = ["SODIUM_STATIC"]
         if self.settings.os in ("FreeBSD", "Linux"):

--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -197,7 +197,6 @@ class LibsodiumConan(ConanFile):
 # FIXME needed?                    "-install_name @rpath/"
 # FIXME needed?                )
             autotools = Autotools(self)
-            autotools.autoreconf()
             autotools.configure()
             autotools.make()
 

--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import export_conandata_patches, apply_conandata_patches, get, rmdir, copy, rm, replace_in_file
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc, MSBuildDeps, MSBuildToolchain, MSBuild, VCVars, unix_path, msvc_runtime_flag, vs_layout
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime, MSBuildDeps, MSBuildToolchain, MSBuild, VCVars, unix_path, msvc_runtime_flag, vs_layout
 import os
 
 required_conan_version = ">=1.52.0"
@@ -69,7 +69,7 @@ class LibsodiumConan(ConanFile):
             basic_layout(self, src_folder="src")
 
     def validate(self):
-        if self.options.shared and is_msvc(self) and "MT" in msvc_runtime_flag(self):
+        if self.options.shared and is_msvc(self) and is_msvc_static_runtime(self):
             raise ConanInvalidConfiguration("Cannot build shared libsodium libraries with static runtime")
 
     def build_requirements(self):

--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -1,12 +1,10 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import is_msvc, VCVars, unix_path, msvc_runtime_flag
-from conan.tools.files import export_conandata_patches, apply_conandata_patches, get, chdir, rmdir, copy, rm, replace_in_file
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.layout import basic_layout, vs_layout
-from conan.tools.microsoft import is_msvc, MSBuildDeps, MSBuildToolchain, MSBuild, VCVars
+from conan.tools.files import export_conandata_patches, apply_conandata_patches, get, rmdir, copy, rm
 from conan.tools.gnu import Autotools, AutotoolsToolchain
-from conan.tools.apple import is_apple_os
+from conan.tools.layout import basic_layout, vs_layout
+from conan.tools.microsoft import is_msvc, MSBuildDeps, MSBuildToolchain, MSBuild, VCVars, unix_path, msvc_runtime_flag
 import os
 
 required_conan_version = ">=1.52.0"
@@ -111,7 +109,8 @@ class LibsodiumConan(ConanFile):
 
             if self._is_mingw:
                 # add libssp (gcc support library) for some missing symbols (e.g. __strcpy_chk)
-                autotools.libs.append("ssp")
+                # FIXME how do I do this in conan v2?
+                # autotools.libs.append("ssp")
 
             if self.settings.os == "Emscripten":
                 # FIXME: this is an old comment/test, has not been re-tested with conan2 upgrade
@@ -163,7 +162,8 @@ class LibsodiumConan(ConanFile):
 
     def _build_msvc(self):
         msvc_sln_folder = self._msvc_sln_folder or ("vs2022" if self.version != "1.0.18" else "vs2019")
-        upgrade_project = self._msvc_sln_folder is None
+        # FIXME how do I upgrade the SLN in conan 2?
+        # upgrade_project = self._msvc_sln_folder is None
         sln_path = os.path.join(self.build_folder, self.source_folder, "builds", "msvc", msvc_sln_folder, "libsodium.sln")
 
         build_type = "{}{}".format(

--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import export_conandata_patches, apply_conandata_patches, get, rmdir, copy, rm, replace_in_file
 from conan.tools.gnu import Autotools, AutotoolsToolchain
@@ -184,13 +184,13 @@ class LibsodiumConan(ConanFile):
         )
 
     def _build_msvc(self):
-        msvc_ver_folder = self._msvc_sln_folder or ("vs2022" if self.version != "1.0.18" else "vs2019")
-        msvc_sln_folder = os.path.join(self.build_folder, self.source_folder, "builds", "msvc", msvc_ver_folder)
+        msvc_ver_subfolder = self._msvc_sln_folder or ("vs2022" if self.version != "1.0.18" else "vs2019")
+        msvc_sln_folder = os.path.join(self.build_folder, self.source_folder, "builds", "msvc", msvc_ver_subfolder)
 
         msvc_sln_path = os.path.join(msvc_sln_folder, "libsodium.sln")
 
         # 1.0.18 only supported up to vs2019. Add support for newer toolsets.
-        if self.version == "1.0.18" and msvc_sln_folder == "vs2019":
+        if self.version == "1.0.18" and msvc_ver_subfolder == "vs2019":
             vcxproj_path = os.path.join(msvc_sln_folder, "libsodium", "libsodium.vcxproj")
             self._fix_msvc_platform_toolset(vcxproj_path, "v142")
 

--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -127,12 +127,14 @@ class LibsodiumConan(ConanFile):
                 "15": "vs2017",
                 "16": "vs2019",
             }
-        else:
+        elif self.settings.compiler == "msvc":
             folder = {
                 "190": "vs2015",
                 "191": "vs2017",
                 "192": "vs2019",
             }
+        else:
+            raise ConanException("Should not call this function with any other compiler")
 
         if self.version != "1.0.18":
             if self.settings.compiler == "Visual Studio":

--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -3,8 +3,8 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import export_conandata_patches, apply_conandata_patches, get, rmdir, copy, rm
 from conan.tools.gnu import Autotools, AutotoolsToolchain
-from conan.tools.layout import basic_layout, vs_layout
-from conan.tools.microsoft import is_msvc, MSBuildDeps, MSBuildToolchain, MSBuild, VCVars, unix_path, msvc_runtime_flag
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc, MSBuildDeps, MSBuildToolchain, MSBuild, VCVars, unix_path, msvc_runtime_flag, vs_layout
 import os
 
 required_conan_version = ">=1.52.0"

--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -107,7 +107,7 @@ class LibsodiumConan(ConanFile):
 
             env = tc.environment()
 
-            if self._is_mingw:
+            # if self._is_mingw:
                 # add libssp (gcc support library) for some missing symbols (e.g. __strcpy_chk)
                 # FIXME how do I do this in conan v2?
                 # autotools.libs.append("ssp")

--- a/recipes/libsodium/all/conanfile.py
+++ b/recipes/libsodium/all/conanfile.py
@@ -78,7 +78,7 @@ class LibsodiumConan(ConanFile):
                 self.tool_requires("libtool/2.4.7")
             if self._settings_build.os == "Windows":
                 self.win_bash = True
-                if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
+                if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                     self.tool_requires("msys2/cci.latest")
 
     def generate(self):

--- a/recipes/libsodium/all/test_package/CMakeLists.txt
+++ b/recipes/libsodium/all/test_package/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(libsodium REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE libsodium::libsodium)

--- a/recipes/libsodium/all/test_package/conanfile.py
+++ b/recipes/libsodium/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "arch", "build_type"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libsodium/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libsodium/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
+target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})

--- a/recipes/libsodium/all/test_v1_package/conanfile.py
+++ b/recipes/libsodium/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "arch", "build_type"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
I expect this to build on the CI ok, and the latest version builds locally on vs2022,

but interestingly (bug in conan?), I can't get it to build the older 1.0.18 version for vs2022.

The older 1.0.18 has a vs2019 (and older) sln only, and the new autotools doesn't seem to have a vs-upgrade_project option anymore, so the build fails and asks me to install vs2019.

I'm not sure what to do about that.