### PR TITLE
libvpx: support for conan v2

### DIFF
--- a/recipes/libvpx/all/conandata.yml
+++ b/recipes/libvpx/all/conandata.yml
@@ -12,15 +12,15 @@ patches:
   "1.11.0":
     - patch_file: "patches/0001-extended-support-1.10.0.patch"
       patch_type: "portability"
-      patch_description: "add support for more compilers"
+      patch_description: "Add support for more compilers"
   "1.10.0":
     - patch_file: "patches/0001-extended-support-1.10.0.patch"
       patch_type: "portability"
-      patch_description: "add support for more compilers"
+      patch_description: "Add support for more compilers"
   "1.9.0":
     - patch_file: "patches/0001-extended-support-1.9.0.patch"
       patch_type: "portability"
-      patch_description: "add support for more compilers"
+      patch_description: "Add support for more compilers"
     - patch_file: "patches/0002-msvc_conan_build.patch"
       patch_type: "portability"
-      patch_description: "add support for more compilers"
+      patch_description: "Add support for more compilers"

--- a/recipes/libvpx/all/conandata.yml
+++ b/recipes/libvpx/all/conandata.yml
@@ -11,12 +11,16 @@ sources:
 patches:
   "1.11.0":
     - patch_file: "patches/0001-extended-support-1.10.0.patch"
-      base_path: "source_subfolder"
+      patch_type: "portability"
+      patch_description: "add support for more compilers"
   "1.10.0":
     - patch_file: "patches/0001-extended-support-1.10.0.patch"
-      base_path: "source_subfolder"
+      patch_type: "portability"
+      patch_description: "add support for more compilers"
   "1.9.0":
     - patch_file: "patches/0001-extended-support-1.9.0.patch"
-      base_path: "source_subfolder"
+      patch_type: "portability"
+      patch_description: "add support for more compilers"
     - patch_file: "patches/0002-msvc_conan_build.patch"
-      base_path: "source_subfolder"
+      patch_type: "portability"
+      patch_description: "add support for more compilers"

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -117,6 +117,11 @@ class LibVPXConan(ConanFile):
     def _execute_configure(self):
         configure_args = [os.path.join(self.source_folder, "configure")]
 
+        if self.options.shared:
+            configure_args.extend(["--enable-shared", "--disable-static"])
+        else:
+            configure_args.extend(["--disable-shared", "--enable-static"])
+
         # Note the output_goes_here workaround, libvpx does not like --prefix=/
         # as it fails the test for "libdir must be a subfolder of prefix"
         # libvpx src/build/make/configure.sh:683

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -8,11 +8,11 @@ from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, VCVars, unix_path, msvc_runtime_flag
 from conan.tools.microsoft.visual import msvc_version_to_vs_ide_version
 from conan.tools.scm import Version
-from conans.tools import stdcpp_library # TODO: import from conan.tools.build in conan 1.54.0 (https://github.com/conan-io/conan/pull/12269)
+from conan.tools.build import stdcpp_library
 import os
 import re
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.54.0"
 
 
 class LibVPXConan(ConanFile):

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -6,7 +6,6 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, VCVars, unix_path, msvc_runtime_flag
-from conan.tools.microsoft.visual import msvc_version_to_vs_ide_version
 from conan.tools.scm import Version
 from conan.tools.build import stdcpp_library
 import os
@@ -159,7 +158,9 @@ class LibVPXConan(ConanFile):
             vc_version = self.settings.compiler.version
             compiler = f"vs{vc_version}"
         elif is_msvc(self):
-            vc_version = msvc_version_to_vs_ide_version(self.settings.compiler.version)
+            vc_version = str(self.settings.compiler.version)
+            if Version(self.settings.compiler.version) > "100": # New msvc compiler to triplet used in configure script for vpx
+                vc_version = {"190": "14", "191": "15", "192": "16"}[vc_version]
             compiler = f"vs{vc_version}"
         elif self.settings.compiler in ["gcc", "clang", "apple-clang"]:
             compiler = 'gcc'

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -225,21 +225,21 @@ class LibVPXConan(ConanFile):
 """
             )
 
-        # autotools = Autotools(self)
-        # # autotools.configure()
-        # self._execute_configure()
-        # autotools.make()
+        autotools = Autotools(self)
+        # NOT USED # autotools.configure() # FIXME can use this if we can remove --host and --build flags
+        self._execute_configure()
+        autotools.make()
 
         # Helpful lines for recipe debugging.  The configure script is not real autotools and is a pain to debug.
         # replace_in_file(self, os.path.join(self.source_folder, "configure"), "#!/bin/sh", "#!/bin/sh -x\nprintenv")
-        autotools = Autotools(self)
-        # NOT USED # autotools.configure()
-        self._execute_configure()
-        self.output.info("config.log file generated is:")
-        self.output.info(open(os.path.join(self.build_folder, "config.log")).read())
-        # self.output.info("mk file generated is:")
-        # self.output.info(open(os.path.join(self.build_folder, "libs-x86_64-linux-gcc.mk")).read())
-        autotools.make("SHELL='sh -x'")
+        # autotools = Autotools(self)
+        # # NOT USED # autotools.configure()
+        # self._execute_configure()
+        # self.output.info("config.log file generated is:")
+        # self.output.info(open(os.path.join(self.build_folder, "config.log")).read())
+        # # self.output.info("mk file generated is:")
+        # # self.output.info(open(os.path.join(self.build_folder, "libs-x86_64-linux-gcc.mk")).read())
+        # autotools.make("SHELL='sh -x'")
 
     @property
     def _lib_name(self):

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -155,14 +155,16 @@ class LibVPXConan(ConanFile):
                 'mips': 'mips32',
                 'mips64': 'mips64',
                 'sparc': 'sparc'}.get(str(self.settings.arch))
-        if is_msvc(self):
-            if self.settings.compiler == "Visual Studio":
-                vc_version = self.settings.compiler.version
-            else:
-                vc_version = msvc_version_to_vs_ide_version(self.settings.compiler.version)
+        if self.settings.compiler == "Visual Studio":
+            vc_version = self.settings.compiler.version
+            compiler = f"vs{vc_version}"
+        elif is_msvc(self):
+            vc_version = msvc_version_to_vs_ide_version(self.settings.compiler.version)
             compiler = f"vs{vc_version}"
         elif self.settings.compiler in ["gcc", "clang", "apple-clang"]:
             compiler = 'gcc'
+        else:
+            raise ConanInvalidConfiguration(f"Unknown compiler '{self.settings.compiler}'")
 
         host_os = str(self.settings.os)
         if host_os == 'Windows':

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -183,6 +183,22 @@ class LibVPXConan(ConanFile):
             else:
                 self.output.info("Enabling LTO")
 
+        # The compile script wants to use CC for some of the platforms (Linux, etc),
+        # but incorrectly assumes gcc is the compiler for those platforms.
+        # This can fail some of the configure tests, and -lpthread isn't added to the link command.
+        replace_in_file(self,
+            os.path.join(self.source_folder, "build", "make", "configure.sh"),
+            "  LD=${LD:-${CROSS}${link_with_cc:-ld}}",
+            """
+  LD=${LD:-${CROSS}${link_with_cc:-ld}}
+  if [ "${link_with_cc}" = "gcc" ]
+  then
+   echo "using compiler as linker"
+   LD=${CC}
+  fi
+"""
+            )
+
         autotools = Autotools(self)
         autotools.configure()
         autotools.make()

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -84,6 +84,7 @@ class LibVPXConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def generate(self):
+        self.output.info(f"Library name: {self._lib_name}")
         env = VirtualBuildEnv(self)
         env.generate()
 
@@ -232,14 +233,14 @@ class LibVPXConan(ConanFile):
 
         # Helpful lines for recipe debugging.  The configure script is not real autotools and is a pain to debug.
         # replace_in_file(self, os.path.join(self.source_folder, "configure"), "#!/bin/sh", "#!/bin/sh -x\nprintenv")
-        # autotools = Autotools(self)
-        # # NOT USED # autotools.configure()
-        # self._execute_configure()
-        # self.output.info("config.log file generated is:")
-        # self.output.info(open(os.path.join(self.build_folder, "config.log")).read())
-        # # self.output.info("mk file generated is:")
-        # # self.output.info(open(os.path.join(self.build_folder, "libs-x86_64-linux-gcc.mk")).read())
-        # autotools.make("SHELL='sh -x'")
+        autotools = Autotools(self)
+        # NOT USED # autotools.configure()
+        self._execute_configure()
+        self.output.info("config.log file generated is:")
+        self.output.info(open(os.path.join(self.build_folder, "config.log")).read())
+        # self.output.info("mk file generated is:")
+        # self.output.info(open(os.path.join(self.build_folder, "libs-x86_64-linux-gcc.mk")).read())
+        autotools.make("SHELL='sh -x'")
 
     @property
     def _lib_name(self):

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -115,7 +115,7 @@ class LibVPXConan(ConanFile):
     # and doesn't support some parameters like --host --build and --prefix=/
     # so we will avoid using conan's configure() call generator and run our own.
     def _execute_configure(self):
-        configure_args = [os.path.join(self.source_folder, "configure")]
+        configure_args = [unix_path(self,os.path.join(self.source_folder, "configure"))]
 
         if self.options.shared:
             configure_args.extend(["--enable-shared", "--disable-static"])

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -203,6 +203,16 @@ class LibVPXConan(ConanFile):
         autotools.configure()
         autotools.make()
 
+        # Helpful lines for recipe debugging.  The configure script is not real autotools and is a pain to debug.
+        # replace_in_file(self, os.path.join(self.source_folder, "configure"), "#!/bin/sh", "#!/bin/sh -x\nprintenv")
+        # autotools = Autotools(self)
+        # autotools.configure()
+        # self.output.info("config.log file generated is:")
+        # self.output.info(open(os.path.join(self.build_folder, "config.log")).read())
+        # self.output.info("mk file generated is:")
+        # self.output.info(open(os.path.join(self.build_folder, "libs-x86_64-linux-gcc.mk")).read())
+        # autotools.make("SHELL='sh -x'")
+
     def package(self):
         copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         autotools = Autotools(self)

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -84,7 +84,6 @@ class LibVPXConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def generate(self):
-        self.output.info(f"Library name: {self._lib_name}")
         env = VirtualBuildEnv(self)
         env.generate()
 
@@ -233,14 +232,14 @@ class LibVPXConan(ConanFile):
 
         # Helpful lines for recipe debugging.  The configure script is not real autotools and is a pain to debug.
         # replace_in_file(self, os.path.join(self.source_folder, "configure"), "#!/bin/sh", "#!/bin/sh -x\nprintenv")
-        autotools = Autotools(self)
-        # NOT USED # autotools.configure()
-        self._execute_configure()
-        self.output.info("config.log file generated is:")
-        self.output.info(open(os.path.join(self.build_folder, "config.log")).read())
-        # self.output.info("mk file generated is:")
-        # self.output.info(open(os.path.join(self.build_folder, "libs-x86_64-linux-gcc.mk")).read())
-        autotools.make("SHELL='sh -x'")
+        # autotools = Autotools(self)
+        # # NOT USED # autotools.configure()
+        # self._execute_configure()
+        # self.output.info("config.log file generated is:")
+        # self.output.info(open(os.path.join(self.build_folder, "config.log")).read())
+        # # self.output.info("mk file generated is:")
+        # # self.output.info(open(os.path.join(self.build_folder, "libs-x86_64-linux-gcc.mk")).read())
+        # autotools.make("SHELL='sh -x'")
 
     @property
     def _lib_name(self):

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -199,19 +199,19 @@ class LibVPXConan(ConanFile):
 """
             )
 
-        autotools = Autotools(self)
-        autotools.configure()
-        autotools.make()
+        # autotools = Autotools(self)
+        # autotools.configure()
+        # autotools.make()
 
         # Helpful lines for recipe debugging.  The configure script is not real autotools and is a pain to debug.
         # replace_in_file(self, os.path.join(self.source_folder, "configure"), "#!/bin/sh", "#!/bin/sh -x\nprintenv")
-        # autotools = Autotools(self)
-        # autotools.configure()
-        # self.output.info("config.log file generated is:")
-        # self.output.info(open(os.path.join(self.build_folder, "config.log")).read())
+        autotools = Autotools(self)
+        autotools.configure()
+        self.output.info("config.log file generated is:")
+        self.output.info(open(os.path.join(self.build_folder, "config.log")).read())
         # self.output.info("mk file generated is:")
         # self.output.info(open(os.path.join(self.build_folder, "libs-x86_64-linux-gcc.mk")).read())
-        # autotools.make("SHELL='sh -x'")
+        autotools.make("SHELL='sh -x'")
 
     def package(self):
         copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -137,10 +137,14 @@ class LibVPXConan(ConanFile):
             "--as=yasm",
         ])
 
-        # Note: release libs are always built, we just avoid keeping the release lib
+        # Note for MSVC: release libs are always built, we just avoid keeping the release lib
+        # Note2: Can't use --enable-debug_libs (to help install on Windows),
+        #     the makefile's install step fails as it wants to install a library that doesn't exist.
+        #     Instead, we will copy the desired library manually in the package step.
         if self.settings.build_type == "Debug":
             configure_args.extend([
-                "--enable-debug_libs",
+                # "--enable-debug_libs",
+                "--enable-debug",
             ])
 
         if is_msvc(self) and "MT" in msvc_runtime_flag(self):

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -70,11 +70,11 @@ class LibVPXConan(ConanFile):
     def layout(self):
         basic_layout(self, src_folder="src")
 
-        # libvpx configure is unusual and requires a workaround,
+        # libvpx configure is unusual and requires a workaround, otherwise it will fail with an error.
         # look for "output_goes_here" below for more in this thread.
         self.cpp.package.bindirs = []
         self.cpp.package.includedirs = []
-        self.cpp.package.libdirs = []
+        self.cpp.package.libdirs = []   # not strictly necessary, but lets do all as a group
 
     def build_requirements(self):
         self.tool_requires("yasm/1.3.0")
@@ -222,6 +222,10 @@ class LibVPXConan(ConanFile):
             libcxx = tools_legacy.stdcpp_library(self)
             if libcxx:
                 self.cpp_info.system_libs.append(libcxx)
+        # reset the paths we cleared in layout()
+        self.cpp_info.includedirs = ['include']
+        self.cpp_info.libdirs = ['lib']
+        self.cpp_info.bindirs = ['bin']
 
         # TODO: to remove in conan v2 once pkg_config generator removed
         self.cpp_info.names["pkg_config"] = "vpx"

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -78,7 +78,7 @@ class LibVPXConan(ConanFile):
         self.tool_requires("yasm/1.3.0")
         if self._settings_build.os == "Windows":
             self.win_bash = True
-            if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")
 
     def source(self):

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -55,7 +55,7 @@ class LibVPXConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            self.options.safe_rm("fPIC")
+            self.options.rm_safe("fPIC")
 
     def validate(self):
         if self.settings.os == "Windows" and self.options.shared:

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -220,6 +220,10 @@ class LibVPXConan(ConanFile):
             libcxx = stdcpp_library(self)
             if libcxx:
                 self.cpp_info.system_libs.append(libcxx)
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.system_libs.append("m")
+
         # reset the paths we cleared in layout()
         self.cpp_info.includedirs = ['include']
         self.cpp_info.libdirs = ['lib']

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -8,7 +8,8 @@ from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, VCVars, unix_path, msvc_runtime_flag
 from conan.tools.microsoft.visual import msvc_version_to_vs_ide_version
 from conan.tools.scm import Version
-from conans import tools as tools_legacy
+from conans.tools import get_env # FIXME how to port this?
+from conans.tools import stdcpp_library # TODO: import from conan.tools.build in conan 1.54.0 (https://github.com/conan-io/conan/pull/12269)
 import os
 import re
 
@@ -170,8 +171,8 @@ class LibVPXConan(ConanFile):
         apply_conandata_patches(self)
         # Disable LTO for Visual Studio when CFLAGS doesn't contain -GL
         if is_msvc(self):
-            self.output.info(f"CFLAGS = {tools_legacy.get_env('CFLAGS', '')}")
-            lto = any(re.finditer("(^| )[/-]GL($| )", tools_legacy.get_env("CFLAGS", "")))
+            self.output.info(f"CFLAGS = {get_env('CFLAGS', '')}")
+            lto = any(re.finditer("(^| )[/-]GL($| )", get_env("CFLAGS", "")))
             if not lto:
                 self.output.info("Disabling LTO")
                 replace_in_file(self,
@@ -216,7 +217,7 @@ class LibVPXConan(ConanFile):
         suffix = msvc_runtime_flag(self).lower() if is_msvc(self) else ""
         self.cpp_info.libs = [f"vpx{suffix}"]
         if not self.options.shared:
-            libcxx = tools_legacy.stdcpp_library(self)
+            libcxx = stdcpp_library(self)
             if libcxx:
                 self.cpp_info.system_libs.append(libcxx)
         # reset the paths we cleared in layout()

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -68,7 +68,7 @@ class LibVPXConan(ConanFile):
             raise ConanInvalidConfiguration("Windows shared builds are not supported")
         if str(self.settings.compiler) not in ["Visual Studio", "msvc", "gcc", "clang", "apple-clang"]:
             raise ConanInvalidConfiguration("Unsupported compiler {}.".format(self.settings.compiler))
-        if self.settings.os == "Macos" and self.settings.arch == "armv8" and tools.Version(self.version) < "1.10.0":
+        if self.settings.os == "Macos" and self.settings.arch == "armv8" and Version(self.version) < "1.10.0":
             raise ConanInvalidConfiguration("M1 only supported since 1.10, please upgrade")
 
     def layout(self):

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -1,16 +1,13 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
-from conan.tools.build import check_min_cppstd, cross_building
-from conan.tools.env import Environment, VirtualBuildEnv, VirtualRunEnv
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir, replace_in_file, rename
-from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps
+from conan.tools.env import Environment, VirtualBuildEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, replace_in_file, rename
+from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc, unix_path
-from conan.tools.microsoft import is_msvc, MSBuildDeps, MSBuildToolchain, MSBuild, VCVars
-
-from conan.tools.microsoft import msvc_runtime_flag
+from conan.tools.microsoft import is_msvc, VCVars, unix_path, msvc_runtime_flag
 from conan.tools.microsoft.visual import msvc_version_to_vs_ide_version
+from conan.tools.scm import Version
 from conans import tools as tools_legacy
 import os
 import re

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -146,19 +146,19 @@ class LibVPXConan(ConanFile):
                 if not self.options.get_safe(name):
                     tc.configure_args.append(f"--disable-{name}")
 
-# FIXME not possible ?....        if is_msvc(self):
-# FIXME not possible ?....            # gen_msvs_vcxproj.sh doesn't like custom flags
-# FIXME not possible ?....            autotools.cxxflags = []
-# FIXME not possible ?....            autotools.flags = []
         if is_apple_os(self) and self.settings.get_safe("compiler.libcxx") == "libc++":
             # special case, as gcc/g++ is hard-coded in makefile, it implicitly assumes -lstdc++
 # FIXME what to do
             tc.extra_ldflags.append("-stdlib=libc++")
 
         env = Environment()
-        env.define("CC", "")
-        env.define("CFLAGS", "")
-        env.define("CXXFLAGS", "")
+
+        if is_msvc(self):
+            # gen_msvs_vcxproj.sh doesn't like custom flags
+            env.define("CC", "")
+            # FIXME can we leave these alone?
+            # env.define("CFLAGS", "")
+            # env.define("CXXFLAGS", "")
 
         tc.generate(env=env)
 

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -1,12 +1,22 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.apple import is_apple_os
+from conan.tools.build import check_min_cppstd, cross_building
+from conan.tools.env import Environment, VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir, replace_in_file
+from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc, unix_path
+from conan.tools.microsoft import is_msvc, MSBuildDeps, MSBuildToolchain, MSBuild, VCVars
+
 from conan.tools.microsoft import msvc_runtime_flag
 from conan.tools.microsoft.visual import msvc_version_to_vs_ide_version
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
-from conans.errors import ConanInvalidConfiguration
-import functools
+from conans import tools as tools_legacy
 import os
 import re
 
-required_conan_version = ">=1.43.0"
+required_conan_version = ">=1.52.0"
 
 
 class LibVPXConan(ConanFile):
@@ -33,16 +43,11 @@ class LibVPXConan(ConanFile):
     default_options.update({name: 'avx' not in name for name in _arch_options})
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _is_msvc(self):
-        return str(self.settings.compiler) in ["Visual Studio", "msvc"]
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
     def export_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == 'Windows':
@@ -53,7 +58,10 @@ class LibVPXConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
 
     def validate(self):
         if self.settings.os == "Windows" and self.options.shared:
@@ -63,57 +71,55 @@ class LibVPXConan(ConanFile):
         if self.settings.os == "Macos" and self.settings.arch == "armv8" and tools.Version(self.version) < "1.10.0":
             raise ConanInvalidConfiguration("M1 only supported since 1.10, please upgrade")
 
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def build_requirements(self):
-        self.build_requires("yasm/1.3.0")
-        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
-            self.build_requires("msys2/cci.latest")
+        self.tool_requires("yasm/1.3.0")
+        if self._settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
+                self.tool_requires("msys2/cci.latest")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def _patch_sources(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+        apply_conandata_patches(self)
         # relocatable shared lib on macOS
-        tools.replace_in_file(os.path.join(self._source_subfolder, "build", "make", "Makefile"),
+# FIXME is this still needed?
+        replace_in_file(self, os.path.join(self.source_folder, "build", "make", "Makefile"),
                               "-dynamiclib",
                               "-dynamiclib -install_name @rpath/$$(LIBVPX_SO)")
         # Disable LTO for Visual Studio when CFLAGS doesn't contain -GL
-        if self._is_msvc:
+        if is_msvc(self):
+# FIXME what is the proper way to do this?
             lto = any(re.finditer("(^| )[/-]GL($| )", tools.get_env("CFLAGS", "")))
             if not lto:
-                tools.replace_in_file(
-                    os.path.join(self._source_subfolder, "build", "make", "gen_msvs_vcxproj.sh"),
+                replace_in_file(self,
+                    os.path.join(self.source_folder, "build", "make", "gen_msvs_vcxproj.sh"),
                     "tag_content WholeProgramOptimization true",
                     "tag_content WholeProgramOptimization false",
                 )
 
-    @functools.lru_cache(1)
-    def _configure_autotools(self):
-        args = [
-            "--prefix={}".format(tools.unix_path(self.package_folder)),
+    def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+
+        tc = AutotoolsToolchain(self)
+
+        tc.configure_args.extend([
+            # "--prefix={}".format(unix_path(self, self.package_folder)),
             "--disable-examples",
             "--disable-unit-tests",
             "--disable-tools",
             "--disable-docs",
             "--enable-vp9-highbitdepth",
             "--as=yasm",
-        ]
-        if self.options.shared:
-            args.extend(['--disable-static', '--enable-shared'])
-        else:
-            args.extend(['--disable-shared', '--enable-static'])
-        if self.settings.os != 'Windows' and self.options.get_safe("fPIC", True):
-            args.append('--enable-pic')
-        if self.settings.build_type == "Debug":
-            args.append('--enable-debug')
-        if self._is_msvc and "MT" in msvc_runtime_flag(self):
-            args.append('--enable-static-msvcrt')
+        ])
+# FIXME is this handled by toolchain?
+        if is_msvc(self) and "MT" in msvc_runtime_flag(self):
+            tc.configure_args.append('--enable-static-msvcrt')
 
         arch = {'x86': 'x86',
                 'x86_64': 'x86_64',
@@ -122,7 +128,7 @@ class LibVPXConan(ConanFile):
                 'mips': 'mips32',
                 'mips64': 'mips64',
                 'sparc': 'sparc'}.get(str(self.settings.arch))
-        if self._is_msvc:
+        if is_msvc(self):
             if self.settings.compiler == "Visual Studio":
                 vc_version = self.settings.compiler.version
             else:
@@ -134,7 +140,7 @@ class LibVPXConan(ConanFile):
         host_os = str(self.settings.os)
         if host_os == 'Windows':
             os_name = 'win32' if self.settings.arch == 'x86' else 'win64'
-        elif tools.is_apple_os(host_os):
+        elif is_apple_os(self):
             if self.settings.arch in ["x86", "x86_64"]:
                 os_name = 'darwin11'
             elif self.settings.arch == "armv8" and self.settings.os == "Macos":
@@ -149,50 +155,58 @@ class LibVPXConan(ConanFile):
         elif host_os == 'Android':
             os_name = 'android'
         target = "%s-%s-%s" % (arch, os_name, compiler)
-        args.append('--target=%s' % target)
+        tc.configure_args.append('--target=%s' % target)
         if str(self.settings.arch) in ["x86", "x86_64"]:
             for name in self._arch_options:
                 if not self.options.get_safe(name):
-                    args.append('--disable-%s' % name)
-        autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
-        if self._is_msvc:
+                    tc.configure_args.append('--disable-%s' % name)
+
+        if is_msvc(self):
             # gen_msvs_vcxproj.sh doesn't like custom flags
+# FIXME what to do
             autotools.cxxflags = []
             autotools.flags = []
-        if tools.is_apple_os(self.settings.os) and self.settings.get_safe("compiler.libcxx") == "libc++":
+        if is_apple_os(self) and self.settings.get_safe("compiler.libcxx") == "libc++":
             # special case, as gcc/g++ is hard-coded in makefile, it implicitly assumes -lstdc++
+# FIXME what to do
             autotools.link_flags.append("-stdlib=libc++")
-        autotools.configure(args=args, configure_dir=self._source_subfolder, host=False, build=False, target=False)
-        return autotools
+
+        tc.generate()
+
+        if is_msvc(self):
+            tc = VCVars(self)
+            tc.generate()
+
 
     def build(self):
         self._patch_sources()
-        with tools.vcvars(self) if self._is_msvc else tools.no_op():
-            autotools = self._configure_autotools()
-            autotools.make()
+
+        autotools = Autotools(self)
+        autotools.configure()
+        # autotools.configure(args=args, configure_dir=self._source_subfolder, host=False, build=False, target=False)
+        autotools.make()
 
     def package(self):
-        self.copy(pattern="LICENSE", src=self._source_subfolder, dst="licenses")
-        with tools.vcvars(self) if self._is_msvc else tools.no_op():
-            autotools = self._configure_autotools()
-            autotools.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        autotools = Autotools(self)
+        autotools.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
-        if self._is_msvc:
+        if is_msvc(self):
             # don't trust install target
-            tools.rmdir(os.path.join(self.package_folder, "lib"))
+            rmdir(self, os.path.join(self.package_folder, "lib"))
             libdir = os.path.join(
                 "Win32" if self.settings.arch == "x86" else "x64",
                 "Debug" if self.settings.build_type == "Debug" else "Release",
             )
-            self.copy("vpx*.lib", src=libdir, dst="lib")
+            copy(self, "vpx*.lib", src=os.path.join(self.source_folder, libdir), dst=os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "vpx")
-        suffix = msvc_runtime_flag(self).lower() if self._is_msvc else ""
+        suffix = msvc_runtime_flag(self).lower() if is_msvc(self) else ""
         self.cpp_info.libs = [f"vpx{suffix}"]
         if not self.options.shared:
-            libcxx = tools.stdcpp_library(self)
+            libcxx = legacy_tools.stdcpp_library(self)
             if libcxx:
                 self.cpp_info.system_libs.append(libcxx)
 

--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -60,7 +60,7 @@ class LibVPXConan(ConanFile):
         if self.settings.os == "Windows" and self.options.shared:
             raise ConanInvalidConfiguration("Windows shared builds are not supported")
         if str(self.settings.compiler) not in ["Visual Studio", "msvc", "gcc", "clang", "apple-clang"]:
-            raise ConanInvalidConfiguration("Unsupported compiler {}.".format(self.settings.compiler))
+            raise ConanInvalidConfiguration(f"Unsupported compiler {self.settings.compiler}")
         if self.settings.os == "Macos" and self.settings.arch == "armv8" and Version(self.version) < "1.10.0":
             raise ConanInvalidConfiguration("M1 only supported since 1.10, please upgrade")
 
@@ -118,7 +118,7 @@ class LibVPXConan(ConanFile):
                 vc_version = self.settings.compiler.version
             else:
                 vc_version = msvc_version_to_vs_ide_version(self.settings.compiler.version)
-            compiler = "vs{}".format(vc_version)
+            compiler = f"vs{vc_version}"
         elif self.settings.compiler in ["gcc", "clang", "apple-clang"]:
             compiler = 'gcc'
 
@@ -139,12 +139,12 @@ class LibVPXConan(ConanFile):
             os_name = 'solaris'
         elif host_os == 'Android':
             os_name = 'android'
-        target = "%s-%s-%s" % (arch, os_name, compiler)
-        tc.configure_args.append('--target=%s' % target)
+        target = f"{arch}-{os_name}-{compiler}"
+        tc.configure_args.append(f"--target={target}")
         if str(self.settings.arch) in ["x86", "x86_64"]:
             for name in self._arch_options:
                 if not self.options.get_safe(name):
-                    tc.configure_args.append('--disable-%s' % name)
+                    tc.configure_args.append(f"--disable-{name}")
 
 # FIXME not possible ?....        if is_msvc(self):
 # FIXME not possible ?....            # gen_msvs_vcxproj.sh doesn't like custom flags

--- a/recipes/libvpx/all/test_package/CMakeLists.txt
+++ b/recipes/libvpx/all/test_package/CMakeLists.txt
@@ -1,10 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+cmake_minimum_required(VERSION 3.8)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package C)
 
 find_package(libvpx REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} libvpx::libvpx)
+target_link_libraries(${PROJECT_NAME} PRIVATE libvpx::libvpx)

--- a/recipes/libvpx/all/test_package/conanfile.py
+++ b/recipes/libvpx/all/test_package/conanfile.py
@@ -1,19 +1,20 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
+# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
-    def build_requirements(self):
-        if self.settings.os == "Macos" and self.settings.arch == "armv8":
-            # Workaround for CMake bug with error message:
-            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
-            # set. This could be because you are using a Mac OS X version less than 10.5
-            # or because CMake's platform configuration is corrupt.
-            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
-            self.build_requires("cmake/3.22.0")
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -21,6 +22,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libvpx/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libvpx/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(libvpx REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} libvpx::libvpx)

--- a/recipes/libvpx/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libvpx/all/test_v1_package/CMakeLists.txt
@@ -4,7 +4,5 @@ project(test_package C)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(libvpx REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} libvpx::libvpx)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/libvpx/all/test_v1_package/conanfile.py
+++ b/recipes/libvpx/all/test_v1_package/conanfile.py
@@ -1,4 +1,5 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
 import os
 
 
@@ -6,21 +7,12 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
-    def build_requirements(self):
-        if self.settings.os == "Macos" and self.settings.arch == "armv8":
-            # Workaround for CMake bug with error message:
-            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
-            # set. This could be because you are using a Mac OS X version less than 10.5
-            # or because CMake's platform configuration is corrupt.
-            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
-            self.build_requires("cmake/3.22.0")
-
     def build(self):
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/libvpx/all/test_v1_package/conanfile.py
+++ b/recipes/libvpx/all/test_v1_package/conanfile.py
@@ -1,0 +1,26 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build_requirements(self):
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            # Workaround for CMake bug with error message:
+            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
+            # set. This could be because you are using a Mac OS X version less than 10.5
+            # or because CMake's platform configuration is corrupt.
+            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
+            self.build_requires("cmake/3.22.0")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Started work, got this weird message and I'm wondering if conan is injecting --bindir 

Any advice please?

```
libvpx/1.11.0: Calling:
 > "/build/conandata/conan-data/libvpx/1.11.0/_/_/build/a7d7b9773babc7a104bc397939b61bb2babf96bc/src/configure" '--disable-shared' '--enable-static' '--prefix=/' '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' '--libdir=${prefix}/lib' '--includedir=${prefix}/include' '--oldincludedir=${prefix}/include' '--disable-examples' '--disable-unit-tests' '--disable-tools' '--disable-docs' '--enable-vp9-highbitdepth' '--as=yasm' '--target=x86_64-linux-gcc' '--disable-avx' '--disable-avx2' '--disable-avx512' 
  disabling shared
Unknown option "--bindir=${prefix}/bin".
```
