### PR TITLE
flac: add 1.4.2

### DIFF
--- a/recipes/flac/all/conandata.yml
+++ b/recipes/flac/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.2":
+    url: "https://github.com/xiph/flac/releases/download/1.4.2/flac-1.4.2.tar.xz"
+    sha256: "e322d58a1f48d23d9dd38f432672865f6f79e73a6f9cc5a5f57fcaa83eb5a8e4"
   "1.3.3":
     url: "https://github.com/xiph/flac/archive/1.3.3.tar.gz"
     sha256: "668cdeab898a7dd43cf84739f7e1f3ed6b35ece2ef9968a5c7079fe9adfe1689"

--- a/recipes/flac/all/conanfile.py
+++ b/recipes/flac/all/conanfile.py
@@ -57,6 +57,8 @@ class FlacConan(ConanFile):
         tc.variables["BUILD_EXAMPLES"] = False
         tc.variables["BUILD_DOCS"] = False
         tc.variables["BUILD_TESTING"] = False
+        # Honor BUILD_SHARED_LIBS from conan_toolchain (see https://github.com/conan-io/conan/issues/11840)
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
         cd = CMakeDeps(self)
         cd.generate()

--- a/recipes/flac/all/conanfile.py
+++ b/recipes/flac/all/conanfile.py
@@ -80,6 +80,8 @@ class FlacConan(ConanFile):
         copy(self, "*.h", src=os.path.join(self.source_folder, "include", "share", "grabbag"),
                           dst=os.path.join(self.package_folder, "include", "share", "grabbag"), keep_path=False)
         rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "flac")

--- a/recipes/flac/all/conanfile.py
+++ b/recipes/flac/all/conanfile.py
@@ -1,7 +1,8 @@
-from conan import ConanFile
+from conan import ConanFile, conan_version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, get, rmdir
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.47.0"
@@ -41,7 +42,7 @@ class FlacConan(ConanFile):
         self.requires("ogg/1.3.5")
 
     def build_requirements(self):
-        if self.settings.arch in ["x86", "x86_64"]:
+        if Version(self.version) < "1.4.2" and self.settings.arch in ["x86", "x86_64"]:
             self.tool_requires("nasm/2.15.05")
 
     def layout(self):
@@ -97,16 +98,17 @@ class FlacConan(ConanFile):
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["libflac"].system_libs += ["m"]
 
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable: {}".format(bin_path))
-        self.env_info.PATH.append(bin_path)
+        # TODO remove once conan v2 is the only support and recipes have been migrated
+        if Version(conan_version) < "2.0.0-beta":
+            bin_path = os.path.join(self.package_folder, "bin")
+            self.output.info("Appending PATH environment variable: {}".format(bin_path))
+            self.env_info.PATH.append(bin_path)
 
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "flac"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "flac"
-        self.cpp_info.names["cmake_find_package"] = "FLAC"
-        self.cpp_info.names["cmake_find_package_multi"] = "FLAC"
-        self.cpp_info.components["libflac"].names["cmake_find_package"] = "FLAC"
-        self.cpp_info.components["libflac"].names["cmake_find_package_multi"] = "FLAC"
-        self.cpp_info.components["libflac++"].names["cmake_find_package"] = "FLAC++"
-        self.cpp_info.components["libflac++"].names["cmake_find_package_multi"] = "FLAC++"
+            self.cpp_info.filenames["cmake_find_package"] = "flac"
+            self.cpp_info.filenames["cmake_find_package_multi"] = "flac"
+            self.cpp_info.names["cmake_find_package"] = "FLAC"
+            self.cpp_info.names["cmake_find_package_multi"] = "FLAC"
+            self.cpp_info.components["libflac"].names["cmake_find_package"] = "FLAC"
+            self.cpp_info.components["libflac"].names["cmake_find_package_multi"] = "FLAC"
+            self.cpp_info.components["libflac++"].names["cmake_find_package"] = "FLAC++"
+            self.cpp_info.components["libflac++"].names["cmake_find_package_multi"] = "FLAC++"

--- a/recipes/flac/config.yml
+++ b/recipes/flac/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.4.2":
+    folder: all
   "1.3.3":
     folder: all


### PR DESCRIPTION
Flac 1.4.2 removed the build dependency on nasm

https://github.com/xiph/flac/releases/tag/1.4.2

Also switching to the official source download which we can't use for 1.3.3 because it does not include the CMake files.


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
