### PR TITLE
[docs] Document inactive users process

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -409,3 +409,9 @@ merging to the master branch. Feel free to contribute to a new Github Action tha
 
 No. The [pylint](v2_linter.md) has an important role of keeping any recipe prepared for [Conan v2 migration](v2_migration.md). In case you are having
 difficult to understand [linter errors](linters.md), please comment on your pull request about the problem to receive help from the community.
+
+## How long can I be inactive before being removed from the authorized users list?
+
+For now, it's configured for 4 months. It's computed based on your last commit, not comments or issues.
+After that time, the CI bot will ask to remove your user name from the authorized users' list through the access request PR, which occurs a few times every week.
+In case you are interested in coming back, please, ask again to be included in the issue [#4](https://github.com/conan-io/conan-center-index/issues/4), the process will be precise like for newcomers.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -412,6 +412,4 @@ difficult to understand [linter errors](linters.md), please comment on your pull
 
 ## How long can I be inactive before being removed from the authorized users list?
 
-For now, it's configured for 4 months. It's computed based on your last commit, not comments or issues.
-After that time, the CI bot will ask to remove your user name from the authorized users' list through the access request PR, which occurs a few times every week.
-In case you are interested in coming back, please, ask again to be included in the issue [#4](https://github.com/conan-io/conan-center-index/issues/4), the process will be precise like for newcomers.
+Please, read [Inactivity and user removal section](how_to_add_packages.md#inactivity-and-user-removal).

--- a/docs/how_to_add_packages.md
+++ b/docs/how_to_add_packages.md
@@ -49,7 +49,7 @@ You can view your signed CLA's by going to <https://cla-assistant.io/> and signi
 ## Inactivity and user removal
 
 For security reasons related to the CI, when a user no longer contributes for a long period, it will be considered inactive and removed from the authorized user's list.
-For now, it's configured for **4 months**, and it's computed based on the lastest commit, not comments or opened issues.
+For now, it's configured for **4 months**, and it's computed based on the latest commit, not comments or opened issues.
 After that time, the CI bot will ask to remove the user name from the authorized users' list through the access request PR, which occurs a few times every week.
 In case you are interested in coming back, please, ask again to be included in the issue [#4](https://github.com/conan-io/conan-center-index/issues/4), the process will be precise like for newcomers.
 

--- a/docs/how_to_add_packages.md
+++ b/docs/how_to_add_packages.md
@@ -45,6 +45,14 @@ This process helps conan-center-index against spam and malicious code. The proce
 When submitting a pull request for the first time, you will be prompted to sign the [CLA](CONTRIBUTOR_LICENSE_AGREEMENT.md) for your code contributions.
 You can view your signed CLA's by going to <https://cla-assistant.io/> and signing in.
 
+
+## Inactivity and user removal
+
+For security reasons related to the CI, when an user no longer contributes for a longe period, it will consired inactive and removed from the authorized users list.
+For now, it's configured for **4 months**, and it's computed based on the lastest commit, not comments or opened issues.
+After that time, the CI bot will ask to remove the user name from the authorized users' list through the access request PR, which occurs a few times every week.
+In case you are interested in coming back, please, ask again to be included in the issue [#4](https://github.com/conan-io/conan-center-index/issues/4), the process will be precise like for newcomers.
+
 ## Submitting a Package
 
 :two: To contribute a package, you can submit a [Pull Request](https://github.com/conan-io/conan-center-index/pulls) to this GitHub repository https://github.com/conan-io/conan-center-index.

--- a/docs/how_to_add_packages.md
+++ b/docs/how_to_add_packages.md
@@ -48,7 +48,7 @@ You can view your signed CLA's by going to <https://cla-assistant.io/> and signi
 
 ## Inactivity and user removal
 
-For security reasons related to the CI, when an user no longer contributes for a longe period, it will consired inactive and removed from the authorized users list.
+For security reasons related to the CI, when a user no longer contributes for a long period, it will be considered inactive and removed from the authorized user's list.
 For now, it's configured for **4 months**, and it's computed based on the lastest commit, not comments or opened issues.
 After that time, the CI bot will ask to remove the user name from the authorized users' list through the access request PR, which occurs a few times every week.
 In case you are interested in coming back, please, ask again to be included in the issue [#4](https://github.com/conan-io/conan-center-index/issues/4), the process will be precise like for newcomers.


### PR DESCRIPTION
When an user becomes inactive (passed 4 months), the CI will ask to that user with the Access Request PR.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
