### PR TITLE
GDAL: Add cmake_find_packages_multi generator 

### DIFF
--- a/recipes/gdal/post_3.5.0/conanfile.py
+++ b/recipes/gdal/post_3.5.0/conanfile.py
@@ -16,7 +16,7 @@ class GdalConan(ConanFile):
 
     settings = "os", "arch", "compiler", "build_type"
 
-    generators = "cmake", "cmake_find_package"
+    generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
 
     # A list of gdal dependencies can be taken from cmake/helpers/CheckDependentLibraries.cmake
     # within gdal sources with the command:


### PR DESCRIPTION
This fixes issue https://github.com/conan-io/conan-center-index/issues/13818 

Specify library name and version:  gdal/3.5.* 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
