### PR TITLE
watcher: add version 0.3.3

### DIFF
--- a/recipes/watcher/all/conandata.yml
+++ b/recipes/watcher/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.3.3":
+    url: "https://github.com/e-dant/watcher/archive/release/0.3.3.tar.gz"
+    sha256: "1cb4a898741306bb9089bd24175bcbb2cb434531eac6bbcfe1a3679b8bf1f44c"
   "0.3.2":
     url: "https://github.com/e-dant/watcher/archive/refs/tags/release/0.3.2.tar.gz"
     sha256: "f00247ad8ee492cb70143917bd19f80056227f4ebd4263015727f02750e4fbd5"

--- a/recipes/watcher/config.yml
+++ b/recipes/watcher/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.3.3":
+    folder: all
   "0.3.2":
     folder: all
   "0.3.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **watcher/0.3.3**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
