### PR TITLE
[docs] Bump version label only accepts SEMVER and MAJOR.MINOR

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -22,7 +22,7 @@ special meaning:
 
 Label [`Bump dependencies`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+dependencies%22+)
 is assigned by the bot to pull-requests that are just upgrading the version of the requirements that were already in the
-recipe.
+recipe. For now, only [SEMVER](https://semver.org/#semantic-versioning-200) and `<MAJOR.MINOR>` are acceptable version formats.
 
 > These pull-requests will be merged right away without requiring any approval (CI and CLA checks must have passed).
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -22,7 +22,7 @@ special meaning:
 
 Label [`Bump dependencies`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+dependencies%22+)
 is assigned by the bot to pull-requests that are just upgrading the version of the requirements that were already in the
-recipe. For now, only [SEMVER](https://semver.org/#semantic-versioning-200) and `<MAJOR.MINOR>` are acceptable version formats.
+recipe.
 
 > These pull-requests will be merged right away without requiring any approval (CI and CLA checks must have passed).
 
@@ -32,8 +32,8 @@ If the pull request modifies anything else, the label won't be assigned, we need
 
 Label [`Bump version`](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+is%3Apr+label%3A%22Bump+version%22)
 is assigned by the bot to pull-requests that are just adding a new version of the library. The new version should satisfy
-some extra conditions: sources should provide from the same URL domain as previous versions and the version itself should
-be valid semver.
+some extra conditions: sources should provide from the same URL domain as previous versions.
+For now, only [SEMVER](https://semver.org/#semantic-versioning-200) and `<MAJOR.MINOR>` are acceptable version formats.
 
 > These pull-requests will be merged right away without requiring any approval (CI and CLA checks must have passed).
 


### PR DESCRIPTION
- Document those acceptable version formats computed by the CI automatically.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
