### PR TITLE
add gtest v1.10.0 support

### DIFF
--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -8,4 +8,9 @@ sources:
 patches:
   "1.10.0":
     - patch_file: "patches/gtest-1.10.0.patch"
+      patch_description: "correct the order of cmake min and project"
+      patch_type: "conan"
     - patch_file: "patches/gtest-1.10.0-override.patch"
+      patch_description: "correct the order of cmake min and project"
+      patch_type: "backport"
+      patch_source: "https://github.com/google/googletest/pull/2507"

--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -8,9 +8,9 @@ sources:
 patches:
   "1.10.0":
     - patch_file: "patches/gtest-1.10.0.patch"
-      patch_description: "correct the order of cmake min and project"
+      patch_description: "add CUSTOM_DEBUG_POSTFIX option"
       patch_type: "conan"
     - patch_file: "patches/gtest-1.10.0-override.patch"
-      patch_description: "correct the order of cmake min and project"
+      patch_description: "prevent compiler from complaining while compiling"
       patch_type: "backport"
       patch_source: "https://github.com/google/googletest/pull/2507"

--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -2,3 +2,10 @@ sources:
   "1.12.1":
     url: "https://github.com/google/googletest/archive/release-1.12.1.tar.gz"
     sha256: "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2"
+  "1.10.0":
+    url: "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
+    sha256: "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb"
+patches:
+  "1.10.0":
+    - patch_file: "patches/gtest-1.10.0.patch"
+    - patch_file: "patches/gtest-1.10.0-override.patch"

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -3,9 +3,10 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import copy, get, replace_in_file, rm, rmdir
+from conan.tools.files import apply_conandata_patches, copy, get, replace_in_file, rm, rmdir
 from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.51.1"
 
@@ -53,9 +54,16 @@ class GTestConan(ConanFile):
     def _is_clang_cl(self):
         return self.settings.os == "Windows" and self.settings.compiler == "clang"
 
+    def export_sources(self):
+        if Version(self.version) < "1.12.0":
+            for patch in self.conan_data.get("patches", {}).get(self.version, []):
+                copy(self, patch["patch_file"], self.recipe_folder, self.export_sources_folder)
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) < "1.12.0" and self.settings.build_type != "Debug":
+            del self.options.debug_postfix
 
     def configure(self):
         if self.options.shared:
@@ -63,8 +71,14 @@ class GTestConan(ConanFile):
                 del self.options.fPIC
             except Exception:
                 pass
-        if self.options.debug_postfix != "deprecated":
-            self.output.warn("gtest/*:debug_postfix is deprecated.")
+        if Version(self.version) >= "1.12.0":
+            if self.options.debug_postfix != "deprecated":
+                self.output.warn("gtest/*:debug_postfix is deprecated in 1.12.0.")
+
+        if Version(self.version) < "1.12.0" and self.settings.build_type == "Debug":
+            if self.options.debug_postfix == "deprecated":
+                # in 1.10.0,  use 'd' as default
+                self.options.debug_postfix = "d"
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -105,6 +119,10 @@ class GTestConan(ConanFile):
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.variables["BUILD_GMOCK"] = bool(self.options.build_gmock)
         tc.variables["gtest_hide_internal_symbols"] = bool(self.options.hide_symbols)
+
+        if self.settings.build_type == "Debug" and Version(self.version) < "1.12.0":
+            tc.cache_variables["CUSTOM_DEBUG_POSTFIX"] = str(self.options.debug_postfix)
+
         if is_msvc(self) or self._is_clang_cl:
             tc.variables["gtest_force_shared_crt"] = not is_msvc_static_runtime(self)
         if self.settings.os == "Windows" and self.settings.compiler == "gcc":
@@ -112,10 +130,15 @@ class GTestConan(ConanFile):
         tc.generate()
 
     def _patch_sources(self):
+        internal_utils = os.path.join(self.source_folder, "googletest",
+                                      "cmake", "internal_utils.cmake")
+        if Version(self.version) < "1.12.0":
+            apply_conandata_patches(self)
+            replace_in_file(self, internal_utils, "-Werror", "")
+
         if is_msvc(self) or self._is_clang_cl:
             # No warnings as errors
-            replace_in_file(self, os.path.join(self.source_folder, "googletest",
-                                        "cmake", "internal_utils.cmake"), "-WX", "")
+            replace_in_file(self, internal_utils, "-WX", "")
 
     def build(self):
         self._patch_sources()
@@ -131,6 +154,13 @@ class GTestConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
 
+    @property
+    def _postfix(self):
+        # In 1.12.0, gtest remove debug postfix.
+        if Version(self.version) >= "1.12.0":
+            return ""
+        return self.options.debug_postfix if self.settings.build_type == "Debug" else ""
+
     def package_info(self):
         self.cpp_info.set_property("cmake_find_mode", "both")
         self.cpp_info.set_property("cmake_file_name", "GTest")
@@ -139,7 +169,7 @@ class GTestConan(ConanFile):
         self.cpp_info.components["libgtest"].set_property("cmake_target_name", "GTest::gtest")
         self.cpp_info.components["libgtest"].set_property("cmake_target_aliases", ["GTest::GTest"])
         self.cpp_info.components["libgtest"].set_property("pkg_config_name", "gtest")
-        self.cpp_info.components["libgtest"].libs = ["gtest"]
+        self.cpp_info.components["libgtest"].libs = [f"gtest{self._postfix}"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libgtest"].system_libs.append("m")
             self.cpp_info.components["libgtest"].system_libs.append("pthread")
@@ -153,21 +183,21 @@ class GTestConan(ConanFile):
             self.cpp_info.components["gtest_main"].set_property("cmake_target_name", "GTest::gtest_main")
             self.cpp_info.components["gtest_main"].set_property("cmake_target_aliases", ["GTest::Main"])
             self.cpp_info.components["gtest_main"].set_property("pkg_config_name", "gtest_main")
-            self.cpp_info.components["gtest_main"].libs = ["gtest_main"]
+            self.cpp_info.components["gtest_main"].libs = [f"gtest_main{self._postfix}"]
             self.cpp_info.components["gtest_main"].requires = ["libgtest"]
 
         # gmock
         if self.options.build_gmock:
             self.cpp_info.components["gmock"].set_property("cmake_target_name", "GTest::gmock")
             self.cpp_info.components["gmock"].set_property("pkg_config_name", "gmock")
-            self.cpp_info.components["gmock"].libs = ["gmock"]
+            self.cpp_info.components["gmock"].libs = [f"gmock{self._postfix}"]
             self.cpp_info.components["gmock"].requires = ["libgtest"]
 
             # gmock_main
             if not self.options.no_main:
                 self.cpp_info.components["gmock_main"].set_property("cmake_target_name", "GTest::gmock_main")
                 self.cpp_info.components["gmock_main"].set_property("pkg_config_name", "gmock_main")
-                self.cpp_info.components["gmock_main"].libs = ["gmock_main"]
+                self.cpp_info.components["gmock_main"].libs = [f"gmock_main{self._postfix}"]
                 self.cpp_info.components["gmock_main"].requires = ["gmock"]
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -55,8 +55,7 @@ class GTestConan(ConanFile):
         return self.settings.os == "Windows" and self.settings.compiler == "clang"
 
     def export_sources(self):
-        if Version(self.version) < "1.12.0":
-            export_conandata_patches(self)
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -77,7 +76,7 @@ class GTestConan(ConanFile):
                 pass
         if Version(self.version) >= "1.12.0":
             if self.options.debug_postfix != "deprecated":
-                self.output.warn("gtest/*:debug_postfix is deprecated in 1.12.0.")
+                self.output.warn(f"{self.ref}:debug_postfix is deprecated in 1.12.0.")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/gtest/all/patches/gtest-1.10.0-override.patch
+++ b/recipes/gtest/all/patches/gtest-1.10.0-override.patch
@@ -1,0 +1,450 @@
+From 3cddd56e195b516f449bea6dcd3edd4494195631 Mon Sep 17 00:00:00 2001
+From: Robert Luberda <robert@debian.org>
+Date: Wed, 9 Oct 2019 21:48:00 +0200
+Subject: [PATCH] Add more override keywords
+
+Mark more functions with "override" keyword, just like
+it was done in commit 2460f97152c.
+
+This should prevent compiler from complaining while compiling both
+user code, and the googletest code itself with the -Wsuggest-override
+option turned on; with the exception of:
+ * calls to new MOCK_METHOD() in test/gmock-function-mocker_test.cc
+ * calls to old MOCK_METHODx()/MOCK_CONST_METHODx() in other
+   unit test files.
+
+Closes #2493
+---
+ .../include/gmock/gmock-generated-actions.h   | 24 ++---
+ .../gmock/gmock-generated-actions.h.pump      |  4 +-
+ .../include/gmock/gmock-generated-matchers.h  | 88 +++++++++----------
+ .../gmock/gmock-generated-matchers.h.pump     |  8 +-
+ googletest/include/gtest/gtest-typed-test.h   |  4 +-
+ .../include/gtest/internal/gtest-port.h       |  4 +-
+ googletest/test/gtest_unittest.cc             |  4 +-
+ 7 files changed, 68 insertions(+), 68 deletions(-)
+
+diff --git a/googlemock/include/gmock/gmock-generated-actions.h b/googlemock/include/gmock/gmock-generated-actions.h
+index 981af78ff..cee96dae8 100644
+--- a/googlemock/include/gmock/gmock-generated-actions.h
++++ b/googlemock/include/gmock/gmock-generated-actions.h
+@@ -663,7 +663,7 @@ class ActionHelper {
+       typedef typename ::testing::internal::Function<F>::ArgumentTuple\
+           args_type;\
+       explicit gmock_Impl GMOCK_INTERNAL_INIT_##value_params {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -726,7 +726,7 @@ class ActionHelper {
+       typedef typename ::testing::internal::Function<F>::ArgumentTuple\
+           args_type;\
+       gmock_Impl() {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -776,7 +776,7 @@ class ActionHelper {
+           args_type;\
+       explicit gmock_Impl(p0##_type gmock_p0) : \
+           p0(::std::forward<p0##_type>(gmock_p0)) {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -832,7 +832,7 @@ class ActionHelper {
+       gmock_Impl(p0##_type gmock_p0, \
+           p1##_type gmock_p1) : p0(::std::forward<p0##_type>(gmock_p0)), \
+           p1(::std::forward<p1##_type>(gmock_p1)) {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -893,7 +893,7 @@ class ActionHelper {
+           p2##_type gmock_p2) : p0(::std::forward<p0##_type>(gmock_p0)), \
+           p1(::std::forward<p1##_type>(gmock_p1)), \
+           p2(::std::forward<p2##_type>(gmock_p2)) {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -961,7 +961,7 @@ class ActionHelper {
+           p1(::std::forward<p1##_type>(gmock_p1)), \
+           p2(::std::forward<p2##_type>(gmock_p2)), \
+           p3(::std::forward<p3##_type>(gmock_p3)) {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -1038,7 +1038,7 @@ class ActionHelper {
+           p2(::std::forward<p2##_type>(gmock_p2)), \
+           p3(::std::forward<p3##_type>(gmock_p3)), \
+           p4(::std::forward<p4##_type>(gmock_p4)) {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -1119,7 +1119,7 @@ class ActionHelper {
+           p3(::std::forward<p3##_type>(gmock_p3)), \
+           p4(::std::forward<p4##_type>(gmock_p4)), \
+           p5(::std::forward<p5##_type>(gmock_p5)) {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -1206,7 +1206,7 @@ class ActionHelper {
+           p4(::std::forward<p4##_type>(gmock_p4)), \
+           p5(::std::forward<p5##_type>(gmock_p5)), \
+           p6(::std::forward<p6##_type>(gmock_p6)) {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -1302,7 +1302,7 @@ class ActionHelper {
+           p5(::std::forward<p5##_type>(gmock_p5)), \
+           p6(::std::forward<p6##_type>(gmock_p6)), \
+           p7(::std::forward<p7##_type>(gmock_p7)) {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -1404,7 +1404,7 @@ class ActionHelper {
+           p6(::std::forward<p6##_type>(gmock_p6)), \
+           p7(::std::forward<p7##_type>(gmock_p7)), \
+           p8(::std::forward<p8##_type>(gmock_p8)) {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -1513,7 +1513,7 @@ class ActionHelper {
+           p7(::std::forward<p7##_type>(gmock_p7)), \
+           p8(::std::forward<p8##_type>(gmock_p8)), \
+           p9(::std::forward<p9##_type>(gmock_p9)) {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+diff --git a/googlemock/include/gmock/gmock-generated-actions.h.pump b/googlemock/include/gmock/gmock-generated-actions.h.pump
+index 209603c5a..283abcdc2 100644
+--- a/googlemock/include/gmock/gmock-generated-actions.h.pump
++++ b/googlemock/include/gmock/gmock-generated-actions.h.pump
+@@ -395,7 +395,7 @@ $range k 0..n-1
+       typedef typename ::testing::internal::Function<F>::ArgumentTuple\
+           args_type;\
+       explicit gmock_Impl GMOCK_INTERNAL_INIT_##value_params {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+@@ -482,7 +482,7 @@ $var macro_name = [[$if i==0 [[ACTION]] $elif i==1 [[ACTION_P]]
+       typedef typename ::testing::internal::Function<F>::ArgumentTuple\
+           args_type;\
+       [[$if i==1 [[explicit ]]]]gmock_Impl($ctor_param_list)$inits {}\
+-      virtual return_type Perform(const args_type& args) {\
++      return_type Perform(const args_type& args) override {\
+         return ::testing::internal::ActionHelper<return_type, gmock_Impl>::\
+             Perform(this, args);\
+       }\
+diff --git a/googlemock/include/gmock/gmock-generated-matchers.h b/googlemock/include/gmock/gmock-generated-matchers.h
+index 690a57f1c..61892380c 100644
+--- a/googlemock/include/gmock/gmock-generated-matchers.h
++++ b/googlemock/include/gmock/gmock-generated-matchers.h
+@@ -269,13 +269,13 @@
+      public:\
+       gmock_Impl()\
+            {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\
+      private:\
+@@ -318,13 +318,13 @@
+      public:\
+       explicit gmock_Impl(p0##_type gmock_p0)\
+            : p0(::std::move(gmock_p0)) {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\
+       p0##_type const p0;\
+@@ -371,13 +371,13 @@
+      public:\
+       gmock_Impl(p0##_type gmock_p0, p1##_type gmock_p1)\
+            : p0(::std::move(gmock_p0)), p1(::std::move(gmock_p1)) {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\
+       p0##_type const p0;\
+@@ -431,13 +431,13 @@
+       gmock_Impl(p0##_type gmock_p0, p1##_type gmock_p1, p2##_type gmock_p2)\
+            : p0(::std::move(gmock_p0)), p1(::std::move(gmock_p1)), \
+                p2(::std::move(gmock_p2)) {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\
+       p0##_type const p0;\
+@@ -495,13 +495,13 @@
+           p3##_type gmock_p3)\
+            : p0(::std::move(gmock_p0)), p1(::std::move(gmock_p1)), \
+                p2(::std::move(gmock_p2)), p3(::std::move(gmock_p3)) {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\
+       p0##_type const p0;\
+@@ -568,13 +568,13 @@
+            : p0(::std::move(gmock_p0)), p1(::std::move(gmock_p1)), \
+                p2(::std::move(gmock_p2)), p3(::std::move(gmock_p3)), \
+                p4(::std::move(gmock_p4)) {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\
+       p0##_type const p0;\
+@@ -644,13 +644,13 @@
+            : p0(::std::move(gmock_p0)), p1(::std::move(gmock_p1)), \
+                p2(::std::move(gmock_p2)), p3(::std::move(gmock_p3)), \
+                p4(::std::move(gmock_p4)), p5(::std::move(gmock_p5)) {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\
+       p0##_type const p0;\
+@@ -726,13 +726,13 @@
+                p2(::std::move(gmock_p2)), p3(::std::move(gmock_p3)), \
+                p4(::std::move(gmock_p4)), p5(::std::move(gmock_p5)), \
+                p6(::std::move(gmock_p6)) {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\
+       p0##_type const p0;\
+@@ -814,13 +814,13 @@
+                p2(::std::move(gmock_p2)), p3(::std::move(gmock_p3)), \
+                p4(::std::move(gmock_p4)), p5(::std::move(gmock_p5)), \
+                p6(::std::move(gmock_p6)), p7(::std::move(gmock_p7)) {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\
+       p0##_type const p0;\
+@@ -909,13 +909,13 @@
+                p4(::std::move(gmock_p4)), p5(::std::move(gmock_p5)), \
+                p6(::std::move(gmock_p6)), p7(::std::move(gmock_p7)), \
+                p8(::std::move(gmock_p8)) {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\
+       p0##_type const p0;\
+@@ -1009,13 +1009,13 @@
+                p4(::std::move(gmock_p4)), p5(::std::move(gmock_p5)), \
+                p6(::std::move(gmock_p6)), p7(::std::move(gmock_p7)), \
+                p8(::std::move(gmock_p8)), p9(::std::move(gmock_p9)) {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\
+       p0##_type const p0;\
+diff --git a/googlemock/include/gmock/gmock-generated-matchers.h.pump b/googlemock/include/gmock/gmock-generated-matchers.h.pump
+index ae90917cc..69d2ae418 100644
+--- a/googlemock/include/gmock/gmock-generated-matchers.h.pump
++++ b/googlemock/include/gmock/gmock-generated-matchers.h.pump
+@@ -302,13 +302,13 @@ $var param_field_decls2 = [[$for j
+      public:\
+       [[$if i==1 [[explicit ]]]]gmock_Impl($impl_ctor_param_list)\
+           $impl_inits {}\
+-      virtual bool MatchAndExplain(\
++      bool MatchAndExplain(\
+           GTEST_REFERENCE_TO_CONST_(arg_type) arg,\
+-          ::testing::MatchResultListener* result_listener) const;\
+-      virtual void DescribeTo(::std::ostream* gmock_os) const {\
++          ::testing::MatchResultListener* result_listener) const override;\
++      void DescribeTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(false);\
+       }\
+-      virtual void DescribeNegationTo(::std::ostream* gmock_os) const {\
++      void DescribeNegationTo(::std::ostream* gmock_os) const override {\
+         *gmock_os << FormatDescription(true);\
+       }\$param_field_decls
+      private:\
+diff --git a/googletest/include/gtest/gtest-typed-test.h b/googletest/include/gtest/gtest-typed-test.h
+index 095ce0580..6b7c9c8a0 100644
+--- a/googletest/include/gtest/gtest-typed-test.h
++++ b/googletest/include/gtest/gtest-typed-test.h
+@@ -201,7 +201,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
+    private:                                                                   \
+     typedef CaseName<gtest_TypeParam_> TestFixture;                           \
+     typedef gtest_TypeParam_ TypeParam;                                       \
+-    virtual void TestBody();                                                  \
++    void TestBody() override;                                                 \
+   };                                                                          \
+   static bool gtest_##CaseName##_##TestName##_registered_                     \
+         GTEST_ATTRIBUTE_UNUSED_ =                                             \
+@@ -276,7 +276,7 @@ INSTANTIATE_TYPED_TEST_SUITE_P(My, FooTest, MyTypes);
+      private:                                                         \
+       typedef SuiteName<gtest_TypeParam_> TestFixture;                \
+       typedef gtest_TypeParam_ TypeParam;                             \
+-      virtual void TestBody();                                        \
++      void TestBody() override;                                       \
+     };                                                                \
+     static bool gtest_##TestName##_defined_ GTEST_ATTRIBUTE_UNUSED_ = \
+         GTEST_TYPED_TEST_SUITE_P_STATE_(SuiteName).AddTestName(       \
+diff --git a/googletest/include/gtest/internal/gtest-port.h b/googletest/include/gtest/internal/gtest-port.h
+index f6433c58a..2b4770ff5 100644
+--- a/googletest/include/gtest/internal/gtest-port.h
++++ b/googletest/include/gtest/internal/gtest-port.h
+@@ -1599,7 +1599,7 @@ class ThreadLocal : public ThreadLocalBase {
+   class DefaultValueHolderFactory : public ValueHolderFactory {
+    public:
+     DefaultValueHolderFactory() {}
+-    virtual ValueHolder* MakeNewHolder() const { return new ValueHolder(); }
++    ValueHolder* MakeNewHolder() const override { return new ValueHolder(); }
+ 
+    private:
+     GTEST_DISALLOW_COPY_AND_ASSIGN_(DefaultValueHolderFactory);
+@@ -1608,7 +1608,7 @@ class ThreadLocal : public ThreadLocalBase {
+   class InstanceValueHolderFactory : public ValueHolderFactory {
+    public:
+     explicit InstanceValueHolderFactory(const T& value) : value_(value) {}
+-    virtual ValueHolder* MakeNewHolder() const {
++    ValueHolder* MakeNewHolder() const override {
+       return new ValueHolder(value_);
+     }
+ 
+diff --git a/googletest/test/gtest_unittest.cc b/googletest/test/gtest_unittest.cc
+index 8312bd10e..d17a15540 100644
+--- a/googletest/test/gtest_unittest.cc
++++ b/googletest/test/gtest_unittest.cc
+@@ -6170,7 +6170,7 @@ TEST_F(ParseFlagsTest, WideStrings) {
+ #if GTEST_USE_OWN_FLAGFILE_FLAG_
+ class FlagfileTest : public ParseFlagsTest {
+  public:
+-  virtual void SetUp() {
++  void SetUp() override {
+     ParseFlagsTest::SetUp();
+ 
+     testdata_path_.Set(internal::FilePath(
+@@ -6180,7 +6180,7 @@ class FlagfileTest : public ParseFlagsTest {
+     EXPECT_TRUE(testdata_path_.CreateFolder());
+   }
+ 
+-  virtual void TearDown() {
++  void TearDown() override {
+     testing::internal::posix::RmDir(testdata_path_.c_str());
+     ParseFlagsTest::TearDown();
+   }

--- a/recipes/gtest/all/patches/gtest-1.10.0.patch
+++ b/recipes/gtest/all/patches/gtest-1.10.0.patch
@@ -1,0 +1,13 @@
+diff --git a/googletest/cmake/internal_utils.cmake b/googletest/cmake/internal_utils.cmake
+index 2f70f0b0..8cd03693 100644
+--- a/googletest/cmake/internal_utils.cmake
++++ b/googletest/cmake/internal_utils.cmake
+@@ -154,7 +154,7 @@ function(cxx_library_with_type name type cxx_flags)
+   # Generate debug library name with a postfix.
+   set_target_properties(${name}
+     PROPERTIES
+-    DEBUG_POSTFIX "d")
++    DEBUG_POSTFIX "${CUSTOM_DEBUG_POSTFIX}")
+   # Set the output directory for build artifacts
+   set_target_properties(${name}
+     PROPERTIES

--- a/recipes/gtest/config.yml
+++ b/recipes/gtest/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.12.1":
     folder: all
+  "1.10.0":
+    folder: all


### PR DESCRIPTION
**gtest/1.10.0**

there is a compatible issue in version > 1.10.0.
'enum class' is forced to use ADL lookup, and what's more, the template<> version does not work. The user has to write lots of customized funciton operator<<() to pass compiling, it is a bit annoying. Add 1.10.0 support for convenience.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
