### PR TITLE
jsonnet: add version 0.19.1

### DIFF
--- a/recipes/jsonnet/all/conandata.yml
+++ b/recipes/jsonnet/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.19.1":
+    url: "https://github.com/google/jsonnet/archive/v0.19.1.tar.gz"
+    sha256: "f5a20f2dc98fdebd5d42a45365f52fa59a7e6b174e43970fea4f9718a914e887"
   "0.18.0":
     url: "https://github.com/google/jsonnet/archive/v0.18.0.tar.gz"
     sha256: "85c240c4740f0c788c4d49f9c9c0942f5a2d1c2ae58b2c71068107bc80a3ced4"
@@ -6,6 +9,11 @@ sources:
     url: "https://github.com/google/jsonnet/archive/v0.17.0.tar.gz"
     sha256: "076b52edf888c01097010ad4299e3b2e7a72b60a41abbc65af364af1ed3c8dbe"
 patches:
+  "0.19.1":
+    - patch_file: "patches/0.18.0/0001-fix-nlohmann-include.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0.18.0/0002-cmake-fixes.patch"
+      base_path: "source_subfolder"
   "0.18.0":
     - patch_file: "patches/0.18.0/0001-fix-nlohmann-include.patch"
       base_path: "source_subfolder"

--- a/recipes/jsonnet/config.yml
+++ b/recipes/jsonnet/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.19.1":
+    folder: all
   "0.18.0":
     folder: all
   "0.17.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **jsonnet/0.19.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
