### PR TITLE
highway: add version 1.0.2

### DIFF
--- a/recipes/highway/all/conandata.yml
+++ b/recipes/highway/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.2":
+    url: "https://github.com/google/highway/archive/1.0.2.tar.gz"
+    sha256: "e8ef71236ac0d97f12d553ec1ffc5b6375d57b5f0b860c7447dd69b6ed1072db"
   "1.0.1":
     url: "https://github.com/google/highway/archive/1.0.1.tar.gz"
     sha256: "7ca6af7dc2e3e054de9e17b9dfd88609a7fd202812b1c216f43cc41647c97311"

--- a/recipes/highway/config.yml
+++ b/recipes/highway/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.2":
+    folder: all
   "1.0.1":
     folder: all
   "1.0.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **highway/1.0.2**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
