### PR TITLE
libmp3lame: fix msvc & mingw build regressions

### DIFF
--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -1,8 +1,8 @@
 from conan import ConanFile
 from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.files import export_conandata_patches, apply_conandata_patches, get, chdir, rmdir, copy, rm, replace_in_file, rename
-from conan.tools.layout import basic_layout
 from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, unix_path, VCVars
 from conans import VisualStudioBuildEnvironment
 import os

--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.files import export_conandata_patches, apply_conandata_patches,
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, unix_path, VCVars
-from conans import VisualStudioBuildEnvironment
 import os
 import shutil
 
@@ -80,13 +79,13 @@ class LibMP3LameConan(ConanFile):
     def _generate_vs(self):
         tc = VCVars(self)
         tc.generate()
-        # TODO: no conan v2 build helper for NMake yet (see https://github.com/conan-io/conan/issues/12188)
-        #       Better than nothing: rely on legacy VisualStudioBuildEnvironment to inject CL & LIB env vars
-        #       in order to honor build_type & runtime from profile
-        env = Environment()
-        for var, value in VisualStudioBuildEnvironment(self).vars.items():
-            env.define(var, value)
-        env.vars(self).save_script("buildenv_nmake")
+        # FIXME: no conan v2 build helper for NMake yet (see https://github.com/conan-io/conan/issues/12188)
+        #        So populate CL with AutotoolsToolchain cflags
+        c_flags = AutotoolsToolchain(self).cflags
+        if c_flags:
+            env = Environment()
+            env.define("CL", c_flags)
+            env.vars(self).save_script("conanbuildenv_nmake")
 
     def _generate_autotools(self):
         env = VirtualBuildEnv(self)

--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -59,7 +59,7 @@ class LibMP3LameConan(ConanFile):
 
     def build_requirements(self):
         if not is_msvc(self) and not self._is_clang_cl:
-            self.build_requires("gnu-config/cci.20201022")
+            self.tool_requires("gnu-config/cci.20201022")
             if self._settings_build.os == "Windows":
                 self.win_bash = True
                 if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):

--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -36,10 +36,6 @@ class LibMP3LameConan(ConanFile):
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
-    @property
-    def _user_info_build(self):
-        return getattr(self, "user_info_build", self.deps_user_info)
-
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -133,10 +129,12 @@ class LibMP3LameConan(ConanFile):
             self.run(command)
 
     def _build_autotools(self):
-        copy(self, "config.sub", self._user_info_build["gnu-config"].CONFIG_SUB,
-                    os.path.join(self.source_folder))
-        copy(self, "config.guess", self._user_info_build["gnu-config"].CONFIG_GUESS,
-                    os.path.join(self.source_folder))
+        for gnu_config in [
+            self.conf.get("user.gnu-config:config_guess", check_type=str),
+            self.conf.get("user.gnu-config:config_sub", check_type=str),
+        ]:
+            if gnu_config:
+                copy(self, os.path.basename(gnu_config), src=os.path.dirname(gnu_config), dst=self.source_folder)
         autotools = Autotools(self)
         autotools.configure()
         autotools.make()

--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -68,10 +68,10 @@ class LibMP3LameConan(ConanFile):
 
     def build_requirements(self):
         if not is_msvc(self) and not self._is_clang_cl:
-            self.tool_requires("gnu-config/cci.20201022")
+            self.tool_requires("gnu-config/cci.20210814")
             if self._settings_build.os == "Windows":
                 self.win_bash = True
-                if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
+                if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                     self.tool_requires("msys2/cci.latest")
 
     def source(self):

--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -8,7 +8,7 @@ from conans import VisualStudioBuildEnvironment
 import os
 import shutil
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class LibMP3LameConan(ConanFile):
@@ -50,18 +50,9 @@ class LibMP3LameConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -8,7 +8,7 @@ from conans import VisualStudioBuildEnvironment
 import os
 import shutil
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.52.0"
 
 
 class LibMP3LameConan(ConanFile):
@@ -50,9 +50,18 @@ class LibMP3LameConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            self.options.rm_safe("fPIC")
-        self.settings.rm_safe("compiler.libcxx")
-        self.settings.rm_safe("compiler.cppstd")
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+        try:
+            del self.settings.compiler.libcxx
+        except Exception:
+            pass
+        try:
+            del self.settings.compiler.cppstd
+        except Exception:
+            pass
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.env import Environment, VirtualBuildEnv
-from conan.tools.files import export_conandata_patches, apply_conandata_patches, get, chdir, rmdir, copy, rm, replace_in_file, rename
+from conan.tools.files import apply_conandata_patches, chdir, copy, export_conandata_patches, get, rename, replace_in_file, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, unix_path, VCVars

--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.microsoft import is_msvc, unix_path, VCVars
 import os
 import shutil
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class LibMP3LameConan(ConanFile):
@@ -45,18 +45,9 @@ class LibMP3LameConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -114,14 +114,14 @@ class LibMP3LameConan(ConanFile):
             replace_in_file(self, "Makefile.MSVC", "ADDL_OBJ = bufferoverflowU.lib", "")
             command = "nmake -f Makefile.MSVC comp=msvc"
             if self._is_clang_cl:
-                cl = os.environ.get('CC', "clang-cl")
-                link = os.environ.get("LD", 'lld-link')
-                replace_in_file(self, 'Makefile.MSVC', 'CC = cl', 'CC = %s' % cl)
-                replace_in_file(self, 'Makefile.MSVC', 'LN = link', 'LN = %s' % link)
+                cl = os.environ.get("CC", "clang-cl")
+                link = os.environ.get("LD", "lld-link")
+                replace_in_file(self, "Makefile.MSVC", "CC = cl", f"CC = {cl}")
+                replace_in_file(self, "Makefile.MSVC", "LN = link", f"LN = {link}")
                 # what is /GAy? MSDN doesn't know it
                 # clang-cl: error: no such file or directory: '/GAy'
                 # https://docs.microsoft.com/en-us/cpp/build/reference/ga-optimize-for-windows-application?view=msvc-170
-                replace_in_file(self, 'Makefile.MSVC', '/GAy', '/GA')
+                replace_in_file(self, "Makefile.MSVC", "/GAy", "/GA")
             if self.settings.arch == "x86_64":
                 replace_in_file(self, "Makefile.MSVC", "MACHINE = /machine:I386", "MACHINE =/machine:X64")
                 command += " MSVCVER=Win64 asm=yes"

--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -60,7 +60,7 @@ class LibMP3LameConan(ConanFile):
     def build_requirements(self):
         if not is_msvc(self) and not self._is_clang_cl:
             self.build_requires("gnu-config/cci.20201022")
-            if self.settings.os == "Windows":
+            if self._settings_build.os == "Windows":
                 self.win_bash = True
                 if not self.conf.get("tools.microsoft.bash:path", default=False, check_type=str):
                     self.tool_requires("msys2/cci.latest")

--- a/recipes/libmp3lame/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libmp3lame/all/test_v1_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(libmp3lame REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} libmp3lame::libmp3lame)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
Regarding msvc, see https://github.com/conan-io/conan-center-index/pull/13791#discussion_r1008586781 & https://github.com/conan-io/conan/issues/12188

MinGW cross-build from linux to Windows was likely broken due to another regression coming from https://github.com/conan-io/conan-center-index/pull/13791 where target os was tested instead of build machien os.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
