### PR TITLE
daw_header_libraries: add version 2.73.1

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.73.1":
+    url: "https://github.com/beached/header_libraries/archive/v2.73.1.tar.gz"
+    sha256: "62bd26398afa7eba1aae7bbbf107865044b8be0539d266085c36aed82557ae07"
   "2.72.0":
     url: "https://github.com/beached/header_libraries/archive/v2.72.0.tar.gz"
     sha256: "f681755183af4af35f4741f3bcb7d99c6707911806e39e3acc982f9532aacc08"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.73.1":
+    folder: all
   "2.72.0":
     folder: all
   "2.71.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **daw_header_libraries/2.73.1**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
