### PR TITLE
ninja: do not override `tools.cmake.cmaketoolchain:generator`

### DIFF
--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -45,8 +45,6 @@ class NinjaConan(ConanFile):
     def package_info(self):
         self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []
-        self.cpp_info.resdirs = []
-        self.conf_info.define("tools.cmake.cmaketoolchain:generator", "Ninja")
 
         # TODO: to remove in conan v2
         if Version(conan_version).major < 2:


### PR DESCRIPTION
It's not the responsibility of ninja recipe to set `tools.cmake.cmaketoolchain:generator` config (or `tools.meson.mesontoolchain:backend`), and change behavior of another tool, it's a user preference.
`CONAN_CMAKE_GENERATOR` is kept (for conan v1 build helpers) to avoid potential breakage.

see https://github.com/conan-io/conan-center-index/pull/12918#discussion_r1008700211

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
