### PR TITLE
trompeloeil: add version 43

### DIFF
--- a/recipes/trompeloeil/all/conandata.yml
+++ b/recipes/trompeloeil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "43":
+    url: "https://github.com/rollbear/trompeloeil/archive/v43.tar.gz"
+    sha256: "86a0afa2e97347202a0a883ab43da78c1d4bfff0d6cb93205cfc433d0d9eb9eb"
   "42":
     url: "https://github.com/rollbear/trompeloeil/archive/v42.tar.gz"
     sha256: "96f3b518eeb609216f8f5ba5cf9314181d1d340ebbf25a73ee63a482a669cc4c"

--- a/recipes/trompeloeil/config.yml
+++ b/recipes/trompeloeil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "43":
+    folder: all
   "42":
     folder: all
   "41":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **trompeloeil/***

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
