### PR TITLE
[gcc] Bump gcc recipe version to 12.2.0

### DIFF
--- a/recipes/gcc/all/conandata.yml
+++ b/recipes/gcc/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "10.2.0":
     sha256: 27e879dccc639cd7b0cc08ed575c1669492579529b53c9ff27b0b96265fa867d
     url: https://ftp.gnu.org/gnu/gcc/gcc-10.2.0/gcc-10.2.0.tar.gz
+  "12.2.0":
+    sha256: ac6b317eb4d25444d87cf29c0d141dedc1323a1833ec9995211b13e1a851261c
+    url: https://ftp.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.gz

--- a/recipes/gcc/all/test_package/conanfile.py
+++ b/recipes/gcc/all/test_package/conanfile.py
@@ -11,8 +11,8 @@ class TestPackageConan(ConanFile):
             if os.name == 'posix':
                 os.chmod(name, os.stat(name).st_mode | 0o111)
 
-        cc = os.environ["CC"]
-        cxx = os.environ["CXX"]
+        cc = self.deps_env_info["gcc"].CC
+        cxx = self.deps_env_info["gcc"].CXX
         hello_c = os.path.join(self.source_folder, "hello.c")
         hello_cpp = os.path.join(self.source_folder, "hello.cpp")
         self.run("%s --version" % cc, run_environment=True)

--- a/recipes/gcc/all/test_package/hello.c
+++ b/recipes/gcc/all/test_package/hello.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-    puts("Bincrafters\n");
+    puts("Hello, World!\n");
     return 0;
 }
 

--- a/recipes/gcc/all/test_package/hello.cpp
+++ b/recipes/gcc/all/test_package/hello.cpp
@@ -2,7 +2,7 @@
 
 int main()
 {
-    std::cout << "Bincrafters\n";
+    std::cout << "Hello, World!\n";
     return 0;
 }
 

--- a/recipes/gcc/config.yml
+++ b/recipes/gcc/config.yml
@@ -1,3 +1,5 @@
 versions:
   "10.2.0":
     folder: all
+  "12.2.0":
+    folder: all


### PR DESCRIPTION
* Bump GCC recipe version to 12.2.0
* Modify test recipe to use `deps_env_info` instead of `os.environ` to extract `CC` and `CXX` data. This is because `env_info.{CC,CXX}` was not being propagated to the run environment and the generated compilers were not being appropriately tested.
* Rename the output from the test executable to be `"Hello, World!"` for consistency with the filename, remove references to Bincrafters

Closes #13812.

Specify library name and version:  **gcc/12.2.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

Bumping version prior to investigating a recipe migration for conan 2.0

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
