### PR TITLE
icu: fix emscripten build for 71.1

### DIFF
--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -48,4 +48,3 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0001-71.1-fix-emscripten.patch"
       base_path: "source_subfolder"
-      

--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -32,6 +32,8 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0001-71.1-fix-undef-strict-ansi.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0001-71.1-fix-emscripten.patch"
+      base_path: "source_subfolder"
   "70.1":
     - patch_file: "patches/0001-69.1-fix-mingw.patch"
       base_path: "source_subfolder"
@@ -45,6 +47,4 @@ patches:
     - patch_file: "patches/6aba9344a18f4f32e8070ee53b79495630901c26.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0001-67.1-fix-mingw.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0001-71.1-fix-emscripten.patch"
       base_path: "source_subfolder"

--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -33,6 +33,9 @@ patches:
     - patch_file: "patches/0001-71.1-fix-undef-strict-ansi.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0001-71.1-fix-emscripten.patch"
+      patch_description: "Add config file for wasm-emscripten platform"
+      patch_type: "portability"
+      patch_source: "https://gerrit.libreoffice.org/c/core/+/111130/9/external/icu/icu4c-emscripten-cross.patch.1"
       base_path: "source_subfolder"
   "70.1":
     - patch_file: "patches/0001-69.1-fix-mingw.patch"

--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -48,3 +48,4 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0001-71.1-fix-emscripten.patch"
       base_path: "source_subfolder"
+      

--- a/recipes/icu/all/conandata.yml
+++ b/recipes/icu/all/conandata.yml
@@ -46,3 +46,5 @@ patches:
       base_path: "source_subfolder"
     - patch_file: "patches/0001-67.1-fix-mingw.patch"
       base_path: "source_subfolder"
+    - patch_file: "patches/0001-71.1-fix-emscripten.patch"
+      base_path: "source_subfolder"

--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -64,7 +64,7 @@ class ICUBase(ConanFile):
 
     @property
     def _enable_icu_tools(self):
-        return self.settings.os not in ["iOS", "tvOS", "watchOS"]
+        return self.settings.os not in ["iOS", "tvOS", "watchOS", "Emscripten"]
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -191,6 +191,8 @@ class ICUBase(ConanFile):
                 args.append("--host={}".format(get_gnu_triplet("Macos", str(self.settings.arch))))
             elif env_build.host:
                 args.append("--host={}".format(env_build.host))
+            if env_build.build:
+                args.append("--build={}".format(env_build.build))
             bin_path = self.deps_env_info["icu"].PATH[0].replace("\\", "/")
             base_path, _ = bin_path.rsplit('/', 1)
             args.append("--with-cross-build={}".format(base_path))

--- a/recipes/icu/all/patches/0001-71.1-fix-emscripten.patch
+++ b/recipes/icu/all/patches/0001-71.1-fix-emscripten.patch
@@ -1,15 +1,3 @@
-From de06899372c4645a2b978b5e2c6dbc6392253d35 Mon Sep 17 00:00:00 2001
-From: ovostrikov <oleksii.vostrikov@materialise.kiev.ua>
-Date: Fri, 28 Oct 2022 17:42:00 +0300
-Subject: [PATCH] 71.1 fix emscripten
-
----
- source/acinclude.m4         |  1 +
- source/config/mh-emscripten | 86 +++++++++++++++++++++++++++++++++++++
- source/configure            |  1 +
- 3 files changed, 88 insertions(+)
- create mode 100644 source/config/mh-emscripten
-
 diff --git a/source/acinclude.m4 b/source/acinclude.m4
 index 507f41f..2980ef1 100644
 --- a/source/acinclude.m4
@@ -127,6 +115,3 @@ index 71e1462..4a8140e 100644
  *) 		icu_cv_host_frag=mh-unknown ;;
  esac
  
--- 
-2.33.0.windows.2
-

--- a/recipes/icu/all/patches/0001-71.1-fix-emscripten.patch
+++ b/recipes/icu/all/patches/0001-71.1-fix-emscripten.patch
@@ -1,0 +1,132 @@
+From de06899372c4645a2b978b5e2c6dbc6392253d35 Mon Sep 17 00:00:00 2001
+From: ovostrikov <oleksii.vostrikov@materialise.kiev.ua>
+Date: Fri, 28 Oct 2022 17:42:00 +0300
+Subject: [PATCH] 71.1 fix emscripten
+
+---
+ source/acinclude.m4         |  1 +
+ source/config/mh-emscripten | 86 +++++++++++++++++++++++++++++++++++++
+ source/configure            |  1 +
+ 3 files changed, 88 insertions(+)
+ create mode 100644 source/config/mh-emscripten
+
+diff --git a/source/acinclude.m4 b/source/acinclude.m4
+index 507f41f..2980ef1 100644
+--- a/source/acinclude.m4
++++ b/source/acinclude.m4
+@@ -84,6 +84,7 @@ x86_64-*-cygwin)
+ *-dec-osf*) icu_cv_host_frag=mh-alpha-osf ;;
+ *-*-nto*)	icu_cv_host_frag=mh-qnx ;;
+ *-ncr-*)	icu_cv_host_frag=mh-mpras ;;
++wasm*-*-emscripten*)	icu_cv_host_frag=mh-emscripten ;;
+ *) 		icu_cv_host_frag=mh-unknown ;;
+ esac
+ 		]
+diff --git a/source/config/mh-emscripten b/source/config/mh-emscripten
+new file mode 100644
+index 0000000..ee2b90b
+--- /dev/null
++++ b/source/config/mh-emscripten
+@@ -0,0 +1,86 @@
++## Emscripten-specific setup
++## Copyright (c) 1999-2013, International Business Machines Corporation and
++## others. All Rights Reserved.
++## Commands to generate dependency files
++GEN_DEPS.c=  $(CC) -E -MM $(DEFS) $(CPPFLAGS)
++GEN_DEPS.cc= $(CXX) -E -MM $(DEFS) $(CPPFLAGS) $(CXXFLAGS)
++ 
++## Flags for position independent code
++SHAREDLIBCFLAGS = -fPIC
++SHAREDLIBCXXFLAGS = -fPIC
++SHAREDLIBCPPFLAGS = -DPIC
++
++## Additional flags when building libraries and with threads
++THREADSCPPFLAGS = -D_REENTRANT
++LIBCPPFLAGS =
++
++## Compiler switch to embed a runtime search path
++LD_RPATH= -Wl,-zorigin,-rpath,'$$'ORIGIN
++LD_RPATH_PRE = -Wl,-rpath,
++
++## Force RPATH=$ORIGIN to locate own dependencies w/o need for LD_LIBRARY_PATH:
++ENABLE_RPATH=YES
++RPATHLDFLAGS=${LD_RPATH_PRE}'$$ORIGIN'
++
++## These are the library specific LDFLAGS
++#LDFLAGSICUDT=-nodefaultlibs -nostdlib
++# Debian change: linking icudata as data only causes too many problems.
++LDFLAGSICUDT=
++
++## Compiler switch to embed a library name
++# The initial tab in the next line is to prevent icu-config from reading it.
++	LD_SONAME = -Wl,-soname -Wl,$(notdir $(MIDDLE_SO_TARGET))
++#SH# # We can't depend on MIDDLE_SO_TARGET being set.
++#SH# LD_SONAME=
++
++## Shared library options
++LD_SOOPTIONS= -Wl,-Bsymbolic-functions
++
++## Shared object suffix
++SO = so
++## Non-shared intermediate object suffix
++STATIC_O = o
++
++## Compilation rules
++# WASM needs -pthread for atomics support
++%.$(STATIC_O): $(srcdir)/%.c
++	$(call SILENT_COMPILE,$(strip $(COMPILE.c) $(STATICCPPFLAGS) $(STATICCFLAGS)) -pthread -o $@ $<)
++
++%.$(STATIC_O): $(srcdir)/%.cpp
++	$(call SILENT_COMPILE,$(strip $(COMPILE.cc) $(STATICCPPFLAGS) $(STATICCXXFLAGS)) -pthread -o $@ $<)
++
++
++## Dependency rules
++%.d: $(srcdir)/%.c
++	$(call ICU_MSG,(deps)) $<
++	@$(SHELL) -ec '$(GEN_DEPS.c) $< \
++		| sed '\''s%\($*\)\.o[ :]*%\1.o $@ : %g'\'' > $@; \
++		[ -s $@ ] || rm -f $@'
++
++%.d: $(srcdir)/%.cpp
++	$(call ICU_MSG,(deps)) $<
++	@$(SHELL) -ec '$(GEN_DEPS.cc) $< \
++		| sed '\''s%\($*\)\.o[ :]*%\1.o $@ : %g'\'' > $@; \
++		[ -s $@ ] || rm -f $@'
++
++## Versioned libraries rules
++
++%.$(SO).$(SO_TARGET_VERSION_MAJOR): %.$(SO).$(SO_TARGET_VERSION)
++	$(RM) $@ && ln -s ${<F} $@
++%.$(SO): %.$(SO).$(SO_TARGET_VERSION_MAJOR)
++	$(RM) $@ && ln -s ${*F}.$(SO).$(SO_TARGET_VERSION) $@
++
++##  Bind internal references
++
++# LDflags that pkgdata will use
++BIR_LDFLAGS= -Wl,-Bsymbolic
++
++# Dependencies [i.e. map files] for the final library
++BIR_DEPS=
++
++## Remove shared library 's'
++STATIC_PREFIX_WHEN_USED =
++STATIC_PREFIX =
++
++## without assembly
++PKGDATA_OPTS = -O $(top_builddir)/data/icupkg.inc -w
+\ No newline at end of file
+diff --git a/source/configure b/source/configure
+index 71e1462..4a8140e 100644
+--- a/source/configure
++++ b/source/configure
+@@ -5339,6 +5339,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ *-dec-osf*) icu_cv_host_frag=mh-alpha-osf ;;
+ *-*-nto*)	icu_cv_host_frag=mh-qnx ;;
+ *-ncr-*)	icu_cv_host_frag=mh-mpras ;;
++wasm*-*-emscripten*)	icu_cv_host_frag=mh-emscripten ;;
+ *) 		icu_cv_host_frag=mh-unknown ;;
+ esac
+ 
+-- 
+2.33.0.windows.2
+


### PR DESCRIPTION
Specify library name and version:  **icu/71.1**

Fixes https://github.com/conan-io/conan-center-index/issues/13888

There were bunch of underlying issues:

- ICU didn't recognise wasm32-*-emscripten as a host (fixed with a patch).
- ICU's autoconfig didn't properly recognize that we are cross-building (fixed by adding "--build=" parameter to build configuration in the recipe).
- ICU tools needs to be disabled for emscripten (fixed in the recipe).
- While packaging ICU data '-w' param needs to be passed in the PKGDATA_OPTS (fixed with a patch), because there is no pre-built assembly code for wasm

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
