### PR TITLE
boost: Add -headerpad_max_install_names link flag on Apple platforms

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1056,6 +1056,9 @@ class BoostConan(ConanFile):
             elif self._is_msvc:
                 cxx_flags.append("/Z7")
 
+        # Set headerpad on apple systems to allow rpath modifications
+        if tools.is_apple_os(self.settings.os) and self.options.shared:
+            link_flags.append('-headerpad_max_install_names')
 
         # Standalone toolchain fails when declare the std lib
         if self.settings.os not in ("Android", "Emscripten"):


### PR DESCRIPTION
Add `-headerpad_max_install_names` linker flag for boost building on Apple platforms. This change reflects what is done on CMake based builds by default and allows proper library modification for relative load paths after the build.

Specify library name and version:  **boost/1.80.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

**I'm building a hobby project of mine using conan for the dependencies and found that boost doesn't allow packing via dylibbuilder to correct @rpath linking to work inside the app package. On the conan Slack on cpplang I was told that for cmake `-headerpad_max_install_names` is a default linker flag. This modifies the boost conanfile to add the appropriate linker flag to the b2 build flags. Hope that is the right place to do this?**

I'm currently a bit short on time so I haven't yet checked every item on the checklist below but maybe there can be some general feedback if this approach is good and this change is welcomed.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
