### PR TITLE
utf8proc: add version 2.8.0

### DIFF
--- a/recipes/utf8proc/all/conandata.yml
+++ b/recipes/utf8proc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.8.0":
+    url: "https://github.com/JuliaStrings/utf8proc/archive/v2.8.0.tar.gz"
+    sha256: "a0a60a79fe6f6d54e7d411facbfcc867a6e198608f2cd992490e46f04b1bcecc"
   "2.7.0":
     url: "https://github.com/JuliaStrings/utf8proc/archive/v2.7.0.tar.gz"
     sha256: "4bb121e297293c0fd55f08f83afab6d35d48f0af4ecc07523ad8ec99aa2b12a1"

--- a/recipes/utf8proc/config.yml
+++ b/recipes/utf8proc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.8.0":
+    folder: all
   "2.7.0":
     folder: all
   "2.6.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **utf8proc/2.8.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
