### PR TITLE
add matplotplusplus/1.1.0

### DIFF
--- a/recipes/matplotplusplus/all/conandata.yml
+++ b/recipes/matplotplusplus/all/conandata.yml
@@ -1,0 +1,15 @@
+sources:
+  "1.1.0":
+    url: "https://github.com/alandefreitas/matplotplusplus/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "5c3a1bdfee12f5c11fd194361040fe4760f57e334523ac125ec22b2cb03f27bb"
+patches:
+  "1.1.0":
+    - patch_file: "patches/1.1.0-0001-cmake-install.patch"
+      patch_description: "Install dll & matplot_opengl"
+      patch_type: "conan"
+    - patch_file: "patches/1.1.0-0002-cmake-dependencies.patch"
+      patch_description: "Robust dependencies handling"
+      patch_type: "conan"
+    - patch_file: "patches/1.1.0-0003-cmake-flags.patch"
+      patch_description: "Honor default build type flags"
+      patch_type: "conan"

--- a/recipes/matplotplusplus/all/conanfile.py
+++ b/recipes/matplotplusplus/all/conanfile.py
@@ -1,0 +1,140 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=1.52.0"
+
+
+class MatplotPlusPlusConan(ConanFile):
+    name = "matplotplusplus"
+    description = "A C++ Graphics Library for Data Visualization"
+    license = "MIT"
+    topics = ("matplot", "chart", "data-visualization", "data-science", "plot", "graphics", "graph")
+    homepage = "https://alandefreitas.github.io/matplotplusplus"
+    url = "https://github.com/conan-io/conan-center-index"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "high_resolution_world_map": [True, False],
+        "documentation_images": [True, False],
+        "with_opengl": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "high_resolution_world_map": True,
+        "documentation_images": False,
+        "with_opengl": False,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return "17"
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "7",
+            "Visual Studio": "15",
+            "msvc": "191",
+            "clang": "6",
+            "apple-clang": "10",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            try:
+                del self.options.fPIC
+            except Exception:
+                pass
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("cimg/3.0.2")
+        self.requires("nodesoup/cci.20200905")
+        # FIXME: add gnuplot, it's a mandatory runtime dependency of matplot component
+        if self.options.with_opengl:
+            self.requires("glad/0.1.36")
+            self.requires("glfw/3.3.8")
+
+    def validate(self):
+        if self.info.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
+        if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.",
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_EXAMPLES"] = False
+        tc.variables["BUILD_TESTS"] = False
+        tc.variables["BUILD_INSTALLER"] = True
+        tc.variables["BUILD_PACKAGE"] = False
+        tc.variables["BUILD_WITH_PEDANTIC_WARNINGS"] = False
+        tc.variables["BUILD_WITH_SANITIZERS"] = False
+        tc.variables["BUILD_WITH_EXCEPTIONS"] = False
+        tc.variables["BUILD_HIGH_RESOLUTION_WORLD_MAP"] = self.options.high_resolution_world_map
+        tc.variables["BUILD_FOR_DOCUMENTATION_IMAGES"] = self.options.documentation_images
+        tc.variables["BUILD_EXPERIMENTAL_OPENGL_BACKEND"] = self.options.with_opengl
+        tc.variables["WITH_SYSTEM_CIMG"] = True
+        tc.variables["WITH_SYSTEM_NODESOUP"] = True
+        tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "Matplot++")
+        self.cpp_info.set_property(
+            "cmake_target_name",
+            "Matplot++::matplot_opengl" if self.options.with_opengl else "Matplot++::matplot",
+        )
+
+        self.cpp_info.components["matplot"].set_property("cmake_target_name", "Matplot++::matplot")
+        self.cpp_info.components["matplot"].libs = ["matplot"]
+        self.cpp_info.components["matplot"].requires = ["cimg::cimg", "nodesoup::nodesoup"]
+        if not self.options.shared:
+            if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) < "9":
+                self.cpp_info.components["matplot"].system_libs.append("stdc++fs")
+
+        if self.options.with_opengl:
+            self.cpp_info.components["matplot_opengl"].set_property("cmake_target_name", "Matplot++::matplot_opengl")
+            self.cpp_info.components["matplot_opengl"].libs = ["matplot_opengl"]
+            self.cpp_info.components["matplot_opengl"].requires = ["matplot", "glad::glad", "glfw::glfw"]
+
+        # TODO: to remove in conan v2
+        self.cpp_info.names["cmake_find_package"] = "Matplot++"
+        self.cpp_info.names["cmake_find_package_multi"] = "Matplot++"

--- a/recipes/matplotplusplus/all/patches/1.1.0-0001-cmake-install.patch
+++ b/recipes/matplotplusplus/all/patches/1.1.0-0001-cmake-install.patch
@@ -1,0 +1,30 @@
+--- a/source/matplot/CMakeLists.txt
++++ b/source/matplot/CMakeLists.txt
+@@ -236,7 +239,7 @@ if (BUILD_EXPERIMENTAL_OPENGL_BACKEND)
+             backend/opengl.h
+             backend/opengl.cpp
+             )
+-    target_include_directories(matplot_opengl PUBLIC matplot)
++    target_include_directories(matplot_opengl PUBLIC $<BUILD_INTERFACE:${MATPLOT_ROOT_DIR}/source>)
+     target_link_libraries(matplot_opengl PUBLIC matplot glad glfw ${CMAKE_DL_LIBS})
+ endif()
+ 
+@@ -249,7 +252,18 @@ if (BUILD_INSTALLER)
+             EXPORT Matplot++Targets
+             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+             )
++    if(BUILD_EXPERIMENTAL_OPENGL_BACKEND)
++        install(
++            TARGETS matplot_opengl
++            EXPORT Matplot++Targets
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++        )
++    endif()
+ 
+     # Install headers
+     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/recipes/matplotplusplus/all/patches/1.1.0-0002-cmake-dependencies.patch
+++ b/recipes/matplotplusplus/all/patches/1.1.0-0002-cmake-dependencies.patch
@@ -1,0 +1,62 @@
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -1,2 +1,3 @@
+-add_subdirectory(3rd_party)
++find_package(cimg REQUIRED CONFIG)
++find_package(nodesoup REQUIRED CONFIG)
+ add_subdirectory(matplot)
+\ No newline at end of file
+--- a/source/matplot/CMakeLists.txt
++++ b/source/matplot/CMakeLists.txt
+@@ -97,9 +97,14 @@ target_include_directories(matplot
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+ 
+ # Dependencies
+-target_link_libraries_system(matplot
+-  PRIVATE cimg nodesoup std::filesystem)
+-
++target_link_libraries(matplot
++  PRIVATE cimg::cimg nodesoup::nodesoup std::filesystem)
++if(WIN32)
++    target_compile_definitions(matplot PRIVATE cimg_display=2)
++    target_link_libraries(matplot PRIVATE gdi32)
++else()
++    target_compile_definitions(matplot PRIVATE cimg_display=0)
++endif()
+ # Required compiler features required
+ # https://cmake.org/cmake/help/v3.14/manual/cmake-compile-features.7.html#requiring-language-standards
+ target_compile_features(matplot PUBLIC cxx_std_17)
+@@ -203,11 +208,10 @@ if (BUILD_EXPERIMENTAL_OPENGL_BACKEND)
+     # The biggest con of the OpenGL backend is that it cannot open a window
+     #     in another thread. All it can do is get in the middle of the render
+     #     loop and draw the plot.
+-    find_package(OpenGL REQUIRED)
+ 
+     # https://github.com/Dav1dde/glad
+-    find_package(GLAD QUIET)
+-    if (NOT GLAD_FOUND AND NOT TARGET glad)
++    find_package(glad REQUIRED CONFIG)
++    if (0)
+         # Use CPM only if not found, to avoid ODR violations
+         # find_package(GLAD REQUIRE) would suffice if it worked well
+         FetchContent_Declare(glad GIT_REPOSITORY https://github.com/Dav1dde/glad.git GIT_TAG df8e9e16110b305479a875399cee13daa0ccadd9)
+@@ -215,15 +219,14 @@ if (BUILD_EXPERIMENTAL_OPENGL_BACKEND)
+     else ()
+         # FindGLAD does not usually create a target, so we create an interface target
+         if (NOT TARGET glad)
+-            add_library(glad INTERFACE)
+-            target_include_directories(glad INTERFACE ${GLAD_INCLUDE_PATH})
+-            target_link_libraries(glad INTERFACE ${GLAD_LIBRARIES})
++            add_library(glad INTERFACE IMPORTED)
++            set_target_properties(glad PROPERTIES INTERFACE_LINK_LIBRARIES glad::glad)
+         endif ()
+     endif ()
+ 
+     # https://github.com/glfw/glfw
+-    find_package(glfw3 QUIET)
+-    if (NOT GLFW3_FOUND AND NOT TARGET glfw)
++    find_package(glfw3 REQUIRED CONFIG)
++    if (0)
+         # Use CPM only if not found, to avoid ODR violations
+         # find_package(glfw3 REQUIRE) would suffice if it worked well
+         FetchContent_Declare(glfw3 GIT_REPOSITORY https://github.com/glfw/glfw.git GIT_TAG 3.3.2)

--- a/recipes/matplotplusplus/all/patches/1.1.0-0003-cmake-flags.patch
+++ b/recipes/matplotplusplus/all/patches/1.1.0-0003-cmake-flags.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,7 +31,6 @@ include(cmake/functions.cmake)
+ # Set variables with project properties
+ set_master_project_booleans() # detect if master project / dev mode
+ set_debug_booleans() # detect if debug
+-set_optimization_flags() # detect and set default optimization flags
+ set_compiler_booleans() # detect compiler
+ 
+ # What to build

--- a/recipes/matplotplusplus/all/test_package/CMakeLists.txt
+++ b/recipes/matplotplusplus/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
+
+find_package(Matplot++ REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE Matplot++::matplot)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/matplotplusplus/all/test_package/conanfile.py
+++ b/recipes/matplotplusplus/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/matplotplusplus/all/test_package/test_package.cpp
+++ b/recipes/matplotplusplus/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+#include <matplot/matplot.h>
+
+#include <cmath>
+#include <vector>
+
+int main()
+{
+    std::vector<double> x = matplot::linspace(0, 2 * matplot::pi);
+    std::vector<double> y = matplot::transform(x, [](auto x) { return std::sin(x); });
+    return 0;
+}

--- a/recipes/matplotplusplus/all/test_v1_package/CMakeLists.txt
+++ b/recipes/matplotplusplus/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/matplotplusplus/all/test_v1_package/conanfile.py
+++ b/recipes/matplotplusplus/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/matplotplusplus/config.yml
+++ b/recipes/matplotplusplus/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.0":
+    folder: "all"


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/7086
closes https://github.com/conan-io/conan-center-index/issues/11058

https://github.com/conan-io/conan-center-index/issues/13903 is required at runtime, since it's the default backend (though I've cheated a little bit in test_package by skipping functions executing gnuplot executable under the hood). Opengl backend works fine (but experimental and disabled by default).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
