### PR TITLE
etl: add version 20.35.0

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.35.0":
+    url: "https://github.com/ETLCPP/etl/archive/20.35.0.tar.gz"
+    sha256: "1bfbc5679bce41625add0e5d7354ab8521dc4811f13e1627a9816af65f49f42b"
   "20.34.0":
     url: "https://github.com/ETLCPP/etl/archive/20.34.0.tar.gz"
     sha256: "56e25968f20167a161ee50c3eecda3daa91f696660ba59654c1afd22e502c465"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.35.0":
+    folder: all
   "20.34.0":
     folder: all
   "20.33.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **etl/20.35.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
