### PR TITLE
Add opentelemetry/1.7.0 and missing  libraries

### DIFF
--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -24,29 +24,29 @@ sources:
 patches:
   "1.7.0":
     - patch_file: "patches/1.7.0-0001-fix-cmake.patch"
-      patch_description: "fix lack of linking libraries"
-      patch_type: "backport"
+      patch_description: "fix lack of linking libraries due to conan not generating the variables that are expected"
+      patch_type: "conan"
   "1.6.1":
     - patch_file: "patches/1.6.1-0001-fix-cmake.patch"
-      patch_description: "fix lack of linking libraries"
-      patch_type: "backport"
+      patch_description: "fix lack of linking libraries due to conan not generating the variables that are expected"
+      patch_type: "conan"
   "1.4.1":
     - patch_file: "patches/1.4.0-0001-fix-cmake.patch"
-      patch_description: "fix lack of linking libraries"
-      patch_type: "backport"
+      patch_description: "fix lack of linking libraries due to conan not generating the variables that are expected"
+      patch_type: "conan"
   "1.4.0":
     - patch_file: "patches/1.4.0-0001-fix-cmake.patch"
-      patch_description: "fix lack of linking libraries"
-      patch_type: "backport"
+      patch_description: "fix lack of linking libraries due to conan not generating the variables that are expected"
+      patch_type: "conan"
   "1.3.0":
     - patch_file: "patches/1.3.0-0001-fix-cmake.patch"
-      patch_description: "fix lack of linking libraries"
-      patch_type: "backport"
+      patch_description: "fix lack of linking libraries due to conan not generating the variables that are expected"
+      patch_type: "conan"
   "1.2.0":
     - patch_file: "patches/1.2.0-0001-fix-cmake.patch"
-      patch_description: "fix lack of linking libraries"
-      patch_type: "backport"
+      patch_description: "fix lack of linking libraries due to conan not generating the variables that are expected"
+      patch_type: "conan"
   "1.0.1":
     - patch_file: "patches/1.0.1-0001-fix-cmake.patch"
-      patch_description: "fix lack of linking libraries"
-      patch_type: "backport"
+      patch_description: "fix lack of linking libraries due to conan not generating the variables that are expected"
+      patch_type: "conan"

--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.7.0":
+    url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.7.0.tar.gz"
+    sha256: "2ad0911cdc94fe84a93334773bef4789a38bd1f01e39560cabd4a5c267e823c3"
   "1.6.1":
     url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.6.1.tar.gz"
     sha256: "1fc371be049b3220b8b9571c8b713f03e9a84f3c5684363f64ccc814638391a5"
@@ -19,6 +22,10 @@ sources:
     sha256: "32f12ff15ec257e3462883f84bc291c2d5dc30055604c12ec4b46a36dfa3f189"
 
 patches:
+  "1.7.0":
+    - patch_file: "patches/1.7.0-0001-fix-cmake.patch"
+      patch_description: "fix lack of linking libraries"
+      patch_type: "backport"
   "1.6.1":
     - patch_file: "patches/1.6.1-0001-fix-cmake.patch"
       patch_description: "fix lack of linking libraries"

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -64,7 +64,6 @@ class OpenTelemetryCppConan(ConanFile):
         self.requires("thrift/0.17.0")
         if Version(self.version) >= "1.3.0":
             self.requires("boost/1.80.0")
-        self.requires("zlib/1.2.13")
 
     def validate(self):
         if self.info.settings.arch != "x86_64":

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -44,7 +44,7 @@ class OpenTelemetryCppConan(ConanFile):
         if self.options.shared:
             try:
                 del self.options.fPIC
-            except AttributeError:
+            except Exception:
                 pass
 
     def layout(self):

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -162,21 +162,28 @@ class OpenTelemetryCppConan(ConanFile):
         libraries = [
             self._http_client_name,
             "opentelemetry_common",
-            "opentelemetry_exporter_otlp_http_client",
             "opentelemetry_exporter_in_memory",
             "opentelemetry_exporter_jaeger_trace",
             "opentelemetry_exporter_ostream_span",
-            "opentelemetry_exporter_ostream_metrics",
             "opentelemetry_exporter_otlp_grpc",
             "opentelemetry_exporter_otlp_http",
             "opentelemetry_exporter_zipkin_trace",
             "opentelemetry_otlp_recordable",
-            "opentelemetry_metrics",
             "opentelemetry_proto",
             "opentelemetry_resources",
             "opentelemetry_trace",
             "opentelemetry_version",
         ]
+
+        if Version(self.version) >= "1.1.0":
+            libraries.append("opentelemetry_exporter_otlp_http_client")
+
+        if Version(self.version) >= "1.2.0":
+            libraries.append("opentelemetry_metrics")
+
+        if Version(self.version) >= "1.4.0":
+            libraries.append("opentelemetry_exporter_ostream_metrics")
+
         if Version(self.version) >= "1.5.0":
             libraries.append("opentelemetry_exporter_otlp_grpc_metrics")
             libraries.append("opentelemetry_exporter_otlp_http_metric")

--- a/recipes/opentelemetry-cpp/all/patches/1.7.0-0001-fix-cmake.patch
+++ b/recipes/opentelemetry-cpp/all/patches/1.7.0-0001-fix-cmake.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e7597fc8..d880a90d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -217,7 +217,6 @@ if(WITH_JAEGER)
+   find_package(Thrift QUIET)
+   if(Thrift_FOUND)
+     find_package(Boost REQUIRED)
+-    include_directories(${Boost_INCLUDE_DIR})
+   else()
+     # Install Thrift and propagate via vcpkg toolchain file
+     if(WIN32 AND (NOT DEFINED CMAKE_TOOLCHAIN_FILE))
+diff --git a/cmake/opentelemetry-proto.cmake b/cmake/opentelemetry-proto.cmake
+index 629ea815..3b09b92e 100644
+--- a/cmake/opentelemetry-proto.cmake
++++ b/cmake/opentelemetry-proto.cmake
+@@ -242,6 +242,10 @@ else() # cmake 3.8 or lower
+   target_link_libraries(opentelemetry_proto INTERFACE ${Protobuf_LIBRARIES})
+ endif()
+ 
++if(TARGET gRPC::grpc++)
++  target_link_libraries(opentelemetry_proto PUBLIC gRPC::grpc++)
++endif()
++
+ if(BUILD_SHARED_LIBS)
+   set_property(TARGET opentelemetry_proto PROPERTY POSITION_INDEPENDENT_CODE ON)
+ endif()

--- a/recipes/opentelemetry-cpp/config.yml
+++ b/recipes/opentelemetry-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.7.0":
+    folder: all
   "1.6.1":
     folder: all
   "1.4.1":


### PR DESCRIPTION
Specify library name and version:  **opentelemetry/1.7.0**

In addition to adding the new version, I also noticed that we're missing a number of libraries in the package info meaning they couldn't be linked when consuming the package, so I've added the ones that I could see were missing.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
