### PR TITLE
bzip3: add version 1.2.0

### DIFF
--- a/recipes/bzip3/all/conandata.yml
+++ b/recipes/bzip3/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.0":
+    url: "https://github.com/kspalaiologos/bzip3/archive/1.2.0.tar.gz"
+    sha256: "6f9bd935ac1e845cb49e64ad23969db914e4760dad7feec0995f5cdbd336c10d"
   "1.1.8":
     url: "https://github.com/kspalaiologos/bzip3/releases/download/1.1.8/bzip3-1.1.8.tar.bz2"
     sha256: "bc15d0e4599aad18d9ed71ee0f7e859af89051bf5105b0751e8ca3a26117567d"

--- a/recipes/bzip3/config.yml
+++ b/recipes/bzip3/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.0":
+    folder: all
   "1.1.8":
     folder: all
   "1.1.7":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **bzip3/1.2.0**



---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
