### PR TITLE
lcms: add version 2.14

### DIFF
--- a/recipes/lcms/all/conandata.yml
+++ b/recipes/lcms/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.14":
+    url: "https://github.com/mm2/Little-CMS/archive/lcms2.14.tar.gz"
+    sha256: "05869269f14e589b0b6d05a76f510c68c67fabb304904d16c6bd818abec80a83"
   "2.13.1":
     url: "https://github.com/mm2/Little-CMS/archive/refs/tags/lcms2.13.1.tar.gz"
     sha256: "6f84c942ecde1b4852b5a051894502ac8c98d010acb3400dec958c6db1bc94ef"

--- a/recipes/lcms/config.yml
+++ b/recipes/lcms/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.14":
+    folder: all
   "2.13.1":
     folder: all
   "2.12":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **lcms/2.14**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
