### PR TITLE
objectbox: add version 0.18.0

### DIFF
--- a/recipes/objectbox/all/conandata.yml
+++ b/recipes/objectbox/all/conandata.yml
@@ -1,9 +1,15 @@
 sources:
+  "0.18.0":
+    url: "https://github.com/objectbox/objectbox-c/archive/v0.18.0.tar.gz"
+    sha256: "e86e921d59c6c36a4a0c0ddc5a2b641789bfa012e0824506c285feb4e9285ae7"
   "0.17.0":
     url: "https://github.com/objectbox/objectbox-c/archive/refs/tags/v0.17.0.tar.gz"
     sha256: "3b936b3352ae0c8ea3706cc0a1790d2714a415cdce16007c2caca367ead5af8d"
 
 patches:
+  "0.18.0":
+    - patch_file: "patches/0001-fix-cmake.patch"
+      base_path: "source_subfolder"
   "0.17.0":
     - patch_file: "patches/0001-fix-cmake.patch"
       base_path: "source_subfolder"

--- a/recipes/objectbox/config.yml
+++ b/recipes/objectbox/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.18.0":
+    folder: all
   "0.17.0":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **objectbox/0.18.0**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
