### PR TITLE
Boost: Add embed_bitcode option

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -106,6 +106,7 @@ class BoostConan(ConanFile):
         "buildid": "ANY",
         "python_buildid": "ANY",
         "system_use_utf8": [True, False],
+        "embed_bitcode": [True, False], # enables embedding bitcode for iOS
     }
     options.update({f"without_{_name}": [True, False] for _name in CONFIGURE_OPTIONS})
 
@@ -144,6 +145,7 @@ class BoostConan(ConanFile):
         "buildid": None,
         "python_buildid": None,
         "system_use_utf8": False,
+        "embed_bitcode": True,
     }
     default_options.update({f"without_{_name}": False for _name in CONFIGURE_OPTIONS})
     default_options.update({f"without_{_name}": True for _name in ("graph_parallel", "mpi", "python")})
@@ -288,6 +290,11 @@ class BoostConan(ConanFile):
                 self.options.without_fiber = True
                 self.options.without_json = True
                 self.options.without_nowide = True
+
+        # bitcode is deprecated in Xcode 14, and the AppStore will not accept submissions from Xcode 14 with bitcode enabled
+        # https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
+        if not is_apple_os(self) or Version(self.settings.compiler.version) >= 14.0:
+            del self.options.embed_bitcode
 
         # iconv is off by default on Windows and Solaris
         if self._is_windows_platform or self.settings.os == "SunOS":
@@ -1109,7 +1116,8 @@ class BoostConan(ConanFile):
             if self.options.multithreading:
                 cxx_flags.append("-DBOOST_SP_USE_SPINLOCK")
 
-            cxx_flags.append("-fembed-bitcode")
+            if "embed_bitcode" in self.options and self.options.embed_bitcode:
+                cxx_flags.append("-fembed-bitcode")
 
         if self._with_iconv:
             flags.append(f"-sICONV_PATH={self.deps_cpp_info['libiconv'].rootpath}")


### PR DESCRIPTION
As of Xcode 14, Bitcode is deprecated and no longer accepted for AppStore submissions.

(see: https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes under the "Apple Clang Compiler: Deprecations" heading.)

This commit adds an `embed_bitcode` option with a default value of `True` to match the current behavior.

When the compiler version is 14.0+ the option is deleted and the `-fembed-bitcode` flag is not added to the cxx_flags.

Specify library name and version:  **lib/1.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
