### PR TITLE
runtimeqml/* reduce cmake required version

### DIFF
--- a/recipes/runtimeqml/all/CMakeLists.txt
+++ b/recipes/runtimeqml/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21.1)
+cmake_minimum_required(VERSION 3.13)
 
 project(runtimeqml LANGUAGES CXX)
 


### PR DESCRIPTION
Specify library name and version:  **runtimeqml/***

Previous cmake version was excessively new for the features being used.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
