### PR TITLE
ignore test_package's output at all levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Conan specific
-test_package/build/
-test_package/test_output/
+**/test_package/build/
+**/test_package/test_output/
 conan.lock
 conanbuildinfo.txt
 conaninfo.txt
@@ -23,7 +23,7 @@ CMakeUserPresets.json
 
 # Byte-compiled / optimized / DLL files / Cache
 __pycache__/
-test_package/__pycache__/
+**/test_package/__pycache__/
 *.pyc
 *.py[cod]
 *$py.class


### PR DESCRIPTION
according to git docs
> If there is a separator at the beginning or middle (or both) > of the pattern, then the pattern is relative to the directory
> level of the particular .gitignore file itself.


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
