### PR TITLE
[expat] upgrade to 2.5.0 (CVE fix)

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.0":
+    sha256: "ef2420f0232c087801abf705e89ae65f6257df6b7931d37846a193ef2e8cdcbe"
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_5_0/expat-2.5.0.tar.xz"
   "2.4.9":
     sha256: "6e8c0728fe5c7cd3f93a6acce43046c5e4736c7b4b68e032e9350daa0efc0354"
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_4_9/expat-2.4.9.tar.xz"

--- a/recipes/expat/all/test_v1_package/conanfile.py
+++ b/recipes/expat/all/test_v1_package/conanfile.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 from conans import ConanFile, CMake, tools
 import os
 

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.0":
+    folder: all
   "2.4.9":
     folder: all
   "2.4.8":


### PR DESCRIPTION
CVE-2022-43680, Score 7.5 is fixed

see:
- https://github.com/libexpat/libexpat/blob/R_2_5_0/expat/Changes
- https://nvd.nist.gov/vuln/detail/CVE-2022-43680

Needed as a pre-requisite for the Poco v1.12.4 update, see #13963

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
