### PR TITLE
glaze: add version 0.1.4

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.1.4":
+    url: "https://github.com/stephenberry/glaze/archive/v0.1.4.tar.gz"
+    sha256: "dd46e77973fe5b3cf4cd68fd597ba6b1010ecffd3e10cd8ccbd6cd615e6ffaff"
   "0.1.3":
     url: "https://github.com/stephenberry/glaze/archive/v0.1.3.tar.gz"
     sha256: "291e71244bf6fde5e57daf53d8e2fdd4793a7e93fe68c546f746f43a0e534d07"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.1.4":
+    folder: all
   "0.1.3":
     folder: all
   "0.1.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **glaze/0.1.4**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
