### PR TITLE
highfive: add v2.5.1 and v2.6.2

### DIFF
--- a/recipes/highfive/all/conandata.yml
+++ b/recipes/highfive/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
-  "2.6.1":
-    url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.6.1.tar.gz"
+  "2.6.2":
+    url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.6.2.tar.gz"
     sha256: "b5002c1221cf1821e02fb2ab891b0160bac88b43f56655bd844a472106ca3397"
   "2.5.1":
     url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.5.1.tar.gz"

--- a/recipes/highfive/all/conandata.yml
+++ b/recipes/highfive/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "2.6.2":
     url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.6.2.tar.gz"
-    sha256: "b5002c1221cf1821e02fb2ab891b0160bac88b43f56655bd844a472106ca3397"
+    sha256: "ab51b9fbb49e877dd1aa7b53b4b26875f41e4e0b8ee0fc2f1d735e0d1e43d708"
   "2.5.1":
     url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.5.1.tar.gz"
     sha256: "1ba05aa31cdeda03d013094eebc10f932783e4e071e253e9eaa8889120f241c7"

--- a/recipes/highfive/all/conandata.yml
+++ b/recipes/highfive/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.0":
+    url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.5.0.tar.gz"
+    sha256: "27f55596570df3cc8b878a1681a0d4ba0fe2e3da4a0ef8d436722990d77dc93a"
   "2.4.1":
     url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.4.1.tar.gz"
     sha256: "6826471ef5c645ebf947d29574b302991525a8a8ff1ef687aba7311d9a0ea36f"

--- a/recipes/highfive/all/conandata.yml
+++ b/recipes/highfive/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
-  "2.5.0":
-    url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.5.0.tar.gz"
-    sha256: "27f55596570df3cc8b878a1681a0d4ba0fe2e3da4a0ef8d436722990d77dc93a"
+  "2.6.1":
+    url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.6.1.tar.gz"
+    sha256: "b5002c1221cf1821e02fb2ab891b0160bac88b43f56655bd844a472106ca3397"
+  "2.5.1":
+    url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.5.1.tar.gz"
+    sha256: "1ba05aa31cdeda03d013094eebc10f932783e4e071e253e9eaa8889120f241c7"
   "2.4.1":
     url: "https://github.com/BlueBrain/HighFive/archive/refs/tags/v2.4.1.tar.gz"
     sha256: "6826471ef5c645ebf947d29574b302991525a8a8ff1ef687aba7311d9a0ea36f"

--- a/recipes/highfive/all/conanfile.py
+++ b/recipes/highfive/all/conanfile.py
@@ -27,7 +27,7 @@ class HighFiveConan(ConanFile):
         "with_boost": True,
         "with_eigen": True,
         "with_xtensor": True,
-        "with_opencv": True,
+        "with_opencv": False,
     }
 
     def layout(self):

--- a/recipes/highfive/config.yml
+++ b/recipes/highfive/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.0":
+    folder: all
   "2.4.1":
     folder: all
   "2.3.1":

--- a/recipes/highfive/config.yml
+++ b/recipes/highfive/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.6.1":
+  "2.6.2":
     folder: all
   "2.5.1":
     folder: all

--- a/recipes/highfive/config.yml
+++ b/recipes/highfive/config.yml
@@ -1,5 +1,7 @@
 versions:
-  "2.5.0":
+  "2.6.1":
+    folder: all
+  "2.5.1":
     folder: all
   "2.4.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **highfive/2.x.x**

Add version 2.5.1 and 2.6.2

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
