### PR TITLE
spdlog: add v1.11.0

### DIFF
--- a/recipes/spdlog/all/conandata.yml
+++ b/recipes/spdlog/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.11.0":
+    url: "https://github.com/gabime/spdlog/archive/v1.11.0.tar.gz"
+    sha256: "ca5cae8d6cac15dae0ec63b21d6ad3530070650f68076f3a4a862ca293a858bb"
   "1.10.0":
     url: "https://github.com/gabime/spdlog/archive/v1.10.0.tar.gz"
     sha256: "697f91700237dbae2326b90469be32b876b2b44888302afbc7aceb68bcfe8224"

--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -52,7 +52,9 @@ class SpdlogConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if Version(self.version) >= "1.10.0":
+        if Version(self.version) >= "1.11.0":
+            self.requires("fmt/9.1.0", transitive_headers=True)
+        elif Version(self.version) >= "1.10.0":
             self.requires("fmt/8.1.1", transitive_headers=True)
         elif Version(self.version) >= "1.9.0":
             self.requires("fmt/8.0.1", transitive_headers=True)

--- a/recipes/spdlog/config.yml
+++ b/recipes/spdlog/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.11.0":
+    folder: "all"
   "1.10.0":
     folder: "all"
   "1.9.2":


### PR DESCRIPTION
Specify library name and version:  **spdlog/1.11.0**

Add v1.11.0.

Also bump fmt to v9.1.0 to follow the version used upstream (see [here](https://github.com/gabime/spdlog/releases/tag/v1.11.0)).

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
