### PR TITLE
Flex: Conan v2 support

### DIFF
--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -103,5 +103,6 @@ class FlexConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "_FLEX"  # Don't replace CMake's built-in
         self.cpp_info.names["cmake_find_package_multi"] = "_FLEX"
         flex_root = self.package_folder
-        self.output.info("Setting FLEX_ROOT environment variable: {flex_root}")
+        self.output.info(f"Setting FLEX_ROOT environment variable: {flex_root}")
         self.env_info.FLEX_ROOT = flex_root
+        self.buildenv_info.define_path("FLEX_ROOT", flex_root)

--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -35,9 +35,9 @@ class FlexConan(ConanFile):
         self.requires("m4/1.4.19")
 
     def build_requirements(self):
-        self.build_requires("m4/1.4.19")
+        self.tool_requires("m4/1.4.19")
         if hasattr(self, "settings_build") and cross_building(self):
-            self.build_requires(f"{self.name}/{self.version}")
+            self.tool_requires(f"{self.name}/{self.version}")
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -53,11 +53,7 @@ class FlexConan(ConanFile):
 
     def generate(self):
         tc = AutotoolsToolchain(self)
-        def yes_no(v):
-            return "yes" if v else "no"
         tc.configure_args.extend([
-            f"--enable-shared={yes_no(self.options.shared)}",
-            f"--enable-static={yes_no(not self.options.shared)}",
             "--disable-nls",
             "--disable-bootstrap",
             "HELP2MAN=/bin/true",
@@ -72,7 +68,7 @@ class FlexConan(ConanFile):
         tc.generate()
 
         tc = VirtualBuildEnv(self)
-        tc.generate(scope="build")
+        tc.generate()
 
     def build(self):
         autotools = Autotools(self)

--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -88,6 +88,8 @@ class FlexConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["fl"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
 
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info(f"Appending PATH environment variable: {bindir}")

--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -1,5 +1,8 @@
-from conans import ConanFile, AutoToolsBuildEnvironment, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import cross_building
+from conan.tools.files import get, rmdir, rm
+from conans import AutoToolsBuildEnvironment
 import functools
 import os
 
@@ -29,15 +32,15 @@ class FlexConan(ConanFile):
         return "source_subfolder"
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self._source_subfolder, strip_root=True)
 
     def requirements(self):
         self.requires("m4/1.4.19")
 
     def build_requirements(self):
         self.build_requires("m4/1.4.19")
-        if hasattr(self, "settings_build") and tools.cross_building(self):
+        if hasattr(self, "settings_build") and cross_building(self):
             self.build_requires(f"{self.name}/{self.version}")
 
     def config_options(self):
@@ -80,8 +83,8 @@ class FlexConan(ConanFile):
         self.copy("COPYING", src=self._source_subfolder, dst="licenses")
         autotools = self._configure_autotools()
         autotools.install()
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.remove_files_by_mask(os.path.join(self.package_folder, "lib"), "*.la")
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
         self.cpp_info.libs = ["fl"]

--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
 from conan.tools.env import VirtualBuildEnv
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.47.0"
 
 
 class FlexConan(ConanFile):

--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -95,3 +95,14 @@ class FlexConan(ConanFile):
         lex_path = os.path.join(bindir, "flex").replace("\\", "/")
         self.output.info("Setting LEX environment variable: {}".format(lex_path))
         self.env_info.LEX = lex_path
+
+        # Don't produce files in CMakeDeps. Instead set FLEX_ROOT, and the built-in FindFLEX
+        # will find the executable, includes, and libraries. Important because the built-in
+        # defines a flex_target macro.
+        # <PackageName>_ROOT variables are available starting in CMake 3.12
+        self.cpp_info.set_property("cmake_find_mode", "none")
+        self.cpp_info.names["cmake_find_package"] = "_FLEX"  # Don't replace CMake's built-in
+        self.cpp_info.names["cmake_find_package_multi"] = "_FLEX"
+        flex_root = self.package_folder
+        self.output.info("Setting FLEX_ROOT environment variable: {}".format(flex_root))
+        self.env_info.FLEX_ROOT = flex_root

--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -53,10 +53,11 @@ class FlexConan(ConanFile):
 
     def generate(self):
         tc = AutotoolsToolchain(self)
-        yes_no = lambda v: "yes" if v else "no"
+        def yes_no(v):
+            return "yes" if v else "no"
         tc.configure_args.extend([
-            "--enable-shared={}".format(yes_no(self.options.shared)),
-            "--enable-static={}".format(not yes_no(self.options.shared)),
+            f"--enable-shared={yes_no(self.options.shared)}",
+            f"--enable-static={yes_no(not self.options.shared)}",
             "--disable-nls",
             "--disable-bootstrap",
             "HELP2MAN=/bin/true",
@@ -89,11 +90,11 @@ class FlexConan(ConanFile):
         self.cpp_info.libs = ["fl"]
 
         bindir = os.path.join(self.package_folder, "bin")
-        self.output.info("Appending PATH environment variable: {}".format(bindir))
+        self.output.info(f"Appending PATH environment variable: {bindir}")
         self.env_info.PATH.append(bindir)
 
         lex_path = os.path.join(bindir, "flex").replace("\\", "/")
-        self.output.info("Setting LEX environment variable: {}".format(lex_path))
+        self.output.info(f"Setting LEX environment variable: {lex_path}")
         self.env_info.LEX = lex_path
 
         # Don't produce files in CMakeDeps. Instead set FLEX_ROOT, and the built-in FindFLEX
@@ -104,5 +105,5 @@ class FlexConan(ConanFile):
         self.cpp_info.names["cmake_find_package"] = "_FLEX"  # Don't replace CMake's built-in
         self.cpp_info.names["cmake_find_package_multi"] = "_FLEX"
         flex_root = self.package_folder
-        self.output.info("Setting FLEX_ROOT environment variable: {}".format(flex_root))
+        self.output.info("Setting FLEX_ROOT environment variable: {flex_root}")
         self.env_info.FLEX_ROOT = flex_root

--- a/recipes/flex/all/conanfile.py
+++ b/recipes/flex/all/conanfile.py
@@ -27,13 +27,9 @@ class FlexConan(ConanFile):
         "fPIC": True,
     }
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+            destination=self.source_folder, strip_root=True)
 
     def requirements(self):
         self.requires("m4/1.4.19")
@@ -80,8 +76,8 @@ class FlexConan(ConanFile):
         autotools.make()
 
     def package(self):
-        self.copy("COPYING", src=self._source_subfolder, dst="licenses")
-        autotools = self._configure_autotools()
+        self.copy("COPYING", src=self.source_folder, dst="licenses")
+        autotools = Autotools(self)
         autotools.install()
         rmdir(self, os.path.join(self.package_folder, "share"))
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))

--- a/recipes/flex/all/test_package/CMakeLists.txt
+++ b/recipes/flex/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(test_package)
+project(test_package LANGUAGES C)
 
 find_package(FLEX REQUIRED)
 

--- a/recipes/flex/all/test_package/CMakeLists.txt
+++ b/recipes/flex/all/test_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(test_package LANGUAGES C)
+project(test_package)
 
 find_package(FLEX REQUIRED)
 

--- a/recipes/flex/all/test_package/CMakeLists.txt
+++ b/recipes/flex/all/test_package/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
-# Find FLEX before `conanbuildinfo.cmake` because that file will let `find_program`
-# look for  executables in host packages (let's hope conan 2.0 fixes this)
-find_package(FLEX REQUIRED)
-
-include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup(TARGETS)
-
 find_package(FLEX REQUIRED)
 
 flex_target(flex_scanner basic_nr.l "${PROJECT_BINARY_DIR}/basic_nr.cpp")

--- a/recipes/flex/all/test_package/CMakeLists.txt
+++ b/recipes/flex/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 project(test_package)
 
 find_package(FLEX REQUIRED)

--- a/recipes/flex/all/test_package/conanfile.py
+++ b/recipes/flex/all/test_package/conanfile.py
@@ -15,7 +15,7 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def build_requirements(self):
-        self.build_requires(self.tested_reference_str)
+        self.tool_requires(self.tested_reference_str)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/flex/all/test_package/conanfile.py
+++ b/recipes/flex/all/test_package/conanfile.py
@@ -19,7 +19,6 @@ class TestPackageConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        # tc.variables["FLEX_ROOT"] = self.deps_cpp_info["flex"].rootpath
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
@@ -46,9 +45,9 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if not cross_building(self, skip_x64_x86=True):
-            bin_path = os.path.join("bin", "test_package")
+            bin_path = os.path.join(self.build_folder, "test_package")
             src = os.path.join(self.source_folder, "basic_nr.txt")
             self.run(f"{bin_path} {src}", run_environment=True)
 
-            test_yywrap = os.path.join("bin", "test_yywrap")
+            test_yywrap = os.path.join(self.build_folder, "test_yywrap")
             self.run(test_yywrap, run_environment=True)

--- a/recipes/flex/all/test_package/conanfile.py
+++ b/recipes/flex/all/test_package/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.env import VirtualBuildEnv
 import os
+import shutil
 
 
 class TestPackageConan(ConanFile):
@@ -31,7 +32,7 @@ class TestPackageConan(ConanFile):
     def build(self):
         if not hasattr(self, "settings_build"):
             # Only test location of flex executable when not cross building
-            flex_bin = tools.which("flex")
+            flex_bin = shutil.which("flex")
             if not flex_bin.startswith(self.deps_cpp_info["flex"].rootpath):
                 raise ConanException("Wrong flex executable captured")
 
@@ -47,7 +48,7 @@ class TestPackageConan(ConanFile):
         if not cross_building(self, skip_x64_x86=True):
             bin_path = os.path.join("bin", "test_package")
             src = os.path.join(self.source_folder, "basic_nr.txt")
-            self.run("{} {}".format(bin_path, src), run_environment=True)
+            self.run(f"{bin_path} {src}", run_environment=True)
 
             test_yywrap = os.path.join("bin", "test_yywrap")
             self.run(test_yywrap, run_environment=True)

--- a/recipes/flex/all/test_v1_package/CMakeLists.txt
+++ b/recipes/flex/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+# Find FLEX before `conanbuildinfo.cmake` because that file will let `find_program`
+# look for  executables in host packages (let's hope conan 2.0 fixes this)
+find_package(FLEX REQUIRED)
+
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup(TARGETS)
+
+find_package(FLEX REQUIRED)
+
+flex_target(flex_scanner basic_nr.l "${PROJECT_BINARY_DIR}/basic_nr.cpp")
+
+add_executable(${PROJECT_NAME} basic_nr.cpp)
+target_include_directories(${PROJECT_NAME} PRIVATE ${FLEX_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${FLEX_LIBRARIES})
+
+add_executable(test_yywrap test_yywrap.c)
+target_link_libraries(test_yywrap PRIVATE ${FLEX_LIBRARIES})

--- a/recipes/flex/all/test_v1_package/basic_nr.l
+++ b/recipes/flex/all/test_v1_package/basic_nr.l
@@ -1,0 +1,89 @@
+/*
+ * This file is part of flex.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of the University nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+
+%option C++ noyywrap
+
+%{
+int mylineno = 0;
+%}
+
+string	\"[^\n"]+\"
+
+ws	[ \t]+
+
+alpha	[A-Za-z]
+dig	[0-9]
+name	({alpha}|{dig}|\$)({alpha}|{dig}|\_|\.|\-|\/|\$)*
+num1	[-+]?{dig}+\.?([eE][-+]?{dig}+)?
+num2	[-+]?{dig}*\.{dig}+([eE][-+]?{dig}+)?
+number	{num1}|{num2}
+
+%%
+
+{ws}	/* skip blanks and tabs */
+
+"/*"		{
+		int c;
+
+		while((c = yyinput()) != 0)
+			{
+			if(c == '\n')
+				++mylineno;
+
+			else if(c == '*')
+				{
+				if((c = yyinput()) == '/')
+					break;
+				else
+					unput(c);
+				}
+			}
+		}
+
+{number}	std::cout << "number " << YYText() << '\n';
+
+\n		mylineno++;
+
+{name}		std::cout << "name " << YYText() << '\n';
+
+{string}	std::cout << "string " << YYText() << '\n';
+
+%%
+
+extern "C" {
+    int yylex() {return 0;}
+}
+
+#include <fstream>
+
+int main( int argc, const char *argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "Need an argument\n");
+        return 1;
+    }
+    std::ifstream ifs(argv[1]);
+	FlexLexer *lexer = new yyFlexLexer(ifs, std::cout);
+	while(lexer->yylex() != 0)
+		;
+	return 0;
+}

--- a/recipes/flex/all/test_v1_package/basic_nr.txt
+++ b/recipes/flex/all/test_v1_package/basic_nr.txt
@@ -1,0 +1,6 @@
+/* this is a multi line comment
+still in the comment
+and done */
+foo = "bar"
+num = 43
+setting = false

--- a/recipes/flex/all/test_v1_package/conanfile.py
+++ b/recipes/flex/all/test_v1_package/conanfile.py
@@ -12,7 +12,7 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str)
 
     def build_requirements(self):
-        self.build_requires(self.tested_reference_str)
+        self.tool_requires(self.tested_reference_str)
 
     def build(self):
         if not hasattr(self, "settings_build"):

--- a/recipes/flex/all/test_v1_package/conanfile.py
+++ b/recipes/flex/all/test_v1_package/conanfile.py
@@ -34,7 +34,7 @@ class TestPackageConan(ConanFile):
         if not tools.cross_building(self, skip_x64_x86=True):
             bin_path = os.path.join("bin", "test_package")
             src = os.path.join(self.source_folder, "basic_nr.txt")
-            self.run("{} {}".format(bin_path, src), run_environment=True)
+            self.run(f"{bin_path} {src}", run_environment=True)
 
             test_yywrap = os.path.join("bin", "test_yywrap")
             self.run(test_yywrap, run_environment=True)

--- a/recipes/flex/all/test_v1_package/conanfile.py
+++ b/recipes/flex/all/test_v1_package/conanfile.py
@@ -1,0 +1,40 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanException
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.build_requires(self.tested_reference_str)
+
+    def build(self):
+        if not hasattr(self, "settings_build"):
+            # Only test location of flex executable when not cross building
+            flex_bin = tools.which("flex")
+            if not flex_bin.startswith(self.deps_cpp_info["flex"].rootpath):
+                raise ConanException("Wrong flex executable captured")
+
+        if not tools.cross_building(self, skip_x64_x86=True) or hasattr(self, "settings_build"):
+            self.run("flex --version", run_environment=not hasattr(self, "settings_build"))
+
+            print(os.environ["PATH"])
+            cmake = CMake(self)
+            cmake.definitions["FLEX_ROOT"] = self.deps_cpp_info["flex"].rootpath
+            cmake.configure()
+            cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self, skip_x64_x86=True):
+            bin_path = os.path.join("bin", "test_package")
+            src = os.path.join(self.source_folder, "basic_nr.txt")
+            self.run("{} {}".format(bin_path, src), run_environment=True)
+
+            test_yywrap = os.path.join("bin", "test_yywrap")
+            self.run(test_yywrap, run_environment=True)

--- a/recipes/flex/all/test_v1_package/test_yywrap.c
+++ b/recipes/flex/all/test_v1_package/test_yywrap.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+int yywrap(void);
+int yylex(void) {
+    return 0;
+}
+
+int main() {
+    printf("yywrap() returned: %d.\n", yywrap());
+}


### PR DESCRIPTION
Specify library name and version:  **flex/2.4.1**

Add v2 support to flex.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
