### PR TITLE
[docs] Remove sha256 for patches in conandata.yml

### DIFF
--- a/docs/conandata_yml_format.md
+++ b/docs/conandata_yml_format.md
@@ -138,7 +138,6 @@ patches:
       patch_description: "Link CoreFoundation and CoreServices with find_library"
       patch_type: "portability"
       patch_source: "https://a-url-to-a-pull-request-mail-list-topic-issue-or-question"
-      sha256: "qafe4rq54533qa43esdaq53ewqa5"
 ```
 
 ### Patches fields
@@ -233,9 +232,3 @@ For the `patch_type: conan`, it doesn't make sense to submit patch upstream, so 
 _Optional_
 
 Specifies a sub-directory in project's sources to apply patch. This directory is relative to the [source_folder](https://docs.conan.io/en/latest/reference/conanfile/attributes.html?highlight=source_folder#source-folder). Usually, it would be a `source_subfolder`, but could be a lower-level sub-directory (e.g. if it's a patch for a submodule).
-
-#### sha256
-
-_Optional_
-
-This is the hash for the patch itself, in the same way this field is used in the `sources` section.


### PR DESCRIPTION
Related to https://github.com/conan-io/conan/issues/12455#issuecomment-1301954685

- patches are local copied, do not need to download and validate
- there is no intention to validate by apply_conandata_patches

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
