### PR TITLE
Update cppcommon to 1.0.3.0

### DIFF
--- a/recipes/cppcommon/all/conandata.yml
+++ b/recipes/cppcommon/all/conandata.yml
@@ -11,6 +11,9 @@ sources:
   "1.0.2.0":
     url: "https://github.com/chronoxor/CppCommon/archive/1.0.2.0.tar.gz"
     sha256: "1a748159ab5d0eb74a6c7b110606718caa779cdf17b3e91bf0dbd0e297823dec"
+  "1.0.3.0":
+    url: "https://github.com/chronoxor/CppCommon/archive/1.0.3.0.tar.gz"
+    sha256: "af530d3550a050d4ed73a680b016e043ea6f4f56e11163226f2a6e24d9eae4ca"
 
 patches:
   "1.0.0.0":
@@ -30,6 +33,11 @@ patches:
       base_path: "source_subfolder"
   "1.0.2.0":
     - patch_file: "patches/0001-update-cmakelists-1-0-1-0.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0003-define-win32-winnt-1-0-1-0.patch"
+      base_path: "source_subfolder"
+  "1.0.3.0":
+    - patch_file: "patches/0001-update-cmakelists-1-0-3-0.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0003-define-win32-winnt-1-0-1-0.patch"
       base_path: "source_subfolder"

--- a/recipes/cppcommon/all/patches/0001-update-cmakelists-1-0-3-0.patch
+++ b/recipes/cppcommon/all/patches/0001-update-cmakelists-1-0-3-0.patch
@@ -2,6 +2,12 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index aa5447a8..10a0065b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.20)
++cmake_minimum_required(VERSION 3.18.2)
+ 
+ # Global properties
+ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 @@ -17,49 +17,36 @@ if(DOXYGEN_FOUND)
    endif()
  endif()

--- a/recipes/cppcommon/all/patches/0001-update-cmakelists-1-0-3-0.patch
+++ b/recipes/cppcommon/all/patches/0001-update-cmakelists-1-0-3-0.patch
@@ -1,0 +1,127 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index aa5447a8..10a0065b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -17,49 +17,36 @@ if(DOXYGEN_FOUND)
+   endif()
+ endif()
+ 
+-# CMake module path
+-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+-
+-# Compiler features
+-include(SetCompilerFeatures)
+-include(SetCompilerWarnings)
+-include(SetPlatformFeatures)
+-include(SystemInformation)
+-
+ # External packages
+ find_package(Threads REQUIRED)
+ if(UNIX AND NOT APPLE AND NOT MSYS)
+   find_package(LibBFD)
+   find_package(LibDL)
+   find_package(LibRT)
+-  find_package(LibUUID)
++  find_package(libuuid)
+ endif()
+ if(WIN32 OR MSYS)
+   find_package(DbgHelp)
+   find_package(RPC)
+-  find_package(Userenv)
+ endif()
+ 
+-# Modules
+-add_subdirectory("modules")
+-
+ # Link libraries
+ list(APPEND LINKLIBS Threads::Threads)
+ if(UNIX AND NOT APPLE AND NOT MSYS)
+   list(APPEND LINKLIBS ${LIBBFD_LIBRARIES})
+   list(APPEND LINKLIBS ${LIBDL_LIBRARIES})
+   list(APPEND LINKLIBS ${LIBRT_LIBRARIES})
+-  list(APPEND LINKLIBS ${LIBUUID_LIBRARIES})
++  list(APPEND LINKLIBS CONAN_PKG::libuuid)
+ endif()
+ if(WIN32 OR MSYS)
+   list(APPEND LINKLIBS ${DBGHELP_LIBRARIES})
+   list(APPEND LINKLIBS ${RPC_LIBRARIES})
+-  list(APPEND LINKLIBS ${USERENV_LIBRARIES})
++  list(APPEND LINKLIBS userenv)
++  list(APPEND LINKLIBS rpcrt4)
+   list(APPEND LINKLIBS ${VLD_LIBRARIES})
+ endif()
+ 
+ # System directories
+-include_directories(SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/modules")
+ include_directories(SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/plugins")
+ 
+ # Library
+@@ -68,8 +55,9 @@ file(GLOB_RECURSE LIB_INLINE_FILES "include/*.inl" "source/*.inl")
+ file(GLOB_RECURSE LIB_SOURCE_FILES "include/*.cpp" "source/*.cpp")
+ add_library(cppcommon ${LIB_HEADER_FILES} ${LIB_INLINE_FILES} ${LIB_SOURCE_FILES})
+ set_target_properties(cppcommon PROPERTIES COMPILE_FLAGS "${PEDANTIC_COMPILE_FLAGS}" FOLDER "libraries")
+-target_include_directories(cppcommon PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" PUBLIC ${vld})
+-target_link_libraries(cppcommon ${LINKLIBS} fmt)
++target_include_directories(cppcommon PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
++target_compile_features(cppcommon PUBLIC cxx_std_17)
++target_link_libraries(cppcommon PUBLIC ${LINKLIBS} CONAN_PKG::fmt)
+ list(APPEND INSTALL_TARGETS cppcommon)
+ list(APPEND LINKLIBS cppcommon)
+ 
+@@ -92,6 +80,7 @@ if(NOT CPPCOMMON_MODULE)
+   endforeach()
+ 
+   # Examples
++  if(FALSE)
+   file(GLOB EXAMPLE_HEADER_FILES "examples/*.h")
+   file(GLOB EXAMPLE_INLINE_FILES "examples/*.inl")
+   file(GLOB EXAMPLE_SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/examples" "examples/*.cpp")
+@@ -105,8 +94,10 @@ if(NOT CPPCOMMON_MODULE)
+     list(APPEND INSTALL_TARGETS ${EXAMPLE_TARGET})
+     list(APPEND INSTALL_TARGETS_PDB ${EXAMPLE_TARGET})
+   endforeach()
++  endif()
+ 
+   # Benchmarks
++  if(FALSE)
+   file(GLOB BENCHMARK_HEADER_FILES "performance/*.h")
+   file(GLOB BENCHMARK_INLINE_FILES "performance/*.inl")
+   file(GLOB BENCHMARK_SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/performance" "performance/*.cpp")
+@@ -120,8 +111,10 @@ if(NOT CPPCOMMON_MODULE)
+     list(APPEND INSTALL_TARGETS ${BENCHMARK_TARGET})
+     list(APPEND INSTALL_TARGETS_PDB ${BENCHMARK_TARGET})
+   endforeach()
++  endif()
+ 
+   # Tests
++  if(FALSE)
+   file(GLOB TESTS_HEADER_FILES "tests/*.h")
+   file(GLOB TESTS_INLINE_FILES "tests/*.inl")
+   file(GLOB TESTS_SOURCE_FILES "tests/*.cpp")
+@@ -132,19 +125,22 @@ if(NOT CPPCOMMON_MODULE)
+   target_link_libraries(cppcommon-tests ${LINKLIBS})
+   list(APPEND INSTALL_TARGETS cppcommon-tests)
+   list(APPEND INSTALL_TARGETS_PDB cppcommon-tests)
++  endif()
+ 
+   # CTest
++  if(FALSE)
+   enable_testing()
+   add_test(cppcommon-tests cppcommon-tests --durations yes --order lex)
++  endif()
+ 
+   # Install
+   install(TARGETS ${INSTALL_TARGETS}
+-    RUNTIME DESTINATION "${PROJECT_SOURCE_DIR}/bin"
+-    LIBRARY DESTINATION "${PROJECT_SOURCE_DIR}/bin"
+-    ARCHIVE DESTINATION "${PROJECT_SOURCE_DIR}/bin")
++    RUNTIME DESTINATION bin
++    LIBRARY DESTINATION lib
++    ARCHIVE DESTINATION lib)
+ 
+   # Install *.pdb files
+-  if(MSVC)
++  if(FALSE)
+     foreach(INSTALL_TARGET_PDB ${INSTALL_TARGETS_PDB})
+       install(FILES $<TARGET_PDB_FILE:${INSTALL_TARGET_PDB}> DESTINATION "${PROJECT_SOURCE_DIR}/bin")
+     endforeach()

--- a/recipes/cppcommon/config.yml
+++ b/recipes/cppcommon/config.yml
@@ -7,3 +7,5 @@ versions:
     folder: all
   "1.0.2.0":
     folder: all
+  "1.0.3.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  cppcommon/1.0.3.0

Reason : dependency to cpplogging library

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
