### PR TITLE
Add package cpplogging

### DIFF
--- a/recipes/cpplogging/all/CMakeLists.txt
+++ b/recipes/cpplogging/all/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.4)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+add_subdirectory(source_subfolder)

--- a/recipes/cpplogging/all/conandata.yml
+++ b/recipes/cpplogging/all/conandata.yml
@@ -1,0 +1,30 @@
+sources:
+  "1.0.0.0":
+    url: "https://github.com/chronoxor/CppLogging/archive/refs/tags/1.0.0.0.tar.gz"
+    sha256: "c19843a7e6cbe828f8ceb01a3e2289f0e12ac528762e91175051f762325217ea"
+  "1.0.1.0":
+    url: "https://github.com/chronoxor/CppLogging/archive/refs/tags/1.0.1.0.tar.gz"
+    sha256: "46247873f8137ff1511222a85f34a8d54d5f804a93e3f04c6476bf61d8db7113"
+  "1.0.3.0":
+    url: "https://github.com/chronoxor/CppLogging/archive/refs/tags/1.0.3.0.tar.gz"
+    sha256: "5aceac3951430535e542ab7ffb42eb32f90c52b1d16130ae3f8bb56074aca589"
+patches:
+  "1.0.0.0":
+    - patch_file: "patches/0001-cmake-clean-up-1-0-0-0.patch"
+      base_path: "source_subfolder"
+  "1.0.1.0":
+    - patch_file: "patches/0001-cmake-clean-up-1-0-0-0.patch"
+      base_path: "source_subfolder"
+  "1.0.3.0":
+    - patch_file: "patches/0001-cmake-clean-up-1-0-0-0.patch"
+      base_path: "source_subfolder"
+requirements:
+  "1.0.0.0":
+    - zlib/1.2.13
+    - cppcommon/1.0.2.0
+  "1.0.1.0":
+    - zlib/1.2.13
+    - cppcommon/1.0.2.0
+  "1.0.3.0":
+    - zlib/1.2.13
+    - cppcommon/1.0.3.0

--- a/recipes/cpplogging/all/conandata.yml
+++ b/recipes/cpplogging/all/conandata.yml
@@ -18,13 +18,3 @@ patches:
   "1.0.3.0":
     - patch_file: "patches/0001-cmake-clean-up-1-0-0-0.patch"
       base_path: "source_subfolder"
-requirements:
-  "1.0.0.0":
-    - zlib/1.2.13
-    - cppcommon/1.0.2.0
-  "1.0.1.0":
-    - zlib/1.2.13
-    - cppcommon/1.0.2.0
-  "1.0.3.0":
-    - zlib/1.2.13
-    - cppcommon/1.0.3.0

--- a/recipes/cpplogging/all/conandata.yml
+++ b/recipes/cpplogging/all/conandata.yml
@@ -16,5 +16,5 @@ patches:
     - patch_file: "patches/0001-cmake-clean-up-1-0-0-0.patch"
       base_path: "source_subfolder"
   "1.0.3.0":
-    - patch_file: "patches/0001-cmake-clean-up-1-0-0-0.patch"
+    - patch_file: "patches/0001-cmake-clean-up-1-0-3-0.patch"
       base_path: "source_subfolder"

--- a/recipes/cpplogging/all/conanfile.py
+++ b/recipes/cpplogging/all/conanfile.py
@@ -61,6 +61,7 @@ class CpploggingConan(ConanFile):
         if self.options.shared:
             del self.options.fPIC
 
+    def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             build.check_min_cppstd(self, "17")
 

--- a/recipes/cpplogging/all/conanfile.py
+++ b/recipes/cpplogging/all/conanfile.py
@@ -51,8 +51,11 @@ class CpploggingConan(ConanFile):
         }
 
     def requirements(self):
-        for req in self.conan_data["requirements"][self.version]:
-            self.requires(req)
+        self.requires("zlib/1.2.13")
+        if self.version < "1.0.3.0" :
+            self.requires("cppcommon/1.0.2.0")
+        else:
+            self.requires("cppcommon/1.0.3.0")
 
     def configure(self):
         if self.options.shared:

--- a/recipes/cpplogging/all/conanfile.py
+++ b/recipes/cpplogging/all/conanfile.py
@@ -1,0 +1,95 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+import glob
+
+
+class CpploggingConan(ConanFile):
+    name = "cpplogging"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/chronoxor/CppLogging"
+    description = "C++ Logging Library provides functionality to log different events with a high" \
+        " throughput in multithreaded environment into different sinks (console, files, rolling files," \
+        " syslog, etc.). Logging configuration is very flexible and gives functionality to build flexible"\
+        " logger hierarchy with combination of logging processors (sync, async), filters, layouts (binary,"\
+        " hash, text) and appenders."
+    topics = ("performance", "logging", "speed", "logging-library", "low-latency")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"fPIC": [True, False],
+               "shared": [True, False]}
+    default_options = {"fPIC": True,
+                       "shared": False}
+    generators = "cmake", "cmake_find_package"
+    exports_sources = ["patches/**", "CMakeLists.txt"]
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def _configure_cmake(self):
+        if not self._cmake:
+            self._cmake = CMake(self)
+            self._cmake.definitions["CPPLOGGING_MODULE"] = "OFF"
+            self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "9",
+            "Visual Studio": "15",
+            "clang": "5",
+            "apple-clang": "10",
+        }
+
+    def requirements(self):
+        for req in self.conan_data["requirements"][self.version]:
+            self.requires(req)
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, "17")
+
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+
+        if not minimum_version:
+            self.output.warn("cpplogging requires C++17. Your compiler is unknown. Assuming it supports C++17.")
+        elif tools.Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration("cpplogging requires a compiler that supports at least C++17")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = glob.glob("CppLogging-*")[0]
+        os.rename(extracted_dir, self._source_subfolder)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="*.h", dst="include", src=os.path.join(self._source_subfolder, "include"))
+        self.copy(pattern="*.inl", dst="include", src=os.path.join(self._source_subfolder, "include"))
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["ws2_32", "crypt32", "mswsock"]

--- a/recipes/cpplogging/all/patches/0001-cmake-clean-up-1-0-0-0.patch
+++ b/recipes/cpplogging/all/patches/0001-cmake-clean-up-1-0-0-0.patch
@@ -1,6 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 --- a/CMakeLists.txt	2021-12-19 20:42:05.000000000 +0100
 +++ b/CMakeLists.txt	2022-11-02 16:17:59.870658464 +0100
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.20)
++cmake_minimum_required(VERSION 3.18.2)
+ 
+ # Global properties
+ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 @@ -17,20 +17,8 @@
    endif()
  endif()

--- a/recipes/cpplogging/all/patches/0001-cmake-clean-up-1-0-0-0.patch
+++ b/recipes/cpplogging/all/patches/0001-cmake-clean-up-1-0-0-0.patch
@@ -1,0 +1,103 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2021-12-19 20:42:05.000000000 +0100
++++ b/CMakeLists.txt	2022-11-02 16:17:59.870658464 +0100
+@@ -17,20 +17,8 @@
+   endif()
+ endif()
+ 
+-# CMake module path
+-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+-
+-# Compiler features
+-include(SetCompilerFeatures)
+-include(SetCompilerWarnings)
+-include(SetPlatformFeatures)
+-include(SystemInformation)
+-
+-# Modules
+-add_subdirectory("modules")
+-
+ # Link libraries
+-list(APPEND LINKLIBS cppcommon)
++list(APPEND LINKLIBS CONAN_PKG::cppcommon)
+ 
+ # Support zlib/contrib/minizip
+ file(GLOB_RECURSE MINIZIP_FILES "source/logging/appenders/minizip/*.c")
+@@ -60,14 +48,16 @@
+   target_compile_definitions(cpplogging PRIVATE USE_FILE32API=1)
+ endif()
+ target_include_directories(cpplogging PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+-target_link_libraries(cpplogging ${LINKLIBS} zlib)
++target_link_libraries(cpplogging ${LINKLIBS} CONAN_PKG::zlib)
+ list(APPEND INSTALL_TARGETS cpplogging)
+ list(APPEND LINKLIBS cpplogging)
++target_compile_features(cpplogging PRIVATE cxx_std_17)
+ 
+ # Additional module components: benchmarks, examples, plugins, tests, tools and install
+ if(NOT CPPLOGGING_MODULE)
+ 
+   # Examples
++  if(FALSE)
+   file(GLOB EXAMPLE_HEADER_FILES "examples/*.h")
+   file(GLOB EXAMPLE_INLINE_FILES "examples/*.inl")
+   file(GLOB EXAMPLE_SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/examples" "examples/*.cpp")
+@@ -80,8 +70,10 @@
+     list(APPEND INSTALL_TARGETS ${EXAMPLE_TARGET})
+     list(APPEND INSTALL_TARGETS_PDB ${EXAMPLE_TARGET})
+   endforeach()
++  endif()
+ 
+   # Benchmarks
++  if(FALSE)
+   file(GLOB BENCHMARK_HEADER_FILES "performance/*.h")
+   file(GLOB BENCHMARK_INLINE_FILES "performance/*.inl")
+   file(GLOB BENCHMARK_SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/performance" "performance/*.cpp")
+@@ -94,8 +86,10 @@
+     list(APPEND INSTALL_TARGETS ${BENCHMARK_TARGET})
+     list(APPEND INSTALL_TARGETS_PDB ${BENCHMARK_TARGET})
+   endforeach()
++  endif()
+ 
+   # Tools
++  if(FALSE)
+   file(GLOB TOOLS_DIRS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/tools" "tools/*")
+   foreach(TOOLS_DIR ${TOOLS_DIRS})
+     file(GLOB_RECURSE TOOLS_HEADER_FILES "tools/${TOOLS_DIR}/*.h")
+@@ -108,8 +102,10 @@
+     list(APPEND INSTALL_TARGETS ${TOOL_TARGET})
+     list(APPEND INSTALL_TARGETS_PDB ${TOOL_TARGET})
+   endforeach()
++  endif()
+ 
+   # Tests
++  if(FALSE)
+   file(GLOB TESTS_HEADER_FILES "tests/*.h")
+   file(GLOB TESTS_INLINE_FILES "tests/*.inl")
+   file(GLOB TESTS_SOURCE_FILES "tests/*.cpp")
+@@ -119,19 +115,22 @@
+   target_link_libraries(cpplogging-tests ${LINKLIBS})
+   list(APPEND INSTALL_TARGETS cpplogging-tests)
+   list(APPEND INSTALL_TARGETS_PDB cpplogging-tests)
++  endif()
+ 
+   # CTest
++  if(FALSE)
+   enable_testing()
+   add_test(cpplogging-tests cpplogging-tests --durations yes --order lex)
++  endif()
+ 
+   # Install
+   install(TARGETS ${INSTALL_TARGETS}
+-    RUNTIME DESTINATION "${PROJECT_SOURCE_DIR}/bin"
+-    LIBRARY DESTINATION "${PROJECT_SOURCE_DIR}/bin"
+-    ARCHIVE DESTINATION "${PROJECT_SOURCE_DIR}/bin")
++          RUNTIME DESTINATION bin
++          LIBRARY DESTINATION lib
++          ARCHIVE DESTINATION lib)
+ 
+   # Install *.pdb files
+-  if(MSVC)
++  if(FALSE)
+     foreach(INSTALL_TARGET_PDB ${INSTALL_TARGETS_PDB})
+       install(FILES $<TARGET_PDB_FILE:${INSTALL_TARGET_PDB}> DESTINATION "${PROJECT_SOURCE_DIR}/bin")
+     endforeach()

--- a/recipes/cpplogging/all/patches/0001-cmake-clean-up-1-0-3-0.patch
+++ b/recipes/cpplogging/all/patches/0001-cmake-clean-up-1-0-3-0.patch
@@ -1,6 +1,12 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 --- a/CMakeLists.txt	2021-12-19 20:42:05.000000000 +0100
 +++ b/CMakeLists.txt	2022-11-02 16:17:59.870658464 +0100
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.20)
++cmake_minimum_required(VERSION 3.18.2)
+ 
+ # Global properties
+ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 @@ -17,20 +17,8 @@
    endif()
  endif()

--- a/recipes/cpplogging/all/test_package/CMakeLists.txt
+++ b/recipes/cpplogging/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest CXX)
+
+find_package(cpplogging CONFIG REQUIRED)
+
+add_executable(console src/console.cpp)
+target_link_libraries(console cpplogging::cpplogging)
+
+target_compile_features(console PRIVATE cxx_std_17)

--- a/recipes/cpplogging/all/test_package/conanfile.py
+++ b/recipes/cpplogging/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import cross_building
+
+
+class CpploggingTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    # VirtualBuildEnv and VirtualRunEnv can be avoided if "tools.env.virtualenv:auto_use" is defined
+    # (it will be defined in Conan 2.0)
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv"
+    apply_env = False
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if not cross_building(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "console")
+            self.run(cmd, env="conanrun")

--- a/recipes/cpplogging/all/test_package/src/console.cpp
+++ b/recipes/cpplogging/all/test_package/src/console.cpp
@@ -1,0 +1,42 @@
+/*!
+    \file console.cpp
+    \brief Console logger example
+    \author Ivan Shynkarenka
+    \date 29.07.2016
+    \copyright MIT License
+*/
+
+#include "logging/config.h"
+#include "logging/logger.h"
+
+void ConfigureLogger()
+{
+    // Create default logging sink processor with a text layout
+    auto sink = std::make_shared<CppLogging::Processor>(std::make_shared<CppLogging::TextLayout>());
+    // Add console appender
+    sink->appenders().push_back(std::make_shared<CppLogging::ConsoleAppender>());
+
+    // Configure default logger
+    CppLogging::Config::ConfigLogger(sink);
+
+    // Startup the logging infrastructure
+    CppLogging::Config::Startup();
+}
+
+int main(int argc, char** argv)
+{
+    // Configure logger
+    ConfigureLogger();
+
+    // Create default logger
+    CppLogging::Logger logger;
+
+    // Log some messages with different level
+    logger.Debug("Debug message");
+    logger.Info("Info message");
+    logger.Warn("Warning message");
+    logger.Error("Error message");
+    logger.Fatal("Fatal message");
+
+    return 0;
+}

--- a/recipes/cpplogging/all/test_v1_package/CMakeLists.txt
+++ b/recipes/cpplogging/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest CXX)
+
+find_package(cpplogging CONFIG REQUIRED)
+
+add_executable(console src/console.cpp)
+target_link_libraries(console cpplogging::cpplogging)
+
+target_compile_features(console PRIVATE cxx_std_17)

--- a/recipes/cpplogging/all/test_v1_package/conanfile.py
+++ b/recipes/cpplogging/all/test_v1_package/conanfile.py
@@ -1,0 +1,30 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import cross_building
+
+
+class CpploggingTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    # VirtualBuildEnv and VirtualRunEnv can be avoided if "tools.env.virtualenv:auto_use" is defined
+    # (it will be defined in Conan 2.0)
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv", "VirtualRunEnv"
+    apply_env = False
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if not cross_building(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "console")
+            self.run(cmd, env="conanrun")

--- a/recipes/cpplogging/all/test_v1_package/src/console.cpp
+++ b/recipes/cpplogging/all/test_v1_package/src/console.cpp
@@ -1,0 +1,42 @@
+/*!
+    \file console.cpp
+    \brief Console logger example
+    \author Ivan Shynkarenka
+    \date 29.07.2016
+    \copyright MIT License
+*/
+
+#include "logging/config.h"
+#include "logging/logger.h"
+
+void ConfigureLogger()
+{
+    // Create default logging sink processor with a text layout
+    auto sink = std::make_shared<CppLogging::Processor>(std::make_shared<CppLogging::TextLayout>());
+    // Add console appender
+    sink->appenders().push_back(std::make_shared<CppLogging::ConsoleAppender>());
+
+    // Configure default logger
+    CppLogging::Config::ConfigLogger(sink);
+
+    // Startup the logging infrastructure
+    CppLogging::Config::Startup();
+}
+
+int main(int argc, char** argv)
+{
+    // Configure logger
+    ConfigureLogger();
+
+    // Create default logger
+    CppLogging::Logger logger;
+
+    // Log some messages with different level
+    logger.Debug("Debug message");
+    logger.Info("Info message");
+    logger.Warn("Warning message");
+    logger.Error("Error message");
+    logger.Fatal("Fatal message");
+
+    return 0;
+}

--- a/recipes/cpplogging/config.yml
+++ b/recipes/cpplogging/config.yml
@@ -1,0 +1,7 @@
+versions:
+  "1.0.0.0":
+    folder: all
+  "1.0.1.0":
+    folder: all
+  "1.0.3.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  cpplogging/1.0.3.0
requires cppcommon/1.0.3.0
the previous versions (cpplogging/1.0.0.0 and cpplogging/1.0.1.0) require cppcommon/1.0.2.0
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
