### PR TITLE
daw_json_link: add version 3.4.1

### DIFF
--- a/recipes/daw_json_link/all/conandata.yml
+++ b/recipes/daw_json_link/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.4.1":
+    url: "https://github.com/beached/daw_json_link/archive/v3.4.1.tar.gz"
+    sha256: "3f57ccc936a9999b5c8c5684b2b3b8b989f50ef6e1ea8dce7bc311d1c77195ac"
   "3.3.0":
     url: "https://github.com/beached/daw_json_link/archive/v3.3.0.tar.gz"
     sha256: "fd806245fc8b944e613b29da5ef0570c0e6881b6049a7bf65eb0285c58848f40"

--- a/recipes/daw_json_link/config.yml
+++ b/recipes/daw_json_link/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.4.1":
+    folder: "all"
   "3.3.0":
     folder: "all"
   "3.1.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **daw_json_link/3.4.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
