### PR TITLE
Fixed psyinf-gmtl cmake setup

### DIFF
--- a/recipes/psyinf-gmtl/all/conandata.yml
+++ b/recipes/psyinf-gmtl/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.7.1":
     url: "https://github.com/psyinf/gmtl/archive/refs/tags/0.7.1.tar.gz"
-    sha256: "64e36b8c41b1829933921cd5a2f2825111840010b6d0e3aaa82c023c8fd7ebd5"
+    sha256: "02ec5f203f44c253f7d0e6216aa66d2573f82bba79672fe682fc7e0412b6af45"

--- a/recipes/psyinf-gmtl/all/conandata.yml
+++ b/recipes/psyinf-gmtl/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.7.1":
     url: "https://github.com/psyinf/gmtl/archive/refs/tags/0.7.1.tar.gz"
-    sha256: "02ec5f203f44c253f7d0e6216aa66d2573f82bba79672fe682fc7e0412b6af45"
+    sha256: "e7fbc98d8714251655c1f2ab60d35500ca6c1c57e4887419c99ffb4a49fc5030"

--- a/recipes/psyinf-gmtl/all/conanfile.py
+++ b/recipes/psyinf-gmtl/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.layout import basic_layout
 import os
 
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.50.0"
 
 
 class PackageConan(ConanFile):
@@ -39,8 +39,11 @@ class PackageConan(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+        self.cpp_info.names["cmake_find_package"] = "gmtl"
+        self.cpp_info.names["cmake_find_package_multi"] = "gmtl"
+        
         self.cpp_info.set_property("cmake_file_name", "gmtl")
-        self.cpp_info.set_property("cmake_target_name", "gmtl")
+        self.cpp_info.set_property("cmake_target_name", "gmtl::gmtl")
         self.cpp_info.set_property("pkg_config_name", "gmtl")
 
   

--- a/recipes/psyinf-gmtl/all/test_package/CMakeLists.txt
+++ b/recipes/psyinf-gmtl/all/test_package/CMakeLists.txt
@@ -5,4 +5,4 @@ project(test_package CXX)
 find_package(gmtl REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE gmtl)
+target_link_libraries(${PROJECT_NAME} PRIVATE gmtl::gmtl)

--- a/recipes/psyinf-gmtl/all/test_v1_package/CMakeLists.txt
+++ b/recipes/psyinf-gmtl/all/test_v1_package/CMakeLists.txt
@@ -5,7 +5,7 @@ project(test_package CXX)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(psyinf-gmtl REQUIRED CONFIG)
+find_package(gmtl REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE psyinf-gmtl::psyinf-gmtl)
+target_link_libraries(${PROJECT_NAME} PRIVATE gmtl::gmtl)


### PR DESCRIPTION
Updated cmake settings to allow for drop-in replacement use of the library 