### PR TITLE
meson: add version 0.64.0

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.64.0":
+    url: "https://github.com/mesonbuild/meson/archive/0.64.0.tar.gz"
+    sha256: "6477993d781b6efea93091616a6d6a0766c0e026076dbeb11249bf1c9b49a347"
   "0.63.3":
     url: "https://github.com/mesonbuild/meson/archive/0.63.3.tar.gz"
     sha256: "7c516c2099b762203e8a0a22412aa465b7396e6f9b1ab728bad6e6db44dc2659"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.64.0":
+    folder: all
   "0.63.3":
     folder: all
   "0.63.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **meson/0.64.0**

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
