### PR TITLE
utfcpp: add version 3.2.2

### DIFF
--- a/recipes/utfcpp/all/conandata.yml
+++ b/recipes/utfcpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.2.2":
+    url: "https://github.com/nemtrif/utfcpp/archive/v3.2.2.tar.gz"
+    sha256: "6f81e7cb2be2a6a9109a8a0cb7dc39ec947f1bcdb5dfa4a660e11a23face19f5"
   "3.2.1":
     url: "https://github.com/nemtrif/utfcpp/archive/refs/tags/v3.2.1.tar.gz"
     sha256: "8d6aa7d77ad0abb35bb6139cb9a33597ac4c5b33da6a004ae42429b8598c9605"

--- a/recipes/utfcpp/config.yml
+++ b/recipes/utfcpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.2.2":
+    folder: all
   "3.2.1":
     folder: all
   "3.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **utfcpp/3.2.2**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
