### PR TITLE
docs: rename patch field "backport" to "bugfix" to avoid confusion

### DIFF
--- a/docs/conandata_yml_format.md
+++ b/docs/conandata_yml_format.md
@@ -171,33 +171,16 @@ The `patch_type` field specifies the type of the patch. In ConanCenterIndex we c
 
 ##### official
 
-`patch_type: official` indicates the patch is distributed with source code itself. usually, this happens if release managers failed to include a critical fix to the release, but it's too much burden for them to make a new release just because of that single fix.
-[example](https://www.boost.org/users/history/version_1_72_0.html) (notice the `coroutine` patch)
+`patch_type: official` indicates the patch is distributed with source code itself. usually, this happens if release managers
+failed to include a critical fix to the release, but it's too much burden for them to make a new release just because of that single fix.
+[example](https://www.boost.org/users/history/version_1_72_0.html) (notice the `coroutine` patch). The [`patch_source`](#patch_source)
+field shall point to the official distribution of the patch.
 
 ##### vulnerability
 
-`patch_type: vulnerability`: Indicates a patch that addresses the security issue. The patch description
-should include the index of CVE or CWE the patch addresses.
-Usually, original library projects do new releases fixing vulnerabilities for this kind of issues, but in some cases they are either abandoned or inactive.
-
-##### backport
-
-> **Note**: These are likely to undergo extra scrutiny during review as they may modify the source code.
-
-`patch_type: backport`: Indicates a patch that backports an existing bug fix from the newer release or master branch (or equivalent, such as main/develop/trunk/etc). The [`patch_source`](#patch_source) may be a pull request, or bug within the project's issue tracker.
-Backports are accepted only for bugs that break normal execution flow, never for feature requests.
-Usually, the following kind of problems are good candidates for backports:
-
-* Program doesn't start at all.
-* Crash (segmentation fault or access violation).
-* Hang up or deadlock.
-* Memory leak or resource leak in general.
-* Garbage output.
-* Abnormal termination without a crash (e.g. just exit code 1 at very beginning of the execution).
-* Data corruption.
-* Use of outdated or deprecated API or library.
-
-As sources with backports don't act exactly the same as the version officially released, it may be a source of confusion for the consumers who are relying on the buggy behavior (even if it's completely wrong). Therefore, it's required to introduce a new `cci.<YYYYMMDD>` version for such backports, so consumers may choose to use either official version, or modified version with backport(s) included.
+`patch_type: vulnerability`: Indicates a patch that addresses the security issue. The patch description should include the index of CVE
+or CWE the patch addresses. Usually, original library projects do new releases fixing vulnerabilities for this kind of issues, but in some
+cases they are either abandoned or inactive. The [`patch_source`](#patch_source) must be a commit to the official fix of the vulnerability.
 
 ##### portability
 
@@ -211,6 +194,25 @@ Some projects simply do not accept patches for platforms they don't have a build
 `patch_type: conan`: Indicates a patch that is Conan-specific, patches of such kind are usually not welcomed upstream at all, because they provide zero value outside of Conan.
 Examples of such a patches may include modifications of build system files to allow dependencies provided by Conan instead of dependencies provided by projects themselves (e.g. as submodule or just 3rd-party sub-directory) or by the system package manager (rpm/deb).
 Such patches may contain variables and targets generated only by Conan, but not generated normally by the build system (e.g. `CONAN_INCLUDE_DIRS`).
+
+##### bugfix
+
+> **Warning**: These will undergo extra scrutiny during review as they may modify the source code.
+
+`patch_type: bugfix`: Indicates a patch that backports an existing bug fix from the newer release or master branch (or equivalent, such as main/develop/trunk/etc). The [`patch_source`](#patch_source) may be a pull request, or bug within the project's issue tracker.
+Backports are accepted only for bugs that break normal execution flow, never for feature requests.
+Usually, the following kind of problems are good candidates for backports:
+
+* Program doesn't start at all.
+* Crash (segmentation fault or access violation).
+* Hang up or deadlock.
+* Memory leak or resource leak in general.
+* Garbage output.
+* Abnormal termination without a crash (e.g. just exit code 1 at very beginning of the execution).
+* Data corruption.
+* Use of outdated or deprecated API or library.
+
+As sources with backports don't act exactly the same as the version officially released, it may be a source of confusion for the consumers who are relying on the buggy behavior (even if it's completely wrong). Therefore, it's required to introduce a new `cci.<YYYYMMDD>` version for such backports, so consumers may choose to use either official version, or modified version with backport(s) included.
 
 #### patch_source
 

--- a/linter/conandata_yaml_linter.py
+++ b/linter/conandata_yaml_linter.py
@@ -57,7 +57,7 @@ def main():
                 for i, patch in enumerate(patches):
                     type = parsed["patches"][version][i]["patch_type"]
                     if (
-                        type in ["official", "backport", "vulnerability"]
+                        type in ["official", "bugfix", "vulnerability"]
                         and not "patch_source" in patch
                     ):
                         print(


### PR DESCRIPTION
Docs! Config!

The description of this field does not match the normative convention of who it could be used to mean "this came from the project" and not the "this changes source code" which is the written definition here.

This should hopefully reduce the incorrect usage and encourage contributors to pick more descriptive options and fill in the `patch_source` that we offer instead.

