### PR TITLE
cccl: migrate to Conan v2 and add v1.3

### DIFF
--- a/recipes/cccl/all/conandata.yml
+++ b/recipes/cccl/all/conandata.yml
@@ -3,5 +3,5 @@ sources:
     url: https://github.com/swig/cccl/archive/cccl-1.1.tar.gz
     sha256: 03ed67d04e8b1e165b8f8d42546ab62ff6c42b3623a2358a7c8255ced144ce28
   "1.3":
-    url: https://github.com/swig/cccl/archive/6076c51b00f0f95571ed9e7379f1a2c7b6f7b1f2.tar.gz
-    sha256: 1D7F2C1C30822E3CA95A3A21BC2C5C92BE5C8A313971C5A06786690A579AB73A
+    url: https://github.com/swig/cccl/archive/cccl-1.3.tar.gz
+    sha256: 1E34E315CE3AB890D39A75FFABAACCE2E55FE5ED21591F036A45AFDA43A3E989

--- a/recipes/cccl/all/conandata.yml
+++ b/recipes/cccl/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "1.1":
     url: https://github.com/swig/cccl/archive/cccl-1.1.tar.gz
     sha256: 03ed67d04e8b1e165b8f8d42546ab62ff6c42b3623a2358a7c8255ced144ce28
-  "1.2":
-    url: https://github.com/swig/cccl/archive/cccl-1.2.tar.gz
-    sha256: 1936206FAAACA61C4FFA062DF1D760775B89A82FDF222EF3D4A24C604A64B036
   "1.3":
     url: https://github.com/swig/cccl/archive/6076c51b00f0f95571ed9e7379f1a2c7b6f7b1f2.tar.gz
     sha256: 1D7F2C1C30822E3CA95A3A21BC2C5C92BE5C8A313971C5A06786690A579AB73A

--- a/recipes/cccl/all/conandata.yml
+++ b/recipes/cccl/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "1.2":
     url: https://github.com/swig/cccl/archive/cccl-1.2.tar.gz
     sha256: 1936206FAAACA61C4FFA062DF1D760775B89A82FDF222EF3D4A24C604A64B036
+  "1.3":
+    url: https://github.com/swig/cccl/archive/6076c51b00f0f95571ed9e7379f1a2c7b6f7b1f2.tar.gz
+    sha256: 1D7F2C1C30822E3CA95A3A21BC2C5C92BE5C8A313971C5A06786690A579AB73A

--- a/recipes/cccl/all/conandata.yml
+++ b/recipes/cccl/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.1":
     url: https://github.com/swig/cccl/archive/cccl-1.1.tar.gz
     sha256: 03ed67d04e8b1e165b8f8d42546ab62ff6c42b3623a2358a7c8255ced144ce28
+  "1.2":
+    url: https://github.com/swig/cccl/archive/cccl-1.2.tar.gz
+    sha256: 1936206FAAACA61C4FFA062DF1D760775B89A82FDF222EF3D4A24C604A64B036

--- a/recipes/cccl/all/conanfile.py
+++ b/recipes/cccl/all/conanfile.py
@@ -1,5 +1,8 @@
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.files import get, replace_in_file, copy
+from conan.tools.layout import basic_layout
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc
 import os
 
 
@@ -10,6 +13,7 @@ class CcclConan(ConanFile):
     homepage = "https://github.com/swig/cccl/"
     url = "https://github.com/conan-io/conan-center-index"
     license = "GPL-3.0-or-later"
+    settings = "compiler"
     options = {
         "muffle": [True, False],
         "verbose": [True, False],
@@ -18,34 +22,38 @@ class CcclConan(ConanFile):
         "muffle": True,
         "verbose": False,
     }
-    settings = "compiler",
 
-    _source_subfolder = "source_subfolder"
+    @property
+    def _cccl_dir(self):
+        return os.path.join(self.package_folder, "bin")
 
     def configure(self):
-        if self.settings.compiler != "Visual Studio":
-            raise ConanInvalidConfiguration("This recipe support only Visual Studio")
+        if not is_msvc(self):
+            raise ConanInvalidConfiguration("This recipe only supports msvc/Visual Studio.")
         del self.settings.compiler
+
+    def layout(self):
+        basic_layout(self, src_folder="source_subfolder")
 
     def package_id(self):
         del self.info.options.muffle
         del self.info.options.verbose
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  strip_root=True, destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version],
+                  strip_root=True, destination=self.source_folder)
 
-        cccl_path = os.path.join(self.source_folder, self._source_subfolder, "cccl")
-        tools.replace_in_file(cccl_path,
+        cccl_path = os.path.join(self.source_folder, self.source_folder, "cccl")
+        replace_in_file(self, cccl_path,
                               "    --help)",
                               "    *.lib)\n"
                               "        linkopt+=(\"$lib\")"
                               "        ;;\n\n"
                               "    --help)")
-        tools.replace_in_file(cccl_path,
+        replace_in_file(self, cccl_path,
                               "clopt+=(\"$lib\")",
                               "linkopt+=(\"$lib\")")
-        tools.replace_in_file(cccl_path,
+        replace_in_file(self, cccl_path,
                               "    -L*)",
                               "    -LIBPATH:*)\n"
                               "        linkopt+=(\"$1\")\n"
@@ -53,15 +61,16 @@ class CcclConan(ConanFile):
                               "    -L*)")
 
     def package(self):
-        self.copy("cccl", src=os.path.join(self.source_folder, self._source_subfolder), dst="bin")
-        self.copy("COPYING", src=os.path.join(self.source_folder, self._source_subfolder), dst="licenses")
+        copy(self, pattern="cccl", src=os.path.join(self.source_folder, self.source_folder), dst=self._cccl_dir)
+        copy(self, pattern="COPYING", src=os.path.join(self.source_folder, self.source_folder), dst=os.path.join(self.package_folder, "licenses"))
 
     def package_info(self):
-        self.cpp_info.bindirs = ["bin", ]
+        self.cpp_info.libdirs = []
+        self.cpp_info.includedirs = []
+        self.cpp_info.resdirs = []
 
-        bindir = os.path.join(self.package_folder, "bin")
-        self.output.info('Appending PATH environment variable: {}'.format(bindir))
-        self.env_info.PATH.append(bindir)
+        self.cpp_info.bindirs.append(self._cccl_dir)
+        self.buildenv_info.prepend_path("PATH", self._cccl_dir)
 
         cccl_args = [
             "sh",
@@ -73,9 +82,16 @@ class CcclConan(ConanFile):
             cccl_args.append("--cccl-verbose")
         cccl = " ".join(cccl_args)
 
-        self.output.info("Setting CC to '{}'".format(cccl))
+        self.buildenv_info.define("CC", cccl)
+        self.buildenv_info.define("CXX", cccl)
+        self.buildenv_info.define("LD", cccl)
+
+        # TODO: Legacy, to be removed on Conan 2.0
+        self.env_info.path = [self._cccl_dir]
+
+        self.output.info(f"Setting CC to '{cccl}'")
         self.env_info.CC = cccl
-        self.output.info("Setting CXX to '{}'".format(cccl))
+        self.output.info(f"Setting CXX to '{cccl}'")
         self.env_info.CXX = cccl
-        self.output.info("Setting LD to '{}'".format(cccl))
+        self.output.info(f"Setting LD to '{cccl}'")
         self.env_info.LD = cccl

--- a/recipes/cccl/all/conanfile.py
+++ b/recipes/cccl/all/conanfile.py
@@ -38,12 +38,10 @@ class CcclConan(ConanFile):
             raise ConanInvalidConfiguration("This recipe only supports msvc/Visual Studio.")
 
     def source(self):
-        pass
-
-    def build(self):
         get(self, **self.conan_data["sources"][self.version],
                   strip_root=True, destination=self.source_folder)
 
+    def build(self):
         cccl_path = os.path.join(self.source_folder, self.source_folder, "cccl")
         replace_in_file(self, cccl_path,
                               "    --help)",

--- a/recipes/cccl/all/conanfile.py
+++ b/recipes/cccl/all/conanfile.py
@@ -31,9 +31,7 @@ class CcclConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def package_id(self):
-        del self.info.options.muffle
-        del self.info.options.verbose
-        self.info.settings.clear()
+        self.info.clear()
 
     def validate(self):
         if not is_msvc(self):

--- a/recipes/cccl/all/conanfile.py
+++ b/recipes/cccl/all/conanfile.py
@@ -13,7 +13,7 @@ class CcclConan(ConanFile):
     homepage = "https://github.com/swig/cccl/"
     url = "https://github.com/conan-io/conan-center-index"
     license = "GPL-3.0-or-later"
-    settings = "compiler"
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "muffle": [True, False],
         "verbose": [True, False],
@@ -27,17 +27,17 @@ class CcclConan(ConanFile):
     def _cccl_dir(self):
         return os.path.join(self.package_folder, "bin")
 
-    def configure(self):
+    def validate(self):
         if not is_msvc(self):
             raise ConanInvalidConfiguration("This recipe only supports msvc/Visual Studio.")
-        del self.settings.compiler
 
     def layout(self):
-        basic_layout(self, src_folder="source_subfolder")
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
         del self.info.options.muffle
         del self.info.options.verbose
+        self.info.settings.clear()
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
@@ -68,9 +68,6 @@ class CcclConan(ConanFile):
         self.cpp_info.libdirs = []
         self.cpp_info.includedirs = []
         self.cpp_info.resdirs = []
-
-        self.cpp_info.bindirs.append(self._cccl_dir)
-        self.buildenv_info.prepend_path("PATH", self._cccl_dir)
 
         cccl_args = [
             "sh",

--- a/recipes/cccl/all/conanfile.py
+++ b/recipes/cccl/all/conanfile.py
@@ -84,7 +84,7 @@ class CcclConan(ConanFile):
         self.buildenv_info.define("LD", cccl)
 
         # TODO: Legacy, to be removed on Conan 2.0
-        self.env_info.path = [self._cccl_dir]
+        self.env_info.PATH.append(self._cccl_dir)
 
         self.output.info(f"Setting CC to '{cccl}'")
         self.env_info.CC = cccl

--- a/recipes/cccl/all/conanfile.py
+++ b/recipes/cccl/all/conanfile.py
@@ -27,10 +27,6 @@ class CcclConan(ConanFile):
     def _cccl_dir(self):
         return os.path.join(self.package_folder, "bin")
 
-    def validate(self):
-        if not is_msvc(self):
-            raise ConanInvalidConfiguration("This recipe only supports msvc/Visual Studio.")
-
     def layout(self):
         basic_layout(self, src_folder="src")
 
@@ -39,7 +35,14 @@ class CcclConan(ConanFile):
         del self.info.options.verbose
         self.info.settings.clear()
 
+    def validate(self):
+        if not is_msvc(self):
+            raise ConanInvalidConfiguration("This recipe only supports msvc/Visual Studio.")
+
     def source(self):
+        pass
+
+    def build(self):
         get(self, **self.conan_data["sources"][self.version],
                   strip_root=True, destination=self.source_folder)
 
@@ -67,7 +70,6 @@ class CcclConan(ConanFile):
     def package_info(self):
         self.cpp_info.libdirs = []
         self.cpp_info.includedirs = []
-        self.cpp_info.resdirs = []
 
         cccl_args = [
             "sh",

--- a/recipes/cccl/all/test_package/conanfile.py
+++ b/recipes/cccl/all/test_package/conanfile.py
@@ -1,28 +1,27 @@
-from conans import ConanFile, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.env import Environment
 import os
 
 
 class CcclTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
-
+    generators = "VCVars"
+    
     @property
     def _settings_build(self):
         return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+        if self._settings_build.os == "Windows" and not Environment().vars(self).get("CONAN_BASH_PATH"):
             self.build_requires("msys2/cci.latest")
 
     def build(self):
-        environment = {}
-        if self.settings.compiler == "Visual Studio":
-            environment.update(tools.vcvars_dict(self.settings))
-        with tools.environment_append(environment):
-            cxx = tools.get_env("CXX")
-            self.run("{cxx} {src} -o example".format(
-                cxx=cxx, src=os.path.join(self.source_folder, "example.cpp")), win_bash=self.settings.os is "Windows")
+        if can_run(self):
+            cxx = "sh cccl "
+            src = os.path.join(self.source_folder, "example.cpp")
+            self.run(f"{cxx} {src} -o example", win_bash=self.settings.os is "Windows", run_environment=True)
 
     def test(self):
-        if not tools.cross_building(self):
+        if can_run(self):
             self.run(os.path.join(self.build_folder, "example"))

--- a/recipes/cccl/all/test_package/conanfile.py
+++ b/recipes/cccl/all/test_package/conanfile.py
@@ -1,27 +1,34 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.env import Environment
+from conan.tools.microsoft import unix_path
 import os
 
 
 class CcclTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "VCVars"
-    
+    generators = "VCVars", "VirtualBuildEnv"
+    test_type = "explicit"
+    win_bash = True
+
     @property
     def _settings_build(self):
+        # TODO: Remove for Conan v2
         return getattr(self, "settings_build", self.settings)
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows" and not Environment().vars(self).get("CONAN_BASH_PATH"):
-            self.build_requires("msys2/cci.latest")
+        self.tool_requires(self.tested_reference_str)
+        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
+            self.tool_requires("msys2/cci.latest")
 
     def build(self):
-        if can_run(self):
-            cxx = "sh cccl "
-            src = os.path.join(self.source_folder, "example.cpp")
-            self.run(f"{cxx} {src} -o example", win_bash=self.settings.os is "Windows", run_environment=True)
+        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
+            return  # cccl needs a bash if there isn't a bash we can't build
+        cxx = "cccl "
+        src = os.path.join(self.source_folder, "example.cpp").replace("\\", "/")
+        self.run(f"{cxx} {src} -o example", cwd=self.build_folder)
 
     def test(self):
+        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
+            return  # cccl needs a bash if there isn't a bash we can't build
         if can_run(self):
-            self.run(os.path.join(self.build_folder, "example"))
+            self.run("./example") #test self.run still runs in bash, so it needs "./"; seems weird but okay...

--- a/recipes/cccl/all/test_package/conanfile.py
+++ b/recipes/cccl/all/test_package/conanfile.py
@@ -1,6 +1,5 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.microsoft import unix_path
 import os
 
 

--- a/recipes/cccl/all/test_v1_package/conanfile.py
+++ b/recipes/cccl/all/test_v1_package/conanfile.py
@@ -1,0 +1,35 @@
+from conans import ConanFile, tools
+from conan.tools.microsoft import is_msvc
+import os
+
+
+class CcclTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
+
+    def build_requirements(self):
+        if self._settings_build.os == "Windows" and not tools.get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
+
+    def build(self):
+        environment = {}
+        if is_msvc(self):
+            environment.update(tools.vcvars_dict(self.settings))
+            #for k in environment.keys():
+                #self.output.highlight(k)
+                #self.output.highlight(environment[k])
+        with tools.environment_append(environment):
+            cxxTest = tools.get_env("CXX")
+            #cxxB = self.buildenv_info.vars["CXX"]
+            self.output.highlight(f"tools.get_env(\"CXX\") = {cxxTest}")
+            #self.output.highlight(f"self.buildenv_info.vars[\"CXX\"] = {cxxB}")
+            cxx = "sh cccl "
+            self.run("{cxx} {src} -o example".format(
+                cxx=cxx, src=os.path.join(self.source_folder, "example.cpp")), win_bash=self.settings.os is "Windows", run_environment=True)
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run(os.path.join(self.build_folder, "example"))

--- a/recipes/cccl/all/test_v1_package/example.cpp
+++ b/recipes/cccl/all/test_v1_package/example.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello world\n";
+    return 0;
+}

--- a/recipes/cccl/config.yml
+++ b/recipes/cccl/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "1.2":
     folder: all
+  "1.3":
+    folder: all

--- a/recipes/cccl/config.yml
+++ b/recipes/cccl/config.yml
@@ -1,7 +1,5 @@
 versions:
   "1.1":
     folder: all
-  "1.2":
-    folder: all
   "1.3":
     folder: all

--- a/recipes/cccl/config.yml
+++ b/recipes/cccl/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.1":
     folder: all
+  "1.2":
+    folder: all


### PR DESCRIPTION
Specify tool name and version:  **cccl/1.2**

Mainly because it was seemingly broken, and is needed for genie.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
