### PR TITLE
autoconf: fix package info on windows

### DIFF
--- a/recipes/autoconf/all/conanfile.py
+++ b/recipes/autoconf/all/conanfile.py
@@ -1,18 +1,21 @@
-from os import path
-
 from conan import ConanFile
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rmdir, apply_conandata_patches, replace_in_file, export_conandata_patches
-from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
+from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import unix_path, is_msvc
+from conans import tools as tools_legacy
+import os
 
 required_conan_version = ">=1.52.0"
 
 
 class AutoconfConan(ConanFile):
     name = "autoconf"
-    description = "Autoconf is an extensible package of M4 macros that produce shell scripts to automatically configure software source code packages"
+    description = (
+        "Autoconf is an extensible package of M4 macros that produce shell "
+        "scripts to automatically configure software source code packages"
+    )
     license = ("GPL-2.0-or-later", "GPL-3.0-or-later")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.gnu.org/software/autoconf/"
@@ -27,9 +30,6 @@ class AutoconfConan(ConanFile):
     def export_sources(self):
         export_conandata_patches(self)
 
-    def configure(self):
-        self.win_bash = self._settings_build.os == "Windows"
-
     def layout(self):
         basic_layout(self, src_folder="src")
 
@@ -40,15 +40,20 @@ class AutoconfConan(ConanFile):
         self.info.clear()
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", check_type=str):
-            self.tool_requires("msys2/cci.latest")
         self.tool_requires("m4/1.4.19")
+        if self._settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
             destination=self.source_folder, strip_root=True)
 
     def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+
         tc = AutotoolsToolchain(self)
         tc.configure_args.extend([
             "--datarootdir=${prefix}/res",
@@ -68,64 +73,66 @@ class AutoconfConan(ConanFile):
                 tc.configure_args.append(f"--host={host}")
 
         env = tc.environment()
-        env.define("INSTALL", unix_path(self,  path.join(self.source_folder, 'build-aux', 'install-sh')))
+        env.define_path("INSTALL", unix_path(self, os.path.join(self.source_folder, "build-aux", "install-sh")))
         tc.generate(env)
 
-        deps = AutotoolsDeps(self)
-        deps.generate()
-
-        ms = VirtualBuildEnv(self)
-        ms.generate(scope="build")
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+        replace_in_file(self, os.path.join(self.source_folder, "Makefile.in"),
+                        "M4 = /usr/bin/env m4", "#M4 = /usr/bin/env m4")
 
     def build(self):
-        apply_conandata_patches(self)
-        replace_in_file(self, path.join(self.source_folder, "Makefile.in"), "M4 = /usr/bin/env m4", "#M4 = /usr/bin/env m4")
-
+        self._patch_sources()
         autotools = Autotools(self)
         autotools.configure()
         autotools.make()
 
     def package(self):
         autotools = Autotools(self)
-        autotools.install(args=[f"DESTDIR={unix_path(self, self.package_folder)}"])  # Need to specify the `DESTDIR` as a Unix path, aware of the subsystem
+        # TODO: can be replaced by autotools.install() if required_conan_version = ">=1.54.0"
+        autotools.install(args=[f"DESTDIR={unix_path(self, self.package_folder)}"])
 
-        copy(self, "COPYING*", src=self.source_folder, dst=path.join(self.package_folder, "licenses"))
-        rmdir(self, path.join(self.package_folder, "res", "info"))
-        rmdir(self, path.join(self.package_folder, "res", "man"))
+        copy(self, "COPYING*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        rmdir(self, os.path.join(self.package_folder, "res", "info"))
+        rmdir(self, os.path.join(self.package_folder, "res", "man"))
 
     def package_info(self):
         self.cpp_info.libdirs = []
         self.cpp_info.includedirs = []
+        self.cpp_info.resdirs = ["res"]
 
-        bin_path = path.join(self.package_folder, "bin")
-        self.output.info(f"Appending PATH environment variable: {bin_path}")
-        self.env_info.PATH.append(bin_path)
+        # TODO: use legacy unix_path for the moment (see https://github.com/conan-io/conan/issues/12499)
 
-        dataroot_path = path.join(self.package_folder, "res", "autoconf")
+        dataroot_path = tools_legacy.unix_path(os.path.join(self.package_folder, "res", "autoconf"))
         self.output.info(f"Defining AC_MACRODIR environment variable: {dataroot_path}")
-        self.env_info.AC_MACRODIR = dataroot_path
         self.buildenv_info.define_path("AC_MACRODIR", dataroot_path)
 
         self.output.info(f"Defining AUTOM4TE_PERLLIBDIR environment variable: {dataroot_path}")
-        self.env_info.AUTOM4TE_PERLLIBDIR = dataroot_path
         self.buildenv_info.define_path("AUTOM4TE_PERLLIBDIR", dataroot_path)
 
-        autoconf_bin = path.join(bin_path, "autoconf")
+        bin_path = os.path.join(self.package_folder, "bin")
+
+        autoconf_bin = tools_legacy.unix_path(os.path.join(bin_path, "autoconf"))
         self.output.info(f"Defining AUTOCONF environment variable: {autoconf_bin}")
-        self.env_info.AUTOCONF = autoconf_bin
         self.buildenv_info.define_path("AUTOCONF", autoconf_bin)
 
-        autoreconf_bin = path.join(bin_path, "autoreconf")
+        autoreconf_bin = tools_legacy.unix_path(os.path.join(bin_path, "autoreconf"))
         self.output.info(f"Defining AUTORECONF environment variable: {autoreconf_bin}")
-        self.env_info.AUTORECONF = autoreconf_bin
         self.buildenv_info.define_path("AUTORECONF", autoreconf_bin)
 
-        autoheader_bin = path.join(bin_path, "autoheader")
+        autoheader_bin = tools_legacy.unix_path(os.path.join(bin_path, "autoheader"))
         self.output.info(f"Defining AUTOHEADER environment variable: {autoheader_bin}")
-        self.env_info.AUTOHEADER = autoheader_bin
         self.buildenv_info.define_path("AUTOHEADER", autoheader_bin)
 
-        autom4te_bin = path.join(bin_path, "autom4te")
+        autom4te_bin = tools_legacy.unix_path(os.path.join(bin_path, "autom4te"))
         self.output.info(f"Defining AUTOM4TE environment variable: {autom4te_bin}")
-        self.env_info.AUTOM4TE = autom4te_bin
         self.buildenv_info.define_path("AUTOM4TE", autom4te_bin)
+
+        # TODO: to remove in conan v2
+        self.env_info.PATH.append(bin_path)
+        self.env_info.AC_MACRODIR = dataroot_path
+        self.env_info.AUTOM4TE_PERLLIBDIR = dataroot_path
+        self.env_info.AUTOCONF = autoconf_bin
+        self.env_info.AUTORECONF = autoreconf_bin
+        self.env_info.AUTOHEADER = autoheader_bin
+        self.env_info.AUTOM4TE = autom4te_bin

--- a/recipes/autoconf/all/test_package/conanfile.py
+++ b/recipes/autoconf/all/test_package/conanfile.py
@@ -1,53 +1,51 @@
-import shutil
-from os import path
-
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.gnu import Autotools
-from conan.tools.microsoft import unix_path
-
-required_conan_version = ">=1.50.0"
+from conan.tools.env import Environment, VirtualBuildEnv
+from conan.tools.files import copy
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc, unix_path
+import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    exports_sources = "configure.ac", "config.h.in", "Makefile.in", "test_package_c.c", "test_package_cpp.cpp",
-    generators = "AutotoolsDeps", "AutotoolsToolchain", "VirtualBuildEnv"
+    settings = "os", "arch", "compiler", "build_type"
     test_type = "explicit"
+    win_bash = True
 
     @property
     def _settings_build(self):
-        # TODO: Remove for Conan v2
         return getattr(self, "settings_build", self.settings)
 
-    @property
-    def win_bash(self):
-        return self._settings_build.os == "Windows"
+    def layout(self):
+        basic_layout(self)
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
-            self.tool_requires("msys2/cci.latest")  # The conf `tools.microsoft.bash:path` and `tools.microsoft.bash:subsystem` aren't injected for test_package
         self.tool_requires(self.tested_reference_str)
+        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", check_type=str):
+            self.tool_requires("msys2/cci.latest")
+
+    def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+        tc = AutotoolsToolchain(self)
+        tc.generate()
+        if is_msvc(self):
+            env = Environment()
+            env.define("CC", "cl -nologo")
+            env.define("CXX", "cl -nologo")
+            env.vars(self).save_script("conanbuild_msvc")
 
     def build(self):
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
-            return  # autoconf needs a bash if there isn't a bash no need to build
-
-        for src in self.exports_sources:
-            shutil.copy(path.join(self.source_folder, src), self.build_folder)
-
+        for src in ("configure.ac", "config.h.in", "Makefile.in", "test_package_c.c", "test_package_cpp.cpp"):
+            copy(self, src, self.source_folder, self.build_folder)
         self.run("autoconf --verbose")
-
         autotools = Autotools(self)
         autotools.configure(build_script_folder=self.build_folder)
         autotools.make()
 
     def test(self):
-        if self._settings_build.os == "Windows" and not self.conf.get("tools.microsoft.bash:path", default=False, check_type=bool):
-            return  # autoconf needs a bash if there isn't a bash no need to build
-
         if can_run(self):
             ext = ".exe" if self.settings.os == "Windows" else ""
-            test_cmd = unix_path(self, path.join(self.build_folder, f"test_package{ext}"))
-
-            self.run(test_cmd, env="conanbuild")
+            bin_path = unix_path(self, os.path.join(self.build_folder, f"test_package{ext}"))
+            self.run(bin_path, env="conanrun")

--- a/recipes/autoconf/all/test_package/conanfile.py
+++ b/recipes/autoconf/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.files import copy
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc, unix_path
+from conan.tools.microsoft import is_msvc
 import os
 
 
@@ -45,7 +45,7 @@ class TestPackageConan(ConanFile):
         autotools.make()
 
     def test(self):
+        self.win_bash = None
         if can_run(self):
-            ext = ".exe" if self.settings.os == "Windows" else ""
-            bin_path = unix_path(self, os.path.join(self.build_folder, f"test_package{ext}"))
+            bin_path = os.path.join(self.build_folder, "test_package")
             self.run(bin_path, env="conanrun")


### PR DESCRIPTION
Fix regression on windows introduced in https://github.com/conan-io/conan-center-index/pull/12896

We must still use legacy unix_path in package_info().
see: https://github.com/conan-io/conan/issues/12499 & https://github.com/conan-io/conan/issues/12192#issuecomment-1308589581

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
