### PR TITLE
bzip3: add version 1.2.1

### DIFF
--- a/recipes/bzip3/all/conandata.yml
+++ b/recipes/bzip3/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.1":
+    url: "https://github.com/kspalaiologos/bzip3/archive/1.2.1.tar.gz"
+    sha256: "f2fc4c9c7679d3b120e8f44d8c4ecd00f03af9981f53e13dc0f956b5996913c9"
   "1.2.0":
     url: "https://github.com/kspalaiologos/bzip3/archive/1.2.0.tar.gz"
     sha256: "6f9bd935ac1e845cb49e64ad23969db914e4760dad7feec0995f5cdbd336c10d"

--- a/recipes/bzip3/config.yml
+++ b/recipes/bzip3/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.1":
+    folder: all
   "1.2.0":
     folder: all
   "1.1.8":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **bzip3/1.2.1**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
