### PR TITLE
boost: rely on `tools.apple:enable_bitcode` conf instead of a custom option

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -106,7 +106,6 @@ class BoostConan(ConanFile):
         "buildid": "ANY",
         "python_buildid": "ANY",
         "system_use_utf8": [True, False],
-        "embed_bitcode": [True, False], # enables embedding bitcode for iOS
     }
     options.update({f"without_{_name}": [True, False] for _name in CONFIGURE_OPTIONS})
 
@@ -145,7 +144,6 @@ class BoostConan(ConanFile):
         "buildid": None,
         "python_buildid": None,
         "system_use_utf8": False,
-        "embed_bitcode": True,
     }
     default_options.update({f"without_{_name}": False for _name in CONFIGURE_OPTIONS})
     default_options.update({f"without_{_name}": True for _name in ("graph_parallel", "mpi", "python")})
@@ -290,11 +288,6 @@ class BoostConan(ConanFile):
                 self.options.without_fiber = True
                 self.options.without_json = True
                 self.options.without_nowide = True
-
-        # bitcode is deprecated in Xcode 14, and the AppStore will not accept submissions from Xcode 14 with bitcode enabled
-        # https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
-        if not is_apple_os(self) or Version(self.settings.compiler.version) >= 14.0:
-            del self.options.embed_bitcode
 
         # iconv is off by default on Windows and Solaris
         if self._is_windows_platform or self.settings.os == "SunOS":
@@ -1116,7 +1109,7 @@ class BoostConan(ConanFile):
             if self.options.multithreading:
                 cxx_flags.append("-DBOOST_SP_USE_SPINLOCK")
 
-            if "embed_bitcode" in self.options and self.options.embed_bitcode:
+            if self.conf.get("tools.apple:enable_bitcode", check_type=bool):
                 cxx_flags.append("-fembed-bitcode")
 
         if self._with_iconv:


### PR DESCRIPTION
remove option introduced in https://github.com/conan-io/conan-center-index/pull/13970, bitcode is a first class citizen of conan v2 through `tools.apple:enable_bitcode` (but it must be manually handled in build system without conan build helpers).

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
