### PR TITLE
gtest/1.10.0: fix compiler min versions

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -44,10 +44,10 @@ class GTestConan(ConanFile):
     def _minimum_compilers_version(self):
         return {
             "Visual Studio": "14",
-            "msvc": "180",
-            "gcc": "5",
-            "clang": "5",
-            "apple-clang": "9.1"
+            "msvc": "190",
+            "gcc": "4.8.1" if Version(self.version) < "1.11.0" else "5",
+            "clang": "3.3" if Version(self.version) < "1.11.0" else "5",
+            "apple-clang": "5.0" if Version(self.version) < "1.11.0" else "9.1",
         }
 
     @property


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/14143

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
