### PR TITLE
uwebsockets: add version 20.17.0, support conan v2

### DIFF
--- a/recipes/uwebsockets/all/conandata.yml
+++ b/recipes/uwebsockets/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.17.0":
+    url: "https://github.com/uNetworking/uWebSockets/archive/v20.17.0.tar.gz"
+    sha256: "62027b0b847563bcc65a760045dc4233328229fc551f97fe5814e518e272141c"
   "20.14.0":
     url: "https://github.com/uNetworking/uWebSockets/archive/v20.14.0.tar.gz"
     sha256: "15cf995844a930c9a36747e8d714b94ff886b6814b5d4e3b3ee176f05681cccc"

--- a/recipes/uwebsockets/all/conanfile.py
+++ b/recipes/uwebsockets/all/conanfile.py
@@ -1,18 +1,20 @@
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.33.0"
-
+required_conan_version = ">=1.52.0"
 
 class UwebsocketsConan(ConanFile):
     name = "uwebsockets"
-    url = "https://github.com/conan-io/conan-center-index"
     description = "Simple, secure & standards compliant web server for the most demanding of applications"
     license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/uNetworking/uWebSockets"
-    topics = ("websocket", "network", "server")
-
+    topics = ("websocket", "network", "server", "header-only")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "with_zlib": [True, False],
@@ -22,91 +24,83 @@ class UwebsocketsConan(ConanFile):
         "with_zlib": True,
         "with_libdeflate": False,
     }
-
     no_copy_source = True
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "15",
+            "msvc": "191",
+            "gcc": "7" if Version(self.version) < "20.11.0" else "8",
+            "clang": "5" if Version(self.version) < "20.11.0" else "7",
+            "apple-clang": "10",
+        }
 
     def config_options(self):
         # libdeflate is not supported before 19.0.0
-        if tools.Version(self.version) < "19.0.0":
+        if Version(self.version) < "19.0.0":
             del self.options.with_libdeflate
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.12")
+            self.requires("zlib/1.2.13")
         if self.options.get_safe("with_libdeflate"):
-            self.requires("libdeflate/1.10")
+            self.requires("libdeflate/1.14")
 
-        if tools.Version(self.version) >= "19.0.0":
+        if Version(self.version) >= "20.15.0":
+            self.requires("usockets/0.8.2")
+        elif Version(self.version) >= "19.0.0":
             self.requires("usockets/0.8.1")
         else:
             self.requires("usockets/0.4.0")
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
 
     def validate(self):
-        minimal_cpp_standard = "17"
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, minimal_cpp_standard)
-
-        minimal_version = {
-            "Visual Studio": "15",
-            "gcc": "7" if tools.Version(self.version) < "20.11.0" else "8",
-            "clang": "5" if tools.Version(self.version) < "20.11.0" else "7",
-            "apple-clang": "10",
-        }
-
-        compiler = str(self.settings.compiler)
-        if compiler not in minimal_version:
-            self.output.warn(
-                "%s recipe lacks information about the %s compiler standard version support"
-                % (self.name, compiler)
-            )
-            self.output.warn(
-                "%s requires a compiler that supports at least C++%s"
-                % (self.name, minimal_cpp_standard)
-            )
-            return
-
-        version = tools.Version(self.settings.compiler.version)
-        if version < minimal_version[compiler]:
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(
-                "%s requires a compiler that supports at least C++%s"
-                % (self.name, minimal_cpp_standard)
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
 
-        if tools.Version(self.version) >= "20.14.0" and self.settings.compiler == "clang" and str(self.settings .compiler.libcxx) == "libstdc++":
+        if Version(self.version) >= "20.14.0" and self.settings.compiler == "clang" and str(self.settings .compiler.libcxx) == "libstdc++":
             raise ConanInvalidConfiguration("{} needs recent libstdc++ with charconv.".format(self.name))
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self,
             pattern="*.h",
-            src=os.path.join(self._source_subfolder, "src"),
-            dst=os.path.join("include", "uWebSockets"),
+            src=os.path.join(self.source_folder, "src"),
+            dst=os.path.join(self.package_folder, "include", "uWebSockets"),
             keep_path=False,
         )
-        self.copy(
+        copy(self,
             pattern="*.hpp",
-            src=os.path.join(self._source_subfolder, "src", "f2"),
-            dst=os.path.join("include", "uWebSockets", "f2"),
+            src=os.path.join(self.source_folder, "src", "f2"),
+            dst=os.path.join(self.package_folder, "include", "uWebSockets", "f2"),
             keep_path=False,
         )
 
     def package_info(self):
         self.cpp_info.bindirs = []
-        self.cpp_info.frameworkdirs = []
-        self.cpp_info.includedirs.append(os.path.join("include", "uWebSockets"))
         self.cpp_info.libdirs = []
-        self.cpp_info.resdirs = []
+
         if not self.options.with_zlib:
             self.cpp_info.defines.append("UWS_NO_ZLIB")
         if self.options.get_safe("with_libdeflate"):
             self.cpp_info.defines.append("UWS_USE_LIBDEFLATE")
+
+        self.cpp_info.includedirs.append(os.path.join("include", "uWebSockets"))

--- a/recipes/uwebsockets/all/test_package/CMakeLists.txt
+++ b/recipes/uwebsockets/all/test_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(test_package)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-find_package(uwebsockets CONFIG REQUIRED)
+find_package(uwebsockets REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} uwebsockets::uwebsockets)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+target_link_libraries(${PROJECT_NAME} PRIVATE uwebsockets::uwebsockets)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/uwebsockets/all/test_package/conanfile.py
+++ b/recipes/uwebsockets/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/uwebsockets/all/test_v1_package/CMakeLists.txt
+++ b/recipes/uwebsockets/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/uwebsockets/all/test_v1_package/conanfile.py
+++ b/recipes/uwebsockets/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/uwebsockets/config.yml
+++ b/recipes/uwebsockets/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.17.0":
+    folder: all
   "20.14.0":
     folder: all
   "20.9.0":


### PR DESCRIPTION
Specify library name and version:  **uwebsockets/***

- add version 20.17.0
- support conan v2
- update dependencies
- 
uwebsockets/20.30.0 was already released.
However, uwebsockets>=20.18.0 requires the latest usockets which are not yet released.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
