### PR TITLE
benchmark: add version 1.7.1

### DIFF
--- a/recipes/benchmark/all/conandata.yml
+++ b/recipes/benchmark/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.7.1":
+    url: "https://github.com/google/benchmark/archive/v1.7.1.tar.gz"
+    sha256: "6430e4092653380d9dc4ccb45a1e2dc9259d581f4866dc0759713126056bc1d7"
   "1.7.0":
     url: "https://github.com/google/benchmark/archive/refs/tags/v1.7.0.tar.gz"
     sha256: "3aff99169fa8bdee356eaa1f691e835a6e57b1efeadb8a0f9f228531158246ac"

--- a/recipes/benchmark/config.yml
+++ b/recipes/benchmark/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.7.1":
+    folder: all
   "1.7.0":
     folder: all
   "1.6.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **benchmark/1.7.1**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
