### PR TITLE
flatbuffers: add version 22.10.26

### DIFF
--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "22.10.26":
+    url: "https://github.com/google/flatbuffers/archive/v22.10.26.tar.gz"
+    sha256: "34f1820cfd78a3d92abc880fbb1a644c7fb31a71238995f4ed6b5915a1ad4e79"
   "22.9.29":
     url: "https://github.com/google/flatbuffers/archive/refs/tags/v22.9.29.tar.gz"
     sha256: "372df01795c670f6538055a7932fc7eb3e81b3653be4a216c081e9c3c26b1b6d"

--- a/recipes/flatbuffers/config.yml
+++ b/recipes/flatbuffers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "22.10.26":
+    folder: all
   "22.9.29":
     folder: all
   "22.9.24":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **flatbuffers/22.10.26**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
