### PR TITLE
[ginkgo] update to 1.5.0

### DIFF
--- a/recipes/ginkgo/all/conandata.yml
+++ b/recipes/ginkgo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.0":
+    url: "https://github.com/ginkgo-project/ginkgo/archive/v1.5.0.tar.gz"
+    sha256: "3183840feb1ee7369e57906d4db4e4d1853e32c18d515948296c283c968fc020"
   "1.4.0":
     url: "https://github.com/ginkgo-project/ginkgo/archive/v1.4.0.tar.gz"
     sha256: "6dcadbd3e93f6ec58ef6cda5b980fbf51ea3c7c13e27952ef38804058ac93f08"

--- a/recipes/ginkgo/all/conanfile.py
+++ b/recipes/ginkgo/all/conanfile.py
@@ -23,12 +23,14 @@ class GinkgoConan(ConanFile):
         "fPIC": [True, False],
         "openmp": [True, False],
         "cuda": [True, False],
+        "mpi": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": False,
         "openmp": False,
         "cuda": False,
+        "mpi": False,
     }
 
     generators = "cmake"
@@ -112,6 +114,7 @@ class GinkgoConan(ConanFile):
         self._cmake.definitions["GINKGO_BUILD_REFERENCE"] = True
         self._cmake.definitions["GINKGO_BUILD_OMP"] = self.options.openmp
         self._cmake.definitions["GINKGO_BUILD_CUDA"] = self.options.cuda
+        self._cmake.definitions["GINKGO_BUILD_MPI"] = self.options.mpi
         self._cmake.definitions["GINKGO_BUILD_HIP"] = False
         self._cmake.definitions["GINKGO_BUILD_DPCPP"] = False
         self._cmake.definitions["GINKGO_BUILD_HWLOC"] = False

--- a/recipes/ginkgo/config.yml
+++ b/recipes/ginkgo/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.0":
+    folder: all
   "1.4.0":
     folder: all
   "1.3.0":


### PR DESCRIPTION
Specify library name and version:  **ginkgo/1.5.0**

Adds the new [1.5.0 release](https://github.com/ginkgo-project/ginkgo/releases/tag/v1.5.0) of Ginkgo 

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated. (I've had a hard time getting the hooks running, but nothing major changed in the conanfile, so this might be fine :) )