### PR TITLE
simdutf: add version 2.0.3

### DIFF
--- a/recipes/simdutf/all/conandata.yml
+++ b/recipes/simdutf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.3":
+    url: "https://github.com/simdutf/simdutf/archive/refs/tags/v2.0.3.tar.gz"
+    sha256: "076bd07f6fd88c5befba28992cd5a9bf033225c5564d8b88559b8059c3c49cfc"
   "2.0.2":
     url: "https://github.com/simdutf/simdutf/archive/refs/tags/v2.0.2.tar.gz"
     sha256: "ae02a923434c32a9c800e6b136ac039708838ba1f7f6d338175ecb35bf959173"
@@ -6,6 +9,13 @@ sources:
     url: "https://github.com/simdutf/simdutf/archive/refs/tags/v1.0.1.tar.gz"
     sha256: "e7832ba58fb95fe00de76dbbb2f17d844a7ad02a6f5e3e9e5ce9520e820049a0"
 patches:
+  "2.0.3":
+    - patch_file: "patches/2.0.3-0001-fix-cmake.patch"
+      patch_description: "remove static build, enable rpath on macOS"
+      patch_type: "conan"
+    - patch_file: "patches/2.0.2-0002-add-workaround-gcc9.patch"
+      patch_description: "apply gcc8 workaround to gcc9"
+      patch_type: "portability"
   "2.0.2":
     - patch_file: "patches/2.0.2-0001-fix-cmake.patch"
       patch_description: "remove static build, stop to link static libc++ and enable rpath on macOS"

--- a/recipes/simdutf/all/conanfile.py
+++ b/recipes/simdutf/all/conanfile.py
@@ -59,6 +59,8 @@ class SimdutfConan(ConanFile):
         tc.variables["BUILD_TESTING"] = False
         if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) == "8":
             tc.variables["CMAKE_CXX_FLAGS"] = " -mavx512f"
+        if Version(self.version) >= "2.0.3":
+            tc.variables["SIMDUTF_TOOLS"] = False
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/simdutf/all/patches/2.0.3-0001-fix-cmake.patch
+++ b/recipes/simdutf/all/patches/2.0.3-0001-fix-cmake.patch
@@ -1,0 +1,23 @@
+diff --git a/cmake/simdutf-flags.cmake b/cmake/simdutf-flags.cmake
+index 9263a7f..39f5a8c 100644
+--- a/cmake/simdutf-flags.cmake
++++ b/cmake/simdutf-flags.cmake
+@@ -16,4 +16,4 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
+ set(CMAKE_CXX_STANDARD 11)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+-set(CMAKE_MACOSX_RPATH OFF)
++set(CMAKE_MACOSX_RPATH ON)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index f3ede1e..91a1bdd 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -3,6 +3,6 @@ target_include_directories(simdutf-include-source INTERFACE $<BUILD_INTERFACE:${
+ add_library(simdutf-source INTERFACE)
+ target_sources(simdutf-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/simdutf.cpp)
+ target_link_libraries(simdutf-source INTERFACE simdutf-include-source)
+-add_library(simdutf STATIC simdutf.cpp)
++add_library(simdutf simdutf.cpp)
+ target_include_directories(simdutf PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> )
+ target_include_directories(simdutf PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+

--- a/recipes/simdutf/config.yml
+++ b/recipes/simdutf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.3":
+    folder: all
   "2.0.2":
     folder: all
   "1.0.1":


### PR DESCRIPTION
Specify library name and version:  **simdutf/2.0.3**

Since 2.0.3, simdutf provides `SIMDUTF_TOOLS` option to control tools build/installation.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
