### PR TITLE
- [ffmpeg] get_gnu_triplet may return more than 3 values for some triplets

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -329,11 +329,12 @@ class FFMpegConan(ConanFile):
 
     @property
     def _target_arch(self):
-        target_arch, _, _ = tools.get_gnu_triplet(
+        triplet = tools.get_gnu_triplet(
             "Macos" if is_apple_os(self) else str(self.settings.os),
             str(self.settings.arch),
             str(self.settings.compiler) if self.settings.os == "Windows" else None,
-        ).split("-")
+        )
+        target_arch = triplet[0]
         return target_arch
 
     @property
@@ -341,11 +342,12 @@ class FFMpegConan(ConanFile):
         if self._is_msvc:
             return "win32"
         else:
-            _, _, target_os = tools.get_gnu_triplet(
+            triplet = tools.get_gnu_triplet(
                 "Macos" if is_apple_os(self) else str(self.settings.os),
                 str(self.settings.arch),
                 str(self.settings.compiler) if self.settings.os == "Windows" else None,
-            ).split("-")
+            )
+            target_os = triplet[2]
             if target_os == "gnueabihf":
                 target_os = "gnu" # could also be "linux"
             return target_os

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -334,7 +334,7 @@ class FFMpegConan(ConanFile):
             str(self.settings.arch),
             str(self.settings.compiler) if self.settings.os == "Windows" else None,
         )
-        target_arch = triplet[0]
+        target_arch = triplet.split("-")[0]
         return target_arch
 
     @property
@@ -347,7 +347,7 @@ class FFMpegConan(ConanFile):
                 str(self.settings.arch),
                 str(self.settings.compiler) if self.settings.os == "Windows" else None,
             )
-            target_os = triplet[2]
+            target_os = triplet.split("-")[2]
             if target_os == "gnueabihf":
                 target_os = "gnu" # could also be "linux"
             return target_os


### PR DESCRIPTION
ValueError: too many values to unpack (expected 3) for instance, `e2k-unknown-linux-gnu`

Specify library name and version:  **ffmpeg/all**

/cc @r-a-sattarov

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
