### PR TITLE
Update package references to use icu 72.1

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -543,7 +543,7 @@ class BoostConan(ConanFile):
             self.requires("libbacktrace/cci.20210118")
 
         if self._with_icu:
-            self.requires("icu/71.1")
+            self.requires("icu/72.1")
         if self._with_iconv:
             self.requires("libiconv/1.17")
 

--- a/recipes/cxxopts/all/conanfile.py
+++ b/recipes/cxxopts/all/conanfile.py
@@ -44,7 +44,7 @@ class CxxOptsConan(ConanFile):
 
     def requirements(self):
         if self.options.unicode:
-            self.requires("icu/71.1")
+            self.requires("icu/72.1")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/dcmtk/all/conanfile.py
+++ b/recipes/dcmtk/all/conanfile.py
@@ -84,7 +84,7 @@ class DCMTKConan(ConanFile):
         if self.options.charset_conversion == "libiconv":
             self.requires("libiconv/1.16")
         elif self.options.charset_conversion == "icu":
-            self.requires("icu/71.1")
+            self.requires("icu/72.1")
         if self.options.with_libxml2:
             self.requires("libxml2/2.9.13")
         if self.options.with_zlib:

--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -90,7 +90,7 @@ class HarfbuzzConan(ConanFile):
         if self.options.with_freetype:
             self.requires("freetype/2.12.1")
         if self.options.with_icu:
-            self.requires("icu/71.1")
+            self.requires("icu/72.1")
         if self.options.with_glib:
             self.requires("glib/2.73.3")
 

--- a/recipes/itk/all/conanfile.py
+++ b/recipes/itk/all/conanfile.py
@@ -63,7 +63,7 @@ class ITKConan(ConanFile):
         self.requires("fftw/3.3.9")
         self.requires("gdcm/3.0.9")
         self.requires("hdf5/1.12.0")
-        self.requires("icu/71.1") # TODO: to remove? Seems to be a transitivie dependency through dcmtk
+        self.requires("icu/72.1") # TODO: to remove? Seems to be a transitivie dependency through dcmtk
         self.requires("libjpeg/9d")
         self.requires("libpng/1.6.37")
         self.requires("libtiff/4.3.0")

--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -95,7 +95,7 @@ class Libxml2Conan(ConanFile):
         if self.options.iconv:
             self.requires("libiconv/1.17")
         if self.options.icu:
-            self.requires("icu/71.1")
+            self.requires("icu/72.1")
 
     def build_requirements(self):
         if not (self._is_msvc or self._is_mingw_windows):

--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -77,7 +77,7 @@ class MongoCDriverConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/1.5.2")
         if self.options.with_icu:
-            self.requires("icu/71.1")
+            self.requires("icu/72.1")
 
     def validate(self):
         if self.info.options.with_ssl == "darwin" and not is_apple_os(self.settings.os):

--- a/recipes/msix/all/conanfile.py
+++ b/recipes/msix/all/conanfile.py
@@ -98,7 +98,7 @@ class MsixConan(ConanFile):
 
     def requirements(self):
         if self.settings.os == "Linux" and not self.options.skip_bundles:
-            self.requires("icu/71.1")
+            self.requires("icu/72.1")
         if self.options.crypto_lib == "openssl":
             self.requires("openssl/1.1.1q")
         if self.options.use_external_zlib:

--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -371,7 +371,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("with_fontconfig", False):
             self.requires("fontconfig/2.13.93")
         if self.options.get_safe("with_icu", False):
-            self.requires("icu/71.1")
+            self.requires("icu/72.1")
         if self.options.get_safe("with_harfbuzz", False) and not self.options.multiconfiguration:
             self.requires("harfbuzz/5.3.1")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -349,7 +349,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("with_fontconfig", False):
             self.requires("fontconfig/2.13.93")
         if self.options.get_safe("with_icu", False):
-            self.requires("icu/71.1")
+            self.requires("icu/72.1")
         if self.options.get_safe("with_harfbuzz", False) and not self.options.multiconfiguration:
             self.requires("harfbuzz/4.4.1")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:

--- a/recipes/xerces-c/all/conanfile.py
+++ b/recipes/xerces-c/all/conanfile.py
@@ -68,7 +68,7 @@ class XercesCConan(ConanFile):
 
     def requirements(self):
         if "icu" in (self.options.transcoder, self.options.message_loader):
-            self.requires("icu/71.1")
+            self.requires("icu/72.1")
         if self.options.network_accessor == "curl":
             self.requires("libcurl/7.85.0")
 
@@ -100,7 +100,7 @@ class XercesCConan(ConanFile):
 
     def build_requirements(self):
         if hasattr(self, "settings_build") and self.options.message_loader == "icu":
-            self.tool_requires("icu/71.1")
+            self.tool_requires("icu/72.1")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],


### PR DESCRIPTION
Specify library name and version:  **boost/1.80.0**

ICU's recipe was updated to support 72.1 - this PR updates packages that depend on icu/71.1 to depend on icu/72.1 instead.

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
