### PR TITLE
libcurl 7.86.0

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.86.0":
+    url: "https://curl.se/download/curl-7.86.0.tar.gz"
+    sha256: "3dfdd39ba95e18847965cd3051ea6d22586609d9011d91df7bc5521288987a82"
   "7.85.0":
     url: "https://curl.se/download/curl-7.85.0.tar.gz"
     sha256: "78a06f918bd5fde3c4573ef4f9806f56372b32ec1829c9ec474799eeee641c27"

--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -32,3 +32,5 @@ sources:
 patches:
   "7.79.0":
     - patch_file: "patches/004-no-checksrc.patch"
+      patch_description: "don't run checksrc"
+      patch_type: "conan"

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -387,11 +387,13 @@ class LibcurlConan(ConanFile):
             f"--enable-symbol-hiding={self._yes_no(self.options.with_symbol_hiding)}",
             f"--enable-unix-sockets={self._yes_no(self.options.with_unix_sockets)}",
         ])
+
         if self.options.with_ssl == "openssl":
             path = unix_path(self, self.dependencies["openssl"].package_folder)
             tc.configure_args.append(f"--with-ssl={path}")
-        else:
+        elif not self.options.with_ssl:
             tc.configure_args.append("--without-ssl")
+
         if self.options.with_ssl == "wolfssl":
             path = unix_path(self, self.dependencies["wolfssl"].package_folder)
             tc.configure_args.append(f"--with-wolfssl={path}")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -13,7 +13,7 @@ from conan.tools.scm import Version
 import os
 import re
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class LibcurlConan(ConanFile):
@@ -158,18 +158,9 @@ class LibcurlConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
         # These options are not used in CMake build yet
         if self._is_using_cmake_build:

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -622,12 +622,17 @@ class LibcurlConan(ConanFile):
             if self.options.with_ssl == "schannel":
                 self.cpp_info.components["curl"].system_libs.append("crypt32")
         elif is_apple_os(self):
-            if Version(self.version) >= "7.77.0":
+            if Version(self.version) >= "7.78.0":
+                self.cpp_info.components["curl"].frameworks.extend(["CoreFoundation", "SystemConfiguration"])
+            elif Version(self.version) >= "7.77.0":
                 self.cpp_info.components["curl"].frameworks.append("SystemConfiguration")
             if self.options.with_ldap:
                 self.cpp_info.components["curl"].system_libs.append("ldap")
             if self.options.with_ssl == "darwinssl":
-                self.cpp_info.components["curl"].frameworks.extend(["CoreFoundation", "Security"])
+                if Version(self.version) >= "7.78.0":
+                    self.cpp_info.components["curl"].frameworks.append("Security")
+                else:
+                    self.cpp_info.components["curl"].frameworks.extend(["CoreFoundation", "Security"])
 
         if self._is_mingw:
             # provide pthread for dependent packages

--- a/recipes/libcurl/all/test_package/CMakeLists.txt
+++ b/recipes/libcurl/all/test_package/CMakeLists.txt
@@ -5,3 +5,7 @@ find_package(CURL REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} CURL::libcurl)
+if(APPLE)
+  find_library(CORE_FOUNDATION CoreFoundation)
+  target_link_libraries(${PROJECT_NAME} ${CORE_FOUNDATION})
+endif()

--- a/recipes/libcurl/all/test_package/CMakeLists.txt
+++ b/recipes/libcurl/all/test_package/CMakeLists.txt
@@ -5,7 +5,3 @@ find_package(CURL REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.c)
 target_link_libraries(${PROJECT_NAME} CURL::libcurl)
-if(APPLE)
-  find_library(CORE_FOUNDATION CoreFoundation)
-  target_link_libraries(${PROJECT_NAME} ${CORE_FOUNDATION})
-endif()

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.86.0":
+    folder: all
   "7.85.0":
     folder: all
   "7.84.0":


### PR DESCRIPTION
This supersedes https://github.com/conan-io/conan-center-index/pull/14146 in an attempt to get the CLA check to work.

Specify library name and version:  **libcurl/7.86.0**

I saw that https://github.com/conan-io/conan-center-index/pull/13783 had been closed without any comment so figured I'd put up a PR in its place. I ran local builds of this on both macOS and Windows, as the recipe uses autotools on *nix and CMake on Windows. 

If the cleanups I've included as part of this aren't appropriate I can easily back them out.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.