### PR TITLE
json-schema-validator: restore correct CMake target name in CMakeDeps

### DIFF
--- a/recipes/json-schema-validator/all/conanfile.py
+++ b/recipes/json-schema-validator/all/conanfile.py
@@ -119,7 +119,7 @@ class JsonSchemaValidatorConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "nlohmann_json_schema_validator")
-        self.cpp_info.set_property("cmake_target_name", "nlohmann_json_schema_validator::nlohmann_json_schema_validator")
+        self.cpp_info.set_property("cmake_target_name", "nlohmann_json_schema_validator")
         self.cpp_info.libs = ["json-schema-validator" if scm.Version(self.version) < "2.1.0" else "nlohmann_json_schema_validator"]
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed

--- a/recipes/json-schema-validator/all/test_package/CMakeLists.txt
+++ b/recipes/json-schema-validator/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package CXX)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
 find_package(nlohmann_json_schema_validator CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
 target_link_libraries(${PROJECT_NAME} nlohmann_json_schema_validator)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/json-schema-validator/all/test_package/CMakeLists.txt
+++ b/recipes/json-schema-validator/all/test_package/CMakeLists.txt
@@ -5,4 +5,4 @@ find_package(nlohmann_json_schema_validator CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
-target_link_libraries(${PROJECT_NAME} nlohmann_json_schema_validator::nlohmann_json_schema_validator)
+target_link_libraries(${PROJECT_NAME} nlohmann_json_schema_validator)

--- a/recipes/json-schema-validator/all/test_v1_package/CMakeLists.txt
+++ b/recipes/json-schema-validator/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package CXX)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(nlohmann_json_schema_validator CONFIG REQUIRED)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
-target_link_libraries(${PROJECT_NAME} nlohmann_json_schema_validator)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)


### PR DESCRIPTION
handle this regression: https://github.com/conan-io/conan-center-index/pull/13959#discussion_r1022160270

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
