### PR TITLE
(#14198) spdlog: needs builds with header-only fmt

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -109,6 +109,8 @@ class SpdlogConan(ConanFile):
                 tc.variables["SPDLOG_NO_TLS"] = True
             tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
             tc.generate()
+        cmake_deps = CMakeDeps(self)
+        cmake_deps.generate()
 
     def _disable_werror(self):
         replace_in_file(self, os.path.join(self.source_folder, "cmake", "utils.cmake"), "/WX", "")

--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.microsoft import is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class SpdlogConan(ConanFile):
@@ -36,24 +36,25 @@ class SpdlogConan(ConanFile):
         "no_exceptions": False,
         "fmt_header_only": False,
     }
-    generators = "CMakeDeps"
 
     def config_options(self):
-        if self.settings.os == "Windows" or self.options.shared or self.options.header_only:
+        if self.settings.os == "Windows":
             del self.options.fPIC
-
-        if self.options.header_only:
-            del self.options.shared
-
-        if self.settings.os != "Windows":
+        else:
             del self.options.wchar_filenames
             del self.options.wchar_support
 
     def configure(self):
+        if self.options.shared or self.options.header_only:
+            self.options.rm_safe("fPIC")
+
+        if self.options.header_only:
+            del self.options.shared
+
         self.options["fmt"].header_only = self.options.fmt_header_only
 
     def layout(self):
-        cmake_layout(self)
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         if Version(self.version) >= "1.11.0":
@@ -70,7 +71,7 @@ class SpdlogConan(ConanFile):
             self.requires("fmt/6.0.0", transitive_headers=True)
 
     def package_id(self):
-        if self.info.options.header_only:
+        if self.options.header_only:
             self.info.clear()
 
     @property


### PR DESCRIPTION
* Specify library name and version:  `spdlog/*`
* Discussion: #14198 

### Summary
Add possibility to provide builds with a header-only `fmt`, while also fixing such (currently) custom build.

### Changes
- `wchar_*` options removed on non-Windows builds
- Fixed `SPDLOG_FMT_EXTERNAL` and `SPDLOG_FMT_EXTERNAL_HO` mutually exclusive values
- Disable Werror only if not header-only
- ~~`CMakeDeps` didn't set any custom var => made implicit~~
- ~~Option deletions are all made in `config_options()` now~~
- ~~Removed pointless custom layout source dir~~

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
