### PR TITLE
[config] Use larger resources to build cppfront packages

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -184,6 +184,7 @@ pod_size:
   large:
     - "pcl"
     - "duckdb"
+    - "cppfront"
   xlarge:
     - "llvm"
     - "opengv"


### PR DESCRIPTION
Related to https://github.com/conan-io/conan-center-index/pull/13913.

Seems like linux pods are dying when compiling the library. Let's try assigning more resources.
