### PR TITLE
trantor: add version 1.5.8

### DIFF
--- a/recipes/trantor/all/conandata.yml
+++ b/recipes/trantor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.8":
+    url: "https://github.com/an-tao/trantor/archive/v1.5.8.tar.gz"
+    sha256: "705ec0176681be5c99fcc7af37416ece9d65ff4d907bca764cb11471b104fbf8"
   "1.5.7":
     url: "https://github.com/an-tao/trantor/archive/v1.5.7.tar.gz"
     sha256: "42576563afbf1e58c7d68f758cf3fca4d193496d4e3f82c80069d8389a7839d5"

--- a/recipes/trantor/config.yml
+++ b/recipes/trantor/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5.8":
+    folder: "all"
   "1.5.7":
     folder: "all"
   "1.5.6":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **trantor/1.5.8**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
