### PR TITLE
[avahi] Fix regression in namespace

### DIFF
--- a/recipes/avahi/all/conanfile.py
+++ b/recipes/avahi/all/conanfile.py
@@ -91,8 +91,13 @@ class AvahiConan(ConanFile):
         rm(self, "*.la", os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_target_name", "Avahi::Avahi")
+        self.cpp_info.names["cmake_find_package"] = "Avahi"
+        self.cpp_info.names["cmake_find_package_multi"] = "Avahi"
+
         for lib in ("client", "common", "core", "glib", "gobject", "libevent", "compat-libdns_sd"):
             avahi_lib = f"avahi-{lib}"
+            self.cpp_info.components[lib].set_property("cmake_target_name", f"Avahi::{lib}")
             self.cpp_info.components[lib].names["cmake_find_package"] = lib
             self.cpp_info.components[lib].names["cmake_find_package_multi"] = lib
             self.cpp_info.components[lib].names["pkg_config"] = avahi_lib
@@ -110,6 +115,7 @@ class AvahiConan(ConanFile):
 
         for app in ("autoipd", "browse", "daemon", "dnsconfd", "publish", "resolve", "set-host-name"):
             avahi_app = f"avahi-{app}"
+            self.cpp_info.components[app].set_property("cmake_target_name", f"Avahi::{app}")
             self.cpp_info.components[app].names["cmake_find_package"] = app
             self.cpp_info.components[app].names["cmake_find_package_multi"] = app
             self.cpp_info.components[app].names["pkg_config"] = avahi_app

--- a/recipes/avahi/all/test_package/CMakeLists.txt
+++ b/recipes/avahi/all/test_package/CMakeLists.txt
@@ -4,4 +4,4 @@ project(test_package LANGUAGES C)
 find_package(Avahi CONFIG REQUIRED)
  
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE avahi::compat-libdns_sd)
+target_link_libraries(${PROJECT_NAME} PRIVATE Avahi::compat-libdns_sd)

--- a/recipes/avahi/all/test_v1_package/CMakeLists.txt
+++ b/recipes/avahi/all/test_v1_package/CMakeLists.txt
@@ -7,4 +7,4 @@ conan_basic_setup(TARGETS)
 find_package(Avahi CONFIG REQUIRED)
  
 add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE avahi::compat-libdns_sd)
+target_link_libraries(${PROJECT_NAME} PRIVATE Avahi::compat-libdns_sd)


### PR DESCRIPTION
Fix regression in #13206.

The CMake target namespace used in the original recipe was based on some common practice, e.g.
* https://github.com/ruslo/hunter/blob/master/cmake/find/FindAvahi.cmake (`Avahi::Avahi` and `Avahi::{lib}` targets since 2015)
* https://github.com/xbmc/xbmc/blob/master/cmake/modules/FindAvahi.cmake (`Avahi::Avahi` target since 2018)
* https://github.com/sony/nmos-cpp/blob/master/Development/third_party/cmake/FindAvahi.cmake (based on above)
