### PR TITLE
libssh2: upgrade to openssl 1.1.1s and zlib 1.2.13

### DIFF
--- a/recipes/libssh2/all/conanfile.py
+++ b/recipes/libssh2/all/conanfile.py
@@ -56,9 +56,9 @@ class Libssh2Conan(ConanFile):
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.12")
+            self.requires("zlib/1.2.13")
         if self.options.crypto_backend == "openssl":
-            self.requires("openssl/1.1.1q")
+            self.requires("openssl/1.1.1s")
         elif self.options.crypto_backend == "mbedtls":
             # libssh2/<=1.10.0 doesn't support mbedtls/3.x.x
             self.requires("mbedtls/2.25.0")


### PR DESCRIPTION
Specify library name and version:  **libssh2/1.10.0**

The versions used by the libssh2 package are outdated and zlib 1.2.12 contains a security vulnerability.

---

- [+] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [+] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [+] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [-] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
