### PR TITLE
foonathan-lexy: add recipe

### DIFF
--- a/recipes/foonathan-lexy/all/conandata.yml
+++ b/recipes/foonathan-lexy/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2022.05.01":
     url: "https://github.com/foonathan/lexy/releases/download/v2022.05.1/lexy-src.zip"
-    sha256: "59607e4e2691c0c03068f1f9a7043f2d4703f5c9c48ec42a318b43aae9468386"
+    sha256: "de2199f8233ea5ed9d4dbe86a8eaf88d754decd28e28554329a7b29b4d952773"

--- a/recipes/foonathan-lexy/all/conandata.yml
+++ b/recipes/foonathan-lexy/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2022.05.01":
+    url: "https://github.com/foonathan/lexy/releases/download/v2022.05.1/lexy-src.zip"
+    sha256: "59607e4e2691c0c03068f1f9a7043f2d4703f5c9c48ec42a318b43aae9468386"

--- a/recipes/foonathan-lexy/all/conanfile.py
+++ b/recipes/foonathan-lexy/all/conanfile.py
@@ -47,7 +47,7 @@ class FoonathanLexyConan(ConanFile):
     def validate(self):
         if self.info.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)
-        check_min_vs(self, 191)
+        check_min_vs(self, 192)
         if not is_msvc(self):
             minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
             if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:

--- a/recipes/foonathan-lexy/all/conanfile.py
+++ b/recipes/foonathan-lexy/all/conanfile.py
@@ -32,7 +32,7 @@ class FoonathanLexyConan(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            "gcc": "7",
+            "gcc": "8",
             "clang": "7",
             "apple-clang": "10",
         }

--- a/recipes/foonathan-lexy/all/conanfile.py
+++ b/recipes/foonathan-lexy/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import check_min_vs, is_msvc
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, save, mkdir
+from conan.tools.files import get, copy, rm, rmdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
@@ -37,9 +37,6 @@ class FoonathanLexyConan(ConanFile):
             "apple-clang": "10",
         }
 
-    def export_sources(self):
-        export_conandata_patches(self)
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -68,11 +65,7 @@ class FoonathanLexyConan(ConanFile):
         tc.variables["LEXY_BUILD_PACKAGE"] = False
         tc.generate()
 
-    def _patch_sources(self):
-        apply_conandata_patches(self)
-
     def build(self):
-        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
@@ -86,9 +79,7 @@ class FoonathanLexyConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "share"))
-        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
         rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
-        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "lexy")

--- a/recipes/foonathan-lexy/all/conanfile.py
+++ b/recipes/foonathan-lexy/all/conanfile.py
@@ -71,17 +71,6 @@ class FoonathanLexyConan(ConanFile):
     def _patch_sources(self):
         apply_conandata_patches(self)
 
-        file_content = """
-# Copyright (C) 2020-2022 Jonathan Müller and lexy contributors
-# SPDX-License-Identifier: BSL-1.0
-
-# lexy CMake configuration file.
-
-@PACKAGE_INIT@
-
-include ("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")"""
-        save(self, os.path.join(self.source_folder, "cmake", "lexyConfig.cmake.in"), file_content)
-
     def build(self):
         self._patch_sources()
         cmake = CMake(self)

--- a/recipes/foonathan-lexy/all/conanfile.py
+++ b/recipes/foonathan-lexy/all/conanfile.py
@@ -1,0 +1,124 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import check_min_vs, is_msvc
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, save, mkdir
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+import os
+
+required_conan_version = ">=1.53.0"
+
+class FoonathanLexyConan(ConanFile):
+    name = "foonathan-lexy"
+    description = "lexy is a parser combinator library for C++17 and onwards."
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/foonathan/lexy"
+    topics = ("parser", "parser-combinators", "grammar")
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+    options = {
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "7",
+            "clang": "7",
+            "apple-clang": "10",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.info.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        check_min_vs(self, 191)
+        if not is_msvc(self):
+            minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
+            if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+                )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["LEXY_BUILD_EXAMPLES"] = False
+        tc.variables["LEXY_BUILD_TESTS"] = False
+        tc.variables["LEXY_BUILD_PACKAGE"] = False
+        tc.generate()
+
+    def _patch_sources(self):
+        apply_conandata_patches(self)
+
+        file_content = """
+# Copyright (C) 2020-2022 Jonathan Müller and lexy contributors
+# SPDX-License-Identifier: BSL-1.0
+
+# lexy CMake configuration file.
+
+@PACKAGE_INIT@
+
+include ("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")"""
+        save(self, os.path.join(self.source_folder, "cmake", "lexyConfig.cmake.in"), file_content)
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
+        cmake.install()
+
+        # some files extensions and folders are not allowed. Please, read the FAQs to get informed.
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "lexy")
+        self.cpp_info.set_property("cmake_target_name", "foonathan::lexy")
+
+        self.cpp_info.components["lexy_core"].set_property("cmake_target_name", "foonathan::lexy::lexy_core")
+
+        self.cpp_info.components["lexy_file"].set_property("cmake_target_name", "foonathan::lexy::lexy_file")
+        self.cpp_info.components["lexy_file"].libs = ["lexy_file"]
+
+        self.cpp_info.components["lexy_unicode"].set_property("cmake_target_name", "lexy::lexy_unicode")
+        self.cpp_info.components["lexy_unicode"].defines.append("LEXY_HAS_UNICODE_DATABASE=1")
+
+        self.cpp_info.components["lexy_ext"].set_property("cmake_target_name", "lexy::lexy_ext")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "lexy"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "lexy"
+        self.cpp_info.names["cmake_find_package"] = "foonathan"
+        self.cpp_info.names["cmake_find_package_multi"] = "foonathan"
+        self.cpp_info.components["foonathan"].names["cmake_find_package"] = "lexy"
+        self.cpp_info.components["foonathan"].names["cmake_find_package_multi"] = "lexy"

--- a/recipes/foonathan-lexy/all/conanfile.py
+++ b/recipes/foonathan-lexy/all/conanfile.py
@@ -55,6 +55,9 @@ class FoonathanLexyConan(ConanFile):
                     f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
                 )
 
+    def build_requirements(self):
+        self.tool_requires("cmake/3.18.0")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder)
 

--- a/recipes/foonathan-lexy/all/test_package/CMakeLists.txt
+++ b/recipes/foonathan-lexy/all/test_package/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 
-project(test_package CXX)
+project(test_package LANGUAGES CXX)
 
 find_package(lexy REQUIRED CONFIG)
 

--- a/recipes/foonathan-lexy/all/test_package/CMakeLists.txt
+++ b/recipes/foonathan-lexy/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(test_package CXX)
+
+find_package(lexy REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE foonathan::lexy)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/foonathan-lexy/all/test_package/conanfile.py
+++ b/recipes/foonathan-lexy/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/foonathan-lexy/all/test_package/test_package.cpp
+++ b/recipes/foonathan-lexy/all/test_package/test_package.cpp
@@ -1,0 +1,43 @@
+#include <cstdio>
+
+#include <lexy/action/parse.hpp>
+#include <lexy/callback.hpp>
+#include <lexy/dsl.hpp>
+#include <lexy/input/string_input.hpp>
+#include <lexy_ext/report_error.hpp>
+
+struct Color
+{
+    std::uint8_t r, g, b;
+};
+
+namespace grammar
+{
+namespace dsl = lexy::dsl;
+
+struct channel
+{
+    static constexpr auto rule  = dsl::integer<std::uint8_t>(dsl::n_digits<2, dsl::hex>);
+    static constexpr auto value = lexy::forward<std::uint8_t>;
+};
+
+struct color
+{
+    static constexpr auto rule  = dsl::hash_sign + dsl::times<3>(dsl::p<channel>);
+    static constexpr auto value = lexy::construct<Color>;
+};
+} // namespace grammar
+
+int main() {
+    unsigned char array[] = {'#', '5', '5', 'A', 'A', '0', '5'};
+
+    auto input = lexy::string_input(array, array + 7);
+    auto result = lexy::parse<grammar::color>(input, lexy_ext::report_error);
+    if (result.has_value())
+    {
+        auto color = result.value();
+        std::printf("#%02x%02x%02x\n", color.r, color.g, color.b);
+    }
+
+    return result ? 0 : 1;
+}

--- a/recipes/foonathan-lexy/all/test_v1_package/CMakeLists.txt
+++ b/recipes/foonathan-lexy/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/foonathan-lexy/all/test_v1_package/conanfile.py
+++ b/recipes/foonathan-lexy/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/foonathan-lexy/config.yml
+++ b/recipes/foonathan-lexy/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2022.05.01":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **foonathan-lexy/2022.05.01**

Since there is a recipe which has same author name(`foonathan-memory`), 
I added `foonathan` to this recipe as well.
If it is not convenient, please point this out to me so I can correct it.


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
