### PR TITLE
protobuf: Add version 3.21.6

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.21.6":
+    url: "https://github.com/protocolbuffers/protobuf/archive/v3.21.6.tar.gz"
+    sha256: "73c95c7b0c13f597a6a1fec7121b07e90fd12b4ed7ff5a781253b3afe07fc077"
   "3.21.4":
     url: "https://github.com/protocolbuffers/protobuf/archive/v3.21.4.tar.gz"
     sha256: "85d42d4485f36f8cec3e475a3b9e841d7d78523cd775de3a86dba77081f4ca25"


### PR DESCRIPTION
protobuf/3.21.6

Adding protobuf version 3.21.6.
Vendor: Google
Repository: https://github.com/protocolbuffers/protobuf
---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
