### PR TITLE
roaring: add version 0.8.0

### DIFF
--- a/recipes/roaring/all/conandata.yml
+++ b/recipes/roaring/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.8.0":
+    url: "https://github.com/RoaringBitmap/CRoaring/archive/v0.8.0.tar.gz"
+    sha256: "cd6c4770baccfea385c0c6891a8a80133ba26093209740ca0a3eea348aff1a20"
   "0.7.3":
     url: "https://github.com/RoaringBitmap/CRoaring/archive/v0.7.3.tar.gz"
     sha256: "e3f8115ba44ef0e1eb7b982dc3c3233f08f5f95ec1260169c2ad0ca50e56b656"

--- a/recipes/roaring/config.yml
+++ b/recipes/roaring/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.8.0":
+    folder: all
   "0.7.3":
     folder: all
   "0.7.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **roaring/0.8.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
