### PR TITLE
(#13997) gtest/1.10.0: fixes package_id with pre-1.12 in debug mode

### DIFF
--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -83,7 +83,10 @@ class GTestConan(ConanFile):
 
     def package_id(self):
         del self.info.options.no_main # Only used to expose more targets
-        del self.info.options.debug_postfix # deprecated option that no longer exist
+        if Version(self.version) < "1.12.0" and self.settings.build_type != "Debug":
+            del self.info.options.debug_postfix # unused option
+        if Version(self.version) >= "1.12.0":
+            del self.info.options.debug_postfix # deprecated option that no longer exist
 
     def validate(self):
         if self.info.options.shared and (is_msvc(self) or self._is_clang_cl) and is_msvc_static_runtime(self):


### PR DESCRIPTION
Fixes #13997
- debug_postfix has to be taken into account

Specify library name and version:  **gtest/1.10.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
