### PR TITLE
catch2: add version 3.2.0

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.2.0":
+    url: "https://github.com/catchorg/Catch2/archive/v3.2.0.tar.gz"
+    sha256: "feee04647e28ac3cbeff46cb42abc8ee2d8d5f646d36e3fb3ba274b8c69a58ea"
   "3.1.0":
     url: "https://github.com/catchorg/Catch2/archive/v3.1.0.tar.gz"
     sha256: "c252b2d9537e18046d8b82535069d2567f77043f8e644acf9a9fffc22ea6e6f7"

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,15 +1,17 @@
 versions:
-  "2.11.3":
-    folder: 2.x.x
-  "2.12.4":
-    folder: 2.x.x
-  "2.13.7":
-    folder: 2.x.x
-  "2.13.8":
-    folder: 2.x.x
-  "2.13.9":
-    folder: 2.x.x
-  "3.0.1":
+  "3.2.0":
     folder: 3.x.x
   "3.1.0":
     folder: 3.x.x
+  "3.0.1":
+    folder: 3.x.x
+  "2.13.9":
+    folder: 2.x.x
+  "2.13.8":
+    folder: 2.x.x
+  "2.13.7":
+    folder: 2.x.x
+  "2.12.4":
+    folder: 2.x.x
+  "2.11.3":
+    folder: 2.x.x


### PR DESCRIPTION
Specify library name and version:  **catch2/3.2.0**

all patches for 3.1.0 are already merged in 3.2.0.

Try to solve https://github.com/conan-io/conan-center-index/issues/14244.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
