### PR TITLE
libnghttp2: add version 1.51.0

### DIFF
--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.51.0":
+    url: "https://github.com/nghttp2/nghttp2/archive/v1.51.0.tar.gz"
+    sha256: "dfcf41e0b093765a79c9f1fc0ba6dc3d524555e94483ea9ba8b87a6d454971ba"
   "1.50.0":
     url: "https://github.com/nghttp2/nghttp2/archive/v1.50.0.tar.gz"
     sha256: "6de469efc8e9d47059327a6736aebe0a7d73f57e5e37ab4c4f838fb1eebd7889"

--- a/recipes/libnghttp2/config.yml
+++ b/recipes/libnghttp2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.51.0":
+    folder: all
   "1.50.0":
     folder: all
   "1.49.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libnghttp2/1.51.0**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
