### PR TITLE
quill: add version 2.3.4

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.3.4":
+    url: "https://github.com/odygrd/quill/archive/v2.3.4.tar.gz"
+    sha256: "b44d345c07b3023fcd1b88fd9d2554429bb8cccb6285d703d0b0907d9aa85fa1"
   "2.3.3":
     url: "https://github.com/odygrd/quill/archive/v2.3.3.tar.gz"
     sha256: "2979c96123a1cf1afc14a931aab7a1376986e047b0927f450093f4cbae4eb04c"

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.3.4":
+    folder: "all"
   "2.3.3":
     folder: "all"
   "2.3.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **quill/2.3.4**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
