### PR TITLE
[openapi-generator/6.2.1] Add version and improve jar reference

### DIFF
--- a/recipes/openapi-generator/all/conandata.yml
+++ b/recipes/openapi-generator/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.2.1":
+    url: "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.2.1/openapi-generator-cli-6.2.1.jar"
+    sha256: "f2c8600f2c23ee1123eebf47ef0f40db386627e75b0340ca16182c10f4174fa9"
   "6.2.0":
     url: "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.2.0/openapi-generator-cli-6.2.0.jar"
     sha256: "60707e2c8938a94278f6216081d7067d0f1beced8c8eb1277e625e9a59ccd2da"

--- a/recipes/openapi-generator/all/conanfile.py
+++ b/recipes/openapi-generator/all/conanfile.py
@@ -52,7 +52,7 @@ class OpenApiGeneratorConan(ConanFile):
             save(self,
                  path=os.path.join(self.package_folder, "bin", "openapi-generator.bat"),
                  content="""\
-                         java -jar %~dp0\..\res\openapi-generator.jar %*
+                         java -classpath %CLASSPATH% org.openapitools.codegen.OpenAPIGenerator $@
                          """
                  )
         else:
@@ -61,7 +61,7 @@ class OpenApiGeneratorConan(ConanFile):
                  path=bin_path,
                  content="""\
                          #!/bin/bash
-                         java -jar ${0%openapi-generator}../res/openapi-generator.jar $@
+                         java -classpath $CLASSPATH org.openapitools.codegen.OpenAPIGenerator $@
                          """
                  )
             st = os.stat(bin_path)
@@ -73,3 +73,8 @@ class OpenApiGeneratorConan(ConanFile):
         self.cpp_info.libdirs = []
         self.cpp_info.resdirs = []
         self.cpp_info.includedirs = []
+        jar = os.path.join(self.package_folder, "res", "openapi-generator.jar")
+        self.runenv_info.prepend_path("CLASSPATH", jar)
+
+        # TODO: Legacy, to be removed on Conan 2.0
+        self.env_info.CLASSPATH.append(jar)

--- a/recipes/openapi-generator/all/conanfile.py
+++ b/recipes/openapi-generator/all/conanfile.py
@@ -52,7 +52,7 @@ class OpenApiGeneratorConan(ConanFile):
             save(self,
                  path=os.path.join(self.package_folder, "bin", "openapi-generator.bat"),
                  content="""\
-                         java -classpath %CLASSPATH% org.openapitools.codegen.OpenAPIGenerator $@
+                         java -classpath %CLASSPATH% org.openapitools.codegen.OpenAPIGenerator %*
                          """
                  )
         else:

--- a/recipes/openapi-generator/all/conanfile.py
+++ b/recipes/openapi-generator/all/conanfile.py
@@ -48,21 +48,20 @@ class OpenApiGeneratorConan(ConanFile):
     def package(self):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         copy(self, pattern="openapi-generator.jar", dst=os.path.join(self.package_folder, "res"), src=self.source_folder)
-        jar = os.path.join(self.package_folder, "res", "openapi-generator.jar")
         if self.info.settings.os == "Windows":
             save(self,
                  path=os.path.join(self.package_folder, "bin", "openapi-generator.bat"),
-                 content=f"""\
-                         java -jar {jar} %*
+                 content="""\
+                         java -jar %~dp0\..\res\openapi-generator.jar %*
                          """
                  )
         else:
             bin_path = os.path.join(self.package_folder, "bin", "openapi-generator")
             save(self,
                  path=bin_path,
-                 content=f"""\
+                 content="""\
                          #!/bin/bash
-                         java -jar {jar} $@
+                         java -jar ${0%openapi-generator}../res/openapi-generator.jar $@
                          """
                  )
             st = os.stat(bin_path)

--- a/recipes/openapi-generator/config.yml
+++ b/recipes/openapi-generator/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.2.1":
+    folder: all
   "6.2.0":
     folder: all
   "6.1.0":


### PR DESCRIPTION
I change to way to reference the jar file to a relative path because I noticed that if this package was fetched from the conan center, the link to the openapi-generator.jar was absolute to the jar in the ci machine.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
