### PR TITLE
miniaudio: add version 0.11.11, support conan v2

### DIFF
--- a/recipes/miniaudio/all/CMakeLists.txt
+++ b/recipes/miniaudio/all/CMakeLists.txt
@@ -1,12 +1,9 @@
 cmake_minimum_required(VERSION 3.4)
-project(miniaudio C)
+project(miniaudio LANGUAGES C)
 
 include(GNUInstallDirs)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-set(SOURCE_SUBFOLDER ${CMAKE_CURRENT_SOURCE_DIR}/source_subfolder/extras/miniaudio_split/)
+set(SOURCE_SUBFOLDER ${MINIAUDIO_SRC_DIR}/extras/miniaudio_split/)
 add_library(miniaudio ${SOURCE_SUBFOLDER}/miniaudio.c)
 target_include_directories(miniaudio PRIVATE ${SOURCE_SUBFOLDER})
 

--- a/recipes/miniaudio/all/conandata.yml
+++ b/recipes/miniaudio/all/conandata.yml
@@ -23,12 +23,3 @@ sources:
   "0.10.39":
     url: "https://github.com/mackron/miniaudio/archive/8bf157f10e278302f8a6c1c9cd1065f2bea26dd2.tar.gz"
     sha256: "573C511F1FD1C64BD331160E357DE611A144E5BDBAF1CD872195B8D535FA557E"
-  "0.10.35":
-    url: "https://github.com/mackron/miniaudio/archive/199d6a7875b4288af6a7b615367c8fdc2019b03c.tar.gz"
-    sha256: "3D9C5FCB112E24E9C038F7520C93D52882CECE6C93DF259FD33A389B7DEB7C40"
-  "0.10.33":
-    url: "https://github.com/mackron/miniaudio/archive/fca829edefd8389380f8e3ee26cc4b8c426dd742.tar.gz"
-    sha256: "DF1B4E36211112FDC35AF92F2288DAFDEB07290F4010E7C5E2505AFFA880E0EE"
-  "0.10.32":
-    url: "https://github.com/mackron/miniaudio/archive/d06d4983d3ff512690eb37f5edd25bf96f8f3764.tar.gz"
-    sha256: "1FB7784AA6BC1C8138376C966BBDB444FF51CE04EF4289067BC59FB163CF38EA"

--- a/recipes/miniaudio/all/conandata.yml
+++ b/recipes/miniaudio/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.11":
+    url: "https://github.com/mackron/miniaudio/archive/a0dc1037f99a643ff5fad7272cd3d6461f2d63fa.tar.gz"
+    sha256: "4821e2f796d95b772fd4ef1274181d5302854bfe55680125a5cd9b24b8542dcf"
   "0.11.9":
     url: "https://github.com/mackron/miniaudio/archive/4dfe7c4c31df46e78d9a1cc0d2d6f1aef5a5d58c.tar.gz"
     sha256: "76c154a60e320ae2054ac0e93480f2dffc12a5129bdb2ed4a62e0cce8d345c36"

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -49,8 +49,6 @@ class MiniaudioConan(ConanFile):
     def package_id(self):
         if self.options.header_only:
             self.info.clear()
-            # TODO: for KB-H014. It must be removed when latest hooks/conan-center.py
-            self.info.header_only()
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -12,7 +12,7 @@ class MiniaudioConan(ConanFile):
     license = ["Unlicense", "MIT-0"]
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/mackron/miniaudio"
-    topics = ("miniaudio", "header-only", "sound")
+    topics = ("audio" "header-only", "sound")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -1,19 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 import os
-import textwrap
 
-required_conan_version = ">=1.43.0"
-
+required_conan_version = ">=1.53.0"
 
 class MiniaudioConan(ConanFile):
     name = "miniaudio"
     description = "A single file audio playback and capture library."
-    topics = ("miniaudio", "header-only", "sound")
-    homepage = "https://github.com/mackron/miniaudio"
-    url = "https://github.com/conan-io/conan-center-index"
     license = ["Unlicense", "MIT-0"]
-    settings = "os", "compiler", "build_type", "arch"
-
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/mackron/miniaudio"
+    topics = ("miniaudio", "header-only", "sound")
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
@@ -25,66 +24,68 @@ class MiniaudioConan(ConanFile):
         "header_only": True,
     }
 
-    generators = "cmake"
-    _cmake = None
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def export_sources(self):
-        self.copy("CMakeLists.txt")
+        copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        self.license = "miniaudio-{}".format(self.version)
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def package_id(self):
+        if self.options.header_only:
+            self.info.clear()
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-        self._cmake.definitions["MINIAUDIO_VERSION_STRING"] = self.version
-        self._cmake.configure()
-        return self._cmake
+    def generate(self):
+        if self.options.header_only:
+            return
+
+        tc = CMakeToolchain(self)
+        tc.variables["MINIAUDIO_VERSION_STRING"] = self.version
+        tc.generate()
 
     def build(self):
         if self.options.header_only:
             return
 
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses",
-                  src=self._source_subfolder)
-        self.copy(
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
             pattern="**",
-            dst="include/extras",
-            src=os.path.join(self._source_subfolder, "extras"),
+            dst=os.path.join(self.package_folder, "include", "extras"),
+            src=os.path.join(self.source_folder, "extras"),
         )
 
         if self.options.header_only:
-            self.copy(pattern="miniaudio.h", dst="include",
-                      src=self._source_subfolder)
-            self.copy(
+            copy(
+                self,
+                pattern="miniaudio.h", 
+                dst=os.path.join(self.package_folder, "include"),
+                src=self.source_folder)
+            copy(
+                self,
                 pattern="miniaudio.*",
-                dst="include/extras/miniaudio_split",
-                src=os.path.join(self._source_subfolder,
-                                 "extras/miniaudio_split"),
+                dst=os.path.join(self.package_folder, "include", "extras", "miniaudio_split"),
+                src=os.path.join(self.source_folder, "extras", "miniaudio_split"),
             )
         else:
-            cmake = self._configure_cmake()
+            cmake = CMake(self)
             cmake.install()
 
     def package_info(self):
@@ -103,6 +104,3 @@ class MiniaudioConan(ConanFile):
             if self.options.shared:
                 self.cpp_info.defines.append("MA_DLL")
 
-    def package_id(self):
-        if self.options.header_only:
-            self.info.header_only()

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.files import get, copy
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.layout import basic_layout
 import os
 
 required_conan_version = ">=1.53.0"
@@ -32,13 +33,18 @@ class MiniaudioConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
-        if self.options.shared:
+        if self.options.header_only or self.options.shared:
             self.options.rm_safe("fPIC")
+        if self.options.header_only:
+            del self.options.shared
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
-        cmake_layout(self, src_folder="src")
+        if self.options.header_only:
+            basic_layout(self, src_folder="src")
+        else:
+            cmake_layout(self, src_folder="src")
 
     def package_id(self):
         if self.options.header_only:

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -52,6 +52,7 @@ class MiniaudioConan(ConanFile):
             return
 
         tc = CMakeToolchain(self)
+        tc.variables["MINIAUDIO_SRC_DIR"] = self.source_folder.replace("\\", "/")
         tc.variables["MINIAUDIO_VERSION_STRING"] = self.version
         tc.generate()
 
@@ -75,7 +76,7 @@ class MiniaudioConan(ConanFile):
         if self.options.header_only:
             copy(
                 self,
-                pattern="miniaudio.h", 
+                pattern="miniaudio.h",
                 dst=os.path.join(self.package_folder, "include"),
                 src=self.source_folder)
             copy(

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -12,7 +12,7 @@ class MiniaudioConan(ConanFile):
     license = ["Unlicense", "MIT-0"]
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/mackron/miniaudio"
-    topics = ("audio" "header-only", "sound")
+    topics = ("audio", "header-only", "sound")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],

--- a/recipes/miniaudio/all/conanfile.py
+++ b/recipes/miniaudio/all/conanfile.py
@@ -43,6 +43,8 @@ class MiniaudioConan(ConanFile):
     def package_id(self):
         if self.options.header_only:
             self.info.clear()
+            # TODO: for KB-H014. It must be removed when latest hooks/conan-center.py
+            self.info.header_only()
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
@@ -100,7 +102,10 @@ class MiniaudioConan(ConanFile):
             )
             self.cpp_info.defines.append("MA_NO_RUNTIME_LINKING=1")
 
-        if not self.options.header_only:
+        if self.options.header_only:
+            self.cpp_info.bindirs = []
+            self.cpp_info.libdirs = []
+        else:
             self.cpp_info.libs = ["miniaudio"]
             if self.options.shared:
                 self.cpp_info.defines.append("MA_DLL")

--- a/recipes/miniaudio/all/test_package/CMakeLists.txt
+++ b/recipes/miniaudio/all/test_package/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package C)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES C)
 
 find_package(miniaudio REQUIRED)
 
-add_executable(test_package example.c)
-target_link_libraries(test_package miniaudio::miniaudio)
+add_executable(${PROJECT_NAME} example.c)
+target_link_libraries(${PROJECT_NAME} miniaudio::miniaudio)

--- a/recipes/miniaudio/all/test_package/conanfile.py
+++ b/recipes/miniaudio/all/test_package/conanfile.py
@@ -1,9 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -11,6 +20,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")
+

--- a/recipes/miniaudio/all/test_v1_package/CMakeLists.txt
+++ b/recipes/miniaudio/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/miniaudio/all/test_v1_package/conanfile.py
+++ b/recipes/miniaudio/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/miniaudio/config.yml
+++ b/recipes/miniaudio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.11":
+    folder: all
   "0.11.9":
     folder: all
   "0.11.8":

--- a/recipes/miniaudio/config.yml
+++ b/recipes/miniaudio/config.yml
@@ -15,9 +15,3 @@ versions:
     folder: all
   "0.10.39":
     folder: all
-  "0.10.35":
-    folder: all
-  "0.10.33":
-    folder: all
-  "0.10.32":
-    folder: all


### PR DESCRIPTION
Specify library name and version:  **miniaudio/***


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
