### PR TITLE
libpng: add version 1.6.39

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.39":
+    url: "https://github.com/glennrp/libpng/archive/v1.6.39.tar.gz"
+    sha256: "a00e9d2f2f664186e4202db9299397f851aea71b36a35e74910b8820e380d441"
   "1.6.38":
     url: "https://github.com/glennrp/libpng/archive/v1.6.38.tar.gz"
     sha256: "d4160037fa5d09fa7cff555037f2a7f2fefc99ca01e21723b19bfcda33015234"
@@ -11,9 +14,11 @@ sources:
 patches:
   "1.6.37":
     - patch_file: "patches/0001-1.6.37-cmakefile-zlib.patch"
-      patch_description: "Update ZLib include and library paths for conan to provide lib. Remove Zlib dll definition."
+      patch_description: "Update ZLib include and library paths for conan to provide\
+        \ lib. Remove Zlib dll definition."
       patch_type: "conan"
   "1.5.30":
     - patch_file: "patches/0001-1.5.30-cmakefile-zlib.patch"
-      patch_description: "Update ZLib include and library paths for conan to provide lib. Remove Zlib dll definition."
+      patch_description: "Update ZLib include and library paths for conan to provide\
+        \ lib. Remove Zlib dll definition."
       patch_type: "conan"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.39":
+    folder: all
   "1.6.38":
     folder: all
   "1.6.37":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **libpng/1.6.39**


---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
