### PR TITLE
drogon: add version 1.8.2

### DIFF
--- a/recipes/drogon/all/conandata.yml
+++ b/recipes/drogon/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.2":
+    url: "https://github.com/drogonframework/drogon/archive/v1.8.2.tar.gz"
+    sha256: "1182cab00c33e400eac617c6dbf44fa2f358e1844990b6b8c5c87783024f9971"
   "1.8.0":
     url: "https://github.com/drogonframework/drogon/archive/refs/tags/v1.8.0.tar.gz"
     sha256: "bc6503cf213ed961d4a5e9fd7cb8e75b6b11045a67840ea2241e57321dd8711b"
@@ -6,16 +9,26 @@ sources:
     url: "https://github.com/drogonframework/drogon/archive/refs/tags/v1.7.5.tar.gz"
     sha256: "e2af7c55dcabafef16f26f5b3242692f5a2b54c19b7b626840bf9132d24766f6"
 patches:
+  "1.8.2":
+    - patch_file: "patches/1.8.0-0001-disable-unused-data.patch"
+      patch_description: "Consume Trantor package from Conan instead of using the\
+        \ subproject"
+      patch_type: "conan"
+    - patch_file: "patches/1.8.0-0002-find-package-jsoncpp.patch"
+      patch_description: "Fix jsoncpp cmake target name"
+      patch_type: "conan"
   "1.8.0":
     - patch_file: "patches/1.8.0-0001-disable-unused-data.patch"
-      patch_description: "Consume Trantor package from Conan instead of using the subproject"
+      patch_description: "Consume Trantor package from Conan instead of using the\
+        \ subproject"
       patch_type: "conan"
     - patch_file: "patches/1.8.0-0002-find-package-jsoncpp.patch"
       patch_description: "Fix jsoncpp cmake target name"
       patch_type: "conan"
   "1.7.5":
     - patch_file: "patches/1.7.5-0001-disable_trantor.patch"
-      patch_description: "Consume Trantor package from Conan instead of using the subproject"
+      patch_description: "Consume Trantor package from Conan instead of using the\
+        \ subproject"
       patch_type: "conan"
     - patch_file: "patches/1.7.5-0002-remove-boost-components.patch"
       patch_description: "Do not consume specific Boost components"

--- a/recipes/drogon/config.yml
+++ b/recipes/drogon/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.2":
+    folder: "all"
   "1.8.0":
     folder: "all"
   "1.7.5":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **drogon/1.8.2**

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
