### PR TITLE
Ftdi fixes

### DIFF
--- a/recipes/libftdi/1.x/conandata.yml
+++ b/recipes/libftdi/1.x/conandata.yml
@@ -5,5 +5,3 @@ sources:
 patches:
     "1.5":
         - patch_file: "patches/0001-cmake-targets.patch"
-          base_path: "source_subfolder"
-

--- a/recipes/libftdi/1.x/conanfile.py
+++ b/recipes/libftdi/1.x/conanfile.py
@@ -1,6 +1,8 @@
 import os
-from conans import ConanFile, CMake, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.files import get, patch, rmdir
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+from conan.errors import ConanInvalidConfiguration
 
 
 class LibFtdiConan(ConanFile):
@@ -11,7 +13,7 @@ class LibFtdiConan(ConanFile):
     homepage = "https://www.intra2net.com/en/developer/libftdi/"
     url = "https://github.com/conan-io/conan-center-index"
     exports_sources = ["CMakeLists.txt", "patches/*"]
-    generators = "cmake", "cmake_find_package", "pkg_config"
+    generators = "CMakeDeps", "CMakeToolchain"
     settings = "os", "arch", "compiler", "build_type"
     options = {
             "shared"             : [True, False], 
@@ -29,20 +31,18 @@ class LibFtdiConan(ConanFile):
     }
     _cmake = None
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "libftdi1-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
+        get(self, **self.conan_data["sources"][self.version],
+            strip_root=True)
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
             if self.settings.compiler == "Visual Studio":
                 self.options.use_streaming = False
+
+    def layout(self):
+        cmake_layout(self)
 
     def configure(self):
         if self.options.shared:
@@ -62,8 +62,7 @@ class LibFtdiConan(ConanFile):
             "ENABLE_STREAMING": self.options.use_streaming,
             "LIB_SUFFIX": "",
         }
-        self._cmake.definitions.update(options)
-        self._cmake.configure()
+        self._cmake.configure(variables = options)
         return self._cmake
 
     def requirements(self):
@@ -76,30 +75,26 @@ class LibFtdiConan(ConanFile):
             raise ConanInvalidConfiguration("VS doesn't not compile with enabled option use_streaming")
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+        for p in self.conan_data.get("patches", {}).get(self.version, []):
+            patch(self, **p)
         cmake = self._configure_cmake()
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="LICENSE", dst="licenses")
         cmake = self._configure_cmake()
         cmake.install()
         lib_folder = os.path.join(self.package_folder, "lib",)
-        tools.rmdir(os.path.join(lib_folder, "cmake"))
-        tools.rmdir(os.path.join(lib_folder, "pkgconfig"))
+        rmdir(self, os.path.join(lib_folder, "cmake"))
+        rmdir(self, os.path.join(lib_folder, "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.names["cmake_find_package"] = "LibFTDI1"
-        self.cpp_info.names["cmake_find_package_multi"] = "LibFTDI1"
-        self.cpp_info.names["pkgconfig"] = "libftdi1"
-
-        self.cpp_info.components["ftdi"].names["pkg_config"] = "libftdi1"
+        self.cpp_info.names['cmake_find_package'] = "LibFTDI1"
+        self.cpp_info.names['cmake_find_package_multi'] = "LibFTDI1"
         self.cpp_info.components["ftdi"].libs = ["ftdi1"]
         self.cpp_info.components["ftdi"].requires = ["libusb::libusb"]
         self.cpp_info.components["ftdi"].includedirs.append(os.path.join("include", "libftdi1"))
 
         if self.options.enable_cpp_wrapper:
-            self.cpp_info.components["ftdipp"].names["pkg_config"] = "libftdi1pp"
             self.cpp_info.components["ftdipp"].libs = ["ftdipp1"]
             self.cpp_info.components["ftdipp"].requires = ["ftdi", "boost::headers"]

--- a/recipes/libftdi/1.x/conanfile.py
+++ b/recipes/libftdi/1.x/conanfile.py
@@ -103,4 +103,3 @@ class LibFtdiConan(ConanFile):
             self.cpp_info.components["ftdipp"].names["pkg_config"] = "libftdi1pp"
             self.cpp_info.components["ftdipp"].libs = ["ftdipp1"]
             self.cpp_info.components["ftdipp"].requires = ["ftdi", "boost::headers"]
-            self.cpp_info.components["ftdipp"].includedirs.append(os.path.join("include", "libftdipp1"))

--- a/recipes/libftdi/1.x/conanfile.py
+++ b/recipes/libftdi/1.x/conanfile.py
@@ -68,7 +68,8 @@ class LibFtdiConan(ConanFile):
 
     def requirements(self):
         self.requires("libusb/1.0.24")
-        self.requires("boost/1.75.0")
+        if self.options.enable_cpp_wrapper:
+            self.requires("boost/1.75.0")
 
     def validate(self):
         if self.settings.compiler == "Visual Studio" and self.options.use_streaming:
@@ -98,7 +99,8 @@ class LibFtdiConan(ConanFile):
         self.cpp_info.components["ftdi"].requires = ["libusb::libusb"]
         self.cpp_info.components["ftdi"].includedirs.append(os.path.join("include", "libftdi1"))
 
-        self.cpp_info.components["ftdipp"].names["pkg_config"] = "libftdi1pp"
-        self.cpp_info.components["ftdipp"].libs = ["ftdipp1"]
-        self.cpp_info.components["ftdipp"].requires = ["ftdi", "boost::headers"]
-        self.cpp_info.components["ftdipp"].includedirs.append(os.path.join("include", "libftdipp1"))
+        if self.options.enable_cpp_wrapper:
+            self.cpp_info.components["ftdipp"].names["pkg_config"] = "libftdi1pp"
+            self.cpp_info.components["ftdipp"].libs = ["ftdipp1"]
+            self.cpp_info.components["ftdipp"].requires = ["ftdi", "boost::headers"]
+            self.cpp_info.components["ftdipp"].includedirs.append(os.path.join("include", "libftdipp1"))

--- a/recipes/libftdi/1.x/conanfile.py
+++ b/recipes/libftdi/1.x/conanfile.py
@@ -60,6 +60,7 @@ class LibFtdiConan(ConanFile):
             "FTDIPP" : self.options.enable_cpp_wrapper,
             "STATICLIBS": not self.options.shared,
             "ENABLE_STREAMING": self.options.use_streaming,
+            "LIB_SUFFIX": "",
         }
         self._cmake.definitions.update(options)
         self._cmake.configure()


### PR DESCRIPTION
Specify library name and version:  **libftdi/1.5**

This PR fixes four issues:
- On certain 64bit operation system (e.g. OpenSuse in my case) the ftdi library (ligftdi1.a) was installed in a folder called "lib64" but expected to be in "lib". The consumer got `cannot find -lftdi1: No such file or directory`.
- The option `enable_cpp_wrapper` requires `boost` as a dependency. But `boost` was also required when the option had been set to `False`.
- Remove an include directory (`include/libftdipp1`) from the recipe, because it doesn't exist in the installed package.
- Adapt the recipe for Conan 2.0

@ reviewers: please pay special attention at the last commit (the conan 2.0 fixes) and bear with me, as I am not experienced in writing Conan recipes.


---

- [ x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
