### PR TITLE
libpqxx: add version 6.4.8, support conan v2, remove older versions

### DIFF
--- a/recipes/libpqxx/all/CMakeLists.txt
+++ b/recipes/libpqxx/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.1.2)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory(source_subfolder)

--- a/recipes/libpqxx/all/conandata.yml
+++ b/recipes/libpqxx/all/conandata.yml
@@ -1,206 +1,75 @@
 sources:
-  "7.0.1":
-    url: "https://github.com/jtv/libpqxx/archive/7.0.1.tar.gz"
-    sha256: "8c607ea4142223823ec400a3ff8f9561e8674e5888243cb7c6a610bf548ae0f0"
-  "7.0.2":
-    url: "https://github.com/jtv/libpqxx/archive/7.0.2.tar.gz"
-    sha256: "0e99df348623f2adaee5c79405279fb0e0182b9f4aebedb6bf007d982ab90dff"
-  "7.0.3":
-    url: "https://github.com/jtv/libpqxx/archive/7.0.3.tar.gz"
-    sha256: "7e28ad68cf6563246d97ccdeba5996dd71316c589f39b253f2cb2fbac0c2f7ef"
-  "7.0.4":
-    url: "https://github.com/jtv/libpqxx/archive/7.0.4.tar.gz"
-    sha256: "b56b441eb49755b39f0ba194b81047f7596540ee23c1caa8aa1b963f1bded9f5"
-  "7.0.5":
-    url: "https://github.com/jtv/libpqxx/archive/7.0.5.tar.gz"
-    sha256: "64f60d26a1ebc56fa356b9e3f18bd5b0f2ffbb0f123165ab1a5389ce0a9eeb1e"
-  "7.0.6":
-    url: "https://github.com/jtv/libpqxx/archive/7.0.6.tar.gz"
-    sha256: "8905377a387dfcc950fc03cc3a6c0e02825065207f20f563f0bd2a5ddfdd3bcc"
-  "7.0.7":
-    url: "https://github.com/jtv/libpqxx/archive/7.0.7.tar.gz"
-    sha256: "856fffb76141a236df608a86aa7d63b04f82816c9bbf80d33189705a0b2682eb"
-  "7.1.1":
-    url: "https://github.com/jtv/libpqxx/archive/7.1.1.tar.gz"
-    sha256: "cdf1efdc77de20e65f3affa0d4d9f819891669feb159eff8893696bf7692c00d"
-  "7.1.2":
-    url: "https://github.com/jtv/libpqxx/archive/7.1.2.tar.gz"
-    sha256: "3af7b4cfd572c67275ad24fea31bcf9d9f365ec16a1b7e90d4bde930936707f3"
-  "7.2.0":
-    url: "https://github.com/jtv/libpqxx/archive/7.2.0.tar.gz"
-    sha256: "c482a31c5d08402bc9e8df8291bed3555640ea80b3cb354fca958b1b469870dd"
-  "7.2.1":
-    url: "https://github.com/jtv/libpqxx/archive/7.2.1.tar.gz"
-    sha256: "3fd8318d2e421483495bf1a8ea1365fce4105934e9600ca87be0dff470d8c8dc"
-  "7.3.0":
-    url: "https://github.com/jtv/libpqxx/archive/7.3.0.tar.gz"
-    sha256: "55563821727310828cd79737732ca7e14a49dbbaa86bdce7c5829d440dafde59"
-  "7.3.1":
-    url: "https://github.com/jtv/libpqxx/archive/7.3.1.tar.gz"
-    sha256: "c794e7e5c4f1ef078463ecafe747a6508a0272d83b32a8cdcfb84bb37218a78b"
-  "7.3.2":
-    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.3.2.tar.gz"
-    sha256: "493991345de5cbddfed8836917a333add2cd00ecbfd21b1acbc9345ce784225f"
-  "7.4.0":
-    url: "https://github.com/jtv/libpqxx/archive/7.4.0.tar.gz"
-    sha256: "930e95d0c709905f9d842081cd33b5226f5803ed1fc6ef5b6e3b131ddaeddecb"
-  "7.4.1":
-    url: "https://github.com/jtv/libpqxx/archive/7.4.1.tar.gz"
-    sha256: "73b2f0a0af786d6039291b60250bee577bc7ea7c10b7550ec37da448940848b7"
-  "7.4.2":
-    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.4.2.tar.gz"
-    sha256: "325d50c51a417e890f7d71805f90a8d7949dce659f721b0f15d7f91bf954091d"
-  "7.5.0":
-    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.5.0.tar.gz"
-    sha256: "62744ddba939880675f1e76275c98c1653f60b0e725f013299f4a437351bf2b0"
-  "7.5.1":
-    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.5.1.tar.gz"
-    sha256: "16a3a4097a6772a9824ba584dbe5a1feee163ab954b94497358fe591eb236e3d"
-  "7.5.2":
-    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.5.2.tar.gz"
-    sha256: "62e140667fb1bc9b61fa01cbf46f8ff73236eba6f3f7fbcf98108ce6bbc18dcd"
-  "7.5.3":
-    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.5.3.tar.gz"
-    sha256: "4229ed9205e484a4bafb10edd6ce75b98c12d63c082a98baada0c01766d218e0"
-  "7.6.0":
-    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.6.0.tar.gz"
-    sha256: "8194ce4eff3fee5325963ccc28d3542cfaa54ba1400833d0df6948de3573c118"
-  "7.6.1":
-    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.6.1.tar.gz"
-    sha256: "7f4ad37fce20e8c9a61387cd5d6f85cf264f2bc9c0e6b27e8d5751a5429f87d0"
-  "7.7.0":
-    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.7.0.tar.gz"
-    sha256: "2d99de960aa3016915bc69326b369fcee04425e57fbe9dad48dd3fa6203879fb"
-  "7.7.2":
-    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.7.2.tar.gz"
-    sha256: "4b7a0b67cbd75d1c31e1e8a07c942ffbe9eec4e32c29b15d71cc225dc737e243"
-  "7.7.3":
-    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.7.3.tar.gz"
-    sha256: "11e147bbe2d3024d68d29b38eab5d75899dbb6131e421a2dbf9f88bac9bf4b0d"
   "7.7.4":
     url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.7.4.tar.gz"
     sha256: "65b0a06fffd565a19edacedada1dcfa0c1ecd782cead0ee067b19e2464875c36"
-patches:
-  "7.0.1":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-missing-limits-include.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch"
-      base_path: "source_subfolder"
-  "7.0.2":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-missing-limits-include.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch"
-      base_path: "source_subfolder"
-  "7.0.3":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-missing-limits-include.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch"
-      base_path: "source_subfolder"
-  "7.0.4":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-missing-limits-include.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch"
-      base_path: "source_subfolder"
-  "7.0.5":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.1_to_7.0.5.patch"
-      base_path: "source_subfolder"
-  "7.0.6":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.6_to_7.0.7.patch"
-      base_path: "source_subfolder"
-  "7.0.7":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.6_to_7.0.7.patch"
-      base_path: "source_subfolder"
-  "7.1.1":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.1.1.patch"
-      base_path: "source_subfolder"
-  "7.1.2":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-  "7.2.0":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-  "7.2.1":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-  "7.3.0":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-  "7.3.1":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-msvc-compilation-7.3.1.patch"
-      base_path: "source_subfolder"
-  "7.3.2":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-msvc-compilation-7.3.1.patch"
-      base_path: "source_subfolder"
-  "7.4.0":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-apple-clang-compilation-7.4.0.patch"
-      base_path: "source_subfolder"
-  "7.4.1":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-  "7.4.2":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-  "7.5.0":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-  "7.5.1":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-  "7.5.2":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-  "7.5.3":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-  "7.6.0":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-inline-constexpr-local-variable-problem-7.6.0.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-remove-unlikely-annotation-before-return-7.6.0_to_7.6.1.patch"
-      base_path: "source_subfolder"
-  "7.6.1":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-inline-constexpr-local-variable-problem-7.6.0.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-remove-unlikely-annotation-before-return-7.6.0_to_7.6.1.patch"
-      base_path: "source_subfolder"
-  "7.7.0":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-clang-compilation-7.7.0.patch"
-      base_path: "source_subfolder"
-  "7.7.2":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/fix-install-library-symlink-7.7.2.patch"
-      base_path: "source_subfolder"
   "7.7.3":
-    - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.7.3.tar.gz"
+    sha256: "11e147bbe2d3024d68d29b38eab5d75899dbb6131e421a2dbf9f88bac9bf4b0d"
+  "7.7.2":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.7.2.tar.gz"
+    sha256: "4b7a0b67cbd75d1c31e1e8a07c942ffbe9eec4e32c29b15d71cc225dc737e243"
+  "7.7.0":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.7.0.tar.gz"
+    sha256: "2d99de960aa3016915bc69326b369fcee04425e57fbe9dad48dd3fa6203879fb"
+  "7.6.1":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.6.1.tar.gz"
+    sha256: "7f4ad37fce20e8c9a61387cd5d6f85cf264f2bc9c0e6b27e8d5751a5429f87d0"
+  "7.6.0":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.6.0.tar.gz"
+    sha256: "8194ce4eff3fee5325963ccc28d3542cfaa54ba1400833d0df6948de3573c118"
+  "7.5.3":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.5.3.tar.gz"
+    sha256: "4229ed9205e484a4bafb10edd6ce75b98c12d63c082a98baada0c01766d218e0"
+  "7.4.2":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.4.2.tar.gz"
+    sha256: "325d50c51a417e890f7d71805f90a8d7949dce659f721b0f15d7f91bf954091d"
+  "7.3.2":
+    url: "https://github.com/jtv/libpqxx/archive/refs/tags/7.3.2.tar.gz"
+    sha256: "493991345de5cbddfed8836917a333add2cd00ecbfd21b1acbc9345ce784225f"
+  "7.2.1":
+    url: "https://github.com/jtv/libpqxx/archive/7.2.1.tar.gz"
+    sha256: "3fd8318d2e421483495bf1a8ea1365fce4105934e9600ca87be0dff470d8c8dc"
+  "7.1.2":
+    url: "https://github.com/jtv/libpqxx/archive/7.1.2.tar.gz"
+    sha256: "3af7b4cfd572c67275ad24fea31bcf9d9f365ec16a1b7e90d4bde930936707f3"
+  "7.0.7":
+    url: "https://github.com/jtv/libpqxx/archive/7.0.7.tar.gz"
+    sha256: "856fffb76141a236df608a86aa7d63b04f82816c9bbf80d33189705a0b2682eb"
+  "6.4.8":
+    url: "https://github.com/jtv/libpqxx/archive/6.4.8.tar.gz"
+    sha256: "3f7aba951822e01f1b9f9f353702954773323dd9f9dc376ffb57cb6bbd9a7a2f"
+patches:
   "7.7.4":
     - patch_file: "patches/0001-cmake-fix-module.patch"
-      base_path: "source_subfolder"
+  "7.7.3":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+  "7.7.2":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+    - patch_file: "patches/fix-install-library-symlink-7.7.2.patch"
+  "7.7.0":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+    - patch_file: "patches/fix-clang-compilation-7.7.0.patch"
+  "7.6.1":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+    - patch_file: "patches/fix-inline-constexpr-local-variable-problem-7.6.0.patch"
+    - patch_file: "patches/fix-remove-unlikely-annotation-before-return-7.6.0_to_7.6.1.patch"
+  "7.6.0":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+    - patch_file: "patches/fix-inline-constexpr-local-variable-problem-7.6.0.patch"
+    - patch_file: "patches/fix-remove-unlikely-annotation-before-return-7.6.0_to_7.6.1.patch"
+  "7.5.3":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+  "7.4.2":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+  "7.3.2":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+    - patch_file: "patches/fix-msvc-compilation-7.3.1.patch"
+  "7.2.1":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+  "7.1.2":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+  "7.0.7":
+    - patch_file: "patches/0001-cmake-fix-module.patch"
+    - patch_file: "patches/fix-not-declared-dumb_stringstream-7.0.6_to_7.0.7.patch"
+  "6.4.8":
+    - patch_file: "patches/0001-cmake-fix-module-6.4.8.patch"

--- a/recipes/libpqxx/all/conanfile.py
+++ b/recipes/libpqxx/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
-from conan.tools.microsoft import check_min_vs, is_msvc
+from conan.tools.microsoft import check_min_vs, is_msvc, msvc_runtime_flag
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
@@ -79,7 +79,7 @@ class LibpqxxConan(ConanFile):
         else:
             check_min_vs(self, 192)
 
-        if is_msvc(self) and self.options.shared and self.settings.compiler.runtime == "MTd":
+        if is_msvc(self) and self.options.shared and msvc_runtime_flag(self) == "MTd":
             raise ConanInvalidConfiguration(f"{self.ref} recipes does not support build shared library with MTd runtime.")
 
         if not is_msvc(self):

--- a/recipes/libpqxx/all/conanfile.py
+++ b/recipes/libpqxx/all/conanfile.py
@@ -1,18 +1,21 @@
-from conan.tools.microsoft import msvc_runtime_flag
-from conans import CMake, ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
-import functools
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.microsoft import check_min_vs, is_msvc
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.43.0"
-
+required_conan_version = ">=1.53.0"
 
 class LibpqxxConan(ConanFile):
     name = "libpqxx"
     description = "The official C++ client API for PostgreSQL"
+    license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/jtv/libpqxx"
-    license = "BSD-3-Clause"
     topics = ("libpqxx", "postgres", "postgresql", "database", "db")
 
     settings = "os", "arch", "compiler", "build_type"
@@ -25,24 +28,31 @@ class LibpqxxConan(ConanFile):
         "fPIC": True,
     }
 
-    generators = "cmake", "cmake_find_package"
+    @property
+    def _min_cppstd(self):
+        return 14 if Version(self.version) < "7.0" else "17"
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
+    def _compilers_minimum_version(self):
+        if Version(self.version) < "7.0":
+            return {
+                "gcc": "7",
+                "clang": "6",
+                "apple-clang": "10"
+            }
+        else:
+            return {
+                "gcc": "7" if Version(self.version) < "7.5.0" else "8",
+                "clang": "6",
+                "apple-clang": "10"
+            }
 
     @property
     def _mac_os_minimum_required_version(self):
         return "10.15"
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -50,77 +60,70 @@ class LibpqxxConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libpq/14.2")
+        self.requires("libpq/14.5")
 
     def validate(self):
-        if self.options.shared and msvc_runtime_flag(self) == "MTd":
-            raise ConanInvalidConfiguration(
-                "{} recipes does not support build shared library with MTd runtime."
-                .format(self.name,))
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
 
-        compiler = str(self.settings.compiler)
-        compiler_version = tools.Version(self.settings.compiler.version)
+        if Version(self.version) < "7.0":
+            check_min_vs(self, 190)
+        elif Version(self.version) < "7.6":
+            check_min_vs(self, 191)
+        else:
+            check_min_vs(self, 192)
 
-        lib_version = tools.Version(self.version)
-        lib_version_7_6_0_or_later = lib_version >= "7.6.0"
-        minimum_compiler_version = {
-            "Visual Studio": "16" if lib_version_7_6_0_or_later else "15",
-            "msvc": "192" if lib_version_7_6_0_or_later else "191",
-            "gcc": "8" if lib_version >= "7.5.0" else "7",
-            "clang": "6",
-            "apple-clang": "10"
-        }
+        if is_msvc(self) and self.options.shared and self.settings.compiler.runtime == "MTd":
+            raise ConanInvalidConfiguration(f"{self.ref} recipes does not support build shared library with MTd runtime.")
 
-        minimum_cpp_standard = 17
+        if not is_msvc(self):
+            minimum_version = self._compilers_minimum_version.get(str(self.info.settings.compiler), False)
+            if minimum_version and Version(self.info.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+                )
 
-        if compiler in minimum_compiler_version and \
-           compiler_version < minimum_compiler_version[compiler]:
-            raise ConanInvalidConfiguration("{} requires a compiler that supports"
-                                            " at least C++{}. {} {} is not"
-                                            " supported."
-                                            .format(self.name, minimum_cpp_standard, compiler, compiler_version))
-
-        if self.settings.os == "Macos":
+        if is_apple_os(self):
             os_version = self.settings.get_safe("os.version")
-            if os_version and tools.Version(os_version) < self._mac_os_minimum_required_version:
+            if os_version and Version(os_version) < self._mac_os_minimum_required_version:
                 raise ConanInvalidConfiguration(
                     "Macos Mojave (10.14) and earlier cannot to be built because C++ standard library too old.")
 
-        if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, minimum_cpp_standard)
-
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["BUILD_DOC"] = False
-        cmake.definitions["BUILD_TEST"] = False
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_DOC"] = False
+        tc.variables["BUILD_TEST"] = False
         # Set `-mmacosx-version-min` to enable C++17 standard library support.
-        cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"] = self._mac_os_minimum_required_version
-        cmake.configure(build_folder=self._build_subfolder)
-        return cmake
+        tc.variables["CMAKE_OSX_DEPLOYMENT_TARGET"] = self._mac_os_minimum_required_version
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        copy(self, pattern="COPYING", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
 
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
         cmake.install()
 
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "libpqxx")

--- a/recipes/libpqxx/all/conanfile.py
+++ b/recipes/libpqxx/all/conanfile.py
@@ -134,6 +134,8 @@ class LibpqxxConan(ConanFile):
         self.cpp_info.components["pqxx"].libs = ["pqxx"]
         if self.settings.os == "Windows":
             self.cpp_info.components["pqxx"].system_libs = ["wsock32", "ws2_32"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
 
         # TODO: to remove in conan v2 once cmake_find_package_* generators removed
         self.cpp_info.components["pqxx"].set_property("cmake_target_name", "libpqxx::pqxx")

--- a/recipes/libpqxx/all/patches/0001-cmake-fix-module-6.4.8.patch
+++ b/recipes/libpqxx/all/patches/0001-cmake-fix-module-6.4.8.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 86ffa24..e35824b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,7 +10,8 @@ if(NOT "${CMAKE_CXX_STANDARD}")
+ endif()
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
++list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
++
+ 
+ if(NOT SKIP_BUILD_TEST)
+ 	option(BUILD_TEST "Build all test cases" ON)

--- a/recipes/libpqxx/all/test_package/CMakeLists.txt
+++ b/recipes/libpqxx/all/test_package/CMakeLists.txt
@@ -3,13 +3,15 @@ cmake_minimum_required(VERSION 3.8)
 # Set `-mmacosx-version-min` to enable C++17 standard library support.
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 
-project(test_package CXX)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES CXX)
 
 find_package(libpqxx REQUIRED CONFIG)
 
+
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} libpqxx::pqxx)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_link_libraries(${PROJECT_NAME} PRIVATE libpqxx::pqxx)
+if(libpqxx_VERSION VERSION_LESS "7.0")
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+else()
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+endif()

--- a/recipes/libpqxx/all/test_package/conanfile.py
+++ b/recipes/libpqxx/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
-
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libpqxx/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libpqxx/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/libpqxx/all/test_v1_package/conanfile.py
+++ b/recipes/libpqxx/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libpqxx/config.yml
+++ b/recipes/libpqxx/config.yml
@@ -1,55 +1,27 @@
 versions:
-  "7.0.1":
-    folder: all
-  "7.0.2":
-    folder: all
-  "7.0.3":
-    folder: all
-  "7.0.4":
-    folder: all
-  "7.0.5":
-    folder: all
-  "7.0.6":
-    folder: all
-  "7.0.7":
-    folder: all
-  "7.1.1":
-    folder: all
-  "7.1.2":
-    folder: all
-  "7.2.0":
-    folder: all
-  "7.2.1":
-    folder: all
-  "7.3.0":
-    folder: all
-  "7.3.1":
-    folder: all
-  "7.3.2":
-    folder: all
-  "7.4.0":
-    folder: all
-  "7.4.1":
-    folder: all
-  "7.4.2":
-    folder: all
-  "7.5.0":
-    folder: all
-  "7.5.1":
-    folder: all
-  "7.5.2":
-    folder: all
-  "7.5.3":
-    folder: all
-  "7.6.0":
-    folder: all
-  "7.6.1":
-    folder: all
-  "7.7.0":
-    folder: all
-  "7.7.2":
+  "7.7.4":
     folder: all
   "7.7.3":
     folder: all
-  "7.7.4":
+  "7.7.2":
+    folder: all
+  "7.7.0":
+    folder: all
+  "7.6.1":
+    folder: all
+  "7.6.0":
+    folder: all
+  "7.5.3":
+    folder: all
+  "7.4.2":
+    folder: all
+  "7.3.2":
+    folder: all
+  "7.2.1":
+    folder: all
+  "7.1.2":
+    folder: all
+  "7.0.7":
+    folder: all
+  "6.4.8":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libpqxx/***

- add version 6.4.8 (last C++14 version)
- remove older versions
- suppor conan v2

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
