### PR TITLE
taywee-args: add version 6.4.2

### DIFF
--- a/recipes/taywee-args/all/conandata.yml
+++ b/recipes/taywee-args/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.4.2":
+    url: "https://github.com/Taywee/args/archive/6.4.2.tar.gz"
+    sha256: "882adaf179471edf0ac468bab67a0ee53979e4efe91fe4992d5b38422067dd85"
   "6.4.1":
     url: "https://github.com/Taywee/args/archive/6.4.1.tar.gz"
     sha256: "9b3f78208c9cfb06ccbeb7c44903018c8b036b6592a2d9a7d8695d1944060b35"

--- a/recipes/taywee-args/config.yml
+++ b/recipes/taywee-args/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.4.2":
+    folder: all
   "6.4.1":
     folder: all
   "6.3.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **taywee-args/6.4.2**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
