### PR TITLE
opentdf-client: add version 1.3.4

### DIFF
--- a/recipes/opentdf-client/all/conandata.yml
+++ b/recipes/opentdf-client/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.4":
+    url: "https://github.com/opentdf/client-cpp/archive/1.3.4.tar.gz"
+    sha256: "4b9836bff368249b709fc40e67c3a8664fed85a5d8247475ca1f741486210409"
   "1.3.3":
     url: "https://github.com/opentdf/client-cpp/archive/1.3.3.tar.gz"
     sha256: "7949e662dc55a425771e5ecf2d96e25295d1e2394e805608aed72d1131896948"

--- a/recipes/opentdf-client/config.yml
+++ b/recipes/opentdf-client/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.4":
+    folder: all
   "1.3.3":
     folder: all
   "1.3.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version: opentdf-client/1.3.4

 - For decrypt use KAS URL from tdf

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
