### PR TITLE
Version bump for si to 2.5.1

### DIFF
--- a/recipes/si/all/conandata.yml
+++ b/recipes/si/all/conandata.yml
@@ -23,3 +23,6 @@ sources:
   2.5.0:
     url: https://github.com/bernedom/SI/archive/2.5.0.tar.gz
     sha256: dc00eb8cfaa32e19c83595b238726188d2b857f8999dae08fe3001d0107ba276
+  2.5.1:
+    url: https://github.com/bernedom/SI/archive/2.5.1.tar.gz
+    sha256: b7b977c04c220a47a2bd3b8e2b6acfd640d286dfe1ae609f20e184cfec998798

--- a/recipes/si/config.yml
+++ b/recipes/si/config.yml
@@ -15,3 +15,5 @@ versions:
     folder: all
   2.5.0:
     folder: all
+  2.5.1:
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **si/2.5.1**

2.5.1 contains an important bugfix. I am the author of si

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
