### PR TITLE
(#14402) boost: Add filesystem_use_std_fs option

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -78,6 +78,7 @@ class BoostConan(ConanFile):
         "system_no_deprecated": [True, False],
         "asio_no_deprecated": [True, False],
         "filesystem_no_deprecated": [True, False],
+        "filesystem_use_std_fs": [True, False],
         "filesystem_version": [None, "3", "4"],
         "fPIC": [True, False],
         "layout": ["system", "versioned", "tagged", "b2-default"],
@@ -116,6 +117,7 @@ class BoostConan(ConanFile):
         "system_no_deprecated": False,
         "asio_no_deprecated": False,
         "filesystem_no_deprecated": False,
+        "filesystem_use_std_fs": False,
         "filesystem_version": None,
         "fPIC": True,
         "layout": "system",
@@ -1080,6 +1082,8 @@ class BoostConan(ConanFile):
             flags.append("define=BOOST_ASIO_NO_DEPRECATED=1")
         if self.options.filesystem_no_deprecated:
             flags.append("define=BOOST_FILESYSTEM_NO_DEPRECATED=1")
+        if self.options.filesystem_use_std_fs:
+            flags.append("define=BOOST_DLL_USE_STD_FS=1")
         if self.options.system_use_utf8:
             flags.append("define=BOOST_SYSTEM_USE_UTF8=1")
         if self.options.segmented_stacks:
@@ -1448,6 +1452,9 @@ class BoostConan(ConanFile):
 
         if self.options.filesystem_no_deprecated:
             self.cpp_info.components["headers"].defines.append("BOOST_FILESYSTEM_NO_DEPRECATED")
+
+        if self.options.filesystem_use_std_fs:
+            self.cpp_info.components["headers"].defines.append("BOOST_DLL_USE_STD_FS")
 
         if self.options.filesystem_version:
             self.cpp_info.components["headers"].defines.append(f"BOOST_FILESYSTEM_VERSION={self.options.filesystem_version}")


### PR DESCRIPTION
Use C++17's std::filesystem::path, std::system_error and std::error_code

Specify library name and version:  **boost/all**

Closes #14402 

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
