### PR TITLE
(#14407) [nativefiledialog] Fix not being able to use VS 2022

### DIFF
--- a/recipes/nativefiledialog/all/conanfile.py
+++ b/recipes/nativefiledialog/all/conanfile.py
@@ -12,7 +12,7 @@ class NativefiledialogConan(ConanFile):
     topics = ("conan", "dialog", "gui")
     settings = "os", "compiler", "build_type", "arch"
     generators = "pkg_config",
-    
+
     @property
     def _source_subfolder(self):
         return "source_subfolder"
@@ -38,7 +38,8 @@ class NativefiledialogConan(ConanFile):
 
     def build(self):
         if self.settings.compiler == "Visual Studio":
-            generator = "vs" + {"16": "2019",
+            generator = "vs" + {"17": "2019", # premake does not know about current compilers...
+                                "16": "2019",
                                 "15": "2017",
                                 "14": "2015",
                                 "12": "2013",


### PR DESCRIPTION
Specify library name and version:  **nativefiledialog/116**

Fix not being able to build the package using VS2022. Fixes #14407 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
