### PR TITLE
fast_float: add version 3.8.0

### DIFF
--- a/recipes/fast_float/all/conandata.yml
+++ b/recipes/fast_float/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.8.0":
+    url: "https://github.com/fastfloat/fast_float/archive/v3.8.0.tar.gz"
+    sha256: "8cb82dc35da3b745b3beb1a9974402307c9ded0e875aea077dbb3ea63833dd2e"
   "3.7.0":
     url: "https://github.com/fastfloat/fast_float/archive/v3.7.0.tar.gz"
     sha256: "4a30c43d14bbc979130a7807aecb2de5ff513951dd99a8b77cc32acfc610f850"

--- a/recipes/fast_float/config.yml
+++ b/recipes/fast_float/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.8.0":
+    folder: all
   "3.7.0":
     folder: all
   "3.6.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **fast_float/3.8.0**



---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
