### PR TITLE
immer: add version 0.8.0

### DIFF
--- a/recipes/immer/all/conandata.yml
+++ b/recipes/immer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.8.0":
+    url: "https://github.com/arximboldi/immer/archive/v0.8.0.tar.gz"
+    sha256: "4ed9e86a525f293e0ba053107b937d88b032674ec6e5db958816f2e412677fde"
   "0.7.0":
     url: "https://github.com/arximboldi/immer/archive/v0.7.0.tar.gz"
     sha256: "cf67ab428aa3610eb0f72d0ea936c15cce3f91df26ee143ab783acd053507fe4"

--- a/recipes/immer/config.yml
+++ b/recipes/immer/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.8.0":
+    folder: all
   "0.7.0":
     folder: all
   "0.6.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **immer/0.8.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
