### PR TITLE
botan: add version 2.19.3

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -41,6 +41,9 @@ sources:
   "2.19.2":
     url: "https://github.com/randombit/botan/archive/2.19.2.tar.gz"
     sha256: "47bb0330255cf1a439db3f2bc91894b2f41788e58eb71d27e0abf36038d93f1e"
+  "2.19.3":
+    url: "https://github.com/randombit/botan/archive/2.19.3.tar.gz"
+    sha256: "8f568bf74c2e476d92ac8a1cfc2ba8407ec038fe9458bd0a11e7da827a9b8199"
 patches:
   "2.12.1":
     - patch_file: "patches/dll-dir.patch"

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -27,3 +27,5 @@ versions:
     folder: all
   "2.19.2":
     folder: all
+  "2.19.3":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **botan/2.19.3**

Botan has fixed a vulnerability in its OCSP response validation.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
