### PR TITLE
arrow: fix compute option dependency

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -212,7 +212,7 @@ class ArrowConan(ConanFile):
 
     def _compute(self, required=False):
         if required or self.options.compute == "auto":
-            return bool(self._dataset_modules()) or bool(self.options.get_safe("substrait", False))
+            return bool(self._parquet() or self._dataset_modules()) or bool(self.options.get_safe("substrait", False))
         else:
             return bool(self.options.compute)
 


### PR DESCRIPTION
Specify library name and version:  **arrow/***

compute module is also required by parquet module: https://github.com/apache/arrow/commit/75cf66a895e257cb3a432d57c3d8bfa70febb0da#diff-645ff3e44561e45a579725c47e88f7b46b0120f240c4999ab82770a128044e97R25

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
