### PR TITLE
quill: add version 2.5.1

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.1":
+    url: "https://github.com/odygrd/quill/archive/v2.5.1.tar.gz"
+    sha256: "62227595cc2b4c0c42ed35f17ef5b7487d8231aca9e75234a4c0e346cea19928"
   "2.4.2":
     url: "https://github.com/odygrd/quill/archive/v2.4.2.tar.gz"
     sha256: "4771dc08c0ff01cea9081d645ed7cae27cfa073185c986177ef3ce13743136af"

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.5.1":
+    folder: "all"
   "2.4.2":
     folder: "all"
   "2.3.4":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **quill/2.5.1**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
