### PR TITLE
protopuf: add version 2.2.1

### DIFF
--- a/recipes/protopuf/all/conandata.yml
+++ b/recipes/protopuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.1":
+    url: "https://github.com/PragmaTwice/protopuf/archive/v2.2.1.tar.gz"
+    sha256: "8d4940206d8e8664f75ae1cdfff8c14fa9a196c03967d520725284429744c19c"
   "2.2.0":
     url: "https://github.com/PragmaTwice/protopuf/archive/refs/tags/v2.2.0.tar.gz"
     sha256: "f19aed66c7ff44fee2ae980f869746e2000fb484893f53f2e4ea021352444ea9"

--- a/recipes/protopuf/config.yml
+++ b/recipes/protopuf/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.2.1":
+    folder: all
   "2.2.0":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **protopuf/2.2.1**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
