### PR TITLE
wasmtime-cpp: add version 3.0.0

### DIFF
--- a/recipes/wasmtime-cpp/all/conandata.yml
+++ b/recipes/wasmtime-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.0":
+    url: "https://github.com/bytecodealliance/wasmtime-cpp/archive/v3.0.0.tar.gz"
+    sha256: "9840637cc3040f924db1caf957b883efcfa4ad9d92a86245cc0fd3967ea3db09"
   "2.0.0":
     url: "https://github.com/bytecodealliance/wasmtime-cpp/archive/refs/tags/v2.0.0.tar.gz"
     sha256: "27dcf8fbbc8dbe0387bde2d38e9d78a829b649a0bf86750c5d2a1327a5971b18"

--- a/recipes/wasmtime-cpp/config.yml
+++ b/recipes/wasmtime-cpp/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.0":
+    folder: all
   "2.0.0":
     folder: all
   "1.0.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **wasmtime-cpp/3.0.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
