### PR TITLE
flatbuffers: add version 22.11.23

### DIFF
--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "22.11.23":
+    url: "https://github.com/google/flatbuffers/archive/v22.11.23.tar.gz"
+    sha256: "8e9bacc942db59ca89a383dd7923f3e69a377d6e579d1ba13557de1fdfddf56a"
   "22.10.26":
     url: "https://github.com/google/flatbuffers/archive/v22.10.26.tar.gz"
     sha256: "34f1820cfd78a3d92abc880fbb1a644c7fb31a71238995f4ed6b5915a1ad4e79"

--- a/recipes/flatbuffers/config.yml
+++ b/recipes/flatbuffers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "22.11.23":
+    folder: all
   "22.10.26":
     folder: all
   "22.9.29":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **flatbuffers/22.11.23**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
