### PR TITLE
confu_json: add version 0.0.10

### DIFF
--- a/recipes/confu_json/all/conandata.yml
+++ b/recipes/confu_json/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   0.0.9:
     url: https://github.com/werto87/confu_json/archive/refs/tags/v0.0.9.tar.gz
     sha256: 29b2940b939cb04f11fdab4964c86bcb23ac75c588550bf54048e024444d2718
+  "0.0.10":
+    url: "https://github.com/werto87/confu_json/archive/v0.0.10.tar.gz"
+    sha256: "b31aab1bce952c0dc0bfc1f955a7b88be5103350b5a5eee1a4586ccec0e51fc1"

--- a/recipes/confu_json/config.yml
+++ b/recipes/confu_json/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   0.0.9:
     folder: all
+  "0.0.10":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **confu_json/0.0.10**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
