### PR TITLE
[llvm-core] Allow to compile with ZLIB support on Windows

### DIFF
--- a/recipes/llvm-core/all/CMakeLists.txt
+++ b/recipes/llvm-core/all/CMakeLists.txt
@@ -12,11 +12,14 @@ if(LLVM_ENABLE_ZLIB)
   list(GET ZLIB_LIBRARIES 0 ZLIB_LIBRARY)
   set_property(TARGET ZLIB::ZLIB PROPERTY LOCATION "${ZLIB_LIBRARY}")
 
+  # Additionally LLVM 11.1.0 requires the zlib lib dir to be in the library path.
+  # This is not needed for later versions and can be removed once
+  # LLVM-12 becomes the oldest supported version.
   if(UNIX)
-    # Additionally LLVM 11.1.0 requires the zlib lib dir to be in the library path.
-    # This is not needed for later versions and can be removed once
-	# LLVM-12 becomes the oldest supported version.
     set(ENV{LIBRARY_PATH} "${CONAN_LIB_DIRS_ZLIB}:$ENV{LIBRARY_PATH}")
+  elseif(WIN32)
+    file(TO_NATIVE_PATH "${CONAN_LIB_DIRS_ZLIB}" WINDOWS_ZLIB_PATH)	
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " /LIBPATH:${WINDOWS_ZLIB_PATH}")
   endif()
 endif()
 

--- a/recipes/llvm-core/all/conanfile.py
+++ b/recipes/llvm-core/all/conanfile.py
@@ -196,7 +196,6 @@ class LLVMCoreConan(ConanFile):
     def config_options(self):
         if self.settings.os == 'Windows':
             del self.options.fPIC
-            del self.options.with_zlib
             del self.options.with_xml2
 
     def requirements(self):


### PR DESCRIPTION
There is no reason why we can't allow compiling with ZLIB support on Windows. It is supported and works fine in my tests with version 13.0.0.

Let's see if the CI agrees.

Specify library name and version:  **llvm-core/<all_versions>**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
