### PR TITLE
qwt: rely on self.info.options in validate()

### DIFF
--- a/recipes/qwt/all/conanfile.py
+++ b/recipes/qwt/all/conanfile.py
@@ -63,13 +63,13 @@ class QwtConan(ConanFile):
         if hasattr(self, "settings_build") and cross_building(self):
             raise ConanInvalidConfiguration("Qwt recipe does not support cross-compilation yet")
         qt_options = self.dependencies["qt"].options
-        if self.options.widgets and not qt_options.widgets:
+        if self.info.options.widgets and not qt_options.widgets:
             raise ConanInvalidConfiguration("qwt:widgets=True requires qt:widgets=True")
-        if self.options.svg and not qt_options.qtsvg:
+        if self.info.options.svg and not qt_options.qtsvg:
             raise ConanInvalidConfiguration("qwt:svg=True requires qt:qtsvg=True")
-        if self.options.opengl and qt_options.opengl == "no":
+        if self.info.options.opengl and qt_options.opengl == "no":
             raise ConanInvalidConfiguration("qwt:opengl=True is not compatible with qt:opengl=no")
-        if self.options.designer and not (qt_options.qttools and qt_options.gui and qt_options.widgets):
+        if self.info.options.designer and not (qt_options.qttools and qt_options.gui and qt_options.widgets):
             raise ConanInvalidConfiguration("qwt:designer=True requires qt:qttools=True, qt::gui=True and qt::widgets=True")
 
     def build_requirements(self):


### PR DESCRIPTION
small conan v2 fix of verifications introduced in https://github.com/conan-io/conan-center-index/pull/14249

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
