### PR TITLE
libgettext - add -FS flag for RelWithDebInfo as well as Debug builds

### DIFF
--- a/recipes/libgettext/all/conanfile.py
+++ b/recipes/libgettext/all/conanfile.py
@@ -120,7 +120,8 @@ class GetTextConan(ConanFile):
             if target is not None:
                 tc.configure_args += [f"--host={target}", f"--build={target}"]
 
-            if (self.settings.build_type == "RelWithDebInfo" or self.settings.build_type == "Debug") and Version(self.settings.compiler.version) >= "12":
+            if (self.settings.compiler == "Visual Studio" and Version(self.settings.compiler.version) >= "12") or \
+               (self.settings.compiler == "msvc" and Version(self.settings.compiler.version) >= "180"):
                 tc.extra_cflags += ["-FS"]
 
         tc.make_args += ["-C", "intl"]

--- a/recipes/libgettext/all/conanfile.py
+++ b/recipes/libgettext/all/conanfile.py
@@ -120,7 +120,7 @@ class GetTextConan(ConanFile):
             if target is not None:
                 tc.configure_args += [f"--host={target}", f"--build={target}"]
 
-            if self.settings.build_type == "Debug" and Version(self.settings.compiler.version) >= "12":
+            if (self.settings.build_type == "RelWithDebInfo" or self.settings.build_type == "Debug") and Version(self.settings.compiler.version) >= "12":
                 tc.extra_cflags += ["-FS"]
 
         tc.make_args += ["-C", "intl"]


### PR DESCRIPTION
For MSVC / VisualStudio, you need the -FS if multiple compiler instances are writing to the same .PDB at the same time.

The existing recipe adds `-FS` correctly, but only when building in Debug mode.
This change adds the flag for the RelWithDebInfo mode as well.