### PR TITLE
[nativefiledialog-extended] Add nativefiledialog-extended 1.0.1

### DIFF
--- a/recipes/nativefiledialog-extended/all/conandata.yml
+++ b/recipes/nativefiledialog-extended/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.1":
+    url: "https://github.com/btzy/nativefiledialog-extended/archive/refs/tags/v1.0.1.tar.gz"
+    sha256: "d4c0fff7df4fd789f544d34b9ddfe7d0807a4acde764a2a4dbe297ecba9d572e"

--- a/recipes/nativefiledialog-extended/all/conanfile.py
+++ b/recipes/nativefiledialog-extended/all/conanfile.py
@@ -1,0 +1,90 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import get, copy, rmdir, rm
+import os
+
+required_conan_version = '>=1.53.0'
+
+class NativeFileDialogExtendedConan(ConanFile):
+    name = 'nativefiledialog-extended'
+    license = 'Zlib'
+    url = 'https://github.com/conan-io/conan-center-index'
+    homepage = 'https://github.com/btzy/nativefiledialog-extended'
+    description = 'A tiny, neat C library that portably invokes native file open and save dialogs. Includes basic C++ wrapper'
+    topics = ('dialog', 'gui', 'filedialog')
+    settings = 'os', 'compiler', 'build_type', 'arch'
+    options = {
+        'shared': [True, False],
+        'fPIC': [True, False],
+        'auto_extension': [True, False],
+        'use_portal': [True, False],
+        'force_allowedFileTypes': [True, False],
+    }
+    default_options = {
+        'shared': False,
+        'fPIC': True,
+        'auto_extension': False,
+        'use_portal': False,
+        'force_allowedFileTypes': False,
+    }
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        if self.settings.os == 'Linux':
+            if self.options.use_portal:
+                self.requires('dbus/1.15.2')
+            else:
+                self.requires('gtk/3.24.24')
+
+    def configure(self):
+        if self.settings.os == 'Windows':
+            self.options.rm_safe('fPIC')
+            self.options.rm_safe('auto_extension')
+            self.options.rm_safe('use_portal')
+            self.options.rm_safe('force_allowedFileTypes')
+        if self.settings.os == 'Linux':
+            self.options.rm_safe('force_allowedFileTypes')
+        if self.settings.os == 'Macos':
+            self.options.rm_safe('auto_extension')
+            self.options.rm_safe('use_portal')
+
+    def source(self):
+        get(self, **self.conan_data['sources'][self.version], destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables['NFD_BUILD_TESTS'] = False
+        tc.variables['NFD_INSTALL'] = True
+        if self.settings.os == 'Macos':
+            tc.variables['NFD_USE_ALLOWEDCONTENTTYPES_IF_AVAILABLE'] = not self.options.force_allowedFileTypes
+        elif self.settings.os == 'Linux':
+            tc.variables['NFD_PORTAL'] = self.options.use_portal
+            tc.variables['NFD_APPEND_EXTENSION'] = self.options.auto_extension
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, 'lib', 'cmake'))
+        rmdir(self, os.path.join(self.package_folder, 'lib', 'pkgconfig'))
+        rm(self, '*.la', os.path.join(self.package_folder, 'lib'))
+        rm(self, '*.pdb', os.path.join(self.package_folder, 'lib'))
+        rm(self, '*.pdb', os.path.join(self.package_folder, 'bin'))
+
+        copy(self, pattern='LICENSE', dst=os.path.join(self.package_folder, 'licenses'), src=self.source_folder)
+
+    def package_info(self):
+        self.cpp_info.libs = ['nfd']
+        if self.settings.os == 'Macos':
+            self.cpp_info.frameworks = ['AppKit', 'UniformTypeIdentifiers']
+        elif self.settings.os == 'Windows':
+            self.cpp_info.system_libs = ['shell32.lib', 'ole32.lib', 'uuid.lib']

--- a/recipes/nativefiledialog-extended/config.yml
+++ b/recipes/nativefiledialog-extended/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.1":
+    folder: "all"


### PR DESCRIPTION
Specify library name and version:  **nativefiledialogs-extended/1.0.1**

Using this and had to make a conan package for it. Thought I'd share it in case anyone else wants to use it.
This is a version of the already existing nativefiledialogs library, which offers custom titles for filters

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
