### PR TITLE
stb: add version cci.20220909 for restoring stb_perlin.h

### DIFF
--- a/recipes/stb/all/conandata.yml
+++ b/recipes/stb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20220909":
+    url: "https://github.com/nothings/stb/archive/8b5f1f37b5b75829fc72d38e7b5d4bcbf8a26d55.zip"
+    sha256: "93a16ee3e866e719feec459f6f132cce932c5ec751eb38e3ec1975f911353d2e"
   "cci.20210910":
     url: "https://github.com/nothings/stb/archive/af1a5bc352164740c1cc1354942b1c6b72eacb8a.zip"
     sha256: "e3d0edbecd356506d3d69b87419de2f9d180a98099134c6343177885f6c2cbef"

--- a/recipes/stb/config.yml
+++ b/recipes/stb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20220909":
+    folder: all
   "cci.20210910":
     folder: all
   "cci.20210713":


### PR DESCRIPTION
Specify library name and version:  **stb/cci.20220909**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
