### PR TITLE
catch2: add console_width parameter

### DIFF
--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -23,7 +23,7 @@ class Catch2Conan(ConanFile):
         "fPIC": [True, False],
         "with_prefix": [True, False],
         "default_reporter": [None, "ANY"],
-        "console_width": range(80, 1000),
+        "console_width": [None, "ANY"],
     }
     default_options = {
         "shared": False,

--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -30,7 +30,7 @@ class Catch2Conan(ConanFile):
         "fPIC": True,
         "with_prefix": False,
         "default_reporter": None,
-        "console_width": 80,
+        "console_width": "80",
     }
 
     @property

--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -84,9 +84,9 @@ class Catch2Conan(ConanFile):
                 raise ConanInvalidConfiguration(
                         f"option 'console_width' must be >= {self._min_console_width}, "
                         f"got {self.options.console_width}")
-        except ValueError:
+        except ValueError as e:
             raise ConanInvalidConfiguration(f"option 'console_width' must be an integer, "
-                                            f"got '{self.options.console_width}'")
+                                            f"got '{self.options.console_width}'") from e
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)

--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -83,7 +83,7 @@ class Catch2Conan(ConanFile):
             if int(self.options.console_width) < self._min_console_width:
                 raise ConanInvalidConfiguration(
                         f"option 'console_width' must be >= {self._min_console_width}, "
-                        f"got {self.options.console_width}")
+                        f"got {self.options.console_width}. Contributions welcome if this should work!")
         except ValueError as e:
             raise ConanInvalidConfiguration(f"option 'console_width' must be an integer, "
                                             f"got '{self.options.console_width}'") from e

--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -38,6 +38,11 @@ class Catch2Conan(ConanFile):
         return "14"
 
     @property
+    def _min_console_width(self):
+        # Catch2 doesn't build if less than this value
+        return 46
+
+    @property
     def _compilers_minimum_version(self):
         return {
             "gcc": "7",
@@ -73,6 +78,15 @@ class Catch2Conan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler doesn't support",
             )
+
+        try:
+            if int(self.options.console_width) < self._min_console_width:
+                raise ConanInvalidConfiguration(
+                        f"option 'console_width' must be >= {self._min_console_width}, "
+                        f"got {self.options.console_width}")
+        except ValueError:
+            raise ConanInvalidConfiguration(f"option 'console_width' must be an integer, "
+                                            f"got '{self.options.console_width}'")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)

--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -84,7 +84,7 @@ class Catch2Conan(ConanFile):
         tc.cache_variables["CATCH_INSTALL_EXTRAS"] = True
         tc.cache_variables["CATCH_DEVELOPMENT_BUILD"] = False
         tc.variables["CATCH_CONFIG_PREFIX_ALL"] = self.options.with_prefix
-        tc.variables["CATCH_CONFIG_CONSOLE_WIDTH"] = f"{self.options.console_width}"
+        tc.variables["CATCH_CONFIG_CONSOLE_WIDTH"] = self.options.console_width
         if self.options.default_reporter:
             tc.variables["CATCH_CONFIG_DEFAULT_REPORTER"] = self._default_reporter_str
         tc.generate()

--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -23,12 +23,14 @@ class Catch2Conan(ConanFile):
         "fPIC": [True, False],
         "with_prefix": [True, False],
         "default_reporter": [None, "ANY"],
+        "console_width": range(80, 1000),
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_prefix": False,
         "default_reporter": None,
+        "console_width": 80,
     }
 
     @property
@@ -82,6 +84,7 @@ class Catch2Conan(ConanFile):
         tc.cache_variables["CATCH_INSTALL_EXTRAS"] = True
         tc.cache_variables["CATCH_DEVELOPMENT_BUILD"] = False
         tc.variables["CATCH_CONFIG_PREFIX_ALL"] = self.options.with_prefix
+        tc.variables["CATCH_CONFIG_CONSOLE_WIDTH"] = f"{self.options.console_width}"
         if self.options.default_reporter:
             tc.variables["CATCH_CONFIG_DEFAULT_REPORTER"] = self._default_reporter_str
         tc.generate()


### PR DESCRIPTION
Specify library name and version:  **catch2/3.x**

`catch2` has a build parameter which can set the width of the console. By default it is 80, but in some cases it might be good to make this wider. I set up an arbitrary upper bound in this PR.

I am not sure if for such a small change I need to [Request access](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/README.md#request-access) - as it is also not a new package. But in any case let me know.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
