### PR TITLE
Fix soxr for Apple Silicon architecture

### DIFF
--- a/recipes/soxr/all/CMakeLists.txt
+++ b/recipes/soxr/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 2.8.11)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup(KEEP_RPATHS)
-
-add_subdirectory("source_subfolder")

--- a/recipes/soxr/all/conandata.yml
+++ b/recipes/soxr/all/conandata.yml
@@ -5,4 +5,8 @@ sources:
 patches:
   "0.1.3":
     - patch_file: "patches/findpackage-openmp.patch"
+      patch_description: make OpenMP required to fail when not found
+      patch_type: conan
     - patch_file: "patches/cmake-source-dir.patch"
+      patch_description: point to the right source dir
+      patch_type: conan

--- a/recipes/soxr/all/conandata.yml
+++ b/recipes/soxr/all/conandata.yml
@@ -4,7 +4,5 @@ sources:
     sha256: "b111c15fdc8c029989330ff559184198c161100a59312f5dc19ddeb9b5a15889"
 patches:
   "0.1.3":
-    - base_path: source_subfolder
-      patch_file: "patches/findpackage-openmp.patch"
-    - base_path: source_subfolder
-      patch_file: "patches/cmake-source-dir.patch"
+    - patch_file: "patches/findpackage-openmp.patch"
+    - patch_file: "patches/cmake-source-dir.patch"

--- a/recipes/soxr/all/conanfile.py
+++ b/recipes/soxr/all/conanfile.py
@@ -1,6 +1,7 @@
-import functools
 import os
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, load, save, rmdir
 from conan.tools.microsoft import msvc_runtime_flag, is_msvc
 
 
@@ -27,20 +28,11 @@ class SoxrConan(ConanFile):
         "with_openmp": False,
         "with_lsr_bindings": True
     }
-    generators = "cmake"
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
+    exports_sources = "CMakeLists.txt"
 
     def export_sources(self):
-        self.copy("CMakeLists.txt")
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            self.copy(patch["patch_file"])
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -48,52 +40,53 @@ class SoxrConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.cppstd
-        del self.settings.compiler.libcxx
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-            destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
+    def generate(self):
+        tc = CMakeToolchain(self)
         if is_msvc(self):
-            cmake.definitions["BUILD_SHARED_RUNTIME"] = msvc_runtime_flag(self) == "MD"
+            tc.variables["BUILD_SHARED_RUNTIME"] = msvc_runtime_flag(self) == "MD"
         # Disable SIMD based resample engines for Apple Silicon architecture
         if self.settings.os == "Macos" and self.settings.arch == "armv8":
-            cmake.definitions["WITH_CR32S"] = False
-            cmake.definitions["WITH_CR64S"] = False
-        cmake.definitions["BUILD_TESTS"] = False
-        cmake.definitions["WITH_OPENMP"] = self.options.with_openmp
-        cmake.definitions["WITH_LSR_BINDINGS"] = self.options.with_lsr_bindings
-        cmake.configure(build_folder=self._build_subfolder)
-        return cmake
+            tc.variables["WITH_CR32S"] = False
+            tc.variables["WITH_CR64S"] = False
+        tc.variables["BUILD_TESTS"] = False
+        tc.variables["WITH_OPENMP"] = self.options.with_openmp
+        tc.variables["WITH_LSR_BINDINGS"] = self.options.with_lsr_bindings
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-        cmake = self._configure_cmake()
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def _extract_pffft_license(self):
-        pffft_c = tools.load(os.path.join(self._source_subfolder, "src", "pffft.c"))
+        pffft_c = load(self, os.path.join(self.source_folder, "src", "pffft.c"))
         license_contents = pffft_c[pffft_c.find("/* Copyright")+3:pffft_c.find("modern CPUs.")+13]
-        tools.save(os.path.join(self.package_folder, "licenses", "LICENSE"), license_contents)
+        save(self, os.path.join(self.package_folder, "licenses", "LICENSE"), license_contents)
 
     def package(self):
-        self.copy("LICENCE", dst="licenses", src=self._source_subfolder)
+        copy(self, "LICENCE", dst="licenses", src=self.source_folder)
         self._extract_pffft_license()
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "doc"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "doc"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         # core component
-        self.cpp_info.components["core"].names["pkg_config"] = "soxr"
+        self.cpp_info.components["core"].set_property("pkg_config_name", "soxr")
         self.cpp_info.components["core"].libs = ["soxr"]
         if self.settings.os in ("FreeBSD", "Linux"):
             self.cpp_info.components["core"].system_libs = ["m"]
@@ -112,7 +105,7 @@ class SoxrConan(ConanFile):
             self.cpp_info.components["core"].sharedlinkflags = openmp_flags
         # lsr component
         if self.options.with_lsr_bindings:
-            self.cpp_info.components["lsr"].names["pkg_config"] = "soxr-lsr"
+            self.cpp_info.components["lsr"].set_property("pkg_config_name", "soxr-lsr")
             self.cpp_info.components["lsr"].libs = ["soxr-lsr"]
             if self.settings.os == "Windows" and self.options.shared:
                 self.cpp_info.components["lsr"].defines.append("SOXR_DLL")

--- a/recipes/soxr/all/conanfile.py
+++ b/recipes/soxr/all/conanfile.py
@@ -29,8 +29,6 @@ class SoxrConan(ConanFile):
         "with_lsr_bindings": True
     }
 
-    exports_sources = "CMakeLists.txt"
-
     def export_sources(self):
         export_conandata_patches(self)
 

--- a/recipes/soxr/all/conanfile.py
+++ b/recipes/soxr/all/conanfile.py
@@ -61,6 +61,10 @@ class SoxrConan(ConanFile):
         cmake = CMake(self)
         if is_msvc(self):
             cmake.definitions["BUILD_SHARED_RUNTIME"] = msvc_runtime_flag(self) == "MD"
+        # Disable SIMD based resample engines for Apple Silicon architecture
+        if self.settings.os == "Macos" and self.settings.arch == "armv8":
+            cmake.definitions["WITH_CR32S"] = False
+            cmake.definitions["WITH_CR64S"] = False
         cmake.definitions["BUILD_TESTS"] = False
         cmake.definitions["WITH_OPENMP"] = self.options.with_openmp
         cmake.definitions["WITH_LSR_BINDINGS"] = self.options.with_lsr_bindings

--- a/recipes/soxr/all/conanfile.py
+++ b/recipes/soxr/all/conanfile.py
@@ -3,6 +3,7 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, load, save, rmdir
 from conan.tools.microsoft import msvc_runtime_flag, is_msvc
+from conan.tools.scm import Version
 
 
 required_conan_version = ">=1.45.0"
@@ -51,6 +52,11 @@ class SoxrConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        # Honor BUILD_SHARED_LIBS from conan_toolchain (see https://github.com/conan-io/conan/issues/11840) 
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        if Version(self.version) < "3.21":
+            # silence warning
+            tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0115"] = "OLD"
         if is_msvc(self):
             tc.variables["BUILD_SHARED_RUNTIME"] = msvc_runtime_flag(self) == "MD"
         # Disable SIMD based resample engines for Apple Silicon architecture

--- a/recipes/soxr/all/conanfile.py
+++ b/recipes/soxr/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.microsoft import msvc_runtime_flag, is_msvc
 from conan.tools.scm import Version
 
 
-required_conan_version = ">=1.45.0"
+required_conan_version = ">=1.53.0"
 
 
 class SoxrConan(ConanFile):

--- a/recipes/soxr/all/test_package/conanfile.py
+++ b/recipes/soxr/all/test_package/conanfile.py
@@ -7,6 +7,7 @@ from conan.tools.cmake import CMake, cmake_layout
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/soxr/all/test_package/conanfile.py
+++ b/recipes/soxr/all/test_package/conanfile.py
@@ -2,6 +2,7 @@ import os
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
+import yaml
 
 
 class TestPackageConan(ConanFile):
@@ -9,8 +10,23 @@ class TestPackageConan(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
+    _tests_todo = []
+
+    @property
+    def _todos_filename(self):
+        return os.path.join(self.recipe_folder, self.folders.generators, "catch2_test_to_do.yml")
+
     def requirements(self):
         self.requires(self.tested_reference_str)
+
+    def generate(self):
+        # note: this is required as self.dependencies is not available in test()
+        self._tests_todo.append("test_package_core")
+        if self.dependencies[self.tested_reference_str].options.with_lsr_bindings:
+            self._tests_todo.append("test_package_lsr")
+
+        with open(self._todos_filename, "w", encoding="utf-8") as file:
+            yaml.dump(self._tests_todo, file)
 
     def layout(self):
         cmake_layout(self)
@@ -21,11 +37,8 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
+        with open(self._todos_filename, "r", encoding="utf-8") as file:
+            self._tests_todo = yaml.safe_load(file)
         if can_run(self):
-            # core component
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package_core")
-            self.run(bin_path, env="conanrun")
-            # lsr component
-            if self.dependencies[self.tested_reference_str].options.with_lsr_bindings:
-                bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package_lsr")
-                self.run(bin_path, env="conanrun")
+            for test_name in self._tests_todo:
+                self.run(os.path.join(self.cpp.build.bindirs[0], test_name), env="conanrun")

--- a/recipes/soxr/all/test_package/conanfile.py
+++ b/recipes/soxr/all/test_package/conanfile.py
@@ -1,6 +1,6 @@
 import os
 from conan import ConanFile
-from conan.tools.build import cross_building
+from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
 
 
@@ -21,7 +21,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
+        if can_run(self):
             # core component
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package_core")
             self.run(bin_path, env="conanrun")

--- a/recipes/soxr/all/test_package/conanfile.py
+++ b/recipes/soxr/all/test_package/conanfile.py
@@ -14,7 +14,7 @@ class TestPackageConan(ConanFile):
 
     @property
     def _todos_filename(self):
-        return os.path.join(self.recipe_folder, self.folders.generators, "catch2_test_to_do.yml")
+        return os.path.join(self.recipe_folder, self.folders.generators, "soxr_test_to_do.yml")
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/soxr/all/test_v1_package/CMakeLists.txt
+++ b/recipes/soxr/all/test_v1_package/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(soxr CONFIG REQUIRED)
 
 add_executable(test_package_core test_package_core.c)

--- a/recipes/soxr/all/test_v1_package/conanfile.py
+++ b/recipes/soxr/all/test_v1_package/conanfile.py
@@ -1,0 +1,21 @@
+import os
+from conans import ConanFile, CMake, tools
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            # core component
+            bin_path = os.path.join("bin", "test_package_core")
+            self.run(bin_path, run_environment=True)
+            # lsr component
+            if self.options["soxr"].with_lsr_bindings:
+                bin_path = os.path.join("bin", "test_package_lsr")
+                self.run(bin_path, run_environment=True)

--- a/recipes/soxr/all/test_v1_package/test_package_core.c
+++ b/recipes/soxr/all/test_v1_package/test_package_core.c
@@ -1,0 +1,7 @@
+#include <soxr.h>
+#include <stdio.h>
+
+int main() {
+    printf("soxr version: %s\n", soxr_version());
+    return 0;
+}

--- a/recipes/soxr/all/test_v1_package/test_package_lsr.c
+++ b/recipes/soxr/all/test_v1_package/test_package_lsr.c
@@ -1,0 +1,7 @@
+#include <soxr-lsr.h>
+#include <stdio.h>
+
+int main() {
+    printf("soxr-lsr version: %s\n", src_get_version());
+    return 0;
+}


### PR DESCRIPTION
Specify library name and version:  **soxr/0.1.3**

This should fix #14485. At least it is a workaround to get soxr compiled for the Apple Silicon Macs. Im not an expert with this new architecture and SIMD, but for me it seems it is not supported by Apple Silicon.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
