### PR TITLE
cpp-httplib: add version 0.11.3

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.3":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.11.3.tar.gz"
+    sha256: "799b2daa0441d207f6cd1179ae3a34869722084a434da6614978be1682c1e12d"
   "0.11.2":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.11.2.tar.gz"
     sha256: "e620d030215733c4831fdc7813d5eb37a6fd599f8192a730662662e1748a741b"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.3":
+    folder: all
   "0.11.2":
     folder: all
   "0.11.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **cpp-httplib/0.11.3**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
