### PR TITLE
arrow: fix with_utf8proc option dependency

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -295,7 +295,7 @@ class ArrowConan(ConanFile):
 
     def _with_utf8proc(self, required=False):
         if required or self.options.with_utf8proc == "auto":
-            return False
+            return bool(self._compute() or self.options.gandiva)
         else:
             return bool(self.options.with_utf8proc)
 


### PR DESCRIPTION
Specify library name and version:  **arrow/***

compute module and gandiva module use utf8proc:
* https://github.com/apache/arrow/blob/apache-arrow-10.0.1/cpp/src/arrow/compute/kernels/scalar_string_utf8.cc#L22-L24
* https://github.com/apache/arrow/blob/apache-arrow-10.0.1/cpp/cmake_modules/DefineOptions.cmake#L330-L335

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/masterf/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
