### PR TITLE
android-ndk: define `tools.build:compiler_executables` config

### DIFF
--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -282,12 +282,12 @@ class AndroidNDKConan(ConanFile):
         self.conf_info.define("tools.android:ndk_path", os.path.join(self.package_folder, "bin"))
 
         compiler_executables = {
-            "cc": self._define_tool_var("CC", "clang"),
-            "cxx": self._define_tool_var("CXX", "clang++"),
+            "c": self._define_tool_var("CC", "clang"),
+            "cpp": self._define_tool_var("CXX", "clang++"),
         }
         self.conf_info.define("tools.build:compiler_executables", compiler_executables)
-        self.buildenv_info.define_path("CC", compiler_executables.get("cc"))
-        self.buildenv_info.define_path("CXX", compiler_executables.get("cxx"))
+        self.buildenv_info.define_path("CC", compiler_executables.get("c"))
+        self.buildenv_info.define_path("CXX", compiler_executables.get("cpp"))
 
         # Versions greater than 23 had the naming convention
         # changed to no longer include the triplet.
@@ -337,8 +337,8 @@ class AndroidNDKConan(ConanFile):
             cmake_wrapper = os.path.join(self.package_folder, "bin", cmake_wrapper)
             self.env_info.CONAN_CMAKE_PROGRAM = cmake_wrapper
             self.env_info.CONAN_CMAKE_TOOLCHAIN_FILE = os.path.join(self.package_folder, "bin", "build", "cmake", "android.toolchain.cmake")
-            self.env_info.CC = compiler_executables.get("cc")
-            self.env_info.CXX = compiler_executables.get("cxx")
+            self.env_info.CC = compiler_executables.get("c")
+            self.env_info.CXX = compiler_executables.get("cpp")
             self.env_info.AR = self._define_tool_var("AR", "ar", bare)
             self.env_info.AS = self._define_tool_var("AS", "as", bare)
             self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib", bare)

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -281,8 +281,13 @@ class AndroidNDKConan(ConanFile):
         # when `tools.android:ndk_path` is provided, so it MUST NOT be manually injected here to `tools.cmake.cmaketoolchain:user_toolchain` conf_info
         self.conf_info.define("tools.android:ndk_path", os.path.join(self.package_folder, "bin"))
 
-        self.buildenv_info.define_path("CC", self._define_tool_var("CC", "clang"))
-        self.buildenv_info.define_path("CXX", self._define_tool_var("CXX", "clang++"))
+        compiler_executables = {
+            "cc": self._define_tool_var("CC", "clang"),
+            "cxx": self._define_tool_var("CXX", "clang++"),
+        }
+        self.conf_info.define("tools.build:compiler_executables", compiler_executables)
+        self.buildenv_info.define_path("CC", compiler_executables.get("cc"))
+        self.buildenv_info.define_path("CXX", compiler_executables.get("cxx"))
 
         # Versions greater than 23 had the naming convention
         # changed to no longer include the triplet.
@@ -332,8 +337,8 @@ class AndroidNDKConan(ConanFile):
             cmake_wrapper = os.path.join(self.package_folder, "bin", cmake_wrapper)
             self.env_info.CONAN_CMAKE_PROGRAM = cmake_wrapper
             self.env_info.CONAN_CMAKE_TOOLCHAIN_FILE = os.path.join(self.package_folder, "bin", "build", "cmake", "android.toolchain.cmake")
-            self.env_info.CC = self._define_tool_var("CC", "clang")
-            self.env_info.CXX = self._define_tool_var("CXX", "clang++")
+            self.env_info.CC = compiler_executables.get("cc")
+            self.env_info.CXX = compiler_executables.get("cxx")
             self.env_info.AR = self._define_tool_var("AR", "ar", bare)
             self.env_info.AS = self._define_tool_var("AS", "as", bare)
             self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib", bare)

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -285,9 +285,9 @@ class AndroidNDKConan(ConanFile):
             "c": self._define_tool_var("CC", "clang"),
             "cpp": self._define_tool_var("CXX", "clang++"),
         }
-        self.conf_info.define("tools.build:compiler_executables", compiler_executables)
-        self.buildenv_info.define_path("CC", compiler_executables.get("c"))
-        self.buildenv_info.define_path("CXX", compiler_executables.get("cpp"))
+        self.conf_info.update("tools.build:compiler_executables", compiler_executables)
+        self.buildenv_info.define_path("CC", compiler_executables["c"])
+        self.buildenv_info.define_path("CXX", compiler_executables["cpp"])
 
         # Versions greater than 23 had the naming convention
         # changed to no longer include the triplet.
@@ -337,8 +337,8 @@ class AndroidNDKConan(ConanFile):
             cmake_wrapper = os.path.join(self.package_folder, "bin", cmake_wrapper)
             self.env_info.CONAN_CMAKE_PROGRAM = cmake_wrapper
             self.env_info.CONAN_CMAKE_TOOLCHAIN_FILE = os.path.join(self.package_folder, "bin", "build", "cmake", "android.toolchain.cmake")
-            self.env_info.CC = compiler_executables.get("c")
-            self.env_info.CXX = compiler_executables.get("cpp")
+            self.env_info.CC = compiler_executables["c"]
+            self.env_info.CXX = compiler_executables["cpp"]
             self.env_info.AR = self._define_tool_var("AR", "ar", bare)
             self.env_info.AS = self._define_tool_var("AS", "as", bare)
             self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib", bare)


### PR DESCRIPTION
define new `tools.build:compiler_executables` config introduced in conan 1.55.0, see https://github.com/conan-io/conan/pull/12556

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
