### PR TITLE
ICU: Workaround for proper cross-building after conan v2 recipe update

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -119,6 +119,11 @@ class ICUConan(ConanFile):
         if cross_building(self):
             base_path = unix_path(self, self.dependencies.build["icu"].package_folder)
             tc.configure_args.append(f"--with-cross-build={base_path}")
+            if (not is_msvc(self)):
+                # --with-cross-build above prevents tc.generate() from setting --build option.
+                # Workaround for https://github.com/conan-io/conan/issues/12642
+                gnu_triplet = get_gnu_triplet(str(self._settings_build.os), str(self._settings_build.arch))
+                tc.configure_args.append(f"--build={gnu_triplet}")
             if self.settings.os in ["iOS", "tvOS", "watchOS"]:
                 gnu_triplet = get_gnu_triplet("Macos", str(self.settings.arch))
                 tc.configure_args.append(f"--host={gnu_triplet}")

--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -122,7 +122,7 @@ class ICUConan(ConanFile):
             if (not is_msvc(self)):
                 # --with-cross-build above prevents tc.generate() from setting --build option.
                 # Workaround for https://github.com/conan-io/conan/issues/12642
-                gnu_triplet = get_gnu_triplet(str(self._settings_build.os), str(self._settings_build.arch))
+                gnu_triplet = get_gnu_triplet(str(self._settings_build.os), str(self._settings_build.arch), str(self.settings.compiler))
                 tc.configure_args.append(f"--build={gnu_triplet}")
             if self.settings.os in ["iOS", "tvOS", "watchOS"]:
                 gnu_triplet = get_gnu_triplet("Macos", str(self.settings.arch))


### PR DESCRIPTION
Specify library name and version: icu/*

Fixes https://github.com/conan-io/conan-center-index/issues/14513.
Workaround for https://github.com/conan-io/conan/issues/12642.

Passing `--with-cross-build` icu config options messes up with `AutotoolsToolchain` and it doesn't pass `--build` option.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
