### PR TITLE
opentelemetry-cpp: add version 1.8.0, update dependencies

### DIFF
--- a/recipes/opentelemetry-cpp/all/conandata.yml
+++ b/recipes/opentelemetry-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.0":
+    url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.8.0.tar.gz"
+    sha256: "8eddcbeae191a58d2d2a19305ed0a60776e43999eb29b64536566ba24506a6c1"
   "1.7.0":
     url: "https://github.com/open-telemetry/opentelemetry-cpp/archive/v1.7.0.tar.gz"
     sha256: "2ad0911cdc94fe84a93334773bef4789a38bd1f01e39560cabd4a5c267e823c3"
@@ -22,6 +25,10 @@ sources:
     sha256: "32f12ff15ec257e3462883f84bc291c2d5dc30055604c12ec4b46a36dfa3f189"
 
 patches:
+  "1.8.0":
+    - patch_file: "patches/1.8.0-0001-fix-cmake.patch"
+      patch_description: "fix lack of linking libraries due to conan not generating the variables that are expected"
+      patch_type: "conan"
   "1.7.0":
     - patch_file: "patches/1.7.0-0001-fix-cmake.patch"
       patch_description: "fix lack of linking libraries due to conan not generating the variables that are expected"

--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -52,10 +52,10 @@ class OpenTelemetryCppConan(ConanFile):
 
     def requirements(self):
         self.requires("abseil/20220623.0")
-        self.requires("grpc/1.48.0")
-        self.requires("libcurl/7.85.0")
+        self.requires("grpc/1.50.1")
+        self.requires("libcurl/7.86.0")
         self.requires("nlohmann_json/3.11.2")
-        self.requires("openssl/1.1.1q")
+        self.requires("openssl/1.1.1s")
         if Version(self.version) <= "1.4.1":
             self.requires("opentelemetry-proto/0.11.0")
         else:

--- a/recipes/opentelemetry-cpp/all/patches/1.8.0-0001-fix-cmake.patch
+++ b/recipes/opentelemetry-cpp/all/patches/1.8.0-0001-fix-cmake.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9b9710d..6eb42bb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -222,7 +222,6 @@ if(WITH_JAEGER)
+   find_package(Thrift QUIET)
+   if(Thrift_FOUND)
+     find_package(Boost REQUIRED)
+-    include_directories(${Boost_INCLUDE_DIR})
+   else()
+     # Install Thrift and propagate via vcpkg toolchain file
+     if(WIN32 AND (NOT DEFINED CMAKE_TOOLCHAIN_FILE))
+diff --git a/cmake/opentelemetry-proto.cmake b/cmake/opentelemetry-proto.cmake
+index 47f57a6..ebf5869 100644
+--- a/cmake/opentelemetry-proto.cmake
++++ b/cmake/opentelemetry-proto.cmake
+@@ -280,6 +280,10 @@ else() # cmake 3.8 or lower
+   target_link_libraries(opentelemetry_proto INTERFACE ${Protobuf_LIBRARIES})
+ endif()
+ 
++if(TARGET gRPC::grpc++)
++  target_link_libraries(opentelemetry_proto PUBLIC gRPC::grpc++)
++endif()
++
+ if(BUILD_SHARED_LIBS)
+   set_property(TARGET opentelemetry_proto PROPERTY POSITION_INDEPENDENT_CODE ON)
+ endif()


### PR DESCRIPTION
Specify library name and version:  **opentelemetry-cpp/***

- add version 1.8.0
- update dependencies (except protobuf because there is a same reason of https://github.com/conan-io/conan-center-index/pull/14471.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
