### PR TITLE
Add Boost.LEAF to Conan Center

### DIFF
--- a/recipes/boost-leaf/all/conandata.yml
+++ b/recipes/boost-leaf/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.81.0-prerelease":
+    url: "https://github.com/boostorg/leaf/archive/refs/tags/1.81.0-prerelease.tar.gz"
+    sha256: "ce434749631cd978ae657e2007d814b5ddf6bb1a2701b855d08cfdd0c145bf90"

--- a/recipes/boost-leaf/all/conandata.yml
+++ b/recipes/boost-leaf/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "1.81.0":
-    url: "https://github.com/boostorg/leaf/archive/refs/tags/1.81.1.tar.gz"
-    sha256: "129240c1c110db0df891007b0696c6b32b770fc6c81bb827b82004b7a6951ee1"
+    url: "https://github.com/boostorg/leaf/archive/refs/tags/1.81.0.tar.gz"
+    sha256: "6a2bfa8727891e844f1f95c9c68af192f4c5f53b1707acce54290932118b48c0"

--- a/recipes/boost-leaf/all/conandata.yml
+++ b/recipes/boost-leaf/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.81.0-prerelease":
-    url: "https://github.com/boostorg/leaf/archive/refs/tags/1.81.0-prerelease.tar.gz"
-    sha256: "ce434749631cd978ae657e2007d814b5ddf6bb1a2701b855d08cfdd0c145bf90"
+  "1.81.0":
+    url: "https://github.com/boostorg/leaf/archive/refs/tags/1.81.1.tar.gz"
+    sha256: "129240c1c110db0df891007b0696c6b32b770fc6c81bb827b82004b7a6951ee1"

--- a/recipes/boost-leaf/all/conanfile.py
+++ b/recipes/boost-leaf/all/conanfile.py
@@ -75,7 +75,15 @@ class BoostLEAFConan(ConanFile):
              "include"), src=os.path.join(self.source_folder, "include"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "boost-leaf")
         self.cpp_info.set_property("cmake_target_name", "boost::leaf")
+
+        self.cpp_info.names["cmake_find_package"] = "boost"
+        self.cpp_info.names["cmake_find_package_multi"] = "boost"
+        self.cpp_info.filenames["cmake_find_package"] = "boost-leaf"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "boost-leaf"
+        self.cpp_info.components["leaf"].names["cmake_find_package"] = "leaf"
+        self.cpp_info.components["leaf"].names["cmake_find_package_multi"] = "leaf"
 
         self.cpp_info.bindirs = []
         self.cpp_info.frameworkdirs = []

--- a/recipes/boost-leaf/all/conanfile.py
+++ b/recipes/boost-leaf/all/conanfile.py
@@ -31,11 +31,11 @@ class BoostLEAFConan(ConanFile):
     @property
     def _compilers_minimum_version(self):
         return {
-            "gcc": "11",
+            "gcc": "4.8",
             "Visual Studio": "17",
-            "msvc": "193",
-            "clang": "13",
-            "apple-clang": "13.1.6"
+            "msvc": "141",
+            "clang": "3.9",
+            "apple-clang": "10.0.0"
         }
 
     def requirements(self):

--- a/recipes/boost-leaf/all/conanfile.py
+++ b/recipes/boost-leaf/all/conanfile.py
@@ -1,0 +1,83 @@
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+from conan.tools.build import check_min_cppstd
+from conan.errors import ConanInvalidConfiguration
+import os
+
+
+required_conan_version = ">=1.50.0"
+
+
+class BoostLEAFConan(ConanFile):
+    name = "boost-leaf"
+    version = "1.81.0-prerelease"
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/boostorg/leaf"
+    description = ("Lightweight Error Augmentation Framework")
+    topics = ("multi-platform", "multi-threading", "cpp11", "error-handling",
+              "header-only", "low-latency", "no-dependencies", "single-header")
+    settings = "os", "compiler", "arch", "build_type"
+    no_copy_source = True
+
+    def package_id(self):
+        self.info.clear()
+
+    @property
+    def _min_cppstd(self):
+        return "11"
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "11",
+            "Visual Studio": "17",
+            "msvc": "193",
+            "clang": "13",
+            "apple-clang": "13.1.6"
+        }
+
+    def requirements(self):
+        pass
+
+    def validate(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+        def lazy_lt_semver(v1, v2):
+            lv1 = [int(v) for v in v1.split(".")]
+            lv2 = [int(v) for v in v2.split(".")]
+            min_length = min(len(lv1), len(lv2))
+            return lv1[:min_length] < lv2[:min_length]
+
+        compiler = str(self.settings.compiler)
+        version = str(self.settings.compiler.version)
+        minimum_version = self._compilers_minimum_version.get(compiler, False)
+
+        if minimum_version and lazy_lt_semver(version, minimum_version):
+            raise ConanInvalidConfiguration(
+                f"{self.name} {self.version} requires C++{self._min_cppstd}, which your compiler ({compiler}-{version}) does not support")
+
+    def layout(self):
+        basic_layout(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE_1_0.txt", dst=os.path.join(
+            self.package_folder, "licenses"),  src=self.source_folder)
+        copy(self, "*.h", dst=os.path.join(self.package_folder, "include"),
+             src=os.path.join(self.source_folder, "include"))
+        copy(self, "*.hpp", dst=os.path.join(self.package_folder,
+             "include"), src=os.path.join(self.source_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_target_name", "boost::leaf")
+
+        self.cpp_info.bindirs = []
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []

--- a/recipes/boost-leaf/all/conanfile.py
+++ b/recipes/boost-leaf/all/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class BoostLEAFConan(ConanFile):
     name = "boost-leaf"
-    version = "1.81.0-prerelease"
+    version = "1.81.0"
     license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/boostorg/leaf"

--- a/recipes/boost-leaf/all/conanfile.py
+++ b/recipes/boost-leaf/all/conanfile.py
@@ -11,7 +11,6 @@ required_conan_version = ">=1.50.0"
 
 class BoostLEAFConan(ConanFile):
     name = "boost-leaf"
-    version = "1.81.0"
     license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/boostorg/leaf"

--- a/recipes/boost-leaf/all/test_package/CMakeLists.txt
+++ b/recipes/boost-leaf/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.12)
+project(test_package LANGUAGES CXX)
+
+find_package(boost-leaf REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} main.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
+target_link_libraries(${PROJECT_NAME} PRIVATE boost::leaf)

--- a/recipes/boost-leaf/all/test_package/CMakeLists.txt
+++ b/recipes/boost-leaf/all/test_package/CMakeLists.txt
@@ -4,6 +4,6 @@ project(test_package LANGUAGES CXX)
 find_package(boost-leaf REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} main.cpp)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 target_link_libraries(${PROJECT_NAME} PRIVATE boost::leaf)

--- a/recipes/boost-leaf/all/test_package/conanfile.py
+++ b/recipes/boost-leaf/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import cross_building
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/boost-leaf/all/test_package/conanfile.py
+++ b/recipes/boost-leaf/all/test_package/conanfile.py
@@ -7,6 +7,7 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
@@ -20,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
+        if can_run(self):
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/boost-leaf/all/test_package/conanfile.py
+++ b/recipes/boost-leaf/all/test_package/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.build import cross_building
+from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
 import os
 

--- a/recipes/boost-leaf/all/test_package/main.cpp
+++ b/recipes/boost-leaf/all/test_package/main.cpp
@@ -3,7 +3,7 @@
 
 using namespace boost;
 
-enum error_t
+enum custom_error_t
 {
   err1,
   err2,
@@ -25,7 +25,7 @@ leaf::result<int> g(int a, int b)
   int sum = a + b;
   if (sum == 20)
   {
-    return leaf::new_error(error_t::err2);
+    return leaf::new_error(custom_error_t::err2);
   }
   return sum;
 }
@@ -40,12 +40,12 @@ int main()
 
         return g(v1, v2);
       },
-      [](leaf::match<error_t, error_t::err1, error_t::err3>) -> leaf::result<int>
+      [](leaf::match<custom_error_t, custom_error_t::err1, custom_error_t::err3>) -> leaf::result<int>
       {
         exit(1);
         return -1;
       },
-      [](error_t e) -> leaf::result<int>
+      [](custom_error_t e) -> leaf::result<int>
       {
         printf("Error value [%d] handled\n", static_cast<int>(e));
         return 17;

--- a/recipes/boost-leaf/all/test_package/main.cpp
+++ b/recipes/boost-leaf/all/test_package/main.cpp
@@ -1,0 +1,64 @@
+#include <cstdio>
+#include <boost/leaf.hpp>
+
+using namespace boost;
+
+enum error_t
+{
+  err1,
+  err2,
+  err3,
+};
+
+leaf::result<int> f1()
+{
+  return 5;
+}
+
+leaf::result<int> f2()
+{
+  return 15;
+}
+
+leaf::result<int> g(int a, int b)
+{
+  int sum = a + b;
+  if (sum == 20)
+  {
+    return leaf::new_error(error_t::err2);
+  }
+  return sum;
+}
+
+int main()
+{
+  leaf::result<int> r = leaf::try_handle_some(
+      []() -> leaf::result<int>
+      {
+        BOOST_LEAF_AUTO(v1, f1());
+        BOOST_LEAF_AUTO(v2, f2());
+
+        return g(v1, v2);
+      },
+      [](leaf::match<error_t, error_t::err1, error_t::err3>) -> leaf::result<int>
+      {
+        exit(1);
+        return -1;
+      },
+      [](error_t e) -> leaf::result<int>
+      {
+        printf("Error value [%d] handled\n", static_cast<int>(e));
+        return 17;
+      });
+
+  if (r)
+  {
+    printf("value of r = %d\n", r.value());
+  }
+  else
+  {
+    printf("r contains an error!\n");
+  }
+
+  return 0;
+}

--- a/recipes/boost-leaf/all/test_v1_package/CMakeLists.txt
+++ b/recipes/boost-leaf/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.12)
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(boost-leaf REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} ../test_package/main.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
+target_link_libraries(${PROJECT_NAME} PRIVATE boost::leaf)

--- a/recipes/boost-leaf/all/test_v1_package/CMakeLists.txt
+++ b/recipes/boost-leaf/all/test_v1_package/CMakeLists.txt
@@ -7,6 +7,6 @@ conan_basic_setup(TARGETS)
 find_package(boost-leaf REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} ../test_package/main.cpp)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 target_link_libraries(${PROJECT_NAME} PRIVATE boost::leaf)

--- a/recipes/boost-leaf/all/test_v1_package/conanfile.py
+++ b/recipes/boost-leaf/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class LibhalTestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = ("cmake", "cmake_find_package_multi")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if cross_building(self):
+            bin_path = os.path.join(self.build_folder, "bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/boost-leaf/all/test_v1_package/conanfile.py
+++ b/recipes/boost-leaf/all/test_v1_package/conanfile.py
@@ -13,6 +13,6 @@ class LibhalTestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if cross_building(self):
+        if not cross_building(self):
             bin_path = os.path.join(self.build_folder, "bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/boost-leaf/config.yml
+++ b/recipes/boost-leaf/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.81.0-prerelease":
+    folder: "all"

--- a/recipes/boost-leaf/config.yml
+++ b/recipes/boost-leaf/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.81.0-prerelease":
+  "1.81.0":
     folder: "all"


### PR DESCRIPTION
Resolves boostorg/leaf#47

Specify library name and version:  **boost-leaf/1.81.0-prerelease**

I work with and have consent by the author to put `Boost.LEAF` on the Conan Center Index. This library is a dependency of my library `libhal`.

---

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
