### PR TITLE
usockets: add version 0.8.3

### DIFF
--- a/recipes/usockets/all/conandata.yml
+++ b/recipes/usockets/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.8.3":
+    url: "https://github.com/uNetworking/uSockets/archive/v0.8.3.tar.gz"
+    sha256: "2f96a26365b87badbea2360a82521a382c0c3ee2dcf4f32c79b11d0cb1989a53"
   "0.8.2":
     url: "https://github.com/uNetworking/uSockets/archive/v0.8.2.tar.gz"
     sha256: "c17fc99773a30552cdd7741ff98af177eeecb26b89fc38011b430956b3b2eca5"
@@ -15,6 +18,11 @@ sources:
     url: "https://github.com/uNetworking/uSockets/archive/v0.4.0.tar.gz"
     sha256: "f9f15b395def578cc79a5b32abc64fa9cff5dac873062911f515b984b90f7cc2"
 patches:
+  "0.8.3":
+    - patch_file: "patches/0001-makefile_0.8.3.patch"
+      base_path: "source_subfolder"
+      patch_description: "remove lto options"
+      patch_type: "portability"
   "0.8.2":
     - patch_file: "patches/0001-makefile_0.8.2.patch"
       base_path: "source_subfolder"

--- a/recipes/usockets/all/conanfile.py
+++ b/recipes/usockets/all/conanfile.py
@@ -2,10 +2,13 @@ from conan import ConanFile
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rmdir, chdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
+from conan.tools.microsoft import is_msvc
 from conan.errors import ConanInvalidConfiguration
 from conans import MSBuild, AutoToolsBuildEnvironment
+from conans.tools import vcvars, environment_append, unix_path, get_env
 
 import os
+import contextlib
 
 required_conan_version = ">=1.52.0"
 
@@ -60,6 +63,10 @@ class UsocketsConan(ConanFile):
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    @property
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -123,6 +130,12 @@ class UsocketsConan(ConanFile):
         elif self.options.eventloop == "boost":
             self.requires("boost/1.80.0")
 
+    def build_requirements(self):
+        if self._settings_build.os == "Windows" and not get_env("CONAN_BASH_PATH"):
+            self.build_requires("msys2/cci.latest")
+        if self.settings.compiler == "Visual Studio":
+            self.build_requires("automake/1.16.5")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], destination=self._source_subfolder, strip_root=True)
 
@@ -134,11 +147,34 @@ class UsocketsConan(ConanFile):
             msbuild = MSBuild(self)
             msbuild.build(project_file="uSockets.vcxproj", platforms={"x86": "Win32"})
 
+    @contextlib.contextmanager
+    def _build_context(self):
+        if is_msvc(self):
+            with vcvars(self):
+                env = {
+                    "CC": "{} cl -nologo".format(unix_path(self.deps_user_info["automake"].compile)),
+                    "CXX": "{} cl -nologo".format(unix_path(self.deps_user_info["automake"].compile)),
+                    "CFLAGS": "-{}".format(self.settings.compiler.runtime),
+                    "LD": "link",
+                    "NM": "dumpbin -symbols",
+                    "STRIP": ":",
+                    "AR": "{} lib".format(unix_path(self.deps_user_info["automake"].ar_lib)),
+                    "RANLIB": ":",
+                }
+
+                if self.options.eventloop == "libuv":
+                    env["CPPFLAGS"] = "-I" + unix_path(self.deps_cpp_info["libuv"].include_paths[0]) + " "
+
+                with environment_append(env):
+                    yield
+        else:
+            yield
+
     def _build_configure(self):
         autotools = AutoToolsBuildEnvironment(self)
         autotools.fpic = self.options.get_safe("fPIC", False)
         with chdir(self, self._source_subfolder):
-            args = []
+            args = ["WITH_LTO=0"]
             if self.options.with_ssl == "openssl":
                 args.append("WITH_OPENSSL=1")
             elif self.options.with_ssl == "wolfssl":
@@ -156,16 +192,17 @@ class UsocketsConan(ConanFile):
 
     def build(self):
         self._patch_sources()
-        if self.settings.compiler == "Visual Studio":
+        if Version(self.version) < "0.8.3" and is_msvc(self):
             self._build_msvc()
         else:
-            self._build_configure()
+            with self._build_context():
+                self._build_configure()
 
     def package(self):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self._source_subfolder)
         copy(self, pattern="*.h", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self._source_subfolder, "src"), keep_path=True)
-        copy(self, pattern="*.a", dst=os.path.join(self.package_folder, "lib"), src=self._source_subfolder, keep_path=False)
-        copy(self, pattern="*.lib", dst=os.path.join(self.package_folder, "lib"), src=self._source_subfolder, keep_path=False)
+        copy(self, pattern="*.a", dst=os.path.join(self.package_folder, "lib"), src=self.build_folder, keep_path=False)
+        copy(self, pattern="*.lib", dst=os.path.join(self.package_folder, "lib"), src=self.build_folder, keep_path=False)
         # drop internal headers
         rmdir(self, os.path.join(self.package_folder, "include", "internal"))
 

--- a/recipes/usockets/all/patches/0001-makefile_0.8.3.patch
+++ b/recipes/usockets/all/patches/0001-makefile_0.8.3.patch
@@ -1,0 +1,40 @@
+diff --git a/Makefile b/Makefile
+index f6e2c6b..087d021 100644
+--- a/Makefile
++++ b/Makefile
+@@ -63,21 +63,21 @@ endif
+ # By default we build the uSockets.a static library
+ default:
+ 	rm -f *.o
+-	$(CC) $(CFLAGS) -O3 -c src/*.c src/eventing/*.c src/crypto/*.c
++	$(CC) $(CFLAGS) $(CPPFLAGS) -O3 -c src/*.c src/eventing/*.c src/crypto/*.c
+ # Also link in Boost Asio support
+ ifeq ($(WITH_ASIO),1)
+-	$(CXX) $(CXXFLAGS) -Isrc -std=c++14 -flto -O3 -c src/eventing/asio.cpp
++	$(CXX) $(CXXFLAGS) -Isrc -std=c++14 $(CPPFLAGS) -O3 -c src/eventing/asio.cpp
+ endif
+ 
+ # For now we do rely on C++17 for OpenSSL support but we will be porting this work to C11
+ ifeq ($(WITH_OPENSSL),1)
+-	$(CXX) $(CXXFLAGS) -std=c++17 -flto -O3 -c src/crypto/*.cpp
++	$(CXX) $(CXXFLAGS) -std=c++17 $(CPPFLAGS) -O3 -c src/crypto/*.cpp
+ endif
+ ifeq ($(WITH_BORINGSSL),1)
+-	$(CXX) $(CXXFLAGS) -std=c++17 -flto -O3 -c src/crypto/*.cpp
++	$(CXX) $(CXXFLAGS) -std=c++17 $(CPPFLAGS) -O3 -c src/crypto/*.cpp
+ endif
+ # Create a static library (try windows, then unix)
+-	lib.exe /out:uSockets.a *.o || $(AR) rvs uSockets.a *.o
++	lib.exe /out:uSockets.lib *.obj || $(AR) rvs libuSockets.a *.o
+ 
+ # BoringSSL needs cmake and golang
+ .PHONY: boringssl
+@@ -87,7 +87,7 @@ boringssl:
+ # Builds all examples
+ .PHONY: examples
+ examples: default
+-	for f in examples/*.c; do $(CC) -O3 $(CFLAGS) -o $$(basename "$$f" ".c")$(EXEC_SUFFIX) "$$f" $(LDFLAGS); done
++	for f in examples/*.c; do $(CC) $(CPPFLAGS) -O3 $(CFLAGS) -o $$(basename "$$f" ".c")$(EXEC_SUFFIX) "$$f" $(LDFLAGS); done
+ 
+ swift_examples:
+ 	swiftc -O -I . examples/swift_http_server/main.swift uSockets.a -o swift_http_server

--- a/recipes/usockets/config.yml
+++ b/recipes/usockets/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.8.3":
+    folder: all
   "0.8.2":
     folder: all
   "0.8.1":


### PR DESCRIPTION
Specify library name and version:  **usockets/0.8.3**

- add version 0.8.3
- Since 0.8.3, usockets don't provide `uSockets.vcxproj`, upstream provides makefile for cl.exe

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
