### PR TITLE
libxml2: Error option 'docbook' doesn't exist in 2.10.3

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -79,6 +79,7 @@ class Libxml2Conan(ConanFile):
             del self.options.fPIC
         if Version(self.version) >= "2.10.3":
             del self.options.docbook
+            del self.default_options.docbook
 
     def configure(self):
         if self.options.shared:


### PR DESCRIPTION
Specify library name and version:  libxml2/2.10.3

when installing wayland/1.21.0#a8294930413cc095eac3fc9d102f49a8, gets following error.
```
ERROR: libxml2/2.10.3: option 'docbook' doesn't exist Possible options are ['shared', 'fPIC', 'include_utils', 'c14n', 'catalog', 'ftp', 'http', 'html', 'iconv', 'icu', 'iso8859x', 'legacy', 'mem-debug', 'output', 'pattern', 'push', 'python', 'reader', 'regexps', 'run-debug', 'sax1', 'schemas', 'schematron', 'threads', 'tree', 'valid', 'writer', 'xinclude', 'xpath', 'xptr', 'zlib', 'lzma']
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
