### PR TITLE
libdeflate: fix installation for conan >=1.55.0

### DIFF
--- a/recipes/libdeflate/all/conanfile.py
+++ b/recipes/libdeflate/all/conanfile.py
@@ -106,7 +106,7 @@ class LibdeflateConan(ConanFile):
         autotools = Autotools(self)
         with chdir(self, self.source_folder):
             # Note: not actually an autotools project, is a Makefile project.
-            autotools.install(args=[f"PREFIX={unix_path(self, self.package_folder)}"])
+            autotools.install(args=[f"DESTDIR={unix_path(self, self.package_folder)}", "PREFIX=/"])
         rmdir(self, os.path.join(self.package_folder, "bin"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rm(self, "*.a" if self.options.shared else "*.[so|dylib]*", os.path.join(self.package_folder, "lib") )


### PR DESCRIPTION
closes https://github.com/conan-io/conan-center-index/issues/14545

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
