### PR TITLE
daw_header_libraries: add version 2.76.3

### DIFF
--- a/recipes/daw_header_libraries/all/conandata.yml
+++ b/recipes/daw_header_libraries/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.76.3":
+    url: "https://github.com/beached/header_libraries/archive/v2.76.3.tar.gz"
+    sha256: "2d66f9aec38fb9a42779e0283fa2fc5842e04d34f2bf655c72a9beb4bf5cc8c8"
   "2.76.2":
     url: "https://github.com/beached/header_libraries/archive/v2.76.2.tar.gz"
     sha256: "bfa2da192360a66e400d03a52f8a7bf0fccd23de1f446a812a8890b11df2c592"

--- a/recipes/daw_header_libraries/config.yml
+++ b/recipes/daw_header_libraries/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.76.3":
+    folder: all
   "2.76.2":
     folder: all
   "2.74.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **daw_header_libraries/2.76.3**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
