### PR TITLE
daw_utf_range: add version 2.2.3

### DIFF
--- a/recipes/daw_utf_range/all/conandata.yml
+++ b/recipes/daw_utf_range/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.3":
+    url: "https://github.com/beached/utf_range/archive/v2.2.3.tar.gz"
+    sha256: "cfa36285ffbdf8d4d08fbbe95d054e67ad845c064a92419ea68a770415ad7a98"
   "2.2.2":
     url: "https://github.com/beached/utf_range/archive/refs/tags/v2.2.2.tar.gz"
     sha256: "5380ade7c7eb5c82a748211896fc7385eaec00d3215af1374aec8f0e326f91fd"

--- a/recipes/daw_utf_range/config.yml
+++ b/recipes/daw_utf_range/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.3":
+    folder: "all"
   "2.2.2":
     folder: "all"
   "2.2.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **daw_utf_range/2.2.3**



---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
