### PR TITLE
fruit: add version 3.7.0

### DIFF
--- a/recipes/fruit/all/conandata.yml
+++ b/recipes/fruit/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "3.6.0":
     url: "https://github.com/google/fruit/archive/v3.6.0.tar.gz"
     sha256: "b35b9380f3affe0b3326f387505fa80f3584b0d0a270362df1f4ca9c39094eb5"
+  "3.7.0":
+    url: "https://github.com/google/fruit/archive/refs/tags/v3.7.0.tar.gz"
+    sha256: "134d65c8e6dff204aeb771058c219dcd9a353853e30a3961a5d17a6cff434a09"
 patches:
   "3.4.0":
     - patch_file: "patches/0001-fruit-3.4.0-cmake.patch"
@@ -25,4 +28,7 @@ patches:
     - patch_file: "patches/0003-supports-cmake-multi-configuration-generator.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0004-set-options-for-cmake-target.patch"
+      base_path: "source_subfolder"
+  "3.7.0":
+    - patch_file: "patches/fix-cmakelists-problems.patch"
       base_path: "source_subfolder"

--- a/recipes/fruit/all/patches/fix-cmakelists-problems.patch
+++ b/recipes/fruit/all/patches/fix-cmakelists-problems.patch
@@ -1,0 +1,202 @@
+# Avoid problems with CMakeLists.txt in fruit.
+#
+# 1. Cennot support CMake multi configuration generator.
+#   Branching by the variable `CMAKE_BUILD_TYPE` does not work and must be
+#   removed.
+#   And the variable `FRUIT_ADDITIONAL_COMPILE_FLAGS` should be replaced with 
+#   CMake generator expression.
+#
+# 2. Use preferred cmake-commands
+#   It is recommended to use `target_include_directories()` rather than
+#   `include_directories()` and `target_compile_options()` rather than
+#   `add_definitions()`.
+#
+# 3. Do not build unnecessary targets
+#   It is not necessary to add `tests`, `examples`, and `extras` to the build
+#   target with `add_subdirectory()`.
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 74c62a5..89655f6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,15 +20,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ # CMake on OSX likes to see this set explicitly, otherwise it outputs a warning.
+ set(CMAKE_MACOSX_RPATH 1)
+ 
+-if(NOT "${CMAKE_BUILD_TYPE}" MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
+-  message(FATAL_ERROR "Please re-run CMake, specifying -DCMAKE_BUILD_TYPE=Debug , -DCMAKE_BUILD_TYPE=Release , -DCMAKE_BUILD_TYPE=RelWithDebInfo or -DCMAKE_BUILD_TYPE=MinSizeRel .")
+-endif()
+-
+ option(BUILD_SHARED_LIBS "Build shared library" ON)
+ 
+-# The Visual Studio CMake generators default to multiple configurations, but Fruit doesn't support multi-configuration build directories.
+-set(CMAKE_CONFIGURATION_TYPES "${CMAKE_BUILD_TYPE}")
+-
+ set(FRUIT_ADDITIONAL_CXX_FLAGS "" CACHE STRING "Additional CXX compiler flags." FORCE)
+ 
+ set(FRUIT_ADDITIONAL_COMPILE_FLAGS "${FRUIT_ADDITIONAL_CXX_FLAGS}")
+@@ -42,23 +35,18 @@ if(NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "^(GNU|Clang|AppleClang|MSVC)$")
+   #   - https://software.intel.com/en-us/forums/intel-c-compiler/topic/606049
+ endif()
+ 
+-option(FRUIT_ADD_WNO_UNKNOWN_WARNING_OPTION "Add -Wno-unknown-warning-option to the compiler options for GCC, Clang, ICC and AppleClang" ON)
+-
+-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(GNU|Clang|Intel|AppleClang)$")
+-  set(FRUIT_ADDITIONAL_COMPILE_FLAGS "${FRUIT_ADDITIONAL_COMPILE_FLAGS} -std=c++11 -W -Wall -Wno-missing-braces")
+-  if(${FRUIT_ADD_WNO_UNKNOWN_WARNING_OPTION})
+-    set(FRUIT_ADDITIONAL_COMPILE_FLAGS "${FRUIT_ADDITIONAL_COMPILE_FLAGS} -Wno-unknown-warning-option")
+-  endif()
+-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(MSVC)$")
+-  # TODO: we currently disable the warning C4709 because MSVC emits it even when there is no reason to. Re-enable it when possible.
+-  # TODO: the warning C4141 is disabled, because MSVC emits it ("'inline': used more than once") when a function/method is marked with both __forceinline and inline.
+-  # TODO: the warning C4714 is disabled, MSVC emits it when it decides not to inline a __forceinline function/method.
+-  # The warning C4577 is disabled because we don't need a termination guarantee on exceptions for functions marked with
+-  # 'noexcept'.
+-  # The warning C4530 is disabled because it's triggered by MSVC's STL.
+-  # The warning C5205 is disabled, MSVC emits it for abstract classes in example code with non-virtual destructors, but we never call delete on those (even though std::default_delete<Scaler> is instantiated for those types).
+-  set(FRUIT_ADDITIONAL_COMPILE_FLAGS "${FRUIT_ADDITIONAL_COMPILE_FLAGS} /nologo /FS /W4 /wd4324 /wd4709 /wd4459 /wd4141 /wd4714 /wd4577 /wd4530 /wd5205 /D_SCL_SECURE_NO_WARNINGS")
+-endif()
++set(FRUIT_ADDITIONAL_COMPILE_FLAGS_GNU ${FRUIT_ADDITIONAL_COMPILE_FLAGS} -W -Wall -Wno-unknown-warning-option -Wno-missing-braces)
++set(FRUIT_ADDITIONAL_COMPILE_FLAGS_Clang ${FRUIT_ADDITIONAL_COMPILE_FLAGS} -W -Wall -Wno-unknown-warning-option -Wno-missing-braces)
++set(FRUIT_ADDITIONAL_COMPILE_FLAGS_Intel ${FRUIT_ADDITIONAL_COMPILE_FLAGS} -W -Wall -Wno-unknown-warning-option -Wno-missing-braces)
++set(FRUIT_ADDITIONAL_COMPILE_FLAGS_AppleClang ${FRUIT_ADDITIONAL_COMPILE_FLAGS} -W -Wall -Wno-unknown-warning-option -Wno-missing-braces)
++set(FRUIT_ADDITIONAL_COMPILE_FLAGS_MSVC ${FRUIT_ADDITIONAL_COMPILE_FLAGS} /nologo /FS /W4 /wd4324 /wd4709 /wd4459 /wd4141 /wd4714 /wd4577 /wd4530 /wd5205 /D_SCL_SECURE_NO_WARNINGS)
++
++list(APPEND FRUIT_ADDITIONAL_COMPILE_FLAGS
++  $<$<CXX_COMPILER_ID:GNU>:${FRUIT_ADDITIONAL_COMPILE_FLAGS_GNU}>
++  $<$<CXX_COMPILER_ID:Clang>:${FRUIT_ADDITIONAL_COMPILE_FLAGS_Clang}>
++  $<$<CXX_COMPILER_ID:Intel>:${FRUIT_ADDITIONAL_COMPILE_FLAGS_Intel}>
++  $<$<CXX_COMPILER_ID:AppleClang>:${FRUIT_ADDITIONAL_COMPILE_FLAGS_AppleClang}>
++  $<$<CXX_COMPILER_ID:MSVC>:${FRUIT_ADDITIONAL_COMPILE_FLAGS_MSVC}>)
+ 
+ option(FRUIT_ENABLE_COVERAGE "Enable collection of test coverage. This is meant to be used by Fruit developers. It's only supported when using GCC on Linux." OFF)
+ if("${FRUIT_ENABLE_COVERAGE}")
+@@ -72,21 +60,6 @@ set(FRUIT_USES_BOOST TRUE CACHE BOOL
+         "Whether to use Boost (specifically, boost::unordered_set and boost::unordered_map).
+         If this is false, Fruit will use std::unordered_set and std::unordered_map instead (however this causes injection to be a bit slower).")
+ 
+-if(${FRUIT_USES_BOOST})
+-
+-  if(DEFINED BOOST_DIR)
+-    message(DEPRECATION "BOOST_DIR is deprecated. Use Boost_INCLUDE_DIR instead.")
+-    set(Boost_INCLUDE_DIR "${BOOST_DIR}" CACHE PATH "")
+-  endif()
+-
+-  find_package(Boost)
+-  if(Boost_FOUND)
+-    include_directories(${Boost_INCLUDE_DIRS})
+-  else()
+-    message(FATAL_ERROR "Please re-run CMake, specifying the boost library path as Boost_INCLUDE_DIR, e.g. -DBoost_INCLUDE_DIR=C:\\boost\\boost_1_62_0, or specify -DFRUIT_USES_BOOST=False to not use boost.")
+-  endif()
+-endif()
+-
+ set(RUN_TESTS_UNDER_VALGRIND FALSE CACHE BOOL "Whether to run Fruit tests under valgrind")
+ if ("${RUN_TESTS_UNDER_VALGRIND}")
+   set(RUN_TESTS_UNDER_VALGRIND_FLAG "1")
+@@ -95,17 +68,10 @@ endif()
+ # Unsafe, only for debugging/benchmarking.
+ #set(FRUIT_ADDITIONAL_COMPILE_FLAGS "${FRUIT_ADDITIONAL_COMPILE_FLAGS} -DFRUIT_NO_LOOP_CHECK=1")
+ 
+-add_definitions(${FRUIT_ADDITIONAL_COMPILE_FLAGS})
+ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${FRUIT_ADDITIONAL_LINKER_FLAGS}")
+ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${FRUIT_ADDITIONAL_LINKER_FLAGS}")
+ set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${FRUIT_ADDITIONAL_LINKER_FLAGS}")
+ 
+-if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+-    set(FRUIT_COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} ${FRUIT_ADDITIONAL_COMPILE_FLAGS}")
+-else()
+-    set(FRUIT_COMPILE_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG} ${FRUIT_ADDITIONAL_COMPILE_FLAGS}")
+-endif()
+-
+ set(FRUIT_CLANG_TIDY_CHECKS
+     bugprone*,-bugprone-reserved-identifier,-bugprone-exception-escape,clang-analyzer*,performance*,google*,-google-readability*,-google-runtime-references,clang-diagnostic-unused-command-line-argument,misc-macro-parentheses,-clang-diagnostic-dtor-name)
+ 
+@@ -118,8 +84,7 @@ if(${FRUIT_ENABLE_CLANG_TIDY})
+     -warnings-as-errors=*;)
+ endif()
+ 
+-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+-include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
++set(FRUIT_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
+ 
+ # (debug-only) compile switch to get deep template instantiation stacktraces for errors (instead
+ # of the user-friendly default that hides Fruit internals).
+@@ -130,19 +95,6 @@ include(GNUInstallDirs)
+ add_subdirectory(configuration)
+ add_subdirectory(src)
+ 
+-if(NOT "${FRUIT_IS_BEING_BUILT_BY_CONAN}")
+-  if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+-    # Do not exclude these from "make all" in debug mode, they must build.
+-    add_subdirectory(examples)
+-    add_subdirectory(tests)
+-  else()
+-    add_subdirectory(examples EXCLUDE_FROM_ALL)
+-    add_subdirectory(tests)
+-  endif()
+-
+-  add_subdirectory(extras EXCLUDE_FROM_ALL)
+-endif()
+-
+ install(DIRECTORY include/fruit/
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fruit
+   FILES_MATCHING PATTERN "*.h")
+diff --git a/configuration/CMakeLists.txt b/configuration/CMakeLists.txt
+index 11d8445..a78a5bb 100644
+--- a/configuration/CMakeLists.txt
++++ b/configuration/CMakeLists.txt
+@@ -1,7 +1,17 @@
+ 
+ include(CheckCXXSourceCompiles)
+ 
+-set(CMAKE_REQUIRED_FLAGS "${FRUIT_COMPILE_FLAGS}")
++if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
++    set(CMAKE_REQUIRED_FLAGS ${FRUIT_ADDITIONAL_COMPILE_FLAGS_GNU})
++elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "^Clang$")
++    set(CMAKE_REQUIRED_FLAGS ${FRUIT_ADDITIONAL_COMPILE_FLAGS_Clang})
++elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
++    set(CMAKE_REQUIRED_FLAGS ${FRUIT_ADDITIONAL_COMPILE_FLAGS_Intel})
++elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
++    set(CMAKE_REQUIRED_FLAGS ${FRUIT_ADDITIONAL_COMPILE_FLAGS_AppleClang})
++elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
++    set(CMAKE_REQUIRED_FLAGS ${FRUIT_ADDITIONAL_COMPILE_FLAGS_MSVC})
++endif()
+ 
+ CHECK_CXX_SOURCE_COMPILES("
+ int main() {}
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 0e328cf..da63e76 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -11,16 +11,28 @@ normalized_component_storage_holder.cpp
+ semistatic_map.cpp
+ semistatic_graph.cpp)
+ 
+-if("${BUILD_SHARED_LIBS}")
++if(BUILD_SHARED_LIBS)
+     add_library(fruit SHARED ${FRUIT_SOURCES})
+ 
+-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+-        set_target_properties(fruit PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+-    endif()
++    set_target_properties(fruit PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+ else()
+     add_library(fruit STATIC ${FRUIT_SOURCES})
+ endif()
+ 
++target_include_directories(fruit
++    PUBLIC
++    ${FRUIT_INCLUDE_DIRS})
++target_compile_options(fruit
++    PUBLIC
++    ${FRUIT_ADDITIONAL_COMPILE_FLAGS})
++
++if(FRUIT_USES_BOOST)
++    find_package(Boost REQUIRED)
++    target_include_directories(fruit
++        PRIVATE
++        ${Boost_INCLUDE_DIRS})
++endif()
++
+ install(TARGETS fruit
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/recipes/fruit/config.yml
+++ b/recipes/fruit/config.yml
@@ -5,3 +5,5 @@ versions:
     folder: all
   "3.6.0":
     folder: all
+  "3.7.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **fruit/3.7.0**

A new minor version has been released.

Note the patch file ``fix-cmakelists-problems.patch, which had been divided into several files, is now combined into a single file.
This is because patch compatibility was often lost with version upgrades.

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
