### PR TITLE
wasmedge: add version 0.11.2, support conan v2

### DIFF
--- a/recipes/wasmedge/all/conandata.yml
+++ b/recipes/wasmedge/all/conandata.yml
@@ -102,26 +102,6 @@ sources:
             sha256: "c000bf96d0a73a1d360659246c0806c2ce78620b6f78c1147fbf9e2be0280bd9"
           - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.10.0/LICENSE"
             sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
-    Macos:
-      "x86_64":
-        "gcc":
-          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.10.0/WasmEdge-0.10.0-darwin_x86_64.tar.gz"
-            sha256: "9c3f199e06a13f50568e37c24d8ddea563864f2ae7c7882f5e9fa8da11ec3707"
-          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.10.0/LICENSE"
-            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
-      "armv8":
-        "gcc":
-          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.10.0/WasmEdge-0.10.0-darwin_arm64.tar.gz"
-            sha256: "05ab84ea2815b8a4db18819e6f1514d4d914ca40bfec325f571b94618e0bdf3a"
-          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.10.0/LICENSE"
-            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
-    Android:
-      "armv8":
-        "gcc":
-          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.10.0/WasmEdge-0.10.0-android_aarch64.tar.gz"
-            sha256: "160483194c814d2fae569294b616e1fd6f9bba93cb655d19fabd853ea1ef3661"
-          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.10.0/LICENSE"
-            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
   "0.9.1":
     Windows:
       "x86_64":

--- a/recipes/wasmedge/all/conandata.yml
+++ b/recipes/wasmedge/all/conandata.yml
@@ -1,4 +1,45 @@
 sources:
+  "0.11.2":
+    Windows:
+      "x86_64":
+        Visual Studio:
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.11.2/WasmEdge-0.11.2-windows.zip"
+            sha256: "ca49b98c0cf5f187e08c3ba71afc8d71365fde696f10b4219379a4a4d1a91e6d"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.11.2/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+    Linux:
+      "x86_64":
+        "gcc":
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.11.2/WasmEdge-0.11.2-manylinux2014_x86_64.tar.gz"
+            sha256: "784bf1eb25928e2cf02aa88e9372388fad682b4a188485da3cd9162caeedf143"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.11.2/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+      "armv8":
+        "gcc":
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.11.2/WasmEdge-0.11.2-manylinux2014_aarch64.tar.gz"
+            sha256: "a2766a4c1edbaea298a30e5431a4e795003a10d8398a933d923f23d4eb4fa5d1"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.11.1/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+    Macos:
+      "x86_64":
+        "gcc":
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.11.2/WasmEdge-0.11.2-darwin_x86_64.tar.gz"
+            sha256: "aedec53f29b1e0b657e46e67dba3e2f32a2924f4d9136e60073ea1aba3073e70"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.11.2/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+      "armv8":
+        "gcc":
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.11.2/WasmEdge-0.11.2-darwin_arm64.tar.gz"
+            sha256: "fe391df90e1eee69cf1e976f5ddf60c20f29b651710aaa4fc03e2ab4fe52c0d3"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.11.2/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+    Android:
+      "armv8":
+        "gcc":
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.11.2/WasmEdge-0.11.2-android_aarch64.tar.gz"
+            sha256: "69e308f5927c753b2bb5639569d10219b60598174d8b304bdf310093fd7b2464"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.11.2/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
   "0.11.1":
     Windows:
       "x86_64":
@@ -20,6 +61,26 @@ sources:
             sha256: "cb9ea32932360463991cfda80e09879b2cf6c69737f12f3f2b371cd0af4e9ce8"
           - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.11.1/LICENSE"
             sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+    Macos:
+      "x86_64":
+        "gcc":
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.11.1/WasmEdge-0.11.1-darwin_x86_64.tar.gz"
+            sha256: "56df2b00669c25b8143ea2c17370256cd6a33f3b316d3b47857dd38d603cb69a"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.11.1/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+      "armv8":
+        "gcc":
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.11.1/WasmEdge-0.11.1-darwin_arm64.tar.gz"
+            sha256: "82f7da1a7a36ec1923fb045193784dd090a03109e84da042af97297205a71f08"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.11.1/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+    Android:
+      "armv8":
+        "gcc":
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.11.1/WasmEdge-0.11.1-android_aarch64.tar.gz"
+            sha256: "af8694e93bf72ac5506450d4caebccc340fbba254dca3d58ec0712e96ec9dedd"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.11.1/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
   "0.10.0":
     Windows:
       "x86_64":
@@ -39,6 +100,26 @@ sources:
         "gcc":
           - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.10.0/WasmEdge-0.10.0-manylinux2014_aarch64.tar.gz"
             sha256: "c000bf96d0a73a1d360659246c0806c2ce78620b6f78c1147fbf9e2be0280bd9"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.10.0/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+    Macos:
+      "x86_64":
+        "gcc":
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.10.0/WasmEdge-0.10.0-darwin_x86_64.tar.gz"
+            sha256: "9c3f199e06a13f50568e37c24d8ddea563864f2ae7c7882f5e9fa8da11ec3707"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.10.0/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+      "armv8":
+        "gcc":
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.10.0/WasmEdge-0.10.0-darwin_arm64.tar.gz"
+            sha256: "05ab84ea2815b8a4db18819e6f1514d4d914ca40bfec325f571b94618e0bdf3a"
+          - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.10.0/LICENSE"
+            sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+    Android:
+      "armv8":
+        "gcc":
+          - url: "https://github.com/WasmEdge/WasmEdge/releases/download/0.10.0/WasmEdge-0.10.0-android_aarch64.tar.gz"
+            sha256: "160483194c814d2fae569294b616e1fd6f9bba93cb655d19fabd853ea1ef3661"
           - url: "https://raw.githubusercontent.com/WasmEdge/WasmEdge/0.10.0/LICENSE"
             sha256: "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
   "0.9.1":

--- a/recipes/wasmedge/all/conanfile.py
+++ b/recipes/wasmedge/all/conanfile.py
@@ -77,3 +77,14 @@ class WasmedgeConan(ConanFile):
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info("Appending PATH environment variable: {}".format(bindir))
         self.env_info.PATH.append(bindir)
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.append("ws2_32")
+            self.cpp_info.system_libs.append("wsock32")
+            self.cpp_info.system_libs.append("shlwapi")
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
+            self.cpp_info.system_libs.append("dl")
+            self.cpp_info.system_libs.append("rt")
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/wasmedge/all/conanfile.py
+++ b/recipes/wasmedge/all/conanfile.py
@@ -58,12 +58,12 @@ class WasmedgeConan(ConanFile):
             copy(self, pattern="wasmedge.lib", src=srclibdir, dst=dstlibdir, keep_path=False)
             copy(self, pattern="wasmedge.dll", src=srcbindir, dst=dstbindir, keep_path=False)
             copy(self, pattern="libwasmedge.so*", src=srclibdir, dst=dstlibdir, keep_path=False)
-            copy(self, pattern="libwasmedge.dylib", src=srclibdir,  dst=dstlibdir, keep_path=False)
+            copy(self, pattern="libwasmedge*.dylib", src=srclibdir,  dst=dstlibdir, keep_path=False)
         else:
             copy(self, pattern="wasmedge_c.lib", src=srclibdir, dst=dstlibdir, keep_path=False)
             copy(self, pattern="wasmedge_c.dll", src=srcbindir, dst=dstbindir, keep_path=False)
             copy(self, pattern="libwasmedge_c.so*", src=srclibdir, dst=dstlibdir, keep_path=False)
-            copy(self, pattern="libwasmedge_c.dylib", src=srclibdir,  dst=dstlibdir, keep_path=False)
+            copy(self, pattern="libwasmedge_c*.dylib", src=srclibdir,  dst=dstlibdir, keep_path=False)
 
         copy(self, pattern="wasmedge*", src=srcbindir, dst=dstbindir, keep_path=False)
         copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"), keep_path=False)

--- a/recipes/wasmedge/all/conanfile.py
+++ b/recipes/wasmedge/all/conanfile.py
@@ -41,7 +41,7 @@ class WasmedgeConan(ConanFile):
 
     def source(self):
         # This is packaging binaries so the download needs to be in build
-        get(self, **self.conan_data["sources"][self.version][self._sources_os_key][str(self.settings.arch)][self._compiler_alias][0],
+        get(self, **self.conan_data["sources"][self.version][str(self.settings.os)][str(self.settings.arch)][self._compiler_alias][0],
             destination=self.source_folder, strip_root=True)
         download(self, filename="LICENSE",
                  **self.conan_data["sources"][self.version][str(self.settings.os)][str(self.settings.arch)][self._compiler_alias][1])

--- a/recipes/wasmedge/all/conanfile.py
+++ b/recipes/wasmedge/all/conanfile.py
@@ -1,25 +1,22 @@
 from conan import ConanFile
-from conan.tools.files import get, download
+from conan.tools.files import get, copy, download
 from conan.tools.scm import Version
 from conan.errors import ConanInvalidConfiguration
+
 import os
 
-required_conan_version = ">=1.33.0"
+required_conan_version = ">=1.47.0"
 
 class WasmedgeConan(ConanFile):
     name = "wasmedge"
     description = ("WasmEdge is a lightweight, high-performance, and extensible WebAssembly runtime"
                 "for cloud native, edge, and decentralized applications."
                 "It powers serverless apps, embedded functions, microservices, smart contracts, and IoT devices.")
-    topics = ("webassembly", "wasm", "wasi", "emscripten")
     license = "Apache-2.0"
-    homepage = "https://github.com/WasmEdge/WasmEdge/"
     url = "https://github.com/conan-io/conan-center-index"
-    settings = "os", "arch", "compiler",
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    homepage = "https://github.com/WasmEdge/WasmEdge/"
+    topics = ("webassembly", "wasm", "wasi", "emscripten")
+    settings = "os", "arch", "compiler", "build_type"
 
     @property
     def _compiler_alias(self):
@@ -43,31 +40,33 @@ class WasmedgeConan(ConanFile):
         self.info.settings.compiler = self._compiler_alias
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version][str(self.settings.os)][str(self.settings.arch)][self._compiler_alias][0],
-                  destination=self._source_subfolder, strip_root=True)
+        # This is packaging binaries so the download needs to be in build
+        get(self, **self.conan_data["sources"][self.version][self._sources_os_key][str(self.settings.arch)][self._compiler_alias][0],
+            destination=self.source_folder, strip_root=True)
         download(self, filename="LICENSE",
-                       **self.conan_data["sources"][self.version][str(self.settings.os)][str(self.settings.arch)][self._compiler_alias][1])  # noqa: E128
+                 **self.conan_data["sources"][self.version][str(self.settings.os)][str(self.settings.arch)][self._compiler_alias][1])
 
     def package(self):
-        self.copy("*.h", src=os.path.join(self._source_subfolder, "include"), dst="include", keep_path=True)
-        self.copy("*.inc", src=os.path.join(self._source_subfolder, "include"), dst="include", keep_path=True)
+        copy(self, pattern="*.h", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self.source_folder, "include"), keep_path=True)
+        copy(self, pattern="*.inc", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self.source_folder, "include"), keep_path=True)
 
-        srclibdir = os.path.join(self._source_subfolder, "lib64" if self.settings.os == "Linux" else "lib")
-        srcbindir = os.path.join(self._source_subfolder, "bin")
+        srclibdir = os.path.join(self.source_folder, "lib64" if self.settings.os == "Linux" else "lib")
+        srcbindir = os.path.join(self.source_folder, "bin")
+        dstlibdir = os.path.join(self.package_folder, "lib")
+        dstbindir = os.path.join(self.package_folder, "bin")
         if Version(self.version) >= "0.11.1":
-            self.copy("wasmedge.lib", src=srclibdir, dst="lib", keep_path=False)
-            self.copy("wasmedge.dll", src=srcbindir, dst="bin", keep_path=False)
-            self.copy("libwasmedge.so*", src=srclibdir, dst="lib", keep_path=False)
-            self.copy("libwasmedge.dylib", src=srclibdir,  dst="lib", keep_path=False)
+            copy(self, pattern="wasmedge.lib", src=srclibdir, dst=dstlibdir, keep_path=False)
+            copy(self, pattern="wasmedge.dll", src=srcbindir, dst=dstbindir, keep_path=False)
+            copy(self, pattern="libwasmedge.so*", src=srclibdir, dst=dstlibdir, keep_path=False)
+            copy(self, pattern="libwasmedge.dylib", src=srclibdir,  dst=dstlibdir, keep_path=False)
         else:
-            self.copy("wasmedge_c.lib", src=srclibdir, dst="lib", keep_path=False)
-            self.copy("wasmedge_c.dll", src=srcbindir, dst="bin", keep_path=False)
-            self.copy("libwasmedge_c.so*", src=srclibdir, dst="lib", keep_path=False)
-            self.copy("libwasmedge_c.dylib", src=srclibdir,  dst="lib", keep_path=False)
+            copy(self, pattern="wasmedge_c.lib", src=srclibdir, dst=dstlibdir, keep_path=False)
+            copy(self, pattern="wasmedge_c.dll", src=srcbindir, dst=dstbindir, keep_path=False)
+            copy(self, pattern="libwasmedge_c.so*", src=srclibdir, dst=dstlibdir, keep_path=False)
+            copy(self, pattern="libwasmedge_c.dylib", src=srclibdir,  dst=dstlibdir, keep_path=False)
 
-        self.copy("wasmedge*", src=srcbindir, dst="bin", keep_path=False)
-
-        self.copy("LICENSE", dst="licenses", keep_path=False)
+        copy(self, pattern="wasmedge*", src=srcbindir, dst=dstbindir, keep_path=False)
+        copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"), keep_path=False)
 
     def package_info(self):
         if Version(self.version) >= "0.11.1":

--- a/recipes/wasmedge/all/test_package/CMakeLists.txt
+++ b/recipes/wasmedge/all/test_package/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
 find_package(wasmedge REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)

--- a/recipes/wasmedge/all/test_package/conanfile.py
+++ b/recipes/wasmedge/all/test_package/conanfile.py
@@ -1,19 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
-    def build_requirements(self):
-        if self.settings.os == "Macos" and self.settings.arch == "armv8":
-            # Workaround for CMake bug with error message:
-            # Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
-            # set. This could be because you are using a Mac OS X version less than 10.5
-            # or because CMake's platform configuration is corrupt.
-            # FIXME: Remove once CMake on macOS/M1 CI runners is upgraded.
-            self.build_requires("cmake/3.20.1")
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -21,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/wasmedge/all/test_v1_package/CMakeLists.txt
+++ b/recipes/wasmedge/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/wasmedge/all/test_v1_package/conanfile.py
+++ b/recipes/wasmedge/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/wasmedge/config.yml
+++ b/recipes/wasmedge/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.2":
+    folder: "all"
   "0.11.1":
     folder: "all"
   "0.10.0":


### PR DESCRIPTION
Specify library name and version:  **wasmedge/0.11.2**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
