### PR TITLE
glfw: few fixes for MinGW (shared lib name, no static link to libgcc, define GLFW_DLL)

### DIFF
--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -73,6 +73,10 @@ class GlfwConan(ConanFile):
         # don't force PIC
         replace_in_file(self, os.path.join(self.source_folder, "src", "CMakeLists.txt"),
                               "POSITION_INDEPENDENT_CODE ON", "")
+        # don't force static link to libgcc if MinGW
+        replace_in_file(self, os.path.join(self.source_folder, "src", "CMakeLists.txt"),
+                              "target_link_libraries(glfw PRIVATE \"-static-libgcc\")", "")
+
         # Allow to link vulkan-loader into shared glfw
         if self.options.vulkan_static:
             cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")

--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -131,6 +131,7 @@ class GlfwConan(ConanFile):
             libname += "3"
         if self.settings.os == "Windows" and self.options.shared:
             libname += "dll"
+            self.cpp_info.defines.append("GLFW_DLL")
         self.cpp_info.libs = [libname]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["m", "pthread", "dl", "rt"])

--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -129,7 +129,7 @@ class GlfwConan(ConanFile):
         libname = "glfw"
         if self.settings.os == "Windows" or not self.options.shared:
             libname += "3"
-        if is_msvc(self) and self.options.shared:
+        if self.settings.os == "Windows" and self.options.shared:
             libname += "dll"
         self.cpp_info.libs = [libname]
         if self.settings.os in ["Linux", "FreeBSD"]:


### PR DESCRIPTION
- lib name suffix if shared on Windows: https://github.com/glfw/glfw/blob/3.3.8/src/CMakeLists.txt#L165-L169
- GLFW_DLL: https://github.com/glfw/glfw/blob/3.3.8/src/CMakeLists.txt#L172
- don't force static link to libgcc if MinGW since it may not be the default behavior of the compiler, so it's removed (but users can statically link to libgcc with appropriate flags in profile)

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
