### PR TITLE
duckdb: add version 0.6.1, update openssl

### DIFF
--- a/recipes/duckdb/all/conandata.yml
+++ b/recipes/duckdb/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.1":
+    url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.6.0.tar.gz"
+    sha256: "700b09114f8b99892a9d19ba21ca962ae65d1ea8085622418a2fa50ff915b244"
   "0.6.0":
     url: "https://github.com/duckdb/duckdb/archive/refs/tags/v0.6.0.tar.gz"
     sha256: "700b09114f8b99892a9d19ba21ca962ae65d1ea8085622418a2fa50ff915b244"
@@ -7,6 +10,13 @@ sources:
     sha256: "3dab7ba0d0f8d024d3c73fd3d4fb8834203c31d7b0ddb1e8539ee266e11b0e9b"
 
 patches:
+  "0.6.1":
+    - patch_file: "patches/0.6.0-0001-fix-cmake.patch"
+      patch_description: "install static of shared library, add installation for odbc extention"
+      patch_type: "portability"
+    - patch_file: "patches/0.6.0-0002-include-stdlib.patch"
+      patch_description: "include stdlib for abort function"
+      patch_type: "portability"
   "0.6.0":
     - patch_file: "patches/0.6.0-0001-fix-cmake.patch"
       patch_description: "install static of shared library, add installation for odbc extention"

--- a/recipes/duckdb/all/conanfile.py
+++ b/recipes/duckdb/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
 import os
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 class DuckdbConan(ConanFile):
     name = "duckdb"
@@ -70,10 +70,7 @@ class DuckdbConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -83,7 +80,7 @@ class DuckdbConan(ConanFile):
         if self.options.with_odbc:
             self.requires("odbc/2.3.11")
         if self.options.with_httpfs:
-            self.requires("openssl/3.0.5")
+            self.requires("openssl/3.0.7")
 
     def validate(self):
         if self.info.settings.compiler.cppstd:

--- a/recipes/duckdb/all/test_v1_package/CMakeLists.txt
+++ b/recipes/duckdb/all/test_v1_package/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(duckdb REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE duckdb::duckdb)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/duckdb/config.yml
+++ b/recipes/duckdb/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.1":
+    folder: "all"
   "0.6.0":
     folder: "all"
   "0.5.1":


### PR DESCRIPTION
Specify library name and version:  **duckdb/***

- add version 0.6.1
- update openssl
- use `rm_safe`

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
