### PR TITLE
xmlsec: add version 1.2.37

### DIFF
--- a/recipes/xmlsec/all/conandata.yml
+++ b/recipes/xmlsec/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.37":
+    url: "https://github.com/lsh123/xmlsec/archive/xmlsec-1_2_37.tar.gz"
+    sha256: "d197790ca0b8be59d2d9bf614622e573c413a960a7e1e3f832d91c51b1113214"
   "1.2.32":
     url: "https://github.com/lsh123/xmlsec/archive/xmlsec-1_2_32.tar.gz"
     sha256: "e33e551fb9f6da5576b1a55ce962048adf337332c27e6be9dba04d360b6a5584"

--- a/recipes/xmlsec/config.yml
+++ b/recipes/xmlsec/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.37":
+    folder: all
   "1.2.32":
     folder: all
   "1.2.31":


### PR DESCRIPTION
Specify library name and version:  **xmlsec/1.2.37**

Just a version update triggered from [Conan Center Bot](https://github.com/qchateau/conan-center-bot). /cc @qchateau 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
