### PR TITLE
pybind11_json: add version 0.2.13

### DIFF
--- a/recipes/pybind11_json/all/conandata.yml
+++ b/recipes/pybind11_json/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.13":
+    url: "https://github.com/pybind/pybind11_json/archive/0.2.13.tar.gz"
+    sha256: "6b12ddb4930a3135322890318fc15c4a69134f21120ea82163827c11411107a3"
   "0.2.12":
     url: "https://github.com/pybind/pybind11_json/archive/0.2.12.tar.gz"
     sha256: "a9e308d4cf3de16d192cd0baf641bfe17a3a3046e8652e6724204afa3e736db7"

--- a/recipes/pybind11_json/config.yml
+++ b/recipes/pybind11_json/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.13":
+    folder: all
   "0.2.12":
     folder: all
   "0.2.11":


### PR DESCRIPTION
Specify library name and version:  **pybind11_json/0.2.13**

Just a new version patch by [Conan Center Bot](https://github.com/qchateau/conan-center-bot). /cc @qchateau 

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
