### PR TITLE
(#14620) libzip: Use robust github mirror

### DIFF
--- a/recipes/libzip/all/conandata.yml
+++ b/recipes/libzip/all/conandata.yml
@@ -1,9 +1,15 @@
 sources:
   "1.8.0":
-    url: "https://libzip.org/download/libzip-1.8.0.tar.gz"
+    url: [
+      "https://libzip.org/download/libzip-1.8.0.tar.gz",
+      "https://github.com/nih-at/libzip/releases/download/v1.8.0/libzip-1.8.0.tar.gz",
+    ]
     sha256: "30ee55868c0a698d3c600492f2bea4eb62c53849bcf696d21af5eb65f3f3839e"
   "1.7.3":
-    url: "https://libzip.org/download/libzip-1.7.3.tar.gz"
+    url: [
+      "https://libzip.org/download/libzip-1.7.3.tar.gz",
+      "https://github.com/nih-at/libzip/releases/download/v1.7.3/libzip-1.7.3.tar.gz",
+    ]
     sha256: "0e2276c550c5a310d4ebf3a2c3dfc43fb3b4602a072ff625842ad4f3238cb9cc"
 patches:
   "1.8.0":


### PR DESCRIPTION
https://libzip.org is down
Use github mirror for releases.
The difference in SHA-s is related to .github directory and .clang-format file, which are present in github release.

The source was compared to original used by conan to avoid potential attack by getting libzip.org down and fak-ing github sources

Specify library name and version:  **libzip/all**

Closes #14620

This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks!

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
