### PR TITLE
b2: pass toolset to b2

### DIFF
--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -141,6 +141,8 @@ class B2Conan(ConanFile):
         self.output.info("Install..")
         command = os.path.join(
             self._b2_engine_dir, "b2.exe" if use_windows_commands else "b2")
+        if self.options.toolset not in ["auto", "cxx", "cross-cxx"]:
+            command += " toolset=" + str(self.options.toolset)
         full_command = \
             ("{0} --ignore-site-config " +
              "--prefix={1} " +

--- a/recipes/b2/portable/conanfile.py
+++ b/recipes/b2/portable/conanfile.py
@@ -141,8 +141,8 @@ class B2Conan(ConanFile):
         self.output.info("Install..")
         command = os.path.join(
             self._b2_engine_dir, "b2.exe" if use_windows_commands else "b2")
-        if self.options.toolset not in ["auto", "cxx", "cross-cxx"]:
-            command += " toolset=" + str(self.options.toolset)
+        if b2_toolset not in ["auto", "cxx", "cross-cxx"]:
+            command += " toolset=" + str(b2_toolset)
         full_command = \
             ("{0} --ignore-site-config " +
              "--prefix={1} " +


### PR DESCRIPTION
Specify library name and version:  **b2/all**

Readd toolset option for install that was lost during conan v2 migration.

Fixes #14621

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
