### PR TITLE
[googleapis] Use is_msvc to abstract away compiler name setting

### DIFF
--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -7,12 +7,14 @@ from conans import CMake, tools
 
 from conan import ConanFile
 from conan.tools.files import get, copy
+from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 
 from conan.errors import ConanInvalidConfiguration
 
 from helpers import parse_proto_libraries
 
+required_conan_version = ">=1.45.0"
 
 class GoogleAPIS(ConanFile):
     name = "googleapis"
@@ -55,7 +57,7 @@ class GoogleAPIS(ConanFile):
         if self.settings.compiler == "gcc" and Version(self.settings.compiler.version) <= "5":
             raise ConanInvalidConfiguration("Build with GCC 5 fails")
 
-        if self.settings.compiler in ["Visual Studio", "msvc"] and self.options.shared:
+        if is_msvc(self) and self.options.shared:
             raise ConanInvalidConfiguration("Source code generated from protos is missing some export macro")
         if self.options.shared and not self.options["protobuf"].shared:
             raise ConanInvalidConfiguration("If built as shared, protobuf must be shared as well. Please, use `protobuf:shared=True`")


### PR DESCRIPTION
Specify library name and version:  **googleapis/all**

An issue was reported were installation was failing due to an out of date settings.yml were `msvc` was missing (https://github.com/conan-io/conan/issues/12646). In Conan 2 the opposite is the case ("Visual Studio" is no longer the compiler name). This PR updates the recipe logic such that it uses the helper that abstracts away the compiler check in a way that is compatible with both (and, also, covers the case for users with an older settings.yml in conan 1.x) 