### PR TITLE
(#14632) libzip: Bump to 1.9.2

### DIFF
--- a/recipes/libzip/all/conandata.yml
+++ b/recipes/libzip/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.9.2":
+    url: [
+      "https://libzip.org/download/libzip-1.9.2.tar.gz",
+      "https://github.com/nih-at/libzip/releases/download/v1.9.2/libzip-1.9.2.tar.gz",
+    ]
+    sha256: "fd6a7f745de3d69cf5603edc9cb33d2890f0198e415255d0987a0cf10d824c6f"
   "1.8.0":
     url: [
       "https://libzip.org/download/libzip-1.8.0.tar.gz",
@@ -12,6 +18,8 @@ sources:
     ]
     sha256: "0e2276c550c5a310d4ebf3a2c3dfc43fb3b4602a072ff625842ad4f3238cb9cc"
 patches:
+  "1.9.2":
+    - patch_file: "patches/0001-cmake-install-bundle.patch"
   "1.8.0":
     - patch_file: "patches/0001-cmake-install-bundle.patch"
   "1.7.3":

--- a/recipes/libzip/all/conanfile.py
+++ b/recipes/libzip/all/conanfile.py
@@ -114,8 +114,13 @@ class LibZipConan(ConanFile):
         top_cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
         # Honor zstd enabled
         if self._has_zstd_support:
+            def zstd_find_package_pattern(version):
+                if version >= "1.9.2":
+                    return "find_package(Zstd 1.3.6)"
+                else:
+                    return "find_package(Zstd)"
             lib_cmakelists = os.path.join(self.source_folder, "lib", "CMakeLists.txt")
-            replace_in_file(self, top_cmakelists, "find_package(Zstd", "find_package(zstd")
+            replace_in_file(self, top_cmakelists, zstd_find_package_pattern(Version(self.version)), "find_package(zstd)")
             replace_in_file(self, top_cmakelists, "Zstd_FOUND", "zstd_FOUND")
             replace_in_file(
                 self,

--- a/recipes/libzip/all/conanfile.py
+++ b/recipes/libzip/all/conanfile.py
@@ -115,7 +115,7 @@ class LibZipConan(ConanFile):
         # Honor zstd enabled
         if self._has_zstd_support:
             lib_cmakelists = os.path.join(self.source_folder, "lib", "CMakeLists.txt")
-            replace_in_file(self, top_cmakelists, "find_package(Zstd)", "find_package(zstd)")
+            replace_in_file(self, top_cmakelists, "find_package(Zstd", "find_package(zstd")
             replace_in_file(self, top_cmakelists, "Zstd_FOUND", "zstd_FOUND")
             replace_in_file(
                 self,

--- a/recipes/libzip/config.yml
+++ b/recipes/libzip/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.9.2":
+    folder: all
   "1.8.0":
     folder: all
   "1.7.3":


### PR DESCRIPTION
find_package(Zstd) was replaced to find_package(Zstd, 1.3.6)

Specify library name and version:  **libzip/1.9.2**

Closes #14632
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
