### PR TITLE
modern-cpp-kafka: add version 2022.12.07, support conan v2

### DIFF
--- a/recipes/modern-cpp-kafka/all/conandata.yml
+++ b/recipes/modern-cpp-kafka/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2022.12.07":
+    url: "https://github.com/morganstanley/modern-cpp-kafka/archive/v2022.12.07.tar.gz"
+    sha256: "980533fe5e0f5630d7deab6567ed051cf51d61ac341e4a75810f68d58cbff439"
   "2022.10.12":
     url: "https://github.com/morganstanley/modern-cpp-kafka/archive/v2022.10.12.tar.gz"
     sha256: "f60c6d6328e64a8ae0c3233921078160fc4e42a3484eb823d9918895f5f1b39f"
@@ -6,5 +9,5 @@ sources:
     url: "https://github.com/morganstanley/modern-cpp-kafka/archive/v2022.08.01.tar.gz"
     sha256: "77998caf50ffcc55c77713571d9ce04a37020ccff7b713d14abad9eb8ceb05b3"
   "2022.06.15":
-    url: https://github.com/morganstanley/modern-cpp-kafka/archive/refs/tags/v2022.06.15.tar.gz
-    sha256: 478fcf560057b7cf7b4be851838ebf0520806d057b172de23261606fce088d27
+    url: "https://github.com/morganstanley/modern-cpp-kafka/archive/refs/tags/v2022.06.15.tar.gz"
+    sha256: "478fcf560057b7cf7b4be851838ebf0520806d057b172de23261606fce088d27"

--- a/recipes/modern-cpp-kafka/all/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/conanfile.py
@@ -1,41 +1,71 @@
-from conans import ConanFile, tools
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+from conan.tools.microsoft import check_min_vs, is_msvc
 import os
 
-required_conan_version = ">=1.33.0"
-
+required_conan_version = ">=1.52.0"
 
 class ModernCppKafkaConan(ConanFile):
     name = "modern-cpp-kafka"
     description = "A C++ API for Kafka clients (i.e. KafkaProducer, KafkaConsumer, AdminClient)"
     license = "Apache-2.0"
-    topics = ("kafka", "librdkafka", "kafkaproducer", "kafkaconsumer")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/morganstanley/modern-cpp-kafka"
-    settings = "arch", "build_type", "compiler", "os"
+    topics = ("kafka", "librdkafka", "kafkaproducer", "kafkaconsumer", "header-only")
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
-    def requirements(self):
-        self.requires("librdkafka/1.8.2")
+    @property
+    def _min_cppstd(self):
+        return 17
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "12",
+        }
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("librdkafka/1.9.2")
+
+    def package_id(self):
+        self.info.clear()
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, 17)
+            check_min_cppstd(self, self._min_cppstd)
+        check_min_vs(self, 192)
+        if not is_msvc(self):
+            minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+            if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+                )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+
 
     def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy(pattern="*.h", dst="include", src=os.path.join(self._source_subfolder, "include"))
-
-    def package_id(self):
-        self.info.header_only()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="*.h",
+            dst=os.path.join(self.package_folder, "include"),
+            src=os.path.join(self.source_folder, "include"),
+        )
 
     def package_info(self):
+       self.cpp_info.set_property("cmake_file_name", "ModernCppKafka")
        self.cpp_info.set_property("cmake_target_name", "ModernCppKafka::ModernCppKafka")
 
        self.cpp_info.names["cmake_find_package"] = "ModernCppKafka"

--- a/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
+++ b/recipes/modern-cpp-kafka/all/test_package/CMakeLists.txt
@@ -1,12 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
-
-set(CMAKE_CXX_STANDARD 17)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
 find_package(ModernCppKafka REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ModernCppKafka::ModernCppKafka)
+target_link_libraries(${PROJECT_NAME} PRIVATE ModernCppKafka::ModernCppKafka)
+target_compile_features(${PROJECT_NAME}  PRIVATE cxx_std_17)

--- a/recipes/modern-cpp-kafka/all/test_package/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/test_package/conanfile.py
@@ -1,10 +1,18 @@
-from conans import ConanFile, CMake
-from conan.tools.build import cross_building
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +20,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/modern-cpp-kafka/all/test_v1_package/CMakeLists.txt
+++ b/recipes/modern-cpp-kafka/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/modern-cpp-kafka/all/test_v1_package/conanfile.py
+++ b/recipes/modern-cpp-kafka/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/modern-cpp-kafka/config.yml
+++ b/recipes/modern-cpp-kafka/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2022.12.07":
+    folder: all
   "2022.10.12":
     folder: all
   "2022.08.01":


### PR DESCRIPTION
Specify library name and version:  **modern-cpp-kafka/***

- add version 2022.12.07
- support conan v2
- update librdkafka
- add cmake_file_name

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
