### PR TITLE
Update changelog 09-December-2022

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 09-December-2022 - 11:38 CET
+
+- [feature] Add environment variable to build with different Xcode/apple-clang compilers on Macos agents.
+- [feature] Add `MACOSX_DEPLOYMENT_TARGET` and `SDKROOT` env variables to build stages on Macos.
+- [feature] Add `LongPathsEnabled` registry key check on Windows to Validate Infrastructure job.
+- [fix] Fix git user on commits when updating docs for supported platforms and configurations.
+- [fix] Fix getting commit hash when writing GitHub error messages.
+- [fix] Fix Conan v2 inspect command.
+- [fix] Fix condition when waiting for another job to finish.
+
 ### 14-November-2022 - 11:54 CET
 
 - [feature] Disable inactivity count for Access Request job.


### PR DESCRIPTION
A couple of comments on the changes:

- New env var for macos to select the xcode version will allow the service to build for different apple-clang versions regardless of the machine we select. Previously, each macos machine had only one apple-clang compiler and this caused huge bottlenecks. Now with other env vars like `SDKROOT` and `MACOSX_DEPLOYMENT_TARGET` we make sure that the environment is the correct one to produce the same binaries.

- We have added a check to verify out windows machines have long paths enabled. However, they have not been updated yet (they had this reg key disabled). It will be added soon and updated its status at https://github.com/conan-io/conan-center-index/issues/14216
