### PR TITLE
Deprecate Boost.LEAF

### DIFF
--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration, ConanException
 
 required_conan_version = ">=1.52.0"
 
@@ -23,6 +23,7 @@ class UTConan(ConanFile):
     no_copy_source = True
     options = { "disable_module": [True, False], }
     default_options = { "disable_module": False, }
+    deprecated = 'boost'
 
     @property
     def _minimum_cpp_standard(self):
@@ -44,6 +45,9 @@ class UTConan(ConanFile):
             del self.options.disable_module
         elif is_msvc(self):
             self.options.disable_module = True
+
+    def configure(self):
+        raise ConanException("This recipe is deprecated in favor of Boost >=1.75.0")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -84,7 +88,7 @@ class UTConan(ConanFile):
         if disable_module:
             tc.cache_variables["BOOST_UT_DISABLE_MODULE"] = disable_module
         tc.generate()
-    
+
     def build(self):
         apply_conandata_patches(self)
         cmake = CMake(self)

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
-from conan.errors import ConanInvalidConfiguration, ConanException
+from conan.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.52.0"
 
@@ -47,7 +47,7 @@ class UTConan(ConanFile):
             self.options.disable_module = True
 
     def configure(self):
-        raise ConanException("This recipe is deprecated in favor of Boost >=1.75.0")
+        raise ConanInvalidConfiguration("This recipe is deprecated in favor of Boost >=1.75.0")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/boost-ext-ut/all/conanfile.py
+++ b/recipes/boost-ext-ut/all/conanfile.py
@@ -23,7 +23,6 @@ class UTConan(ConanFile):
     no_copy_source = True
     options = { "disable_module": [True, False], }
     default_options = { "disable_module": False, }
-    deprecated = 'boost'
 
     @property
     def _minimum_cpp_standard(self):
@@ -45,9 +44,6 @@ class UTConan(ConanFile):
             del self.options.disable_module
         elif is_msvc(self):
             self.options.disable_module = True
-
-    def configure(self):
-        raise ConanInvalidConfiguration("This recipe is deprecated in favor of Boost >=1.75.0")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -88,7 +84,7 @@ class UTConan(ConanFile):
         if disable_module:
             tc.cache_variables["BOOST_UT_DISABLE_MODULE"] = disable_module
         tc.generate()
-
+    
     def build(self):
         apply_conandata_patches(self)
         cmake = CMake(self)

--- a/recipes/boost-leaf/all/conanfile.py
+++ b/recipes/boost-leaf/all/conanfile.py
@@ -19,6 +19,10 @@ class BoostLEAFConan(ConanFile):
               "header-only", "low-latency", "no-dependencies", "single-header")
     settings = "os", "compiler", "arch", "build_type"
     no_copy_source = True
+    deprecated = True
+
+    def configure(self):
+        raise ConanInvalidConfiguration(f"{self.ref} is deprecated in favor of Boost >=1.75.0")
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
Reverting Boost Leaf as it's part of Boost itself and does not make sense splitting Boost, as we already tried in the past. 

https://github.com/conan-io/conan-center-index/pull/14525#pullrequestreview-1211744714

/cc @grafikrobot 

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
