### PR TITLE
magic_enum: add version 0.8.2

### DIFF
--- a/recipes/magic_enum/all/conandata.yml
+++ b/recipes/magic_enum/all/conandata.yml
@@ -23,3 +23,6 @@ sources:
   "0.8.1":
     url: "https://github.com/Neargye/magic_enum/archive/v0.8.1.tar.gz"
     sha256: "6b948d1680f02542d651fc82154a9e136b341ce55c5bf300736b157e23f9df11"
+  "0.8.2":
+    url: "https://github.com/Neargye/magic_enum/archive/v0.8.2.tar.gz"
+    sha256: "62bd7034bbbfc3d7806001767d5775ab42f3ff33bb38366e1ceb21102f0dff9a"

--- a/recipes/magic_enum/config.yml
+++ b/recipes/magic_enum/config.yml
@@ -15,3 +15,5 @@ versions:
     folder: all
   "0.8.1":
     folder: all
+  "0.8.2":
+    folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **magic_enum/0.8.2**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
