### PR TITLE
sqlite_orm: add version 1.8

### DIFF
--- a/recipes/sqlite_orm/all/conandata.yml
+++ b/recipes/sqlite_orm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8":
+    url: "https://github.com/fnc12/sqlite_orm/archive/v1.8.tar.gz"
+    sha256: "90893bb0035daf9803ad9e6d45b3e67f48b5515e69ed3a7577feffed7a9f3309"
   "1.7.1":
     url: "https://github.com/fnc12/sqlite_orm/archive/refs/tags/v1.7.1.tar.gz"
     sha256: "dbf58c2d3c5b1efe295d592799edaa1a5dbe9d591a0bfb1abd22a2843a5123e0"

--- a/recipes/sqlite_orm/config.yml
+++ b/recipes/sqlite_orm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8":
+    folder: all
   "1.7.1":
     folder: all
   "1.7":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **sqlite_orm/1.8**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
