### PR TITLE
Fix unix sockets configure error on MinGW windows

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -474,6 +474,8 @@ class LibcurlConan(ConanFile):
             elif self.settings.os == "Android":
                 pass # this just works, conan is great!
 
+        env = None
+
         # tweaks for mingw
         if self._is_mingw:
             rcflags = "-O COFF"
@@ -492,7 +494,7 @@ class LibcurlConan(ConanFile):
         if cross_building(self) and is_apple_os(self):
             tc.extra_defines.extend(['HAVE_SOCKET', 'HAVE_FCNTL_O_NONBLOCK'])
 
-        tc.generate()
+        tc.generate(env)
         tc = PkgConfigDeps(self)
         tc.generate()
         tc = AutotoolsDeps(self)

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -299,7 +299,8 @@ class LibcurlConan(ConanFile):
             # add directives to build dll
             # used only for native mingw-make
             if not cross_building(self):
-                added_content = load(self, "lib_Makefile_add.am")
+                # The patch file is located in the base src folder
+                added_content = load(self, os.path.join(self.folders.base_source, "lib_Makefile_add.am"))
                 save(self, lib_makefile, added_content, append=True)
 
     def _patch_cmake(self):
@@ -352,6 +353,11 @@ class LibcurlConan(ConanFile):
         if not cross_building(self):
             env = VirtualRunEnv(self)
             env.generate(scope="build")
+
+        # Before 7.86.0, enabling unix sockets configure option would fail on windows
+        # It was fixed with this PR: https://github.com/curl/curl/pull/9688
+        if self._is_mingw and Version(self.version) < "7.86.0":
+            self.options.with_unix_sockets = False
 
         tc = AutotoolsToolchain(self)
         tc.configure_args.extend([

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -604,9 +604,9 @@ class LibcurlConan(ConanFile):
             rm(self, "*.la", os.path.join(self.package_folder, "lib"))
             if self._is_mingw and self.options.shared:
                 # Handle only mingw libs
-                copy(self, pattern="*.dll", src=self.build_folder, dst="bin", keep_path=False)
-                copy(self, pattern="*.dll.a", src=self.build_folder, dst="lib", keep_path=False)
-                copy(self, pattern="*.lib", src=self.build_folder, dst="lib", keep_path=False)
+                copy(self, pattern="*.dll", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
+                copy(self, pattern="*.dll.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+                copy(self, pattern="*.lib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -475,7 +475,7 @@ class LibcurlConan(ConanFile):
             elif self.settings.os == "Android":
                 pass # this just works, conan is great!
 
-        env = None
+        env = tc.environment()
 
         # tweaks for mingw
         if self._is_mingw:
@@ -485,7 +485,6 @@ class LibcurlConan(ConanFile):
             elif self.settings.arch == "x86_64":
                 rcflags += " --target=pe-x86-64"
                 tc.extra_defines.append("_AMD64_")
-            env = tc.environment()
             env.define("RCFLAGS", rcflags)
 
         if self.settings.os != "Windows":

--- a/recipes/libcurl/all/test_package/test_package.c
+++ b/recipes/libcurl/all/test_package/test_package.c
@@ -23,7 +23,7 @@ int main(void)
     /* provide a buffer to store errors in */
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
 
-    /* always cleanup */ 
+    /* always cleanup */
     curl_easy_cleanup(curl);
     printf("Succeed\n");
   } else {


### PR DESCRIPTION
Fix building shared library on MinGW windows

Specify library name and version:  **libcurl/7.78.0**

Closes https://github.com/conan-io/conan-center-index/issues/14668

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
