### PR TITLE
luau: add version 0.556

### DIFF
--- a/recipes/luau/all/conandata.yml
+++ b/recipes/luau/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.556":
+    url: "https://github.com/Roblox/luau/archive/0.556.tar.gz"
+    sha256: "dc72f91f4e866a2b25f7608e062c91c84e92a2e5611026e9789f127c3caf39f6"
   "0.552":
     url: "https://github.com/Roblox/luau/archive/0.552.tar.gz"
     sha256: "c638aee88010197d7e6f22e592fa12360e38a69f54ed91980b11ac0f89676db5"
@@ -25,6 +28,13 @@ sources:
     sha256: "24122d3192083b2133de47d8039fb744b8007c6667fc1b6f254a2a8d72e15d53"
 
 patches:
+  "0.556":
+    - patch_file: "patches/0.552-0001-fix-cmake.patch"
+      patch_description: "enable shared build"
+      patch_type: "portability"
+    - patch_file: "patches/0.536-0002-rename-lerp.patch"
+      patch_description: "rename lerp function to avoid name conflict"
+      patch_type: "portability"
   "0.552":
     - patch_file: "patches/0.552-0001-fix-cmake.patch"
       patch_description: "enable shared build"

--- a/recipes/luau/config.yml
+++ b/recipes/luau/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.556":
+    folder: all
   "0.552":
     folder: all
   "0.548":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **luau/0.556**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
