### PR TITLE
fast_double_parser: add version 0.7.0

### DIFF
--- a/recipes/fast_double_parser/all/conandata.yml
+++ b/recipes/fast_double_parser/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.7.0":
+    url: "https://github.com/lemire/fast_double_parser/archive/v0.7.0.tar.gz"
+    sha256: "eb80a1d9c406bbe8cb22fffd3c007651f716abd03225009302d8aba8e9c4df77"
   "0.6.0":
     url: "https://github.com/lemire/fast_double_parser/archive/refs/tags/v0.6.0.tar.gz"
     sha256: "90835c770a2577a38442601e92330207ad8b917f956614938303b8439d13b282"

--- a/recipes/fast_double_parser/config.yml
+++ b/recipes/fast_double_parser/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.7.0":
+    folder: all
   "0.6.0":
     folder: all
   "0.5.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **fast_double_parser/0.7.0**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
