### PR TITLE
tgbot: add version 1.5

### DIFF
--- a/recipes/tgbot/all/conandata.yml
+++ b/recipes/tgbot/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5":
+    url: "https://github.com/reo7sp/tgbot-cpp/archive/v1.5.tar.gz"
+    sha256: "ecd5a21ea45b890828aba1639ac49401cfdd5b30f791322cb1ba84c9ac77647c"
   "1.3":
     url: "https://github.com/reo7sp/tgbot-cpp/archive/v1.3.tar.gz"
     sha256: "85b9aef49c595d39fc9dc330b1b83625bea9509966dc623f7b4c1ee7309679c9"

--- a/recipes/tgbot/config.yml
+++ b/recipes/tgbot/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.5":
+    folder: all
   "1.3":
     folder: all
   "1.2.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **tgbot/1.5**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
