### PR TITLE
seasocks: add version 1.4.5

### DIFF
--- a/recipes/seasocks/all/conandata.yml
+++ b/recipes/seasocks/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.5":
+    url: "https://github.com/mattgodbolt/seasocks/archive/v1.4.5.tar.gz"
+    sha256: "82211959cf8aabc85b300358c5f68cf9c56dfdf4eaa09e548580fce908acfc1b"
   "1.4.4":
     url: "https://github.com/mattgodbolt/seasocks/archive/v1.4.4.tar.gz"
     sha256: "5ec016ee87d4985a031212fa23a00de3de5f0fa1ceb82d7b9a3d1c189356bf8d"

--- a/recipes/seasocks/config.yml
+++ b/recipes/seasocks/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.4.5":
+    folder: "all"
   "1.4.4":
     folder: "all"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **seasocks/1.4.5**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
