### PR TITLE
nanobench: add version 4.3.9

### DIFF
--- a/recipes/nanobench/all/conandata.yml
+++ b/recipes/nanobench/all/conandata.yml
@@ -14,3 +14,6 @@ sources:
   "4.3.7":
     url: "https://github.com/martinus/nanobench/archive/v4.3.7.tar.gz"
     sha256: "6a2dadb8230370c7fb7a9362be1c3677e44d8e06193a4ecb489a4748ef9483d7"
+  "4.3.9":
+    url: "https://github.com/martinus/nanobench/archive/v4.3.9.tar.gz"
+    sha256: "4a7fd8fdd5819e4d1c34ae558df010a0ccf36db0508c41c51cd0181bc04c6356"

--- a/recipes/nanobench/config.yml
+++ b/recipes/nanobench/config.yml
@@ -9,3 +9,5 @@ versions:
     folder: "all"
   "4.3.7":
     folder: "all"
+  "4.3.9":
+    folder: "all"


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **nanobench/4.3.9**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
