### PR TITLE
imath: add version 3.1.6

### DIFF
--- a/recipes/imath/all/conandata.yml
+++ b/recipes/imath/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.1.6":
+    url: "https://github.com/AcademySoftwareFoundation/Imath/archive/v3.1.6.tar.gz"
+    sha256: "ea5592230f5ab917bea3ceab266cf38eb4aa4a523078d46eac0f5a89c52304db"
   "3.1.5":
     url: "https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.1.5.tar.gz"
     sha256: "1e9c7c94797cf7b7e61908aed1f80a331088cc7d8873318f70376e4aed5f25fb"

--- a/recipes/imath/config.yml
+++ b/recipes/imath/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.1.6":
+    folder: all
   "3.1.5":
     folder: all
   "3.1.4":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **imath/3.1.6**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
