### PR TITLE
[hana] Deprecate package in favor of Boost

### DIFF
--- a/recipes/hana/all/conanfile.py
+++ b/recipes/hana/all/conanfile.py
@@ -1,5 +1,7 @@
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.tools.files import get, save
+from conan.tools.build import check_min_cppstd
+from conan.errors import ConanInvalidConfiguration
 import os
 import textwrap
 
@@ -32,7 +34,7 @@ class HanaConan(ConanFile):
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
-            tools.check_min_cppstd(self, "14")
+            check_min_cppstd(self, "14")
 
         def lazy_lt_semver(v1, v2):
             lv1 = [int(v) for v in v1.split(".")]
@@ -49,11 +51,11 @@ class HanaConan(ConanFile):
         raise ConanInvalidConfiguration(f"{self.ref} is deprecated of Boost. Please, use boost package.")
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(**self.conan_data["sources"][self.version],
+              destination=self._source_subfolder, strip_root=True)
 
     def package(self):
         self.copy("LICENSE.md", dst="licenses", src=self._source_subfolder)
@@ -73,7 +75,7 @@ class HanaConan(ConanFile):
                     set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
                 endif()
             """.format(alias=alias, aliased=aliased))
-        tools.save(module_file, content)
+        save(module_file, content)
 
     @property
     def _module_subfolder(self):

--- a/recipes/hana/all/conanfile.py
+++ b/recipes/hana/all/conanfile.py
@@ -65,7 +65,6 @@ class HanaConan(ConanFile):
             {"hana": "hana::hana"}
         )
 
-    @staticmethod
     def _create_cmake_module_alias_targets(module_file, targets):
         content = ""
         for alias, aliased in targets.items():
@@ -75,7 +74,7 @@ class HanaConan(ConanFile):
                     set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
                 endif()
             """.format(alias=alias, aliased=aliased))
-        save(module_file, content)
+        save(self, module_file, content)
 
     @property
     def _module_subfolder(self):

--- a/recipes/hana/all/conanfile.py
+++ b/recipes/hana/all/conanfile.py
@@ -61,11 +61,13 @@ class HanaConan(ConanFile):
         self.copy("LICENSE.md", dst="licenses", src=self._source_subfolder)
         self.copy("*.hpp", dst="include", src=os.path.join(self._source_subfolder, "include"))
         self._create_cmake_module_alias_targets(
+            self,
             os.path.join(self.package_folder, self._module_file_rel_path),
             {"hana": "hana::hana"}
         )
 
-    def _create_cmake_module_alias_targets(module_file, targets):
+    @staticmethod
+    def _create_cmake_module_alias_targets(conanfile, module_file, targets):
         content = ""
         for alias, aliased in targets.items():
             content += textwrap.dedent("""\
@@ -74,7 +76,7 @@ class HanaConan(ConanFile):
                     set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
                 endif()
             """.format(alias=alias, aliased=aliased))
-        save(self, module_file, content)
+        save(conanfile, module_file, content)
 
     @property
     def _module_subfolder(self):

--- a/recipes/hana/all/conanfile.py
+++ b/recipes/hana/all/conanfile.py
@@ -15,6 +15,7 @@ class HanaConan(ConanFile):
     topics = ("hana", "metaprogramming", "boost")
     settings = "compiler"
     no_copy_source = True
+    deprecated = "boost"
 
     @property
     def _source_subfolder(self):
@@ -44,6 +45,8 @@ class HanaConan(ConanFile):
             self.output.warn("{} {} requires C++14. Your compiler is unknown. Assuming it supports C++14.".format(self.name, self.version))
         elif lazy_lt_semver(str(self.settings.compiler.version), minimum_version):
             raise ConanInvalidConfiguration("{} {} requires C++14, which your compiler does not support.".format(self.name, self.version))
+
+        raise ConanInvalidConfiguration(f"{self.ref} is deprecated of Boost. Please, use boost package.")
 
     def package_id(self):
         self.info.header_only()


### PR DESCRIPTION
Specify library name and version:  **hana/1.79.0**

This PR is the continuation of #14660. We decided to keep only Boost as main package.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
