### PR TITLE
catch2: add version 3.2.1

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.2.1":
+    url: "https://github.com/catchorg/Catch2/archive/v3.2.1.tar.gz"
+    sha256: "4613d3e8142b672159fcae252a4860d72c8cf8e2df5043b1ae3541db9ef5d73c"
   "3.2.0":
     url: "https://github.com/catchorg/Catch2/archive/v3.2.0.tar.gz"
     sha256: "feee04647e28ac3cbeff46cb42abc8ee2d8d5f646d36e3fb3ba274b8c69a58ea"

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.2.1":
+    folder: 3.x.x
   "3.2.0":
     folder: 3.x.x
   "3.1.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **catch2/3.2.1**



---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
