### PR TITLE
add tinycthreadpool

### DIFF
--- a/recipes/tinycthreadpool/all/conandata.yml
+++ b/recipes/tinycthreadpool/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "1.0":
-    url: "https://github.com/bennyhuo/tinycthreadpool/archive/refs/tags/1.0.tar.gz"
-    sha256: "2a144e883251dc63179990e671b5a9ce3ebaf42186471baee00ecad322dd2fd9"
+    url: "https://github.com/bennyhuo/tinycthreadpool/archive/refs/tags/v1.0.tar.gz"
+    sha256: "a3e9876d3e3008cffed96216d026504b57ab6be6ee3df62d5916fecd4106ede5"

--- a/recipes/tinycthreadpool/all/conandata.yml
+++ b/recipes/tinycthreadpool/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0":
+    url: "https://github.com/bennyhuo/tinycthreadpool/archive/refs/tags/1.0.tar.gz"
+    sha256: "2a144e883251dc63179990e671b5a9ce3ebaf42186471baee00ecad322dd2fd9"

--- a/recipes/tinycthreadpool/all/conanfile.py
+++ b/recipes/tinycthreadpool/all/conanfile.py
@@ -46,8 +46,6 @@ class TinyCThreadPoolConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        if is_msvc(self):
-            tc.variables["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
         tc.generate()
 
         tc = CMakeDeps(self)

--- a/recipes/tinycthreadpool/all/conanfile.py
+++ b/recipes/tinycthreadpool/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.microsoft import is_msvc_static_runtime, is_msvc
 from conan.tools.files import get, copy
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=1.54.0"
 
 
 class TinyCThreadPoolConan(ConanFile):

--- a/recipes/tinycthreadpool/all/conanfile.py
+++ b/recipes/tinycthreadpool/all/conanfile.py
@@ -1,7 +1,6 @@
 import os
 
 from conan import ConanFile
-from conan.tools.microsoft import is_msvc_static_runtime, is_msvc
 from conan.tools.files import get, copy
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 

--- a/recipes/tinycthreadpool/all/conanfile.py
+++ b/recipes/tinycthreadpool/all/conanfile.py
@@ -36,7 +36,7 @@ class TinyCThreadPoolConan(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/tinycthreadpool/all/conanfile.py
+++ b/recipes/tinycthreadpool/all/conanfile.py
@@ -41,6 +41,9 @@ class TinyCThreadPoolConan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    def requirements(self):
+        self.requires("tinycthread/cci.20161001", transitive_headers=True)
+
     def generate(self):
         tc = CMakeToolchain(self)
         if is_msvc(self):

--- a/recipes/tinycthreadpool/all/conanfile.py
+++ b/recipes/tinycthreadpool/all/conanfile.py
@@ -1,7 +1,6 @@
 import os
 
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import is_msvc_static_runtime, is_msvc
 from conan.tools.scm import Version
 from conan.tools.files import get, copy

--- a/recipes/tinycthreadpool/all/conanfile.py
+++ b/recipes/tinycthreadpool/all/conanfile.py
@@ -2,7 +2,6 @@ import os
 
 from conan import ConanFile
 from conan.tools.microsoft import is_msvc_static_runtime, is_msvc
-from conan.tools.scm import Version
 from conan.tools.files import get, copy
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 

--- a/recipes/tinycthreadpool/all/conanfile.py
+++ b/recipes/tinycthreadpool/all/conanfile.py
@@ -45,8 +45,6 @@ class TinyCThreadPoolConan(ConanFile):
         tc = CMakeToolchain(self)
         if is_msvc(self):
             tc.variables["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
-
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
 
         tc = CMakeDeps(self)

--- a/recipes/tinycthreadpool/all/conanfile.py
+++ b/recipes/tinycthreadpool/all/conanfile.py
@@ -61,15 +61,6 @@ class TinyCThreadPoolConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.set_property("cmake_file_name", "tinycthreadpool")
-        self.cpp_info.set_property("cmake_target_name", "tinycthreadpool::tinycthreadpool")
-        self.cpp_info.set_property("pkg_config_name", "tinycthreadpool")
-
         self.cpp_info.libs = ["tinycthreadpool"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("pthread")
-
-        # TODO: to remove in conan v2
-        self.cpp_info.names["cmake_find_package"] = "tinycthreadpool"
-        self.cpp_info.names["cmake_find_package_multi"] = "tinycthreadpool"
-

--- a/recipes/tinycthreadpool/all/conanfile.py
+++ b/recipes/tinycthreadpool/all/conanfile.py
@@ -1,0 +1,79 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc_static_runtime, is_msvc
+from conan.tools.scm import Version
+from conan.tools.files import get, copy
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+
+required_conan_version = ">=1.53.0"
+
+
+class TinyCThreadPoolConan(ConanFile):
+    name = "tinycthreadpool"
+    description = "Portable C thread pool"
+    license = "BSD-2-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/bennyhuo/tinycthreadpool"
+    topics = ("thread-pool", "threading", "pure-c")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, strip_root=True)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if is_msvc(self):
+            tc.variables["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
+
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        tc.generate()
+
+        tc = CMakeDeps(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "tinycthreadpool")
+        self.cpp_info.set_property("cmake_target_name", "tinycthreadpool::tinycthreadpool")
+        self.cpp_info.set_property("pkg_config_name", "tinycthreadpool")
+
+        self.cpp_info.libs = ["tinycthreadpool"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")
+
+        # TODO: to remove in conan v2
+        self.cpp_info.names["cmake_find_package"] = "tinycthreadpool"
+        self.cpp_info.names["cmake_find_package_multi"] = "tinycthreadpool"
+

--- a/recipes/tinycthreadpool/all/test_package/CMakeLists.txt
+++ b/recipes/tinycthreadpool/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest C)
+
+find_package(tinycthreadpool REQUIRED CONFIG)
+
+add_executable(example example.c)
+target_link_libraries(example tinycthreadpool::tinycthreadpool)
+target_compile_features(example PRIVATE c_std_11)

--- a/recipes/tinycthreadpool/all/test_package/conanfile.py
+++ b/recipes/tinycthreadpool/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class ThreadpoolTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps","CMakeToolchain","VirtualRunEnv"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "example")
+            self.run(cmd, env="conanrun")

--- a/recipes/tinycthreadpool/all/test_package/example.c
+++ b/recipes/tinycthreadpool/all/test_package/example.c
@@ -1,0 +1,14 @@
+#include <threadpool.h>
+#include <tinycthread.h>
+#include <stdio.h>
+
+int main(void) {
+  puts("Start Testing!");
+  threadpool_t *threadpool = threadpool_create(3, 5, 0);
+  printf("Create thread pool: %#x.\n", threadpool);
+  if (threadpool){
+    int result = threadpool_destroy(threadpool, 0);
+    printf("End Testing! result: %d\n", result);
+  }
+  return 0;
+}

--- a/recipes/tinycthreadpool/all/test_v1_package/CMakeLists.txt
+++ b/recipes/tinycthreadpool/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/tinycthreadpool/all/test_v1_package/conanfile.py
+++ b/recipes/tinycthreadpool/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+# legacy validation with Conan 1.x
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/tinycthreadpool/config.yml
+++ b/recipes/tinycthreadpool/config.yml
@@ -1,0 +1,4 @@
+versions:
+  # Newer versions at the top
+  "1.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version:  **tinycthreadpool/1.0**

This is a portable C threadpool. It is based on [tinycthread](https://github.com/tinycthread/tinycthread) and supports both Windows and POSIX systems.
---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
