### PR TITLE
wavelet_buffer: add version 0.5.0

### DIFF
--- a/recipes/wavelet_buffer/all/conandata.yml
+++ b/recipes/wavelet_buffer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.5.0":
+    url: "https://github.com/panda-official/WaveletBuffer/archive/v0.5.0.tar.gz"
+    sha256: "2b1fa552f9a6e032dfd9f59bd05c049bf0cac46aced7cd42f49ff0d020cfdb50"
   "0.4.0":
     url: "https://github.com/panda-official/WaveletBuffer/archive/refs/tags/v0.4.0.tar.gz"
     sha256: "0a30080a6d1e9e7f8947ae0c3395d3c86888900c7ae09730f8dd0ed5138daab2"

--- a/recipes/wavelet_buffer/config.yml
+++ b/recipes/wavelet_buffer/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.5.0":
+    folder: all
   "0.4.0":
     folder: all


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **wavelet_buffer/0.5.0**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
