### PR TITLE
Add tracy options

### DIFF
--- a/recipes/tracy/all/test_package/test_package.cpp
+++ b/recipes/tracy/all/test_package/test_package.cpp
@@ -5,7 +5,7 @@
 #endif
 
 int main(int argc, char **argv) {
-  ZoneScopedN("main")
+  ZoneScopedN("main");
 
   return 0;
 }


### PR DESCRIPTION
Specify library name and version:  **tracy/0.9**

This patch fixes two issues with tracy library:
- Several tracy options where missing from the conan package. This patch adds them
- Tracy options set to ON are exported as PUBLIC defines in CMake. However, the conan package was not adding the corresponding defines, so the behavior was different between original CMakeLists and conan package. This patch fixes that
---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
