### PR TITLE
[ffmpeg] Fix armv7 android build

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -350,6 +350,8 @@ class FFMpegConan(ConanFile):
             target_os = triplet.split("-")[2]
             if target_os == "gnueabihf":
                 target_os = "gnu" # could also be "linux"
+            if target_os.startswith("android"):
+                target_os = "android"
             return target_os
 
     def _patch_sources(self):


### PR DESCRIPTION
get_gnu_triplet() returns `androideabi` for ARMv7 Android which is not recognized by FFMPEG's configure script.

Specify library name and version:  **ffmpeg/all**

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
