### PR TITLE
[pkgconf] Fix min `required_conan_version` check

### DIFF
--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 import functools
 import os
 
-required_conan_version = ">= 1.36.0"
+required_conan_version = ">=1.36.0"
 
 
 class PkgConfConan(ConanFile):


### PR DESCRIPTION
Specify library name and version:  **pkgconf**

We fixed the symptom yesterday with https://github.com/conan-io/conan/pull/12695, but not the cause.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
