### PR TITLE
liburing: add version 2.3

### DIFF
--- a/recipes/liburing/all/conandata.yml
+++ b/recipes/liburing/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.3":
+    url: "https://github.com/axboe/liburing/archive/liburing-2.3.tar.gz"
+    sha256: "60b367dbdc6f2b0418a6e0cd203ee0049d9d629a36706fcf91dfb9428bae23c8"
   "2.2":
     url: "https://github.com/axboe/liburing/archive/liburing-2.2.tar.gz"
     sha256: "e092624af6aa244ade2d52181cc07751ac5caba2f3d63e9240790db9ed130bbc"

--- a/recipes/liburing/config.yml
+++ b/recipes/liburing/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.3":
+    folder: all
   "2.2":
     folder: all
   "2.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **liburing/2.3**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
