### PR TITLE
qt6: allow gcc11 and clang12 consumers

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -252,7 +252,7 @@ class QtConan(ConanFile):
         if os.getenv('NOT_ON_C3I', '0') == '0':
             if self.info.settings.compiler == "gcc" and Version(self.info.settings.compiler.version) >= "11" or \
                 self.info.settings.compiler == "clang" and Version(self.info.settings.compiler.version) >= "12":
-                raise ConanInvalidConfiguration("qt is not supported on gcc11 and clang >= 12 on C3I until conan-io/conan-center-index#13472 is fixed\n"/
+                raise ConanInvalidConfiguration("qt is not supported on gcc11 and clang >= 12 on C3I until conan-io/conan-center-index#13472 is fixed\n"\
                                                 "If your distro is modern enough (xcb >= 1.12), set environment variable NOT_ON_C3I=1")
 
         # C++ minimum standard required

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -249,7 +249,7 @@ class QtConan(ConanFile):
                 _enablemodule(module)
 
     def validate(self):
-        if os.getenv('NOT_ON_C3I', '0') == '0'):
+        if os.getenv('NOT_ON_C3I', '0') == '0':
             if self.info.settings.compiler == "gcc" and Version(self.info.settings.compiler.version) >= "11" or \
                 self.info.settings.compiler == "clang" and Version(self.info.settings.compiler.version) >= "12":
                 raise ConanInvalidConfiguration("qt is not supported on gcc11 and clang >= 12 on C3I until conan-io/conan-center-index#13472 is fixed\n"/

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -249,9 +249,11 @@ class QtConan(ConanFile):
                 _enablemodule(module)
 
     def validate(self):
-        if self.info.settings.compiler == "gcc" and Version(self.info.settings.compiler.version) >= "11" or \
-            self.info.settings.compiler == "clang" and Version(self.info.settings.compiler.version) >= "12":
-            raise ConanInvalidConfiguration("qt is not supported on gcc11 and clang >= 12 on C3I until conan-io/conan-center-index#13472 is fixed")
+        if os.getenv('NOT_ON_C3I', '0') == '0'):
+            if self.info.settings.compiler == "gcc" and Version(self.info.settings.compiler.version) >= "11" or \
+                self.info.settings.compiler == "clang" and Version(self.info.settings.compiler.version) >= "12":
+                raise ConanInvalidConfiguration("qt is not supported on gcc11 and clang >= 12 on C3I until conan-io/conan-center-index#13472 is fixed\n"/
+                                                "If your distro is modern enough (xcb >= 1.12), set environment variable NOT_ON_C3I=1")
 
         # C++ minimum standard required
         if self.settings.compiler.get_safe("cppstd"):


### PR DESCRIPTION
Specify library name and version:  **qt/6.***

related to https://github.com/conan-io/conan-center-index/issues/13472


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
