### PR TITLE
[config] Add new windows nodes and bump conan v1 version

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -3,7 +3,7 @@
 id: 'conan-io/conan-center-index'
 
 conan:
-  version: 1.53.0
+  version: 1.54.0
 
 artifactory:
   url: "https://c3i.jfrog.io/c3i"

--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -159,7 +159,7 @@ node_labels:
   Windows:
     x86_64:
       "Visual Studio":
-        default: "windows20221024"
+        default: "windows20221212"
   Macos:
     x86_64:
       "apple-clang":

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -87,7 +87,7 @@ node_labels:
   Windows:
     x86_64:
       "msvc":
-        default: "windows20221024"
+        default: "windows20221212"
   Macos:
     x86_64:
       "apple-clang":


### PR DESCRIPTION
New windows machines added to the CI (with new environment for conan 1.54.0 and long paths enabled)
closes #14624 

Related to the latest changes described at #14658 as it closes https://github.com/conan-io/conan-center-index/issues/14216 