### PR TITLE
(#14752) perfetto: Fix MSVC build for v31.0

### DIFF
--- a/recipes/perfetto/all/conandata.yml
+++ b/recipes/perfetto/all/conandata.yml
@@ -36,6 +36,12 @@ sources:
     url: "https://github.com/google/perfetto/archive/refs/tags/v20.1.tar.gz"
     sha256: "d681bb76e2b73e6ba46db53c1502f31f4f16c36cd6e91d4ae839a3b44272f646"
 patches:
+  "31.0":
+    - patch_file: "patches/v31.0/0001-tracing-fix-compile-on-MSVC.patch"
+      patch_description: "Fix compilation on MSVC"
+      patch_type: "backport"
+      patch_source: "https://android-review.googlesource.com/c/platform/external/perfetto/+/2355222"
+      sha256: "ad253a9bba3941bd8d1f206422d60eb1c06cb6d75d60eff5b5b8ae0f2ec7e15c"
   "25.0":
     - patch_file: "patches/v25.0/0001-MSVC-Fix-narrowing-conversion-error.patch"
   "22.1":

--- a/recipes/perfetto/all/patches/v31.0/0001-tracing-fix-compile-on-MSVC.patch
+++ b/recipes/perfetto/all/patches/v31.0/0001-tracing-fix-compile-on-MSVC.patch
@@ -1,0 +1,19 @@
+diff --git a/sdk/perfetto.h b/sdk/perfetto.h
+index 175c092..682cea7 100644
+--- a/sdk/perfetto.h
++++ b/sdk/perfetto.h
+@@ -18090,8 +18090,9 @@ class TrackEventDataSource
+   } while (false)
+ 
+ // C++17 doesn't like a move constructor being defined for the EventFinalizer
+-// class but C++11 doesn't compile without it being defined so support both.
+-#if PERFETTO_IS_AT_LEAST_CPP17()
++// class but C++11 and MSVC doesn't compile without it being defined so support
++// both.
++#if PERFETTO_IS_AT_LEAST_CPP17() && !PERFETTO_BUILDFLAG(PERFETTO_COMPILER_MSVC)
+ #define PERFETTO_INTERNAL_EVENT_FINALIZER_KEYWORD delete
+ #else
+ #define PERFETTO_INTERNAL_EVENT_FINALIZER_KEYWORD default
+-- 
+2.24.3 (Apple Git-128)
+


### PR DESCRIPTION
Specify library name and version:  **perfetto/31.0**

Bugreport: https://github.com/google/perfetto/issues/407
Bugfix: https://android-review.googlesource.com/c/platform/external/perfetto/+/2355222

The patch is located in `sdk.h` since this file is a result of multiple headers homologation during perfetto release process.
The fix is only needed till 32.0 is released and already merged to master.

Closes #14752 

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
