### PR TITLE
cd3-boost-unit-definition updates

### DIFF
--- a/recipes/cd3-boost-unit-definitions/all/conanfile.py
+++ b/recipes/cd3-boost-unit-definitions/all/conanfile.py
@@ -17,8 +17,8 @@ class PackageConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/CD3/BoostUnitDefinitions"
     topics = ("physical dimensions", "header-only")
-    settings = "os", "arch", "compiler", "build_type"  # even for header only
-    no_copy_source = True  # do not copy sources to build folder for header only projects, unless, need to apply patches
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
 
     @property
     def _min_cppstd(self):
@@ -28,7 +28,7 @@ class PackageConan(ConanFile):
     def _compilers_minimum_version(self):
         return {
             "Visual Studio": "15",
-            "msvc": "14.1",
+            "msvc": "19.0",
             "gcc": "5",
             "clang": "5",
             "apple-clang": "5.1",

--- a/recipes/cd3-boost-unit-definitions/all/conanfile.py
+++ b/recipes/cd3-boost-unit-definitions/all/conanfile.py
@@ -41,7 +41,7 @@ class PackageConan(ConanFile):
         basic_layout(self)
 
     def requirements(self):
-        self.requires("boost/1.72.0", transitive_headers=True)
+        self.requires("boost/[>=1.69.0]", transitive_headers=True)
 
     def package_id(self):
         self.info.clear()

--- a/recipes/cd3-boost-unit-definitions/all/conanfile.py
+++ b/recipes/cd3-boost-unit-definitions/all/conanfile.py
@@ -41,7 +41,7 @@ class PackageConan(ConanFile):
         basic_layout(self)
 
     def requirements(self):
-        self.requires("boost/[>=1.69.0]", transitive_headers=True)
+        self.requires("boost/1.80.0", transitive_headers=True)
 
     def package_id(self):
         self.info.clear()

--- a/recipes/cd3-boost-unit-definitions/all/test_package/CMakeLists.txt
+++ b/recipes/cd3-boost-unit-definitions/all/test_package/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX) # if the project uses c++
+project(test_package LANGUAGES CXX)
 
 find_package(BoostUnitDefinitions REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-# don't link to ${CONAN_LIBS} or CONAN_PKG::package
 target_link_libraries(${PROJECT_NAME} PRIVATE BoostUnitDefinitions::BoostUnitDefinitions)
-# In case the target project need a specific C++ standard
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/cd3-boost-unit-definitions/all/test_v1_package/CMakeLists.txt
+++ b/recipes/cd3-boost-unit-definitions/all/test_v1_package/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(test_package LANGUAGES CXX) # if the project uses c++
+project(test_package LANGUAGES CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)


### PR DESCRIPTION
Some additional cleanup and changes from the last review.

Changed the boost dependency to a range [>=1.69.0]

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
