### PR TITLE
glaze: add version 0.2.2, fix wrong url for 0.2.1, delete older versions

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
+  "0.2.2":
+    url: "https://github.com/stephenberry/glaze/archive/v0.2.2.tar.gz"
+    sha256: "d0d2edcc546b0ebb4bedaeedfb4a54aa678a6fdffa6b20dd6b252ef6325a9e75"
   "0.2.1":
-    url: "https://github.com/stephenberry/glaze/archive/v0.2.0.tar.gz"
-    sha256: "2ad0d91f89465eac94efbeb91e435a5b36b7d54c9d8d6ccfb0708f6c6c0c5f87"
+    url: "https://github.com/stephenberry/glaze/archive/v0.2.1.tar.gz"
+    sha256: "dcf9ddf51b186dbc4cfd3b9324f9ee238cc1ba46fc2a62effa9293971ac4d1d4"
   "0.2.0":
     url: "https://github.com/stephenberry/glaze/archive/v0.2.0.tar.gz"
     sha256: "2ad0d91f89465eac94efbeb91e435a5b36b7d54c9d8d6ccfb0708f6c6c0c5f87"
@@ -14,15 +17,6 @@ sources:
   "0.1.4":
     url: "https://github.com/stephenberry/glaze/archive/v0.1.4.tar.gz"
     sha256: "dd46e77973fe5b3cf4cd68fd597ba6b1010ecffd3e10cd8ccbd6cd615e6ffaff"
-  "0.1.3":
-    url: "https://github.com/stephenberry/glaze/archive/v0.1.3.tar.gz"
-    sha256: "291e71244bf6fde5e57daf53d8e2fdd4793a7e93fe68c546f746f43a0e534d07"
-  "0.1.2":
-    url: "https://github.com/stephenberry/glaze/archive/v0.1.2.tar.gz"
-    sha256: "5de894dbad95a773a7b1e3c43eeb42ec79bf30bc04355d4d055db0cba1ae52db"
-  "0.1.0":
-    url: "https://github.com/stephenberry/glaze/archive/v0.1.0.tar.gz"
-    sha256: "bb709637217b68c835c5c17d49d6e1d10682a9fb5d3899b4452f737f64961a67"
   "0.0.7":
     url: "https://github.com/stephenberry/glaze/archive/refs/tags/v0.0.7.tar.gz"
     sha256: "124f7e8fea58c012b548ba1b643684fe428c7dbfeb8d8a5f701eb7db4356a759"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.2.2":
+    folder: all
   "0.2.1":
     folder: all
   "0.2.0":
@@ -8,12 +10,6 @@ versions:
   "0.1.7":
     folder: all
   "0.1.4":
-    folder: all
-  "0.1.3":
-    folder: all
-  "0.1.2":
-    folder: all
-  "0.1.0":
     folder: all
   "0.0.7":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **glaze/***

- add version 0.2.2
- fix wrong url for 0.2.1 (sorry, my fault)
- delete older versions

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
