### PR TITLE
kaitai_struct_cpp_stl_runtime: add version 0.10, support conan v 2

### DIFF
--- a/recipes/kaitai_struct_cpp_stl_runtime/all/CMakeLists.txt
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/CMakeLists.txt
@@ -1,7 +1,0 @@
-cmake_minimum_required(VERSION 3.3)
-project(cmake_wrapper)
-
-include(conanbuildinfo.cmake)
-conan_basic_setup()
-
-add_subdirectory(source_subfolder)

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/conandata.yml
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/conandata.yml
@@ -5,3 +5,12 @@ sources:
   "cci.20210701":
     url: "https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/archive/cb09b3a84c7e905c6a3fecfe9617cf864d9af781.zip"
     sha256: "058c01828692bf193cb862372651c572fcc43babbf2d664674409511b9f54e5b"
+patches:
+  "0.10":
+    patch_file: "patches/0001-cmake-minimum-required.patch"
+    patch_description: "declare cmake_minimum_required first"
+    patch_type: "portability"
+  "cci.20210701":
+    patch_file: "patches/0001-cmake-minimum-required.patch"
+    patch_description: "declare cmake_minimum_required first"
+    patch_type: "portability"

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/conandata.yml
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/conandata.yml
@@ -7,10 +7,10 @@ sources:
     sha256: "058c01828692bf193cb862372651c572fcc43babbf2d664674409511b9f54e5b"
 patches:
   "0.10":
-    patch_file: "patches/0001-cmake-minimum-required.patch"
-    patch_description: "declare cmake_minimum_required first"
-    patch_type: "portability"
+    - patch_file: "patches/0001-cmake-minimum-required.patch"
+      patch_description: "declare cmake_minimum_required first"
+      patch_type: "portability"
   "cci.20210701":
-    patch_file: "patches/0001-cmake-minimum-required.patch"
-    patch_description: "declare cmake_minimum_required first"
-    patch_type: "portability"
+    - patch_file: "patches/0001-cmake-minimum-required.patch"
+      patch_description: "declare cmake_minimum_required first"
+      patch_type: "portability"

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/conandata.yml
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.10":
+    url: "https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/archive/refs/tags/0.10.tar.gz"
+    sha256: "9a7d382b2acbbe6498ecca23fc7b6b98cbcc418af83fb569f94395f29712171c"
   "cci.20210701":
     url: "https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime/archive/cb09b3a84c7e905c6a3fecfe9617cf864d9af781.zip"
     sha256: "058c01828692bf193cb862372651c572fcc43babbf2d664674409511b9f54e5b"

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/conanfile.py
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.files import get, copy
+from conan.tools.files import get, copy, export_conandata_patches, apply_conandata_patches
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
@@ -22,6 +22,9 @@ class KaitaiStructCppStlRuntimeConan(ConanFile):
         "with_iconv": False,
     }
     short_paths = True
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -47,6 +50,7 @@ class KaitaiStructCppStlRuntimeConan(ConanFile):
         deps.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/conanfile.py
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/conanfile.py
@@ -1,68 +1,60 @@
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-from conans import ConanFile, CMake, tools
-
+required_conan_version = ">=1.53.0"
 
 class KaitaiStructCppStlRuntimeConan(ConanFile):
     name = "kaitai_struct_cpp_stl_runtime"
+    description = "kaitai struct c++ runtime library"
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://kaitai.io/"
-    description = "kaitai struct c++ runtime library"
-    topics = ("parsers", "streams", "dsl")
-    settings = "os", "compiler", "build_type", "arch"
-    exports_sources = "CMakeLists.txt"
-    generators = "cmake"
+    topics = ("parsers", "streams", "dsl", "kaitai struct")
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "with_zlib": [True, False],
-        "with_iconv": [True, False]
+        "with_iconv": [True, False],
     }
     default_options = {
         "with_zlib": False,
-        "with_iconv": False
+        "with_iconv": False,
     }
     short_paths = True
-    _cmake = None
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.11")
+            self.requires("zlib/1.2.13")
         if self.options.with_iconv:
-            self.requires("libiconv/1.16")
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    @property
-    def _build_subfolder(self):
-        return "build_subfolder"
+            self.requires("libiconv/1.17")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if self.options.with_iconv:
+            tc.variables["STRING_ENCODING_TYPE"] = "ICONV"
+        else:
+            tc.variables["STRING_ENCODING_TYPE"] = "NONE"
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
-    def _configure_cmake(self):
-        if self._cmake:
-            return self._cmake
-        self._cmake = CMake(self)
-
-        if self.options.with_iconv:
-            self._cmake.definitions["STRING_ENCODING_TYPE"] = "ICONV"
-        else:
-            self._cmake.definitions["STRING_ENCODING_TYPE"] = "NONE"
-
-        self._cmake.configure(build_folder=self._build_subfolder)
-        return self._cmake
-
     def package(self):
-        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs = ["kaitai_struct_cpp_stl_runtime"]

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/patches/0001-cmake-minimum-required.patch
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/patches/0001-cmake-minimum-required.patch
@@ -1,0 +1,11 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7f72825..fa3d4e4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+-project (kaitai_struct_cpp_stl_runtime CXX)
+ cmake_minimum_required (VERSION 3.3)
++project (kaitai_struct_cpp_stl_runtime CXX)
+ 
+ set (CMAKE_INCLUDE_CURRENT_DIR ON)
+ 

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/test_package/CMakeLists.txt
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/test_package/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
-project(PackageTest CXX)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(kaitai_struct_cpp_stl_runtime REQUIRED CONFIG)
 
-add_executable(test_package test_package.cpp)
-target_link_libraries(test_package ${CONAN_LIBS})
-
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE kaitai_struct_cpp_stl_runtime::kaitai_struct_cpp_stl_runtime)

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/test_package/conanfile.py
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/test_v1_package/CMakeLists.txt
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/kaitai_struct_cpp_stl_runtime/all/test_v1_package/conanfile.py
+++ b/recipes/kaitai_struct_cpp_stl_runtime/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/kaitai_struct_cpp_stl_runtime/config.yml
+++ b/recipes/kaitai_struct_cpp_stl_runtime/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.10":
+    folder: all
   "cci.20210701":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **kaitai_struct_cpp_stl_runtime/***


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
