### PR TITLE
[config] Activate conan v2 pipeline feedback in github comments

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -33,13 +33,17 @@ slack:
 
 # Things related to Jenkins jobs
 tasks:
-  conan_v2_run_export: true
+  conan_v2_run_export: false
   write_comments: true
   detailed_status_checks: true
   update_labels: true
   automatic_merge:
     reviews_required_total: 2  # Reviews that a PR needs so it can be merged
     reviews_required_team: 1  # Reviews from the Conan team that a PR needs so it can be merged
+  cci_wait_for_multibranch:  # CCI jobs should wait for other multibranch job for that same PR
+    job_name: "prod-v2/cci"  # e.g. "cci-v2/cci" -> this means waiting for cci-v2/cci/PR-<number>
+    timeout_seconds: 600  # Maximum time to wait for the multibranch job
+    merge_messages: true  # Merge messages from the multibranch job waited for
 
 # Profile configurations to build packages
 configurations:

--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -30,6 +30,7 @@ github:
 
 # Things related to Jenkins jobs:
 tasks:
+  feedback_title: "Conan v2 pipeline (informative, not required for merge)"
   write_comments: false
   detailed_status_checks: false
   update_labels: false


### PR DESCRIPTION
- Enables merging feedback from conan v1 pipeline and conan v2 one.
- Adds title to conan v2 pipeline: informative, not required for merging the PR.
- Removes conan v2 export step in conan v1 pipeline
