### PR TITLE
simdutf: add version 2.0.9

### DIFF
--- a/recipes/simdutf/all/conandata.yml
+++ b/recipes/simdutf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.9":
+    url: "https://github.com/simdutf/simdutf/archive/v2.0.9.tar.gz"
+    sha256: "ff6a19de4c23671e7f1077cf6c0f60bc01197f29c6e4f56fa485c9cd732576ac"
   "2.0.8":
     url: "https://github.com/simdutf/simdutf/archive/refs/tags/v2.0.8.tar.gz"
     sha256: "bd7aa550a8d9a1aba2c0b4eb2088f90c964375b13394f9076f7ba49f51dc40b5"
@@ -15,6 +18,10 @@ sources:
     url: "https://github.com/simdutf/simdutf/archive/refs/tags/v1.0.1.tar.gz"
     sha256: "e7832ba58fb95fe00de76dbbb2f17d844a7ad02a6f5e3e9e5ce9520e820049a0"
 patches:
+  "2.0.9":
+    - patch_file: "patches/2.0.3-0001-fix-cmake.patch"
+      patch_description: "remove static build, enable rpath on macOS"
+      patch_type: "conan"
   "2.0.8":
     - patch_file: "patches/2.0.3-0001-fix-cmake.patch"
       patch_description: "remove static build, enable rpath on macOS"
@@ -35,7 +42,8 @@ patches:
       patch_type: "portability"
   "2.0.2":
     - patch_file: "patches/2.0.2-0001-fix-cmake.patch"
-      patch_description: "remove static build, stop to link static libc++ and enable rpath on macOS"
+      patch_description: "remove static build, stop to link static libc++ and enable\
+        \ rpath on macOS"
       patch_type: "conan"
     - patch_file: "patches/2.0.2-0002-add-workaround-gcc9.patch"
       patch_description: "apply gcc8 workaround to gcc9"

--- a/recipes/simdutf/config.yml
+++ b/recipes/simdutf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.9":
+    folder: all
   "2.0.8":
     folder: all
   "2.0.6":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **simdutf/2.0.9**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
