### PR TITLE
c-blosc2: add version 2.6.1

### DIFF
--- a/recipes/c-blosc2/all/conandata.yml
+++ b/recipes/c-blosc2/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.6.1":
+    url: "https://github.com/Blosc/c-blosc2/archive/v2.6.1.tar.gz"
+    sha256: "514a793368093893c1a7cae030f7e31faca7f86465ae69dd576f256d8bf28c08"
   "2.6.0":
     url: "https://github.com/Blosc/c-blosc2/archive/v2.6.0.tar.gz"
     sha256: "ca4fc79a7c4a4d4f53da856ee0bb7083c16236210fdd6263397124572c25a507"
@@ -16,6 +19,10 @@ sources:
     sha256: "66f9977de26d6bc9ea1c0e623d873c3225e4fff709aa09b3335fd09d41d57c0e"
 
 patches:
+  "2.6.1":
+    - patch_file: "patches/2.6.0-0001-fix-cmake.patch"
+      patch_description: "use cci package"
+      patch_type: "conan"
   "2.6.0":
     - patch_file: "patches/2.6.0-0001-fix-cmake.patch"
       patch_description: "use cci package"

--- a/recipes/c-blosc2/config.yml
+++ b/recipes/c-blosc2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.6.1":
+    folder: all
   "2.6.0":
     folder: all
   "2.4.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **c-blosc2/2.6.1**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
