### PR TITLE
Use new environment tool in pybind11 test_package for v2 compatibility

### DIFF
--- a/recipes/pybind11/all/test_package/conanfile.py
+++ b/recipes/pybind11/all/test_package/conanfile.py
@@ -1,9 +1,7 @@
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain
-from conan.tools.env import VirtualRunEnv
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import Environment, VirtualRunEnv
 from conan.tools.build import can_run
-from conan.tools.layout import cmake_layout
-from conans.tools import environment_append
 
 import os
 from pathlib import PurePath
@@ -25,6 +23,10 @@ class TestPackageConan(ConanFile):
         toolchain.variables["PYTHON_EXECUTABLE"] = PurePath(self._python_interpreter).as_posix()
         toolchain.generate()
 
+        env = Environment()
+        env.append_path("PYTHONPATH", os.path.join(self.build_folder, self.cpp.build.libdirs[0]))
+        env.vars(self, scope="run").save_script("testrun")
+
         run = VirtualRunEnv(self)
         run.generate()
 
@@ -44,7 +46,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            python_path = os.path.join(self.build_folder, self.cpp.build.libdirs[0])
-            with environment_append({"PYTHONPATH": python_path}):
-                module_path = os.path.join(self.source_folder, "test.py")
-                self.run(f"{self._python_interpreter} {module_path}", env="conanrun")
+            module_path = os.path.join(self.source_folder, "test.py")
+            self.run(f"{self._python_interpreter} {module_path}", env="conanrun")


### PR DESCRIPTION
## `pybind11` test package

* Use new `Environment` object in `generate()` method instead of the legacy `environment_append` which is not present in Conan 2
* Fix import for `cmake_layout`, which is in `conan.tools.cmake` 
