### PR TITLE
s2n: add version 1.3.31

### DIFF
--- a/recipes/s2n/all/conandata.yml
+++ b/recipes/s2n/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.31":
+    url: "https://github.com/aws/s2n-tls/archive/v1.3.31.tar.gz"
+    sha256: "23cfb42f82cbe1ce94b59f3b1c1c8eb9d24af2a1ae4c8f854209ff88fddd3900"
   "1.3.15":
     url: "https://github.com/aws/s2n-tls/archive/v1.3.15.tar.gz"
     sha256: "e3fc3405bb56334cbec90c35cbdf0e8a0f53199749a3f4b8fddb8d8a41e6db8b"

--- a/recipes/s2n/config.yml
+++ b/recipes/s2n/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.31":
+    folder: all
   "1.3.15":
     folder: all
   "1.3.9":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **s2n/1.3.31**



---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
