### PR TITLE
g3log: add version 2.1

### DIFF
--- a/recipes/g3log/all/conandata.yml
+++ b/recipes/g3log/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1":
+    url: "https://github.com/KjellKod/g3log/archive/2.1.tar.gz"
+    sha256: "13c9d8cc0387792301f264c4f623618fc4dea9814d9b5844931ffbfd9aafb1fe"
   "1.3.4":
     url: "https://github.com/KjellKod/g3log/archive/refs/tags/1.3.4.tar.gz"
     sha256: "2fe8815e5f5afec6b49bdfedfba1e86b8e58a5dc89fd97f4868fb7f3141aed19"

--- a/recipes/g3log/config.yml
+++ b/recipes/g3log/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1":
+    folder: all
   "1.3.4":
     folder: all
   "1.3.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **g3log/2.1**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
