### PR TITLE
shapelib: Disable SO versioning

### DIFF
--- a/recipes/shapelib/all/conanfile.py
+++ b/recipes/shapelib/all/conanfile.py
@@ -47,6 +47,7 @@ class ShapelibConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.variables["BUILD_TESTING"] = False
+        tc.variables["CMAKE_PLATFORM_NO_VERSIONED_SONAME"] = True
         tc.variables["USE_RPATH"] = False
         tc.generate()
 


### PR DESCRIPTION
The SO versioning creates symlinks that complicate the recipe. This PR disables generating these symlinks with a CMake variable. This simplifies the recipe to only include `libshp.so`.

Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
