### PR TITLE
libxml2: fix msvc & mingw build tricks for icu

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -187,7 +187,8 @@ class Libxml2Conan(ConanFile):
             def fix_library(option, package, old_libname):
                 if option:
                     libs = []
-                    for lib in itertools.chain(self.dependencies[package].cpp_info.libs, self.dependencies[package].cpp_info.system_libs):
+                    aggregated_cpp_info = self.dependencies[package].cpp_info.aggregated_components()
+                    for lib in itertools.chain(aggregated_cpp_info.libs, aggregated_cpp_info.system_libs):
                         libname = lib
                         if not libname.endswith('.lib'):
                             libname += '.lib'
@@ -246,10 +247,11 @@ class Libxml2Conan(ConanFile):
             # build
             def fix_library(option, package, old_libname):
                 if option:
+                    aggregated_cpp_info = self.dependencies[package].cpp_info.aggregated_components()
                     replace_in_file(self,
                         "Makefile.mingw",
                         f"LIBS += -l{old_libname}",
-                        f"LIBS += -l{' -l'.join(self.dependencies[package].cpp_info.libs)}",
+                        f"LIBS += -l{' -l'.join(aggregated_cpp_info.libs)}",
                     )
 
             fix_library(self.options.iconv, "libiconv", "iconv")


### PR DESCRIPTION
icu has components, therefore cpp_info of components must be aggregated first

see https://github.com/conan-io/conan/issues/12733

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
