### PR TITLE
nanobench: add version 4.3.9, support conan v2

### DIFF
--- a/recipes/nanobench/all/conandata.yml
+++ b/recipes/nanobench/all/conandata.yml
@@ -23,3 +23,4 @@ patches:
     - patch_file: "patches/4.3.9-0001-support-older-msvc.patch"
       patch_description: "fix compilation error on msvc < 1928"
       patch_type: "portability"
+      patch_source: "https://github.com/martinus/nanobench/pull/82"

--- a/recipes/nanobench/all/conandata.yml
+++ b/recipes/nanobench/all/conandata.yml
@@ -1,16 +1,19 @@
 sources:
-  "4.0.0":
-    url: "https://github.com/martinus/nanobench/archive/v4.0.0.tar.gz"
-    sha256: 34b9bbfc7bf3bc30599f3b7cb398455539edb8ea67930aaef22b707f1ad3824f
-  "4.3.0":
-    url: "https://github.com/martinus/nanobench/archive/v4.3.0.tar.gz"
-    sha256: 6cf97e940eca42394f64d4e9d341e72804c92575247269695beb24f7e2539e82
-  "4.3.5":
-    url: "https://github.com/martinus/nanobench/archive/v4.3.5.tar.gz"
-    sha256: "205e6cf0ea901f64af971335bfe8011c1f6bd66f6ae678c616da0eddfbe70437"
-  "4.3.6":
-    url: "https://github.com/martinus/nanobench/archive/v4.3.6.tar.gz"
-    sha256: "cfa223fefca8752c0c96416f3440a9b02219f4695a8307db7e8c7054aaed7f01"
+  "4.3.9":
+    url: "https://github.com/martinus/nanobench/archive/v4.3.9.tar.gz"
+    sha256: "4a7fd8fdd5819e4d1c34ae558df010a0ccf36db0508c41c51cd0181bc04c6356"
   "4.3.7":
     url: "https://github.com/martinus/nanobench/archive/v4.3.7.tar.gz"
     sha256: "6a2dadb8230370c7fb7a9362be1c3677e44d8e06193a4ecb489a4748ef9483d7"
+  "4.3.6":
+    url: "https://github.com/martinus/nanobench/archive/v4.3.6.tar.gz"
+    sha256: "cfa223fefca8752c0c96416f3440a9b02219f4695a8307db7e8c7054aaed7f01"
+  "4.3.5":
+    url: "https://github.com/martinus/nanobench/archive/v4.3.5.tar.gz"
+    sha256: "205e6cf0ea901f64af971335bfe8011c1f6bd66f6ae678c616da0eddfbe70437"
+  "4.3.0":
+    url: "https://github.com/martinus/nanobench/archive/v4.3.0.tar.gz"
+    sha256: "6cf97e940eca42394f64d4e9d341e72804c92575247269695beb24f7e2539e82"
+  "4.0.0":
+    url: "https://github.com/martinus/nanobench/archive/v4.0.0.tar.gz"
+    sha256: "34b9bbfc7bf3bc30599f3b7cb398455539edb8ea67930aaef22b707f1ad3824f"

--- a/recipes/nanobench/all/conandata.yml
+++ b/recipes/nanobench/all/conandata.yml
@@ -17,3 +17,9 @@ sources:
   "4.0.0":
     url: "https://github.com/martinus/nanobench/archive/v4.0.0.tar.gz"
     sha256: "34b9bbfc7bf3bc30599f3b7cb398455539edb8ea67930aaef22b707f1ad3824f"
+
+patches:
+  "4.3.9":
+    - patch_file: "patches/4.3.9-0001-support-older-msvc.patch"
+      patch_description: "fix compilation error on msvc < 1928"
+      patch_type: "portability"

--- a/recipes/nanobench/all/conanfile.py
+++ b/recipes/nanobench/all/conanfile.py
@@ -1,33 +1,48 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
 import os
-import glob
-from conans import ConanFile, tools
 
+required_conan_version = ">=1.52.0"
 
 class NanobenchConan(ConanFile):
     name = "nanobench"
     description = """ankerl::nanobench is a platform independent
                      microbenchmarking library for C++11/14/17/20."""
-    topics = ("conan", "nanobench", "benchmark", "microbenchmark")
+    license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/martinus/nanobench"
-    license = "MIT"
+    topics = ("benchmark", "microbenchmark", "header-only")
+    settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _min_cppstd(self):
+        return 11
 
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = glob.glob(self.name + "-*/")[0]
-        os.rename(extracted_dir, self._source_subfolder)
-
-    def package(self):
-        include_folder = os.path.join(
-            self._source_subfolder, os.path.join("src", "include"))
-        self.copy(pattern="LICENSE", dst="licenses",
-                  src=self._source_subfolder)
-        self.copy(pattern="*.h", dst="include", src=include_folder)
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="*.h",
+            dst=os.path.join(self.package_folder, "include"),
+            src=os.path.join(self.source_folder, "src", "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/nanobench/all/conanfile.py
+++ b/recipes/nanobench/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import get, copy
+from conan.tools.files import get, copy, export_conandata_patches, apply_conandata_patches
 from conan.tools.layout import basic_layout
 import os
 
@@ -15,11 +15,13 @@ class NanobenchConan(ConanFile):
     homepage = "https://github.com/martinus/nanobench"
     topics = ("benchmark", "microbenchmark", "header-only")
     settings = "os", "arch", "compiler", "build_type"
-    no_copy_source = True
 
     @property
     def _min_cppstd(self):
         return 11
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -33,6 +35,9 @@ class NanobenchConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        apply_conandata_patches(self)
 
     def package(self):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)

--- a/recipes/nanobench/all/patches/4.3.9-0001-support-older-msvc.patch
+++ b/recipes/nanobench/all/patches/4.3.9-0001-support-older-msvc.patch
@@ -1,0 +1,28 @@
+diff --git a/src/include/nanobench.h b/src/include/nanobench.h
+index c03d9ad..9bc6eeb 100644
+--- a/src/include/nanobench.h
++++ b/src/include/nanobench.h
+@@ -405,7 +405,11 @@ struct Config {
+     Config& operator=(Config const&);
+     Config& operator=(Config&&);
+     Config(Config const&);
++#if defined(_MSC_VER) && _MSC_VER < 1928
++    Config(Config&&);
++#else
+     Config(Config&&) noexcept;
++#endif
+ };
+ ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+ 
+@@ -2854,7 +2858,11 @@ Config::~Config() = default;
+ Config& Config::operator=(Config const&) = default;
+ Config& Config::operator=(Config&&) = default;
+ Config::Config(Config const&) = default;
++#if defined(_MSC_VER) && _MSC_VER < 1928
++Config::Config(Config&&) = default;
++#else
+ Config::Config(Config&&) noexcept = default;
++#endif
+ 
+ // provide implementation here so it's only generated once
+ Result::~Result() = default;

--- a/recipes/nanobench/all/patches/4.3.9-0001-support-older-msvc.patch
+++ b/recipes/nanobench/all/patches/4.3.9-0001-support-older-msvc.patch
@@ -1,5 +1,5 @@
 diff --git a/src/include/nanobench.h b/src/include/nanobench.h
-index c03d9ad..9bc6eeb 100644
+index c03d9ad..30f7353 100644
 --- a/src/include/nanobench.h
 +++ b/src/include/nanobench.h
 @@ -405,7 +405,11 @@ struct Config {
@@ -14,7 +14,19 @@ index c03d9ad..9bc6eeb 100644
  };
  ANKERL_NANOBENCH(IGNORE_PADDED_POP)
  
-@@ -2854,7 +2858,11 @@ Config::~Config() = default;
+@@ -431,7 +435,11 @@ public:
+     Result& operator=(Result const&);
+     Result& operator=(Result&&);
+     Result(Result const&);
++#if defined(_MSC_VER) && _MSC_VER < 1928
++    Result(Result&&);
++#else
+     Result(Result&&) noexcept;
++#endif
+ 
+     // adds new measurement results
+     // all values are scaled by iters (except iters...)
+@@ -2854,14 +2862,22 @@ Config::~Config() = default;
  Config& Config::operator=(Config const&) = default;
  Config& Config::operator=(Config&&) = default;
  Config::Config(Config const&) = default;
@@ -26,3 +38,14 @@ index c03d9ad..9bc6eeb 100644
  
  // provide implementation here so it's only generated once
  Result::~Result() = default;
+ Result& Result::operator=(Result const&) = default;
+ Result& Result::operator=(Result&&) = default;
+ Result::Result(Result const&) = default;
++#if defined(_MSC_VER) && _MSC_VER < 1928
++Result::Result(Result&&) = default;
++#else
+ Result::Result(Result&&) noexcept = default;
++#endif
+ 
+ namespace detail {
+ template <typename T>

--- a/recipes/nanobench/all/test_package/CMakeLists.txt
+++ b/recipes/nanobench/all/test_package/CMakeLists.txt
@@ -1,9 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(nanobench REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)
+target_link_libraries(${PROJECT_NAME} PRIVATE nanobench::nanobench)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/recipes/nanobench/all/test_package/conanfile.py
+++ b/recipes/nanobench/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/nanobench/all/test_v1_package/CMakeLists.txt
+++ b/recipes/nanobench/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/nanobench/all/test_v1_package/conanfile.py
+++ b/recipes/nanobench/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/nanobench/config.yml
+++ b/recipes/nanobench/config.yml
@@ -1,11 +1,13 @@
 versions:
-  "4.0.0":
+  "4.3.8":
     folder: "all"
-  "4.3.0":
-    folder: "all"
-  "4.3.5":
+  "4.3.7":
     folder: "all"
   "4.3.6":
     folder: "all"
-  "4.3.7":
+  "4.3.5":
+    folder: "all"
+  "4.3.0":
+    folder: "all"
+  "4.0.0":
     folder: "all"

--- a/recipes/nanobench/config.yml
+++ b/recipes/nanobench/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "4.3.8":
+  "4.3.9":
     folder: "all"
   "4.3.7":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **nanobench/***

- add version 4.3.9
- support conan v2
- sort conandata.yaml, config.yml

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
