### PR TITLE
homog2d: fix msvc compilation error by proper way

### DIFF
--- a/recipes/homog2d/all/conandata.yml
+++ b/recipes/homog2d/all/conandata.yml
@@ -15,4 +15,3 @@ patches:
       patch_description: "fix msvc compilation error"
       patch_type: "portability"
       patch_source: "https://github.com/skramm/homog2d/issues/2"
-

--- a/recipes/homog2d/all/conandata.yml
+++ b/recipes/homog2d/all/conandata.yml
@@ -11,3 +11,8 @@ patches:
     - patch_file: "patches/0002-pretty_function-for-msvc.patch"
       patch_description: "use __FUNCSIG__ instead of __PRETTY_FUNCTION__ on MSVC"
       patch_type: "portability"
+    - patch_file: "patches/0003-support-msvc.patch"
+      patch_description: "fix msvc compilation error"
+      patch_type: "portability"
+      patch_source: "https://github.com/skramm/homog2d/issues/2"
+

--- a/recipes/homog2d/all/patches/0002-pretty_function-for-msvc.patch
+++ b/recipes/homog2d/all/patches/0002-pretty_function-for-msvc.patch
@@ -1,5 +1,5 @@
 diff --git a/homog2d.hpp b/homog2d.hpp
-index f30d150..68bc280 100644
+index f30d150..d82d7e5 100644
 --- a/homog2d.hpp
 +++ b/homog2d.hpp
 @@ -115,12 +115,18 @@ See https://github.com/skramm/homog2d
@@ -31,15 +31,3 @@ index f30d150..68bc280 100644
  			<< "\n -Error count=" << ++errorCount(); \
  		throw std::runtime_error( oss.str() ); \
  	}
-@@ -2914,11 +2920,6 @@ private:
- 	h2d::operator * ( const h2d::Point2d_<FPT1>&, const h2d::Point2d_<FPT2>& )
- 	-> h2d::Line2d_<FPT1>;
-
--	template<typename T,typename U>
--	friend auto
--	h2d::operator * ( const h2d::Homogr_<U>&, const h2d::Line2d_<T>& )
--	-> h2d::Line2d_<T>;
--
- 	template<typename T1,typename T2,typename FPT1,typename FPT2>
- 	friend base::LPBase<T1,FPT1>
- 	detail::crossProduct( const base::LPBase<T2,FPT1>&, const base::LPBase<T2,FPT2>& );

--- a/recipes/homog2d/all/patches/0003-support-msvc.patch
+++ b/recipes/homog2d/all/patches/0003-support-msvc.patch
@@ -1,0 +1,22 @@
+diff --git a/homog2d.hpp b/homog2d.hpp
+index 77f6841..ab8646b 100644
+--- a/homog2d.hpp
++++ b/homog2d.hpp
+@@ -729,12 +729,11 @@ auto
+ operator << ( std::ostream&, const h2d::base::LPBase<LP,FPT>& )
+ -> std::ostream&;
+ }
+-/*
+-template<typename LP,typename FPT>
+-auto
+-operator << ( std::ostream&, const h2d::Point2d_<FPT>& )
+--> std::ostream&;
+-*/
++
++// forward declaration, related to https://github.com/skramm/homog2d/issues/2
++template<typename T,typename U>
++Line2d_<T>
++operator * ( const Homogr_<U>&, const Line2d_<T>& );
+ 
+ namespace detail {
+ 


### PR DESCRIPTION
Specify library name and version:  **homog2d/2.9**

create patch for msvc compilation error in upstream.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
