### PR TITLE
etl: add version 20.35.7

### DIFF
--- a/recipes/etl/all/conandata.yml
+++ b/recipes/etl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20.35.7":
+    url: "https://github.com/ETLCPP/etl/archive/20.35.7.tar.gz"
+    sha256: "20127e36c12a33142645dd5ec0a08d12b34ce9b33986847eeaa8c4201e025895"
   "20.35.5":
     url: "https://github.com/ETLCPP/etl/archive/20.35.5.tar.gz"
     sha256: "d67aead4f1c023eaeb9ae67b62b0aed76138aa1b7dac48f627530ab3ea366281"

--- a/recipes/etl/config.yml
+++ b/recipes/etl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20.35.7":
+    folder: all
   "20.35.5":
     folder: all
   "20.35.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **etl/20.35.7**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
