### PR TITLE
libbacktrace: set minimum version of Visual Studio

### DIFF
--- a/recipes/libbacktrace/all/conanfile.py
+++ b/recipes/libbacktrace/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, rm
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc, unix_path
+from conan.tools.microsoft import check_min_vs, is_msvc, unix_path
 from conan.tools.scm import Version
 import os
 
@@ -63,6 +63,7 @@ class LibbacktraceConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def validate(self):
+        check_min_vs(self, "180")
         if is_msvc(self) and self.info.options.shared:
             raise ConanInvalidConfiguration("libbacktrace shared is not supported with Visual Studio")
 
@@ -83,8 +84,7 @@ class LibbacktraceConan(ConanFile):
         env.generate()
 
         tc = AutotoolsToolchain(self)
-        if (self.settings.compiler == "Visual Studio" and Version(self.settings.compiler.version) >= "12") or \
-           (self.settings.compiler == "msvc" and Version(self.settings.compiler.version) >= "180"):
+        if is_msvc(self):
             tc.extra_cflags.append("-FS")
         tc.generate()
 

--- a/recipes/libbacktrace/all/conanfile.py
+++ b/recipes/libbacktrace/all/conanfile.py
@@ -85,6 +85,7 @@ class LibbacktraceConan(ConanFile):
 
         tc = AutotoolsToolchain(self)
         if is_msvc(self):
+            # https://github.com/conan-io/conan/issues/6514
             tc.extra_cflags.append("-FS")
         tc.generate()
 


### PR DESCRIPTION
### Summary of changes:

* Error out if the compiler version is not equal to or greater than 180 (Visual Studio 2013 as minimum)
* Reference the issue that motivates passing the `-FS` flag.

### Context:
* The recipe fails to build with the compiler from Visual Studio 2012, with actual compiler errors that appear directly related to the sources rather than anything in the recipe.
* CCI does not build or test this configuration - we rely on community contributions for this one.
* The recipe itself does not work out of the box for older Visual Studio compilers. In Conan 2.0 support for older versions is limited as per [this proposal](https://github.com/conan-io/tribe/blob/main/design/032-msvc_support.md) - which applies to this recipe since it moved to using the new integrations. Nonetheless have opened https://github.com/conan-io/conan/issues/12739 for a followup.

