### PR TITLE
CryptoPP: get android ndk path from tools.android:ndk_path conf

### DIFF
--- a/recipes/cryptopp/all/conanfile.py
+++ b/recipes/cryptopp/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, collect_libs, copy, get, rename, replace_in_file, rmdir, save
 from conan.tools.scm import Version
-from conans import tools as tools_legacy
+
 import os
 import textwrap
 
@@ -100,8 +100,10 @@ class CryptoPPConan(ConanFile):
     def _patch_sources(self):
         apply_conandata_patches(self)
         # Use cpu-features.h from Android NDK
-        if self.settings.os == "Android":
-            android_ndk_home = tools_legacy.get_env("ANDROID_NDK_HOME")
+        if self.settings.os == "Android" and Version(self.version) < "8.4.0":
+            # Replicate logic from: https://github.com/weidai11/cryptopp/blob/CRYPTOPP_8_2_0/cpu.cpp#L46-L52
+            # In more recent versions this is already taken care of by cryptopp-cmake
+            android_ndk_home = self.conf.get("tools.android:ndk_path")
             if android_ndk_home:
                 copy(
                     self,


### PR DESCRIPTION
### Summary:

* Replace `tools_legacy.get_env("ANDROID_NDK_HOME")` with `self.conf.get("tools.android:ndk_path")`
* Constrain the copying of `cpu-features.h` to versions older than `8.4.0` - `cryptopp-cmake` already does it: https://github.com/abdes/cryptopp-cmake/blob/206aab4cb1e6e78b8460b8c0fe08449c280e321e/cryptopp/sources.cmake#L438-L443