### PR TITLE
libiconv: Update SPDX license identifier and set license based on version

### DIFF
--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -24,7 +24,7 @@ required_conan_version = ">=1.53.0"
 class LibiconvConan(ConanFile):
     name = "libiconv"
     description = "Convert text to and from Unicode"
-    license = "LGPL-2.1-or-later"
+    license = ("LGPL-2.0-or-later", "LGPL-2.1-or-later")
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.gnu.org/software/libiconv/"
     topics = ("iconv", "text", "encoding", "locale", "unicode", "conversion")
@@ -63,7 +63,9 @@ class LibiconvConan(ConanFile):
             self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
-        if Version(self.version) < "1.17":
+        if Version(self.version) >= "1.17":
+            self.license = "LGPL-2.1-or-later"
+        else:
             self.license = "LGPL-2.0-or-later"
 
     def layout(self):

--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -24,7 +24,7 @@ required_conan_version = ">=1.53.0"
 class LibiconvConan(ConanFile):
     name = "libiconv"
     description = "Convert text to and from Unicode"
-    license = "LGPL-2.1"
+    license = "LGPL-2.1-or-later"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.gnu.org/software/libiconv/"
     topics = ("iconv", "text", "encoding", "locale", "unicode", "conversion")
@@ -63,6 +63,8 @@ class LibiconvConan(ConanFile):
             self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
+        if Version(self.version) < "1.17":
+            self.license = "LGPL-2.0-or-later"
 
     def layout(self):
         basic_layout(self, src_folder="src")


### PR DESCRIPTION
libiconv 1.17 switched to the LGPL-2.1 from the LGPL-2.0 license. The Conan package previously didn't express the license for older versions correctly.

Specify library name and version:  **lib/1.0**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
