### PR TITLE
leptonica: add version 1.83.0

### DIFF
--- a/recipes/leptonica/all/conandata.yml
+++ b/recipes/leptonica/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.83.0":
+    url: "https://github.com/DanBloomberg/leptonica/archive/1.83.0.tar.gz"
+    sha256: "14cf531c2219a1414e8e3c51a3caa5cf021a52e782c4a6561bf64d0ef2119282"
   "1.82.0":
     url: "https://github.com/DanBloomberg/leptonica/archive/1.82.0.tar.gz"
     sha256: "40fa9ac1e815b91e0fa73f0737e60c9eec433a95fa123f95f2573dd3127dd669"

--- a/recipes/leptonica/all/conandata.yml
+++ b/recipes/leptonica/all/conandata.yml
@@ -21,4 +21,5 @@ patches:
   "1.78.0":
     - patch_file: "patches/fix-find-modules-variables.patch"
       patch_description: "CMake: robust handling of dependencies"
-      patch_type: "conan"
+      patch_type: "portability"
+      patch_source: "https://github.com/DanBloomberg/leptonica/pull/456"

--- a/recipes/leptonica/all/conandata.yml
+++ b/recipes/leptonica/all/conandata.yml
@@ -20,3 +20,5 @@ sources:
 patches:
   "1.78.0":
     - patch_file: "patches/fix-find-modules-variables.patch"
+      patch_description: "CMake: robust handling of dependencies"
+      patch_type: "conan"

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -130,7 +130,6 @@ class LeptonicaConan(ConanFile):
             replace_in_file(self, cmakelists_src, "if (ZLIB_LIBRARIES)", "if(0)")
             replace_in_file(self, cmake_configure, "if (ZLIB_FOUND)", "if(0)")
         ## giflib
-        replace_in_file(self, cmakelists, "find_package(GIF)", "find_package(GIFLIB)")
         replace_in_file(self, cmakelists_src, "${GIF_LIBRARIES}", "GIF::GIF")
         if not self.options.with_gif:
             replace_in_file(self, cmakelists_src, "if (GIF_LIBRARIES)", "if(0)")

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -168,6 +168,7 @@ class LeptonicaConan(ConanFile):
         ## We have to be more aggressive with dependencies found with pkgconfig
         ## Injection of libdirs is ensured by conan_basic_setup()
         ## openjpeg
+        replace_in_file(self, cmakelists_src, "${JP2K_LIBRARIES}", "openjp2")
         if Version(self.version) < "1.83.0":
             # versions below 1.83.0 do not have an option toggle
             replace_in_file(self, cmakelists, "if(NOT JP2K)", "if(0)")
@@ -179,11 +180,6 @@ class LeptonicaConan(ConanFile):
             if not self.options.with_openjpeg:
                 replace_in_file(self, cmake_configure, "if(JP2K_FOUND)", "if(0)")
 
-        replace_in_file(self, cmakelists_src,
-                              "if (JP2K_FOUND)",
-                              "if (JP2K_FOUND)\n"
-                              "target_link_directories(leptonica PRIVATE ${JP2K_LIBRARY_DIRS})\n"
-                              "target_compile_definitions(leptonica PRIVATE ${JP2K_CFLAGS_OTHER})")
         ## libwebp
         if Version(self.version) < "1.83.0":
             # versions below 1.83.0 do not have an option toggle

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -171,7 +171,10 @@ class LeptonicaConan(ConanFile):
         replace_in_file(self, cmakelists_src, "${JP2K_LIBRARIES}", "openjp2")
         if Version(self.version) < "1.83.0":
             # pkgconfig is prefered to CMake. Disable pkgconfig so only CMake is used
-            replace_in_file(self, cmakelists, "pkg_check_modules(JP2K libopenjp2>=2.0 QUIET)", "")
+            if Version(self.version) <= "1.78.0":
+                replace_in_file(self, cmakelists, "pkg_check_modules(JP2K libopenjp2)", "")
+            else:
+                replace_in_file(self, cmakelists, "pkg_check_modules(JP2K libopenjp2>=2.0 QUIET)", "")
             # versions below 1.83.0 do not have an option toggle
             replace_in_file(self, cmakelists, "if(NOT JP2K)", "if(0)")
             if not self.options.with_openjpeg:

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -72,7 +72,7 @@ class LeptonicaConan(ConanFile):
         if self.options.with_jpeg == "libjpeg-turbo":
             self.requires("libjpeg-turbo/2.1.4")
         if self.options.with_png:
-            self.requires("libpng/1.6.38")
+            self.requires("libpng/1.6.39")
         if self.options.with_tiff:
             self.requires("libtiff/4.4.0")
         if self.options.with_openjpeg:

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -176,6 +176,8 @@ class LeptonicaConan(ConanFile):
                 replace_in_file(self, cmake_configure, "if (JP2K_FOUND)", "if(0)")
         else:
             replace_in_file(self, cmakelists, "set(JP2K_INCLUDE_DIRS ${OPENJPEG_INCLUDE_DIRS})", "set(JP2K_INCLUDE_DIRS ${OpenJPEG_INCLUDE_DIRS})")
+            if not self.options.with_openjpeg:
+                replace_in_file(self, cmake_configure, "if(JP2K_FOUND)", "if(0)")
 
         replace_in_file(self, cmakelists_src,
                               "if (JP2K_FOUND)",

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -133,22 +133,34 @@ class LeptonicaConan(ConanFile):
         replace_in_file(self, cmakelists_src, "${GIF_LIBRARIES}", "GIF::GIF")
         if not self.options.with_gif:
             replace_in_file(self, cmakelists_src, "if (GIF_LIBRARIES)", "if(0)")
-            replace_in_file(self, cmake_configure, "if (GIF_FOUND)", "if(0)")
+            if Version(self.version) >= "1.83.0":
+                replace_in_file(self, cmake_configure, "if(GIF_FOUND)", "if(0)")
+            else:
+                replace_in_file(self, cmake_configure, "if (GIF_FOUND)", "if(0)")
         ## libjpeg
         replace_in_file(self, cmakelists_src, "${JPEG_LIBRARIES}", "JPEG::JPEG")
         if not self.options.with_jpeg:
             replace_in_file(self, cmakelists_src, "if (JPEG_LIBRARIES)", "if(0)")
-            replace_in_file(self, cmake_configure, "if (JPEG_FOUND)", "if(0)")
+            if Version(self.version) >= "1.83.0":
+                replace_in_file(self, cmake_configure, "if(JPEG_FOUND)", "if(0)")
+            else:
+                replace_in_file(self, cmake_configure, "if (JPEG_FOUND)", "if(0)")
         ## libpng
         replace_in_file(self, cmakelists_src, "${PNG_LIBRARIES}", "PNG::PNG")
         if not self.options.with_png:
             replace_in_file(self, cmakelists_src, "if (PNG_LIBRARIES)", "if(0)")
-            replace_in_file(self, cmake_configure, "if (PNG_FOUND)", "if(0)")
+            if Version(self.version) >= "1.83.0":
+                replace_in_file(self, cmake_configure, "if(PNG_FOUND)", "if(0)")
+            else:
+                replace_in_file(self, cmake_configure, "if (PNG_FOUND)", "if(0)")
         ## libtiff
         replace_in_file(self, cmakelists_src, "${TIFF_LIBRARIES}", "TIFF::TIFF")
         if not self.options.with_tiff:
             replace_in_file(self, cmakelists_src, "if (TIFF_LIBRARIES)", "if(0)")
-            replace_in_file(self, cmake_configure, "if (TIFF_FOUND)", "if(0)")
+            if Version(self.version) >= "1.83.0":
+                replace_in_file(self, cmake_configure, "if(TIFF_FOUND)", "if(0)")
+            else:
+                replace_in_file(self, cmake_configure, "if (TIFF_FOUND)", "if(0)")
         ## We have to be more aggressive with dependencies found with pkgconfig
         ## Injection of libdirs is ensured by conan_basic_setup()
         ## openjpeg

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -164,28 +164,35 @@ class LeptonicaConan(ConanFile):
         ## We have to be more aggressive with dependencies found with pkgconfig
         ## Injection of libdirs is ensured by conan_basic_setup()
         ## openjpeg
-        replace_in_file(self, cmakelists, "if(NOT JP2K)", "if(0)")
+        if Version(self.version) < "1.83.0":
+            # versions below 1.83.0 do not have an option toggle
+            replace_in_file(self, cmakelists, "if(NOT JP2K)", "if(0)")
+            if not self.options.with_openjpeg:
+                replace_in_file(self, cmakelists_src, "if (JP2K_FOUND)", "if(0)")
+                replace_in_file(self, cmake_configure, "if (JP2K_FOUND)", "if(0)")
+        else:
+            replace_in_file(self, cmakelists, "set(JP2K_INCLUDE_DIRS ${OPENJPEG_INCLUDE_DIRS})", "set(JP2K_INCLUDE_DIRS ${OpenJPEG_INCLUDE_DIRS})")
+
         replace_in_file(self, cmakelists_src,
                               "if (JP2K_FOUND)",
                               "if (JP2K_FOUND)\n"
                               "target_link_directories(leptonica PRIVATE ${JP2K_LIBRARY_DIRS})\n"
                               "target_compile_definitions(leptonica PRIVATE ${JP2K_CFLAGS_OTHER})")
-        if not self.options.with_openjpeg:
-            replace_in_file(self, cmakelists_src, "if (JP2K_FOUND)", "if(0)")
-            replace_in_file(self, cmake_configure, "if (JP2K_FOUND)", "if(0)")
         ## libwebp
-        replace_in_file(self, cmakelists, "if(NOT WEBP)", "if(0)")
+        if Version(self.version) < "1.83.0":
+            # versions below 1.83.0 do not have an option toggle
+            replace_in_file(self, cmakelists, "if(NOT WEBP)", "if(0)")
+            if Version(self.version) >= "1.79.0":
+                replace_in_file(self, cmakelists, "if(NOT WEBPMUX)", "if(0)")
+            if not self.options.with_webp:
+                replace_in_file(self, cmakelists_src, "if (WEBP_FOUND)", "if(0)")
+                replace_in_file(self, cmake_configure, "if (WEBP_FOUND)", "if(0)")
         replace_in_file(self, cmakelists_src,
                               "if (WEBP_FOUND)",
                               "if (WEBP_FOUND)\n"
                               "target_link_directories(leptonica PRIVATE ${WEBP_LIBRARY_DIRS} ${WEBPMUX_LIBRARY_DIRS})\n"
                               "target_compile_definitions(leptonica PRIVATE ${WEBP_CFLAGS_OTHER} ${WEBPMUX_CFLAGS_OTHER})")
         replace_in_file(self, cmakelists_src, "${WEBP_LIBRARIES}", "${WEBP_LIBRARIES} ${WEBPMUX_LIBRARIES}")
-        if Version(self.version) >= "1.79.0":
-            replace_in_file(self, cmakelists, "if(NOT WEBPMUX)", "if(0)")
-        if not self.options.with_webp:
-            replace_in_file(self, cmakelists_src, "if (WEBP_FOUND)", "if(0)")
-            replace_in_file(self, cmake_configure, "if (WEBP_FOUND)", "if(0)")
 
         # Remove detection of fmemopen() on macOS < 10.13
         # CheckFunctionExists will find it in the link library.

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -76,7 +76,11 @@ class LeptonicaConan(ConanFile):
         if self.options.with_tiff:
             self.requires("libtiff/4.4.0")
         if self.options.with_openjpeg:
-            self.requires("openjpeg/2.5.0")
+            if Version(self.version) >= "1.83.0":
+                # newer leptonica can autodetect any openjpeg version
+                self.requires("openjpeg/2.5.0")
+            else:
+                self.requires("openjpeg/2.4.0")
         if self.options.with_webp:
             self.requires("libwebp/1.2.4")
 

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -76,11 +76,7 @@ class LeptonicaConan(ConanFile):
         if self.options.with_tiff:
             self.requires("libtiff/4.4.0")
         if self.options.with_openjpeg:
-            if Version(self.version) >= "1.83.0":
-                # newer leptonica can autodetect any openjpeg version
-                self.requires("openjpeg/2.5.0")
-            else:
-                self.requires("openjpeg/2.4.0")
+            self.requires("openjpeg/2.5.0")
         if self.options.with_webp:
             self.requires("libwebp/1.2.4")
 

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -130,6 +130,7 @@ class LeptonicaConan(ConanFile):
             replace_in_file(self, cmakelists_src, "if (ZLIB_LIBRARIES)", "if(0)")
             replace_in_file(self, cmake_configure, "if (ZLIB_FOUND)", "if(0)")
         ## giflib
+        replace_in_file(self, cmakelists, "find_package(GIF)", "find_package(GIFLIB)")
         replace_in_file(self, cmakelists_src, "${GIF_LIBRARIES}", "GIF::GIF")
         if not self.options.with_gif:
             replace_in_file(self, cmakelists_src, "if (GIF_LIBRARIES)", "if(0)")

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.scm import Version
 import os
 import textwrap
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class LeptonicaConan(ConanFile):
@@ -55,18 +55,9 @@ class LeptonicaConan(ConanFile):
         if self.options.with_tiff:
             self.options["libtiff"].jpeg = self.options.with_jpeg
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -99,6 +99,9 @@ class LeptonicaConan(ConanFile):
             tc.variables["STATIC"] = not self.options.shared
         tc.variables["BUILD_PROG"] = False
         tc.variables["SW_BUILD"] = False
+        if Version(self.version) >= "1.83.0":
+            tc.variables["LIBWEBP_SUPPORT"] = self.options.with_webp
+            tc.variables["OPENJPEG_SUPPORT"] = self.options.with_openjpeg
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -170,6 +170,8 @@ class LeptonicaConan(ConanFile):
         ## openjpeg
         replace_in_file(self, cmakelists_src, "${JP2K_LIBRARIES}", "openjp2")
         if Version(self.version) < "1.83.0":
+            # pkgconfig is prefered to CMake. Disable pkgconfig so only CMake is used
+            replace_in_file(self, cmakelists, "pkg_check_modules(JP2K libopenjp2>=2.0 QUIET)", "")
             # versions below 1.83.0 do not have an option toggle
             replace_in_file(self, cmakelists, "if(NOT JP2K)", "if(0)")
             if not self.options.with_openjpeg:

--- a/recipes/leptonica/config.yml
+++ b/recipes/leptonica/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.83.0":
+    folder: all
   "1.82.0":
     folder: all
   "1.81.0":


### PR DESCRIPTION
Specify library name and version:  **leptonica/1.83.0**

There is one moment I don't fully understand. Upstream uses `find_package(GIF)` which seems to be totally fine.
But Conan generators create a bunch of `giflib-*` files so the find_package doesn't find them but picks up a system include path `/Library/Frameworks/UnixImageIO.framework/Headers`. Using `find_package(GIFLIB)` fixes the problem.

Recent giflib changes do not change a `cmake_file_name` property. If it is not changed, why doesn't it work?


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
