### PR TITLE
packio: add version 2.3.0, support conan v2

### DIFF
--- a/recipes/packio/all/conandata.yml
+++ b/recipes/packio/all/conandata.yml
@@ -1,34 +1,49 @@
 sources:
-  1.0.1:
-    sha256: 873ebd2ce8c8dbf8a4e7b777b1aa735fe4da3863131a5d6c938e339ee7e0a4d1
-    url: https://github.com/qchateau/packio/archive/1.0.1.tar.gz
-  1.0.2:
-    sha256: 040389f2de4a6da5df1cc323cdd80bc21bfc6a7f9bb9e56090d1ea0b1260226d
-    url: https://github.com/qchateau/packio/archive/1.0.2.tar.gz
-  1.1.0:
-    sha256: fb8baeeb903335b71b4241433faaff895e42e671da1c15b100e24b060f1d3784
-    url: https://github.com/qchateau/packio/archive/1.1.0.tar.gz
-  1.1.1:
-    sha256: 5f77bcbb843cc7dd7731c37db586e9e4f3997ebf04a8d1eccb9eae21841c7e55
-    url: https://github.com/qchateau/packio/archive/1.1.1.tar.gz
-  1.2.0:
-    sha256: b459c50a2ae7b90b45cd99a727dcd133e48602634571378491533148e642c511
-    url: https://github.com/qchateau/packio/archive/1.2.0.tar.gz
-  1.2.1:
-    sha256: 1b3f1654e8321148dd58172fcc6807451382dff30bb803967449a318b33101c5
-    url: https://github.com/qchateau/packio/archive/1.2.1.tar.gz
-  1.3.0:
-    sha256: adb723ef14b4a3ec41e9a7c17c48c8ee58712604b678b24f44e6a8aa471f18e5
-    url: https://github.com/qchateau/packio/archive/1.3.0.tar.gz
-  2.0.0:
-    sha256: b647b3088830c127a1d5d475a95476cc00c81675244cf7d17c9ca1f12e88740e
-    url: https://github.com/qchateau/packio/archive/2.0.0.tar.gz
-  2.0.1:
-    sha256: 081d378be922262c39218e115eabdf77f257e4773928011dff95795b8146b520
-    url: https://github.com/qchateau/packio/archive/2.0.1.tar.gz
-  2.1.0:
-    sha256: d13be083cd5a133b02fdd1da0d89fb75988c16109ccdcd631d53f9ca2457ad42
-    url: https://github.com/qchateau/packio/archive/2.1.0.tar.gz
+  "2.3.0":
+    url: "https://github.com/qchateau/packio/archive/2.3.0.tar.gz"
+    sha256: "4ef3bc76934855cc1a17eb00311bb42f5f14f616c75d4d1cc35151efcc988358"
   "2.2.0":
     url: "https://github.com/qchateau/packio/archive/2.2.0.tar.gz"
     sha256: "ac9f33d5e8dd92bd3cdec106e10453424060bae9c4cd97281aa5d20fb20476f7"
+  "2.1.0":
+    url: "https://github.com/qchateau/packio/archive/2.1.0.tar.gz"
+    sha256: "d13be083cd5a133b02fdd1da0d89fb75988c16109ccdcd631d53f9ca2457ad42"
+  "2.0.1":
+    url: "https://github.com/qchateau/packio/archive/2.0.1.tar.gz"
+    sha256: "081d378be922262c39218e115eabdf77f257e4773928011dff95795b8146b520"
+  "2.0.0":
+    url: "https://github.com/qchateau/packio/archive/2.0.0.tar.gz"
+    sha256: "b647b3088830c127a1d5d475a95476cc00c81675244cf7d17c9ca1f12e88740e"
+  "1.3.0":
+    url: "https://github.com/qchateau/packio/archive/1.3.0.tar.gz"
+    sha256: "adb723ef14b4a3ec41e9a7c17c48c8ee58712604b678b24f44e6a8aa471f18e5"
+  "1.2.1":
+    url: "https://github.com/qchateau/packio/archive/1.2.1.tar.gz"
+    sha256: "1b3f1654e8321148dd58172fcc6807451382dff30bb803967449a318b33101c5"
+  "1.2.0":
+    url: "https://github.com/qchateau/packio/archive/1.2.0.tar.gz"
+    sha256: "b459c50a2ae7b90b45cd99a727dcd133e48602634571378491533148e642c511"
+  "1.1.1":
+    url: "https://github.com/qchateau/packio/archive/1.1.1.tar.gz"
+    sha256: "5f77bcbb843cc7dd7731c37db586e9e4f3997ebf04a8d1eccb9eae21841c7e55"
+  "1.1.0":
+    url: "https://github.com/qchateau/packio/archive/1.1.0.tar.gz"
+    sha256: "fb8baeeb903335b71b4241433faaff895e42e671da1c15b100e24b060f1d3784"
+  "1.0.2":
+    url: "https://github.com/qchateau/packio/archive/1.0.2.tar.gz"
+    sha256: "040389f2de4a6da5df1cc323cdd80bc21bfc6a7f9bb9e56090d1ea0b1260226d"
+  "1.0.1":
+    url: "https://github.com/qchateau/packio/archive/1.0.1.tar.gz"
+    sha256: "873ebd2ce8c8dbf8a4e7b777b1aa735fe4da3863131a5d6c938e339ee7e0a4d1"
+
+patches:
+  "2.2.0":
+    - patch_file: "patches/2.1.0-0001-fix-boost-json-hash-conflict.patch"
+      patch_description: "fix compilation error caused by boost json hash function conflict"
+      patch_type: "backport"
+      patch_source: "https://github.com/qchateau/packio/commit/d1e0b30378ccafc96da039cf5fc9ffa754e4c2fe"
+  "2.1.0":
+    - patch_file: "patches/2.1.0-0001-fix-boost-json-hash-conflict.patch"
+      patch_description: "fix compilation error caused by boost json hash function conflict"
+      patch_type: "backport"
+      patch_source: "https://github.com/qchateau/packio/commit/d1e0b30378ccafc96da039cf5fc9ffa754e4c2fe"

--- a/recipes/packio/all/conandata.yml
+++ b/recipes/packio/all/conandata.yml
@@ -40,10 +40,10 @@ patches:
   "2.2.0":
     - patch_file: "patches/2.1.0-0001-fix-boost-json-hash-conflict.patch"
       patch_description: "fix compilation error caused by boost json hash function conflict"
-      patch_type: "backport"
+      patch_type: "bugfix"
       patch_source: "https://github.com/qchateau/packio/commit/d1e0b30378ccafc96da039cf5fc9ffa754e4c2fe"
   "2.1.0":
     - patch_file: "patches/2.1.0-0001-fix-boost-json-hash-conflict.patch"
       patch_description: "fix compilation error caused by boost json hash function conflict"
-      patch_type: "backport"
+      patch_type: "bugfix"
       patch_source: "https://github.com/qchateau/packio/commit/d1e0b30378ccafc96da039cf5fc9ffa754e4c2fe"

--- a/recipes/packio/all/conanfile.py
+++ b/recipes/packio/all/conanfile.py
@@ -1,18 +1,22 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
-from conans.tools import Version
 
+required_conan_version = ">=1.52.0"
 
 class PackioConan(ConanFile):
     name = "packio"
     license = "MPL-2.0"
+    description = "An asynchronous msgpack-RPC and JSON-RPC library built on top of Boost.Asio."
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/qchateau/packio"
-    description = "An asynchronous msgpack-RPC and JSON-RPC library built on top of Boost.Asio."
     topics = ("rpc", "msgpack", "json", "asio", "async", "cpp17", "cpp20", "coroutines")
-    settings = "compiler"
-    no_copy_source = True
+    settings = "os", "arch", "compiler", "build_type"
+
     options = {
         "standalone_asio": [True, False],
         "msgpack": [True, False],
@@ -27,8 +31,8 @@ class PackioConan(ConanFile):
     }
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _min_cppstd(self):
+        return 17
 
     @property
     def _compilers_minimum_version(self):
@@ -36,21 +40,28 @@ class PackioConan(ConanFile):
             "apple-clang": 10,
             "clang": 6,
             "gcc": 7,
+            "msvc": 192,
             "Visual Studio": 16,
         }
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def config_options(self):
-        if tools.Version(self.version) < "1.2.0":
+        if Version(self.version) < "1.2.0":
             del self.options.standalone_asio
-        if tools.Version(self.version) < "2.0.0":
+        if Version(self.version) < "2.0.0":
             del self.options.msgpack
             del self.options.nlohmann_json
-        if tools.Version(self.version) < "2.1.0":
+        if Version(self.version) < "2.1.0":
             del self.options.boost_json
 
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
     def requirements(self):
-        if self.options.get_safe("msgpack") or tools.Version(self.version) < "2.0.0":
-            self.requires("msgpack/3.2.1")
+        if self.options.get_safe("msgpack") or Version(self.version) < "2.0.0":
+            self.requires("msgpack/3.3.0")
 
         if self.options.get_safe("nlohmann_json"):
             self.requires("nlohmann_json/3.9.1")
@@ -60,36 +71,40 @@ class PackioConan(ConanFile):
             self.options.boost_json = not self.options.standalone_asio
 
         if self.options.get_safe("boost_json") or not self.options.get_safe("standalone_asio"):
-            self.requires("boost/1.75.0")
+            self.requires("boost/1.80.0")
 
         if self.options.get_safe("standalone_asio"):
-            self.requires("asio/1.18.1")
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = "packio-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
-
-    def configure(self):
-        if self.settings.compiler.cppstd:
-            tools.check_min_cppstd(self, "17")
-
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version:
-            if tools.Version(self.settings.compiler.version) < minimum_version:
-                raise ConanInvalidConfiguration("packio requires C++17, which your compiler does not support.")
-        else:
-            self.output.warn("packio requires C++17. Your compiler is unknown. Assuming it supports C++17.")
-
-    def package(self):
-        self.copy("LICENSE.md", dst="licenses", src=self._source_subfolder)
-        self.copy("*.h", dst="include", src=os.path.join(self._source_subfolder, "include"))
+            self.requires("asio/1.24.0")
 
     def package_id(self):
         self.info.header_only()
 
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version:
+            if Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
+        else:
+            self.output.warn(f"{self.ref} requires C++{self._min_cppstd}. Your compiler is unknown. Assuming it supports C++{self._min_cppstd}.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        apply_conandata_patches(self)
+
+    def package(self):
+        copy(self, pattern="LICENSE.md", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, "*.h", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self.source_folder, "include"))
+
     def package_info(self):
-        if tools.Version(self.version) < "2.1.0":
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        if Version(self.version) < "2.1.0":
             if self.options.get_safe("standalone_asio"):
                 self.cpp_info.defines.append("PACKIO_STANDALONE_ASIO")
         else:

--- a/recipes/packio/all/patches/2.1.0-0001-fix-boost-json-hash-conflict.patch
+++ b/recipes/packio/all/patches/2.1.0-0001-fix-boost-json-hash-conflict.patch
@@ -1,0 +1,27 @@
+diff --git a/include/packio/json_rpc/hash.h b/include/packio/json_rpc/hash.h
+index 9f6e3dd..664696d 100644
+--- a/include/packio/json_rpc/hash.h
++++ b/include/packio/json_rpc/hash.h
+@@ -6,11 +6,15 @@
+ #define PACKIO_JSON_RPC_HASH_H
+ 
+ #include <boost/json.hpp>
++#include <boost/version.hpp>
++
++#if BOOST_VERSION < 107700
+ 
+ namespace packio {
+ namespace json_rpc {
+ namespace internal {
+ 
++
+ inline std::size_t combine(std::size_t seed, std::size_t h) noexcept
+ {
+     seed ^= h + 0x9e3779b9 + (seed << 6U) + (seed >> 2U);
+@@ -72,4 +76,6 @@ struct hash<boost::json::value> {
+ 
+ } // std
+ 
++#endif // BOOST_VERSION < 107700
++
+ #endif // PACKIO_JSON_RPC_HASH_H

--- a/recipes/packio/all/test_package/CMakeLists.txt
+++ b/recipes/packio/all/test_package/CMakeLists.txt
@@ -1,16 +1,17 @@
-cmake_minimum_required(VERSION 3.1)
-project(TestPackage CXX)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
 
-if (PACKIO_VERSION VERSION_LESS "1.2.0")
-    add_executable(main 1.0.x-1.1.x.cpp)
-elseif (PACKIO_VERSION VERSION_LESS "2.0.0")
-    add_executable(main 1.2.x.cpp)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+find_package(packio REQUIRED CONFIG)
+
+if (packio_VERSION VERSION_LESS "1.2.0")
+    add_executable(${PROJECT_NAME} 1.0.x-1.1.x.cpp)
+elseif (packio_VERSION VERSION_LESS "2.0.0")
+    add_executable(${PROJECT_NAME} 1.2.x.cpp)
 else ()
-    add_executable(main latest.cpp)
+    add_executable(${PROJECT_NAME} latest.cpp)
 endif ()
 
-target_link_libraries(main ${CONAN_LIBS})
-set_property(TARGET main PROPERTY CXX_STANDARD 17)
+target_link_libraries(${PROJECT_NAME} PRIVATE packio::packio)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/packio/all/test_package/CMakeLists.txt
+++ b/recipes/packio/all/test_package/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(test_package LANGUAGES CXX)
 
-
-set(CMAKE_VERBOSE_MAKEFILE ON)
 find_package(packio REQUIRED CONFIG)
 
 if (packio_VERSION VERSION_LESS "1.2.0")

--- a/recipes/packio/all/test_package/conanfile.py
+++ b/recipes/packio/all/test_package/conanfile.py
@@ -1,18 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
-
-from conans import ConanFile, CMake, tools
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
-        packio_version = self.deps_cpp_info["packio"].version
         cmake = CMake(self)
-        cmake.configure(defs={"PACKIO_VERSION": packio_version})
+        cmake.configure()
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            self.run(os.path.join("bin", "main"), run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/packio/all/test_v1_package/CMakeLists.txt
+++ b/recipes/packio/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/packio/all/test_v1_package/conanfile.py
+++ b/recipes/packio/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/packio/config.yml
+++ b/recipes/packio/config.yml
@@ -1,23 +1,25 @@
 versions:
-  1.0.1:
-    folder: all
-  1.0.2:
-    folder: all
-  1.1.0:
-    folder: all
-  1.1.1:
-    folder: all
-  1.2.0:
-    folder: all
-  1.2.1:
-    folder: all
-  1.3.0:
-    folder: all
-  2.0.0:
-    folder: all
-  2.0.1:
-    folder: all
-  2.1.0:
+  "2.3.0":
     folder: all
   "2.2.0":
+    folder: all
+  "2.1.0":
+    folder: all
+  "2.0.1":
+    folder: all
+  "2.0.0":
+    folder: all
+  "1.3.0":
+    folder: all
+  "1.2.1":
+    folder: all
+  "1.2.0":
+    folder: all
+  "1.1.1":
+    folder: all
+  "1.1.0":
+    folder: all
+  "1.0.2":
+    folder: all
+  "1.0.1":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **packio/***

- add version 2.3.0
- support conan v2
- sort config.yml, conandata.yml
- create patch for boost >= 1.78.0 in packio 2.1.0, 2.2.0

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
