### PR TITLE
libmp3lame: restore relocatable shared lib on macOS

### DIFF
--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.files import apply_conandata_patches, chdir, copy, export_conandata_patches, get, rename, replace_in_file, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
@@ -155,6 +156,7 @@ class LibMP3LameConan(ConanFile):
             autotools.install(args=[f"DESTDIR={unix_path(self, self.package_folder)}"])
             rmdir(self, os.path.join(self.package_folder, "share"))
             rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+            fix_apple_shared_install_name(self)
 
     def package_info(self):
         self.cpp_info.libs = ["mp3lame"]


### PR DESCRIPTION
`libmp3lame` shared lib was relocatable on macOS (`@rpath` in install_name) since https://github.com/conan-io/conan-center-index/pull/9457, but https://github.com/conan-io/conan-center-index/pull/13791 broke it by removing the patch without using `fix_apple_shared_install_name()` after packaging.

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
