### PR TITLE
[gnutls] Add new recipe with Conan v1 & v2 support

### DIFF
--- a/recipes/gnutls/all/conandata.yml
+++ b/recipes/gnutls/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.7.4":
+    url: "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.4.tar.xz"
+    sha256: "e6adbebcfbc95867de01060d93c789938cf89cc1d1f6ef9ef661890f6217451f"

--- a/recipes/gnutls/all/conandata.yml
+++ b/recipes/gnutls/all/conandata.yml
@@ -1,4 +1,9 @@
 sources:
-  "3.7.4":
-    url: "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.4.tar.xz"
-    sha256: "e6adbebcfbc95867de01060d93c789938cf89cc1d1f6ef9ef661890f6217451f"
+  "3.7.8":
+    url: [
+        "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.8.tar.xz",
+        "http://www.ring.gr.jp/pub/net/gnupg/gnutls/v3.7/gnutls-3.7.8.tar.xz",
+        "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnutls/v3.7/gnutls-3.7.8.tar.xz",
+
+    ]
+    sha256: "c58ad39af0670efe6a8aee5e3a8b2331a1200418b64b7c51977fb396d4617114"

--- a/recipes/gnutls/all/conanfile.py
+++ b/recipes/gnutls/all/conanfile.py
@@ -1,0 +1,79 @@
+import os
+import functools
+from conans import ConanFile, tools, AutoToolsBuildEnvironment
+from conans.errors import ConanInvalidConfiguration
+
+
+class GnuTLSConan(ConanFile):
+    name = "gnutls"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.gnutls.org"
+    description = "GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols"
+    license = "LGPL-2.1"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {'shared': False, 'fPIC': True}
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def validate(self):
+        if self.settings.os == "Windows" and self.settings.compiler in ("Visual Studio", "msvc"):
+            raise ConanInvalidConfiguration("The GnuTLS package cannot be deployed on Visual Studio.")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version], strip_root=True, destination=self._source_subfolder)
+
+    def requirements(self):
+        self.requires("nettle/3.5")
+        self.requires("gmp/6.2.1")
+        self.requires("libiconv/1.16")
+
+    @functools.lru_cache(1)
+    def _configure_autotools(self):
+        autotools = AutoToolsBuildEnvironment(self)
+        configure_args = ["--disable-tests",
+                          "--disable-full-test-suite",
+                          "--disable-maintainer-mode",
+                          "--without-p11-kit",
+                          "--without-idn",
+                          "--with-included-libtasn1",
+                          "--enable-local-libopts",
+                          "--with-included-unistring",
+                          "--with-libiconv-prefix={}".format(self.deps_cpp_info["libiconv"].rootpath)]
+        configure_vars = autotools.vars
+        configure_vars.update({
+            "NETTLE_CFLAGS": "-I{}".format(self.deps_cpp_info["nettle"].include_paths[0]),
+            "NETTLE_LIBS": "-L{} -lnettle".format(self.deps_cpp_info["nettle"].lib_paths[0]),
+            "HOGWEED_CFLAGS": "-I{}".format(self.deps_cpp_info["nettle"].include_paths[0]),
+            "HOGWEED_LIBS": "-L{} -lhogweed".format(self.deps_cpp_info["nettle"].lib_paths[0]),
+            "GMP_CFLAGS": "-I{}".format(self.deps_cpp_info["gmp"].include_paths[0]),
+            "GMP_LIBS": "-L{} -lgmp".format(self.deps_cpp_info["gmp"].lib_paths[0]),
+        })
+
+        if self.options.shared:
+            configure_args.extend(["--enable-shared", "--disable-static"])
+        else:
+            configure_args.extend(["--disable-shared", "--enable-static"])
+        autotools.configure(args=configure_args, configure_dir=self._source_subfolder, vars=configure_vars)
+        return autotools
+
+    def build(self):
+        autotools = self._configure_autotools()
+        autotools.make()
+
+    def package(self):
+        self.copy("COPYING", dst="licenses", src=self._source_subfolder)
+        autotools = self._configure_autotools()
+        autotools.install()
+        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.libs = tools.collect_libs(self)

--- a/recipes/gnutls/all/test_package/CMakeLists.txt
+++ b/recipes/gnutls/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(gnutls REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} gnutls::gnutls)

--- a/recipes/gnutls/all/test_package/CMakeLists.txt
+++ b/recipes/gnutls/all/test_package/CMakeLists.txt
@@ -1,10 +1,7 @@
-cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES C)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-find_package(gnutls REQUIRED CONFIG)
+find_package(GnuTLS REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} gnutls::gnutls)
+target_link_libraries(${PROJECT_NAME} PRIVATE GnuTLS::GnuTLS)

--- a/recipes/gnutls/all/test_package/conanfile.py
+++ b/recipes/gnutls/all/test_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/gnutls/all/test_package/conanfile.py
+++ b/recipes/gnutls/all/test_package/conanfile.py
@@ -1,10 +1,20 @@
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
-from conans import ConanFile, CMake, tools
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +22,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/gnutls/all/test_package/test_package.c
+++ b/recipes/gnutls/all/test_package/test_package.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+#include <gmp.h>
+
+int main (void) {
+
+  mpz_t a,b,c;
+  mpz_inits(a,b,c,NULL);
+
+  mpz_set_str(a, "1234", 10);
+  return EXIT_SUCCESS;
+}

--- a/recipes/gnutls/all/test_package/test_package.c
+++ b/recipes/gnutls/all/test_package/test_package.c
@@ -1,11 +1,16 @@
 #include <stdlib.h>
-#include <gmp.h>
+#include <gnutls/gnutls.h>
 
 int main (void) {
+    int result = 0;
+    gnutls_session_t session;
 
-  mpz_t a,b,c;
-  mpz_inits(a,b,c,NULL);
+    gnutls_global_init();
+    gnutls_global_set_log_level(0);
 
-  mpz_set_str(a, "1234", 10);
-  return EXIT_SUCCESS;
+    gnutls_init(&session, GNUTLS_SERVER);
+    gnutls_deinit(session);
+    gnutls_global_deinit();
+
+    return EXIT_SUCCESS;
 }

--- a/recipes/gnutls/all/test_v1_package/CMakeLists.txt
+++ b/recipes/gnutls/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package LANGUAGES C)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/gnutls/all/test_v1_package/conanfile.py
+++ b/recipes/gnutls/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+import os
+from conans import ConanFile, CMake, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/gnutls/config.yml
+++ b/recipes/gnutls/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.7.4":
+    folder: "all"

--- a/recipes/gnutls/config.yml
+++ b/recipes/gnutls/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "3.7.4":
+  "3.7.8":
     folder: "all"


### PR DESCRIPTION
After having the three basic components (nettle, gmp and libiconv) now we can add GnuTLS to CCI.

- Support for Conan v2
- CMake targets based on https://cmake.org/cmake/help/v3.16/module/FindGnuTLS.html
- pkgconfig based on gnutls generated pc files
- Compression libraries are optional (zlib, brotli and zstd)
- C++ support is optional, but enabled by default

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
