### PR TITLE
boost/*: fix compiling boost with zstd

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1180,12 +1180,15 @@ class BoostConan(ConanFile):
 
         contents = ""
         if self._zip_bzip2_requires_needed:
-            def create_library_config(deps_name, name):
+            def create_library_config(deps_name, name, component=None):
                 includedir = self.dependencies[deps_name].cpp_info.includedirs[0].replace("\\", "/")
                 includedir = f"\"{includedir}\""
                 libdir = self.dependencies[deps_name].cpp_info.libdirs[0].replace("\\", "/")
                 libdir = f"\"{libdir}\""
-                lib = self.dependencies[deps_name].cpp_info.libs[0]
+                if component is None:
+                    lib = self.dependencies[deps_name].cpp_info.libs[0]
+                else:
+                    lib = self.dependencies[deps_name].cpp_info.components[component].libs[0]                
                 version = self.dependencies[deps_name].ref.version
                 return f"\nusing {name} : {version} : " \
                        f"<include>{includedir} " \
@@ -1200,7 +1203,7 @@ class BoostConan(ConanFile):
             if self._with_lzma:
                 contents += create_library_config("xz_utils", "lzma")
             if self._with_zstd:
-                contents += create_library_config("zstd", "zstd")
+                contents += create_library_config("zstd", "zstd", "zstdlib")
 
         if not self.options.without_python:
             # https://www.boost.org/doc/libs/1_70_0/libs/python/doc/html/building/configuring_boost_build.html


### PR DESCRIPTION
Specify library name and version:  **boost/***

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->

When building boost with zstd, `lib = self.dependencies[deps_name].cpp_info.libs` is empty becaue the zstd library is defined as a component.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
