### PR TITLE
bitsery: add version 5.2.3

### DIFF
--- a/recipes/bitsery/all/conandata.yml
+++ b/recipes/bitsery/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.2.3":
+    url: "https://github.com/fraillt/bitsery/archive/v5.2.3.tar.gz"
+    sha256: "896d82ab4ccea9899ff2098aa69ad6d25e524ee1d4c747ce3232d0afe3cd05a5"
   "5.2.2":
     url: "https://github.com/fraillt/bitsery/archive/v5.2.2.tar.gz"
     sha256: "5e932c463f16db15228b2546632a5851a502c68e605a1e313b0f1a35c061e4ae"

--- a/recipes/bitsery/config.yml
+++ b/recipes/bitsery/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.2.3":
+    folder: all
   "5.2.2":
     folder: all
   "5.2.1":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **bitsery/5.2.3**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
