### PR TITLE
Feature/msys2 develop2

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -47,12 +47,12 @@ class MSYS2Conan(ConanFile):
     license = "MSYS license"
     topics = ("msys", "unix", "subsystem")
 
-    settings = "os", "arch", "compiler", "build_type"
+    settings = "os", "arch"
     # "exclude_files" "packages" "additional_packages" values are a comma separated list
     options = {
         "exclude_files": ["ANY"],
         "packages": ["ANY"],
-        "additional_packages": ["ANY"],
+        "additional_packages": [None, "ANY"],
     }
     default_options = {
         "exclude_files": "*/link.exe",
@@ -62,14 +62,10 @@ class MSYS2Conan(ConanFile):
 
     short_paths = True
 
-    def package_id(self):
-        del self.info.settings.compiler
-        del self.info.settings.build_type
-
     def validate(self):
-        if self.info.settings.os != "Windows":
+        if self.settings.os != "Windows":
             raise ConanInvalidConfiguration("Only Windows supported")
-        if self.info.settings.arch != "x86_64":
+        if self.settings.arch != "x86_64":
             raise ConanInvalidConfiguration("Only Windows x64 supported")
 
     def source(self):

--- a/recipes/msys2/all/test_package/conanfile.py
+++ b/recipes/msys2/all/test_package/conanfile.py
@@ -1,10 +1,10 @@
 from conan import ConanFile
 from conan.tools.env import Environment
-from io import StringIO
+from conan.tools.files import load
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "arch", "compiler", "build_type"
+    settings = "os", "arch"
     generators = "VirtualBuildEnv"
     test_type = "explicit"
 
@@ -29,7 +29,7 @@ class TestPackageConan(ConanFile):
         self.run('bash.exe -c ^"! test -f /bin/link^"')
         self.run('bash.exe -c ^"! test -f /usr/bin/link^"')
 
-        output = StringIO()
-        self.run('bash.exe -c "echo $PKG_CONFIG_PATH"', output=output)
-        print(output.getvalue())
-        assert self._secret_value in output.getvalue()
+        self.run('bash.exe -c "echo $PKG_CONFIG_PATH" > output.txt')
+        output = load(self, "output.txt")
+        self.output.info(output)
+        assert self._secret_value in output

--- a/recipes/msys2/all/test_package/conanfile.py
+++ b/recipes/msys2/all/test_package/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.env import Environment
-from conan.tools.files import load
+from io import StringIO
 
 
 class TestPackageConan(ConanFile):
@@ -29,7 +29,7 @@ class TestPackageConan(ConanFile):
         self.run('bash.exe -c ^"! test -f /bin/link^"')
         self.run('bash.exe -c ^"! test -f /usr/bin/link^"')
 
-        self.run('bash.exe -c "echo $PKG_CONFIG_PATH" > output.txt')
-        output = load(self, "output.txt")
-        self.output.info(output)
-        assert self._secret_value in output
+        output = StringIO()
+        self.run('bash.exe -c "echo $PKG_CONFIG_PATH"', output)
+        print(output.getvalue())
+        assert secret_value in output.getvalue()

--- a/recipes/msys2/all/test_package/conanfile.py
+++ b/recipes/msys2/all/test_package/conanfile.py
@@ -32,4 +32,4 @@ class TestPackageConan(ConanFile):
         output = StringIO()
         self.run('bash.exe -c "echo $PKG_CONFIG_PATH"', output)
         print(output.getvalue())
-        assert secret_value in output.getvalue()
+        assert self._secret_value in output.getvalue()


### PR DESCRIPTION
Specify library name and version:  **msys2/cci.latest**

Building this recipe was failing in 2.0, because the ``None`` option value should be explicitly defined, not only "ANY".
It was also failing in the ``test_package``, because of the ``output`` parameter

It seems that https://github.com/conan-io/conan-center-index/pull/14686 is also open for this, but it also does some other extra stuff that might need more discussion, while this PR seems the bare minimum

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
