### PR TITLE
Fix libcurl build with HTTP2

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
 from conan.tools.build import cross_building
-from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import apply_conandata_patches, copy, download, export_conandata_patches, get, load, replace_in_file, rm, rmdir, save
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps
@@ -515,6 +515,8 @@ class LibcurlConan(ConanFile):
         return version
 
     def _generate_with_cmake(self):
+        dc = CMakeDeps(self)
+        dc.generate()
         if self._is_win_x_android:
             tc = CMakeToolchain(self, generator="Ninja")
         else:

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -105,9 +105,6 @@ class Nghttp2Conan(ConanFile):
         tc.variables["WITH_JEMALLOC"] = self.options.get_safe("with_jemalloc", False)
         tc.variables["WITH_SPDYLAY"] = False
         tc.variables["ENABLE_ASIO_LIB"] = self.options.with_asio
-        if Version(self.version) >= "1.42.0":
-            # backward-incompatible change in 1.42.0
-            tc.variables["STATIC_LIB_SUFFIX"] = "_static"
         if is_apple_os(self):
             # workaround for: install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
             tc.cache_variables["CMAKE_MACOSX_BUNDLE"] = False
@@ -164,7 +161,7 @@ class Nghttp2Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.components["nghttp2"].set_property("pkg_config_name", "libnghttp2")
-        suffix = "_static" if Version(self.version) > "1.39.2" and not self.options.shared else ""
+        suffix = "_static" if Version(self.version) == "1.40.0" and not self.options.shared else ""
         self.cpp_info.components["nghttp2"].libs = [f"nghttp2{suffix}"]
         if is_msvc(self) and not self.options.shared:
             self.cpp_info.components["nghttp2"].defines.append("NGHTTP2_STATICLIB")


### PR DESCRIPTION
Specify library name and version:  `libnghttp/*`, `libcurl/*`

This PR addresses #6241 by following the comment here: https://github.com/curl/curl/pull/7515#issuecomment-890320856
Additionally, it fixes the Windows build of `libcurl` with `libnghttp2` enabled.

Tested on Linux, macOS and Windows. Everything seems to be working fine.

fixes #6241 

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
