### PR TITLE
fix: preserve dependencies between googleapis libs

### DIFF
--- a/recipes/googleapis/all/CMakeLists.txt
+++ b/recipes/googleapis/all/CMakeLists.txt
@@ -9,3 +9,5 @@ conan_basic_setup(TARGETS)
 find_package(Protobuf REQUIRED CONFIG)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+include("${CMAKE_CURRENT_SOURCE_DIR}/generated_targets.cmake")

--- a/recipes/googleapis/all/conandata.yml
+++ b/recipes/googleapis/all/conandata.yml
@@ -22,9 +22,17 @@ sources:
 patches:
   "cci.20220711":
     - patch_file: "patches/cci.20220711/001-fix-google-api-deps.patch"
+      patch_description: "Fix incorrect dependency name in BUILD.bazel file"
+      patch_type: "bugfix"
   "cci.20220531":
     - patch_file: "patches/cci.20220531/001-fix-google-api-deps.patch"
+      patch_description: "Fix incorrect dependency name in BUILD.bazel file"
+      patch_type: "bugfix"
   "cci.20211122":
     - patch_file: "patches/cci.20211122/001-fix-google-api-deps.patch"
+      patch_description: "Fix incorrect dependency name in BUILD.bazel file"
+      patch_type: "bugfix"
   "cci.20210730":
     - patch_file: "patches/cci.20210730/001-fix-google-api-deps.patch"
+      patch_description: "Fix incorrect dependency name in BUILD.bazel file"
+      patch_type: "bugfix"

--- a/recipes/googleapis/all/conandata.yml
+++ b/recipes/googleapis/all/conandata.yml
@@ -24,15 +24,19 @@ patches:
     - patch_file: "patches/cci.20220711/001-fix-google-api-deps.patch"
       patch_description: "Fix incorrect dependency name in BUILD.bazel file"
       patch_type: "bugfix"
+      patch_source: "https://github.com/googleapis/googleapis/commit/5fd35b6a1316570df7f117426ed35af9086e9bda"
   "cci.20220531":
     - patch_file: "patches/cci.20220531/001-fix-google-api-deps.patch"
       patch_description: "Fix incorrect dependency name in BUILD.bazel file"
       patch_type: "bugfix"
+      patch_source: "https://github.com/googleapis/googleapis/commit/5fd35b6a1316570df7f117426ed35af9086e9bda"
   "cci.20211122":
     - patch_file: "patches/cci.20211122/001-fix-google-api-deps.patch"
       patch_description: "Fix incorrect dependency name in BUILD.bazel file"
       patch_type: "bugfix"
+      patch_source: "https://github.com/googleapis/googleapis/commit/5fd35b6a1316570df7f117426ed35af9086e9bda"
   "cci.20210730":
     - patch_file: "patches/cci.20210730/001-fix-google-api-deps.patch"
       patch_description: "Fix incorrect dependency name in BUILD.bazel file"
       patch_type: "bugfix"
+      patch_source: "https://github.com/googleapis/googleapis/commit/5fd35b6a1316570df7f117426ed35af9086e9bda"

--- a/recipes/googleapis/all/conandata.yml
+++ b/recipes/googleapis/all/conandata.yml
@@ -19,3 +19,12 @@ sources:
   "cci.20210730":  # Used by grpc 1.46.3
     url: "https://github.com/googleapis/googleapis/archive/2f9af297c84c55c8b871ba4495e01ade42476c92.zip"
     sha256: "c53ef0768e07bd4e2334cdacba8c6672d2252bef307a889f94893652e8e7f3a4"
+patches:
+  "cci.20220711":
+    - patch_file: "patches/cci.20220711/001-fix-google-api-deps.patch"
+  "cci.20220531":
+    - patch_file: "patches/cci.20220531/001-fix-google-api-deps.patch"
+  "cci.20211122":
+    - patch_file: "patches/cci.20211122/001-fix-google-api-deps.patch"
+  "cci.20210730":
+    - patch_file: "patches/cci.20210730/001-fix-google-api-deps.patch"

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -71,7 +71,7 @@ class GoogleAPIS(ConanFile):
     def build_requirements(self):
         self.build_requires('protobuf/3.21.4')
         # CMake >= 3.20 is required. There is a proto with dots in the name 'k8s.min.proto' and CMake fails to generate project files
-        self.build_requires('cmake/[>3.19]')
+        self.build_requires('cmake/3.20')
 
     @functools.lru_cache(1)
     def _configure_cmake(self):

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 import functools
 import glob
+from io import StringIO
 
 from conans import CMake, tools
 
@@ -65,13 +66,28 @@ class GoogleAPIS(ConanFile):
         if self.options.shared and not self.options["protobuf"].shared:
             raise ConanInvalidConfiguration("If built as shared, protobuf must be shared as well. Please, use `protobuf:shared=True`")
 
+    @property
+    def _cmake_new_enough(self):
+        try:
+            import re
+            output = StringIO()
+            self.run("cmake --version", output=output)
+            m = re.search(r'cmake version (\d+)\.(\d+)\.(\d+)', output.getvalue())
+            major, minor = int(m.group(1)), int(m.group(2))
+            assert major >= 3 and minor >= 20
+        except:
+            return False
+        else:
+            return True
+
     def requirements(self):
         self.requires('protobuf/3.21.4')
 
     def build_requirements(self):
         self.build_requires('protobuf/3.21.4')
         # CMake >= 3.20 is required. There is a proto with dots in the name 'k8s.min.proto' and CMake fails to generate project files
-        self.build_requires('cmake/3.20')
+        if not self._cmake_new_enough:
+            self.build_requires('cmake/3.23.2')
 
     @functools.lru_cache(1)
     def _configure_cmake(self):

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -190,3 +190,5 @@ class GoogleAPIS(ConanFile):
                 if libtype == 'LIB':
                     self.cpp_info.components[name].libs = [name]
                 self.cpp_info.components[name].names["pkg_config"] = name
+                if self.settings.os == "Linux":
+                    self.cpp_info.components[name].system_libs.extend(["m"])

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -1,6 +1,7 @@
 import os
 import functools
 import glob
+from dataclasses import dataclass
 
 from conans import CMake, tools
 
@@ -14,6 +15,13 @@ from conan.errors import ConanInvalidConfiguration
 from helpers import parse_proto_libraries
 
 required_conan_version = ">=1.45.0"
+
+
+@dataclass
+class Node:
+    mark: str
+    deps: list
+
 
 class GoogleAPIS(ConanFile):
     name = "googleapis"
@@ -172,12 +180,6 @@ class GoogleAPIS(ConanFile):
         copy(self, pattern="*.dylib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
         copy(self, pattern="*.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
 
-        from dataclasses import dataclass
-        @dataclass
-        class Node:
-            mark: str
-            deps: list()
-
         graph = {}
         types = {}
         for lib in filter(lambda u: u.is_used, self._parse_proto_libraries()):
@@ -199,11 +201,11 @@ class GoogleAPIS(ConanFile):
             L.insert(0, name)
 
         def tsort():
-            sorted = []
-            for name in graph.keys():
-                visit(name, graph, sorted)
-            return sorted
-        
+            result = []
+            for name in graph:
+                visit(name, graph, result)
+            return result
+
         ts = tsort()
         with open(os.path.join(self.package_folder, self._DEPS_FILE), "w", encoding="utf-8") as f:
             for name in ts:

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -118,6 +118,7 @@ class GoogleAPIS(ConanFile):
         if Version(self.deps_cpp_info["protobuf"].version) <= "3.21.5" and self.settings.os == "Macos" or \
             self.settings.os == "Android":
             deactivate_library("//google/storagetransfer/v1:storagetransfer_proto")
+            deactivate_library("//google/storagetransfer/v1:storagetransfer_cc_proto")
         #  - Inconvenient macro names from /usr/include/math.h : DOMAIN
         if (self.settings.os == "Linux" and self.settings.compiler == "clang" and self.settings.compiler.libcxx == "libc++") or \
             self.settings.compiler in ["Visual Studio", "msvc"]:

--- a/recipes/googleapis/all/conanfile.py
+++ b/recipes/googleapis/all/conanfile.py
@@ -186,7 +186,7 @@ class GoogleAPIS(ConanFile):
             graph[lib.cmake_target] = Node(mark=None, deps=lib.cmake_deps)
             types[lib.cmake_target] = 'LIB' if lib.srcs else 'INTERFACE'
 
-        def visit(name : str, dag : dict, L : list[str]):
+        def visit(name : str, dag : dict, L : list):
             # Ignore external deps that are not in the dag, such as protobuf::libprotobuf.
             # Also skip nodes that are already completely processed
             if name not in dag or dag[name].mark == 'DONE':

--- a/recipes/googleapis/all/patches/cci.20210730/001-fix-google-api-deps.patch
+++ b/recipes/googleapis/all/patches/cci.20210730/001-fix-google-api-deps.patch
@@ -1,0 +1,19 @@
+diff --git a/google/api/BUILD.bazel b/google/api/BUILD.bazel
+index ebb9ba8..7188218 100644
+--- a/google/api/BUILD.bazel
++++ b/google/api/BUILD.bazel
+@@ -509,12 +509,12 @@ cc_proto_library(
+ 
+ cc_proto_library(
+     name = "monitoring_cc_proto",
+-    deps = ["monitoring_proto"],
++    deps = [":monitoring_proto"],
+ )
+ 
+ cc_proto_library(
+     name = "quota_cc_proto",
+-    deps = ["quota_proto"],
++    deps = [":quota_proto"],
+ )
+ 
+ cc_proto_library(

--- a/recipes/googleapis/all/patches/cci.20211122/001-fix-google-api-deps.patch
+++ b/recipes/googleapis/all/patches/cci.20211122/001-fix-google-api-deps.patch
@@ -1,0 +1,19 @@
+diff --git a/google/api/BUILD.bazel b/google/api/BUILD.bazel
+index ebb9ba8..7188218 100644
+--- a/google/api/BUILD.bazel
++++ b/google/api/BUILD.bazel
+@@ -574,12 +574,12 @@ cc_proto_library(
+ 
+ cc_proto_library(
+     name = "monitoring_cc_proto",
+-    deps = ["monitoring_proto"],
++    deps = [":monitoring_proto"],
+ )
+ 
+ cc_proto_library(
+     name = "quota_cc_proto",
+-    deps = ["quota_proto"],
++    deps = [":quota_proto"],
+ )
+ 
+ cc_proto_library(

--- a/recipes/googleapis/all/patches/cci.20220531/001-fix-google-api-deps.patch
+++ b/recipes/googleapis/all/patches/cci.20220531/001-fix-google-api-deps.patch
@@ -1,0 +1,19 @@
+diff --git a/google/api/BUILD.bazel b/google/api/BUILD.bazel
+index ebb9ba8..7188218 100644
+--- a/google/api/BUILD.bazel
++++ b/google/api/BUILD.bazel
+@@ -578,12 +578,12 @@ cc_proto_library(
+ 
+ cc_proto_library(
+     name = "monitoring_cc_proto",
+-    deps = ["monitoring_proto"],
++    deps = [":monitoring_proto"],
+ )
+ 
+ cc_proto_library(
+     name = "quota_cc_proto",
+-    deps = ["quota_proto"],
++    deps = [":quota_proto"],
+ )
+ 
+ cc_proto_library(

--- a/recipes/googleapis/all/patches/cci.20220711/001-fix-google-api-deps.patch
+++ b/recipes/googleapis/all/patches/cci.20220711/001-fix-google-api-deps.patch
@@ -1,0 +1,19 @@
+diff --git a/google/api/BUILD.bazel b/google/api/BUILD.bazel
+index ebb9ba8..7188218 100644
+--- a/google/api/BUILD.bazel
++++ b/google/api/BUILD.bazel
+@@ -580,12 +580,12 @@ cc_proto_library(
+ 
+ cc_proto_library(
+     name = "monitoring_cc_proto",
+-    deps = ["monitoring_proto"],
++    deps = [":monitoring_proto"],
+ )
+ 
+ cc_proto_library(
+     name = "quota_cc_proto",
+-    deps = ["quota_proto"],
++    deps = [":quota_proto"],
+ )
+ 
+ cc_proto_library(

--- a/recipes/googleapis/all/test_package/conanfile.py
+++ b/recipes/googleapis/all/test_package/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.layout import cmake_layout
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "VirtualRunEnv"
+    generators = "cmake_find_package", "CMakeDeps", "VirtualRunEnv"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/googleapis/all/test_package/test_package.cpp
+++ b/recipes/googleapis/all/test_package/test_package.cpp
@@ -1,14 +1,13 @@
 #include <iostream>
-#include "google/type/color.pb.h"
+#include <google/bigtable/v2/bigtable.pb.h>
 
 int main() {
     std::cout << "Conan - test package for googleapis\n";
 
-    google::type::Color c;
-    c.set_red(255);
-    c.set_blue(255);
+    google::bigtable::v2::CheckAndMutateRowRequest request;
+    request.set_table_name("projects/my-project/instances/my-instance/tables/my-table");
 
-    std::cout << c.DebugString();
+    std::cout << request.DebugString();
 
     return 0;
 }


### PR DESCRIPTION
The googleapis package contains over 500 libraries. These libraries depend on each other, and cannot be statically linked successfully if the libraries are out of order.

We use a file in the package to preserve this dependency order. It seems like too much of a maintenance burden to keep such information in the `conanfile.py` code.

Specify library name and version:  **googleapis/_**

Fixes #14881 


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
