### PR TITLE
linter: reduce spam for notification from actions + lower error level

### DIFF
--- a/.github/workflows/linter-yaml.yml
+++ b/.github/workflows/linter-yaml.yml
@@ -56,13 +56,9 @@ jobs:
       - name: Run schema check (conandata.yml)
         if: steps.changed_files.outputs.any_changed == 'true' && always()
         run: |
-          err=0
           for file in ${{ env.CONANDATA_FILES_PATH }}; do
-            python3 linter/conandata_yaml_linter.py ${file} || err=1
+            python3 linter/conandata_yaml_linter.py ${file}
           done
-          if [[ $err == 1 ]]; then
-              exit 1
-          fi
 
   lint_pr_files:
     # Lint files modified in the pull_request
@@ -118,8 +114,5 @@ jobs:
           echo "::remove-matcher owner=yamllint_matcher::"
 
           for file in ${{ steps.changed_files_conandata.outputs.all_changed_files }}; do
-            python3 linter/conandata_yaml_linter.py ${file} || err=1
+            python3 linter/conandata_yaml_linter.py ${file}
           done
-          if [[ $err == 1 ]]; then
-              exit 1
-          fi

--- a/linter/conandata_yaml_linter.py
+++ b/linter/conandata_yaml_linter.py
@@ -54,8 +54,10 @@ def main():
         parsed = load(content, schema)
     except YAMLValidationError as error:
         pretty_print_yaml_validate_error(args, error) # Error when "source" is missing or when "patches" has no versions
+        return
     except BaseException as error:
         pretty_print_yaml_validate_error(args, error) # YAML could not be parsed
+        return
 
     if "patches" in parsed:
         for version in parsed["patches"]:


### PR DESCRIPTION
- Stop GitHub Actions from sending email notifications about failed workflows
- Lower the patch fields to a warning to accurately reflect they dont block PRs

closes #14865 