### PR TITLE
sentry-breakpad: add version 0.5.3

### DIFF
--- a/recipes/sentry-breakpad/all/conandata.yml
+++ b/recipes/sentry-breakpad/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.5.3":
+    url: "https://github.com/getsentry/sentry-native/releases/download/0.5.3/sentry-native.zip"
+    sha256: "d9a2434783e558bc9e074518ce155bda129bfa12d376dde939e6a732c92f9757"
   "0.5.0":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.5.0/sentry-native.zip"
     sha256: "1a65767a7c6c368a6dea44125eb268ed8374100f33168829f21df78cbfa8632b"
@@ -17,4 +20,3 @@ sources:
   "0.2.6":
     url: "https://github.com/getsentry/sentry-native/releases/download/0.2.6/sentry-native-0.2.6.zip"
     sha256: "0d93bd77f70a64f3681d4928dfca6b327374218a84d33ee31489114d8e4716c0"
-#patches:

--- a/recipes/sentry-breakpad/config.yml
+++ b/recipes/sentry-breakpad/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.5.3":
+    folder: all
   "0.5.0":
     folder: all
   "0.4.18":


### PR DESCRIPTION
Specify library name and version:  **sentry-breakpad/0.5.3**

<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
