### PR TITLE
libnghttp2: do not specify static lib suffix

### DIFF
--- a/recipes/libnghttp2/all/conandata.yml
+++ b/recipes/libnghttp2/all/conandata.yml
@@ -57,6 +57,12 @@ patches:
   "1.40.0":
     - patch_file: "patches/fix-findJemalloc.cmake"
     - patch_file: "patches/fix-findLibevent.cmake"
+    - patch_file: "patches/1.40.0-remove-static-suffix.patch"
+      patch_type: "backport"
+      patch_source: https://github.com/curl/curl/pull/7515#issuecomment-890320856
+      patch_description: >-
+        Fix the breaking change that was introduced in 1.40.0 and made optional
+        in 1.40.1
   "1.39.2":
     - patch_file: "patches/fix-addNghttp2IncludesPathCMake.patch"
     - patch_file: "patches/fix-findJemalloc.cmake"

--- a/recipes/libnghttp2/all/conanfile.py
+++ b/recipes/libnghttp2/all/conanfile.py
@@ -105,9 +105,6 @@ class Nghttp2Conan(ConanFile):
         tc.variables["WITH_JEMALLOC"] = self.options.get_safe("with_jemalloc", False)
         tc.variables["WITH_SPDYLAY"] = False
         tc.variables["ENABLE_ASIO_LIB"] = self.options.with_asio
-        if Version(self.version) >= "1.42.0":
-            # backward-incompatible change in 1.42.0
-            tc.variables["STATIC_LIB_SUFFIX"] = "_static"
         if is_apple_os(self):
             # workaround for: install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
             tc.cache_variables["CMAKE_MACOSX_BUNDLE"] = False
@@ -164,8 +161,7 @@ class Nghttp2Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.components["nghttp2"].set_property("pkg_config_name", "libnghttp2")
-        suffix = "_static" if Version(self.version) > "1.39.2" and not self.options.shared else ""
-        self.cpp_info.components["nghttp2"].libs = [f"nghttp2{suffix}"]
+        self.cpp_info.components["nghttp2"].libs = ["nghttp2"]
         if is_msvc(self) and not self.options.shared:
             self.cpp_info.components["nghttp2"].defines.append("NGHTTP2_STATICLIB")
 

--- a/recipes/libnghttp2/all/patches/1.40.0-remove-static-suffix.patch
+++ b/recipes/libnghttp2/all/patches/1.40.0-remove-static-suffix.patch
@@ -1,0 +1,11 @@
+--- lib/CMakeLists.txt.orig	2022-12-23 11:01:09.000000000 +0200
++++ lib/CMakeLists.txt	2022-12-23 11:01:22.000000000 +0200
+@@ -62,7 +62,7 @@ if(HAVE_CUNIT OR ENABLE_STATIC_LIB)
+   set_target_properties(nghttp2_static PROPERTIES
+     COMPILE_FLAGS "${WARNCFLAGS}"
+     VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
+-    ARCHIVE_OUTPUT_NAME nghttp2_static
++    ARCHIVE_OUTPUT_NAME nghttp2
+   )
+   target_compile_definitions(nghttp2_static PUBLIC "-DNGHTTP2_STATICLIB")
+   if(ENABLE_STATIC_LIB)


### PR DESCRIPTION
Specify library name and version:  `libnghttp2/*`

This patch removes an explicit setting of `STATIC_LIB_SUFFIX` thus renaming static library back to `libnghttp2.a`. It also changes `package_info` to set `nghttp2_static` as a library name only for version 1.40.0 as pointed by the author of the original change in libnghttp2:
https://github.com/curl/curl/pull/7515#issuecomment-890320856

Fixes #6241



<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
