### PR TITLE
libcurl: add CMakeDeps generator

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
 from conan.tools.build import cross_building
-from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import apply_conandata_patches, copy, download, export_conandata_patches, get, load, replace_in_file, rm, rmdir, save
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps
@@ -515,6 +515,8 @@ class LibcurlConan(ConanFile):
         return version
 
     def _generate_with_cmake(self):
+        dc = CMakeDeps(self)
+        dc.generate()
         if self._is_win_x_android:
             tc = CMakeToolchain(self, generator="Ninja")
         else:


### PR DESCRIPTION
Specify library name and version:  `libcurl/*`

With cmake build, libcurl relies on internal cmake modules that find the dependencies. For libnghttp2, this behaviour is overridden in `_patch_cmake` by making cmake look for package `libnghttp2` instead of `NGHTTP2`. This package, however, is only generated with `CMakeDeps` generator, and due to lack of it the build failed on Windows. This commit adds this generator to the recipe.


<!-- This is also a good place to share with all of us **why you are submitting this PR** (specially if it is a new addition to ConanCenter): is it a dependency of other libraries you want to package? Are you the author of the library? Thanks! -->


---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
