### PR TITLE
[luajit] Add 2.1.0-beta3 

### DIFF
--- a/recipes/luajit/all/conandata.yml
+++ b/recipes/luajit/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "2.0.5":
     url: "http://luajit.org/download/LuaJIT-2.0.5.tar.gz"
     sha256: "874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"
+  "2.1.0-beta3":
+    url: "https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz"
+    sha256: "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"

--- a/recipes/luajit/all/conandata.yml
+++ b/recipes/luajit/all/conandata.yml
@@ -5,3 +5,8 @@ sources:
   "2.0.5":
     url: "http://luajit.org/download/LuaJIT-2.0.5.tar.gz"
     sha256: "874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"
+patches:
+  "2.1.0-beta3":
+    - patch_file: "patches/2.1.0-beta3-0001-remove-mac-deploy.patch"
+      patch_type: "conan"
+      patch_description: "Do not enforce default value for MACOSX_DEPLOYMENT_TARGET"

--- a/recipes/luajit/all/conandata.yml
+++ b/recipes/luajit/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.0.5":
-    url: "http://luajit.org/download/LuaJIT-2.0.5.tar.gz"
-    sha256: "874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"
   "2.1.0-beta3":
     url: "https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz"
     sha256: "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
+  "2.0.5":
+    url: "http://luajit.org/download/LuaJIT-2.0.5.tar.gz"
+    sha256: "874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"

--- a/recipes/luajit/all/conandata.yml
+++ b/recipes/luajit/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20230104":
+    url: "https://github.com/LuaJIT/LuaJIT/archive/d0e88930ddde28ff662503f9f20facf34f7265aa.tar.gz"
+    sha256: "aa354d1265814db5a1ee9dfff6049e19b148e1fd818f1ecfa4fcf2b19f6e4dd9"
   "2.1.0-beta3":
     url: "https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz"
     sha256: "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
@@ -6,6 +9,10 @@ sources:
     url: "http://luajit.org/download/LuaJIT-2.0.5.tar.gz"
     sha256: "874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"
 patches:
+  "cci.20230104":
+    - patch_file: "patches/20230104-0001-remove-mac-deploy.patch"
+      patch_type: "conan"
+      patch_description: "Do not enforce default value for MACOSX_DEPLOYMENT_TARGET"
   "2.1.0-beta3":
     - patch_file: "patches/2.1.0-beta3-0001-remove-mac-deploy.patch"
       patch_type: "conan"

--- a/recipes/luajit/all/conandata.yml
+++ b/recipes/luajit/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "cci.20230104":
-    url: "https://github.com/LuaJIT/LuaJIT/archive/d0e88930ddde28ff662503f9f20facf34f7265aa.tar.gz"
-    sha256: "aa354d1265814db5a1ee9dfff6049e19b148e1fd818f1ecfa4fcf2b19f6e4dd9"
   "2.1.0-beta3":
     url: "https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz"
     sha256: "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
@@ -9,10 +6,6 @@ sources:
     url: "http://luajit.org/download/LuaJIT-2.0.5.tar.gz"
     sha256: "874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"
 patches:
-  "cci.20230104":
-    - patch_file: "patches/20230104-0001-remove-mac-deploy.patch"
-      patch_type: "conan"
-      patch_description: "Do not enforce default value for MACOSX_DEPLOYMENT_TARGET"
   "2.1.0-beta3":
     - patch_file: "patches/2.1.0-beta3-0001-remove-mac-deploy.patch"
       patch_type: "conan"

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -90,9 +90,7 @@ class LuajitConan(ConanFile):
                 env["MACOSX_DEPLOYMENT_TARGET"] = version
             with chdir(self, self._source_subfolder), tools.environment_append(env):
                 env_build = self._configure_autotools()
-                compiler = "clang" if "clang" in str(self.settings.compiler) else str(self.settings.compiler)
-                compiler = tools.get_env("CC", compiler)
-                env_build.make(args=[f"PREFIX={self.package_folder}", f"CC={compiler}"])
+                env_build.make(args=[f"PREFIX={self.package_folder}"])
 
     def package(self):
         copy(self, "COPYRIGHT", dst=os.path.join(self.package_folder, "licenses"), src=os.path.join(self.source_folder, self._source_subfolder))

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -65,7 +65,7 @@ class LuajitConan(ConanFile):
             if self.info.settings.os == "Macos":
                 env = Environment()
                 env.define("MACOSX_DEPLOYMENT_TARGET", self._macosx_deployment_target)
-                env.define("SYSTEM_VERSION_COMPAT", 1)
+                env.define("SYSTEM_VERSION_COMPAT", "1")
                 envvars = env.vars(self, scope="build")
                 envvars.save_script("conanbuildenv_macosx_deploy_target")
 

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -47,9 +47,9 @@ class LuajitConan(ConanFile):
             self._env_build = AutoToolsBuildEnvironment(self)
         return self._env_build
 
-    #def validate(self):
-    #    if Version(self.version) < "2.1.0-beta1" and self.settings.os == "Macos" and self.settings.arch == "armv8":
-    #        raise ConanInvalidConfiguration(f"{self.ref} is not supported by Mac M1. Please, try any version >=2.1")
+    def validate(self):
+        if Version(self.version) < "2.1.0-beta1" and self.settings.os == "Macos" and self.settings.arch == "armv8":
+            raise ConanInvalidConfiguration(f"{self.ref} is not supported by Mac M1. Please, try any version >=2.1")
 
     def build(self):
         if is_msvc(self):

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -90,7 +90,9 @@ class LuajitConan(ConanFile):
                 env["MACOSX_DEPLOYMENT_TARGET"] = version
             with chdir(self, self._source_subfolder), tools.environment_append(env):
                 env_build = self._configure_autotools()
-                env_build.make(args=[f"PREFIX={self.package_folder}"])
+                compiler = "clang" if "clang" in str(self.settings.compiler) else str(self.settings.compiler)
+                compiler = tools.get_env("CC", compiler)
+                env_build.make(args=[f"PREFIX={self.package_folder}", f"CC={compiler}"])
 
     def package(self):
         copy(self, "COPYRIGHT", dst=os.path.join(self.package_folder, "licenses"), src=os.path.join(self.source_folder, self._source_subfolder))

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -90,6 +90,8 @@ class LuajitConan(ConanFile):
                 replace_in_file(self, makefile,
                                       'TARGET_O= $(LUAJIT_A)',
                                       'TARGET_O= $(LUAJIT_SO)')
+            if "clang" in str(self.settings.compiler):
+                replace_in_file(self, makefile, 'CC= $(DEFAULT_CC)', 'CC= clang')
 
     @property
     def _macosx_deployment_target(self):

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -65,6 +65,7 @@ class LuajitConan(ConanFile):
             if self.info.settings.os == "Macos":
                 env = Environment()
                 env.define("MACOSX_DEPLOYMENT_TARGET", self._macosx_deployment_target)
+                env.define("SYSTEM_VERSION_COMPAT", 1)
                 envvars = env.vars(self, scope="build")
                 envvars.save_script("conanbuildenv_macosx_deploy_target")
 

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -73,7 +73,10 @@ class LuajitConan(ConanFile):
                 # is not set then it's forced to 10.4, which breaks compile on Mojave.
                 version = self.settings.get_safe("os.version")
                 if not version and platform.system() == "Darwin":
-                    major, minor, _ = platform.mac_ver()[0].split(".")
+                    platform.mac_ver
+                    listversion = platform.mac_ver()[0].split(".")
+                    major = listversion[0]
+                    minor = listversion[1]
                     version = "%s.%s" % (major, minor)
                 env["MACOSX_DEPLOYMENT_TARGET"] = version
             with tools.chdir(self._source_subfolder), tools.environment_append(env):

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.scm import Version
-from conan.tools.files import get, chdir, replace_in_file, copy, rmdir
+from conan.tools.files import get, chdir, replace_in_file, copy, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.microsoft import is_msvc, MSBuildToolchain, VCVars, unix_path
 from conan.tools.layout import basic_layout
 from conan.tools.gnu import Autotools, AutotoolsToolchain
@@ -23,6 +23,9 @@ class LuajitConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -97,6 +100,7 @@ class LuajitConan(ConanFile):
         return args
 
     def build(self):
+        apply_conandata_patches(self)
         if is_msvc(self):
             variant = '' if self.options.shared else 'static'
             self.run("msvcbuild.bat %s" % variant, env="conanrun")

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -41,7 +41,7 @@ class LuajitConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def validate(self):
-        if Version(self.version) <= "2.1.0-beta3" and self.settings.os == "Macos" and self.settings.arch == "armv8" and cross_building(self):
+        if self.settings.os == "Macos" and self.settings.arch == "armv8" and cross_building(self):
             raise ConanInvalidConfiguration(f"{self.ref} can not be cross-built to Mac M1. Please, try any version >=2.1")
         elif Version(self.version) <= "2.1.0-beta1" and self.settings.os == "Macos" and self.settings.arch == "armv8":
             raise ConanInvalidConfiguration(f"{self.ref} is not supported by Mac M1. Please, try any version >=2.1")

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -92,6 +92,13 @@ class LuajitConan(ConanFile):
             args.append(f"MACOSX_DEPLOYMENT_TARGET={self._macosx_deployment_target}")
         return args
 
+    @property
+    def _luajit_include_folder(self):
+        luaversion = Version(self.version)
+        if luaversion.major == "2":
+            return f"luajit-{luaversion.major}.{luaversion.minor}"
+        return "luajit-2.1"
+
     def build(self):
         apply_conandata_patches(self)
         self._patch_sources()
@@ -107,7 +114,7 @@ class LuajitConan(ConanFile):
     def package(self):
         copy(self, "COPYRIGHT", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         src_folder = os.path.join(self.source_folder, "src")
-        include_folder = os.path.join(self.package_folder, "include", f"luajit-{Version(self.version).major}.{Version(self.version).minor}")
+        include_folder = os.path.join(self.package_folder, "include", self._luajit_include_folder)
         if is_msvc(self):
             copy(self, "lua.h", src=src_folder, dst=include_folder)
             copy(self, "lualib.h", src=src_folder, dst=include_folder)
@@ -127,7 +134,6 @@ class LuajitConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["lua51" if is_msvc(self) else "luajit-5.1"]
         self.cpp_info.set_property("pkg_config_name", "luajit")
-        luaversion = Version(self.version)
-        self.cpp_info.includedirs = [os.path.join("include", f"luajit-{luaversion.major}.{luaversion.minor}")]
+        self.cpp_info.includedirs = [os.path.join("include", self._luajit_include_folder)]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["m", "dl"])

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -40,7 +40,7 @@ class LuajitConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def validate(self):
-        if Version(self.version) < "2.1.0-beta1" and self.settings.os == "Macos" and self.settings.arch == "armv8":
+        if Version(self.version) <= "2.1.0-beta3" and self.settings.os == "Macos" and self.settings.arch == "armv8":
             raise ConanInvalidConfiguration(f"{self.ref} is not supported by Mac M1. Please, try any version >=2.1")
 
     def source(self):

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -84,18 +84,12 @@ class LuajitConan(ConanFile):
 
     @property
     def _macosx_deployment_target(self):
-        # Per https://luajit.org/install.html: If MACOSX_DEPLOYMENT_TARGET
-        # is not set then it's forced to 10.4, which breaks compile on Mojave.
-        version = self.settings.get_safe("os.version")
-        if not version and platform.system() == "Darwin":
-            macversion = Version(platform.mac_ver()[0])
-            version = f"{macversion.major}.{macversion.minor}"
-        return version
+        return self.settings.get_safe("os.version")
 
     @property
     def _make_arguments(self):
         args = [f"PREFIX={unix_path(self, self.package_folder)}"]
-        if is_apple_os(self):
+        if is_apple_os(self) and self._macosx_deployment_target:
             args.append(f"MACOSX_DEPLOYMENT_TARGET={self._macosx_deployment_target}")
         return args
 

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -10,7 +10,7 @@ import os
 import platform
 
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.52.0"
 
 
 class LuajitConan(ConanFile):
@@ -30,18 +30,9 @@ class LuajitConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            try:
-                del self.options.fPIC
-            except Exception:
-                pass
-        try:
-            del self.settings.compiler.libcxx
-        except Exception:
-            pass
-        try:
-            del self.settings.compiler.cppstd
-        except Exception:
-            pass
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.microsoft import is_msvc, MSBuildToolchain, VCVars, unix_path
 from conan.tools.layout import basic_layout
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.apple import is_apple_os
+from conan.tools.build import cross_building
 from conan.errors import ConanInvalidConfiguration
 import os
 
@@ -40,7 +41,9 @@ class LuajitConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def validate(self):
-        if Version(self.version) <= "2.1.0-beta3" and self.settings.os == "Macos" and self.settings.arch == "armv8":
+        if Version(self.version) <= "2.1.0-beta3" and self.settings.os == "Macos" and self.settings.arch == "armv8" and cross_building(self):
+            raise ConanInvalidConfiguration(f"{self.ref} can not be cross-built to Mac M1. Please, try any version >=2.1")
+        elif Version(self.version) <= "2.1.0-beta1" and self.settings.os == "Macos" and self.settings.arch == "armv8":
             raise ConanInvalidConfiguration(f"{self.ref} is not supported by Mac M1. Please, try any version >=2.1")
 
     def source(self):

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.tools.scm import Version
 from conan.tools.files import get, chdir, replace_in_file, copy, rmdir
-from conan.tools.microsoft import is_msvc, MSBuildToolchain, VCVars
+from conan.tools.microsoft import is_msvc, MSBuildToolchain, VCVars, unix_path
 from conan.tools.layout import basic_layout
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.apple import is_apple_os
@@ -10,7 +10,7 @@ import os
 import platform
 
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=1.53.0"
 
 
 class LuajitConan(ConanFile):
@@ -91,7 +91,7 @@ class LuajitConan(ConanFile):
 
     @property
     def _make_arguments(self):
-        args = [f"PREFIX={self.package_folder}"]
+        args = [f"PREFIX={unix_path(self, self.package_folder)}"]
         if is_apple_os(self):
             args.append(f"MACOSX_DEPLOYMENT_TARGET={self._macosx_deployment_target}")
         return args
@@ -122,7 +122,7 @@ class LuajitConan(ConanFile):
         else:
             with chdir(self, self.source_folder):
                 autotools = Autotools(self)
-                autotools.install(args=self._make_arguments)
+                autotools.install(args=self._make_arguments + ["DESTDIR="])
             rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
             rmdir(self, os.path.join(self.package_folder, "share"))
 

--- a/recipes/luajit/all/patches/2.1.0-beta3-0001-remove-mac-deploy.patch
+++ b/recipes/luajit/all/patches/2.1.0-beta3-0001-remove-mac-deploy.patch
@@ -1,0 +1,14 @@
+diff --git a/src/Makefile b/src/Makefile
+index f56465d..a6838bc 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -312,9 +312,6 @@ ifeq (,$(shell $(TARGET_CC) -o /dev/null -c -x c /dev/null -fno-stack-protector
+   TARGET_XCFLAGS+= -fno-stack-protector
+ endif
+ ifeq (Darwin,$(TARGET_SYS))
+-  ifeq (,$(MACOSX_DEPLOYMENT_TARGET))
+-    export MACOSX_DEPLOYMENT_TARGET=10.4
+-  endif
+   TARGET_STRIP+= -x
+   TARGET_XSHLDFLAGS= -dynamiclib -single_module -undefined dynamic_lookup -fPIC
+   TARGET_DYNXLDOPTS=

--- a/recipes/luajit/all/patches/20230104-0001-remove-mac-deploy.patch
+++ b/recipes/luajit/all/patches/20230104-0001-remove-mac-deploy.patch
@@ -1,0 +1,14 @@
+diff --git a/src/Makefile b/src/Makefile
+index 30d64be..b753ea1 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -316,9 +316,6 @@ ifeq (,$(shell $(TARGET_CC) -o /dev/null -c -x c /dev/null -fno-stack-protector
+   TARGET_XCFLAGS+= -fno-stack-protector
+ endif
+ ifeq (Darwin,$(TARGET_SYS))
+-  ifeq (,$(MACOSX_DEPLOYMENT_TARGET))
+-    $(error missing: export MACOSX_DEPLOYMENT_TARGET=XX.YY)
+-  endif
+   TARGET_STRIP+= -x
+   TARGET_XCFLAGS+= -DLUAJIT_UNWIND_EXTERNAL
+   TARGET_XSHLDFLAGS= -dynamiclib -single_module -undefined dynamic_lookup -fPIC

--- a/recipes/luajit/all/test_package/CMakeLists.txt
+++ b/recipes/luajit/all/test_package/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package C)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 find_package(luajit REQUIRED CONFIG)
 

--- a/recipes/luajit/all/test_package/conanfile.py
+++ b/recipes/luajit/all/test_package/conanfile.py
@@ -1,11 +1,19 @@
-from conans import ConanFile, CMake
-from conan.tools.build import cross_building
+from conan.tools.build import can_run
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -13,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/luajit/all/test_package/conanfile.py
+++ b/recipes/luajit/all/test_package/conanfile.py
@@ -1,4 +1,5 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
 import os
 
 
@@ -12,6 +13,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
+        if not cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/luajit/all/test_package/conanfile.py
+++ b/recipes/luajit/all/test_package/conanfile.py
@@ -23,4 +23,4 @@ class TestPackageConan(ConanFile):
     def test(self):
         if can_run(self):
             bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
-            self.run(bin_path, run_environment=True)
+            self.run(bin_path, env="conanrun")

--- a/recipes/luajit/all/test_v1_package/CMakeLists.txt
+++ b/recipes/luajit/all/test_v1_package/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(test_package C)
 
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
 find_package(luajit REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.c)
+add_executable(${PROJECT_NAME} ../test_package/test_package.c)
 target_link_libraries(${PROJECT_NAME} luajit::luajit)

--- a/recipes/luajit/all/test_v1_package/CMakeLists.txt
+++ b/recipes/luajit/all/test_v1_package/CMakeLists.txt
@@ -4,7 +4,5 @@ project(test_package C)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(luajit REQUIRED CONFIG)
-
-add_executable(${PROJECT_NAME} ../test_package/test_package.c)
-target_link_libraries(${PROJECT_NAME} luajit::luajit)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/luajit/all/test_v1_package/conanfile.py
+++ b/recipes/luajit/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import can_run
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/luajit/all/test_v1_package/conanfile.py
+++ b/recipes/luajit/all/test_v1_package/conanfile.py
@@ -1,5 +1,4 @@
-from conans import ConanFile, CMake
-from conan.tools.build import can_run
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -13,6 +12,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if can_run(self):
+        if tools.cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/luajit/config.yml
+++ b/recipes/luajit/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.0.5":
     folder: "all"
+  "2.1.0-beta3":
+    folder: "all"

--- a/recipes/luajit/config.yml
+++ b/recipes/luajit/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20230104":
+    folder: "all"
   "2.1.0-beta3":
     folder: "all"
   "2.0.5":

--- a/recipes/luajit/config.yml
+++ b/recipes/luajit/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.0.5":
-    folder: "all"
   "2.1.0-beta3":
+    folder: "all"
+  "2.0.5":
     folder: "all"

--- a/recipes/luajit/config.yml
+++ b/recipes/luajit/config.yml
@@ -1,6 +1,4 @@
 versions:
-  "cci.20230104":
-    folder: "all"
   "2.1.0-beta3":
     folder: "all"
   "2.0.5":


### PR DESCRIPTION
Specify library name and version: luajit/2.1.0-beta3

* The PR #11904  can not be re-opened
* luajit is not prepared to cross-compile from Mac intel to Mac M1
* Mac M1 support has been introduced on 2.1
* No stable release will be released soon, so beta is the only alternative
* Backporting to 2.0.5 M1 support requires a lot of effort
* Do not enforce default MACOSX_DEPLOYMENT_TARGET. It's not really mandatory and may break on OSX 12.

fixes https://github.com/conan-io/conan-center-index/issues/11884

/cc @Bobini1

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
