### PR TITLE
wolfssl: add version 5.5.3

### DIFF
--- a/recipes/wolfssl/all/conandata.yml
+++ b/recipes/wolfssl/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.5.3":
+    url: "https://github.com/wolfSSL/wolfssl/archive/v5.5.3-stable.tar.gz"
+    sha256: "fd3135b8657d09fb96a8aad16585da850b96ea420ae8ce5ac4d5fdfc614c2683"
   "5.5.1":
     url: "https://github.com/wolfSSL/wolfssl/archive/v5.5.1-stable.tar.gz"
     sha256: "97339e6956c90e7c881ba5c748dd04f7c30e5dbe0c06da765418c51375a6dee3"

--- a/recipes/wolfssl/config.yml
+++ b/recipes/wolfssl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.5.3":
+    folder: all
   "5.5.1":
     folder: all
   "5.4.0":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **wolfssl/5.5.3**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
