### PR TITLE
mongo-c-driver: add version 1.22.2, update icu

### DIFF
--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.22.2":
+    url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.22.2/mongo-c-driver-1.22.2.tar.gz"
+    sha256: "2e59b9d38d600bd63ccc0b215dd44c6254a66eeb8085a5ac513748cd6220532e"
   "1.22.0":
     url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.22.0/mongo-c-driver-1.22.0.tar.gz"
     sha256: "272067f75e7e57c98f90a6f0c42500ef818b4b085539343676b6ce6831655eaf"
@@ -15,6 +18,10 @@ sources:
     url: "https://github.com/mongodb/mongo-c-driver/releases/download/1.17.2/mongo-c-driver-1.17.2.tar.gz"
     sha256: "bc53d5f72ab628a1ae549db6888325d6dc34db3ca31c5e16e550c1bb4266d864"
 patches:
+  "1.22.2":
+    - patch_file: "patches/1.22.0-0001-disable-shared-when-static.patch"
+    - patch_file: "patches/1.22.0-0002-fix-uninitialized-warning.patch"
+    - patch_file: "patches/1.22.0-0003-disable-warning-errors.patch"
   "1.22.0":
     - patch_file: "patches/1.22.0-0001-disable-shared-when-static.patch"
     - patch_file: "patches/1.22.0-0002-fix-uninitialized-warning.patch"

--- a/recipes/mongo-c-driver/all/conandata.yml
+++ b/recipes/mongo-c-driver/all/conandata.yml
@@ -20,17 +20,37 @@ sources:
 patches:
   "1.22.2":
     - patch_file: "patches/1.22.0-0001-disable-shared-when-static.patch"
+      patch_description: "separate static and shared builds"
+      patch_type: "conan"
     - patch_file: "patches/1.22.0-0002-fix-uninitialized-warning.patch"
+      patch_description: "fix uninitialized variable warning"
+      patch_type: "portability"
     - patch_file: "patches/1.22.0-0003-disable-warning-errors.patch"
+      patch_description: "disable compiler flags to make warnings into errors"
+      patch_type: "conan"
   "1.22.0":
     - patch_file: "patches/1.22.0-0001-disable-shared-when-static.patch"
+      patch_description: "separate static and shared builds"
+      patch_type: "conan"
     - patch_file: "patches/1.22.0-0002-fix-uninitialized-warning.patch"
+      patch_description: "fix uninitialized variable warning"
+      patch_type: "portability"
     - patch_file: "patches/1.22.0-0003-disable-warning-errors.patch"
+      patch_description: "disable compiler flags to make warnings into errors"
+      patch_type: "conan"
   "1.17.6":
     - patch_file: "patches/1.17.6-0001-disable-shared-when-static.patch"
+      patch_description: "separate static and shared builds"
+      patch_type: "conan"
   "1.17.4":
     - patch_file: "patches/1.17.2-0001-disable-shared-when-static.patch"
+      patch_description: "separate static and shared builds"
+      patch_type: "conan"
   "1.17.3":
     - patch_file: "patches/1.17.2-0001-disable-shared-when-static.patch"
+      patch_description: "separate static and shared builds"
+      patch_type: "conan"
   "1.17.2":
     - patch_file: "patches/1.17.2-0001-disable-shared-when-static.patch"
+      patch_description: "separate static and shared builds"
+      patch_type: "conan"

--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -77,7 +77,7 @@ class MongoCDriverConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/1.5.2")
         if self.options.with_icu:
-            self.requires("icu/71.1")
+            self.requires("icu/72.1")
 
     def validate(self):
         if self.info.options.with_ssl == "darwin" and not is_apple_os(self.settings.os):

--- a/recipes/mongo-c-driver/config.yml
+++ b/recipes/mongo-c-driver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.22.2":
+    folder: all
   "1.22.0":
     folder: all
   "1.17.6":


### PR DESCRIPTION
Specify library name and version:  **mongo-c-driver/***

- add version 1.22.2
- update icu

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
