### PR TITLE
added libinterpolate recipe

### DIFF
--- a/recipes/libinterpolate/all/conandata.yml
+++ b/recipes/libinterpolate/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "2.6.2":
+    url:
+      - "https://github.com/CD3/libInterpolate/archive/refs/tags/2.6.2.tar.gz"
+    sha256: "42f40c9b77fda6e0c52ed39b522458456e89fb4981d63f812aa158c6f4be8ab0"

--- a/recipes/libinterpolate/all/conanfile.py
+++ b/recipes/libinterpolate/all/conanfile.py
@@ -1,0 +1,100 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+import os
+
+
+required_conan_version = ">=1.52.0"
+
+
+class PackageConan(ConanFile):
+    name = "libinterpolate"
+    description = "A C++ interpolation library with a simple interface that supports multiple interpolation methods."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/CD3/libInterpolate"
+    topics = ("math", "spline", "interpolation", "header-only")
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "Visual Studio": "15",
+            "msvc": "19.0",
+            "gcc": "7",
+            "clang": "4",
+            "apple-clang": "10",
+        }
+
+    def export_sources(self):
+        pass
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires("boost/1.80.0", transitive_headers=True)
+        self.requires("eigen/3.3.7", transitive_headers=True)
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(
+            str(self.settings.compiler), False
+        )
+        if (
+            minimum_version
+            and Version(self.settings.compiler.version) < minimum_version
+        ):
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(
+            self,
+            pattern="LICENSE.md",
+            dst=os.path.join(self.package_folder, "licenses"),
+            src=self.source_folder,
+        )
+        copy(
+            self,
+            pattern="*.hpp",
+            dst=os.path.join(self.package_folder, "include"),
+            src=os.path.join(self.source_folder, "src"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        self.cpp_info.set_property("cmake_file_name", "libInterpolate")
+        self.cpp_info.set_property(
+            "cmake_target_name", "libInterpolate::Interpolate"
+        )
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "libInterpolate"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "libInterpolate"
+        self.cpp_info.names["cmake_find_package"] = "libInterpolate"
+        self.cpp_info.names["cmake_find_package_multi"] = "libInterpolate"
+        self.cpp_info.components["Interpolate"].names["cmake_find_package"] = "Interpolate"
+        self.cpp_info.components["Interpolate"].names["cmake_find_package_multi"] = "Interpolate"
+        self.cpp_info.components["Interpolate"].requires = ["eigen::eigen","boost::boost"]

--- a/recipes/libinterpolate/all/conanfile.py
+++ b/recipes/libinterpolate/all/conanfile.py
@@ -38,7 +38,7 @@ class PackageConan(ConanFile):
         pass
 
     def layout(self):
-        basic_layout(self)
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
         self.requires("boost/1.80.0", transitive_headers=True)

--- a/recipes/libinterpolate/all/conanfile.py
+++ b/recipes/libinterpolate/all/conanfile.py
@@ -42,9 +42,6 @@ class PackageConan(ConanFile):
         self.requires("boost/1.80.0", transitive_headers=True)
         self.requires("eigen/3.3.7", transitive_headers=True)
 
-    def package_id(self):
-        self.info.clear()
-
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
@@ -78,6 +75,9 @@ class PackageConan(ConanFile):
             dst=os.path.join(self.package_folder, "include"),
             src=os.path.join(self.source_folder, "src"),
         )
+
+    def package_id(self):
+        self.info.clear()
 
     def package_info(self):
         self.cpp_info.bindirs = []

--- a/recipes/libinterpolate/all/conanfile.py
+++ b/recipes/libinterpolate/all/conanfile.py
@@ -43,6 +43,9 @@ class PackageConan(ConanFile):
         self.requires("eigen/3.3.7", transitive_headers=True)
 
     def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("Library is only support for Linux. PR's are welcome.")
+
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(

--- a/recipes/libinterpolate/all/conanfile.py
+++ b/recipes/libinterpolate/all/conanfile.py
@@ -34,8 +34,6 @@ class PackageConan(ConanFile):
             "apple-clang": "10",
         }
 
-    def export_sources(self):
-        pass
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/libinterpolate/all/conanfile.py
+++ b/recipes/libinterpolate/all/conanfile.py
@@ -44,7 +44,7 @@ class PackageConan(ConanFile):
 
     def validate(self):
         if self.settings.os != "Linux":
-            raise ConanInvalidConfiguration("Library is only support for Linux. PR's are welcome.")
+            raise ConanInvalidConfiguration("libInterpolate currently only supports Linux. Upstream PR's are welcome (https://github.com/CD3/libInterpolate/issues/14).")
 
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)

--- a/recipes/libinterpolate/all/test_package/CMakeLists.txt
+++ b/recipes/libinterpolate/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
+
+find_package(libInterpolate REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE libInterpolate::Interpolate)

--- a/recipes/libinterpolate/all/test_package/conanfile.py
+++ b/recipes/libinterpolate/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+# It will become the standard on Conan 2.x
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libinterpolate/all/test_package/test_package.cpp
+++ b/recipes/libinterpolate/all/test_package/test_package.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <vector>
+
+#include <libInterpolate/Interpolate.hpp>
+
+int main(void)
+{
+  std::vector<double> x(2), y(2);
+
+  x[0] = 0;
+  x[1] = 1;
+  y[0] = 10;
+  y[1] = 20;
+
+  _1D::LinearInterpolator<double> interp;
+  interp.setData(x, y);
+
+  std::cout << "f(0.5) = " << interp(0.5) << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/recipes/libinterpolate/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libinterpolate/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)
+

--- a/recipes/libinterpolate/all/test_v1_package/conanfile.py
+++ b/recipes/libinterpolate/all/test_v1_package/conanfile.py
@@ -1,0 +1,19 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+# legacy validation with Conan 1.x
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libinterpolate/config.yml
+++ b/recipes/libinterpolate/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.6.2":
+    folder: all


### PR DESCRIPTION
libinterpolate/2.6.2

This is an interpolation library with a simple interface that I wrote. https://github.com/CD3/libInterpolate

I submitted a PR last week but the CI builds were failing, which I think was due to the C++17 requirement not being enforced in the recipe

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
