### PR TITLE
libnice: add recipe

### DIFF
--- a/recipes/libnice/all/conandata.yml
+++ b/recipes/libnice/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  0.1.19:
-    url: https://libnice.freedesktop.org/releases/libnice-0.1.19.tar.gz
-    sha256: 6747af710998cf708a2e8ceef51cccd181373d94201dd4b8d40797a070ed47cc
+  0.1.21:
+    url: https://libnice.freedesktop.org/releases/libnice-0.1.21.tar.gz
+    sha256: 72e73a2acf20f59093e21d5601606e405873503eb35f346fa621de23e99b3b39

--- a/recipes/libnice/all/conandata.yml
+++ b/recipes/libnice/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  0.1.19:
+    url: https://libnice.freedesktop.org/releases/libnice-0.1.19.tar.gz
+    sha256: 6747af710998cf708a2e8ceef51cccd181373d94201dd4b8d40797a070ed47cc

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -15,6 +15,7 @@ class LibniceConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     description = "a GLib ICE implementation"
     topics = ("ice", "stun", "turn")
+    package_type = "library"
     settings = "os", "compiler", "build_type", "arch"
     options = {
         "shared": [True, False],
@@ -49,18 +50,18 @@ class LibniceConan(ConanFile):
     def validate(self):
         if self.settings.os != "Windows" and self.options.crypto_library == "win32":
             raise ConanInvalidConfiguration(
-                "-o libnice:crypto_library=win32 is not supported on non-Windows")
+                f"-o {self.ref}:crypto_library=win32 is not supported on non-Windows")
         if self.settings.os == "Windows" and self.options.with_gtk_doc:
             raise ConanInvalidConfiguration(
-                "-o libnice:with_gtk_doc=True is not support on Windows")
-        if is_msvc_static_runtime(self) and self.options["glib"].shared:
+                f"-o {self.ref}:with_gtk_doc=True is not support on Windows")
+        if is_msvc_static_runtime(self) and self.dependencies["glib"].options.shared:
             raise ConanInvalidConfiguration(
-                "-o glib:shared=True with static runtime is not supported")
+                "-o glib/*:shared=True with static runtime is not supported")
 
     def requirements(self):
         self.requires("glib/2.75.2")
         if self.options.crypto_library == "openssl":
-            self.requires("openssl/1.1.1s")
+            self.requires("openssl/1.1.1t")
         if self.options.with_gstreamer:
             self.requires("gstreamer/1.19.2")
 
@@ -72,8 +73,7 @@ class LibniceConan(ConanFile):
             self.tool_requires("gobject-introspection/1.72.0")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version],
-            destination=self.source_folder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = PkgConfigDeps(self)

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -1,9 +1,10 @@
 import os
 from conan import ConanFile
 from conan.tools.meson import Meson, MesonToolchain
-from conan.tools.files import copy, get, rmdir, rename, chdir, replace_in_file
+from conan.tools.files import copy, get, rmdir, rename, chdir
 from conan.tools.layout import basic_layout
 from conan.tools.gnu import PkgConfigDeps
+from conan.tools.microsoft import is_msvc_static_runtime
 from conan.errors import ConanInvalidConfiguration
 
 
@@ -48,13 +49,13 @@ class LibniceConan(ConanFile):
     def validate(self):
         if self.settings.os != "Windows" and self.options.crypto_library == "win32":
             raise ConanInvalidConfiguration(
-                "crypto_library=win32 is not supported on non-Windows")
+                "-o libnice:crypto_library=win32 is not supported on non-Windows")
         if self.settings.os == "Windows" and self.options.with_gtk_doc:
             raise ConanInvalidConfiguration(
-                "gtk-doc is disabled by libnice while building on Windows")
-        if self.settings.get_safe("runtime") in ("MT", "MTd", "static") and self.options["glib"].shared:
+                "-o libnice:with_gtk_doc=True is not support on Windows")
+        if is_msvc_static_runtime(self) and self.options["glib"].shared:
             raise ConanInvalidConfiguration(
-                "glib:shared=True with static runtime is not supported")
+                "-o glib:shared=True with static runtime is not supported")
 
     def requirements(self):
         self.requires("glib/2.75.2")

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -1,7 +1,7 @@
 import os
 from conan import ConanFile
 from conan.tools.meson import Meson, MesonToolchain
-from conan.tools.files import copy, get, rmdir, rename, chdir
+from conan.tools.files import copy, get, rmdir, rename, chdir, rm
 from conan.tools.layout import basic_layout
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.microsoft import is_msvc_static_runtime
@@ -101,6 +101,8 @@ class LibniceConan(ConanFile):
         meson = Meson(self)
         meson.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
+        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
         if self.settings.os == "Windows":
             if not self.options.shared:
                 with chdir(self, os.path.join(self.package_folder, "lib")):

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -9,9 +9,8 @@ from conan.errors import ConanInvalidConfiguration
 
 class LibniceConan(ConanFile):
     name = "libnice"
-    version = "0.1.19"
     homepage = "https://libnice.freedesktop.org/"
-    license = "MPL-1.1 AND LGPL-2.1-only"
+    license = ("MPL-1.1", "LGPL-2.1-only")
     url = "https://github.com/conan-io/conan-center-index"
     description = "a GLib ICE implementation"
     topics = ("ice", "stun", "turn")
@@ -39,9 +38,9 @@ class LibniceConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
+           self.options.rm_safe("fPIC")
+       self.settings.rm_safe("compiler.libcxx")
+       self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -62,11 +61,11 @@ class LibniceConan(ConanFile):
             self.requires("gstreamer/1.19.2")
 
     def build_requirements(self):
-        self.build_requires("meson/0.64.1")
-        self.build_requires("pkgconf/1.9.3")
-        self.build_requires("glib/2.75.0") # for glib-mkenums
+        self.tool_requires("meson/0.64.1")
+        self.tool_requires("pkgconf/1.9.3")
+        self.tool_requires("glib/2.75.0") # for glib-mkenums
         if self.options.with_introspection:
-            self.build_requires("gobject-introspection/1.72.0")
+            self.tool_requires("gobject-introspection/1.72.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -1,0 +1,69 @@
+import os
+from conan import ConanFile
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir, rename
+from conan.tools.layout import basic_layout
+from conan.tools.gnu import PkgConfigDeps
+
+
+class LibniceConan(ConanFile):
+    name = "libnice"
+    version = "0.1.19"
+    homepage = "https://libnice.freedesktop.org/"
+    license = "MPL-1.1 AND LGPL-2.1-only"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = "a GLib ICE implementation"
+    topics = ("ice", "stun", "turn")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    @property
+    def _is_msvc(self):
+        return self.settings.compiler == "Visual Studio"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        del self.settings.compiler.libcxx
+        del self.settings.compiler.cppstd
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("glib/2.75.0")
+
+    def build_requirements(self):
+        self.build_requires("meson/0.64.1")
+        self.build_requires("pkgconf/1.9.3")
+        self.build_requires("glib/2.75.0")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        tc = PkgConfigDeps(self)
+        tc.generate()
+        tc = MesonToolchain(self)
+        tc.generate()
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def package(self):
+        copy(self, pattern="COPYING*", dst=os.path.join(self.package_folder,
+             "licenses"), src=self.source_folder)
+        meson = Meson(self)
+        meson.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["libnice"]

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -1,7 +1,7 @@
 import os
 from conan import ConanFile
 from conan.tools.meson import Meson, MesonToolchain
-from conan.tools.files import copy, get, rmdir, rename, chdir
+from conan.tools.files import copy, get, rmdir, rename, chdir, replace_in_file
 from conan.tools.layout import basic_layout
 from conan.tools.gnu import PkgConfigDeps
 from conan.errors import ConanInvalidConfiguration
@@ -87,6 +87,11 @@ class LibniceConan(ConanFile):
         tc.generate()
 
     def build(self):
+        replace_in_file(
+            self,
+            os.path.join(self.source_folder, "meson.build"),
+            "dependency('openssl', required: false,",
+            "dependency('openssl', required: false, method: 'pkg-config',")
         meson = Meson(self)
         meson.configure()
         meson.build()

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -57,7 +57,7 @@ class LibniceConan(ConanFile):
     def requirements(self):
         self.requires("glib/2.75.0")
         if self.options.crypto_library == "openssl":
-            self.requires("openssl/3.0.7")
+            self.requires("openssl/1.1.1s")
         if self.options.with_gstreamer:
             self.requires("gstreamer/1.19.2")
 
@@ -87,11 +87,6 @@ class LibniceConan(ConanFile):
         tc.generate()
 
     def build(self):
-        replace_in_file(
-            self,
-            os.path.join(self.source_folder, "meson.build"),
-            "dependency('openssl', required: false,",
-            "dependency('openssl', required: false, method: 'pkg-config',")
         meson = Meson(self)
         meson.configure()
         meson.build()

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -39,8 +39,8 @@ class LibniceConan(ConanFile):
     def configure(self):
         if self.options.shared:
            self.options.rm_safe("fPIC")
-       self.settings.rm_safe("compiler.libcxx")
-       self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         basic_layout(self, src_folder="src")

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -38,7 +38,7 @@ class LibniceConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-           self.options.rm_safe("fPIC")
+            self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
 
@@ -52,6 +52,9 @@ class LibniceConan(ConanFile):
         if self.settings.os == "Windows" and self.options.with_gtk_doc:
             raise ConanInvalidConfiguration(
                 "gtk-doc is disabled by libnice while building on Windows")
+        if self.settings.get_safe("runtime") in ("MT", "MTd", "static") and self.options["glib"].shared:
+            raise ConanInvalidConfiguration(
+                "glib:shared=True with static runtime is not supported")
 
     def requirements(self):
         self.requires("glib/2.75.2")
@@ -63,7 +66,7 @@ class LibniceConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("meson/1.0.0")
         self.tool_requires("pkgconf/1.9.3")
-        self.tool_requires("glib/2.75.2") # for glib-mkenums
+        self.tool_requires("glib/2.75.2")  # for glib-mkenums
         if self.options.with_introspection:
             self.tool_requires("gobject-introspection/1.72.0")
 

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -64,6 +64,7 @@ class LibniceConan(ConanFile):
     def build_requirements(self):
         self.build_requires("meson/0.64.1")
         self.build_requires("pkgconf/1.9.3")
+        self.build_requires("glib/2.75.0") # for glib-mkenums
         if self.options.with_introspection:
             self.build_requires("gobject-introspection/1.72.0")
 

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -1,7 +1,7 @@
 import os
 from conan import ConanFile
 from conan.tools.meson import Meson, MesonToolchain
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir, rename
+from conan.tools.files import copy, get, rmdir
 from conan.tools.layout import basic_layout
 from conan.tools.gnu import PkgConfigDeps
 

--- a/recipes/libnice/all/conanfile.py
+++ b/recipes/libnice/all/conanfile.py
@@ -54,16 +54,16 @@ class LibniceConan(ConanFile):
                 "gtk-doc is disabled by libnice while building on Windows")
 
     def requirements(self):
-        self.requires("glib/2.75.0")
+        self.requires("glib/2.75.2")
         if self.options.crypto_library == "openssl":
             self.requires("openssl/1.1.1s")
         if self.options.with_gstreamer:
             self.requires("gstreamer/1.19.2")
 
     def build_requirements(self):
-        self.tool_requires("meson/0.64.1")
+        self.tool_requires("meson/1.0.0")
         self.tool_requires("pkgconf/1.9.3")
-        self.tool_requires("glib/2.75.0") # for glib-mkenums
+        self.tool_requires("glib/2.75.2") # for glib-mkenums
         if self.options.with_introspection:
             self.tool_requires("gobject-introspection/1.72.0")
 

--- a/recipes/libnice/all/test_package/CMakeLists.txt
+++ b/recipes/libnice/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(example LANGUAGES C)
+
+find_package(libnice REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} src/example.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE libnice::libnice)

--- a/recipes/libnice/all/test_package/conanfile.py
+++ b/recipes/libnice/all/test_package/conanfile.py
@@ -13,6 +13,7 @@ class LibniceTestConan(ConanFile):
     def build_requirements(self):
         self.build_requires("meson/0.64.1")
         self.build_requires("pkgconf/1.9.3")
+        self.build_requires("meson/0.64.1")
 
     def build(self):
         meson = Meson(self)

--- a/recipes/libnice/all/test_package/conanfile.py
+++ b/recipes/libnice/all/test_package/conanfile.py
@@ -1,8 +1,8 @@
 import os
 from conan import ConanFile
-from conans import tools
 from conan.tools.meson import Meson
 from conan.tools.layout import basic_layout
+from conan.tools.build import cross_building
 
 
 class LibniceTestConan(ConanFile):
@@ -23,6 +23,6 @@ class LibniceTestConan(ConanFile):
         basic_layout(self)
 
     def test(self):
-        if not tools.cross_building(self):
+        if not cross_building(self, skip_x64_x86=True):
             cmd = os.path.join(self.cpp.build.bindirs[0], "example")
             self.run(cmd, run_environment=True, env="conanrun")

--- a/recipes/libnice/all/test_package/conanfile.py
+++ b/recipes/libnice/all/test_package/conanfile.py
@@ -8,7 +8,6 @@ from conan.tools.build import cross_building
 class LibniceTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "PkgConfigDeps", "MesonToolchain"
-    apply_env = False
 
     def build_requirements(self):
         self.build_requires("meson/0.64.1")

--- a/recipes/libnice/all/test_package/conanfile.py
+++ b/recipes/libnice/all/test_package/conanfile.py
@@ -7,12 +7,15 @@ from conan.tools.build import cross_building
 
 class LibniceTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "PkgConfigDeps", "MesonToolchain"
+    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv"
+    test_type = "explicit"
 
+    def requirements(self):
+        self.requires(tested_reference_str)
     def build_requirements(self):
-        self.build_requires("meson/0.64.1")
-        self.build_requires("pkgconf/1.9.3")
-        self.build_requires("meson/0.64.1")
+        self.tool_requires("meson/0.64.1")
+        self.tool_requires("pkgconf/1.9.3")
+        self.tool_requires("meson/0.64.1")
 
     def build(self):
         meson = Meson(self)

--- a/recipes/libnice/all/test_package/conanfile.py
+++ b/recipes/libnice/all/test_package/conanfile.py
@@ -1,32 +1,27 @@
 import os
 from conan import ConanFile
-from conan.tools.meson import Meson
-from conan.tools.layout import basic_layout
+from conan.tools.cmake import CMake
+from conan.tools.layout import cmake_layout
 from conan.tools.build import cross_building
 
 
 class LibniceTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
-        
-    def build_requirements(self):
-        self.tool_requires("meson/0.64.1")
-        self.tool_requires("pkgconf/1.9.3")
-        self.tool_requires("meson/0.64.1")
 
     def build(self):
-        meson = Meson(self)
-        meson.configure()
-        meson.build()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def layout(self):
-        basic_layout(self)
+        cmake_layout(self)
 
     def test(self):
         if not cross_building(self, skip_x64_x86=True):
             cmd = os.path.join(self.cpp.build.bindirs[0], "example")
-            self.run(cmd, run_environment=True, env="conanrun")
+            self.run(cmd, env="conanrun")

--- a/recipes/libnice/all/test_package/conanfile.py
+++ b/recipes/libnice/all/test_package/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conan import ConanFile
 from conan.tools.cmake import CMake
 from conan.tools.layout import cmake_layout
-from conan.tools.build import cross_building
+from conan.tools.build import can_run
 
 
 class LibniceTestConan(ConanFile):
@@ -22,6 +22,6 @@ class LibniceTestConan(ConanFile):
         cmake_layout(self)
 
     def test(self):
-        if not cross_building(self, skip_x64_x86=True):
+        if can_run(self):
             cmd = os.path.join(self.cpp.build.bindirs[0], "example")
             self.run(cmd, env="conanrun")

--- a/recipes/libnice/all/test_package/conanfile.py
+++ b/recipes/libnice/all/test_package/conanfile.py
@@ -11,7 +11,8 @@ class LibniceTestConan(ConanFile):
     test_type = "explicit"
 
     def requirements(self):
-        self.requires(tested_reference_str)
+        self.requires(self.tested_reference_str)
+        
     def build_requirements(self):
         self.tool_requires("meson/0.64.1")
         self.tool_requires("pkgconf/1.9.3")

--- a/recipes/libnice/all/test_package/conanfile.py
+++ b/recipes/libnice/all/test_package/conanfile.py
@@ -1,0 +1,28 @@
+import os
+from conan import ConanFile
+from conans import tools
+from conan.tools.meson import Meson
+from conan.tools.layout import basic_layout
+
+
+class LibniceTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "PkgConfigDeps", "MesonToolchain"
+    apply_env = False
+
+    def build_requirements(self):
+        self.build_requires("meson/0.64.1")
+        self.build_requires("pkgconf/1.9.3")
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
+
+    def layout(self):
+        basic_layout(self)
+
+    def test(self):
+        if not tools.cross_building(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "example")
+            self.run(cmd, run_environment=True, env="conanrun")

--- a/recipes/libnice/all/test_package/meson.build
+++ b/recipes/libnice/all/test_package/meson.build
@@ -1,0 +1,3 @@
+project('Testlibnice', 'c')
+libnice = dependency('libnice', version : '>=0.1')
+executable('example', 'src/example.c', dependencies: libnice)

--- a/recipes/libnice/all/test_package/meson.build
+++ b/recipes/libnice/all/test_package/meson.build
@@ -1,3 +1,0 @@
-project('Testlibnice', 'c')
-libnice = dependency('libnice', version : '>=0.1')
-executable('example', 'src/example.c', dependencies: libnice)

--- a/recipes/libnice/all/test_package/src/example.c
+++ b/recipes/libnice/all/test_package/src/example.c
@@ -1,0 +1,7 @@
+#include <nice/agent.h>
+
+int main()
+{
+    NiceAgent *agent = nice_agent_new(NULL, NICE_COMPATIBILITY_RFC5245);
+    g_object_unref(agent);
+}

--- a/recipes/libnice/all/test_v1_package/CMakeLists.txt
+++ b/recipes/libnice/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/libnice/all/test_v1_package/conanfile.py
+++ b/recipes/libnice/all/test_v1_package/conanfile.py
@@ -1,0 +1,24 @@
+import os
+from conan import ConanFile
+from conans import Meson
+from conan.tools.build import cross_building
+
+
+class LibniceTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "pkg_config"
+        
+    def build_requirements(self):
+        self.tool_requires("meson/0.64.1")
+        self.tool_requires("pkgconf/1.9.3")
+        self.tool_requires("meson/0.64.1")
+
+    def build(self):
+        meson = Meson(self)
+        meson.configure(build_folder="bin", source_folder="../test_package")
+        meson.build()
+
+    def test(self):
+        if not cross_building(self, skip_x64_x86=True):
+            cmd = os.path.join("bin", "example")
+            self.run(cmd, run_environment=True)

--- a/recipes/libnice/all/test_v1_package/conanfile.py
+++ b/recipes/libnice/all/test_v1_package/conanfile.py
@@ -1,24 +1,19 @@
 import os
 from conan import ConanFile
-from conans import Meson
+from conans import CMake
 from conan.tools.build import cross_building
 
 
 class LibniceTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "pkg_config"
-        
-    def build_requirements(self):
-        self.tool_requires("meson/0.64.1")
-        self.tool_requires("pkgconf/1.9.3")
-        self.tool_requires("meson/0.64.1")
+    generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
-        meson = Meson(self)
-        meson.configure(build_folder="bin", source_folder="../test_package")
-        meson.build()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
-        if not cross_building(self, skip_x64_x86=True):
-            cmd = os.path.join("bin", "example")
-            self.run(cmd, run_environment=True)
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)

--- a/recipes/libnice/all/test_v1_package/conanfile.py
+++ b/recipes/libnice/all/test_v1_package/conanfile.py
@@ -1,7 +1,7 @@
 import os
 from conan import ConanFile
 from conans import CMake
-from conan.tools.build import cross_building
+from conan.tools.build import can_run
 
 
 class LibniceTestConan(ConanFile):
@@ -14,6 +14,6 @@ class LibniceTestConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not cross_building(self):
+        if can_run(self):
             bin_path = os.path.join("bin", "example")
             self.run(bin_path, run_environment=True)

--- a/recipes/libnice/config.yml
+++ b/recipes/libnice/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.19":
+    folder: all

--- a/recipes/libnice/config.yml
+++ b/recipes/libnice/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1.19":
+  "0.1.21":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **libnice/0.1.19**

libnice is is a library that implements the Interactive Connectivity Establishment (ICE) standard ([RFC 5245](https://tools.ietf.org/html/rfc5245) & [RFC 8445](https://tools.ietf.org/html/rfc8445)). It provides a GLib-based library, libnice, as well as [GStreamer](http://gstreamer.freedesktop.org/) elements to use it.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
