### PR TITLE
[ci] Bump c3i conan version to 1.56.0

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -3,7 +3,7 @@
 id: 'conan-io/conan-center-index'
 
 conan:
-  version: 1.54.0
+  version: 1.56.0
 
 artifactory:
   url: "https://c3i.jfrog.io/c3i"


### PR DESCRIPTION
Bump c3i conan version to 1.56.0 to support modernizing recipes.

This is necessary to support #13896

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
