### PR TITLE
Revert "[config] Use larger resources to build cppfront packages"

### DIFF
--- a/.c3i/config_v1.yml
+++ b/.c3i/config_v1.yml
@@ -188,7 +188,6 @@ pod_size:
   large:
     - "pcl"
     - "duckdb"
-    - "cppfront"
   xlarge:
     - "llvm"
     - "opengv"


### PR DESCRIPTION
Reverts conan-io/conan-center-index#14221

This is not needed as the lib couldn't build due to a compiler bug.