### PR TITLE
pkgconf: Fix min required version syntax so proper errors are logged in ci

### DIFF
--- a/recipes/pkgconf/all/conanfile.py
+++ b/recipes/pkgconf/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 import functools
 import os
 
-required_conan_version = ">= 1.36.0"
+required_conan_version = ">=1.36.0"
 
 
 class PkgConfConan(ConanFile):


### PR DESCRIPTION
Minor change so the real errors show up in @prince-chrismc's top 100 action.

CI errors are expected and they were already there. This just makes those visible