### PR TITLE
Prepare zulu-openjdk for 2.0, remove old patch version

### DIFF
--- a/recipes/zulu-openjdk/all/conandata.yml
+++ b/recipes/zulu-openjdk/all/conandata.yml
@@ -19,7 +19,7 @@ sources:
         "url": "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-macosx_x64.tar.gz",
         "sha256": "0b8c8b7cf89c7c55b7e2239b47201d704e8d2170884875b00f3103cf0662d6d7",
       }
-      "armv8" : {
+      "armv8": {
         "url": "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-macosx_aarch64.tar.gz",
         "sha256": "e908a0b4c0da08d41c3e19230f819b364ff2e5f1dafd62d2cf991a85a34d3a17",
       }
@@ -44,7 +44,7 @@ sources:
         "url": "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-macosx_x64.tar.gz",
         "sha256": "2614e5c5de8e989d4d81759de4c333aa5b867b17ab9ee78754309ba65c7f6f55",
       }
-      "armv8" : {
+      "armv8": {
         "url": "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-macosx_aarch64.tar.gz",
         "sha256": "6bb0d2c6e8a29dcd9c577bbb2986352ba12481a9549ac2c0bcfd00ed60e538d2",
       }

--- a/recipes/zulu-openjdk/all/conandata.yml
+++ b/recipes/zulu-openjdk/all/conandata.yml
@@ -1,18 +1,4 @@
 sources:
-  "11.0.8":
-    "Windows": {
-      "url": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-win_x64.zip",
-      "sha256": "3602ed7bae52898c540c2d3ae3230c081cf061b219d14fb9ac15a47f4226d307",
-    }
-    "Linux": {
-      "url": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-linux_x64.tar.gz",
-      "sha256": "f8aee4ab30ca11ab3c8f401477df0e455a9d6b06f2710b2d1b1ddcf06067bc79",
-    }
-    "Macos": {
-      "url": "https://cdn.azul.com/zulu/bin/zulu11.41.23-ca-jdk11.0.8-macosx_x64.tar.gz",
-      "sha256": "1ed070ea9a27030bcca4d7c074dec1d205d3f3506166d36faf4d1b9e083ab365",
-    }
-
   "11.0.12":
     "Windows":
       "x86_64": {

--- a/recipes/zulu-openjdk/all/conandata.yml
+++ b/recipes/zulu-openjdk/all/conandata.yml
@@ -1,50 +1,40 @@
 sources:
   "11.0.12":
     "Windows":
-      "x86_64": {
-        "url": "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-win_x64.zip",
-        "sha256": "42ae65e75d615a3f06a674978e1fa85fdf078cad94e553fee3e779b2b42bb015",
-      }
+      "x86_64":
+        url: "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-win_x64.zip"
+        sha256: "42ae65e75d615a3f06a674978e1fa85fdf078cad94e553fee3e779b2b42bb015"
     "Linux":
-      "x86_64": {
-        "url": "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-linux_x64.tar.gz",
-        "sha256": "b8e8a63b79bc312aa90f3558edbea59e71495ef1a9c340e38900dd28a1c579f3",
-      }
-      "armv8": {
-        "url": "https://cdn.azul.com/zulu-embedded/bin/zulu11.50.19-ca-jdk11.0.12-linux_aarch64.tar.gz",
-        "sha256": "61254688067454d3ccf0ef25993b5dcab7b56c8129e53b73566c28a8dd4d48fb",
-      }
+      "x86_64":
+        url: "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-linux_x64.tar.gz"
+        sha256: "b8e8a63b79bc312aa90f3558edbea59e71495ef1a9c340e38900dd28a1c579f3"
+      "armv8":
+        url: "https://cdn.azul.com/zulu-embedded/bin/zulu11.50.19-ca-jdk11.0.12-linux_aarch64.tar.gz"
+        sha256: "61254688067454d3ccf0ef25993b5dcab7b56c8129e53b73566c28a8dd4d48fb"
     "Macos":
-      "x86_64": {
-        "url": "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-macosx_x64.tar.gz",
-        "sha256": "0b8c8b7cf89c7c55b7e2239b47201d704e8d2170884875b00f3103cf0662d6d7",
-      }
-      "armv8": {
-        "url": "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-macosx_aarch64.tar.gz",
-        "sha256": "e908a0b4c0da08d41c3e19230f819b364ff2e5f1dafd62d2cf991a85a34d3a17",
-      }
+      "x86_64":
+        url: "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-macosx_x64.tar.gz"
+        sha256: "0b8c8b7cf89c7c55b7e2239b47201d704e8d2170884875b00f3103cf0662d6d7"
+      "armv8":
+        url: "https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jdk11.0.12-macosx_aarch64.tar.gz"
+        sha256: "e908a0b4c0da08d41c3e19230f819b364ff2e5f1dafd62d2cf991a85a34d3a17"
 
   "11.0.15":
     "Windows":
-      "x86_64": {
-        "url": "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-win_x64.zip",
-        "sha256": "a106c77389a63b6bd963a087d5f01171bd32aa3ee7377ecef87531390dcb9050",
-      }
+      "x86_64":
+        url: "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-win_x64.zip"
+        sha256: "a106c77389a63b6bd963a087d5f01171bd32aa3ee7377ecef87531390dcb9050"
     "Linux":
-      "x86_64": {
-        "url": "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-linux_x64.tar.gz",
-        "sha256": "e064b61d93304012351242bf0823c6a2e41d9e28add7ea7f05378b7243d34247",
-      }
-      "armv8": {
-        "url": "https://cdn.azul.com/zulu-embedded/bin/zulu11.56.19-ca-jdk11.0.15-linux_aarch64.tar.gz",
-        "sha256": "fc7c41a0005180d4ca471c90d01e049469e0614cf774566d4cf383caa29d1a97",
-      }
+      "x86_64":
+        url: "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-linux_x64.tar.gz"
+        sha256: "e064b61d93304012351242bf0823c6a2e41d9e28add7ea7f05378b7243d34247"
+      "armv8":
+        url: "https://cdn.azul.com/zulu-embedded/bin/zulu11.56.19-ca-jdk11.0.15-linux_aarch64.tar.gz"
+        sha256: "fc7c41a0005180d4ca471c90d01e049469e0614cf774566d4cf383caa29d1a97"
     "Macos":
-      "x86_64": {
-        "url": "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-macosx_x64.tar.gz",
-        "sha256": "2614e5c5de8e989d4d81759de4c333aa5b867b17ab9ee78754309ba65c7f6f55",
-      }
-      "armv8": {
-        "url": "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-macosx_aarch64.tar.gz",
-        "sha256": "6bb0d2c6e8a29dcd9c577bbb2986352ba12481a9549ac2c0bcfd00ed60e538d2",
-      }
+      "x86_64":
+        url: "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-macosx_x64.tar.gz"
+        sha256: "2614e5c5de8e989d4d81759de4c333aa5b867b17ab9ee78754309ba65c7f6f55"
+      "armv8":
+        url: "https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-macosx_aarch64.tar.gz"
+        sha256: "6bb0d2c6e8a29dcd9c577bbb2986352ba12481a9549ac2c0bcfd00ed60e538d2"

--- a/recipes/zulu-openjdk/all/conanfile.py
+++ b/recipes/zulu-openjdk/all/conanfile.py
@@ -1,7 +1,8 @@
-from conans import ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
-from conans.tools import Version
-import os, glob
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import get, copy
 
 
 class ZuluOpenJDK(ConanFile):
@@ -11,11 +12,8 @@ class ZuluOpenJDK(ConanFile):
     homepage = "https://www.azul.com"
     license = "https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-terms-of-use/"
     topics = ("java", "jdk", "openjdk")
-    settings = "os", "arch", "build_type", "compiler"
-
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    settings = "os", "arch"
+    package_type = "application"
 
     @property
     def _settings_build(self):
@@ -26,42 +24,39 @@ class ZuluOpenJDK(ConanFile):
         folder = {"Linux": "linux", "Macos": "darwin", "Windows": "win32"}.get(str(self._settings_build.os))
         return os.path.join("include", folder)
 
-    def package_id(self):
-        del self.info.settings.build_type
-        del self.info.settings.compiler
 
     def validate(self):
-        if Version(self.version) < Version("11.0.12"):
-            supported_archs = ["x86_64"]
-            if self._settings_build.arch not in supported_archs:
-                raise ConanInvalidConfiguration(f"Unsupported Architecture ({self._settings_build.arch}). The version {self.version} currently only supports {supported_archs}.")
-        elif Version(self.version) >= Version("11.0.12"):
-            supported_archs = ["x86_64", "armv8"]
-            if self._settings_build.arch not in supported_archs:
-                raise ConanInvalidConfiguration(f"Unsupported Architecture ({self._settings_build.arch}). This version {self.version} currently only supports {supported_archs}.")
+        supported_archs = ["x86_64", "armv8"]
+        if self._settings_build.arch not in supported_archs:
+            raise ConanInvalidConfiguration(f"Unsupported Architecture ({self._settings_build.arch}). "
+                                             "This version {self.version} currently only supports {supported_archs}.")
         supported_os = ["Windows", "Macos", "Linux"]
         if self._settings_build.os not in supported_os:
-            raise ConanInvalidConfiguration(f"Unsupported os ({self._settings_build.os}). This package currently only support {supported_os}.")
+            raise ConanInvalidConfiguration(f"Unsupported os ({self._settings_build.os}). "
+                                             "This package currently only support {supported_os}.")
 
     def build(self):
-        if Version(self.version) < Version("11.0.12"):
-            tools.get(**self.conan_data["sources"][self.version][str(self._settings_build.os)],
-                    destination=self._source_subfolder, strip_root=True)
-        else:
-            tools.get(**self.conan_data["sources"][self.version][str(self._settings_build.os)][str(self._settings_build.arch)],
-                    destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version][str(self._settings_build.os)][str(self._settings_build.arch)], strip_root=True)
 
     def package(self):
-        self.copy(pattern="*", dst="bin", src=os.path.join(self._source_subfolder, "bin"), excludes=("msvcp140.dll", "vcruntime140.dll"))
-        self.copy(pattern="*", dst="include", src=os.path.join(self._source_subfolder, "include"))
-        self.copy(pattern="*", dst="lib", src=os.path.join(self._source_subfolder, "lib"))
-        self.copy(pattern="*", dst="res", src=os.path.join(self._source_subfolder, "conf"))
+        copy(self, pattern="*", dst=os.path.join(self.package_folder, "bin"),
+             src=os.path.join(self.source_folder, "bin"), 
+             excludes=("msvcp140.dll", "vcruntime140.dll"))
+        copy(self, pattern="*", dst=os.path.join(self.package_folder, "include"), 
+             src=os.path.join(self.source_folder, "include"))
+        copy(self, pattern="*", dst=os.path.join(self.package_folder, "lib"), 
+             src=os.path.join(self.source_folder, "lib"))
+        copy(self, pattern="*", dst=os.path.join(self.package_folder, "res"), 
+             src=os.path.join(self.source_folder, "conf"))
         # conf folder is required for security settings, to avoid
         # java.lang.SecurityException: Can't read cryptographic policy directory: unlimited
         # https://github.com/conan-io/conan-center-index/pull/4491#issuecomment-774555069
-        self.copy(pattern="*", dst="conf", src=os.path.join(self._source_subfolder, "conf"))
-        self.copy(pattern="*", dst="licenses", src=os.path.join(self._source_subfolder, "legal"))
-        self.copy(pattern="*", dst=os.path.join("lib", "jmods"), src=os.path.join(self._source_subfolder, "jmods"))
+        copy(self, pattern="*", dst=os.path.join(self.package_folder, "conf"), 
+             src=os.path.join(self.source_folder, "conf"))
+        copy(self, pattern="*", dst=os.path.join(self.package_folder, "licenses"), 
+             src=os.path.join(self.source_folder, "legal"))
+        copy(self, pattern="*", dst=os.path.join(self.package_folder, "lib", "jmods"), 
+             src=os.path.join(self.source_folder, "jmods"))
 
     def package_info(self):
         self.cpp_info.includedirs.append(self._jni_folder)
@@ -72,6 +67,8 @@ class ZuluOpenJDK(ConanFile):
 
         self.output.info("Creating JAVA_HOME environment variable with : {0}".format(java_home))
         self.env_info.JAVA_HOME = java_home
+        self.buildenv_info.define_path("JAVA_HOME", java_home)
+        self.runenv_info.define_path("JAVA_HOME", java_home)
 
         self.output.info("Appending PATH environment variable with : {0}".format(bin_path))
         self.env_info.PATH.append(bin_path)

--- a/recipes/zulu-openjdk/all/test_package/conanfile.py
+++ b/recipes/zulu-openjdk/all/test_package/conanfile.py
@@ -1,26 +1,29 @@
-from conans import ConanFile, tools
+from conan import ConanFile
+from conan.tools.build import cross_building
 from io import StringIO
 
 
 class TestPackage(ConanFile):
     settings = "os", "arch"
+    test_type = "explicit"
+    generators = "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         pass # nothing to build, but tests should not warn
 
     def test(self):
-        if tools.cross_building(self):
+        if cross_building(self):
             return
             # OK, this needs some explanation
             # You basically do not crosscompile that package, never
             # But C3I does, Macos x86_64 to M1,
             # and this is why there is some cross compilation going on
             # The test will not work in that environment, so .... don't test
-        test_cmd = ['java', '--version']
         output = StringIO()
-        self.run(test_cmd, output=output, run_environment=True)
+        self.run("java --version", output, env="conanrun")
         version_info = output.getvalue()
-        if "Zulu" in version_info:
-            pass
-        else:
+        if "Zulu" not in version_info:
             raise Exception("java call seems not use the Zulu bin")

--- a/recipes/zulu-openjdk/all/test_v1_package/conanfile.py
+++ b/recipes/zulu-openjdk/all/test_v1_package/conanfile.py
@@ -1,0 +1,29 @@
+from conan import ConanFile
+from conan.tools.build import cross_building
+from io import StringIO
+
+
+class TestPackage(ConanFile):
+    settings = "os", "arch"
+    test_type = "explicit"
+    generators = "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        pass # nothing to build, but tests should not warn
+
+    def test(self):
+        if cross_building(self):
+            return
+            # OK, this needs some explanation
+            # You basically do not crosscompile that package, never
+            # But C3I does, Macos x86_64 to M1,
+            # and this is why there is some cross compilation going on
+            # The test will not work in that environment, so .... don't test
+        output = StringIO()
+        self.run("java --version", output, env="conanrun")
+        version_info = output.getvalue()
+        if "Zulu" not in version_info:
+            raise Exception("java call seems not use the Zulu bin")

--- a/recipes/zulu-openjdk/config.yml
+++ b/recipes/zulu-openjdk/config.yml
@@ -1,6 +1,4 @@
 versions:
-  "11.0.8":
-    folder: all
   "11.0.12":
     folder: all
   "11.0.15":


### PR DESCRIPTION
Specify library name and version:  **zulu-openjdk/all**

- Modernizing the recipe to be 2.0 compatible. Tested locally in Win with 1.55 and 2.0
- Removing old patch 11.0.8, it is a patch version, old enough, and allows simplifying a bit the recipe
- Minor updates to the recipe, like removing unnecessary settings
- 
---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
