### PR TITLE
mbits-args: Deprecate missing CMake variable

### DIFF
--- a/recipes/mbits-args/all/conanfile.py
+++ b/recipes/mbits-args/all/conanfile.py
@@ -86,6 +86,7 @@ class MBitsArgsConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["LIBARGS_TESTING"] = False
         tc.variables["LIBARGS_INSTALL"] = True
+        tc.cache_variables["LIBARGS_SHARED"] = self.options.shared
         tc.generate()
 
     def build(self):

--- a/recipes/mbits-args/all/conanfile.py
+++ b/recipes/mbits-args/all/conanfile.py
@@ -83,6 +83,9 @@ class MBitsArgsConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def configure(self):
+        # Hush the hooks
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
         if self.options.shared != "deprecated":
             self.output.warning("shared option is deprecated. This recipe only builds in static mode")
 

--- a/recipes/mbits-args/all/conanfile.py
+++ b/recipes/mbits-args/all/conanfile.py
@@ -37,7 +37,7 @@ class MBitsArgsConan(ConanFile):
     )
     settings = "os", "compiler", "build_type", "arch"
     options = {"fPIC": [True, False], "shared": [True, False, "deprecated"]}
-    default_options = {"fPIC": True}
+    default_options = {"fPIC": True, "shared": "deprecated"}
 
     @property
     def _min_cppstd(self):

--- a/recipes/mbits-args/all/conanfile.py
+++ b/recipes/mbits-args/all/conanfile.py
@@ -36,7 +36,7 @@ class MBitsArgsConan(ConanFile):
         "argument-parsing",
     )
     settings = "os", "compiler", "build_type", "arch"
-    options = {"fPIC": [True, False]}
+    options = {"fPIC": [True, False], "shared": [True, False, "deprecated"]}
     default_options = {"fPIC": True}
 
     @property
@@ -82,11 +82,14 @@ class MBitsArgsConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
+    def configure(self):
+        if self.options.shared != "deprecated":
+            self.output.warning("shared option is deprecated. This recipe only builds in static mode")
+
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["LIBARGS_TESTING"] = False
         tc.variables["LIBARGS_INSTALL"] = True
-        tc.cache_variables["LIBARGS_SHARED"] = self.options.shared
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
~~Specify library name and version:  **mbits-args/**
#14866 added conan v2 support to this library, but in the process a cmake cache variable was missed and is now missing. This adds the variable back. Thanks to @uilianries for guiding me thru his process while checking if this was a bug or not :)~~

We just saw that the plan is to remove support for shared builds in the library. As per CCI policy, this should first be marked as deprecated instead of removed