### PR TITLE
[linter] Fix vs_layout has no folder param. Adds bazel_layout

### DIFF
--- a/linter/check_layout_src_folder.py
+++ b/linter/check_layout_src_folder.py
@@ -32,7 +32,7 @@ class LayoutSrcFolder(BaseChecker):
         if not isinstance(node.func, nodes.Name):
             return
 
-        if node.func.name in ["cmake_layout", "vs_layout", "basic_layout"]:
+        if node.func.name in ["cmake_layout", "bazel_layout", "basic_layout"]:
             for kw in node.keywords:
                 if kw.arg == "src_folder":
                     if not kw.value or kw.value.as_string().strip("\"'") != "src":


### PR DESCRIPTION
Related to https://github.com/conan-io/conan-center-index/pull/14959

bazel_layout is still not documented but it is indeed in conan v2 since https://github.com/conan-io/conan/pull/10812/files

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
