### PR TITLE
dcmtk: Allow enabling/disabling stl via new option

### DIFF
--- a/recipes/dcmtk/all/conanfile.py
+++ b/recipes/dcmtk/all/conanfile.py
@@ -33,6 +33,7 @@ class DCMTKConan(ConanFile):
         "builtin_private_tags": [True, False],
         "external_dictionary": [None, True, False],
         "wide_io": [True, False],
+        "enable_stl": [True, False],
     }
     default_options = {
         "shared": False,
@@ -50,6 +51,7 @@ class DCMTKConan(ConanFile):
         "builtin_private_tags": False,
         "external_dictionary": None,
         "wide_io": False,
+        "enable_stl": True,
     }
 
     generators = "cmake", "cmake_find_package"
@@ -146,7 +148,10 @@ class DCMTKConan(ConanFile):
         if self.options.with_zlib:
             cmake.definitions["WITH_ZLIBINC"] = self.deps_cpp_info["zlib"].rootpath
 
-        cmake.definitions["DCMTK_ENABLE_STL"] = "ON"
+        if self.options.enable_stl:
+            cmake.definitions["DCMTK_ENABLE_STL"] = "ON"
+        else:
+            cmake.definitions["DCMTK_ENABLE_STL"] = "OFF"
         cmake.definitions["DCMTK_ENABLE_CXX11"] = True
 
         cmake.definitions["DCMTK_ENABLE_MANPAGE"] = False

--- a/recipes/dcmtk/all/test_package/conanfile.py
+++ b/recipes/dcmtk/all/test_package/conanfile.py
@@ -1,8 +1,11 @@
-from conans import ConanFile, CMake, tools
+from conans import CMake
+from conan import ConanFile
+from conan.tools.build import cross_building
 import os
 
 
 class TestPackageConan(ConanFile):
+    name = "dcmtk-test-package-conan"
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 
@@ -12,6 +15,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
+        if not cross_building(self):
             bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)

--- a/recipes/dcmtk/all/test_package/conanfile.py
+++ b/recipes/dcmtk/all/test_package/conanfile.py
@@ -5,7 +5,6 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    name = "dcmtk-test-package-conan"
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"
 


### PR DESCRIPTION
Specify library name and version:  **dcmtk/all**

PR [11126](https://github.com/conan-io/conan-center-index/pull/11126) makes the recipe build with `DCMTK_ENABLE_STL` set to `ON`, however, there is no option to disable building with stl.  This PR allows disabling stl in builds.

dcmtk builds with stl enabled will define the dcmtk type `OFString` as `std::string` (instead of using the dcmtk definition).  This breaks consumers who forward declare `OFString`.


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
