### PR TITLE
docs: remove PEP8 formating request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,5 @@ Specify library name and version:  **lib/1.0**
 ---
 
 - [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
-- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
 - [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
 - [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.


### PR DESCRIPTION
https://peps.python.org/pep-0008/#maximum-line-length This is the least followed thing in PRs so it seems a bit misleading to ask people to do this extra since it creates a lot of changes.