### PR TITLE
vulkan-loader: avoid to rely on CMake 3.16 features

### DIFF
--- a/recipes/vulkan-loader/all/conandata.yml
+++ b/recipes/vulkan-loader/all/conandata.yml
@@ -51,17 +51,20 @@ sources:
     url: "https://github.com/KhronosGroup/Vulkan-Loader/archive/sdk-1.2.154.0.tar.gz"
     sha256: "418017d7bab907e72291476df231dd0e7dc7fe20b97e55389c975bcfc48d6433"
 patches:
+  "1.3.236.0":
+    - patch_file: "patches/1.3.236.0-0001-cmake-minimum-required-3.10.patch"
+      patch_description: "Do not use features of CMake 3.16, back to 3.10 as min version"
+      patch_type: "portability"
+      patch_source: "https://github.com/KhronosGroup/Vulkan-Loader/pull/1102"
   "1.3.231.1":
     - patch_file: "patches/1.3.231.1-0001-no-find-package-wayland.patch"
       patch_description: "CMake: remove attempt to find Wayland"
       patch_type: "portability"
       patch_source: "https://github.com/KhronosGroup/Vulkan-Loader/pull/1020"
-      sha256: "f08b35f57884624fea618405affff17215cd747740bbce11af53a69911b48452"
   "1.2.182":
     - patch_file: "patches/1.2.182-0001-fix-mingw.patch"
       patch_description: "Fix MinGW"
       patch_type: "portability"
-      sha256: "a05375c60b7f4a91f48df2278518be27e578e38190034bfcc887e5ceaa289c25"
   "1.2.154.0":
     - patch_file: "patches/1.2.154.0-0001-fix-mingw.patch"
       patch_description: "Fix MinGW"
@@ -70,4 +73,3 @@ patches:
         - "https://github.com/KhronosGroup/Vulkan-Loader/pull/475"
         - "https://github.com/KhronosGroup/Vulkan-Loader/pull/495"
         - "https://github.com/KhronosGroup/Vulkan-Loader/pull/523"
-      sha256: "034e4252276fde22f14630d36404338dc3fa08ebf8fe7d5affe9065e0239f165"

--- a/recipes/vulkan-loader/all/conanfile.py
+++ b/recipes/vulkan-loader/all/conanfile.py
@@ -87,25 +87,11 @@ class VulkanLoaderConan(ConanFile):
         if self.dependencies["vulkan-headers"].ref.version != self.version:
             self.output.warn("vulkan-loader should be built & consumed with the same version than vulkan-headers.")
 
-    def _cmake_new_enough(self, required_version):
-        try:
-            import re
-            from io import StringIO
-            output = StringIO()
-            self.run("cmake --version", output=output)
-            m = re.search(r"cmake version (\d+\.\d+\.\d+)", output.getvalue())
-            return Version(m.group(1)) >= required_version
-        except:
-            return False
-
     def build_requirements(self):
         if self._is_pkgconf_needed:
             self.tool_requires("pkgconf/1.9.3")
         if self._is_mingw:
             self.tool_requires("jwasm/2.13")
-        # see https://github.com/KhronosGroup/Vulkan-Loader/issues/1095#issuecomment-1352420456
-        if Version(self.version) >= "1.3.232" and not self._cmake_new_enough("3.16"):
-            self.tool_requires("cmake/3.25.0")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],

--- a/recipes/vulkan-loader/all/patches/1.3.236.0-0001-cmake-minimum-required-3.10.patch
+++ b/recipes/vulkan-loader/all/patches/1.3.236.0-0001-cmake-minimum-required-3.10.patch
@@ -1,0 +1,24 @@
+--- a/loader/CMakeLists.txt
++++ b/loader/CMakeLists.txt
+@@ -160,9 +160,7 @@ if(WIN32)
+         target_link_libraries(asm_offset PRIVATE loader_specific_options)
+         # If not cross compiling, run asm_offset to generage gen_defines.asm
+         if (NOT CMAKE_CROSSCOMPILING)
+-            add_custom_command(TARGET asm_offset POST_BUILD
+-                COMMAND asm_offset MASM
+-                BYPRODUCTS gen_defines.asm)
++            add_custom_command(OUTPUT gen_defines.asm DEPENDS asm_offset COMMAND asm_offset MASM)
+         else()
+             # Forces compiler to write the intermediate asm file, needed so that we can get sizeof/offset of info out of it.
+             target_compile_options(asm_offset PRIVATE "/Fa$<TARGET_FILE_DIR:asm_offset>/asm_offset.asm" /FA)
+@@ -236,9 +234,7 @@ else() # i.e.: Linux
+         target_link_libraries(asm_offset loader_specific_options)
+         # If not cross compiling, run asm_offset to generage gen_defines.asm
+         if (NOT CMAKE_CROSSCOMPILING)
+-            add_custom_command(TARGET asm_offset POST_BUILD
+-                COMMAND asm_offset GAS
+-                BYPRODUCTS gen_defines.asm)
++            add_custom_command(OUTPUT gen_defines.asm DEPENDS asm_offset COMMAND asm_offset GAS)
+         else()
+             # Forces compiler to write the intermediate asm file, needed so that we can get sizeof/offset of info out of it.
+             target_compile_options(asm_offset PRIVATE -save-temps=obj)


### PR DESCRIPTION
backport an upstream fix https://github.com/KhronosGroup/Vulkan-Loader/pull/1102, instead of adding CMake 3.16 to build requirements, since Vulkan-Loader maintainers seem to want to ensure that it can be built with CMake 3.10

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
