### PR TITLE
docs: Adjust PR template to say current client version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,5 @@ Specify library name and version:  **lib/1.0**
 ---
 
 - [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
-- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/prince-chrismc/conan-center-index/blob/docs/recent-client/.c3i/config_v1.yml#L6).
+- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/docs/recent-client/.c3i/config_v1.yml#L6).
 - [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,5 @@ Specify library name and version:  **lib/1.0**
 ---
 
 - [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
-- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
+- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/prince-chrismc/conan-center-index/blob/docs/recent-client/.c3i/config_v1.yml#L6).
 - [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

--- a/docs/adding_packages/README.md
+++ b/docs/adding_packages/README.md
@@ -53,7 +53,7 @@ The specific steps to add new packages are:
 
 * Fork the [conan-center-index](https://github.com/conan-io/conan-center-index) git repository, and then clone it locally.
 * Copy a template from [package_templates](../package_templates) folder in the recipes/ folder and rename it to the project name (it should be lower-case). Read templates [documentation](../package_templates/README.md) to find more information.
-* Make sure you are using the latest [Conan client](https://conan.io/downloads) version, as recipes might evolve introducing features of the newer Conan releases.
+* Make sure you are using a recent [Conan client](https://conan.io/downloads) version, as recipes might evolve introducing features of the newer Conan releases.
 * Commit and Push to GitHub then submit a pull request.
 * Our automated build service will build 100+ different configurations, and provide messages that indicate if there were any issues found during the pull request on GitHub.
 


### PR DESCRIPTION
we have moved away from being on the bleeding edge and no longer keep the "available in ConanCenter's build service" to the latest as aggressively and are generally 1 behind to encourage stability
