### PR TITLE
itlib: add version 1.8.0

### DIFF
--- a/recipes/itlib/all/conandata.yml
+++ b/recipes/itlib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.0":
+    url: "https://github.com/iboB/itlib/archive/v1.8.0.tar.gz"
+    sha256: "70b6493b0cc3a720ffd48e98e3f009e8d94003380800bf07e61f167e813a9add"
   "1.7.0":
     url: "https://github.com/iboB/itlib/archive/v1.7.0.tar.gz"
     sha256: "9a27138cfa8554eb69436bb1afacfafc5a3888b6e05f9124b2d20da7ab55b723"

--- a/recipes/itlib/config.yml
+++ b/recipes/itlib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.0":
+    folder: all
   "1.7.0":
     folder: all
   "1.6.3":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **itlib/1.8.0**

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/docs/recent-client/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
