### PR TITLE
tuplet: add version 2.1.0

### DIFF
--- a/recipes/tuplet/all/conandata.yml
+++ b/recipes/tuplet/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.1.0":
+    url: "https://github.com/codeinred/tuplet/archive/v2.1.0.tar.gz"
+    sha256: "e77503b81259c4d67d1b16b887b9ab778422e2ffc031d2171b5117d2fddb237c"
   "2.0.0":
     url: "https://github.com/codeinred/tuplet/archive/refs/tags/v2.0.0.tar.gz"
     sha256: "cb754d119ca9d0a17ef165624d2c856b86eed9451bc8bc5c17b41410177a8d9f"

--- a/recipes/tuplet/config.yml
+++ b/recipes/tuplet/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.1.0":
+    folder: all
   "2.0.0":
     folder: all
   "1.2.2":


### PR DESCRIPTION
Generated and committed by [Conan Center Bot](https://github.com/qchateau/conan-center-bot) Find more updatable recipes in the [GitHub Pages](https://qchateau.github.io/conan-center-bot/)

Specify library name and version:  **tuplet/2.1.0**


---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/docs/recent-client/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
