### PR TITLE
plog: add version 1.1.9, support conan v2

### DIFF
--- a/recipes/plog/all/conandata.yml
+++ b/recipes/plog/all/conandata.yml
@@ -5,4 +5,3 @@ sources:
   "1.1.5":
     url: "https://github.com/SergiusTheBest/plog/archive/1.1.5.tar.gz"
     sha256: "6c80b4701183d2415bec927e1f5ca9b1761b3b5c65d3e09fb29c743e016d5609"
-

--- a/recipes/plog/all/conandata.yml
+++ b/recipes/plog/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.9":
+    url: "https://github.com/SergiusTheBest/plog/archive/1.1.9.tar.gz"
+    sha256: "058315b9ec9611b659337d4333519ab4783fad3f2f23b1cc7bb84d977ea38055"
   "1.1.5":
     url: "https://github.com/SergiusTheBest/plog/archive/1.1.5.tar.gz"
     sha256: "6c80b4701183d2415bec927e1f5ca9b1761b3b5c65d3e09fb29c743e016d5609"

--- a/recipes/plog/all/conanfile.py
+++ b/recipes/plog/all/conanfile.py
@@ -1,28 +1,37 @@
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
 import os
-from conans import ConanFile, tools
 
+required_conan_version = ">=1.52.0"
 
 class PlogConan(ConanFile):
     name = "plog"
     description = "Pretty powerful logging library in about 1000 lines of code"
-    homepage = "https://github.com/SergiusTheBest/plog"
-    url = "https://github.com/conan-io/conan-center-index"
     license = "MPL-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/SergiusTheBest/plog"
     topics = ("logging", "header-only", "portable")
     no_copy_source = True
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
-
-    def source(self):
-        tools.get(**self.conan_data["sources"][self.version])
-        extracted_dir = self.name + "-" + self.version
-        os.rename(extracted_dir, self._source_subfolder)
-
-    def package(self):
-        self.copy(pattern="LICENSE", dst="licenses", src=self._source_subfolder)
-        self.copy("*.h", src=os.path.join(self._source_subfolder, "include"), dst=os.path.join("include"))
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
-        self.info.header_only()
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="*.h",
+            dst=os.path.join(self.package_folder, "include"),
+            src=os.path.join(self.source_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/plog/all/test_package/CMakeLists.txt
+++ b/recipes/plog/all/test_package/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package)
+project(test_package LANGUAGES CXX)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(plog REQUIRED CONFIG)
 
 add_executable(${CMAKE_PROJECT_NAME} test_package.cpp)
-target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE plog::plog)
+
+if(plog_VERSION VERSION_GREATER_EQUAL "1.1.6")
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE -DPLOG_EXPLICIT_INIT)
+endif()

--- a/recipes/plog/all/test_package/conanfile.py
+++ b/recipes/plog/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)
@@ -12,7 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self.settings):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
-
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/plog/all/test_package/test_package.cpp
+++ b/recipes/plog/all/test_package/test_package.cpp
@@ -1,6 +1,9 @@
 #include <iostream>
 
 #include <plog/Log.h>
+#ifdef PLOG_EXPLICIT_INIT
+#  include <plog/Initializers/RollingFileInitializer.h>
+#endif
 
 int main() {
     plog::init(plog::debug, "log.txt");

--- a/recipes/plog/all/test_v1_package/CMakeLists.txt
+++ b/recipes/plog/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/plog/all/test_v1_package/conanfile.py
+++ b/recipes/plog/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/plog/config.yml
+++ b/recipes/plog/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.1.9":
+    folder: all
   "1.1.5":
     folder: all


### PR DESCRIPTION
Specify library name and version:  **plog/***

- add version 1.1.9
- support conan v2

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
