### PR TITLE
seasocks: add version 1.4.5, support conan v2

### DIFF
--- a/recipes/seasocks/all/conandata.yml
+++ b/recipes/seasocks/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.5":
+    url: "https://github.com/mattgodbolt/seasocks/archive/v1.4.5.tar.gz"
+    sha256: "82211959cf8aabc85b300358c5f68cf9c56dfdf4eaa09e548580fce908acfc1b"
   "1.4.4":
     url: "https://github.com/mattgodbolt/seasocks/archive/v1.4.4.tar.gz"
     sha256: "5ec016ee87d4985a031212fa23a00de3de5f0fa1ceb82d7b9a3d1c189356bf8d"

--- a/recipes/seasocks/all/conanfile.py
+++ b/recipes/seasocks/all/conanfile.py
@@ -112,7 +112,7 @@ class SeasocksConan(ConanFile):
         # TODO: back to global scope in conan v2 once cmake_find_package* generators removed
         self.cpp_info.components["libseasocks"].libs = ["seasocks"]
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.components["libseasocks"].system_libs.append("pthread")
+            self.cpp_info.components["libseasocks"].system_libs.extend(["pthread", "m"])
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.names["cmake_find_package"] = "Seasocks"

--- a/recipes/seasocks/all/conanfile.py
+++ b/recipes/seasocks/all/conanfile.py
@@ -1,19 +1,20 @@
-from conans import CMake, ConanFile, tools
-from conans.errors import ConanInvalidConfiguration
-import functools
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import get, copy, rmdir, replace_in_file
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.43.0"
-
+required_conan_version = ">=1.53.0"
 
 class SeasocksConan(ConanFile):
     name = "seasocks"
     description = "A tiny embeddable C++ HTTP and WebSocket server for Linux"
-    topics = ("seasocks", "embeddable", "webserver", "websockets")
-    homepage = "https://github.com/mattgodbolt/seasocks"
-    url = "https://github.com/conan-io/conan-center-index"
     license = "BSD-2-Clause"
-
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/mattgodbolt/seasocks"
+    topics = ("embeddable", "webserver", "websockets")
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -26,12 +27,22 @@ class SeasocksConan(ConanFile):
         "with_zlib": True,
     }
 
-    generators = "cmake", "cmake_find_package"
-    exports_sources = "CMakeLists.txt"
+    @property
+    def _min_cppstd(self):
+        return 11 if Version(self.version) < "1.4.5" else 17
 
     @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def _compilers_minimum_version(self):
+        if Version(self.version) < "1.4.5":
+            return {}
+        else:
+            return {
+                "Visual Studio": "16",
+                "msvc": "191",
+                "gcc": "7",
+                "clang": "7",
+                "apple-clang": "10",
+            }
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -39,47 +50,60 @@ class SeasocksConan(ConanFile):
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
         if self.options.with_zlib:
-            self.requires("zlib/1.2.12")
+            self.requires("zlib/1.2.13")
 
     def validate(self):
         if self.settings.os not in ["Linux", "FreeBSD"]:
-            raise ConanInvalidConfiguration(f"Seasocks {self.version} doesn't support this os")
+            raise ConanInvalidConfiguration(f"{self.ref} doesn't support this os")
+
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def _patch_sources(self):
         # No warnings as errors
         cmakelists = os.path.join(self._source_subfolder, "CMakeLists.txt")
-        tools.replace_in_file(cmakelists, "-Werror", "")
-        tools.replace_in_file(cmakelists, "-pedantic-errors", "")
+        replace_in_file(self, cmakelists, "-Werror", "")
+        replace_in_file(self, cmakelists, "-pedantic-errors", "")
 
-    @functools.lru_cache(1)
-    def _configure_cmake(self):
-        cmake = CMake(self)
-        cmake.definitions["DEFLATE_SUPPORT"] = self.options.with_zlib
-        cmake.definitions["SEASOCKS_SHARED"] = self.options.shared
-        cmake.definitions["SEASOCKS_EXAMPLE_APP"] = False
-        cmake.definitions["UNITTESTS"] = False
-        cmake.configure()
-        return cmake
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["DEFLATE_SUPPORT"] = self.options.with_zlib
+        tc.variables["SEASOCKS_SHARED"] = self.options.shared
+        tc.variables["SEASOCKS_EXAMPLE_APP"] = False
+        tc.variables["UNITTESTS"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
         self._patch_sources()
-        cmake = self._configure_cmake()
+        cmake = CMake(self)
+        cmake.configure()
         cmake.build()
 
     def package(self):
-        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
-        cmake = self._configure_cmake()
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
         cmake.install()
-        tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "Seasocks")

--- a/recipes/seasocks/all/conanfile.py
+++ b/recipes/seasocks/all/conanfile.py
@@ -76,7 +76,7 @@ class SeasocksConan(ConanFile):
 
     def _patch_sources(self):
         # No warnings as errors
-        cmakelists = os.path.join(self._source_subfolder, "CMakeLists.txt")
+        cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
         replace_in_file(self, cmakelists, "-Werror", "")
         replace_in_file(self, cmakelists, "-pedantic-errors", "")
 

--- a/recipes/seasocks/all/test_package/CMakeLists.txt
+++ b/recipes/seasocks/all/test_package/CMakeLists.txt
@@ -1,12 +1,13 @@
-cmake_minimum_required(VERSION 3.3)
-project(test_package CXX)
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
 
 find_package(Seasocks REQUIRED CONFIG)
 find_package(Threads REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE Seasocks::seasocks Threads::Threads)
-set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+if(Seasocks_VERSION VERSION_LESS "1.4.5")
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+else()
+    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+endif()

--- a/recipes/seasocks/all/test_package/conanfile.py
+++ b/recipes/seasocks/all/test_package/conanfile.py
@@ -1,10 +1,19 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "cmake", "cmake_find_package_multi"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +21,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/seasocks/all/test_v1_package/CMakeLists.txt
+++ b/recipes/seasocks/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/recipes/seasocks/all/test_v1_package/conanfile.py
+++ b/recipes/seasocks/all/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/seasocks/config.yml
+++ b/recipes/seasocks/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.4.5":
+    folder: "all"
   "1.4.4":
     folder: "all"


### PR DESCRIPTION
Specify library name and version:  **seasocks/***

- add version 1.4.5 (1.4.5 requires C++17)
- support conan v2
- update zlib

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
